### PR TITLE
Fix POS ledger hold release fallback

### DIFF
--- a/docs/plans/2026-05-06-002-fix-pos-legacy-hold-release-plan.md
+++ b/docs/plans/2026-05-06-002-fix-pos-legacy-hold-release-plan.md
@@ -1,0 +1,314 @@
+---
+title: Fix POS Legacy Hold Release
+type: fix
+status: active
+date: 2026-05-06
+---
+
+# Fix POS Legacy Hold Release
+
+## Summary
+
+Remove POS from the legacy quantity-patch hold path so expired POS ledger holds cannot add availability back to `productSku.quantityAvailable`. The work keeps POS session holds ledger-only, moves any remaining non-POS compatibility behind explicit boundaries, and adds regression coverage for cron expiry, manual session expiry, void, clear-cart, and completion.
+
+---
+
+## Problem Frame
+
+The POS cart latency migration moved sale-session holds to `inventoryHold` rows, but the shared release helper still carries a legacy fallback that increments `productSku.quantityAvailable` when it cannot release the requested quantity from active ledger rows. When the POS expiry cron processes an already-expired ledger hold, that fallback can add stock availability that was never subtracted, making available quantity exceed on-hand quantity.
+
+---
+
+## Assumptions
+
+*This plan was authored without synchronous user confirmation. The items below are agent inferences that fill gaps in the input and should be reviewed during implementation and PR review.*
+
+- "Get off the legacy behavior" means POS sale-session commands should no longer support or call tuple-style quantity-patch hold APIs.
+- Existing expense-session quantity-patch behavior should not be silently broken in the POS fix; it should either get an explicit non-POS compatibility helper or be migrated in a separately testable unit.
+- Existing active POS sessions without ledger holds should fail safely by context: expiry/void/clear/remove terminalizes or deletes session state without SKU availability restoration, while completion must reject missing required ledger holds before decrementing stock.
+
+---
+
+## Requirements
+
+- R1. Expiring an active or held POS session with ledger holds must never increase `productSku.quantityAvailable`.
+- R2. POS release, void, clear-cart, manual expire, cron expire, and cashier-recovery expire paths must release or expire ledger hold rows idempotently.
+- R3. POS command integration must stop exposing tuple-style legacy quantity-patch hold acquire/adjust/release calls.
+- R4. POS session schema and completion behavior must not preserve a `legacyQuantityPatch` mode as a valid POS path.
+- R5. Any still-required non-POS quantity-patch behavior must be explicit and tested outside the POS ledger helper.
+- R6. Repo docs and sensors must record that POS cart holds are ledger-only and that release helpers must not restore SKU availability for POS holds.
+
+---
+
+## Scope Boundaries
+
+- This plan does not redesign storefront checkout reservations; storefront quantity-patch reservations remain outside this POS-focused fix.
+- This plan does not add a data backfill for historical POS sessions unless implementation discovers current production data that cannot fail safely.
+- This plan does not change POS UI behavior except where tests need to observe existing command outcomes.
+
+### Deferred to Follow-Up Work
+
+- Full expense-session ledger migration: only do it here if the explicit non-POS compatibility isolation proves unsafe or harder than the migration itself.
+- Storefront reservation ledger migration: keep separate because storefront checkout already owns distinct reservation/session semantics.
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts` is the shared POS inventory hold ledger helper. It currently marks expired active holds as expired, then falls through to `restoreLegacyQuantityPatchHold` when requested release quantity remains.
+- `packages/athena-webapp/convex/inventory/posSessions.ts` powers cron release, manual operations expiry, void, and clear-cart release paths through `releaseInventoryHoldsBatch`.
+- `packages/athena-webapp/convex/pos/infrastructure/integrations/inventoryHoldGateway.ts` still exposes tuple-style legacy acquire/adjust/release calls and has tests asserting direct `quantityAvailable` patches.
+- `packages/athena-webapp/convex/schemas/pos/posSession.ts` still allows `inventoryHoldMode: "legacyQuantityPatch" | "ledger"`.
+- `packages/athena-webapp/convex/inventory/expenseSessions.ts` still calls `releaseInventoryHoldsBatch(ctx.db, releaseItems)` with the array-form compatibility signature.
+- `packages/athena-webapp/docs/agent` routes Convex and POS changes through focused tests, `audit:convex`, `lint:convex:changed`, typecheck/build, graphify rebuild, and harness review before delivery.
+
+### Institutional Learnings
+
+- `docs/solutions/performance/athena-pos-cart-latency-foundation-2026-05-05.md` says POS cart holds should be represented as `inventoryHold` rows, not `productSku.quantityAvailable` patches, and completion should decrement SKU inventory exactly once.
+- `docs/solutions/logic-errors/athena-pos-register-local-catalog-search-2026-05-04.md` warns not to put volatile availability back into full-store POS catalog snapshots.
+- Prior POS hardening guidance treats command-boundary inventory and session lifecycle invariants as production-hardening work that needs concrete regression tests, not a prose-only spec.
+
+### External References
+
+- None. The issue is repo-local Convex/POS state semantics with strong local patterns.
+
+---
+
+## Key Technical Decisions
+
+- Make POS release ledger-only: release helpers used by POS should mark matching active ledger holds `released` or `expired` and should not restore `productSku.quantityAvailable`.
+- Remove tuple-style POS gateway compatibility: keeping both tuple and object call shapes makes it easy for future POS code to re-enter the quantity-patch path.
+- Treat expense compatibility as explicit non-POS behavior: if expense sessions still require quantity-patch release during this batch, give them a clearly named helper rather than keeping array overload behavior in the POS ledger helper.
+- Define missing-ledger behavior by command context: expiry, void, clear-cart, and remove-item should complete their session/item cleanup without SKU availability restoration; completion should reject the sale when required ledger holds are missing or expired; helper-level missing-hold release should be an availability-preserving no-op.
+
+---
+
+## Open Questions
+
+### Resolved During Planning
+
+- Should POS preserve the legacy availability restore fallback? No. It directly causes the reported over-availability bug and contradicts the ledger migration.
+- Should this be one coordinated PR? Yes. Multiple units touch the same helper, tests, docs, graphify output, and possibly generated Convex artifacts.
+
+### Deferred to Implementation
+
+- Whether expense sessions can migrate to the ledger helper in this same batch: decide after characterization tests show the current expense quantity-patch lifecycle clearly enough. U1 must preserve the existing array-form expense release path until U3 replaces it with an explicit non-POS helper or migration.
+- Whether old POS sessions with `inventoryHoldMode` missing need a one-time repair: decide from implementation-time data/model evidence; do not add speculative migration work without proof.
+
+---
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+```mermaid
+flowchart TD
+  A["POS session release path"] --> B["Release ledger holds for session/SKU"]
+  B --> C{"Matching active hold?"}
+  C -->|Not expired| D["Mark released or reduce quantity"]
+  C -->|Expired| E["Mark expired and count as handled"]
+  C -->|Missing| F["Return safe no-op or conflict without SKU availability restore"]
+  D --> G["Patch POS session lifecycle state"]
+  E --> G
+  F --> G
+  H["Expense/session compatibility"] --> I["Explicit non-POS helper or migration"]
+  I -. "No hidden POS fallback" .-> B
+```
+
+---
+
+## Implementation Units
+
+- U1. **Characterize And Remove POS Release Restore**
+
+**Goal:** Prove the current over-availability failure, then remove the POS path that restores `quantityAvailable` when a ledger release sees expired or missing holds.
+
+**Requirements:** R1, R2.
+
+**Dependencies:** None.
+
+**Files:**
+- Modify: `packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts`
+- Modify: `packages/athena-webapp/convex/inventory/helpers/inventoryHolds.test.ts`
+- Modify: `packages/athena-webapp/convex/inventory/posSessions.trace.test.ts`
+- Modify: `packages/athena-webapp/convex/inventory/posSessions.ts`
+
+**Approach:**
+- Add characterization coverage showing the current expired-ledger-hold release would patch availability upward.
+- Change POS ledger release semantics so expired matching holds are considered handled for the requested release quantity and missing ledger rows never trigger an availability restore.
+- Preserve the current expense array-form release behavior while U1 lands; remove or rename that compatibility only in U3 after expense tests are in place.
+- Add at least one test that exercises the real helper behavior from a POS expiry-shaped scenario, not only a mocked `releaseInventoryHoldsBatch` call.
+
+**Execution note:** Characterization-first for the current failure, then test-first for the corrected invariant.
+
+**Patterns to follow:**
+- `packages/athena-webapp/convex/inventory/helpers/inventoryHolds.test.ts` existing in-memory DB harness.
+- `packages/athena-webapp/convex/inventory/posSessions.trace.test.ts` existing session lifecycle coverage, but avoid relying only on mocked helper assertions for the inventory invariant.
+
+**Test scenarios:**
+- Happy path: releasing a non-expired active ledger hold marks it released and leaves `productSku.quantityAvailable` unchanged.
+- Edge case: releasing an expired active ledger hold marks it expired and leaves `productSku.quantityAvailable` unchanged even when item quantity is requested.
+- Edge case: replaying POS expiry after holds were already released or expired is idempotent and does not patch `productSku`.
+- Integration: `releasePosSessionItems` for an expired held POS session with an expired ledger hold marks the session expired and does not make availability exceed inventory count.
+- Integration: `expireSessionFromOperations` manual expiry releases/terminalizes ledger holds without SKU availability restoration.
+- Integration: `voidSession` releases/terminalizes ledger holds without SKU availability restoration and preserves audit-session items as currently designed.
+- Integration: `releaseSessionInventoryHoldsAndDeleteItems` clear-cart cleanup releases/terminalizes ledger holds without SKU availability restoration.
+- Integration: remove-item release deletes the line item without SKU availability restoration when no active matching ledger hold remains.
+- Integration: cashier-recovery expiry through `expireAllSessionsForStaff` releases active/held session holds without SKU availability restore.
+
+**Verification:**
+- POS expiry and helper tests prove `quantityAvailable` is unchanged during release/expiry and only session/hold statuses change.
+
+---
+
+- U2. **Remove POS Gateway Legacy Quantity-Patch API**
+
+**Goal:** Remove tuple-style acquire/adjust/release compatibility from the POS inventory gateway so POS command code can only use object-shaped ledger hold calls.
+
+**Requirements:** R3, R4.
+
+**Dependencies:** U1.
+
+**Files:**
+- Modify: `packages/athena-webapp/convex/pos/infrastructure/integrations/inventoryHoldGateway.ts`
+- Modify: `packages/athena-webapp/convex/pos/infrastructure/integrations/inventoryHoldGateway.test.ts`
+- Modify: `packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts`
+- Modify: `packages/athena-webapp/convex/pos/application/sessionCommands.test.ts`
+- Modify: `packages/athena-webapp/convex/schemas/pos/posSession.ts`
+- Modify: `packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts`
+- Modify: `packages/athena-webapp/convex/pos/application/completeTransaction.test.ts`
+
+**Approach:**
+- Collapse gateway signatures to the ledger object form only.
+- Replace tests that assert tuple quantity-patch behavior with tests that assert tuple behavior is not part of the public POS integration contract.
+- Remove `legacyQuantityPatch` from the POS session schema and make completion validate ledger holds according to the current POS invariant rather than preserving a legacy mode branch.
+
+**Execution note:** Test-first for contract removal; TypeScript failures should guide callsite cleanup.
+
+**Patterns to follow:**
+- `packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts` already creates new POS sessions with `inventoryHoldMode: "ledger"`.
+- `packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts` already contains ledger-specific hold validation and consumption.
+
+**Test scenarios:**
+- Happy path: add/update/remove cart commands still acquire, adjust, and release ledger holds through object-shaped gateway calls.
+- Error path: completion with missing or expired ledger holds fails safely instead of decrementing inventory from an unheld cart.
+- Edge case: sessions with no explicit legacy mode are handled by the new ledger-only policy without SKU availability restoration.
+- Contract: TypeScript/test coverage no longer contains POS tuple acquire/adjust/release usage.
+
+**Verification:**
+- POS gateway and command tests pass without tuple compatibility helpers or `legacyQuantityPatch` schema support.
+
+---
+
+- U3. **Isolate Or Migrate Expense Quantity-Patch Compatibility**
+
+**Goal:** Remove the array-form quantity-patch branch from the shared POS ledger helper without breaking expense-session release behavior accidentally.
+
+**Requirements:** R5.
+
+**Dependencies:** U1.
+
+**Files:**
+- Modify: `packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts`
+- Modify: `packages/athena-webapp/convex/inventory/helpers/inventoryHolds.test.ts`
+- Modify: `packages/athena-webapp/convex/inventory/expenseSessions.ts`
+- Modify: `packages/athena-webapp/convex/inventory/expenseSessions.test.ts`
+- Optional modify: `packages/athena-webapp/convex/inventory/expenseTransactions.ts`
+
+**Approach:**
+- Characterize current expense session release expectations before changing shared helper signatures.
+- Either move quantity-patch release into an explicitly named expense/local helper or migrate expense sessions to ledger-backed holds if the test surface shows the migration is smaller and safer.
+- Ensure the shared POS ledger helper no longer has overloaded behavior where array input means direct SKU availability restoration.
+
+**Execution note:** Characterization-first because expense session hold semantics are still legacy and should not be changed accidentally.
+
+**Patterns to follow:**
+- `packages/athena-webapp/convex/inventory/expenseSessions.test.ts` existing expense lifecycle command-result style.
+- `packages/athena-webapp/convex/inventory/expenseTransactions.ts` current assumption that expense hold acquisition already reduced availability before completion.
+
+**Test scenarios:**
+- Happy path: voiding an expense session releases its held quantities according to the explicit expense behavior.
+- Integration: `releaseExpenseSessionItems` for expired sessions keeps current expense inventory accounting correct.
+- Edge case: expense release no longer reaches the POS ledger helper through an overloaded array signature.
+- Regression: POS helper tests fail if array-form quantity patch is reintroduced.
+
+**Verification:**
+- Expense session tests document either preserved explicit compatibility or the migrated ledger behavior, and POS helper code has no hidden quantity-patch overload.
+
+---
+
+- U4. **Refresh Sensors And Durable Learning**
+
+**Goal:** Keep repo docs, graphify output, and plan/ticket links honest after changing the POS hold contract.
+
+**Requirements:** R6.
+
+**Dependencies:** U1, U2, U3.
+
+**Files:**
+- Modify: `docs/solutions/performance/athena-pos-cart-latency-foundation-2026-05-05.md`
+- Modify: `docs/solutions/logic-errors/athena-pos-register-local-catalog-search-2026-05-04.md`
+- Modify: `docs/plans/2026-05-06-002-fix-pos-legacy-hold-release-plan.md`
+- Generated modify: `graphify-out/*`
+- Generated modify when needed: `packages/athena-webapp/convex/_generated/*`
+- Generated modify when needed: `packages/athena-webapp/docs/agent/*`
+
+**Approach:**
+- Update solution docs to state POS ledger release must not restore SKU availability and to record the specific expired-hold failure mode.
+- Keep the regression tests from U1/U2 as the primary sensor for the invariant; add a lightweight static guard only if implementation leaves a high-risk direct call path such as tuple gateway usage or array-form POS release signatures.
+- Refresh graphify after code changes.
+- Run generated-artifact repair if Convex API or harness docs drift.
+
+**Execution note:** Sensor-only.
+
+**Patterns to follow:**
+- Existing solution-doc frontmatter and prevention sections.
+- Repo rule that code modifications require `bun run graphify:rebuild`.
+
+**Test scenarios:**
+- Test expectation: none -- documentation and generated-artifact refresh only.
+
+**Verification:**
+- Documentation reflects the new invariant and generated artifacts are either unchanged or refreshed through repo-owned commands.
+
+---
+
+## System-Wide Impact
+
+- **Interaction graph:** POS cron expiry, operations expiry, void, clear-cart, remove-item, and completion all depend on the same hold helper contract.
+- **Error propagation:** Missing ledger holds should fail safe or no-op according to command context; no path should compensate by inflating SKU availability.
+- **Missing-hold context rules:** Expiry, void, clear-cart, and remove-item cleanup should not block on missing ledger holds; completion should block because it would otherwise create a sale without a valid hold.
+- **State lifecycle risks:** The risky lifecycle is active ledger hold -> expired by time -> session expiry cron. That transition must mark the hold terminal without SKU availability restore.
+- **API surface parity:** POS infrastructure gateway, shared inventory helper, schema mode, and tests must agree that POS is ledger-only.
+- **Integration coverage:** Helper-level tests alone are not enough; at least one session-expiry-shaped test must prove the bug cannot re-enter through `posSessions.ts`.
+- **Unchanged invariants:** Storefront checkout reservation behavior and broad SKU stock operations remain outside the POS ledger release contract.
+
+---
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Expense sessions rely on shared array-form release behavior | Characterize expense behavior first, then isolate or migrate it explicitly under U3 |
+| Old POS sessions without ledger rows exist in production | Prefer fail-safe/no-op behavior over SKU availability restore; only add migration if implementation evidence shows it is necessary |
+| Tests keep mocking the helper and miss integration behavior | Add at least one inventory invariant test that exercises real helper semantics |
+| Generated artifacts drift across multiple tickets | Execute as a coordinated batch and regenerate shared artifacts once before PR |
+
+---
+
+## Documentation / Operational Notes
+
+- This is a coordinated Linear batch that should land through one integration PR because helper, tests, docs, graphify, and potential Convex generated artifacts overlap.
+- The PR should call out that POS sale-session holds are now ledger-only and that expense compatibility was handled explicitly.
+- If implementation discovers live-data repair is needed, create a follow-up Linear issue unless the repair is essential to make this fix safe.
+
+---
+
+## Sources & References
+
+- Related plan: `docs/plans/2026-05-05-001-refactor-pos-cart-latency-foundation-plan.md`
+- Related solution: `docs/solutions/performance/athena-pos-cart-latency-foundation-2026-05-05.md`
+- Related solution: `docs/solutions/logic-errors/athena-pos-register-local-catalog-search-2026-05-04.md`
+- Related Linear issue: `V26-471`

--- a/docs/solutions/logic-errors/athena-pos-register-local-catalog-search-2026-05-04.md
+++ b/docs/solutions/logic-errors/athena-pos-register-local-catalog-search-2026-05-04.md
@@ -78,6 +78,11 @@ store catalog subscription. Fetch availability only for the bounded set of rows
 currently being displayed or exact-matched, and still let the add-item command be
 the final inventory authority.
 
+POS ledger release must also stay out of SKU availability restoration. Cart
+holds represented by `inventoryHold` rows did not decrement
+`productSku.quantityAvailable` when acquired, so expiry/void/clear-cart cleanup
+should terminalize the hold rows without adding availability back to the SKU.
+
 ## Prevention
 
 - Do not start generic per-keystroke POS product search from active register
@@ -91,6 +96,8 @@ the final inventory authority.
 - Add tests for prefix and typo matching whenever local text ranking changes.
 - Add tests that prove catalog metadata rows exclude volatile availability and
   availability is overlaid from a bounded query.
+- Add tests that prove expired POS ledger holds are released or expired without
+  restoring `productSku.quantityAvailable`.
 
 ## Related Issues
 

--- a/docs/solutions/performance/athena-pos-cart-latency-foundation-2026-05-05.md
+++ b/docs/solutions/performance/athena-pos-cart-latency-foundation-2026-05-05.md
@@ -47,6 +47,9 @@ Keep the register search index stable and make cart operations optimistic:
   `productSku.quantityAvailable` while the cart is being edited.
 - Consume holds during session completion, and decrement SKU inventory exactly
   once at the sale boundary.
+- Release or expire POS ledger holds without restoring `productSku.quantityAvailable`;
+  ledger holds never subtracted that field during cart editing, so adding it
+  back can make available quantity exceed on-hand quantity.
 - Find existing cart lines with `posSessionItem.by_sessionId_productSkuId`.
 
 The UI may update instantly, but command success remains the durable truth.
@@ -65,6 +68,13 @@ consumed POS hold. Legacy sessions that already patched availability during cart
 editing still decrement `inventoryCount` at completion, but do not subtract
 availability a second time.
 
+Do not route POS release, void, clear-cart, manual expiry, cron expiry, or
+cashier-recovery expiry through a quantity-patch fallback. If a matching ledger
+hold is expired, terminalize the hold as expired and leave SKU availability
+unchanged. If a ledger hold is missing during non-completion cleanup, complete
+the cleanup without compensating stock availability. Completion is different: it
+must reject missing or expired required ledger holds before creating the sale.
+
 ## Prevention
 
 - Do not add cart-mutated fields back to the full-store register catalog
@@ -72,6 +82,8 @@ availability a second time.
 - Put volatile availability behind bounded SKU-id queries.
 - Keep cart mutations behind command validation and optimistic rollback tests.
 - Add schema/index tests for hot-path lookup indexes.
+- Add release-path tests that prove expired POS ledger holds do not restore SKU
+  availability.
 - Run graphify after changing these command/read-model boundaries.
 
 ## Related Issues

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 4570 nodes · 4366 edges · 1547 communities detected
+- 4573 nodes · 4369 edges · 1547 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -1633,24 +1633,24 @@ Cohesion: 0.13
 Nodes (18): buildCartSummary(), buildSessionOperationsRow(), expirePosSessionNow(), hasCustomerSnapshotValue(), isUsableRegisterSession(), loadPosSessionItems(), loadSessionCustomer(), loadSessionOperator() (+10 more)
 
 ### Community 12 - "Community 12"
+Cohesion: 0.15
+Nodes (19): acquireExpenseQuantityPatchHold(), adjustExpenseQuantityPatchHold(), createDefaultExpenseSessionCommandService(), createExpenseInventoryHoldGateway(), createExpenseSessionCommandService(), failure(), isActiveRegisterSession(), isSessionExpired() (+11 more)
+
+### Community 13 - "Community 13"
 Cohesion: 0.25
 Nodes (21): buildActiveCycleCountDraftsSubmissionKey(), buildCycleCountDraftSubmissionKey(), createCycleCountDraftWithCtx(), discardCycleCountDraftCommandWithCtx(), ensureCycleCountDraftCommandWithCtx(), ensureCycleCountDraftWithCtx(), findOpenCycleCountDraftWithCtx(), getActiveCycleCountDraftSummaryWithCtx() (+13 more)
 
-### Community 13 - "Community 13"
+### Community 14 - "Community 14"
 Cohesion: 0.27
 Nodes (20): asBoolean(), asMtnMomoSetupStatus(), asNumber(), asOptionalArray(), asRecord(), asString(), cleanUndefined(), firstDefined() (+12 more)
 
-### Community 14 - "Community 14"
+### Community 15 - "Community 15"
 Cohesion: 0.16
 Nodes (16): buildGitProcessEnv(), collectCommandsForChangedFiles(), fileExists(), formatMissingPathPrefixError(), getChangedFilesForHarnessReview(), hasAnyHarnessDocs(), loadReviewTarget(), loadReviewTargets() (+8 more)
 
-### Community 15 - "Community 15"
-Cohesion: 0.18
-Nodes (16): createDefaultSessionCommandService(), createPosSessionCommandService(), failure(), isActiveRegisterSession(), isSessionExpired(), registerSessionMatchesIdentity(), resolveRegisterSessionBinding(), runBindSessionToRegisterSessionCommand() (+8 more)
-
 ### Community 16 - "Community 16"
 Cohesion: 0.18
-Nodes (15): createDefaultExpenseSessionCommandService(), createExpenseSessionCommandService(), failure(), isActiveRegisterSession(), isSessionExpired(), registerSessionMatchesIdentity(), resolveRegisterSessionBinding(), runBindExpenseSessionToRegisterSessionCommand() (+7 more)
+Nodes (16): createDefaultSessionCommandService(), createPosSessionCommandService(), failure(), isActiveRegisterSession(), isSessionExpired(), registerSessionMatchesIdentity(), resolveRegisterSessionBinding(), runBindSessionToRegisterSessionCommand() (+8 more)
 
 ### Community 17 - "Community 17"
 Cohesion: 0.11
@@ -1709,8 +1709,8 @@ Cohesion: 0.22
 Nodes (16): buildDegreeIndex(), buildHotspotLines(), buildPackagePage(), buildRootIndexPage(), collectRepoCodeFiles(), compareHotspots(), countCommunities(), fileExists() (+8 more)
 
 ### Community 31 - "Community 31"
-Cohesion: 0.24
-Nodes (15): acquireInventoryHold(), acquireInventoryHoldsBatch(), adjustInventoryHold(), consumeInventoryHoldsForSession(), getActiveHoldForSessionSku(), listActiveSessionHolds(), markHoldExpired(), readActiveInventoryHoldDetailsForSession() (+7 more)
+Cohesion: 0.23
+Nodes (14): acquireInventoryHold(), acquireInventoryHoldsBatch(), adjustInventoryHold(), consumeInventoryHoldsForSession(), getActiveHoldForSessionSku(), listActiveSessionHolds(), markHoldExpired(), readActiveInventoryHoldDetailsForSession() (+6 more)
 
 ### Community 32 - "Community 32"
 Cohesion: 0.12
@@ -2197,16 +2197,16 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 153 - "Community 153"
-Cohesion: 0.47
-Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
-
-### Community 154 - "Community 154"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 155 - "Community 155"
+### Community 154 - "Community 154"
 Cohesion: 0.4
 Nodes (2): useBulkOperations(), validateOperationValue()
+
+### Community 155 - "Community 155"
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 156 - "Community 156"
 Cohesion: 0.33
@@ -2221,12 +2221,12 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 159 - "Community 159"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 160 - "Community 160"
 Cohesion: 0.53
 Nodes (4): calculatePosChange(), calculatePosRemainingDue(), calculatePosTotalPaid(), roundPosAmount()
+
+### Community 160 - "Community 160"
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 161 - "Community 161"
 Cohesion: 0.33
@@ -2237,40 +2237,40 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 163 - "Community 163"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 164 - "Community 164"
 Cohesion: 0.4
 Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 165 - "Community 165"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
-
-### Community 166 - "Community 166"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 167 - "Community 167"
+### Community 166 - "Community 166"
 Cohesion: 0.47
 Nodes (4): fetchPosTransaction(), getBaseUrl(), getPosTransactionByReceiptToken(), PosTransactionReceiptError
 
-### Community 168 - "Community 168"
+### Community 167 - "Community 167"
 Cohesion: 0.47
 Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
 
-### Community 169 - "Community 169"
+### Community 168 - "Community 168"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 170 - "Community 170"
+### Community 169 - "Community 169"
 Cohesion: 0.4
 Nodes (2): handleConfirm(), handlePrimaryAction()
 
-### Community 171 - "Community 171"
+### Community 170 - "Community 170"
 Cohesion: 0.33
 Nodes (0):
+
+### Community 171 - "Community 171"
+Cohesion: 0.47
+Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
 
 ### Community 172 - "Community 172"
 Cohesion: 0.53
@@ -2329,28 +2329,28 @@ Cohesion: 0.7
 Nodes (4): buildDecision(), classifyCorrectionIntent(), isSupportedCorrectionIntent(), isUnsupportedHighRiskCorrectionIntent()
 
 ### Community 186 - "Community 186"
-Cohesion: 0.6
-Nodes (3): acquireLegacyQuantityPatchHold(), adjustLegacyQuantityPatchHold(), releaseLegacyQuantityPatchHold()
-
-### Community 187 - "Community 187"
 Cohesion: 0.7
 Nodes (4): getPaystackHeaders(), initializeTransaction(), initiateRefund(), verifyTransaction()
 
-### Community 188 - "Community 188"
+### Community 187 - "Community 187"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 189 - "Community 189"
+### Community 188 - "Community 188"
 Cohesion: 0.6
 Nodes (3): buildOnlineOrderReturnExchangePlan(), getApprovalReason(), getKind()
 
-### Community 190 - "Community 190"
+### Community 189 - "Community 189"
 Cohesion: 0.6
 Nodes (3): createOffer(), isDuplicate(), updateStoreFrontActorEmail()
 
-### Community 191 - "Community 191"
+### Community 190 - "Community 190"
 Cohesion: 0.5
 Nodes (2): getNonEmptyString(), normalizeStorefrontObservabilityEvent()
+
+### Community 191 - "Community 191"
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 192 - "Community 192"
 Cohesion: 0.4
@@ -2358,7 +2358,7 @@ Nodes (0):
 
 ### Community 193 - "Community 193"
 Cohesion: 0.4
-Nodes (0):
+Nodes (1): Header()
 
 ### Community 194 - "Community 194"
 Cohesion: 0.4
@@ -2393,20 +2393,20 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 202 - "Community 202"
-Cohesion: 0.4
-Nodes (1): Header()
-
-### Community 203 - "Community 203"
 Cohesion: 0.5
 Nodes (2): getBalanceDueLabel(), getBalanceDuePanel()
 
-### Community 204 - "Community 204"
+### Community 203 - "Community 203"
 Cohesion: 0.6
 Nodes (3): getSummaryAmount(), getSummaryLabel(), getSummaryPanel()
 
-### Community 205 - "Community 205"
+### Community 204 - "Community 204"
 Cohesion: 0.6
 Nodes (3): handleClearSearch(), handleQuickAddSubmit(), resetQuickAddForm()
+
+### Community 205 - "Community 205"
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 206 - "Community 206"
 Cohesion: 0.4
@@ -2421,32 +2421,32 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 209 - "Community 209"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 210 - "Community 210"
 Cohesion: 0.7
 Nodes (4): getRuntimeOrigin(), isLocalHost(), resolveStoreFrontUrl(), trimTrailingSlash()
 
-### Community 211 - "Community 211"
+### Community 210 - "Community 210"
 Cohesion: 0.7
 Nodes (4): bufferToHex(), collectBrowserInfo(), generateBrowserFingerprint(), hashFingerprintSource()
 
-### Community 212 - "Community 212"
+### Community 211 - "Community 211"
 Cohesion: 0.4
 Nodes (1): MockImage
 
-### Community 213 - "Community 213"
+### Community 212 - "Community 212"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 214 - "Community 214"
+### Community 213 - "Community 213"
 Cohesion: 0.6
 Nodes (3): calculatePosCartTotals(), calculatePosItemTotal(), roundPosAmount()
 
-### Community 215 - "Community 215"
+### Community 214 - "Community 214"
 Cohesion: 0.6
 Nodes (4): mapRegisterStateDto(), mapTerminalDto(), useConvexRegisterState(), useConvexTerminalByFingerprint()
+
+### Community 215 - "Community 215"
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 216 - "Community 216"
 Cohesion: 0.4
@@ -2461,84 +2461,84 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 219 - "Community 219"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 220 - "Community 220"
 Cohesion: 0.5
 Nodes (2): completePendingAuthSync(), sleep()
 
-### Community 221 - "Community 221"
+### Community 220 - "Community 220"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 222 - "Community 222"
+### Community 221 - "Community 221"
 Cohesion: 0.7
 Nodes (4): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory()
 
-### Community 223 - "Community 223"
+### Community 222 - "Community 222"
 Cohesion: 0.7
 Nodes (4): getBaseUrl(), getOrder(), getOrders(), updateOrdersOwner()
 
-### Community 224 - "Community 224"
+### Community 223 - "Community 223"
 Cohesion: 0.7
 Nodes (4): getActiveUser(), getBaseUrl(), getGuest(), updateUser()
+
+### Community 224 - "Community 224"
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 225 - "Community 225"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 226 - "Community 226"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 227 - "Community 227"
 Cohesion: 0.7
 Nodes (4): createStorefrontFailureEvent(), emitStorefrontFailure(), inferStorefrontJourneyFromRoute(), normalizeStorefrontError()
 
-### Community 228 - "Community 228"
+### Community 227 - "Community 227"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 229 - "Community 229"
+### Community 228 - "Community 228"
 Cohesion: 0.6
 Nodes (4): collectHarnessRepoValidationSelection(), matchesHarnessRepoValidationPath(), normalizeRepoPath(), sortUniquePaths()
 
-### Community 230 - "Community 230"
+### Community 229 - "Community 229"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 231 - "Community 231"
+### Community 230 - "Community 230"
 Cohesion: 0.7
 Nodes (4): createFixtureRepo(), fixtureEnv(), runGit(), runWorktreeManager()
 
-### Community 232 - "Community 232"
+### Community 231 - "Community 231"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 233 - "Community 233"
+### Community 232 - "Community 232"
 Cohesion: 0.67
 Nodes (2): maskReceiptPhone(), normalizeReceiptPhone()
 
-### Community 234 - "Community 234"
+### Community 233 - "Community 233"
 Cohesion: 0.83
 Nodes (3): createReceiptShareToken(), hashReceiptShareToken(), toHex()
 
-### Community 235 - "Community 235"
+### Community 234 - "Community 234"
 Cohesion: 0.83
 Nodes (3): timingSafeEqual(), toHex(), verifyMetaWebhookSignature()
+
+### Community 235 - "Community 235"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 236 - "Community 236"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 237 - "Community 237"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 238 - "Community 238"
 Cohesion: 0.67
 Nodes (2): createExpenseTransactionFromSessionHandler(), expenseTransactionError()
+
+### Community 238 - "Community 238"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 239 - "Community 239"
 Cohesion: 0.5
@@ -2549,68 +2549,68 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 241 - "Community 241"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 242 - "Community 242"
 Cohesion: 0.67
 Nodes (2): createProductsQueryCtx(), createSkuMutationCtx()
 
-### Community 243 - "Community 243"
+### Community 242 - "Community 242"
 Cohesion: 0.67
 Nodes (2): toDisplayAmount(), toPesewas()
 
-### Community 244 - "Community 244"
+### Community 243 - "Community 243"
 Cohesion: 0.83
 Nodes (3): getCachedTokenRecord(), resolveAccessTokenForStore(), resolveConfigForStore()
 
-### Community 245 - "Community 245"
+### Community 244 - "Community 244"
 Cohesion: 0.67
 Nodes (2): maskMtnPartyId(), normalizeCollectionsTransaction()
 
-### Community 246 - "Community 246"
+### Community 245 - "Community 245"
 Cohesion: 0.67
 Nodes (2): consumeApprovalProofWithCtx(), invalidApprovalProofResult()
 
-### Community 247 - "Community 247"
+### Community 246 - "Community 246"
 Cohesion: 0.67
 Nodes (2): buildOperationalEvent(), recordOperationalEventWithCtx()
 
-### Community 248 - "Community 248"
+### Community 247 - "Community 247"
 Cohesion: 0.67
 Nodes (2): buildOperationalWorkItem(), createOperationalWorkItemWithCtx()
 
-### Community 249 - "Community 249"
+### Community 248 - "Community 248"
 Cohesion: 0.67
 Nodes (2): expectIndex(), getTableIndexes()
+
+### Community 249 - "Community 249"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 250 - "Community 250"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 251 - "Community 251"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 252 - "Community 252"
 Cohesion: 0.83
 Nodes (3): resolveServiceIntakeCustomerProfile(), splitFullName(), trimOptional()
 
-### Community 253 - "Community 253"
+### Community 252 - "Community 252"
 Cohesion: 0.83
 Nodes (3): mapOpenDrawerUserError(), normalizeRegisterNumber(), openDrawer()
 
-### Community 254 - "Community 254"
+### Community 253 - "Community 253"
 Cohesion: 0.83
 Nodes (3): createDbGetMock(), createDbMock(), createDbQueryMock()
 
-### Community 255 - "Community 255"
+### Community 254 - "Community 254"
 Cohesion: 0.83
 Nodes (3): buildRegisterState(), getActiveSessionConflictForRegisterState(), getRegisterState()
 
-### Community 256 - "Community 256"
+### Community 255 - "Community 255"
 Cohesion: 0.67
 Nodes (2): lookupByBarcode(), mapSkuToCatalogResult()
+
+### Community 256 - "Community 256"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 257 - "Community 257"
 Cohesion: 0.5
@@ -2621,24 +2621,24 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 259 - "Community 259"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 260 - "Community 260"
 Cohesion: 0.67
 Nodes (2): expectIndex(), getTableIndexes()
 
-### Community 261 - "Community 261"
+### Community 260 - "Community 260"
 Cohesion: 0.83
 Nodes (3): findExistingCustomerProfileId(), getStoreOrganizationId(), recordStoreFrontCustomerMilestone()
 
-### Community 262 - "Community 262"
+### Community 261 - "Community 261"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 263 - "Community 263"
+### Community 262 - "Community 262"
 Cohesion: 0.83
 Nodes (3): formatStaffDisplayName(), formatStaffDisplayNameOrFallback(), normalizeNamePart()
+
+### Community 263 - "Community 263"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 264 - "Community 264"
 Cohesion: 0.5
@@ -2653,12 +2653,12 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 267 - "Community 267"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 268 - "Community 268"
 Cohesion: 0.67
 Nodes (2): countGroupedAnalytics(), groupAnalytics()
+
+### Community 268 - "Community 268"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 269 - "Community 269"
 Cohesion: 0.5
@@ -2673,12 +2673,12 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 272 - "Community 272"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 273 - "Community 273"
 Cohesion: 0.67
 Nodes (2): handleSubmit(), resetReplacementFields()
+
+### Community 273 - "Community 273"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 274 - "Community 274"
 Cohesion: 0.5
@@ -2705,72 +2705,72 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 280 - "Community 280"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 281 - "Community 281"
 Cohesion: 0.67
 Nodes (2): applyCommandResult(), handleCreateCase()
+
+### Community 281 - "Community 281"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 282 - "Community 282"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 283 - "Community 283"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 284 - "Community 284"
 Cohesion: 0.67
 Nodes (2): getRiskStyles(), RiskIndicators()
 
-### Community 285 - "Community 285"
+### Community 284 - "Community 284"
 Cohesion: 0.67
 Nodes (2): useGetArchivedProducts(), useGetProducts()
 
-### Community 286 - "Community 286"
+### Community 285 - "Community 285"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 287 - "Community 287"
+### Community 286 - "Community 286"
 Cohesion: 0.67
 Nodes (2): extractTraceId(), runCommand()
+
+### Community 287 - "Community 287"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 288 - "Community 288"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 289 - "Community 289"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 290 - "Community 290"
 Cohesion: 0.67
 Nodes (2): mapActiveSessionDto(), normalizeCartItems()
 
-### Community 291 - "Community 291"
+### Community 290 - "Community 290"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 292 - "Community 292"
+### Community 291 - "Community 291"
 Cohesion: 0.83
 Nodes (3): isBrowserFingerprintResult(), readStoredTerminalFingerprint(), readStoredTerminalFingerprintHash()
 
-### Community 293 - "Community 293"
+### Community 292 - "Community 292"
 Cohesion: 0.67
 Nodes (2): getCashierDisplayName(), useExpenseRegisterViewModel()
 
-### Community 294 - "Community 294"
+### Community 293 - "Community 293"
 Cohesion: 0.83
 Nodes (3): getBaseUrl(), getUserRedeemedOffers(), submitOffer()
 
-### Community 295 - "Community 295"
+### Community 294 - "Community 294"
 Cohesion: 0.83
 Nodes (3): getAllStores(), getBaseUrl(), getStore()
 
-### Community 296 - "Community 296"
+### Community 295 - "Community 295"
 Cohesion: 0.83
 Nodes (3): getAllSubcategories(), getBaseUrl(), getSubategory()
+
+### Community 296 - "Community 296"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 297 - "Community 297"
 Cohesion: 0.5
@@ -2797,59 +2797,59 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 303 - "Community 303"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 304 - "Community 304"
 Cohesion: 0.67
 Nodes (2): useOptionalStoreContext(), useStoreContext()
 
-### Community 305 - "Community 305"
+### Community 304 - "Community 304"
 Cohesion: 0.67
 Nodes (2): clearFilters(), onMobileFiltersCloseClick()
 
-### Community 306 - "Community 306"
+### Community 305 - "Community 305"
 Cohesion: 0.83
 Nodes (3): cancelOrder(), getErrorMessage(), placeOrder()
 
-### Community 307 - "Community 307"
+### Community 306 - "Community 306"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 308 - "Community 308"
+### Community 307 - "Community 307"
 Cohesion: 0.83
 Nodes (3): bootstrapCheckout(), createBootstrapToken(), createMarker()
 
-### Community 309 - "Community 309"
+### Community 308 - "Community 308"
 Cohesion: 0.83
 Nodes (3): createFixtureRoot(), write(), writeGraphifyWikiArtifacts()
 
-### Community 310 - "Community 310"
+### Community 309 - "Community 309"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 311 - "Community 311"
+### Community 310 - "Community 310"
 Cohesion: 0.67
 Nodes (2): buildHarnessDocPaths(), buildHarnessDocPathsForArchetype()
 
-### Community 312 - "Community 312"
+### Community 311 - "Community 311"
 Cohesion: 0.67
 Nodes (2): shutdown(), stopValkeyRuntimeServer()
 
-### Community 313 - "Community 313"
+### Community 312 - "Community 312"
 Cohesion: 0.83
 Nodes (3): createFixtureRepo(), createInferentialArtifact(), write()
 
-### Community 314 - "Community 314"
+### Community 313 - "Community 313"
 Cohesion: 0.67
 Nodes (2): collectHarnessTestTargets(), runHarnessTest()
+
+### Community 314 - "Community 314"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 315 - "Community 315"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 316 - "Community 316"
-Cohesion: 0.5
+Cohesion: 0.67
 Nodes (0):
 
 ### Community 317 - "Community 317"
@@ -2857,12 +2857,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 318 - "Community 318"
-Cohesion: 0.67
-Nodes (0):
-
-### Community 319 - "Community 319"
 Cohesion: 1.0
 Nodes (2): providerErrorCategory(), sendWhatsAppReceiptTemplate()
+
+### Community 319 - "Community 319"
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 320 - "Community 320"
 Cohesion: 0.67
@@ -2910,11 +2910,11 @@ Nodes (0):
 
 ### Community 331 - "Community 331"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): PosServerError
 
 ### Community 332 - "Community 332"
 Cohesion: 0.67
-Nodes (1): PosServerError
+Nodes (0):
 
 ### Community 333 - "Community 333"
 Cohesion: 0.67
@@ -2925,20 +2925,20 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 335 - "Community 335"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 336 - "Community 336"
 Cohesion: 1.0
 Nodes (2): getActiveRegisterSessionForRegisterState(), mapRegisterSessionToCashDrawerSummary()
 
-### Community 336 - "Community 336"
+### Community 337 - "Community 337"
 Cohesion: 0.67
 Nodes (0):
-
-### Community 337 - "Community 337"
-Cohesion: 1.0
-Nodes (2): expectIndex(), getTableIndexes()
 
 ### Community 338 - "Community 338"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): expectIndex(), getTableIndexes()
 
 ### Community 339 - "Community 339"
 Cohesion: 0.67
@@ -2953,36 +2953,36 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 342 - "Community 342"
-Cohesion: 1.0
-Nodes (2): listBagItems(), loadBagWithItems()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 343 - "Community 343"
 Cohesion: 1.0
-Nodes (2): buildRegisterSessionTraceSeed(), formatRegisterSessionLabel()
+Nodes (2): listBagItems(), loadBagWithItems()
 
 ### Community 344 - "Community 344"
 Cohesion: 1.0
-Nodes (2): getWorkflowTraceViewByIdWithCtx(), getWorkflowTraceViewByLookupWithCtx()
+Nodes (2): buildRegisterSessionTraceSeed(), formatRegisterSessionLabel()
 
 ### Community 345 - "Community 345"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getWorkflowTraceViewByIdWithCtx(), getWorkflowTraceViewByLookupWithCtx()
 
 ### Community 346 - "Community 346"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 347 - "Community 347"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 348 - "Community 348"
 Cohesion: 1.0
 Nodes (2): createWorkflowTraceId(), normalizeWorkflowTraceLookupValue()
 
-### Community 348 - "Community 348"
-Cohesion: 0.67
-Nodes (1): View()
-
 ### Community 349 - "Community 349"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): View()
 
 ### Community 350 - "Community 350"
 Cohesion: 0.67
@@ -2997,24 +2997,24 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 353 - "Community 353"
-Cohesion: 1.0
-Nodes (2): AnalyticsCombinedUsers(), processAnalyticsToUsers()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 354 - "Community 354"
 Cohesion: 1.0
-Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
+Nodes (2): AnalyticsCombinedUsers(), processAnalyticsToUsers()
 
 ### Community 355 - "Community 355"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
 
 ### Community 356 - "Community 356"
 Cohesion: 0.67
-Nodes (1): FadeIn()
+Nodes (0):
 
 ### Community 357 - "Community 357"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): FadeIn()
 
 ### Community 358 - "Community 358"
 Cohesion: 0.67
@@ -3022,23 +3022,23 @@ Nodes (0):
 
 ### Community 359 - "Community 359"
 Cohesion: 0.67
-Nodes (1): VideoPlayer()
+Nodes (0):
 
 ### Community 360 - "Community 360"
+Cohesion: 0.67
+Nodes (1): VideoPlayer()
+
+### Community 361 - "Community 361"
 Cohesion: 1.0
 Nodes (2): handleRefundOrder(), toast()
 
-### Community 361 - "Community 361"
+### Community 362 - "Community 362"
 Cohesion: 0.67
 Nodes (0):
-
-### Community 362 - "Community 362"
-Cohesion: 1.0
-Nodes (2): CashierAuthDialog(), getStaffDisplayName()
 
 ### Community 363 - "Community 363"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): CashierAuthDialog(), getStaffDisplayName()
 
 ### Community 364 - "Community 364"
 Cohesion: 0.67
@@ -3093,84 +3093,84 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 377 - "Community 377"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 378 - "Community 378"
 Cohesion: 1.0
 Nodes (2): handleKeyDown(), handleSubmit()
 
-### Community 378 - "Community 378"
+### Community 379 - "Community 379"
 Cohesion: 0.67
 Nodes (1): SingleLineError()
 
-### Community 379 - "Community 379"
+### Community 380 - "Community 380"
 Cohesion: 0.67
 Nodes (1): ErrorPage()
 
-### Community 380 - "Community 380"
+### Community 381 - "Community 381"
 Cohesion: 0.67
 Nodes (1): AppSkeleton()
 
-### Community 381 - "Community 381"
+### Community 382 - "Community 382"
 Cohesion: 0.67
 Nodes (1): DashboardSkeleton()
 
-### Community 382 - "Community 382"
+### Community 383 - "Community 383"
 Cohesion: 0.67
 Nodes (1): TableSkeleton()
 
-### Community 383 - "Community 383"
+### Community 384 - "Community 384"
 Cohesion: 0.67
 Nodes (1): TransactionsSkeleton()
 
-### Community 384 - "Community 384"
+### Community 385 - "Community 385"
 Cohesion: 0.67
 Nodes (1): NotFound()
 
-### Community 385 - "Community 385"
+### Community 386 - "Community 386"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 386 - "Community 386"
+### Community 387 - "Community 387"
 Cohesion: 1.0
 Nodes (2): getWorkflowTraceRouteTarget(), WorkflowTraceRouteLink()
 
-### Community 387 - "Community 387"
+### Community 388 - "Community 388"
 Cohesion: 0.67
 Nodes (1): AppContextMenu()
 
-### Community 388 - "Community 388"
+### Community 389 - "Community 389"
 Cohesion: 0.67
 Nodes (1): Badge()
 
-### Community 389 - "Community 389"
+### Community 390 - "Community 390"
 Cohesion: 0.67
 Nodes (1): LoadingButton()
 
-### Community 390 - "Community 390"
+### Community 391 - "Community 391"
 Cohesion: 0.67
 Nodes (1): onChange()
 
-### Community 391 - "Community 391"
+### Community 392 - "Community 392"
 Cohesion: 0.67
 Nodes (1): AlertModal()
 
-### Community 392 - "Community 392"
+### Community 393 - "Community 393"
 Cohesion: 0.67
 Nodes (1): OverlayModal()
 
-### Community 393 - "Community 393"
+### Community 394 - "Community 394"
 Cohesion: 0.67
 Nodes (1): Skeleton()
 
-### Community 394 - "Community 394"
+### Community 395 - "Community 395"
 Cohesion: 0.67
 Nodes (1): Toaster()
 
-### Community 395 - "Community 395"
-Cohesion: 0.67
-Nodes (1): Spinner()
-
 ### Community 396 - "Community 396"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): Spinner()
 
 ### Community 397 - "Community 397"
 Cohesion: 0.67
@@ -3198,11 +3198,11 @@ Nodes (0):
 
 ### Community 403 - "Community 403"
 Cohesion: 0.67
-Nodes (1): useAuth()
+Nodes (0):
 
 ### Community 404 - "Community 404"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): useAuth()
 
 ### Community 405 - "Community 405"
 Cohesion: 0.67
@@ -3213,16 +3213,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 407 - "Community 407"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 408 - "Community 408"
 Cohesion: 1.0
 Nodes (2): getApprovalGuidance(), presentCommandToast()
 
-### Community 408 - "Community 408"
-Cohesion: 0.67
-Nodes (1): isInMaintenanceMode()
-
 ### Community 409 - "Community 409"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): isInMaintenanceMode()
 
 ### Community 410 - "Community 410"
 Cohesion: 0.67
@@ -3234,67 +3234,67 @@ Nodes (0):
 
 ### Community 412 - "Community 412"
 Cohesion: 0.67
-Nodes (1): App()
+Nodes (0):
 
 ### Community 413 - "Community 413"
-Cohesion: 1.0
-Nodes (2): collectSourceFiles(), findIllegalConvexImports()
+Cohesion: 0.67
+Nodes (1): App()
 
 ### Community 414 - "Community 414"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): collectSourceFiles(), findIllegalConvexImports()
 
 ### Community 415 - "Community 415"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 416 - "Community 416"
-Cohesion: 1.0
-Nodes (2): getAthenaDesignTokenStyle(), withAthenaTheme()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 417 - "Community 417"
 Cohesion: 1.0
-Nodes (2): mockGetSku(), validateInventoryForTransaction()
+Nodes (2): getAthenaDesignTokenStyle(), withAthenaTheme()
 
 ### Community 418 - "Community 418"
-Cohesion: 0.67
-Nodes (1): hashPassword()
+Cohesion: 1.0
+Nodes (2): mockGetSku(), validateInventoryForTransaction()
 
 ### Community 419 - "Community 419"
 Cohesion: 0.67
-Nodes (1): createVersionChecker()
+Nodes (1): hashPassword()
 
 ### Community 420 - "Community 420"
 Cohesion: 0.67
-Nodes (1): manualChunks()
+Nodes (1): createVersionChecker()
 
 ### Community 421 - "Community 421"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): manualChunks()
 
 ### Community 422 - "Community 422"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 423 - "Community 423"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 424 - "Community 424"
 Cohesion: 1.0
 Nodes (2): getAllColors(), getBaseUrl()
 
-### Community 424 - "Community 424"
+### Community 425 - "Community 425"
 Cohesion: 0.67
 Nodes (0):
-
-### Community 425 - "Community 425"
-Cohesion: 1.0
-Nodes (2): getBaseUrl(), getLastViewedProduct()
 
 ### Community 426 - "Community 426"
 Cohesion: 1.0
-Nodes (2): getBaseUrl(), getUserOffersEligibility()
+Nodes (2): getBaseUrl(), getLastViewedProduct()
 
 ### Community 427 - "Community 427"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getBaseUrl(), getUserOffersEligibility()
 
 ### Community 428 - "Community 428"
 Cohesion: 0.67
@@ -3305,12 +3305,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 430 - "Community 430"
-Cohesion: 1.0
-Nodes (2): handleKeyDown(), handleRedeemPromoCode()
-
-### Community 431 - "Community 431"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 431 - "Community 431"
+Cohesion: 1.0
+Nodes (2): handleKeyDown(), handleRedeemPromoCode()
 
 ### Community 432 - "Community 432"
 Cohesion: 0.67
@@ -3321,12 +3321,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 434 - "Community 434"
-Cohesion: 1.0
-Nodes (2): getPromoAlertCopy(), PromoAlert()
-
-### Community 435 - "Community 435"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 435 - "Community 435"
+Cohesion: 1.0
+Nodes (2): getPromoAlertCopy(), PromoAlert()
 
 ### Community 436 - "Community 436"
 Cohesion: 0.67
@@ -3397,8 +3397,8 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 453 - "Community 453"
-Cohesion: 1.0
-Nodes (2): createFixtureRepo(), write()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 454 - "Community 454"
 Cohesion: 1.0
@@ -3417,20 +3417,20 @@ Cohesion: 1.0
 Nodes (2): createFixtureRepo(), write()
 
 ### Community 458 - "Community 458"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): createFixtureRepo(), write()
 
 ### Community 459 - "Community 459"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 460 - "Community 460"
-Cohesion: 1.0
-Nodes (2): collectRootScriptTestFiles(), runRootScriptsCoverage()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 461 - "Community 461"
 Cohesion: 1.0
-Nodes (0):
+Nodes (2): collectRootScriptTestFiles(), runRootScriptsCoverage()
 
 ### Community 462 - "Community 462"
 Cohesion: 1.0
@@ -7775,83 +7775,81 @@ Nodes (0):
 ## Knowledge Gaps
 - **1 isolated node(s):** `HelpRequested`
   These have ≤1 connection - possible missing edges or undocumented components.
-- **Thin community `Community 461`** (2 nodes): `getSource()`, `deposits.test.ts`
+- **Thin community `Community 462`** (2 nodes): `getSource()`, `deposits.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 462`** (2 nodes): `paymentAllocationAttribution.test.ts`, `readProjectFile()`
+- **Thin community `Community 463`** (2 nodes): `paymentAllocationAttribution.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 463`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
+- **Thin community `Community 464`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 464`** (2 nodes): `createCommandShimBin()`, `convexAuditScript.test.ts`
+- **Thin community `Community 465`** (2 nodes): `createCommandShimBin()`, `convexAuditScript.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 465`** (2 nodes): `policy.ts`, `assertSupportedCustomerMessagePolicy()`
+- **Thin community `Community 466`** (2 nodes): `policy.ts`, `assertSupportedCustomerMessagePolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 466`** (2 nodes): `repository.test.ts`, `queryResult()`
+- **Thin community `Community 467`** (2 nodes): `repository.test.ts`, `queryResult()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 467`** (2 nodes): `webhookSecurity.test.ts`, `sign()`
+- **Thin community `Community 468`** (2 nodes): `webhookSecurity.test.ts`, `sign()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 468`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
+- **Thin community `Community 469`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 469`** (2 nodes): `subcategories.ts`, `removeStorefrontHiddenSubcategoryList()`
+- **Thin community `Community 470`** (2 nodes): `subcategories.ts`, `removeStorefrontHiddenSubcategoryList()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 470`** (2 nodes): `storefrontCors.test.ts`, `readRouteFile()`
+- **Thin community `Community 471`** (2 nodes): `storefrontCors.test.ts`, `readRouteFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 471`** (2 nodes): `whatsapp.ts`, `mapWebhookStatus()`
+- **Thin community `Community 472`** (2 nodes): `whatsapp.ts`, `mapWebhookStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 472`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
+- **Thin community `Community 473`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 473`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
+- **Thin community `Community 474`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 474`** (2 nodes): `mapAthenaAuthSyncError()`, `auth.ts`
+- **Thin community `Community 475`** (2 nodes): `mapAthenaAuthSyncError()`, `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 475`** (2 nodes): `getHandler()`, `bestSeller.test.ts`
+- **Thin community `Community 476`** (2 nodes): `getHandler()`, `bestSeller.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 476`** (2 nodes): `userErrorFromExpenseItemCommandFailure()`, `expenseSessionItems.ts`
+- **Thin community `Community 477`** (2 nodes): `userErrorFromExpenseItemCommandFailure()`, `expenseSessionItems.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 477`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
+- **Thin community `Community 478`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 478`** (2 nodes): `posSessionItems.ts`, `userErrorFromSessionItemFailure()`
+- **Thin community `Community 479`** (2 nodes): `posSessionItems.ts`, `userErrorFromSessionItemFailure()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 479`** (2 nodes): `productUtil.ts`, `buildAllProductsCacheKey()`
+- **Thin community `Community 480`** (2 nodes): `productUtil.ts`, `buildAllProductsCacheKey()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 480`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
+- **Thin community `Community 481`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 481`** (2 nodes): `commandResultValidator()`, `commandResultValidators.ts`
+- **Thin community `Community 482`** (2 nodes): `commandResultValidator()`, `commandResultValidators.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 482`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
+- **Thin community `Community 483`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 483`** (2 nodes): `callAnthropic()`, `anthropic.ts`
+- **Thin community `Community 484`** (2 nodes): `callAnthropic()`, `anthropic.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 484`** (2 nodes): `callOpenAi()`, `openai.ts`
+- **Thin community `Community 485`** (2 nodes): `callOpenAi()`, `openai.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 485`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
+- **Thin community `Community 486`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 486`** (2 nodes): `consumeCommandApprovalProofWithCtx()`, `approvalActions.ts`
+- **Thin community `Community 487`** (2 nodes): `consumeCommandApprovalProofWithCtx()`, `approvalActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 487`** (2 nodes): `createOperationalEventCtx()`, `approvalAuditEvents.test.ts`
+- **Thin community `Community 488`** (2 nodes): `createOperationalEventCtx()`, `approvalAuditEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 488`** (2 nodes): `createApprovalProofMutationCtx()`, `approvalProofs.test.ts`
+- **Thin community `Community 489`** (2 nodes): `createApprovalProofMutationCtx()`, `approvalProofs.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 489`** (2 nodes): `buildApprovalRequest()`, `approvalRequestHelpers.ts`
+- **Thin community `Community 490`** (2 nodes): `buildApprovalRequest()`, `approvalRequestHelpers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 490`** (2 nodes): `createApprovalRequestMutationCtx()`, `approvalRequests.test.ts`
+- **Thin community `Community 491`** (2 nodes): `createApprovalRequestMutationCtx()`, `approvalRequests.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 491`** (2 nodes): `buildOperationalEventMessage()`, `eventBuilders.ts`
+- **Thin community `Community 492`** (2 nodes): `buildOperationalEventMessage()`, `eventBuilders.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 492`** (2 nodes): `formatValidTime()`, `EmailOTP.ts`
+- **Thin community `Community 493`** (2 nodes): `formatValidTime()`, `EmailOTP.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 493`** (2 nodes): `quickAddCatalogItem.test.ts`, `createQuickAddCtx()`
+- **Thin community `Community 494`** (2 nodes): `quickAddCatalogItem.test.ts`, `createQuickAddCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 494`** (2 nodes): `expectNoCompletionSideEffects()`, `completeTransaction.test.ts`
+- **Thin community `Community 495`** (2 nodes): `expectNoCompletionSideEffects()`, `completeTransaction.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 495`** (2 nodes): `createMutationCtx()`, `correctTransactionPaymentMethod.test.ts`
+- **Thin community `Community 496`** (2 nodes): `createMutationCtx()`, `correctTransactionPaymentMethod.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 496`** (2 nodes): `buildCorrectionOperationalEvent()`, `correctionEvents.ts`
+- **Thin community `Community 497`** (2 nodes): `buildCorrectionOperationalEvent()`, `correctionEvents.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 497`** (2 nodes): `mockCorrectionHistoryDb()`, `getTransactions.test.ts`
+- **Thin community `Community 498`** (2 nodes): `mockCorrectionHistoryDb()`, `getTransactions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 498`** (2 nodes): `createRegisterCatalogCtx()`, `listRegisterCatalog.test.ts`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 499`** (2 nodes): `createCtx()`, `inventoryHoldGateway.test.ts`
+- **Thin community `Community 499`** (2 nodes): `createRegisterCatalogCtx()`, `listRegisterCatalog.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 500`** (2 nodes): `getCashierForRegisterState()`, `cashierRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -3400,6 +3400,42 @@
       "weight": 1
     },
     {
+      "_src": "expensesessioncommands_adjustexpensequantitypatchhold",
+      "_tgt": "expensesessioncommands_acquireexpensequantitypatchhold",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "expensesessioncommands_acquireexpensequantitypatchhold",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
+      "source_location": "L747",
+      "target": "expensesessioncommands_adjustexpensequantitypatchhold",
+      "weight": 1
+    },
+    {
+      "_src": "expensesessioncommands_adjustexpensequantitypatchhold",
+      "_tgt": "expensesessioncommands_releaseexpensequantitypatchhold",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "expensesessioncommands_releaseexpensequantitypatchhold",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
+      "source_location": "L750",
+      "target": "expensesessioncommands_adjustexpensequantitypatchhold",
+      "weight": 1
+    },
+    {
+      "_src": "expensesessioncommands_createdefaultexpensesessioncommandservice",
+      "_tgt": "expensesessioncommands_createexpenseinventoryholdgateway",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "expensesessioncommands_createdefaultexpensesessioncommandservice",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
+      "source_location": "L669",
+      "target": "expensesessioncommands_createexpenseinventoryholdgateway",
+      "weight": 1
+    },
+    {
       "_src": "expensesessioncommands_createdefaultexpensesessioncommandservice",
       "_tgt": "expensesessioncommands_createexpensesessioncommandservice",
       "confidence": "EXTRACTED",
@@ -3407,7 +3443,7 @@
       "relation": "calls",
       "source": "expensesessioncommands_createexpensesessioncommandservice",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
-      "source_location": "L647",
+      "source_location": "L665",
       "target": "expensesessioncommands_createdefaultexpensesessioncommandservice",
       "weight": 1
     },
@@ -3419,7 +3455,7 @@
       "relation": "calls",
       "source": "expensesessioncommands_resolveregistersessionbinding",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
-      "source_location": "L730",
+      "source_location": "L827",
       "target": "expensesessioncommands_failure",
       "weight": 1
     },
@@ -3431,7 +3467,7 @@
       "relation": "calls",
       "source": "expensesessioncommands_isactiveregistersession",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
-      "source_location": "L727",
+      "source_location": "L824",
       "target": "expensesessioncommands_resolveregistersessionbinding",
       "weight": 1
     },
@@ -3443,7 +3479,7 @@
       "relation": "calls",
       "source": "expensesessioncommands_registersessionmatchesidentity",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
-      "source_location": "L728",
+      "source_location": "L825",
       "target": "expensesessioncommands_resolveregistersessionbinding",
       "weight": 1
     },
@@ -3455,7 +3491,7 @@
       "relation": "calls",
       "source": "expensesessioncommands_resolveregistersessionbinding",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
-      "source_location": "L733",
+      "source_location": "L830",
       "target": "expensesessioncommands_success",
       "weight": 1
     },
@@ -3467,7 +3503,7 @@
       "relation": "calls",
       "source": "expensesessioncommands_runbindexpensesessiontoregistersessioncommand",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
-      "source_location": "L618",
+      "source_location": "L636",
       "target": "expensesessioncommands_createdefaultexpensesessioncommandservice",
       "weight": 1
     },
@@ -3479,7 +3515,7 @@
       "relation": "calls",
       "source": "expensesessioncommands_runclearexpensesessionitemscommand",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
-      "source_location": "L641",
+      "source_location": "L659",
       "target": "expensesessioncommands_createdefaultexpensesessioncommandservice",
       "weight": 1
     },
@@ -3491,7 +3527,7 @@
       "relation": "calls",
       "source": "expensesessioncommands_runremoveexpensesessionitemcommand",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
-      "source_location": "L634",
+      "source_location": "L652",
       "target": "expensesessioncommands_createdefaultexpensesessioncommandservice",
       "weight": 1
     },
@@ -3503,7 +3539,7 @@
       "relation": "calls",
       "source": "expensesessioncommands_runresumeexpensesessioncommand",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
-      "source_location": "L611",
+      "source_location": "L629",
       "target": "expensesessioncommands_createdefaultexpensesessioncommandservice",
       "weight": 1
     },
@@ -3515,7 +3551,7 @@
       "relation": "calls",
       "source": "expensesessioncommands_runupsertexpensesessionitemcommand",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
-      "source_location": "L627",
+      "source_location": "L645",
       "target": "expensesessioncommands_createdefaultexpensesessioncommandservice",
       "weight": 1
     },
@@ -3527,7 +3563,7 @@
       "relation": "calls",
       "source": "expensesessioncommands_validateactivesession",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
-      "source_location": "L751",
+      "source_location": "L848",
       "target": "expensesessioncommands_failure",
       "weight": 1
     },
@@ -3539,7 +3575,7 @@
       "relation": "calls",
       "source": "expensesessioncommands_issessionexpired",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
-      "source_location": "L764",
+      "source_location": "L861",
       "target": "expensesessioncommands_validateactivesession",
       "weight": 1
     },
@@ -3551,7 +3587,7 @@
       "relation": "calls",
       "source": "expensesessioncommands_validateactivesession",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
-      "source_location": "L786",
+      "source_location": "L883",
       "target": "expensesessioncommands_success",
       "weight": 1
     },
@@ -3563,7 +3599,7 @@
       "relation": "calls",
       "source": "expensesessioncommands_validatemodifiablesession",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
-      "source_location": "L795",
+      "source_location": "L892",
       "target": "expensesessioncommands_failure",
       "weight": 1
     },
@@ -3575,7 +3611,7 @@
       "relation": "calls",
       "source": "expensesessioncommands_issessionexpired",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
-      "source_location": "L805",
+      "source_location": "L902",
       "target": "expensesessioncommands_validatemodifiablesession",
       "weight": 1
     },
@@ -3587,7 +3623,7 @@
       "relation": "calls",
       "source": "expensesessioncommands_validatemodifiablesession",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
-      "source_location": "L819",
+      "source_location": "L916",
       "target": "expensesessioncommands_success",
       "weight": 1
     },
@@ -8176,30 +8212,6 @@
       "weight": 1
     },
     {
-      "_src": "inventoryholdgateway_adjustlegacyquantitypatchhold",
-      "_tgt": "inventoryholdgateway_acquirelegacyquantitypatchhold",
-      "confidence": "EXTRACTED",
-      "confidence_score": 1,
-      "relation": "calls",
-      "source": "inventoryholdgateway_acquirelegacyquantitypatchhold",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/integrations/inventoryHoldGateway.ts",
-      "source_location": "L143",
-      "target": "inventoryholdgateway_adjustlegacyquantitypatchhold",
-      "weight": 1
-    },
-    {
-      "_src": "inventoryholdgateway_adjustlegacyquantitypatchhold",
-      "_tgt": "inventoryholdgateway_releaselegacyquantitypatchhold",
-      "confidence": "EXTRACTED",
-      "confidence_score": 1,
-      "relation": "calls",
-      "source": "inventoryholdgateway_releaselegacyquantitypatchhold",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/integrations/inventoryHoldGateway.ts",
-      "source_location": "L146",
-      "target": "inventoryholdgateway_adjustlegacyquantitypatchhold",
-      "weight": 1
-    },
-    {
       "_src": "inventoryholds_acquireinventoryhold",
       "_tgt": "inventoryholds_getactiveholdforsessionsku",
       "confidence": "EXTRACTED",
@@ -8231,7 +8243,7 @@
       "relation": "calls",
       "source": "inventoryholds_validateinventoryavailability",
       "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
-      "source_location": "L329",
+      "source_location": "L328",
       "target": "inventoryholds_acquireinventoryholdsbatch",
       "weight": 1
     },
@@ -8243,7 +8255,7 @@
       "relation": "calls",
       "source": "inventoryholds_adjustinventoryhold",
       "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
-      "source_location": "L257",
+      "source_location": "L256",
       "target": "inventoryholds_getactiveholdforsessionsku",
       "weight": 1
     },
@@ -8255,7 +8267,7 @@
       "relation": "calls",
       "source": "inventoryholds_releaseinventoryhold",
       "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
-      "source_location": "L249",
+      "source_location": "L248",
       "target": "inventoryholds_adjustinventoryhold",
       "weight": 1
     },
@@ -8267,7 +8279,7 @@
       "relation": "calls",
       "source": "inventoryholds_validateinventoryavailability",
       "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
-      "source_location": "L273",
+      "source_location": "L272",
       "target": "inventoryholds_adjustinventoryhold",
       "weight": 1
     },
@@ -8279,7 +8291,7 @@
       "relation": "calls",
       "source": "inventoryholds_consumeinventoryholdsforsession",
       "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
-      "source_location": "L457",
+      "source_location": "L456",
       "target": "inventoryholds_listactivesessionholds",
       "weight": 1
     },
@@ -8291,7 +8303,7 @@
       "relation": "calls",
       "source": "inventoryholds_consumeinventoryholdsforsession",
       "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
-      "source_location": "L463",
+      "source_location": "L462",
       "target": "inventoryholds_markholdexpired",
       "weight": 1
     },
@@ -8303,7 +8315,7 @@
       "relation": "calls",
       "source": "inventoryholds_readactiveinventoryholddetailsforsession",
       "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
-      "source_location": "L525",
+      "source_location": "L524",
       "target": "inventoryholds_listactivesessionholds",
       "weight": 1
     },
@@ -8315,7 +8327,7 @@
       "relation": "calls",
       "source": "inventoryholds_readactiveinventoryholdquantitiesforsession",
       "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
-      "source_location": "L499",
+      "source_location": "L498",
       "target": "inventoryholds_listactivesessionholds",
       "weight": 1
     },
@@ -8327,7 +8339,7 @@
       "relation": "calls",
       "source": "inventoryholds_releaseactiveinventoryholdsforsession",
       "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
-      "source_location": "L418",
+      "source_location": "L417",
       "target": "inventoryholds_listactivesessionholds",
       "weight": 1
     },
@@ -8356,18 +8368,6 @@
       "weight": 1
     },
     {
-      "_src": "inventoryholds_releaseinventoryhold",
-      "_tgt": "inventoryholds_restorelegacyquantitypatchhold",
-      "confidence": "EXTRACTED",
-      "confidence_score": 1,
-      "relation": "calls",
-      "source": "inventoryholds_releaseinventoryhold",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
-      "source_location": "L233",
-      "target": "inventoryholds_restorelegacyquantitypatchhold",
-      "weight": 1
-    },
-    {
       "_src": "inventoryholds_releaseinventoryholdsforsession",
       "_tgt": "inventoryholds_listactivesessionholds",
       "confidence": "EXTRACTED",
@@ -8375,7 +8375,7 @@
       "relation": "calls",
       "source": "inventoryholds_releaseinventoryholdsforsession",
       "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
-      "source_location": "L394",
+      "source_location": "L393",
       "target": "inventoryholds_listactivesessionholds",
       "weight": 1
     },
@@ -10775,7 +10775,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_inventory_expensesessions_test_ts",
       "source_file": "packages/athena-webapp/convex/inventory/expenseSessions.test.ts",
-      "source_location": "L149",
+      "source_location": "L235",
       "target": "expensesessions_test_buildsession",
       "weight": 1
     },
@@ -10787,7 +10787,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_inventory_expensesessions_test_ts",
       "source_file": "packages/athena-webapp/convex/inventory/expenseSessions.test.ts",
-      "source_location": "L39",
+      "source_location": "L53",
       "target": "expensesessions_test_createmutationctx",
       "weight": 1
     },
@@ -10799,7 +10799,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_inventory_expensesessions_test_ts",
       "source_file": "packages/athena-webapp/convex/inventory/expenseSessions.test.ts",
-      "source_location": "L164",
+      "source_location": "L250",
       "target": "expensesessions_test_gethandler",
       "weight": 1
     },
@@ -11003,7 +11003,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_inventory_helpers_inventoryholds_test_ts",
       "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.test.ts",
-      "source_location": "L467",
+      "source_location": "L566",
       "target": "inventoryholds_test_buildhold",
       "weight": 1
     },
@@ -11015,7 +11015,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_inventory_helpers_inventoryholds_test_ts",
       "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.test.ts",
-      "source_location": "L38",
+      "source_location": "L40",
       "target": "inventoryholds_test_createdb",
       "weight": 1
     },
@@ -11039,7 +11039,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_inventory_helpers_inventoryholds_ts",
       "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
-      "source_location": "L319",
+      "source_location": "L318",
       "target": "inventoryholds_acquireinventoryholdsbatch",
       "weight": 1
     },
@@ -11051,7 +11051,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_inventory_helpers_inventoryholds_ts",
       "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
-      "source_location": "L242",
+      "source_location": "L241",
       "target": "inventoryholds_adjustinventoryhold",
       "weight": 1
     },
@@ -11063,7 +11063,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_inventory_helpers_inventoryholds_ts",
       "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
-      "source_location": "L446",
+      "source_location": "L445",
       "target": "inventoryholds_consumeinventoryholdsforsession",
       "weight": 1
     },
@@ -11075,7 +11075,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_inventory_helpers_inventoryholds_ts",
       "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
-      "source_location": "L580",
+      "source_location": "L579",
       "target": "inventoryholds_getactiveholdforsessionsku",
       "weight": 1
     },
@@ -11087,7 +11087,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_inventory_helpers_inventoryholds_ts",
       "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
-      "source_location": "L609",
+      "source_location": "L608",
       "target": "inventoryholds_listactivesessionholds",
       "weight": 1
     },
@@ -11099,7 +11099,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_inventory_helpers_inventoryholds_ts",
       "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
-      "source_location": "L637",
+      "source_location": "L636",
       "target": "inventoryholds_markholdexpired",
       "weight": 1
     },
@@ -11111,7 +11111,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_inventory_helpers_inventoryholds_ts",
       "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
-      "source_location": "L517",
+      "source_location": "L516",
       "target": "inventoryholds_readactiveinventoryholddetailsforsession",
       "weight": 1
     },
@@ -11123,7 +11123,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_inventory_helpers_inventoryholds_ts",
       "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
-      "source_location": "L490",
+      "source_location": "L489",
       "target": "inventoryholds_readactiveinventoryholdquantitiesforsession",
       "weight": 1
     },
@@ -11135,7 +11135,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_inventory_helpers_inventoryholds_ts",
       "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
-      "source_location": "L410",
+      "source_location": "L409",
       "target": "inventoryholds_releaseactiveinventoryholdsforsession",
       "weight": 1
     },
@@ -11159,7 +11159,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_inventory_helpers_inventoryholds_ts",
       "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
-      "source_location": "L348",
+      "source_location": "L347",
       "target": "inventoryholds_releaseinventoryholdsbatch",
       "weight": 1
     },
@@ -11171,20 +11171,20 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_inventory_helpers_inventoryholds_ts",
       "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
-      "source_location": "L386",
+      "source_location": "L385",
       "target": "inventoryholds_releaseinventoryholdsforsession",
       "weight": 1
     },
     {
       "_src": "packages_athena_webapp_convex_inventory_helpers_inventoryholds_ts",
-      "_tgt": "inventoryholds_restorelegacyquantitypatchhold",
+      "_tgt": "inventoryholds_releaselegacyexpensequantitypatchholds",
       "confidence": "EXTRACTED",
       "confidence_score": 1,
       "relation": "contains",
       "source": "packages_athena_webapp_convex_inventory_helpers_inventoryholds_ts",
       "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
-      "source_location": "L649",
-      "target": "inventoryholds_restorelegacyquantitypatchhold",
+      "source_location": "L367",
+      "target": "inventoryholds_releaselegacyexpensequantitypatchholds",
       "weight": 1
     },
     {
@@ -11195,7 +11195,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_inventory_helpers_inventoryholds_ts",
       "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
-      "source_location": "L547",
+      "source_location": "L546",
       "target": "inventoryholds_sumactiveheldquantity",
       "weight": 1
     },
@@ -14813,13 +14813,37 @@
     },
     {
       "_src": "packages_athena_webapp_convex_pos_application_commands_expensesessioncommands_ts",
+      "_tgt": "expensesessioncommands_acquireexpensequantitypatchhold",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_convex_pos_application_commands_expensesessioncommands_ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
+      "source_location": "L695",
+      "target": "expensesessioncommands_acquireexpensequantitypatchhold",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_convex_pos_application_commands_expensesessioncommands_ts",
+      "_tgt": "expensesessioncommands_adjustexpensequantitypatchhold",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_convex_pos_application_commands_expensesessioncommands_ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
+      "source_location": "L735",
+      "target": "expensesessioncommands_adjustexpensequantitypatchhold",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_convex_pos_application_commands_expensesessioncommands_ts",
       "_tgt": "expensesessioncommands_buildnextsessionnumber",
       "confidence": "EXTRACTED",
       "confidence_score": 1,
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_expensesessioncommands_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
-      "source_location": "L656",
+      "source_location": "L753",
       "target": "expensesessioncommands_buildnextsessionnumber",
       "weight": 1
     },
@@ -14831,8 +14855,20 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_expensesessioncommands_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
-      "source_location": "L644",
+      "source_location": "L662",
       "target": "expensesessioncommands_createdefaultexpensesessioncommandservice",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_convex_pos_application_commands_expensesessioncommands_ts",
+      "_tgt": "expensesessioncommands_createexpenseinventoryholdgateway",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_convex_pos_application_commands_expensesessioncommands_ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
+      "source_location": "L674",
+      "target": "expensesessioncommands_createexpenseinventoryholdgateway",
       "weight": 1
     },
     {
@@ -14843,7 +14879,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_expensesessioncommands_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
-      "source_location": "L136",
+      "source_location": "L154",
       "target": "expensesessioncommands_createexpensesessioncommandservice",
       "weight": 1
     },
@@ -14855,7 +14891,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_expensesessioncommands_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
-      "source_location": "L829",
+      "source_location": "L926",
       "target": "expensesessioncommands_failure",
       "weight": 1
     },
@@ -14867,7 +14903,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_expensesessioncommands_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
-      "source_location": "L667",
+      "source_location": "L764",
       "target": "expensesessioncommands_isactiveregistersession",
       "weight": 1
     },
@@ -14879,7 +14915,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_expensesessioncommands_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
-      "source_location": "L738",
+      "source_location": "L835",
       "target": "expensesessioncommands_issessionexpired",
       "weight": 1
     },
@@ -14891,7 +14927,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_expensesessioncommands_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
-      "source_location": "L28",
+      "source_location": "L24",
       "target": "expensesessioncommands_normalizeregisternumber",
       "weight": 1
     },
@@ -14903,7 +14939,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_expensesessioncommands_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
-      "source_location": "L550",
+      "source_location": "L568",
       "target": "expensesessioncommands_recordsessiontrace",
       "weight": 1
     },
@@ -14915,8 +14951,20 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_expensesessioncommands_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
-      "source_location": "L673",
+      "source_location": "L770",
       "target": "expensesessioncommands_registersessionmatchesidentity",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_convex_pos_application_commands_expensesessioncommands_ts",
+      "_tgt": "expensesessioncommands_releaseexpensequantitypatchhold",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_convex_pos_application_commands_expensesessioncommands_ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
+      "source_location": "L719",
+      "target": "expensesessioncommands_releaseexpensequantitypatchhold",
       "weight": 1
     },
     {
@@ -14927,7 +14975,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_expensesessioncommands_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
-      "source_location": "L702",
+      "source_location": "L799",
       "target": "expensesessioncommands_resolveregistersessionbinding",
       "weight": 1
     },
@@ -14939,7 +14987,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_expensesessioncommands_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
-      "source_location": "L614",
+      "source_location": "L632",
       "target": "expensesessioncommands_runbindexpensesessiontoregistersessioncommand",
       "weight": 1
     },
@@ -14951,7 +14999,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_expensesessioncommands_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
-      "source_location": "L637",
+      "source_location": "L655",
       "target": "expensesessioncommands_runclearexpensesessionitemscommand",
       "weight": 1
     },
@@ -14963,7 +15011,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_expensesessioncommands_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
-      "source_location": "L630",
+      "source_location": "L648",
       "target": "expensesessioncommands_runremoveexpensesessionitemcommand",
       "weight": 1
     },
@@ -14975,7 +15023,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_expensesessioncommands_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
-      "source_location": "L607",
+      "source_location": "L625",
       "target": "expensesessioncommands_runresumeexpensesessioncommand",
       "weight": 1
     },
@@ -14987,7 +15035,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_expensesessioncommands_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
-      "source_location": "L588",
+      "source_location": "L606",
       "target": "expensesessioncommands_runstartexpensesessioncommand",
       "weight": 1
     },
@@ -14999,7 +15047,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_expensesessioncommands_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
-      "source_location": "L623",
+      "source_location": "L641",
       "target": "expensesessioncommands_runupsertexpensesessionitemcommand",
       "weight": 1
     },
@@ -15011,7 +15059,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_expensesessioncommands_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
-      "source_location": "L822",
+      "source_location": "L919",
       "target": "expensesessioncommands_success",
       "weight": 1
     },
@@ -15023,7 +15071,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_expensesessioncommands_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
-      "source_location": "L745",
+      "source_location": "L842",
       "target": "expensesessioncommands_validateactivesession",
       "weight": 1
     },
@@ -15035,7 +15083,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_expensesessioncommands_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
-      "source_location": "L789",
+      "source_location": "L886",
       "target": "expensesessioncommands_validatemodifiablesession",
       "weight": 1
     },
@@ -15335,7 +15383,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_sessioncommands_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L765",
+      "source_location": "L766",
       "target": "sessioncommands_buildnextsessionnumber",
       "weight": 1
     },
@@ -15347,7 +15395,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_sessioncommands_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L720",
+      "source_location": "L721",
       "target": "sessioncommands_createdefaultsessioncommandservice",
       "weight": 1
     },
@@ -15371,7 +15419,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_sessioncommands_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L958",
+      "source_location": "L959",
       "target": "sessioncommands_failure",
       "weight": 1
     },
@@ -15383,7 +15431,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_sessioncommands_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L776",
+      "source_location": "L777",
       "target": "sessioncommands_isactiveregistersession",
       "weight": 1
     },
@@ -15395,7 +15443,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_sessioncommands_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L867",
+      "source_location": "L868",
       "target": "sessioncommands_issessionexpired",
       "weight": 1
     },
@@ -15419,7 +15467,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_sessioncommands_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L732",
+      "source_location": "L733",
       "target": "sessioncommands_recordsessionlifecyclebesteffort",
       "weight": 1
     },
@@ -15431,7 +15479,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_sessioncommands_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L782",
+      "source_location": "L783",
       "target": "sessioncommands_registersessionmatchesidentity",
       "weight": 1
     },
@@ -15443,7 +15491,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_sessioncommands_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L811",
+      "source_location": "L812",
       "target": "sessioncommands_resolveregistersessionbinding",
       "weight": 1
     },
@@ -15455,7 +15503,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_sessioncommands_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L697",
+      "source_location": "L698",
       "target": "sessioncommands_runbindsessiontoregistersessioncommand",
       "weight": 1
     },
@@ -15467,7 +15515,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_sessioncommands_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L686",
+      "source_location": "L687",
       "target": "sessioncommands_runholdsessioncommand",
       "weight": 1
     },
@@ -15479,7 +15527,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_sessioncommands_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L713",
+      "source_location": "L714",
       "target": "sessioncommands_runremovesessionitemcommand",
       "weight": 1
     },
@@ -15491,7 +15539,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_sessioncommands_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L690",
+      "source_location": "L691",
       "target": "sessioncommands_runresumesessioncommand",
       "weight": 1
     },
@@ -15503,7 +15551,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_sessioncommands_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L669",
+      "source_location": "L670",
       "target": "sessioncommands_runstartsessioncommand",
       "weight": 1
     },
@@ -15515,7 +15563,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_sessioncommands_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L706",
+      "source_location": "L707",
       "target": "sessioncommands_runupsertsessionitemcommand",
       "weight": 1
     },
@@ -15527,7 +15575,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_sessioncommands_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L951",
+      "source_location": "L952",
       "target": "sessioncommands_success",
       "weight": 1
     },
@@ -15539,7 +15587,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_sessioncommands_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L874",
+      "source_location": "L875",
       "target": "sessioncommands_validateactivesession",
       "weight": 1
     },
@@ -15551,7 +15599,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_sessioncommands_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L847",
+      "source_location": "L848",
       "target": "sessioncommands_validateactivesessionregisterbinding",
       "weight": 1
     },
@@ -15563,7 +15611,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_commands_sessioncommands_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L918",
+      "source_location": "L919",
       "target": "sessioncommands_validatemodifiablesession",
       "weight": 1
     },
@@ -16223,7 +16271,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_sessioncommands_test_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L2404",
+      "source_location": "L2406",
       "target": "sessioncommands_test_builditem",
       "weight": 1
     },
@@ -16235,7 +16283,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_sessioncommands_test_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L2398",
+      "source_location": "L2400",
       "target": "sessioncommands_test_buildregistersession",
       "weight": 1
     },
@@ -16247,7 +16295,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_sessioncommands_test_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L2394",
+      "source_location": "L2396",
       "target": "sessioncommands_test_buildsession",
       "weight": 1
     },
@@ -16259,7 +16307,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_sessioncommands_test_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L2414",
+      "source_location": "L2416",
       "target": "sessioncommands_test_createcommandservice",
       "weight": 1
     },
@@ -16271,7 +16319,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_sessioncommands_test_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L2153",
+      "source_location": "L2155",
       "target": "sessioncommands_test_createdependencies",
       "weight": 1
     },
@@ -16283,7 +16331,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_sessioncommands_test_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L2250",
+      "source_location": "L2252",
       "target": "sessioncommands_test_createfakerepository",
       "weight": 1
     },
@@ -16295,7 +16343,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_sessioncommands_test_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L2135",
+      "source_location": "L2137",
       "target": "sessioncommands_test_loadcommandservice",
       "weight": 1
     },
@@ -16343,32 +16391,32 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_infrastructure_integrations_inventoryholdgateway_test_ts",
       "source_file": "packages/athena-webapp/convex/pos/infrastructure/integrations/inventoryHoldGateway.test.ts",
-      "source_location": "L5",
+      "source_location": "L16",
       "target": "inventoryholdgateway_test_createctx",
       "weight": 1
     },
     {
-      "_src": "packages_athena_webapp_convex_pos_infrastructure_integrations_inventoryholdgateway_ts",
-      "_tgt": "inventoryholdgateway_acquirelegacyquantitypatchhold",
+      "_src": "packages_athena_webapp_convex_pos_infrastructure_integrations_inventoryholdgateway_test_ts",
+      "_tgt": "inventoryholdgateway_test_createlegacypatchctx",
       "confidence": "EXTRACTED",
       "confidence_score": 1,
       "relation": "contains",
-      "source": "packages_athena_webapp_convex_pos_infrastructure_integrations_inventoryholdgateway_ts",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/integrations/inventoryHoldGateway.ts",
-      "source_location": "L91",
-      "target": "inventoryholdgateway_acquirelegacyquantitypatchhold",
+      "source": "packages_athena_webapp_convex_pos_infrastructure_integrations_inventoryholdgateway_test_ts",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/integrations/inventoryHoldGateway.test.ts",
+      "source_location": "L22",
+      "target": "inventoryholdgateway_test_createlegacypatchctx",
       "weight": 1
     },
     {
       "_src": "packages_athena_webapp_convex_pos_infrastructure_integrations_inventoryholdgateway_ts",
-      "_tgt": "inventoryholdgateway_adjustlegacyquantitypatchhold",
+      "_tgt": "inventoryholdgateway_assertobjectshapedholdargs",
       "confidence": "EXTRACTED",
       "confidence_score": 1,
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_infrastructure_integrations_inventoryholdgateway_ts",
       "source_file": "packages/athena-webapp/convex/pos/infrastructure/integrations/inventoryHoldGateway.ts",
-      "source_location": "L131",
-      "target": "inventoryholdgateway_adjustlegacyquantitypatchhold",
+      "source_location": "L43",
+      "target": "inventoryholdgateway_assertobjectshapedholdargs",
       "weight": 1
     },
     {
@@ -16379,20 +16427,8 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_infrastructure_integrations_inventoryholdgateway_ts",
       "source_file": "packages/athena-webapp/convex/pos/infrastructure/integrations/inventoryHoldGateway.ts",
-      "source_location": "L63",
+      "source_location": "L24",
       "target": "inventoryholdgateway_createinventoryholdgateway",
-      "weight": 1
-    },
-    {
-      "_src": "packages_athena_webapp_convex_pos_infrastructure_integrations_inventoryholdgateway_ts",
-      "_tgt": "inventoryholdgateway_releaselegacyquantitypatchhold",
-      "confidence": "EXTRACTED",
-      "confidence_score": 1,
-      "relation": "contains",
-      "source": "packages_athena_webapp_convex_pos_infrastructure_integrations_inventoryholdgateway_ts",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/integrations/inventoryHoldGateway.ts",
-      "source_location": "L115",
-      "target": "inventoryholdgateway_releaselegacyquantitypatchhold",
       "weight": 1
     },
     {
@@ -49295,7 +49331,7 @@
       "relation": "calls",
       "source": "sessioncommands_createpossessioncommandservice",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L723",
+      "source_location": "L724",
       "target": "sessioncommands_createdefaultsessioncommandservice",
       "weight": 1
     },
@@ -49307,7 +49343,7 @@
       "relation": "calls",
       "source": "sessioncommands_resolveregistersessionbinding",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L839",
+      "source_location": "L840",
       "target": "sessioncommands_failure",
       "weight": 1
     },
@@ -49319,7 +49355,7 @@
       "relation": "calls",
       "source": "sessioncommands_isactiveregistersession",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L836",
+      "source_location": "L837",
       "target": "sessioncommands_resolveregistersessionbinding",
       "weight": 1
     },
@@ -49331,7 +49367,7 @@
       "relation": "calls",
       "source": "sessioncommands_registersessionmatchesidentity",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L837",
+      "source_location": "L838",
       "target": "sessioncommands_resolveregistersessionbinding",
       "weight": 1
     },
@@ -49343,7 +49379,7 @@
       "relation": "calls",
       "source": "sessioncommands_resolveregistersessionbinding",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L842",
+      "source_location": "L843",
       "target": "sessioncommands_success",
       "weight": 1
     },
@@ -49355,7 +49391,7 @@
       "relation": "calls",
       "source": "sessioncommands_runbindsessiontoregistersessioncommand",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L701",
+      "source_location": "L702",
       "target": "sessioncommands_createdefaultsessioncommandservice",
       "weight": 1
     },
@@ -49367,7 +49403,7 @@
       "relation": "calls",
       "source": "sessioncommands_runholdsessioncommand",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L687",
+      "source_location": "L688",
       "target": "sessioncommands_createdefaultsessioncommandservice",
       "weight": 1
     },
@@ -49379,7 +49415,7 @@
       "relation": "calls",
       "source": "sessioncommands_runremovesessionitemcommand",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L717",
+      "source_location": "L718",
       "target": "sessioncommands_createdefaultsessioncommandservice",
       "weight": 1
     },
@@ -49391,7 +49427,7 @@
       "relation": "calls",
       "source": "sessioncommands_runresumesessioncommand",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L694",
+      "source_location": "L695",
       "target": "sessioncommands_createdefaultsessioncommandservice",
       "weight": 1
     },
@@ -49403,7 +49439,7 @@
       "relation": "calls",
       "source": "sessioncommands_runupsertsessionitemcommand",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L710",
+      "source_location": "L711",
       "target": "sessioncommands_createdefaultsessioncommandservice",
       "weight": 1
     },
@@ -49415,7 +49451,7 @@
       "relation": "calls",
       "source": "sessioncommands_validateactivesession",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L880",
+      "source_location": "L881",
       "target": "sessioncommands_failure",
       "weight": 1
     },
@@ -49427,7 +49463,7 @@
       "relation": "calls",
       "source": "sessioncommands_issessionexpired",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L893",
+      "source_location": "L894",
       "target": "sessioncommands_validateactivesession",
       "weight": 1
     },
@@ -49439,7 +49475,7 @@
       "relation": "calls",
       "source": "sessioncommands_validateactivesession",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L915",
+      "source_location": "L916",
       "target": "sessioncommands_success",
       "weight": 1
     },
@@ -49451,7 +49487,7 @@
       "relation": "calls",
       "source": "sessioncommands_validateactivesessionregisterbinding",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L855",
+      "source_location": "L856",
       "target": "sessioncommands_failure",
       "weight": 1
     },
@@ -49463,7 +49499,7 @@
       "relation": "calls",
       "source": "sessioncommands_resolveregistersessionbinding",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L858",
+      "source_location": "L859",
       "target": "sessioncommands_validateactivesessionregisterbinding",
       "weight": 1
     },
@@ -49475,7 +49511,7 @@
       "relation": "calls",
       "source": "sessioncommands_validatemodifiablesession",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L924",
+      "source_location": "L925",
       "target": "sessioncommands_failure",
       "weight": 1
     },
@@ -49487,7 +49523,7 @@
       "relation": "calls",
       "source": "sessioncommands_issessionexpired",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L934",
+      "source_location": "L935",
       "target": "sessioncommands_validatemodifiablesession",
       "weight": 1
     },
@@ -49499,7 +49535,7 @@
       "relation": "calls",
       "source": "sessioncommands_validatemodifiablesession",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L948",
+      "source_location": "L949",
       "target": "sessioncommands_success",
       "weight": 1
     },
@@ -56811,199 +56847,217 @@
     {
       "community": 12,
       "file_type": "code",
-      "id": "cyclecountdrafts_buildactivecyclecountdraftssubmissionkey",
-      "label": "buildActiveCycleCountDraftsSubmissionKey()",
-      "norm_label": "buildactivecyclecountdraftssubmissionkey()",
-      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
-      "source_location": "L90"
+      "id": "expensesessioncommands_acquireexpensequantitypatchhold",
+      "label": "acquireExpenseQuantityPatchHold()",
+      "norm_label": "acquireexpensequantitypatchhold()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
+      "source_location": "L695"
     },
     {
       "community": 12,
       "file_type": "code",
-      "id": "cyclecountdrafts_buildcyclecountdraftsubmissionkey",
-      "label": "buildCycleCountDraftSubmissionKey()",
-      "norm_label": "buildcyclecountdraftsubmissionkey()",
-      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
-      "source_location": "L75"
+      "id": "expensesessioncommands_adjustexpensequantitypatchhold",
+      "label": "adjustExpenseQuantityPatchHold()",
+      "norm_label": "adjustexpensequantitypatchhold()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
+      "source_location": "L735"
     },
     {
       "community": 12,
       "file_type": "code",
-      "id": "cyclecountdrafts_createcyclecountdraftwithctx",
-      "label": "createCycleCountDraftWithCtx()",
-      "norm_label": "createcyclecountdraftwithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
-      "source_location": "L190"
+      "id": "expensesessioncommands_buildnextsessionnumber",
+      "label": "buildNextSessionNumber()",
+      "norm_label": "buildnextsessionnumber()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
+      "source_location": "L753"
     },
     {
       "community": 12,
       "file_type": "code",
-      "id": "cyclecountdrafts_discardcyclecountdraftcommandwithctx",
-      "label": "discardCycleCountDraftCommandWithCtx()",
-      "norm_label": "discardcyclecountdraftcommandwithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
-      "source_location": "L481"
+      "id": "expensesessioncommands_createdefaultexpensesessioncommandservice",
+      "label": "createDefaultExpenseSessionCommandService()",
+      "norm_label": "createdefaultexpensesessioncommandservice()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
+      "source_location": "L662"
     },
     {
       "community": 12,
       "file_type": "code",
-      "id": "cyclecountdrafts_ensurecyclecountdraftcommandwithctx",
-      "label": "ensureCycleCountDraftCommandWithCtx()",
-      "norm_label": "ensurecyclecountdraftcommandwithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
-      "source_location": "L347"
+      "id": "expensesessioncommands_createexpenseinventoryholdgateway",
+      "label": "createExpenseInventoryHoldGateway()",
+      "norm_label": "createexpenseinventoryholdgateway()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
+      "source_location": "L674"
     },
     {
       "community": 12,
       "file_type": "code",
-      "id": "cyclecountdrafts_ensurecyclecountdraftwithctx",
-      "label": "ensureCycleCountDraftWithCtx()",
-      "norm_label": "ensurecyclecountdraftwithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
-      "source_location": "L235"
+      "id": "expensesessioncommands_createexpensesessioncommandservice",
+      "label": "createExpenseSessionCommandService()",
+      "norm_label": "createexpensesessioncommandservice()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
+      "source_location": "L154"
     },
     {
       "community": 12,
       "file_type": "code",
-      "id": "cyclecountdrafts_findopencyclecountdraftwithctx",
-      "label": "findOpenCycleCountDraftWithCtx()",
-      "norm_label": "findopencyclecountdraftwithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
-      "source_location": "L103"
+      "id": "expensesessioncommands_failure",
+      "label": "failure()",
+      "norm_label": "failure()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
+      "source_location": "L926"
     },
     {
       "community": 12,
       "file_type": "code",
-      "id": "cyclecountdrafts_getactivecyclecountdraftsummarywithctx",
-      "label": "getActiveCycleCountDraftSummaryWithCtx()",
-      "norm_label": "getactivecyclecountdraftsummarywithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
-      "source_location": "L289"
+      "id": "expensesessioncommands_isactiveregistersession",
+      "label": "isActiveRegisterSession()",
+      "norm_label": "isactiveregistersession()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
+      "source_location": "L764"
     },
     {
       "community": 12,
       "file_type": "code",
-      "id": "cyclecountdrafts_getactivecyclecountdraftwithctx",
-      "label": "getActiveCycleCountDraftWithCtx()",
-      "norm_label": "getactivecyclecountdraftwithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
-      "source_location": "L264"
+      "id": "expensesessioncommands_issessionexpired",
+      "label": "isSessionExpired()",
+      "norm_label": "issessionexpired()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
+      "source_location": "L835"
     },
     {
       "community": 12,
       "file_type": "code",
-      "id": "cyclecountdrafts_getcyclecountdraftlinewithctx",
-      "label": "getCycleCountDraftLineWithCtx()",
-      "norm_label": "getcyclecountdraftlinewithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
-      "source_location": "L155"
+      "id": "expensesessioncommands_normalizeregisternumber",
+      "label": "normalizeRegisterNumber()",
+      "norm_label": "normalizeregisternumber()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
+      "source_location": "L24"
     },
     {
       "community": 12,
       "file_type": "code",
-      "id": "cyclecountdrafts_listcyclecountdraftlineswithctx",
-      "label": "listCycleCountDraftLinesWithCtx()",
-      "norm_label": "listcyclecountdraftlineswithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
-      "source_location": "L144"
+      "id": "expensesessioncommands_recordsessiontrace",
+      "label": "recordSessionTrace()",
+      "norm_label": "recordsessiontrace()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
+      "source_location": "L568"
     },
     {
       "community": 12,
       "file_type": "code",
-      "id": "cyclecountdrafts_listopencyclecountdraftswithctx",
-      "label": "listOpenCycleCountDraftsWithCtx()",
-      "norm_label": "listopencyclecountdraftswithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
-      "source_location": "L123"
+      "id": "expensesessioncommands_registersessionmatchesidentity",
+      "label": "registerSessionMatchesIdentity()",
+      "norm_label": "registersessionmatchesidentity()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
+      "source_location": "L770"
     },
     {
       "community": 12,
       "file_type": "code",
-      "id": "cyclecountdrafts_liststalecyclecountdraftlines",
-      "label": "listStaleCycleCountDraftLines()",
-      "norm_label": "liststalecyclecountdraftlines()",
-      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
-      "source_location": "L612"
+      "id": "expensesessioncommands_releaseexpensequantitypatchhold",
+      "label": "releaseExpenseQuantityPatchHold()",
+      "norm_label": "releaseexpensequantitypatchhold()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
+      "source_location": "L719"
     },
     {
       "community": 12,
       "file_type": "code",
-      "id": "cyclecountdrafts_mapcyclecountdrafterror",
-      "label": "mapCycleCountDraftError()",
-      "norm_label": "mapcyclecountdrafterror()",
-      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
-      "source_location": "L904"
+      "id": "expensesessioncommands_resolveregistersessionbinding",
+      "label": "resolveRegisterSessionBinding()",
+      "norm_label": "resolveregistersessionbinding()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
+      "source_location": "L799"
     },
     {
       "community": 12,
       "file_type": "code",
-      "id": "cyclecountdrafts_refreshcyclecountdraftlinebaselinecommandwithctx",
-      "label": "refreshCycleCountDraftLineBaselineCommandWithCtx()",
-      "norm_label": "refreshcyclecountdraftlinebaselinecommandwithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
-      "source_location": "L530"
+      "id": "expensesessioncommands_runbindexpensesessiontoregistersessioncommand",
+      "label": "runBindExpenseSessionToRegisterSessionCommand()",
+      "norm_label": "runbindexpensesessiontoregistersessioncommand()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
+      "source_location": "L632"
     },
     {
       "community": 12,
       "file_type": "code",
-      "id": "cyclecountdrafts_refreshcyclecountdraftsummarywithctx",
-      "label": "refreshCycleCountDraftSummaryWithCtx()",
-      "norm_label": "refreshcyclecountdraftsummarywithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
-      "source_location": "L170"
+      "id": "expensesessioncommands_runclearexpensesessionitemscommand",
+      "label": "runClearExpenseSessionItemsCommand()",
+      "norm_label": "runclearexpensesessionitemscommand()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
+      "source_location": "L655"
     },
     {
       "community": 12,
       "file_type": "code",
-      "id": "cyclecountdrafts_requirecyclecountdraftaccess",
-      "label": "requireCycleCountDraftAccess()",
-      "norm_label": "requirecyclecountdraftaccess()",
-      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
-      "source_location": "L43"
+      "id": "expensesessioncommands_runremoveexpensesessionitemcommand",
+      "label": "runRemoveExpenseSessionItemCommand()",
+      "norm_label": "runremoveexpensesessionitemcommand()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
+      "source_location": "L648"
     },
     {
       "community": 12,
       "file_type": "code",
-      "id": "cyclecountdrafts_savecyclecountdraftlinecommandwithctx",
-      "label": "saveCycleCountDraftLineCommandWithCtx()",
-      "norm_label": "savecyclecountdraftlinecommandwithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
-      "source_location": "L370"
+      "id": "expensesessioncommands_runresumeexpensesessioncommand",
+      "label": "runResumeExpenseSessionCommand()",
+      "norm_label": "runresumeexpensesessioncommand()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
+      "source_location": "L625"
     },
     {
       "community": 12,
       "file_type": "code",
-      "id": "cyclecountdrafts_submitactivecyclecountdraftscommandwithctx",
-      "label": "submitActiveCycleCountDraftsCommandWithCtx()",
-      "norm_label": "submitactivecyclecountdraftscommandwithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
-      "source_location": "L776"
+      "id": "expensesessioncommands_runstartexpensesessioncommand",
+      "label": "runStartExpenseSessionCommand()",
+      "norm_label": "runstartexpensesessioncommand()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
+      "source_location": "L606"
     },
     {
       "community": 12,
       "file_type": "code",
-      "id": "cyclecountdrafts_submitcyclecountdraftcommandwithctx",
-      "label": "submitCycleCountDraftCommandWithCtx()",
-      "norm_label": "submitcyclecountdraftcommandwithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
-      "source_location": "L645"
+      "id": "expensesessioncommands_runupsertexpensesessionitemcommand",
+      "label": "runUpsertExpenseSessionItemCommand()",
+      "norm_label": "runupsertexpensesessionitemcommand()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
+      "source_location": "L641"
     },
     {
       "community": 12,
       "file_type": "code",
-      "id": "cyclecountdrafts_trimrequiredscopekey",
-      "label": "trimRequiredScopeKey()",
-      "norm_label": "trimrequiredscopekey()",
-      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
-      "source_location": "L65"
+      "id": "expensesessioncommands_success",
+      "label": "success()",
+      "norm_label": "success()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
+      "source_location": "L919"
     },
     {
       "community": 12,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_stockops_cyclecountdrafts_ts",
-      "label": "cycleCountDrafts.ts",
-      "norm_label": "cyclecountdrafts.ts",
-      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
+      "id": "expensesessioncommands_validateactivesession",
+      "label": "validateActiveSession()",
+      "norm_label": "validateactivesession()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
+      "source_location": "L842"
+    },
+    {
+      "community": 12,
+      "file_type": "code",
+      "id": "expensesessioncommands_validatemodifiablesession",
+      "label": "validateModifiableSession()",
+      "norm_label": "validatemodifiablesession()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
+      "source_location": "L886"
+    },
+    {
+      "community": 12,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_commands_expensesessioncommands_ts",
+      "label": "expenseSessionCommands.ts",
+      "norm_label": "expensesessioncommands.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
       "source_location": "L1"
     },
     {
@@ -58539,200 +58593,200 @@
     {
       "community": 13,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_storeconfig_ts",
-      "label": "storeConfig.ts",
-      "norm_label": "storeconfig.ts",
-      "source_file": "packages/athena-webapp/src/lib/storeConfig.ts",
-      "source_location": "L1"
+      "id": "cyclecountdrafts_buildactivecyclecountdraftssubmissionkey",
+      "label": "buildActiveCycleCountDraftsSubmissionKey()",
+      "norm_label": "buildactivecyclecountdraftssubmissionkey()",
+      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
+      "source_location": "L90"
     },
     {
       "community": 13,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_storeconfig_ts",
-      "label": "storeConfig.ts",
-      "norm_label": "storeconfig.ts",
-      "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
-      "source_location": "L1"
+      "id": "cyclecountdrafts_buildcyclecountdraftsubmissionkey",
+      "label": "buildCycleCountDraftSubmissionKey()",
+      "norm_label": "buildcyclecountdraftsubmissionkey()",
+      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
+      "source_location": "L75"
     },
     {
       "community": 13,
       "file_type": "code",
-      "id": "storeconfig_asboolean",
-      "label": "asBoolean()",
-      "norm_label": "asboolean()",
-      "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
-      "source_location": "L117"
+      "id": "cyclecountdrafts_createcyclecountdraftwithctx",
+      "label": "createCycleCountDraftWithCtx()",
+      "norm_label": "createcyclecountdraftwithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
+      "source_location": "L190"
     },
     {
       "community": 13,
       "file_type": "code",
-      "id": "storeconfig_asmtnmomosetupstatus",
-      "label": "asMtnMomoSetupStatus()",
-      "norm_label": "asmtnmomosetupstatus()",
-      "source_file": "packages/athena-webapp/src/lib/storeConfig.ts",
-      "source_location": "L80"
+      "id": "cyclecountdrafts_discardcyclecountdraftcommandwithctx",
+      "label": "discardCycleCountDraftCommandWithCtx()",
+      "norm_label": "discardcyclecountdraftcommandwithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
+      "source_location": "L481"
     },
     {
       "community": 13,
       "file_type": "code",
-      "id": "storeconfig_asnumber",
-      "label": "asNumber()",
-      "norm_label": "asnumber()",
-      "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
-      "source_location": "L114"
+      "id": "cyclecountdrafts_ensurecyclecountdraftcommandwithctx",
+      "label": "ensureCycleCountDraftCommandWithCtx()",
+      "norm_label": "ensurecyclecountdraftcommandwithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
+      "source_location": "L347"
     },
     {
       "community": 13,
       "file_type": "code",
-      "id": "storeconfig_asoptionalarray",
-      "label": "asOptionalArray()",
-      "norm_label": "asoptionalarray()",
-      "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
-      "source_location": "L132"
+      "id": "cyclecountdrafts_ensurecyclecountdraftwithctx",
+      "label": "ensureCycleCountDraftWithCtx()",
+      "norm_label": "ensurecyclecountdraftwithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
+      "source_location": "L235"
     },
     {
       "community": 13,
       "file_type": "code",
-      "id": "storeconfig_asrecord",
-      "label": "asRecord()",
-      "norm_label": "asrecord()",
-      "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
+      "id": "cyclecountdrafts_findopencyclecountdraftwithctx",
+      "label": "findOpenCycleCountDraftWithCtx()",
+      "norm_label": "findopencyclecountdraftwithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
       "source_location": "L103"
     },
     {
       "community": 13,
       "file_type": "code",
-      "id": "storeconfig_asstring",
-      "label": "asString()",
-      "norm_label": "asstring()",
-      "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
-      "source_location": "L111"
+      "id": "cyclecountdrafts_getactivecyclecountdraftsummarywithctx",
+      "label": "getActiveCycleCountDraftSummaryWithCtx()",
+      "norm_label": "getactivecyclecountdraftsummarywithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
+      "source_location": "L289"
     },
     {
       "community": 13,
       "file_type": "code",
-      "id": "storeconfig_cleanundefined",
-      "label": "cleanUndefined()",
-      "norm_label": "cleanundefined()",
-      "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
-      "source_location": "L143"
+      "id": "cyclecountdrafts_getactivecyclecountdraftwithctx",
+      "label": "getActiveCycleCountDraftWithCtx()",
+      "norm_label": "getactivecyclecountdraftwithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
+      "source_location": "L264"
     },
     {
       "community": 13,
       "file_type": "code",
-      "id": "storeconfig_firstdefined",
-      "label": "firstDefined()",
-      "norm_label": "firstdefined()",
-      "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
-      "source_location": "L120"
-    },
-    {
-      "community": 13,
-      "file_type": "code",
-      "id": "storeconfig_getrawconfig",
-      "label": "getRawConfig()",
-      "norm_label": "getrawconfig()",
-      "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
-      "source_location": "L196"
-    },
-    {
-      "community": 13,
-      "file_type": "code",
-      "id": "storeconfig_getstoreconfigv2",
-      "label": "getStoreConfigV2()",
-      "norm_label": "getstoreconfigv2()",
-      "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
-      "source_location": "L208"
-    },
-    {
-      "community": 13,
-      "file_type": "code",
-      "id": "storeconfig_getstorefallbackimageurl",
-      "label": "getStoreFallbackImageUrl()",
-      "norm_label": "getstorefallbackimageurl()",
-      "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
-      "source_location": "L479"
-    },
-    {
-      "community": 13,
-      "file_type": "code",
-      "id": "storeconfig_hasmtnmomoreceivingaccountdetails",
-      "label": "hasMtnMomoReceivingAccountDetails()",
-      "norm_label": "hasmtnmomoreceivingaccountdetails()",
-      "source_file": "packages/athena-webapp/src/lib/storeConfig.ts",
-      "source_location": "L93"
-    },
-    {
-      "community": 13,
-      "file_type": "code",
-      "id": "storeconfig_isstoremaintenancemode",
-      "label": "isStoreMaintenanceMode()",
-      "norm_label": "isstoremaintenancemode()",
-      "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
-      "source_location": "L465"
-    },
-    {
-      "community": 13,
-      "file_type": "code",
-      "id": "storeconfig_isstorereadonlymode",
-      "label": "isStoreReadOnlyMode()",
-      "norm_label": "isstorereadonlymode()",
-      "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
-      "source_location": "L461"
-    },
-    {
-      "community": 13,
-      "file_type": "code",
-      "id": "storeconfig_mapmtnmomoreceivingaccount",
-      "label": "mapMtnMomoReceivingAccount()",
-      "norm_label": "mapmtnmomoreceivingaccount()",
-      "source_file": "packages/athena-webapp/src/lib/storeConfig.ts",
-      "source_location": "L106"
-    },
-    {
-      "community": 13,
-      "file_type": "code",
-      "id": "storeconfig_mappromo",
-      "label": "mapPromo()",
-      "norm_label": "mappromo()",
-      "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
-      "source_location": "L172"
-    },
-    {
-      "community": 13,
-      "file_type": "code",
-      "id": "storeconfig_mappromotion",
-      "label": "mapPromotion()",
-      "norm_label": "mappromotion()",
-      "source_file": "packages/athena-webapp/src/lib/storeConfig.ts",
-      "source_location": "L172"
-    },
-    {
-      "community": 13,
-      "file_type": "code",
-      "id": "storeconfig_mapstreamreel",
-      "label": "mapStreamReel()",
-      "norm_label": "mapstreamreel()",
-      "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
+      "id": "cyclecountdrafts_getcyclecountdraftlinewithctx",
+      "label": "getCycleCountDraftLineWithCtx()",
+      "norm_label": "getcyclecountdraftlinewithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
       "source_location": "L155"
     },
     {
       "community": 13,
       "file_type": "code",
-      "id": "storeconfig_normalizemtnmomoreceivingaccounts",
-      "label": "normalizeMtnMomoReceivingAccounts()",
-      "norm_label": "normalizemtnmomoreceivingaccounts()",
-      "source_file": "packages/athena-webapp/src/lib/storeConfig.ts",
-      "source_location": "L126"
+      "id": "cyclecountdrafts_listcyclecountdraftlineswithctx",
+      "label": "listCycleCountDraftLinesWithCtx()",
+      "norm_label": "listcyclecountdraftlineswithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
+      "source_location": "L144"
     },
     {
       "community": 13,
       "file_type": "code",
-      "id": "storeconfig_normalizewaivedeliveryfees",
-      "label": "normalizeWaiveDeliveryFees()",
-      "norm_label": "normalizewaivedeliveryfees()",
-      "source_file": "packages/athena-webapp/src/lib/storeConfig.ts",
-      "source_location": "L177"
+      "id": "cyclecountdrafts_listopencyclecountdraftswithctx",
+      "label": "listOpenCycleCountDraftsWithCtx()",
+      "norm_label": "listopencyclecountdraftswithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
+      "source_location": "L123"
+    },
+    {
+      "community": 13,
+      "file_type": "code",
+      "id": "cyclecountdrafts_liststalecyclecountdraftlines",
+      "label": "listStaleCycleCountDraftLines()",
+      "norm_label": "liststalecyclecountdraftlines()",
+      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
+      "source_location": "L612"
+    },
+    {
+      "community": 13,
+      "file_type": "code",
+      "id": "cyclecountdrafts_mapcyclecountdrafterror",
+      "label": "mapCycleCountDraftError()",
+      "norm_label": "mapcyclecountdrafterror()",
+      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
+      "source_location": "L904"
+    },
+    {
+      "community": 13,
+      "file_type": "code",
+      "id": "cyclecountdrafts_refreshcyclecountdraftlinebaselinecommandwithctx",
+      "label": "refreshCycleCountDraftLineBaselineCommandWithCtx()",
+      "norm_label": "refreshcyclecountdraftlinebaselinecommandwithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
+      "source_location": "L530"
+    },
+    {
+      "community": 13,
+      "file_type": "code",
+      "id": "cyclecountdrafts_refreshcyclecountdraftsummarywithctx",
+      "label": "refreshCycleCountDraftSummaryWithCtx()",
+      "norm_label": "refreshcyclecountdraftsummarywithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
+      "source_location": "L170"
+    },
+    {
+      "community": 13,
+      "file_type": "code",
+      "id": "cyclecountdrafts_requirecyclecountdraftaccess",
+      "label": "requireCycleCountDraftAccess()",
+      "norm_label": "requirecyclecountdraftaccess()",
+      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
+      "source_location": "L43"
+    },
+    {
+      "community": 13,
+      "file_type": "code",
+      "id": "cyclecountdrafts_savecyclecountdraftlinecommandwithctx",
+      "label": "saveCycleCountDraftLineCommandWithCtx()",
+      "norm_label": "savecyclecountdraftlinecommandwithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
+      "source_location": "L370"
+    },
+    {
+      "community": 13,
+      "file_type": "code",
+      "id": "cyclecountdrafts_submitactivecyclecountdraftscommandwithctx",
+      "label": "submitActiveCycleCountDraftsCommandWithCtx()",
+      "norm_label": "submitactivecyclecountdraftscommandwithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
+      "source_location": "L776"
+    },
+    {
+      "community": 13,
+      "file_type": "code",
+      "id": "cyclecountdrafts_submitcyclecountdraftcommandwithctx",
+      "label": "submitCycleCountDraftCommandWithCtx()",
+      "norm_label": "submitcyclecountdraftcommandwithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
+      "source_location": "L645"
+    },
+    {
+      "community": 13,
+      "file_type": "code",
+      "id": "cyclecountdrafts_trimrequiredscopekey",
+      "label": "trimRequiredScopeKey()",
+      "norm_label": "trimrequiredscopekey()",
+      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
+      "source_location": "L65"
+    },
+    {
+      "community": 13,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_stockops_cyclecountdrafts_ts",
+      "label": "cycleCountDrafts.ts",
+      "norm_label": "cyclecountdrafts.ts",
+      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
+      "source_location": "L1"
     },
     {
       "community": 130,
@@ -60231,200 +60285,200 @@
     {
       "community": 14,
       "file_type": "code",
-      "id": "harness_review_buildgitprocessenv",
-      "label": "buildGitProcessEnv()",
-      "norm_label": "buildgitprocessenv()",
-      "source_file": "scripts/harness-review.ts",
-      "source_location": "L419"
+      "id": "packages_athena_webapp_src_lib_storeconfig_ts",
+      "label": "storeConfig.ts",
+      "norm_label": "storeconfig.ts",
+      "source_file": "packages/athena-webapp/src/lib/storeConfig.ts",
+      "source_location": "L1"
     },
     {
       "community": 14,
       "file_type": "code",
-      "id": "harness_review_collectcommandsforchangedfiles",
-      "label": "collectCommandsForChangedFiles()",
-      "norm_label": "collectcommandsforchangedfiles()",
-      "source_file": "scripts/harness-review.ts",
-      "source_location": "L302"
+      "id": "packages_storefront_webapp_src_lib_storeconfig_ts",
+      "label": "storeConfig.ts",
+      "norm_label": "storeconfig.ts",
+      "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
+      "source_location": "L1"
     },
     {
       "community": 14,
       "file_type": "code",
-      "id": "harness_review_fileexists",
-      "label": "fileExists()",
-      "norm_label": "fileexists()",
-      "source_file": "scripts/harness-review.ts",
-      "source_location": "L93"
+      "id": "storeconfig_asboolean",
+      "label": "asBoolean()",
+      "norm_label": "asboolean()",
+      "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
+      "source_location": "L117"
     },
     {
       "community": 14,
       "file_type": "code",
-      "id": "harness_review_formatmissingpathprefixerror",
-      "label": "formatMissingPathPrefixError()",
-      "norm_label": "formatmissingpathprefixerror()",
-      "source_file": "scripts/harness-review.ts",
-      "source_location": "L83"
+      "id": "storeconfig_asmtnmomosetupstatus",
+      "label": "asMtnMomoSetupStatus()",
+      "norm_label": "asmtnmomosetupstatus()",
+      "source_file": "packages/athena-webapp/src/lib/storeConfig.ts",
+      "source_location": "L80"
     },
     {
       "community": 14,
       "file_type": "code",
-      "id": "harness_review_getchangedfilesforharnessreview",
-      "label": "getChangedFilesForHarnessReview()",
-      "norm_label": "getchangedfilesforharnessreview()",
-      "source_file": "scripts/harness-review.ts",
-      "source_location": "L425"
+      "id": "storeconfig_asnumber",
+      "label": "asNumber()",
+      "norm_label": "asnumber()",
+      "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
+      "source_location": "L114"
     },
     {
       "community": 14,
       "file_type": "code",
-      "id": "harness_review_hasanyharnessdocs",
-      "label": "hasAnyHarnessDocs()",
-      "norm_label": "hasanyharnessdocs()",
-      "source_file": "scripts/harness-review.ts",
-      "source_location": "L102"
-    },
-    {
-      "community": 14,
-      "file_type": "code",
-      "id": "harness_review_loadreviewtarget",
-      "label": "loadReviewTarget()",
-      "norm_label": "loadreviewtarget()",
-      "source_file": "scripts/harness-review.ts",
+      "id": "storeconfig_asoptionalarray",
+      "label": "asOptionalArray()",
+      "norm_label": "asoptionalarray()",
+      "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
       "source_location": "L132"
     },
     {
       "community": 14,
       "file_type": "code",
-      "id": "harness_review_loadreviewtargets",
-      "label": "loadReviewTargets()",
-      "norm_label": "loadreviewtargets()",
-      "source_file": "scripts/harness-review.ts",
-      "source_location": "L269"
+      "id": "storeconfig_asrecord",
+      "label": "asRecord()",
+      "norm_label": "asrecord()",
+      "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
+      "source_location": "L103"
     },
     {
       "community": 14,
       "file_type": "code",
-      "id": "harness_review_matchespathprefix",
-      "label": "matchesPathPrefix()",
-      "norm_label": "matchespathprefix()",
-      "source_file": "scripts/harness-review.ts",
-      "source_location": "L57"
+      "id": "storeconfig_asstring",
+      "label": "asString()",
+      "norm_label": "asstring()",
+      "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
+      "source_location": "L111"
     },
     {
       "community": 14,
       "file_type": "code",
-      "id": "harness_review_normalizebehaviorscenarioname",
-      "label": "normalizeBehaviorScenarioName()",
-      "norm_label": "normalizebehaviorscenarioname()",
-      "source_file": "scripts/harness-review.ts",
-      "source_location": "L79"
+      "id": "storeconfig_cleanundefined",
+      "label": "cleanUndefined()",
+      "norm_label": "cleanundefined()",
+      "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
+      "source_location": "L143"
     },
     {
       "community": 14,
       "file_type": "code",
-      "id": "harness_review_normalizerepopath",
-      "label": "normalizeRepoPath()",
-      "norm_label": "normalizerepopath()",
-      "source_file": "scripts/harness-review.ts",
-      "source_location": "L53"
+      "id": "storeconfig_firstdefined",
+      "label": "firstDefined()",
+      "norm_label": "firstdefined()",
+      "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
+      "source_location": "L120"
     },
     {
       "community": 14,
       "file_type": "code",
-      "id": "harness_review_normalizevalidationcommand",
-      "label": "normalizeValidationCommand()",
-      "norm_label": "normalizevalidationcommand()",
-      "source_file": "scripts/harness-review.ts",
-      "source_location": "L71"
+      "id": "storeconfig_getrawconfig",
+      "label": "getRawConfig()",
+      "norm_label": "getrawconfig()",
+      "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
+      "source_location": "L196"
     },
     {
       "community": 14,
       "file_type": "code",
-      "id": "harness_review_parseharnessreviewargs",
-      "label": "parseHarnessReviewArgs()",
-      "norm_label": "parseharnessreviewargs()",
-      "source_file": "scripts/harness-review.ts",
-      "source_location": "L666"
+      "id": "storeconfig_getstoreconfigv2",
+      "label": "getStoreConfigV2()",
+      "norm_label": "getstoreconfigv2()",
+      "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
+      "source_location": "L208"
     },
     {
       "community": 14,
       "file_type": "code",
-      "id": "harness_review_readjsonfile",
-      "label": "readJsonFile()",
-      "norm_label": "readjsonfile()",
-      "source_file": "scripts/harness-review.ts",
-      "source_location": "L122"
+      "id": "storeconfig_getstorefallbackimageurl",
+      "label": "getStoreFallbackImageUrl()",
+      "norm_label": "getstorefallbackimageurl()",
+      "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
+      "source_location": "L479"
     },
     {
       "community": 14,
       "file_type": "code",
-      "id": "harness_review_resolveharnessreviewshell",
-      "label": "resolveHarnessReviewShell()",
-      "norm_label": "resolveharnessreviewshell()",
-      "source_file": "scripts/harness-review.ts",
-      "source_location": "L533"
+      "id": "storeconfig_hasmtnmomoreceivingaccountdetails",
+      "label": "hasMtnMomoReceivingAccountDetails()",
+      "norm_label": "hasmtnmomoreceivingaccountdetails()",
+      "source_file": "packages/athena-webapp/src/lib/storeConfig.ts",
+      "source_location": "L93"
     },
     {
       "community": 14,
       "file_type": "code",
-      "id": "harness_review_rungitcommand",
-      "label": "runGitCommand()",
-      "norm_label": "rungitcommand()",
-      "source_file": "scripts/harness-review.ts",
-      "source_location": "L398"
+      "id": "storeconfig_isstoremaintenancemode",
+      "label": "isStoreMaintenanceMode()",
+      "norm_label": "isstoremaintenancemode()",
+      "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
+      "source_location": "L465"
     },
     {
       "community": 14,
       "file_type": "code",
-      "id": "harness_review_runharnessbehaviorscenario",
-      "label": "runHarnessBehaviorScenario()",
-      "norm_label": "runharnessbehaviorscenario()",
-      "source_file": "scripts/harness-review.ts",
-      "source_location": "L568"
+      "id": "storeconfig_isstorereadonlymode",
+      "label": "isStoreReadOnlyMode()",
+      "norm_label": "isstorereadonlymode()",
+      "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
+      "source_location": "L461"
     },
     {
       "community": 14,
       "file_type": "code",
-      "id": "harness_review_runharnessreview",
-      "label": "runHarnessReview()",
-      "norm_label": "runharnessreview()",
-      "source_file": "scripts/harness-review.ts",
-      "source_location": "L582"
+      "id": "storeconfig_mapmtnmomoreceivingaccount",
+      "label": "mapMtnMomoReceivingAccount()",
+      "norm_label": "mapmtnmomoreceivingaccount()",
+      "source_file": "packages/athena-webapp/src/lib/storeConfig.ts",
+      "source_location": "L106"
     },
     {
       "community": 14,
       "file_type": "code",
-      "id": "harness_review_runpackagescript",
-      "label": "runPackageScript()",
-      "norm_label": "runpackagescript()",
-      "source_file": "scripts/harness-review.ts",
-      "source_location": "L519"
+      "id": "storeconfig_mappromo",
+      "label": "mapPromo()",
+      "norm_label": "mappromo()",
+      "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
+      "source_location": "L172"
     },
     {
       "community": 14,
       "file_type": "code",
-      "id": "harness_review_runrawcommand",
-      "label": "runRawCommand()",
-      "norm_label": "runrawcommand()",
-      "source_file": "scripts/harness-review.ts",
-      "source_location": "L554"
+      "id": "storeconfig_mappromotion",
+      "label": "mapPromotion()",
+      "norm_label": "mappromotion()",
+      "source_file": "packages/athena-webapp/src/lib/storeConfig.ts",
+      "source_location": "L172"
     },
     {
       "community": 14,
       "file_type": "code",
-      "id": "harness_review_sortuniquepaths",
-      "label": "sortUniquePaths()",
-      "norm_label": "sortuniquepaths()",
-      "source_file": "scripts/harness-review.ts",
+      "id": "storeconfig_mapstreamreel",
+      "label": "mapStreamReel()",
+      "norm_label": "mapstreamreel()",
+      "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
+      "source_location": "L155"
+    },
+    {
+      "community": 14,
+      "file_type": "code",
+      "id": "storeconfig_normalizemtnmomoreceivingaccounts",
+      "label": "normalizeMtnMomoReceivingAccounts()",
+      "norm_label": "normalizemtnmomoreceivingaccounts()",
+      "source_file": "packages/athena-webapp/src/lib/storeConfig.ts",
       "source_location": "L126"
     },
     {
       "community": 14,
       "file_type": "code",
-      "id": "scripts_harness_review_ts",
-      "label": "harness-review.ts",
-      "norm_label": "harness-review.ts",
-      "source_file": "scripts/harness-review.ts",
-      "source_location": "L1"
+      "id": "storeconfig_normalizewaivedeliveryfees",
+      "label": "normalizeWaiveDeliveryFees()",
+      "norm_label": "normalizewaivedeliveryfees()",
+      "source_file": "packages/athena-webapp/src/lib/storeConfig.ts",
+      "source_location": "L177"
     },
     {
       "community": 140,
@@ -61869,191 +61923,200 @@
     {
       "community": 15,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_commands_sessioncommands_ts",
-      "label": "sessionCommands.ts",
-      "norm_label": "sessioncommands.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
+      "id": "harness_review_buildgitprocessenv",
+      "label": "buildGitProcessEnv()",
+      "norm_label": "buildgitprocessenv()",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L419"
+    },
+    {
+      "community": 15,
+      "file_type": "code",
+      "id": "harness_review_collectcommandsforchangedfiles",
+      "label": "collectCommandsForChangedFiles()",
+      "norm_label": "collectcommandsforchangedfiles()",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L302"
+    },
+    {
+      "community": 15,
+      "file_type": "code",
+      "id": "harness_review_fileexists",
+      "label": "fileExists()",
+      "norm_label": "fileexists()",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L93"
+    },
+    {
+      "community": 15,
+      "file_type": "code",
+      "id": "harness_review_formatmissingpathprefixerror",
+      "label": "formatMissingPathPrefixError()",
+      "norm_label": "formatmissingpathprefixerror()",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L83"
+    },
+    {
+      "community": 15,
+      "file_type": "code",
+      "id": "harness_review_getchangedfilesforharnessreview",
+      "label": "getChangedFilesForHarnessReview()",
+      "norm_label": "getchangedfilesforharnessreview()",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L425"
+    },
+    {
+      "community": 15,
+      "file_type": "code",
+      "id": "harness_review_hasanyharnessdocs",
+      "label": "hasAnyHarnessDocs()",
+      "norm_label": "hasanyharnessdocs()",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L102"
+    },
+    {
+      "community": 15,
+      "file_type": "code",
+      "id": "harness_review_loadreviewtarget",
+      "label": "loadReviewTarget()",
+      "norm_label": "loadreviewtarget()",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L132"
+    },
+    {
+      "community": 15,
+      "file_type": "code",
+      "id": "harness_review_loadreviewtargets",
+      "label": "loadReviewTargets()",
+      "norm_label": "loadreviewtargets()",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L269"
+    },
+    {
+      "community": 15,
+      "file_type": "code",
+      "id": "harness_review_matchespathprefix",
+      "label": "matchesPathPrefix()",
+      "norm_label": "matchespathprefix()",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L57"
+    },
+    {
+      "community": 15,
+      "file_type": "code",
+      "id": "harness_review_normalizebehaviorscenarioname",
+      "label": "normalizeBehaviorScenarioName()",
+      "norm_label": "normalizebehaviorscenarioname()",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L79"
+    },
+    {
+      "community": 15,
+      "file_type": "code",
+      "id": "harness_review_normalizerepopath",
+      "label": "normalizeRepoPath()",
+      "norm_label": "normalizerepopath()",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L53"
+    },
+    {
+      "community": 15,
+      "file_type": "code",
+      "id": "harness_review_normalizevalidationcommand",
+      "label": "normalizeValidationCommand()",
+      "norm_label": "normalizevalidationcommand()",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L71"
+    },
+    {
+      "community": 15,
+      "file_type": "code",
+      "id": "harness_review_parseharnessreviewargs",
+      "label": "parseHarnessReviewArgs()",
+      "norm_label": "parseharnessreviewargs()",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L666"
+    },
+    {
+      "community": 15,
+      "file_type": "code",
+      "id": "harness_review_readjsonfile",
+      "label": "readJsonFile()",
+      "norm_label": "readjsonfile()",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L122"
+    },
+    {
+      "community": 15,
+      "file_type": "code",
+      "id": "harness_review_resolveharnessreviewshell",
+      "label": "resolveHarnessReviewShell()",
+      "norm_label": "resolveharnessreviewshell()",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L533"
+    },
+    {
+      "community": 15,
+      "file_type": "code",
+      "id": "harness_review_rungitcommand",
+      "label": "runGitCommand()",
+      "norm_label": "rungitcommand()",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L398"
+    },
+    {
+      "community": 15,
+      "file_type": "code",
+      "id": "harness_review_runharnessbehaviorscenario",
+      "label": "runHarnessBehaviorScenario()",
+      "norm_label": "runharnessbehaviorscenario()",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L568"
+    },
+    {
+      "community": 15,
+      "file_type": "code",
+      "id": "harness_review_runharnessreview",
+      "label": "runHarnessReview()",
+      "norm_label": "runharnessreview()",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L582"
+    },
+    {
+      "community": 15,
+      "file_type": "code",
+      "id": "harness_review_runpackagescript",
+      "label": "runPackageScript()",
+      "norm_label": "runpackagescript()",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L519"
+    },
+    {
+      "community": 15,
+      "file_type": "code",
+      "id": "harness_review_runrawcommand",
+      "label": "runRawCommand()",
+      "norm_label": "runrawcommand()",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L554"
+    },
+    {
+      "community": 15,
+      "file_type": "code",
+      "id": "harness_review_sortuniquepaths",
+      "label": "sortUniquePaths()",
+      "norm_label": "sortuniquepaths()",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L126"
+    },
+    {
+      "community": 15,
+      "file_type": "code",
+      "id": "scripts_harness_review_ts",
+      "label": "harness-review.ts",
+      "norm_label": "harness-review.ts",
+      "source_file": "scripts/harness-review.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 15,
-      "file_type": "code",
-      "id": "sessioncommands_buildnextsessionnumber",
-      "label": "buildNextSessionNumber()",
-      "norm_label": "buildnextsessionnumber()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L765"
-    },
-    {
-      "community": 15,
-      "file_type": "code",
-      "id": "sessioncommands_createdefaultsessioncommandservice",
-      "label": "createDefaultSessionCommandService()",
-      "norm_label": "createdefaultsessioncommandservice()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L720"
-    },
-    {
-      "community": 15,
-      "file_type": "code",
-      "id": "sessioncommands_createpossessioncommandservice",
-      "label": "createPosSessionCommandService()",
-      "norm_label": "createpossessioncommandservice()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L139"
-    },
-    {
-      "community": 15,
-      "file_type": "code",
-      "id": "sessioncommands_failure",
-      "label": "failure()",
-      "norm_label": "failure()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L958"
-    },
-    {
-      "community": 15,
-      "file_type": "code",
-      "id": "sessioncommands_isactiveregistersession",
-      "label": "isActiveRegisterSession()",
-      "norm_label": "isactiveregistersession()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L776"
-    },
-    {
-      "community": 15,
-      "file_type": "code",
-      "id": "sessioncommands_issessionexpired",
-      "label": "isSessionExpired()",
-      "norm_label": "issessionexpired()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L867"
-    },
-    {
-      "community": 15,
-      "file_type": "code",
-      "id": "sessioncommands_normalizeregisternumber",
-      "label": "normalizeRegisterNumber()",
-      "norm_label": "normalizeregisternumber()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L29"
-    },
-    {
-      "community": 15,
-      "file_type": "code",
-      "id": "sessioncommands_recordsessionlifecyclebesteffort",
-      "label": "recordSessionLifecycleBestEffort()",
-      "norm_label": "recordsessionlifecyclebesteffort()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L732"
-    },
-    {
-      "community": 15,
-      "file_type": "code",
-      "id": "sessioncommands_registersessionmatchesidentity",
-      "label": "registerSessionMatchesIdentity()",
-      "norm_label": "registersessionmatchesidentity()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L782"
-    },
-    {
-      "community": 15,
-      "file_type": "code",
-      "id": "sessioncommands_resolveregistersessionbinding",
-      "label": "resolveRegisterSessionBinding()",
-      "norm_label": "resolveregistersessionbinding()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L811"
-    },
-    {
-      "community": 15,
-      "file_type": "code",
-      "id": "sessioncommands_runbindsessiontoregistersessioncommand",
-      "label": "runBindSessionToRegisterSessionCommand()",
-      "norm_label": "runbindsessiontoregistersessioncommand()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L697"
-    },
-    {
-      "community": 15,
-      "file_type": "code",
-      "id": "sessioncommands_runholdsessioncommand",
-      "label": "runHoldSessionCommand()",
-      "norm_label": "runholdsessioncommand()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L686"
-    },
-    {
-      "community": 15,
-      "file_type": "code",
-      "id": "sessioncommands_runremovesessionitemcommand",
-      "label": "runRemoveSessionItemCommand()",
-      "norm_label": "runremovesessionitemcommand()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L713"
-    },
-    {
-      "community": 15,
-      "file_type": "code",
-      "id": "sessioncommands_runresumesessioncommand",
-      "label": "runResumeSessionCommand()",
-      "norm_label": "runresumesessioncommand()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L690"
-    },
-    {
-      "community": 15,
-      "file_type": "code",
-      "id": "sessioncommands_runstartsessioncommand",
-      "label": "runStartSessionCommand()",
-      "norm_label": "runstartsessioncommand()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L669"
-    },
-    {
-      "community": 15,
-      "file_type": "code",
-      "id": "sessioncommands_runupsertsessionitemcommand",
-      "label": "runUpsertSessionItemCommand()",
-      "norm_label": "runupsertsessionitemcommand()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L706"
-    },
-    {
-      "community": 15,
-      "file_type": "code",
-      "id": "sessioncommands_success",
-      "label": "success()",
-      "norm_label": "success()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L951"
-    },
-    {
-      "community": 15,
-      "file_type": "code",
-      "id": "sessioncommands_validateactivesession",
-      "label": "validateActiveSession()",
-      "norm_label": "validateactivesession()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L874"
-    },
-    {
-      "community": 15,
-      "file_type": "code",
-      "id": "sessioncommands_validateactivesessionregisterbinding",
-      "label": "validateActiveSessionRegisterBinding()",
-      "norm_label": "validateactivesessionregisterbinding()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L847"
-    },
-    {
-      "community": 15,
-      "file_type": "code",
-      "id": "sessioncommands_validatemodifiablesession",
-      "label": "validateModifiableSession()",
-      "norm_label": "validatemodifiablesession()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
-      "source_location": "L918"
     },
     {
       "community": 150,
@@ -62490,56 +62553,56 @@
     {
       "community": 153,
       "file_type": "code",
-      "id": "image_uploader_ondragend",
-      "label": "onDragEnd()",
-      "norm_label": "ondragend()",
-      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L100"
-    },
-    {
-      "community": 153,
-      "file_type": "code",
-      "id": "image_uploader_ondrop",
-      "label": "onDrop()",
-      "norm_label": "ondrop()",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L20"
-    },
-    {
-      "community": 153,
-      "file_type": "code",
-      "id": "image_uploader_removeimage",
-      "label": "removeImage()",
-      "norm_label": "removeimage()",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L31"
-    },
-    {
-      "community": 153,
-      "file_type": "code",
-      "id": "image_uploader_unmarkfordeletion",
-      "label": "unmarkForDeletion()",
-      "norm_label": "unmarkfordeletion()",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L46"
-    },
-    {
-      "community": 153,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_image_uploader_tsx",
-      "label": "image-uploader.tsx",
-      "norm_label": "image-uploader.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
+      "id": "packages_athena_webapp_src_components_ui_sidebar_tsx",
+      "label": "sidebar.tsx",
+      "norm_label": "sidebar.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
       "source_location": "L1"
     },
     {
       "community": 153,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_image_uploader_tsx",
-      "label": "image-uploader.tsx",
-      "norm_label": "image-uploader.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L1"
+      "id": "sidebar_cn",
+      "label": "cn()",
+      "norm_label": "cn()",
+      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
+      "source_location": "L147"
+    },
+    {
+      "community": 153,
+      "file_type": "code",
+      "id": "sidebar_handlekeydown",
+      "label": "handleKeyDown()",
+      "norm_label": "handlekeydown()",
+      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
+      "source_location": "L105"
+    },
+    {
+      "community": 153,
+      "file_type": "code",
+      "id": "sidebar_handleonhover",
+      "label": "handleOnHover()",
+      "norm_label": "handleonhover()",
+      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
+      "source_location": "L224"
+    },
+    {
+      "community": 153,
+      "file_type": "code",
+      "id": "sidebar_handleonmouseleave",
+      "label": "handleOnMouseLeave()",
+      "norm_label": "handleonmouseleave()",
+      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
+      "source_location": "L228"
+    },
+    {
+      "community": 153,
+      "file_type": "code",
+      "id": "sidebar_usesidebar",
+      "label": "useSidebar()",
+      "norm_label": "usesidebar()",
+      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
+      "source_location": "L45"
     },
     {
       "community": 1530,
@@ -62634,56 +62697,56 @@
     {
       "community": 154,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_sidebar_tsx",
-      "label": "sidebar.tsx",
-      "norm_label": "sidebar.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
+      "id": "packages_athena_webapp_src_hooks_usebulkoperations_ts",
+      "label": "useBulkOperations.ts",
+      "norm_label": "usebulkoperations.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
       "source_location": "L1"
     },
     {
       "community": 154,
       "file_type": "code",
-      "id": "sidebar_cn",
-      "label": "cn()",
-      "norm_label": "cn()",
-      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
-      "source_location": "L147"
+      "id": "usebulkoperations_applyoperation",
+      "label": "applyOperation()",
+      "norm_label": "applyoperation()",
+      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
+      "source_location": "L56"
     },
     {
       "community": 154,
       "file_type": "code",
-      "id": "sidebar_handlekeydown",
-      "label": "handleKeyDown()",
-      "norm_label": "handlekeydown()",
-      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
-      "source_location": "L105"
+      "id": "usebulkoperations_calculatepricewithfee",
+      "label": "calculatePriceWithFee()",
+      "norm_label": "calculatepricewithfee()",
+      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
+      "source_location": "L87"
     },
     {
       "community": 154,
       "file_type": "code",
-      "id": "sidebar_handleonhover",
-      "label": "handleOnHover()",
-      "norm_label": "handleonhover()",
-      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
-      "source_location": "L224"
+      "id": "usebulkoperations_computepreview",
+      "label": "computePreview()",
+      "norm_label": "computepreview()",
+      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
+      "source_location": "L101"
     },
     {
       "community": 154,
       "file_type": "code",
-      "id": "sidebar_handleonmouseleave",
-      "label": "handleOnMouseLeave()",
-      "norm_label": "handleonmouseleave()",
-      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
-      "source_location": "L228"
+      "id": "usebulkoperations_usebulkoperations",
+      "label": "useBulkOperations()",
+      "norm_label": "usebulkoperations()",
+      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
+      "source_location": "L158"
     },
     {
       "community": 154,
       "file_type": "code",
-      "id": "sidebar_usesidebar",
-      "label": "useSidebar()",
-      "norm_label": "usesidebar()",
-      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
-      "source_location": "L45"
+      "id": "usebulkoperations_validateoperationvalue",
+      "label": "validateOperationValue()",
+      "norm_label": "validateoperationvalue()",
+      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
+      "source_location": "L139"
     },
     {
       "community": 1540,
@@ -62751,60 +62814,6 @@
     {
       "community": 155,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_usebulkoperations_ts",
-      "label": "useBulkOperations.ts",
-      "norm_label": "usebulkoperations.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 155,
-      "file_type": "code",
-      "id": "usebulkoperations_applyoperation",
-      "label": "applyOperation()",
-      "norm_label": "applyoperation()",
-      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
-      "source_location": "L56"
-    },
-    {
-      "community": 155,
-      "file_type": "code",
-      "id": "usebulkoperations_calculatepricewithfee",
-      "label": "calculatePriceWithFee()",
-      "norm_label": "calculatepricewithfee()",
-      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
-      "source_location": "L87"
-    },
-    {
-      "community": 155,
-      "file_type": "code",
-      "id": "usebulkoperations_computepreview",
-      "label": "computePreview()",
-      "norm_label": "computepreview()",
-      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
-      "source_location": "L101"
-    },
-    {
-      "community": 155,
-      "file_type": "code",
-      "id": "usebulkoperations_usebulkoperations",
-      "label": "useBulkOperations()",
-      "norm_label": "usebulkoperations()",
-      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
-      "source_location": "L158"
-    },
-    {
-      "community": 155,
-      "file_type": "code",
-      "id": "usebulkoperations_validateoperationvalue",
-      "label": "validateOperationValue()",
-      "norm_label": "validateoperationvalue()",
-      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
-      "source_location": "L139"
-    },
-    {
-      "community": 156,
-      "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useexpensesessions_ts",
       "label": "useExpenseSessions.ts",
       "norm_label": "useexpensesessions.ts",
@@ -62812,7 +62821,7 @@
       "source_location": "L1"
     },
     {
-      "community": 156,
+      "community": 155,
       "file_type": "code",
       "id": "useexpensesessions_useexpenseactivesession",
       "label": "useExpenseActiveSession()",
@@ -62821,7 +62830,7 @@
       "source_location": "L42"
     },
     {
-      "community": 156,
+      "community": 155,
       "file_type": "code",
       "id": "useexpensesessions_useexpensesession",
       "label": "useExpenseSession()",
@@ -62830,7 +62839,7 @@
       "source_location": "L32"
     },
     {
-      "community": 156,
+      "community": 155,
       "file_type": "code",
       "id": "useexpensesessions_useexpensesessioncreate",
       "label": "useExpenseSessionCreate()",
@@ -62839,7 +62848,7 @@
       "source_location": "L62"
     },
     {
-      "community": 156,
+      "community": 155,
       "file_type": "code",
       "id": "useexpensesessions_useexpensesessionupdate",
       "label": "useExpenseSessionUpdate()",
@@ -62848,7 +62857,7 @@
       "source_location": "L101"
     },
     {
-      "community": 156,
+      "community": 155,
       "file_type": "code",
       "id": "useexpensesessions_useexpensestoresessions",
       "label": "useExpenseStoreSessions()",
@@ -62857,7 +62866,7 @@
       "source_location": "L10"
     },
     {
-      "community": 157,
+      "community": 156,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useposproducts_ts",
       "label": "usePOSProducts.ts",
@@ -62866,7 +62875,7 @@
       "source_location": "L1"
     },
     {
-      "community": 157,
+      "community": 156,
       "file_type": "code",
       "id": "useposproducts_useposbarcodesearch",
       "label": "usePOSBarcodeSearch()",
@@ -62875,7 +62884,7 @@
       "source_location": "L17"
     },
     {
-      "community": 157,
+      "community": 156,
       "file_type": "code",
       "id": "useposproducts_useposproductidsearch",
       "label": "usePOSProductIdSearch()",
@@ -62884,7 +62893,7 @@
       "source_location": "L24"
     },
     {
-      "community": 157,
+      "community": 156,
       "file_type": "code",
       "id": "useposproducts_useposproductsearch",
       "label": "usePOSProductSearch()",
@@ -62893,7 +62902,7 @@
       "source_location": "L10"
     },
     {
-      "community": 157,
+      "community": 156,
       "file_type": "code",
       "id": "useposproducts_useposquickaddproductsku",
       "label": "usePOSQuickAddProductSku()",
@@ -62902,7 +62911,7 @@
       "source_location": "L33"
     },
     {
-      "community": 157,
+      "community": 156,
       "file_type": "code",
       "id": "useposproducts_usepostransactioncomplete",
       "label": "usePOSTransactionComplete()",
@@ -62911,7 +62920,7 @@
       "source_location": "L31"
     },
     {
-      "community": 158,
+      "community": 157,
       "file_type": "code",
       "id": "behaviorutils_calculateengagementmetrics",
       "label": "calculateEngagementMetrics()",
@@ -62920,7 +62929,7 @@
       "source_location": "L173"
     },
     {
-      "community": 158,
+      "community": 157,
       "file_type": "code",
       "id": "behaviorutils_calculateriskindicators",
       "label": "calculateRiskIndicators()",
@@ -62929,7 +62938,7 @@
       "source_location": "L71"
     },
     {
-      "community": 158,
+      "community": 157,
       "file_type": "code",
       "id": "behaviorutils_getactivitypriority",
       "label": "getActivityPriority()",
@@ -62938,7 +62947,7 @@
       "source_location": "L251"
     },
     {
-      "community": 158,
+      "community": 157,
       "file_type": "code",
       "id": "behaviorutils_getcustomerjourneystage",
       "label": "getCustomerJourneyStage()",
@@ -62947,7 +62956,7 @@
       "source_location": "L36"
     },
     {
-      "community": 158,
+      "community": 157,
       "file_type": "code",
       "id": "behaviorutils_getjourneystageinfo",
       "label": "getJourneyStageInfo()",
@@ -62956,7 +62965,7 @@
       "source_location": "L277"
     },
     {
-      "community": 158,
+      "community": 157,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_behaviorutils_ts",
       "label": "behaviorUtils.ts",
@@ -62965,7 +62974,7 @@
       "source_location": "L1"
     },
     {
-      "community": 159,
+      "community": 158,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_results_ts",
       "label": "results.ts",
@@ -62974,7 +62983,7 @@
       "source_location": "L1"
     },
     {
-      "community": 159,
+      "community": 158,
       "file_type": "code",
       "id": "results_isposusecasesuccess",
       "label": "isPosUseCaseSuccess()",
@@ -62983,7 +62992,7 @@
       "source_location": "L122"
     },
     {
-      "community": 159,
+      "community": 158,
       "file_type": "code",
       "id": "results_mapcommandoutcome",
       "label": "mapCommandOutcome()",
@@ -62992,7 +63001,7 @@
       "source_location": "L68"
     },
     {
-      "community": 159,
+      "community": 158,
       "file_type": "code",
       "id": "results_mapcommandresult",
       "label": "mapCommandResult()",
@@ -63001,7 +63010,7 @@
       "source_location": "L85"
     },
     {
-      "community": 159,
+      "community": 158,
       "file_type": "code",
       "id": "results_maplegacymutationresult",
       "label": "mapLegacyMutationResult()",
@@ -63010,7 +63019,7 @@
       "source_location": "L51"
     },
     {
-      "community": 159,
+      "community": 158,
       "file_type": "code",
       "id": "results_mapthrownerror",
       "label": "mapThrownError()",
@@ -63019,187 +63028,7 @@
       "source_location": "L102"
     },
     {
-      "community": 16,
-      "file_type": "code",
-      "id": "expensesessioncommands_buildnextsessionnumber",
-      "label": "buildNextSessionNumber()",
-      "norm_label": "buildnextsessionnumber()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
-      "source_location": "L656"
-    },
-    {
-      "community": 16,
-      "file_type": "code",
-      "id": "expensesessioncommands_createdefaultexpensesessioncommandservice",
-      "label": "createDefaultExpenseSessionCommandService()",
-      "norm_label": "createdefaultexpensesessioncommandservice()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
-      "source_location": "L644"
-    },
-    {
-      "community": 16,
-      "file_type": "code",
-      "id": "expensesessioncommands_createexpensesessioncommandservice",
-      "label": "createExpenseSessionCommandService()",
-      "norm_label": "createexpensesessioncommandservice()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
-      "source_location": "L136"
-    },
-    {
-      "community": 16,
-      "file_type": "code",
-      "id": "expensesessioncommands_failure",
-      "label": "failure()",
-      "norm_label": "failure()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
-      "source_location": "L829"
-    },
-    {
-      "community": 16,
-      "file_type": "code",
-      "id": "expensesessioncommands_isactiveregistersession",
-      "label": "isActiveRegisterSession()",
-      "norm_label": "isactiveregistersession()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
-      "source_location": "L667"
-    },
-    {
-      "community": 16,
-      "file_type": "code",
-      "id": "expensesessioncommands_issessionexpired",
-      "label": "isSessionExpired()",
-      "norm_label": "issessionexpired()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
-      "source_location": "L738"
-    },
-    {
-      "community": 16,
-      "file_type": "code",
-      "id": "expensesessioncommands_normalizeregisternumber",
-      "label": "normalizeRegisterNumber()",
-      "norm_label": "normalizeregisternumber()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
-      "source_location": "L28"
-    },
-    {
-      "community": 16,
-      "file_type": "code",
-      "id": "expensesessioncommands_recordsessiontrace",
-      "label": "recordSessionTrace()",
-      "norm_label": "recordsessiontrace()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
-      "source_location": "L550"
-    },
-    {
-      "community": 16,
-      "file_type": "code",
-      "id": "expensesessioncommands_registersessionmatchesidentity",
-      "label": "registerSessionMatchesIdentity()",
-      "norm_label": "registersessionmatchesidentity()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
-      "source_location": "L673"
-    },
-    {
-      "community": 16,
-      "file_type": "code",
-      "id": "expensesessioncommands_resolveregistersessionbinding",
-      "label": "resolveRegisterSessionBinding()",
-      "norm_label": "resolveregistersessionbinding()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
-      "source_location": "L702"
-    },
-    {
-      "community": 16,
-      "file_type": "code",
-      "id": "expensesessioncommands_runbindexpensesessiontoregistersessioncommand",
-      "label": "runBindExpenseSessionToRegisterSessionCommand()",
-      "norm_label": "runbindexpensesessiontoregistersessioncommand()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
-      "source_location": "L614"
-    },
-    {
-      "community": 16,
-      "file_type": "code",
-      "id": "expensesessioncommands_runclearexpensesessionitemscommand",
-      "label": "runClearExpenseSessionItemsCommand()",
-      "norm_label": "runclearexpensesessionitemscommand()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
-      "source_location": "L637"
-    },
-    {
-      "community": 16,
-      "file_type": "code",
-      "id": "expensesessioncommands_runremoveexpensesessionitemcommand",
-      "label": "runRemoveExpenseSessionItemCommand()",
-      "norm_label": "runremoveexpensesessionitemcommand()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
-      "source_location": "L630"
-    },
-    {
-      "community": 16,
-      "file_type": "code",
-      "id": "expensesessioncommands_runresumeexpensesessioncommand",
-      "label": "runResumeExpenseSessionCommand()",
-      "norm_label": "runresumeexpensesessioncommand()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
-      "source_location": "L607"
-    },
-    {
-      "community": 16,
-      "file_type": "code",
-      "id": "expensesessioncommands_runstartexpensesessioncommand",
-      "label": "runStartExpenseSessionCommand()",
-      "norm_label": "runstartexpensesessioncommand()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
-      "source_location": "L588"
-    },
-    {
-      "community": 16,
-      "file_type": "code",
-      "id": "expensesessioncommands_runupsertexpensesessionitemcommand",
-      "label": "runUpsertExpenseSessionItemCommand()",
-      "norm_label": "runupsertexpensesessionitemcommand()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
-      "source_location": "L623"
-    },
-    {
-      "community": 16,
-      "file_type": "code",
-      "id": "expensesessioncommands_success",
-      "label": "success()",
-      "norm_label": "success()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
-      "source_location": "L822"
-    },
-    {
-      "community": 16,
-      "file_type": "code",
-      "id": "expensesessioncommands_validateactivesession",
-      "label": "validateActiveSession()",
-      "norm_label": "validateactivesession()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
-      "source_location": "L745"
-    },
-    {
-      "community": 16,
-      "file_type": "code",
-      "id": "expensesessioncommands_validatemodifiablesession",
-      "label": "validateModifiableSession()",
-      "norm_label": "validatemodifiablesession()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
-      "source_location": "L789"
-    },
-    {
-      "community": 16,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_commands_expensesessioncommands_ts",
-      "label": "expenseSessionCommands.ts",
-      "norm_label": "expensesessioncommands.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 160,
+      "community": 159,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_domain_payments_ts",
       "label": "payments.ts",
@@ -63208,7 +63037,7 @@
       "source_location": "L1"
     },
     {
-      "community": 160,
+      "community": 159,
       "file_type": "code",
       "id": "payments_calculateposchange",
       "label": "calculatePosChange()",
@@ -63217,7 +63046,7 @@
       "source_location": "L3"
     },
     {
-      "community": 160,
+      "community": 159,
       "file_type": "code",
       "id": "payments_calculateposremainingdue",
       "label": "calculatePosRemainingDue()",
@@ -63226,7 +63055,7 @@
       "source_location": "L20"
     },
     {
-      "community": 160,
+      "community": 159,
       "file_type": "code",
       "id": "payments_calculatepostotalpaid",
       "label": "calculatePosTotalPaid()",
@@ -63235,7 +63064,7 @@
       "source_location": "L14"
     },
     {
-      "community": 160,
+      "community": 159,
       "file_type": "code",
       "id": "payments_ispospaymentsufficient",
       "label": "isPosPaymentSufficient()",
@@ -63244,7 +63073,7 @@
       "source_location": "L7"
     },
     {
-      "community": 160,
+      "community": 159,
       "file_type": "code",
       "id": "payments_roundposamount",
       "label": "roundPosAmount()",
@@ -63253,7 +63082,196 @@
       "source_location": "L27"
     },
     {
-      "community": 161,
+      "community": 16,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_commands_sessioncommands_ts",
+      "label": "sessionCommands.ts",
+      "norm_label": "sessioncommands.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 16,
+      "file_type": "code",
+      "id": "sessioncommands_buildnextsessionnumber",
+      "label": "buildNextSessionNumber()",
+      "norm_label": "buildnextsessionnumber()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
+      "source_location": "L766"
+    },
+    {
+      "community": 16,
+      "file_type": "code",
+      "id": "sessioncommands_createdefaultsessioncommandservice",
+      "label": "createDefaultSessionCommandService()",
+      "norm_label": "createdefaultsessioncommandservice()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
+      "source_location": "L721"
+    },
+    {
+      "community": 16,
+      "file_type": "code",
+      "id": "sessioncommands_createpossessioncommandservice",
+      "label": "createPosSessionCommandService()",
+      "norm_label": "createpossessioncommandservice()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
+      "source_location": "L139"
+    },
+    {
+      "community": 16,
+      "file_type": "code",
+      "id": "sessioncommands_failure",
+      "label": "failure()",
+      "norm_label": "failure()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
+      "source_location": "L959"
+    },
+    {
+      "community": 16,
+      "file_type": "code",
+      "id": "sessioncommands_isactiveregistersession",
+      "label": "isActiveRegisterSession()",
+      "norm_label": "isactiveregistersession()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
+      "source_location": "L777"
+    },
+    {
+      "community": 16,
+      "file_type": "code",
+      "id": "sessioncommands_issessionexpired",
+      "label": "isSessionExpired()",
+      "norm_label": "issessionexpired()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
+      "source_location": "L868"
+    },
+    {
+      "community": 16,
+      "file_type": "code",
+      "id": "sessioncommands_normalizeregisternumber",
+      "label": "normalizeRegisterNumber()",
+      "norm_label": "normalizeregisternumber()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
+      "source_location": "L29"
+    },
+    {
+      "community": 16,
+      "file_type": "code",
+      "id": "sessioncommands_recordsessionlifecyclebesteffort",
+      "label": "recordSessionLifecycleBestEffort()",
+      "norm_label": "recordsessionlifecyclebesteffort()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
+      "source_location": "L733"
+    },
+    {
+      "community": 16,
+      "file_type": "code",
+      "id": "sessioncommands_registersessionmatchesidentity",
+      "label": "registerSessionMatchesIdentity()",
+      "norm_label": "registersessionmatchesidentity()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
+      "source_location": "L783"
+    },
+    {
+      "community": 16,
+      "file_type": "code",
+      "id": "sessioncommands_resolveregistersessionbinding",
+      "label": "resolveRegisterSessionBinding()",
+      "norm_label": "resolveregistersessionbinding()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
+      "source_location": "L812"
+    },
+    {
+      "community": 16,
+      "file_type": "code",
+      "id": "sessioncommands_runbindsessiontoregistersessioncommand",
+      "label": "runBindSessionToRegisterSessionCommand()",
+      "norm_label": "runbindsessiontoregistersessioncommand()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
+      "source_location": "L698"
+    },
+    {
+      "community": 16,
+      "file_type": "code",
+      "id": "sessioncommands_runholdsessioncommand",
+      "label": "runHoldSessionCommand()",
+      "norm_label": "runholdsessioncommand()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
+      "source_location": "L687"
+    },
+    {
+      "community": 16,
+      "file_type": "code",
+      "id": "sessioncommands_runremovesessionitemcommand",
+      "label": "runRemoveSessionItemCommand()",
+      "norm_label": "runremovesessionitemcommand()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
+      "source_location": "L714"
+    },
+    {
+      "community": 16,
+      "file_type": "code",
+      "id": "sessioncommands_runresumesessioncommand",
+      "label": "runResumeSessionCommand()",
+      "norm_label": "runresumesessioncommand()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
+      "source_location": "L691"
+    },
+    {
+      "community": 16,
+      "file_type": "code",
+      "id": "sessioncommands_runstartsessioncommand",
+      "label": "runStartSessionCommand()",
+      "norm_label": "runstartsessioncommand()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
+      "source_location": "L670"
+    },
+    {
+      "community": 16,
+      "file_type": "code",
+      "id": "sessioncommands_runupsertsessionitemcommand",
+      "label": "runUpsertSessionItemCommand()",
+      "norm_label": "runupsertsessionitemcommand()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
+      "source_location": "L707"
+    },
+    {
+      "community": 16,
+      "file_type": "code",
+      "id": "sessioncommands_success",
+      "label": "success()",
+      "norm_label": "success()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
+      "source_location": "L952"
+    },
+    {
+      "community": 16,
+      "file_type": "code",
+      "id": "sessioncommands_validateactivesession",
+      "label": "validateActiveSession()",
+      "norm_label": "validateactivesession()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
+      "source_location": "L875"
+    },
+    {
+      "community": 16,
+      "file_type": "code",
+      "id": "sessioncommands_validateactivesessionregisterbinding",
+      "label": "validateActiveSessionRegisterBinding()",
+      "norm_label": "validateactivesessionregisterbinding()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
+      "source_location": "L848"
+    },
+    {
+      "community": 16,
+      "file_type": "code",
+      "id": "sessioncommands_validatemodifiablesession",
+      "label": "validateModifiableSession()",
+      "norm_label": "validatemodifiablesession()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts",
+      "source_location": "L919"
+    },
+    {
+      "community": 160,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_presentation_register_selectors_ts",
       "label": "selectors.ts",
@@ -63262,7 +63280,7 @@
       "source_location": "L1"
     },
     {
-      "community": 161,
+      "community": 160,
       "file_type": "code",
       "id": "selectors_buildregisterheaderstate",
       "label": "buildRegisterHeaderState()",
@@ -63271,7 +63289,7 @@
       "source_location": "L28"
     },
     {
-      "community": 161,
+      "community": 160,
       "file_type": "code",
       "id": "selectors_buildregisterinfostate",
       "label": "buildRegisterInfoState()",
@@ -63280,7 +63298,7 @@
       "source_location": "L37"
     },
     {
-      "community": 161,
+      "community": 160,
       "file_type": "code",
       "id": "selectors_getcashierdisplayname",
       "label": "getCashierDisplayName()",
@@ -63289,7 +63307,7 @@
       "source_location": "L12"
     },
     {
-      "community": 161,
+      "community": 160,
       "file_type": "code",
       "id": "selectors_getregistercustomerinfo",
       "label": "getRegisterCustomerInfo()",
@@ -63298,7 +63316,7 @@
       "source_location": "L6"
     },
     {
-      "community": 161,
+      "community": 160,
       "file_type": "code",
       "id": "selectors_isregistersessionactive",
       "label": "isRegisterSessionActive()",
@@ -63307,7 +63325,7 @@
       "source_location": "L49"
     },
     {
-      "community": 162,
+      "community": 161,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_toastservice_ts",
       "label": "toastService.ts",
@@ -63316,7 +63334,7 @@
       "source_location": "L1"
     },
     {
-      "community": 162,
+      "community": 161,
       "file_type": "code",
       "id": "toastservice_handleposoperation",
       "label": "handlePOSOperation()",
@@ -63325,7 +63343,7 @@
       "source_location": "L171"
     },
     {
-      "community": 162,
+      "community": 161,
       "file_type": "code",
       "id": "toastservice_showinventoryerror",
       "label": "showInventoryError()",
@@ -63334,7 +63352,7 @@
       "source_location": "L302"
     },
     {
-      "community": 162,
+      "community": 161,
       "file_type": "code",
       "id": "toastservice_shownoactivesessionerror",
       "label": "showNoActiveSessionError()",
@@ -63343,7 +63361,7 @@
       "source_location": "L319"
     },
     {
-      "community": 162,
+      "community": 161,
       "file_type": "code",
       "id": "toastservice_showsessionexpirederror",
       "label": "showSessionExpiredError()",
@@ -63352,7 +63370,7 @@
       "source_location": "L312"
     },
     {
-      "community": 162,
+      "community": 161,
       "file_type": "code",
       "id": "toastservice_showvalidationerror",
       "label": "showValidationError()",
@@ -63361,7 +63379,7 @@
       "source_location": "L293"
     },
     {
-      "community": 163,
+      "community": 162,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_traces_traceid_tsx",
       "label": "$traceId.tsx",
@@ -63370,7 +63388,7 @@
       "source_location": "L1"
     },
     {
-      "community": 163,
+      "community": 162,
       "file_type": "code",
       "id": "traceid_hasorgnotfoundpayload",
       "label": "hasOrgNotFoundPayload()",
@@ -63379,7 +63397,7 @@
       "source_location": "L12"
     },
     {
-      "community": 163,
+      "community": 162,
       "file_type": "code",
       "id": "traceid_workflowtraceloadingstate",
       "label": "WorkflowTraceLoadingState()",
@@ -63388,7 +63406,7 @@
       "source_location": "L21"
     },
     {
-      "community": 163,
+      "community": 162,
       "file_type": "code",
       "id": "traceid_workflowtraceroute",
       "label": "WorkflowTraceRoute()",
@@ -63397,7 +63415,7 @@
       "source_location": "L101"
     },
     {
-      "community": 163,
+      "community": 162,
       "file_type": "code",
       "id": "traceid_workflowtraceroutecontent",
       "label": "WorkflowTraceRouteContent()",
@@ -63406,7 +63424,7 @@
       "source_location": "L35"
     },
     {
-      "community": 163,
+      "community": 162,
       "file_type": "code",
       "id": "traceid_workflowtracerouteshell",
       "label": "WorkflowTraceRouteShell()",
@@ -63415,7 +63433,7 @@
       "source_location": "L66"
     },
     {
-      "community": 164,
+      "community": 163,
       "file_type": "code",
       "id": "organizationsettingsview_handledeletestore",
       "label": "handleDeleteStore()",
@@ -63424,7 +63442,7 @@
       "source_location": "L155"
     },
     {
-      "community": 164,
+      "community": 163,
       "file_type": "code",
       "id": "organizationsettingsview_navigation",
       "label": "Navigation()",
@@ -63433,7 +63451,7 @@
       "source_location": "L197"
     },
     {
-      "community": 164,
+      "community": 163,
       "file_type": "code",
       "id": "organizationsettingsview_onsubmit",
       "label": "onSubmit()",
@@ -63442,7 +63460,7 @@
       "source_location": "L104"
     },
     {
-      "community": 164,
+      "community": 163,
       "file_type": "code",
       "id": "organizationsettingsview_organizationsettings",
       "label": "OrganizationSettings()",
@@ -63451,7 +63469,7 @@
       "source_location": "L25"
     },
     {
-      "community": 164,
+      "community": 163,
       "file_type": "code",
       "id": "organizationsettingsview_savestorechanges",
       "label": "saveStoreChanges()",
@@ -63460,7 +63478,7 @@
       "source_location": "L72"
     },
     {
-      "community": 164,
+      "community": 163,
       "file_type": "code",
       "id": "packages_athena_webapp_src_settings_organization_components_organizationsettingsview_tsx",
       "label": "OrganizationSettingsView.tsx",
@@ -63469,7 +63487,7 @@
       "source_location": "L1"
     },
     {
-      "community": 165,
+      "community": 164,
       "file_type": "code",
       "id": "packages_athena_webapp_src_settings_store_storesettingsview_tsx",
       "label": "StoreSettingsView.tsx",
@@ -63478,7 +63496,7 @@
       "source_location": "L1"
     },
     {
-      "community": 165,
+      "community": 164,
       "file_type": "code",
       "id": "storesettingsview_handledeleteallproductsinstore",
       "label": "handleDeleteAllProductsInStore()",
@@ -63487,7 +63505,7 @@
       "source_location": "L231"
     },
     {
-      "community": 165,
+      "community": 164,
       "file_type": "code",
       "id": "storesettingsview_handledeletestore",
       "label": "handleDeleteStore()",
@@ -63496,7 +63514,7 @@
       "source_location": "L167"
     },
     {
-      "community": 165,
+      "community": 164,
       "file_type": "code",
       "id": "storesettingsview_onsubmit",
       "label": "onSubmit()",
@@ -63505,7 +63523,7 @@
       "source_location": "L116"
     },
     {
-      "community": 165,
+      "community": 164,
       "file_type": "code",
       "id": "storesettingsview_savestorechanges",
       "label": "saveStoreChanges()",
@@ -63514,7 +63532,7 @@
       "source_location": "L83"
     },
     {
-      "community": 165,
+      "community": 164,
       "file_type": "code",
       "id": "storesettingsview_storesettings",
       "label": "StoreSettings()",
@@ -63523,7 +63541,7 @@
       "source_location": "L29"
     },
     {
-      "community": 166,
+      "community": 165,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_storybook_shell_tsx",
       "label": "storybook-shell.tsx",
@@ -63532,7 +63550,7 @@
       "source_location": "L1"
     },
     {
-      "community": 166,
+      "community": 165,
       "file_type": "code",
       "id": "storybook_shell_storybookcallout",
       "label": "StorybookCallout()",
@@ -63541,7 +63559,7 @@
       "source_location": "L76"
     },
     {
-      "community": 166,
+      "community": 165,
       "file_type": "code",
       "id": "storybook_shell_storybooklist",
       "label": "StorybookList()",
@@ -63550,7 +63568,7 @@
       "source_location": "L55"
     },
     {
-      "community": 166,
+      "community": 165,
       "file_type": "code",
       "id": "storybook_shell_storybookpillrow",
       "label": "StorybookPillRow()",
@@ -63559,7 +63577,7 @@
       "source_location": "L88"
     },
     {
-      "community": 166,
+      "community": 165,
       "file_type": "code",
       "id": "storybook_shell_storybooksection",
       "label": "StorybookSection()",
@@ -63568,7 +63586,7 @@
       "source_location": "L34"
     },
     {
-      "community": 166,
+      "community": 165,
       "file_type": "code",
       "id": "storybook_shell_storybookshell",
       "label": "StorybookShell()",
@@ -63577,7 +63595,7 @@
       "source_location": "L13"
     },
     {
-      "community": 167,
+      "community": 166,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_postransaction_ts",
       "label": "posTransaction.ts",
@@ -63586,7 +63604,7 @@
       "source_location": "L1"
     },
     {
-      "community": 167,
+      "community": 166,
       "file_type": "code",
       "id": "postransaction_fetchpostransaction",
       "label": "fetchPosTransaction()",
@@ -63595,7 +63613,7 @@
       "source_location": "L69"
     },
     {
-      "community": 167,
+      "community": 166,
       "file_type": "code",
       "id": "postransaction_getbaseurl",
       "label": "getBaseUrl()",
@@ -63604,7 +63622,7 @@
       "source_location": "L57"
     },
     {
-      "community": 167,
+      "community": 166,
       "file_type": "code",
       "id": "postransaction_getpostransactionbyreceipttoken",
       "label": "getPosTransactionByReceiptToken()",
@@ -63613,7 +63631,7 @@
       "source_location": "L90"
     },
     {
-      "community": 167,
+      "community": 166,
       "file_type": "code",
       "id": "postransaction_postransactionreceipterror",
       "label": "PosTransactionReceiptError",
@@ -63622,7 +63640,7 @@
       "source_location": "L59"
     },
     {
-      "community": 167,
+      "community": 166,
       "file_type": "code",
       "id": "postransaction_postransactionreceipterror_constructor",
       "label": ".constructor()",
@@ -63631,7 +63649,7 @@
       "source_location": "L62"
     },
     {
-      "community": 168,
+      "community": 167,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_promocodes_ts",
       "label": "promoCodes.ts",
@@ -63640,7 +63658,7 @@
       "source_location": "L1"
     },
     {
-      "community": 168,
+      "community": 167,
       "file_type": "code",
       "id": "promocodes_getbaseurl",
       "label": "getBaseUrl()",
@@ -63649,7 +63667,7 @@
       "source_location": "L4"
     },
     {
-      "community": 168,
+      "community": 167,
       "file_type": "code",
       "id": "promocodes_getpromocodeitems",
       "label": "getPromoCodeItems()",
@@ -63658,7 +63676,7 @@
       "source_location": "L49"
     },
     {
-      "community": 168,
+      "community": 167,
       "file_type": "code",
       "id": "promocodes_getpromocodes",
       "label": "getPromoCodes()",
@@ -63667,7 +63685,7 @@
       "source_location": "L34"
     },
     {
-      "community": 168,
+      "community": 167,
       "file_type": "code",
       "id": "promocodes_getredeemedpromocodes",
       "label": "getRedeemedPromoCodes()",
@@ -63676,7 +63694,7 @@
       "source_location": "L74"
     },
     {
-      "community": 168,
+      "community": 167,
       "file_type": "code",
       "id": "promocodes_redeempromocode",
       "label": "redeemPromoCode()",
@@ -63685,7 +63703,7 @@
       "source_location": "L6"
     },
     {
-      "community": 169,
+      "community": 168,
       "file_type": "code",
       "id": "billingdetails_clearform",
       "label": "clearForm()",
@@ -63694,7 +63712,7 @@
       "source_location": "L173"
     },
     {
-      "community": 169,
+      "community": 168,
       "file_type": "code",
       "id": "billingdetails_enteredbillingaddressdetails",
       "label": "EnteredBillingAddressDetails()",
@@ -63703,7 +63721,7 @@
       "source_location": "L102"
     },
     {
-      "community": 169,
+      "community": 168,
       "file_type": "code",
       "id": "billingdetails_handleusebillingaddressonfile",
       "label": "handleUseBillingAddressOnFile()",
@@ -63712,7 +63730,7 @@
       "source_location": "L201"
     },
     {
-      "community": 169,
+      "community": 168,
       "file_type": "code",
       "id": "billingdetails_onsubmit",
       "label": "onSubmit()",
@@ -63721,7 +63739,7 @@
       "source_location": "L150"
     },
     {
-      "community": 169,
+      "community": 168,
       "file_type": "code",
       "id": "billingdetails_togglesameasdelivery",
       "label": "toggleSameAsDelivery()",
@@ -63730,12 +63748,66 @@
       "source_location": "L155"
     },
     {
-      "community": 169,
+      "community": 168,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_billingdetails_tsx",
       "label": "BillingDetails.tsx",
       "norm_label": "billingdetails.tsx",
       "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 169,
+      "file_type": "code",
+      "id": "mobileproductactions_collapseonpageclick",
+      "label": "collapseOnPageClick()",
+      "norm_label": "collapseonpageclick()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
+      "source_location": "L76"
+    },
+    {
+      "community": 169,
+      "file_type": "code",
+      "id": "mobileproductactions_handleconfirm",
+      "label": "handleConfirm()",
+      "norm_label": "handleconfirm()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
+      "source_location": "L120"
+    },
+    {
+      "community": 169,
+      "file_type": "code",
+      "id": "mobileproductactions_handleprimaryaction",
+      "label": "handlePrimaryAction()",
+      "norm_label": "handleprimaryaction()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
+      "source_location": "L129"
+    },
+    {
+      "community": 169,
+      "file_type": "code",
+      "id": "mobileproductactions_handlesecondaryaction",
+      "label": "handleSecondaryAction()",
+      "norm_label": "handlesecondaryaction()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
+      "source_location": "L133"
+    },
+    {
+      "community": 169,
+      "file_type": "code",
+      "id": "mobileproductactions_updateposition",
+      "label": "updatePosition()",
+      "norm_label": "updateposition()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
+      "source_location": "L44"
+    },
+    {
+      "community": 169,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_page_mobileproductactions_tsx",
+      "label": "MobileProductActions.tsx",
+      "norm_label": "mobileproductactions.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
       "source_location": "L1"
     },
     {
@@ -63921,60 +63993,6 @@
     {
       "community": 170,
       "file_type": "code",
-      "id": "mobileproductactions_collapseonpageclick",
-      "label": "collapseOnPageClick()",
-      "norm_label": "collapseonpageclick()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
-      "source_location": "L76"
-    },
-    {
-      "community": 170,
-      "file_type": "code",
-      "id": "mobileproductactions_handleconfirm",
-      "label": "handleConfirm()",
-      "norm_label": "handleconfirm()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
-      "source_location": "L120"
-    },
-    {
-      "community": 170,
-      "file_type": "code",
-      "id": "mobileproductactions_handleprimaryaction",
-      "label": "handlePrimaryAction()",
-      "norm_label": "handleprimaryaction()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
-      "source_location": "L129"
-    },
-    {
-      "community": 170,
-      "file_type": "code",
-      "id": "mobileproductactions_handlesecondaryaction",
-      "label": "handleSecondaryAction()",
-      "norm_label": "handlesecondaryaction()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
-      "source_location": "L133"
-    },
-    {
-      "community": 170,
-      "file_type": "code",
-      "id": "mobileproductactions_updateposition",
-      "label": "updatePosition()",
-      "norm_label": "updateposition()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
-      "source_location": "L44"
-    },
-    {
-      "community": 170,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_page_mobileproductactions_tsx",
-      "label": "MobileProductActions.tsx",
-      "norm_label": "mobileproductactions.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-page/MobileProductActions.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 171,
-      "file_type": "code",
       "id": "checkoutexpired_checkoutexpired",
       "label": "CheckoutExpired()",
       "norm_label": "checkoutexpired()",
@@ -63982,7 +64000,7 @@
       "source_location": "L9"
     },
     {
-      "community": 171,
+      "community": 170,
       "file_type": "code",
       "id": "checkoutexpired_checkoutsessiongeneric",
       "label": "CheckoutSessionGeneric()",
@@ -63991,7 +64009,7 @@
       "source_location": "L73"
     },
     {
-      "community": 171,
+      "community": 170,
       "file_type": "code",
       "id": "checkoutexpired_checkoutsessionnotfound",
       "label": "CheckoutSessionNotFound()",
@@ -64000,7 +64018,7 @@
       "source_location": "L54"
     },
     {
-      "community": 171,
+      "community": 170,
       "file_type": "code",
       "id": "checkoutexpired_handlesendemail",
       "label": "handleSendEmail()",
@@ -64009,7 +64027,7 @@
       "source_location": "L98"
     },
     {
-      "community": 171,
+      "community": 170,
       "file_type": "code",
       "id": "checkoutexpired_nocheckoutsession",
       "label": "NoCheckoutSession()",
@@ -64018,12 +64036,66 @@
       "source_location": "L33"
     },
     {
-      "community": 171,
+      "community": 170,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_checkout_expired_checkoutexpired_tsx",
       "label": "CheckoutExpired.tsx",
       "norm_label": "checkoutexpired.tsx",
       "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 171,
+      "file_type": "code",
+      "id": "image_uploader_ondragend",
+      "label": "onDragEnd()",
+      "norm_label": "ondragend()",
+      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L100"
+    },
+    {
+      "community": 171,
+      "file_type": "code",
+      "id": "image_uploader_ondrop",
+      "label": "onDrop()",
+      "norm_label": "ondrop()",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L20"
+    },
+    {
+      "community": 171,
+      "file_type": "code",
+      "id": "image_uploader_removeimage",
+      "label": "removeImage()",
+      "norm_label": "removeimage()",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L31"
+    },
+    {
+      "community": 171,
+      "file_type": "code",
+      "id": "image_uploader_unmarkfordeletion",
+      "label": "unmarkForDeletion()",
+      "norm_label": "unmarkfordeletion()",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L46"
+    },
+    {
+      "community": 171,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_image_uploader_tsx",
+      "label": "image-uploader.tsx",
+      "norm_label": "image-uploader.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 171,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_image_uploader_tsx",
+      "label": "image-uploader.tsx",
+      "norm_label": "image-uploader.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
       "source_location": "L1"
     },
     {
@@ -64875,51 +64947,6 @@
     {
       "community": 186,
       "file_type": "code",
-      "id": "inventoryholdgateway_acquirelegacyquantitypatchhold",
-      "label": "acquireLegacyQuantityPatchHold()",
-      "norm_label": "acquirelegacyquantitypatchhold()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/integrations/inventoryHoldGateway.ts",
-      "source_location": "L91"
-    },
-    {
-      "community": 186,
-      "file_type": "code",
-      "id": "inventoryholdgateway_adjustlegacyquantitypatchhold",
-      "label": "adjustLegacyQuantityPatchHold()",
-      "norm_label": "adjustlegacyquantitypatchhold()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/integrations/inventoryHoldGateway.ts",
-      "source_location": "L131"
-    },
-    {
-      "community": 186,
-      "file_type": "code",
-      "id": "inventoryholdgateway_createinventoryholdgateway",
-      "label": "createInventoryHoldGateway()",
-      "norm_label": "createinventoryholdgateway()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/integrations/inventoryHoldGateway.ts",
-      "source_location": "L63"
-    },
-    {
-      "community": 186,
-      "file_type": "code",
-      "id": "inventoryholdgateway_releaselegacyquantitypatchhold",
-      "label": "releaseLegacyQuantityPatchHold()",
-      "norm_label": "releaselegacyquantitypatchhold()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/integrations/inventoryHoldGateway.ts",
-      "source_location": "L115"
-    },
-    {
-      "community": 186,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_infrastructure_integrations_inventoryholdgateway_ts",
-      "label": "inventoryHoldGateway.ts",
-      "norm_label": "inventoryholdgateway.ts",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/integrations/inventoryHoldGateway.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 187,
-      "file_type": "code",
       "id": "packages_athena_webapp_convex_services_paystackservice_ts",
       "label": "paystackService.ts",
       "norm_label": "paystackservice.ts",
@@ -64927,7 +64954,7 @@
       "source_location": "L1"
     },
     {
-      "community": 187,
+      "community": 186,
       "file_type": "code",
       "id": "paystackservice_getpaystackheaders",
       "label": "getPaystackHeaders()",
@@ -64936,7 +64963,7 @@
       "source_location": "L11"
     },
     {
-      "community": 187,
+      "community": 186,
       "file_type": "code",
       "id": "paystackservice_initializetransaction",
       "label": "initializeTransaction()",
@@ -64945,7 +64972,7 @@
       "source_location": "L21"
     },
     {
-      "community": 187,
+      "community": 186,
       "file_type": "code",
       "id": "paystackservice_initiaterefund",
       "label": "initiateRefund()",
@@ -64954,7 +64981,7 @@
       "source_location": "L87"
     },
     {
-      "community": 187,
+      "community": 186,
       "file_type": "code",
       "id": "paystackservice_verifytransaction",
       "label": "verifyTransaction()",
@@ -64963,7 +64990,7 @@
       "source_location": "L65"
     },
     {
-      "community": 188,
+      "community": 187,
       "file_type": "code",
       "id": "adjustments_test_createapprovaldecisionmutationctx",
       "label": "createApprovalDecisionMutationCtx()",
@@ -64972,7 +64999,7 @@
       "source_location": "L173"
     },
     {
-      "community": 188,
+      "community": 187,
       "file_type": "code",
       "id": "adjustments_test_createinventorysnapshotqueryctx",
       "label": "createInventorySnapshotQueryCtx()",
@@ -64981,7 +65008,7 @@
       "source_location": "L33"
     },
     {
-      "community": 188,
+      "community": 187,
       "file_type": "code",
       "id": "adjustments_test_createsubmissionmutationctx",
       "label": "createSubmissionMutationCtx()",
@@ -64990,7 +65017,7 @@
       "source_location": "L318"
     },
     {
-      "community": 188,
+      "community": 187,
       "file_type": "code",
       "id": "adjustments_test_getsource",
       "label": "getSource()",
@@ -64999,7 +65026,7 @@
       "source_location": "L29"
     },
     {
-      "community": 188,
+      "community": 187,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_adjustments_test_ts",
       "label": "adjustments.test.ts",
@@ -65008,7 +65035,7 @@
       "source_location": "L1"
     },
     {
-      "community": 189,
+      "community": 188,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_helpers_returnexchangeoperations_ts",
       "label": "returnExchangeOperations.ts",
@@ -65017,7 +65044,7 @@
       "source_location": "L1"
     },
     {
-      "community": 189,
+      "community": 188,
       "file_type": "code",
       "id": "returnexchangeoperations_buildonlineorderreturnexchangeplan",
       "label": "buildOnlineOrderReturnExchangePlan()",
@@ -65026,7 +65053,7 @@
       "source_location": "L115"
     },
     {
-      "community": 189,
+      "community": 188,
       "file_type": "code",
       "id": "returnexchangeoperations_getapprovalreason",
       "label": "getApprovalReason()",
@@ -65035,7 +65062,7 @@
       "source_location": "L90"
     },
     {
-      "community": 189,
+      "community": 188,
       "file_type": "code",
       "id": "returnexchangeoperations_getkind",
       "label": "getKind()",
@@ -65044,13 +65071,58 @@
       "source_location": "L74"
     },
     {
-      "community": 189,
+      "community": 188,
       "file_type": "code",
       "id": "returnexchangeoperations_getlinerefundamount",
       "label": "getLineRefundAmount()",
       "norm_label": "getlinerefundamount()",
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/returnExchangeOperations.ts",
       "source_location": "L70"
+    },
+    {
+      "community": 189,
+      "file_type": "code",
+      "id": "offers_createoffer",
+      "label": "createOffer()",
+      "norm_label": "createoffer()",
+      "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
+      "source_location": "L89"
+    },
+    {
+      "community": 189,
+      "file_type": "code",
+      "id": "offers_getupsellproducts",
+      "label": "getUpsellProducts()",
+      "norm_label": "getupsellproducts()",
+      "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
+      "source_location": "L765"
+    },
+    {
+      "community": 189,
+      "file_type": "code",
+      "id": "offers_isduplicate",
+      "label": "isDuplicate()",
+      "norm_label": "isduplicate()",
+      "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
+      "source_location": "L37"
+    },
+    {
+      "community": 189,
+      "file_type": "code",
+      "id": "offers_updatestorefrontactoremail",
+      "label": "updateStoreFrontActorEmail()",
+      "norm_label": "updatestorefrontactoremail()",
+      "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
+      "source_location": "L60"
+    },
+    {
+      "community": 189,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_offers_ts",
+      "label": "offers.ts",
+      "norm_label": "offers.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
+      "source_location": "L1"
     },
     {
       "community": 19,
@@ -65235,51 +65307,6 @@
     {
       "community": 190,
       "file_type": "code",
-      "id": "offers_createoffer",
-      "label": "createOffer()",
-      "norm_label": "createoffer()",
-      "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
-      "source_location": "L89"
-    },
-    {
-      "community": 190,
-      "file_type": "code",
-      "id": "offers_getupsellproducts",
-      "label": "getUpsellProducts()",
-      "norm_label": "getupsellproducts()",
-      "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
-      "source_location": "L765"
-    },
-    {
-      "community": 190,
-      "file_type": "code",
-      "id": "offers_isduplicate",
-      "label": "isDuplicate()",
-      "norm_label": "isduplicate()",
-      "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
-      "source_location": "L37"
-    },
-    {
-      "community": 190,
-      "file_type": "code",
-      "id": "offers_updatestorefrontactoremail",
-      "label": "updateStoreFrontActorEmail()",
-      "norm_label": "updatestorefrontactoremail()",
-      "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
-      "source_location": "L60"
-    },
-    {
-      "community": 190,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_offers_ts",
-      "label": "offers.ts",
-      "norm_label": "offers.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 191,
-      "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_storefrontobservabilityreport_ts",
       "label": "storefrontObservabilityReport.ts",
       "norm_label": "storefrontobservabilityreport.ts",
@@ -65287,7 +65314,7 @@
       "source_location": "L1"
     },
     {
-      "community": 191,
+      "community": 190,
       "file_type": "code",
       "id": "storefrontobservabilityreport_buildstorefrontobservabilityreport",
       "label": "buildStorefrontObservabilityReport()",
@@ -65296,7 +65323,7 @@
       "source_location": "L124"
     },
     {
-      "community": 191,
+      "community": 190,
       "file_type": "code",
       "id": "storefrontobservabilityreport_getnonemptystring",
       "label": "getNonEmptyString()",
@@ -65305,7 +65332,7 @@
       "source_location": "L67"
     },
     {
-      "community": 191,
+      "community": 190,
       "file_type": "code",
       "id": "storefrontobservabilityreport_gettrafficsource",
       "label": "getTrafficSource()",
@@ -65314,7 +65341,7 @@
       "source_location": "L106"
     },
     {
-      "community": 191,
+      "community": 190,
       "file_type": "code",
       "id": "storefrontobservabilityreport_normalizestorefrontobservabilityevent",
       "label": "normalizeStorefrontObservabilityEvent()",
@@ -65323,7 +65350,7 @@
       "source_location": "L73"
     },
     {
-      "community": 192,
+      "community": 191,
       "file_type": "code",
       "id": "navbar_appheader",
       "label": "AppHeader()",
@@ -65332,7 +65359,7 @@
       "source_location": "L61"
     },
     {
-      "community": 192,
+      "community": 191,
       "file_type": "code",
       "id": "navbar_header",
       "label": "Header()",
@@ -65341,7 +65368,7 @@
       "source_location": "L75"
     },
     {
-      "community": 192,
+      "community": 191,
       "file_type": "code",
       "id": "navbar_navbar",
       "label": "Navbar()",
@@ -65350,7 +65377,7 @@
       "source_location": "L116"
     },
     {
-      "community": 192,
+      "community": 191,
       "file_type": "code",
       "id": "navbar_settingsheader",
       "label": "SettingsHeader()",
@@ -65359,7 +65386,7 @@
       "source_location": "L20"
     },
     {
-      "community": 192,
+      "community": 191,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_navbar_tsx",
       "label": "Navbar.tsx",
@@ -65368,7 +65395,7 @@
       "source_location": "L1"
     },
     {
-      "community": 193,
+      "community": 192,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productcategorization_tsx",
       "label": "ProductCategorization.tsx",
@@ -65377,7 +65404,7 @@
       "source_location": "L1"
     },
     {
-      "community": 193,
+      "community": 192,
       "file_type": "code",
       "id": "productcategorization_getproductname",
       "label": "getProductName()",
@@ -65386,7 +65413,7 @@
       "source_location": "L287"
     },
     {
-      "community": 193,
+      "community": 192,
       "file_type": "code",
       "id": "productcategorization_handleclose",
       "label": "handleClose()",
@@ -65395,7 +65422,7 @@
       "source_location": "L203"
     },
     {
-      "community": 193,
+      "community": 192,
       "file_type": "code",
       "id": "productcategorization_handleproductvisibility",
       "label": "handleProductVisibility()",
@@ -65404,13 +65431,58 @@
       "source_location": "L243"
     },
     {
-      "community": 193,
+      "community": 192,
       "file_type": "code",
       "id": "productcategorization_setinitialselectedoption",
       "label": "setInitialSelectedOption()",
       "norm_label": "setinitialselectedoption()",
       "source_file": "packages/athena-webapp/src/components/add-product/ProductCategorization.tsx",
       "source_location": "L230"
+    },
+    {
+      "community": 193,
+      "file_type": "code",
+      "id": "index_feesview",
+      "label": "FeesView()",
+      "norm_label": "feesview()",
+      "source_file": "packages/athena-webapp/src/components/assets/index.tsx",
+      "source_location": "L30"
+    },
+    {
+      "community": 193,
+      "file_type": "code",
+      "id": "index_header",
+      "label": "Header()",
+      "norm_label": "header()",
+      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
+      "source_location": "L43"
+    },
+    {
+      "community": 193,
+      "file_type": "code",
+      "id": "index_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
+      "source_location": "L106"
+    },
+    {
+      "community": 193,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_assets_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/components/assets/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 193,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_organization_members_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
+      "source_location": "L1"
     },
     {
       "community": 194,
@@ -66306,51 +66378,6 @@
     {
       "community": 202,
       "file_type": "code",
-      "id": "index_feesview",
-      "label": "FeesView()",
-      "norm_label": "feesview()",
-      "source_file": "packages/athena-webapp/src/components/assets/index.tsx",
-      "source_location": "L30"
-    },
-    {
-      "community": 202,
-      "file_type": "code",
-      "id": "index_header",
-      "label": "Header()",
-      "norm_label": "header()",
-      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
-      "source_location": "L43"
-    },
-    {
-      "community": 202,
-      "file_type": "code",
-      "id": "index_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
-      "source_location": "L106"
-    },
-    {
-      "community": 202,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_assets_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/components/assets/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 202,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 203,
-      "file_type": "code",
       "id": "ordersummary_test_getbalancedueamount",
       "label": "getBalanceDueAmount()",
       "norm_label": "getbalancedueamount()",
@@ -66358,7 +66385,7 @@
       "source_location": "L40"
     },
     {
-      "community": 203,
+      "community": 202,
       "file_type": "code",
       "id": "ordersummary_test_getbalanceduelabel",
       "label": "getBalanceDueLabel()",
@@ -66367,7 +66394,7 @@
       "source_location": "L57"
     },
     {
-      "community": 203,
+      "community": 202,
       "file_type": "code",
       "id": "ordersummary_test_getbalanceduepanel",
       "label": "getBalanceDuePanel()",
@@ -66376,7 +66403,7 @@
       "source_location": "L66"
     },
     {
-      "community": 203,
+      "community": 202,
       "file_type": "code",
       "id": "ordersummary_test_stripwhitespace",
       "label": "stripWhitespace()",
@@ -66385,7 +66412,7 @@
       "source_location": "L36"
     },
     {
-      "community": 203,
+      "community": 202,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_ordersummary_test_tsx",
       "label": "OrderSummary.test.tsx",
@@ -66394,7 +66421,7 @@
       "source_location": "L1"
     },
     {
-      "community": 204,
+      "community": 203,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_paymentsaddedlist_test_tsx",
       "label": "PaymentsAddedList.test.tsx",
@@ -66403,7 +66430,7 @@
       "source_location": "L1"
     },
     {
-      "community": 204,
+      "community": 203,
       "file_type": "code",
       "id": "paymentsaddedlist_test_getsummaryamount",
       "label": "getSummaryAmount()",
@@ -66412,7 +66439,7 @@
       "source_location": "L27"
     },
     {
-      "community": 204,
+      "community": 203,
       "file_type": "code",
       "id": "paymentsaddedlist_test_getsummarylabel",
       "label": "getSummaryLabel()",
@@ -66421,7 +66448,7 @@
       "source_location": "L18"
     },
     {
-      "community": 204,
+      "community": 203,
       "file_type": "code",
       "id": "paymentsaddedlist_test_getsummarypanel",
       "label": "getSummaryPanel()",
@@ -66430,7 +66457,7 @@
       "source_location": "L40"
     },
     {
-      "community": 204,
+      "community": 203,
       "file_type": "code",
       "id": "paymentsaddedlist_test_stripwhitespace",
       "label": "stripWhitespace()",
@@ -66439,7 +66466,7 @@
       "source_location": "L14"
     },
     {
-      "community": 205,
+      "community": 204,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_productentry_tsx",
       "label": "ProductEntry.tsx",
@@ -66448,7 +66475,7 @@
       "source_location": "L1"
     },
     {
-      "community": 205,
+      "community": 204,
       "file_type": "code",
       "id": "productentry_handleclearsearch",
       "label": "handleClearSearch()",
@@ -66457,7 +66484,7 @@
       "source_location": "L234"
     },
     {
-      "community": 205,
+      "community": 204,
       "file_type": "code",
       "id": "productentry_handleopenquickadd",
       "label": "handleOpenQuickAdd()",
@@ -66466,7 +66493,7 @@
       "source_location": "L239"
     },
     {
-      "community": 205,
+      "community": 204,
       "file_type": "code",
       "id": "productentry_handlequickaddsubmit",
       "label": "handleQuickAddSubmit()",
@@ -66475,7 +66502,7 @@
       "source_location": "L272"
     },
     {
-      "community": 205,
+      "community": 204,
       "file_type": "code",
       "id": "productentry_resetquickaddform",
       "label": "resetQuickAddForm()",
@@ -66484,7 +66511,7 @@
       "source_location": "L263"
     },
     {
-      "community": 206,
+      "community": 205,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_registerdrawergate_tsx",
       "label": "RegisterDrawerGate.tsx",
@@ -66493,7 +66520,7 @@
       "source_location": "L1"
     },
     {
-      "community": 206,
+      "community": 205,
       "file_type": "code",
       "id": "registerdrawergate_handlecloseoutsubmit",
       "label": "handleCloseoutSubmit()",
@@ -66502,7 +66529,7 @@
       "source_location": "L80"
     },
     {
-      "community": 206,
+      "community": 205,
       "file_type": "code",
       "id": "registerdrawergate_handleopeningfloatcorrectionsubmit",
       "label": "handleOpeningFloatCorrectionSubmit()",
@@ -66511,7 +66538,7 @@
       "source_location": "L84"
     },
     {
-      "community": 206,
+      "community": 205,
       "file_type": "code",
       "id": "registerdrawergate_handlesubmit",
       "label": "handleSubmit()",
@@ -66520,7 +66547,7 @@
       "source_location": "L73"
     },
     {
-      "community": 206,
+      "community": 205,
       "file_type": "code",
       "id": "registerdrawergate_if",
       "label": "if()",
@@ -66529,7 +66556,7 @@
       "source_location": "L61"
     },
     {
-      "community": 207,
+      "community": 206,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodeview_tsx",
       "label": "PromoCodeView.tsx",
@@ -66538,7 +66565,7 @@
       "source_location": "L1"
     },
     {
-      "community": 207,
+      "community": 206,
       "file_type": "code",
       "id": "promocodeview_handleaddpromocode",
       "label": "handleAddPromoCode()",
@@ -66547,7 +66574,7 @@
       "source_location": "L157"
     },
     {
-      "community": 207,
+      "community": 206,
       "file_type": "code",
       "id": "promocodeview_handleupdatepromocode",
       "label": "handleUpdatePromoCode()",
@@ -66556,7 +66583,7 @@
       "source_location": "L230"
     },
     {
-      "community": 207,
+      "community": 206,
       "file_type": "code",
       "id": "promocodeview_updatehomepagediscountcode",
       "label": "updateHomepageDiscountCode()",
@@ -66565,7 +66592,7 @@
       "source_location": "L322"
     },
     {
-      "community": 207,
+      "community": 206,
       "file_type": "code",
       "id": "promocodeview_updateleaveareviewdiscountcode",
       "label": "updateLeaveAReviewDiscountCode()",
@@ -66574,7 +66601,7 @@
       "source_location": "L377"
     },
     {
-      "community": 208,
+      "community": 207,
       "file_type": "code",
       "id": "date_time_picker_handleclear",
       "label": "handleClear()",
@@ -66583,7 +66610,7 @@
       "source_location": "L99"
     },
     {
-      "community": 208,
+      "community": 207,
       "file_type": "code",
       "id": "date_time_picker_handledateselect",
       "label": "handleDateSelect()",
@@ -66592,7 +66619,7 @@
       "source_location": "L53"
     },
     {
-      "community": 208,
+      "community": 207,
       "file_type": "code",
       "id": "date_time_picker_handletimeblur",
       "label": "handleTimeBlur()",
@@ -66601,7 +66628,7 @@
       "source_location": "L75"
     },
     {
-      "community": 208,
+      "community": 207,
       "file_type": "code",
       "id": "date_time_picker_handletimechange",
       "label": "handleTimeChange()",
@@ -66610,7 +66637,7 @@
       "source_location": "L63"
     },
     {
-      "community": 208,
+      "community": 207,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_date_time_picker_tsx",
       "label": "date-time-picker.tsx",
@@ -66619,7 +66646,7 @@
       "source_location": "L1"
     },
     {
-      "community": 209,
+      "community": 208,
       "file_type": "code",
       "id": "custom_modal_example_basicmodalexample",
       "label": "BasicModalExample()",
@@ -66628,7 +66655,7 @@
       "source_location": "L7"
     },
     {
-      "community": 209,
+      "community": 208,
       "file_type": "code",
       "id": "custom_modal_example_customclosebuttonexample",
       "label": "CustomCloseButtonExample()",
@@ -66637,7 +66664,7 @@
       "source_location": "L69"
     },
     {
-      "community": 209,
+      "community": 208,
       "file_type": "code",
       "id": "custom_modal_example_custompositionmodalexample",
       "label": "CustomPositionModalExample()",
@@ -66646,7 +66673,7 @@
       "source_location": "L44"
     },
     {
-      "community": 209,
+      "community": 208,
       "file_type": "code",
       "id": "custom_modal_example_fullscreenmodalexample",
       "label": "FullScreenModalExample()",
@@ -66655,12 +66682,57 @@
       "source_location": "L103"
     },
     {
-      "community": 209,
+      "community": 208,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_custom_modal_example_tsx",
       "label": "custom-modal-example.tsx",
       "norm_label": "custom-modal-example.tsx",
       "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal-example.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 209,
+      "file_type": "code",
+      "id": "config_getruntimeorigin",
+      "label": "getRuntimeOrigin()",
+      "norm_label": "getruntimeorigin()",
+      "source_file": "packages/athena-webapp/src/config.ts",
+      "source_location": "L12"
+    },
+    {
+      "community": 209,
+      "file_type": "code",
+      "id": "config_islocalhost",
+      "label": "isLocalHost()",
+      "norm_label": "islocalhost()",
+      "source_file": "packages/athena-webapp/src/config.ts",
+      "source_location": "L20"
+    },
+    {
+      "community": 209,
+      "file_type": "code",
+      "id": "config_resolvestorefronturl",
+      "label": "resolveStoreFrontUrl()",
+      "norm_label": "resolvestorefronturl()",
+      "source_file": "packages/athena-webapp/src/config.ts",
+      "source_location": "L24"
+    },
+    {
+      "community": 209,
+      "file_type": "code",
+      "id": "config_trimtrailingslash",
+      "label": "trimTrailingSlash()",
+      "norm_label": "trimtrailingslash()",
+      "source_file": "packages/athena-webapp/src/config.ts",
+      "source_location": "L8"
+    },
+    {
+      "community": 209,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_config_ts",
+      "label": "config.ts",
+      "norm_label": "config.ts",
+      "source_file": "packages/athena-webapp/src/config.ts",
       "source_location": "L1"
     },
     {
@@ -66837,51 +66909,6 @@
     {
       "community": 210,
       "file_type": "code",
-      "id": "config_getruntimeorigin",
-      "label": "getRuntimeOrigin()",
-      "norm_label": "getruntimeorigin()",
-      "source_file": "packages/athena-webapp/src/config.ts",
-      "source_location": "L12"
-    },
-    {
-      "community": 210,
-      "file_type": "code",
-      "id": "config_islocalhost",
-      "label": "isLocalHost()",
-      "norm_label": "islocalhost()",
-      "source_file": "packages/athena-webapp/src/config.ts",
-      "source_location": "L20"
-    },
-    {
-      "community": 210,
-      "file_type": "code",
-      "id": "config_resolvestorefronturl",
-      "label": "resolveStoreFrontUrl()",
-      "norm_label": "resolvestorefronturl()",
-      "source_file": "packages/athena-webapp/src/config.ts",
-      "source_location": "L24"
-    },
-    {
-      "community": 210,
-      "file_type": "code",
-      "id": "config_trimtrailingslash",
-      "label": "trimTrailingSlash()",
-      "norm_label": "trimtrailingslash()",
-      "source_file": "packages/athena-webapp/src/config.ts",
-      "source_location": "L8"
-    },
-    {
-      "community": 210,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_config_ts",
-      "label": "config.ts",
-      "norm_label": "config.ts",
-      "source_file": "packages/athena-webapp/src/config.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 211,
-      "file_type": "code",
       "id": "browserfingerprint_buffertohex",
       "label": "bufferToHex()",
       "norm_label": "buffertohex()",
@@ -66889,7 +66916,7 @@
       "source_location": "L18"
     },
     {
-      "community": 211,
+      "community": 210,
       "file_type": "code",
       "id": "browserfingerprint_collectbrowserinfo",
       "label": "collectBrowserInfo()",
@@ -66898,7 +66925,7 @@
       "source_location": "L23"
     },
     {
-      "community": 211,
+      "community": 210,
       "file_type": "code",
       "id": "browserfingerprint_generatebrowserfingerprint",
       "label": "generateBrowserFingerprint()",
@@ -66907,7 +66934,7 @@
       "source_location": "L65"
     },
     {
-      "community": 211,
+      "community": 210,
       "file_type": "code",
       "id": "browserfingerprint_hashfingerprintsource",
       "label": "hashFingerprintSource()",
@@ -66916,7 +66943,7 @@
       "source_location": "L45"
     },
     {
-      "community": 211,
+      "community": 210,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_browserfingerprint_ts",
       "label": "browserFingerprint.ts",
@@ -66925,7 +66952,7 @@
       "source_location": "L1"
     },
     {
-      "community": 212,
+      "community": 211,
       "file_type": "code",
       "id": "imageutils_test_arraybuffer",
       "label": "arrayBuffer()",
@@ -66934,7 +66961,7 @@
       "source_location": "L78"
     },
     {
-      "community": 212,
+      "community": 211,
       "file_type": "code",
       "id": "imageutils_test_constructor",
       "label": "constructor()",
@@ -66943,7 +66970,7 @@
       "source_location": "L74"
     },
     {
-      "community": 212,
+      "community": 211,
       "file_type": "code",
       "id": "imageutils_test_mockimage",
       "label": "MockImage",
@@ -66952,7 +66979,7 @@
       "source_location": "L103"
     },
     {
-      "community": 212,
+      "community": 211,
       "file_type": "code",
       "id": "imageutils_test_mockimage_src",
       "label": ".src()",
@@ -66961,7 +66988,7 @@
       "source_location": "L109"
     },
     {
-      "community": 212,
+      "community": 211,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_imageutils_test_ts",
       "label": "imageUtils.test.ts",
@@ -66970,7 +66997,7 @@
       "source_location": "L1"
     },
     {
-      "community": 213,
+      "community": 212,
       "file_type": "code",
       "id": "imageutils_convertimagestojpg",
       "label": "convertImagesToJpg()",
@@ -66979,7 +67006,7 @@
       "source_location": "L75"
     },
     {
-      "community": 213,
+      "community": 212,
       "file_type": "code",
       "id": "imageutils_convertimagestowebp",
       "label": "convertImagesToWebp()",
@@ -66988,7 +67015,7 @@
       "source_location": "L26"
     },
     {
-      "community": 213,
+      "community": 212,
       "file_type": "code",
       "id": "imageutils_converttojpg",
       "label": "convertToJpg()",
@@ -66997,7 +67024,7 @@
       "source_location": "L38"
     },
     {
-      "community": 213,
+      "community": 212,
       "file_type": "code",
       "id": "imageutils_getuploadimagesdata",
       "label": "getUploadImagesData()",
@@ -67006,7 +67033,7 @@
       "source_location": "L4"
     },
     {
-      "community": 213,
+      "community": 212,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_imageutils_ts",
       "label": "imageUtils.ts",
@@ -67015,7 +67042,7 @@
       "source_location": "L1"
     },
     {
-      "community": 214,
+      "community": 213,
       "file_type": "code",
       "id": "cart_calculateposcarttotals",
       "label": "calculatePosCartTotals()",
@@ -67024,7 +67051,7 @@
       "source_location": "L3"
     },
     {
-      "community": 214,
+      "community": 213,
       "file_type": "code",
       "id": "cart_calculatepositemtotal",
       "label": "calculatePosItemTotal()",
@@ -67033,7 +67060,7 @@
       "source_location": "L29"
     },
     {
-      "community": 214,
+      "community": 213,
       "file_type": "code",
       "id": "cart_getposeffectiveprice",
       "label": "getPosEffectivePrice()",
@@ -67042,7 +67069,7 @@
       "source_location": "L33"
     },
     {
-      "community": 214,
+      "community": 213,
       "file_type": "code",
       "id": "cart_roundposamount",
       "label": "roundPosAmount()",
@@ -67051,7 +67078,7 @@
       "source_location": "L40"
     },
     {
-      "community": 214,
+      "community": 213,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_domain_cart_ts",
       "label": "cart.ts",
@@ -67060,7 +67087,7 @@
       "source_location": "L1"
     },
     {
-      "community": 215,
+      "community": 214,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_registergateway_ts",
       "label": "registerGateway.ts",
@@ -67069,7 +67096,7 @@
       "source_location": "L1"
     },
     {
-      "community": 215,
+      "community": 214,
       "file_type": "code",
       "id": "registergateway_mapregisterstatedto",
       "label": "mapRegisterStateDto()",
@@ -67078,7 +67105,7 @@
       "source_location": "L12"
     },
     {
-      "community": 215,
+      "community": 214,
       "file_type": "code",
       "id": "registergateway_mapterminaldto",
       "label": "mapTerminalDto()",
@@ -67087,7 +67114,7 @@
       "source_location": "L30"
     },
     {
-      "community": 215,
+      "community": 214,
       "file_type": "code",
       "id": "registergateway_useconvexregisterstate",
       "label": "useConvexRegisterState()",
@@ -67096,7 +67123,7 @@
       "source_location": "L36"
     },
     {
-      "community": 215,
+      "community": 214,
       "file_type": "code",
       "id": "registergateway_useconvexterminalbyfingerprint",
       "label": "useConvexTerminalByFingerprint()",
@@ -67105,7 +67132,7 @@
       "source_location": "L58"
     },
     {
-      "community": 216,
+      "community": 215,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_transactionutils_ts",
       "label": "transactionUtils.ts",
@@ -67114,7 +67141,7 @@
       "source_location": "L1"
     },
     {
-      "community": 216,
+      "community": 215,
       "file_type": "code",
       "id": "transactionutils_calculatechange",
       "label": "calculateChange()",
@@ -67123,7 +67150,7 @@
       "source_location": "L42"
     },
     {
-      "community": 216,
+      "community": 215,
       "file_type": "code",
       "id": "transactionutils_formatcurrency",
       "label": "formatCurrency()",
@@ -67132,7 +67159,7 @@
       "source_location": "L29"
     },
     {
-      "community": 216,
+      "community": 215,
       "file_type": "code",
       "id": "transactionutils_formattimestamp",
       "label": "formatTimestamp()",
@@ -67141,7 +67168,7 @@
       "source_location": "L49"
     },
     {
-      "community": 216,
+      "community": 215,
       "file_type": "code",
       "id": "transactionutils_generatetransactionnumber",
       "label": "generateTransactionNumber()",
@@ -67150,7 +67177,7 @@
       "source_location": "L14"
     },
     {
-      "community": 217,
+      "community": 216,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_timelineutils_ts",
       "label": "timelineUtils.ts",
@@ -67159,7 +67186,7 @@
       "source_location": "L1"
     },
     {
-      "community": 217,
+      "community": 216,
       "file_type": "code",
       "id": "timelineutils_enrichtimelineevent",
       "label": "enrichTimelineEvent()",
@@ -67168,7 +67195,7 @@
       "source_location": "L184"
     },
     {
-      "community": 217,
+      "community": 216,
       "file_type": "code",
       "id": "timelineutils_enrichtimelineevents",
       "label": "enrichTimelineEvents()",
@@ -67177,7 +67204,7 @@
       "source_location": "L200"
     },
     {
-      "community": 217,
+      "community": 216,
       "file_type": "code",
       "id": "timelineutils_gettimerangelabel",
       "label": "getTimeRangeLabel()",
@@ -67186,7 +67213,7 @@
       "source_location": "L244"
     },
     {
-      "community": 217,
+      "community": 216,
       "file_type": "code",
       "id": "timelineutils_groupeventsbytimeframe",
       "label": "groupEventsByTimeframe()",
@@ -67195,7 +67222,7 @@
       "source_location": "L206"
     },
     {
-      "community": 218,
+      "community": 217,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_procurement_index_tsx",
       "label": "procurement.index.tsx",
@@ -67204,7 +67231,7 @@
       "source_location": "L1"
     },
     {
-      "community": 218,
+      "community": 217,
       "file_type": "code",
       "id": "procurement_index_getnextprocurementmodesearch",
       "label": "getNextProcurementModeSearch()",
@@ -67213,7 +67240,7 @@
       "source_location": "L13"
     },
     {
-      "community": 218,
+      "community": 217,
       "file_type": "code",
       "id": "procurement_index_getnextprocurementpagesearch",
       "label": "getNextProcurementPageSearch()",
@@ -67222,7 +67249,7 @@
       "source_location": "L31"
     },
     {
-      "community": 218,
+      "community": 217,
       "file_type": "code",
       "id": "procurement_index_getnextprocurementselectedskusearch",
       "label": "getNextProcurementSelectedSkuSearch()",
@@ -67231,7 +67258,7 @@
       "source_location": "L41"
     },
     {
-      "community": 218,
+      "community": 217,
       "file_type": "code",
       "id": "procurement_index_procurementroute",
       "label": "ProcurementRoute()",
@@ -67240,7 +67267,7 @@
       "source_location": "L67"
     },
     {
-      "community": 219,
+      "community": 218,
       "file_type": "code",
       "id": "authed_authedcomponent",
       "label": "AuthedComponent()",
@@ -67249,7 +67276,7 @@
       "source_location": "L29"
     },
     {
-      "community": 219,
+      "community": 218,
       "file_type": "code",
       "id": "authed_layout",
       "label": "Layout()",
@@ -67258,7 +67285,7 @@
       "source_location": "L99"
     },
     {
-      "community": 219,
+      "community": 218,
       "file_type": "code",
       "id": "authed_topbar",
       "label": "TopBar()",
@@ -67267,7 +67294,7 @@
       "source_location": "L74"
     },
     {
-      "community": 219,
+      "community": 218,
       "file_type": "code",
       "id": "authed_usermenu",
       "label": "UserMenu()",
@@ -67276,12 +67303,57 @@
       "source_location": "L39"
     },
     {
-      "community": 219,
+      "community": 218,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_tsx",
       "label": "_authed.tsx",
       "norm_label": "_authed.tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 219,
+      "file_type": "code",
+      "id": "layout_completependingauthsync",
+      "label": "completePendingAuthSync()",
+      "norm_label": "completependingauthsync()",
+      "source_file": "packages/athena-webapp/src/routes/login/_layout.tsx",
+      "source_location": "L114"
+    },
+    {
+      "community": 219,
+      "file_type": "code",
+      "id": "layout_handlependingauthsync",
+      "label": "handlePendingAuthSync()",
+      "norm_label": "handlependingauthsync()",
+      "source_file": "packages/athena-webapp/src/routes/login/_layout.tsx",
+      "source_location": "L81"
+    },
+    {
+      "community": 219,
+      "file_type": "code",
+      "id": "layout_sleep",
+      "label": "sleep()",
+      "norm_label": "sleep()",
+      "source_file": "packages/athena-webapp/src/routes/login/_layout.tsx",
+      "source_location": "L23"
+    },
+    {
+      "community": 219,
+      "file_type": "code",
+      "id": "layout_usedocumentscrolllock",
+      "label": "useDocumentScrollLock()",
+      "norm_label": "usedocumentscrolllock()",
+      "source_file": "packages/athena-webapp/src/routes/login/_layout.tsx",
+      "source_location": "L27"
+    },
+    {
+      "community": 219,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_login_layout_tsx",
+      "label": "_layout.tsx",
+      "norm_label": "_layout.tsx",
+      "source_file": "packages/athena-webapp/src/routes/login/_layout.tsx",
       "source_location": "L1"
     },
     {
@@ -67458,51 +67530,6 @@
     {
       "community": 220,
       "file_type": "code",
-      "id": "layout_completependingauthsync",
-      "label": "completePendingAuthSync()",
-      "norm_label": "completependingauthsync()",
-      "source_file": "packages/athena-webapp/src/routes/login/_layout.tsx",
-      "source_location": "L114"
-    },
-    {
-      "community": 220,
-      "file_type": "code",
-      "id": "layout_handlependingauthsync",
-      "label": "handlePendingAuthSync()",
-      "norm_label": "handlependingauthsync()",
-      "source_file": "packages/athena-webapp/src/routes/login/_layout.tsx",
-      "source_location": "L81"
-    },
-    {
-      "community": 220,
-      "file_type": "code",
-      "id": "layout_sleep",
-      "label": "sleep()",
-      "norm_label": "sleep()",
-      "source_file": "packages/athena-webapp/src/routes/login/_layout.tsx",
-      "source_location": "L23"
-    },
-    {
-      "community": 220,
-      "file_type": "code",
-      "id": "layout_usedocumentscrolllock",
-      "label": "useDocumentScrollLock()",
-      "norm_label": "usedocumentscrolllock()",
-      "source_file": "packages/athena-webapp/src/routes/login/_layout.tsx",
-      "source_location": "L27"
-    },
-    {
-      "community": 220,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_login_layout_tsx",
-      "label": "_layout.tsx",
-      "norm_label": "_layout.tsx",
-      "source_file": "packages/athena-webapp/src/routes/login/_layout.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 221,
-      "file_type": "code",
       "id": "analytics_getproductviewcount",
       "label": "getProductViewCount()",
       "norm_label": "getproductviewcount()",
@@ -67510,7 +67537,7 @@
       "source_location": "L93"
     },
     {
-      "community": 221,
+      "community": 220,
       "file_type": "code",
       "id": "analytics_logout",
       "label": "logout()",
@@ -67519,7 +67546,7 @@
       "source_location": "L75"
     },
     {
-      "community": 221,
+      "community": 220,
       "file_type": "code",
       "id": "analytics_postanalytics",
       "label": "postAnalytics()",
@@ -67528,7 +67555,7 @@
       "source_location": "L4"
     },
     {
-      "community": 221,
+      "community": 220,
       "file_type": "code",
       "id": "analytics_updateanalyticsowner",
       "label": "updateAnalyticsOwner()",
@@ -67537,7 +67564,7 @@
       "source_location": "L47"
     },
     {
-      "community": 221,
+      "community": 220,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_analytics_ts",
       "label": "analytics.ts",
@@ -67546,7 +67573,7 @@
       "source_location": "L1"
     },
     {
-      "community": 222,
+      "community": 221,
       "file_type": "code",
       "id": "category_getallcategories",
       "label": "getAllCategories()",
@@ -67555,7 +67582,7 @@
       "source_location": "L11"
     },
     {
-      "community": 222,
+      "community": 221,
       "file_type": "code",
       "id": "category_getallcategorieswithsubcategories",
       "label": "getAllCategoriesWithSubcategories()",
@@ -67564,7 +67591,7 @@
       "source_location": "L25"
     },
     {
-      "community": 222,
+      "community": 221,
       "file_type": "code",
       "id": "category_getbaseurl",
       "label": "getBaseUrl()",
@@ -67573,7 +67600,7 @@
       "source_location": "L9"
     },
     {
-      "community": 222,
+      "community": 221,
       "file_type": "code",
       "id": "category_getcategory",
       "label": "getCategory()",
@@ -67582,7 +67609,7 @@
       "source_location": "L39"
     },
     {
-      "community": 222,
+      "community": 221,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_category_ts",
       "label": "category.ts",
@@ -67591,7 +67618,7 @@
       "source_location": "L1"
     },
     {
-      "community": 223,
+      "community": 222,
       "file_type": "code",
       "id": "onlineorder_getbaseurl",
       "label": "getBaseUrl()",
@@ -67600,7 +67627,7 @@
       "source_location": "L4"
     },
     {
-      "community": 223,
+      "community": 222,
       "file_type": "code",
       "id": "onlineorder_getorder",
       "label": "getOrder()",
@@ -67609,7 +67636,7 @@
       "source_location": "L24"
     },
     {
-      "community": 223,
+      "community": 222,
       "file_type": "code",
       "id": "onlineorder_getorders",
       "label": "getOrders()",
@@ -67618,7 +67645,7 @@
       "source_location": "L6"
     },
     {
-      "community": 223,
+      "community": 222,
       "file_type": "code",
       "id": "onlineorder_updateordersowner",
       "label": "updateOrdersOwner()",
@@ -67627,7 +67654,7 @@
       "source_location": "L42"
     },
     {
-      "community": 223,
+      "community": 222,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_onlineorder_ts",
       "label": "onlineOrder.ts",
@@ -67636,7 +67663,7 @@
       "source_location": "L1"
     },
     {
-      "community": 224,
+      "community": 223,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_storefrontuser_ts",
       "label": "storeFrontUser.ts",
@@ -67645,7 +67672,7 @@
       "source_location": "L1"
     },
     {
-      "community": 224,
+      "community": 223,
       "file_type": "code",
       "id": "storefrontuser_getactiveuser",
       "label": "getActiveUser()",
@@ -67654,7 +67681,7 @@
       "source_location": "L28"
     },
     {
-      "community": 224,
+      "community": 223,
       "file_type": "code",
       "id": "storefrontuser_getbaseurl",
       "label": "getBaseUrl()",
@@ -67663,7 +67690,7 @@
       "source_location": "L5"
     },
     {
-      "community": 224,
+      "community": 223,
       "file_type": "code",
       "id": "storefrontuser_getguest",
       "label": "getGuest()",
@@ -67672,7 +67699,7 @@
       "source_location": "L7"
     },
     {
-      "community": 224,
+      "community": 223,
       "file_type": "code",
       "id": "storefrontuser_updateuser",
       "label": "updateUser()",
@@ -67681,7 +67708,7 @@
       "source_location": "L46"
     },
     {
-      "community": 225,
+      "community": 224,
       "file_type": "code",
       "id": "homepage_enableprompts",
       "label": "enablePrompts()",
@@ -67690,7 +67717,7 @@
       "source_location": "L147"
     },
     {
-      "community": 225,
+      "community": 224,
       "file_type": "code",
       "id": "homepage_handleclickonleavereviewbutton",
       "label": "handleClickOnLeaveReviewButton()",
@@ -67699,7 +67726,7 @@
       "source_location": "L186"
     },
     {
-      "community": 225,
+      "community": 224,
       "file_type": "code",
       "id": "homepage_handlescroll",
       "label": "handleScroll()",
@@ -67708,7 +67735,7 @@
       "source_location": "L115"
     },
     {
-      "community": 225,
+      "community": 224,
       "file_type": "code",
       "id": "homepage_homepagereadyshell",
       "label": "HomePageReadyShell()",
@@ -67717,7 +67744,7 @@
       "source_location": "L31"
     },
     {
-      "community": 225,
+      "community": 224,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_homepage_tsx",
       "label": "HomePage.tsx",
@@ -67726,7 +67753,7 @@
       "source_location": "L1"
     },
     {
-      "community": 226,
+      "community": 225,
       "file_type": "code",
       "id": "inventorylevelbadge_lowstockbadge",
       "label": "LowStockBadge()",
@@ -67735,7 +67762,7 @@
       "source_location": "L14"
     },
     {
-      "community": 226,
+      "community": 225,
       "file_type": "code",
       "id": "inventorylevelbadge_sellingfastbadge",
       "label": "SellingFastBadge()",
@@ -67744,7 +67771,7 @@
       "source_location": "L22"
     },
     {
-      "community": 226,
+      "community": 225,
       "file_type": "code",
       "id": "inventorylevelbadge_sellingfastsignal",
       "label": "SellingFastSignal()",
@@ -67753,7 +67780,7 @@
       "source_location": "L30"
     },
     {
-      "community": 226,
+      "community": 225,
       "file_type": "code",
       "id": "inventorylevelbadge_soldoutbadge",
       "label": "SoldOutBadge()",
@@ -67762,7 +67789,7 @@
       "source_location": "L3"
     },
     {
-      "community": 226,
+      "community": 225,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_inventorylevelbadge_tsx",
       "label": "InventoryLevelBadge.tsx",
@@ -67771,7 +67798,7 @@
       "source_location": "L1"
     },
     {
-      "community": 227,
+      "community": 226,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_storefrontfailureobservability_ts",
       "label": "storefrontFailureObservability.ts",
@@ -67780,7 +67807,7 @@
       "source_location": "L1"
     },
     {
-      "community": 227,
+      "community": 226,
       "file_type": "code",
       "id": "storefrontfailureobservability_createstorefrontfailureevent",
       "label": "createStorefrontFailureEvent()",
@@ -67789,7 +67816,7 @@
       "source_location": "L136"
     },
     {
-      "community": 227,
+      "community": 226,
       "file_type": "code",
       "id": "storefrontfailureobservability_emitstorefrontfailure",
       "label": "emitStorefrontFailure()",
@@ -67798,7 +67825,7 @@
       "source_location": "L154"
     },
     {
-      "community": 227,
+      "community": 226,
       "file_type": "code",
       "id": "storefrontfailureobservability_inferstorefrontjourneyfromroute",
       "label": "inferStorefrontJourneyFromRoute()",
@@ -67807,7 +67834,7 @@
       "source_location": "L25"
     },
     {
-      "community": 227,
+      "community": 226,
       "file_type": "code",
       "id": "storefrontfailureobservability_normalizestorefronterror",
       "label": "normalizeStorefrontError()",
@@ -67816,7 +67843,7 @@
       "source_location": "L47"
     },
     {
-      "community": 228,
+      "community": 227,
       "file_type": "code",
       "id": "harness_behavior_test_createbrowser",
       "label": "createBrowser()",
@@ -67825,7 +67852,7 @@
       "source_location": "L52"
     },
     {
-      "community": 228,
+      "community": 227,
       "file_type": "code",
       "id": "harness_behavior_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -67834,7 +67861,7 @@
       "source_location": "L22"
     },
     {
-      "community": 228,
+      "community": 227,
       "file_type": "code",
       "id": "harness_behavior_test_createplaywrightmodule",
       "label": "createPlaywrightModule()",
@@ -67843,7 +67870,7 @@
       "source_location": "L44"
     },
     {
-      "community": 228,
+      "community": 227,
       "file_type": "code",
       "id": "harness_behavior_test_write",
       "label": "write()",
@@ -67852,7 +67879,7 @@
       "source_location": "L16"
     },
     {
-      "community": 228,
+      "community": 227,
       "file_type": "code",
       "id": "scripts_harness_behavior_test_ts",
       "label": "harness-behavior.test.ts",
@@ -67861,7 +67888,7 @@
       "source_location": "L1"
     },
     {
-      "community": 229,
+      "community": 228,
       "file_type": "code",
       "id": "harness_repo_validation_collectharnessrepovalidationselection",
       "label": "collectHarnessRepoValidationSelection()",
@@ -67870,7 +67897,7 @@
       "source_location": "L47"
     },
     {
-      "community": 229,
+      "community": 228,
       "file_type": "code",
       "id": "harness_repo_validation_matchesharnessrepovalidationpath",
       "label": "matchesHarnessRepoValidationPath()",
@@ -67879,7 +67906,7 @@
       "source_location": "L39"
     },
     {
-      "community": 229,
+      "community": 228,
       "file_type": "code",
       "id": "harness_repo_validation_normalizerepopath",
       "label": "normalizeRepoPath()",
@@ -67888,7 +67915,7 @@
       "source_location": "L29"
     },
     {
-      "community": 229,
+      "community": 228,
       "file_type": "code",
       "id": "harness_repo_validation_sortuniquepaths",
       "label": "sortUniquePaths()",
@@ -67897,12 +67924,57 @@
       "source_location": "L33"
     },
     {
-      "community": 229,
+      "community": 228,
       "file_type": "code",
       "id": "scripts_harness_repo_validation_ts",
       "label": "harness-repo-validation.ts",
       "norm_label": "harness-repo-validation.ts",
       "source_file": "scripts/harness-repo-validation.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 229,
+      "file_type": "code",
+      "id": "pre_commit_generated_artifacts_test_log",
+      "label": "log()",
+      "norm_label": "log()",
+      "source_file": "scripts/pre-commit-generated-artifacts.test.ts",
+      "source_location": "L73"
+    },
+    {
+      "community": 229,
+      "file_type": "code",
+      "id": "pre_commit_generated_artifacts_test_spawn",
+      "label": "spawn()",
+      "norm_label": "spawn()",
+      "source_file": "scripts/pre-commit-generated-artifacts.test.ts",
+      "source_location": "L65"
+    },
+    {
+      "community": 229,
+      "file_type": "code",
+      "id": "pre_commit_generated_artifacts_test_withtemprepo",
+      "label": "withTempRepo()",
+      "norm_label": "withtemprepo()",
+      "source_file": "scripts/pre-commit-generated-artifacts.test.ts",
+      "source_location": "L14"
+    },
+    {
+      "community": 229,
+      "file_type": "code",
+      "id": "pre_commit_generated_artifacts_test_writeconvexapifixture",
+      "label": "writeConvexApiFixture()",
+      "norm_label": "writeconvexapifixture()",
+      "source_file": "scripts/pre-commit-generated-artifacts.test.ts",
+      "source_location": "L24"
+    },
+    {
+      "community": 229,
+      "file_type": "code",
+      "id": "scripts_pre_commit_generated_artifacts_test_ts",
+      "label": "pre-commit-generated-artifacts.test.ts",
+      "norm_label": "pre-commit-generated-artifacts.test.ts",
+      "source_file": "scripts/pre-commit-generated-artifacts.test.ts",
       "source_location": "L1"
     },
     {
@@ -68079,51 +68151,6 @@
     {
       "community": 230,
       "file_type": "code",
-      "id": "pre_commit_generated_artifacts_test_log",
-      "label": "log()",
-      "norm_label": "log()",
-      "source_file": "scripts/pre-commit-generated-artifacts.test.ts",
-      "source_location": "L73"
-    },
-    {
-      "community": 230,
-      "file_type": "code",
-      "id": "pre_commit_generated_artifacts_test_spawn",
-      "label": "spawn()",
-      "norm_label": "spawn()",
-      "source_file": "scripts/pre-commit-generated-artifacts.test.ts",
-      "source_location": "L65"
-    },
-    {
-      "community": 230,
-      "file_type": "code",
-      "id": "pre_commit_generated_artifacts_test_withtemprepo",
-      "label": "withTempRepo()",
-      "norm_label": "withtemprepo()",
-      "source_file": "scripts/pre-commit-generated-artifacts.test.ts",
-      "source_location": "L14"
-    },
-    {
-      "community": 230,
-      "file_type": "code",
-      "id": "pre_commit_generated_artifacts_test_writeconvexapifixture",
-      "label": "writeConvexApiFixture()",
-      "norm_label": "writeconvexapifixture()",
-      "source_file": "scripts/pre-commit-generated-artifacts.test.ts",
-      "source_location": "L24"
-    },
-    {
-      "community": 230,
-      "file_type": "code",
-      "id": "scripts_pre_commit_generated_artifacts_test_ts",
-      "label": "pre-commit-generated-artifacts.test.ts",
-      "norm_label": "pre-commit-generated-artifacts.test.ts",
-      "source_file": "scripts/pre-commit-generated-artifacts.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 231,
-      "file_type": "code",
       "id": "scripts_worktree_manager_test_ts",
       "label": "worktree-manager.test.ts",
       "norm_label": "worktree-manager.test.ts",
@@ -68131,7 +68158,7 @@
       "source_location": "L1"
     },
     {
-      "community": 231,
+      "community": 230,
       "file_type": "code",
       "id": "worktree_manager_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -68140,7 +68167,7 @@
       "source_location": "L17"
     },
     {
-      "community": 231,
+      "community": 230,
       "file_type": "code",
       "id": "worktree_manager_test_fixtureenv",
       "label": "fixtureEnv()",
@@ -68149,7 +68176,7 @@
       "source_location": "L72"
     },
     {
-      "community": 231,
+      "community": 230,
       "file_type": "code",
       "id": "worktree_manager_test_rungit",
       "label": "runGit()",
@@ -68158,7 +68185,7 @@
       "source_location": "L45"
     },
     {
-      "community": 231,
+      "community": 230,
       "file_type": "code",
       "id": "worktree_manager_test_runworktreemanager",
       "label": "runWorktreeManager()",
@@ -68167,7 +68194,7 @@
       "source_location": "L59"
     },
     {
-      "community": 232,
+      "community": 231,
       "file_type": "code",
       "id": "convexpaginationantipatterncheck_test_createtemproot",
       "label": "createTempRoot()",
@@ -68176,7 +68203,7 @@
       "source_location": "L12"
     },
     {
-      "community": 232,
+      "community": 231,
       "file_type": "code",
       "id": "convexpaginationantipatterncheck_test_runpaginationcheck",
       "label": "runPaginationCheck()",
@@ -68185,7 +68212,7 @@
       "source_location": "L26"
     },
     {
-      "community": 232,
+      "community": 231,
       "file_type": "code",
       "id": "convexpaginationantipatterncheck_test_writeconvexfile",
       "label": "writeConvexFile()",
@@ -68194,7 +68221,7 @@
       "source_location": "L20"
     },
     {
-      "community": 232,
+      "community": 231,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_convexpaginationantipatterncheck_test_ts",
       "label": "convexPaginationAntiPatternCheck.test.ts",
@@ -68203,7 +68230,7 @@
       "source_location": "L1"
     },
     {
-      "community": 233,
+      "community": 232,
       "file_type": "code",
       "id": "domain_maskreceiptphone",
       "label": "maskReceiptPhone()",
@@ -68212,7 +68239,7 @@
       "source_location": "L67"
     },
     {
-      "community": 233,
+      "community": 232,
       "file_type": "code",
       "id": "domain_normalizereceiptphone",
       "label": "normalizeReceiptPhone()",
@@ -68221,7 +68248,7 @@
       "source_location": "L52"
     },
     {
-      "community": 233,
+      "community": 232,
       "file_type": "code",
       "id": "domain_statusisretryable",
       "label": "statusIsRetryable()",
@@ -68230,7 +68257,7 @@
       "source_location": "L79"
     },
     {
-      "community": 233,
+      "community": 232,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_customermessaging_domain_ts",
       "label": "domain.ts",
@@ -68239,7 +68266,7 @@
       "source_location": "L1"
     },
     {
-      "community": 234,
+      "community": 233,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_customermessaging_token_ts",
       "label": "token.ts",
@@ -68248,7 +68275,7 @@
       "source_location": "L1"
     },
     {
-      "community": 234,
+      "community": 233,
       "file_type": "code",
       "id": "token_createreceiptsharetoken",
       "label": "createReceiptShareToken()",
@@ -68257,7 +68284,7 @@
       "source_location": "L9"
     },
     {
-      "community": 234,
+      "community": 233,
       "file_type": "code",
       "id": "token_hashreceiptsharetoken",
       "label": "hashReceiptShareToken()",
@@ -68266,7 +68293,7 @@
       "source_location": "L15"
     },
     {
-      "community": 234,
+      "community": 233,
       "file_type": "code",
       "id": "token_tohex",
       "label": "toHex()",
@@ -68275,7 +68302,7 @@
       "source_location": "L3"
     },
     {
-      "community": 235,
+      "community": 234,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_customermessaging_webhooksecurity_ts",
       "label": "webhookSecurity.ts",
@@ -68284,7 +68311,7 @@
       "source_location": "L1"
     },
     {
-      "community": 235,
+      "community": 234,
       "file_type": "code",
       "id": "webhooksecurity_timingsafeequal",
       "label": "timingSafeEqual()",
@@ -68293,7 +68320,7 @@
       "source_location": "L9"
     },
     {
-      "community": 235,
+      "community": 234,
       "file_type": "code",
       "id": "webhooksecurity_tohex",
       "label": "toHex()",
@@ -68302,7 +68329,7 @@
       "source_location": "L3"
     },
     {
-      "community": 235,
+      "community": 234,
       "file_type": "code",
       "id": "webhooksecurity_verifymetawebhooksignature",
       "label": "verifyMetaWebhookSignature()",
@@ -68311,7 +68338,7 @@
       "source_location": "L22"
     },
     {
-      "community": 236,
+      "community": 235,
       "file_type": "code",
       "id": "checkout_hasallvisibilesessionitems",
       "label": "hasAllVisibileSessionItems()",
@@ -68320,7 +68347,7 @@
       "source_location": "L109"
     },
     {
-      "community": 236,
+      "community": 235,
       "file_type": "code",
       "id": "checkout_hasvalidcanonicalbagitem",
       "label": "hasValidCanonicalBagItem()",
@@ -68329,7 +68356,7 @@
       "source_location": "L84"
     },
     {
-      "community": 236,
+      "community": 235,
       "file_type": "code",
       "id": "checkout_hasvalidsessionitems",
       "label": "hasValidSessionItems()",
@@ -68338,7 +68365,7 @@
       "source_location": "L95"
     },
     {
-      "community": 236,
+      "community": 235,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_checkout_ts",
       "label": "checkout.ts",
@@ -68347,34 +68374,34 @@
       "source_location": "L1"
     },
     {
-      "community": 237,
+      "community": 236,
       "file_type": "code",
       "id": "expensesessions_test_buildsession",
       "label": "buildSession()",
       "norm_label": "buildsession()",
       "source_file": "packages/athena-webapp/convex/inventory/expenseSessions.test.ts",
-      "source_location": "L149"
+      "source_location": "L235"
     },
     {
-      "community": 237,
+      "community": 236,
       "file_type": "code",
       "id": "expensesessions_test_createmutationctx",
       "label": "createMutationCtx()",
       "norm_label": "createmutationctx()",
       "source_file": "packages/athena-webapp/convex/inventory/expenseSessions.test.ts",
-      "source_location": "L39"
+      "source_location": "L53"
     },
     {
-      "community": 237,
+      "community": 236,
       "file_type": "code",
       "id": "expensesessions_test_gethandler",
       "label": "getHandler()",
       "norm_label": "gethandler()",
       "source_file": "packages/athena-webapp/convex/inventory/expenseSessions.test.ts",
-      "source_location": "L164"
+      "source_location": "L250"
     },
     {
-      "community": 237,
+      "community": 236,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_expensesessions_test_ts",
       "label": "expenseSessions.test.ts",
@@ -68383,7 +68410,7 @@
       "source_location": "L1"
     },
     {
-      "community": 238,
+      "community": 237,
       "file_type": "code",
       "id": "expensetransactions_createexpensetransactionfromsessionhandler",
       "label": "createExpenseTransactionFromSessionHandler()",
@@ -68392,7 +68419,7 @@
       "source_location": "L50"
     },
     {
-      "community": 238,
+      "community": 237,
       "file_type": "code",
       "id": "expensetransactions_expensetransactionerror",
       "label": "expenseTransactionError()",
@@ -68401,7 +68428,7 @@
       "source_location": "L23"
     },
     {
-      "community": 238,
+      "community": 237,
       "file_type": "code",
       "id": "expensetransactions_formatexpensestaffprofilename",
       "label": "formatExpenseStaffProfileName()",
@@ -68410,7 +68437,7 @@
       "source_location": "L37"
     },
     {
-      "community": 238,
+      "community": 237,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_expensetransactions_ts",
       "label": "expenseTransactions.ts",
@@ -68419,7 +68446,7 @@
       "source_location": "L1"
     },
     {
-      "community": 239,
+      "community": 238,
       "file_type": "code",
       "id": "expensesessionexpiration_calculateexpensesessionexpiration",
       "label": "calculateExpenseSessionExpiration()",
@@ -68428,7 +68455,7 @@
       "source_location": "L21"
     },
     {
-      "community": 239,
+      "community": 238,
       "file_type": "code",
       "id": "expensesessionexpiration_getexpensesessionexpiryduration",
       "label": "getExpenseSessionExpiryDuration()",
@@ -68437,7 +68464,7 @@
       "source_location": "L35"
     },
     {
-      "community": 239,
+      "community": 238,
       "file_type": "code",
       "id": "expensesessionexpiration_getexpensesessionexpirydurationminutes",
       "label": "getExpenseSessionExpiryDurationMinutes()",
@@ -68446,13 +68473,49 @@
       "source_location": "L45"
     },
     {
-      "community": 239,
+      "community": 238,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_helpers_expensesessionexpiration_ts",
       "label": "expenseSessionExpiration.ts",
       "norm_label": "expensesessionexpiration.ts",
       "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionExpiration.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 239,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_helpers_sessionexpiration_ts",
+      "label": "sessionExpiration.ts",
+      "norm_label": "sessionexpiration.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionExpiration.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 239,
+      "file_type": "code",
+      "id": "sessionexpiration_calculatesessionexpiration",
+      "label": "calculateSessionExpiration()",
+      "norm_label": "calculatesessionexpiration()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionExpiration.ts",
+      "source_location": "L21"
+    },
+    {
+      "community": 239,
+      "file_type": "code",
+      "id": "sessionexpiration_getsessionexpiryduration",
+      "label": "getSessionExpiryDuration()",
+      "norm_label": "getsessionexpiryduration()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionExpiration.ts",
+      "source_location": "L35"
+    },
+    {
+      "community": 239,
+      "file_type": "code",
+      "id": "sessionexpiration_getsessionexpirydurationminutes",
+      "label": "getSessionExpiryDurationMinutes()",
+      "norm_label": "getsessionexpirydurationminutes()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionExpiration.ts",
+      "source_location": "L45"
     },
     {
       "community": 24,
@@ -68628,42 +68691,6 @@
     {
       "community": 240,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_helpers_sessionexpiration_ts",
-      "label": "sessionExpiration.ts",
-      "norm_label": "sessionexpiration.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionExpiration.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 240,
-      "file_type": "code",
-      "id": "sessionexpiration_calculatesessionexpiration",
-      "label": "calculateSessionExpiration()",
-      "norm_label": "calculatesessionexpiration()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionExpiration.ts",
-      "source_location": "L21"
-    },
-    {
-      "community": 240,
-      "file_type": "code",
-      "id": "sessionexpiration_getsessionexpiryduration",
-      "label": "getSessionExpiryDuration()",
-      "norm_label": "getsessionexpiryduration()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionExpiration.ts",
-      "source_location": "L35"
-    },
-    {
-      "community": 240,
-      "file_type": "code",
-      "id": "sessionexpiration_getsessionexpirydurationminutes",
-      "label": "getSessionExpiryDurationMinutes()",
-      "norm_label": "getsessionexpirydurationminutes()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionExpiration.ts",
-      "source_location": "L45"
-    },
-    {
-      "community": 241,
-      "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_possessions_trace_test_ts",
       "label": "posSessions.trace.test.ts",
       "norm_label": "possessions.trace.test.ts",
@@ -68671,7 +68698,7 @@
       "source_location": "L1"
     },
     {
-      "community": 241,
+      "community": 240,
       "file_type": "code",
       "id": "possessions_trace_test_buildsession",
       "label": "buildSession()",
@@ -68680,7 +68707,7 @@
       "source_location": "L393"
     },
     {
-      "community": 241,
+      "community": 240,
       "file_type": "code",
       "id": "possessions_trace_test_createmutationctx",
       "label": "createMutationCtx()",
@@ -68689,7 +68716,7 @@
       "source_location": "L160"
     },
     {
-      "community": 241,
+      "community": 240,
       "file_type": "code",
       "id": "possessions_trace_test_gethandler",
       "label": "getHandler()",
@@ -68698,7 +68725,7 @@
       "source_location": "L410"
     },
     {
-      "community": 242,
+      "community": 241,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_products_sku_test_ts",
       "label": "products.sku.test.ts",
@@ -68707,7 +68734,7 @@
       "source_location": "L1"
     },
     {
-      "community": 242,
+      "community": 241,
       "file_type": "code",
       "id": "products_sku_test_createproductsqueryctx",
       "label": "createProductsQueryCtx()",
@@ -68716,7 +68743,7 @@
       "source_location": "L112"
     },
     {
-      "community": 242,
+      "community": 241,
       "file_type": "code",
       "id": "products_sku_test_createskumutationctx",
       "label": "createSkuMutationCtx()",
@@ -68725,7 +68752,7 @@
       "source_location": "L23"
     },
     {
-      "community": 242,
+      "community": 241,
       "file_type": "code",
       "id": "products_sku_test_gethandler",
       "label": "getHandler()",
@@ -68734,7 +68761,7 @@
       "source_location": "L19"
     },
     {
-      "community": 243,
+      "community": 242,
       "file_type": "code",
       "id": "currency_todisplayamount",
       "label": "toDisplayAmount()",
@@ -68743,7 +68770,7 @@
       "source_location": "L5"
     },
     {
-      "community": 243,
+      "community": 242,
       "file_type": "code",
       "id": "currency_topesewas",
       "label": "toPesewas()",
@@ -68752,7 +68779,7 @@
       "source_location": "L1"
     },
     {
-      "community": 243,
+      "community": 242,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_lib_currency_ts",
       "label": "currency.ts",
@@ -68761,7 +68788,7 @@
       "source_location": "L1"
     },
     {
-      "community": 243,
+      "community": 242,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_currency_ts",
       "label": "currency.ts",
@@ -68770,7 +68797,7 @@
       "source_location": "L1"
     },
     {
-      "community": 244,
+      "community": 243,
       "file_type": "code",
       "id": "collections_getcachedtokenrecord",
       "label": "getCachedTokenRecord()",
@@ -68779,7 +68806,7 @@
       "source_location": "L26"
     },
     {
-      "community": 244,
+      "community": 243,
       "file_type": "code",
       "id": "collections_resolveaccesstokenforstore",
       "label": "resolveAccessTokenForStore()",
@@ -68788,7 +68815,7 @@
       "source_location": "L79"
     },
     {
-      "community": 244,
+      "community": 243,
       "file_type": "code",
       "id": "collections_resolveconfigforstore",
       "label": "resolveConfigForStore()",
@@ -68797,7 +68824,7 @@
       "source_location": "L33"
     },
     {
-      "community": 244,
+      "community": 243,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_collections_ts",
       "label": "collections.ts",
@@ -68806,7 +68833,7 @@
       "source_location": "L1"
     },
     {
-      "community": 245,
+      "community": 244,
       "file_type": "code",
       "id": "normalize_maskmtnpartyid",
       "label": "maskMtnPartyId()",
@@ -68815,7 +68842,7 @@
       "source_location": "L10"
     },
     {
-      "community": 245,
+      "community": 244,
       "file_type": "code",
       "id": "normalize_normalizecollectionstransaction",
       "label": "normalizeCollectionsTransaction()",
@@ -68824,7 +68851,7 @@
       "source_location": "L18"
     },
     {
-      "community": 245,
+      "community": 244,
       "file_type": "code",
       "id": "normalize_parsecollectionsnotificationrequest",
       "label": "parseCollectionsNotificationRequest()",
@@ -68833,7 +68860,7 @@
       "source_location": "L52"
     },
     {
-      "community": 245,
+      "community": 244,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_normalize_ts",
       "label": "normalize.ts",
@@ -68842,7 +68869,7 @@
       "source_location": "L1"
     },
     {
-      "community": 246,
+      "community": 245,
       "file_type": "code",
       "id": "approvalproofs_consumeapprovalproofwithctx",
       "label": "consumeApprovalProofWithCtx()",
@@ -68851,7 +68878,7 @@
       "source_location": "L98"
     },
     {
-      "community": 246,
+      "community": 245,
       "file_type": "code",
       "id": "approvalproofs_createapprovalproofwithctx",
       "label": "createApprovalProofWithCtx()",
@@ -68860,7 +68887,7 @@
       "source_location": "L56"
     },
     {
-      "community": 246,
+      "community": 245,
       "file_type": "code",
       "id": "approvalproofs_invalidapprovalproofresult",
       "label": "invalidApprovalProofResult()",
@@ -68869,7 +68896,7 @@
       "source_location": "L49"
     },
     {
-      "community": 246,
+      "community": 245,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_approvalproofs_ts",
       "label": "approvalProofs.ts",
@@ -68878,7 +68905,7 @@
       "source_location": "L1"
     },
     {
-      "community": 247,
+      "community": 246,
       "file_type": "code",
       "id": "operationalevents_buildoperationalevent",
       "label": "buildOperationalEvent()",
@@ -68887,7 +68914,7 @@
       "source_location": "L28"
     },
     {
-      "community": 247,
+      "community": 246,
       "file_type": "code",
       "id": "operationalevents_matchesexistingevent",
       "label": "matchesExistingEvent()",
@@ -68896,7 +68923,7 @@
       "source_location": "L42"
     },
     {
-      "community": 247,
+      "community": 246,
       "file_type": "code",
       "id": "operationalevents_recordoperationaleventwithctx",
       "label": "recordOperationalEventWithCtx()",
@@ -68905,7 +68932,7 @@
       "source_location": "L73"
     },
     {
-      "community": 247,
+      "community": 246,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_operationalevents_ts",
       "label": "operationalEvents.ts",
@@ -68914,7 +68941,7 @@
       "source_location": "L1"
     },
     {
-      "community": 248,
+      "community": 247,
       "file_type": "code",
       "id": "operationalworkitems_buildoperationalworkitem",
       "label": "buildOperationalWorkItem()",
@@ -68923,7 +68950,7 @@
       "source_location": "L8"
     },
     {
-      "community": 248,
+      "community": 247,
       "file_type": "code",
       "id": "operationalworkitems_createoperationalworkitemwithctx",
       "label": "createOperationalWorkItemWithCtx()",
@@ -68932,7 +68959,7 @@
       "source_location": "L32"
     },
     {
-      "community": 248,
+      "community": 247,
       "file_type": "code",
       "id": "operationalworkitems_updateoperationalworkitemstatuswithctx",
       "label": "updateOperationalWorkItemStatusWithCtx()",
@@ -68941,7 +68968,7 @@
       "source_location": "L64"
     },
     {
-      "community": 248,
+      "community": 247,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_operationalworkitems_ts",
       "label": "operationalWorkItems.ts",
@@ -68950,7 +68977,7 @@
       "source_location": "L1"
     },
     {
-      "community": 249,
+      "community": 248,
       "file_type": "code",
       "id": "operationsqueryindexes_test_expectindex",
       "label": "expectIndex()",
@@ -68959,7 +68986,7 @@
       "source_location": "L18"
     },
     {
-      "community": 249,
+      "community": 248,
       "file_type": "code",
       "id": "operationsqueryindexes_test_getsource",
       "label": "getSource()",
@@ -68968,7 +68995,7 @@
       "source_location": "L25"
     },
     {
-      "community": 249,
+      "community": 248,
       "file_type": "code",
       "id": "operationsqueryindexes_test_gettableindexes",
       "label": "getTableIndexes()",
@@ -68977,13 +69004,49 @@
       "source_location": "L11"
     },
     {
-      "community": 249,
+      "community": 248,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_operationsqueryindexes_test_ts",
       "label": "operationsQueryIndexes.test.ts",
       "norm_label": "operationsqueryindexes.test.ts",
       "source_file": "packages/athena-webapp/convex/operations/operationsQueryIndexes.test.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 249,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_registersessiontracing_test_ts",
+      "label": "registerSessionTracing.test.ts",
+      "norm_label": "registersessiontracing.test.ts",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 249,
+      "file_type": "code",
+      "id": "registersessiontracing_test_buildctx",
+      "label": "buildCtx()",
+      "norm_label": "buildctx()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.test.ts",
+      "source_location": "L33"
+    },
+    {
+      "community": 249,
+      "file_type": "code",
+      "id": "registersessiontracing_test_buildsession",
+      "label": "buildSession()",
+      "norm_label": "buildsession()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.test.ts",
+      "source_location": "L19"
+    },
+    {
+      "community": 249,
+      "file_type": "code",
+      "id": "registersessiontracing_test_formatstoredtraceamount",
+      "label": "formatStoredTraceAmount()",
+      "norm_label": "formatstoredtraceamount()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.test.ts",
+      "source_location": "L42"
     },
     {
       "community": 25,
@@ -69150,42 +69213,6 @@
     {
       "community": 250,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_registersessiontracing_test_ts",
-      "label": "registerSessionTracing.test.ts",
-      "norm_label": "registersessiontracing.test.ts",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 250,
-      "file_type": "code",
-      "id": "registersessiontracing_test_buildctx",
-      "label": "buildCtx()",
-      "norm_label": "buildctx()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.test.ts",
-      "source_location": "L33"
-    },
-    {
-      "community": 250,
-      "file_type": "code",
-      "id": "registersessiontracing_test_buildsession",
-      "label": "buildSession()",
-      "norm_label": "buildsession()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.test.ts",
-      "source_location": "L19"
-    },
-    {
-      "community": 250,
-      "file_type": "code",
-      "id": "registersessiontracing_test_formatstoredtraceamount",
-      "label": "formatStoredTraceAmount()",
-      "norm_label": "formatstoredtraceamount()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.test.ts",
-      "source_location": "L42"
-    },
-    {
-      "community": 251,
-      "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_registersessions_trace_test_ts",
       "label": "registerSessions.trace.test.ts",
       "norm_label": "registersessions.trace.test.ts",
@@ -69193,7 +69220,7 @@
       "source_location": "L1"
     },
     {
-      "community": 251,
+      "community": 250,
       "file_type": "code",
       "id": "registersessions_trace_test_buildregistersession",
       "label": "buildRegisterSession()",
@@ -69202,7 +69229,7 @@
       "source_location": "L31"
     },
     {
-      "community": 251,
+      "community": 250,
       "file_type": "code",
       "id": "registersessions_trace_test_createmutationctx",
       "label": "createMutationCtx()",
@@ -69211,7 +69238,7 @@
       "source_location": "L48"
     },
     {
-      "community": 251,
+      "community": 250,
       "file_type": "code",
       "id": "registersessions_trace_test_gethandler",
       "label": "getHandler()",
@@ -69220,7 +69247,7 @@
       "source_location": "L131"
     },
     {
-      "community": 252,
+      "community": 251,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_serviceintake_ts",
       "label": "serviceIntake.ts",
@@ -69229,7 +69256,7 @@
       "source_location": "L1"
     },
     {
-      "community": 252,
+      "community": 251,
       "file_type": "code",
       "id": "serviceintake_resolveserviceintakecustomerprofile",
       "label": "resolveServiceIntakeCustomerProfile()",
@@ -69238,7 +69265,7 @@
       "source_location": "L37"
     },
     {
-      "community": 252,
+      "community": 251,
       "file_type": "code",
       "id": "serviceintake_splitfullname",
       "label": "splitFullName()",
@@ -69247,7 +69274,7 @@
       "source_location": "L24"
     },
     {
-      "community": 252,
+      "community": 251,
       "file_type": "code",
       "id": "serviceintake_trimoptional",
       "label": "trimOptional()",
@@ -69256,7 +69283,7 @@
       "source_location": "L19"
     },
     {
-      "community": 253,
+      "community": 252,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_commands_register_ts",
       "label": "register.ts",
@@ -69265,7 +69292,7 @@
       "source_location": "L1"
     },
     {
-      "community": 253,
+      "community": 252,
       "file_type": "code",
       "id": "register_mapopendrawerusererror",
       "label": "mapOpenDrawerUserError()",
@@ -69274,7 +69301,7 @@
       "source_location": "L31"
     },
     {
-      "community": 253,
+      "community": 252,
       "file_type": "code",
       "id": "register_normalizeregisternumber",
       "label": "normalizeRegisterNumber()",
@@ -69283,7 +69310,7 @@
       "source_location": "L26"
     },
     {
-      "community": 253,
+      "community": 252,
       "file_type": "code",
       "id": "register_opendrawer",
       "label": "openDrawer()",
@@ -69292,7 +69319,7 @@
       "source_location": "L53"
     },
     {
-      "community": 254,
+      "community": 253,
       "file_type": "code",
       "id": "opendrawer_test_createdbgetmock",
       "label": "createDbGetMock()",
@@ -69301,7 +69328,7 @@
       "source_location": "L36"
     },
     {
-      "community": 254,
+      "community": 253,
       "file_type": "code",
       "id": "opendrawer_test_createdbmock",
       "label": "createDbMock()",
@@ -69310,7 +69337,7 @@
       "source_location": "L96"
     },
     {
-      "community": 254,
+      "community": 253,
       "file_type": "code",
       "id": "opendrawer_test_createdbquerymock",
       "label": "createDbQueryMock()",
@@ -69319,7 +69346,7 @@
       "source_location": "L71"
     },
     {
-      "community": 254,
+      "community": 253,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_opendrawer_test_ts",
       "label": "openDrawer.test.ts",
@@ -69328,7 +69355,7 @@
       "source_location": "L1"
     },
     {
-      "community": 255,
+      "community": 254,
       "file_type": "code",
       "id": "getregisterstate_buildregisterstate",
       "label": "buildRegisterState()",
@@ -69337,7 +69364,7 @@
       "source_location": "L21"
     },
     {
-      "community": 255,
+      "community": 254,
       "file_type": "code",
       "id": "getregisterstate_getactivesessionconflictforregisterstate",
       "label": "getActiveSessionConflictForRegisterState()",
@@ -69346,7 +69373,7 @@
       "source_location": "L42"
     },
     {
-      "community": 255,
+      "community": 254,
       "file_type": "code",
       "id": "getregisterstate_getregisterstate",
       "label": "getRegisterState()",
@@ -69355,7 +69382,7 @@
       "source_location": "L80"
     },
     {
-      "community": 255,
+      "community": 254,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_queries_getregisterstate_ts",
       "label": "getRegisterState.ts",
@@ -69364,7 +69391,7 @@
       "source_location": "L1"
     },
     {
-      "community": 256,
+      "community": 255,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_queries_searchcatalog_ts",
       "label": "searchCatalog.ts",
@@ -69373,7 +69400,7 @@
       "source_location": "L1"
     },
     {
-      "community": 256,
+      "community": 255,
       "file_type": "code",
       "id": "searchcatalog_lookupbybarcode",
       "label": "lookupByBarcode()",
@@ -69382,7 +69409,7 @@
       "source_location": "L126"
     },
     {
-      "community": 256,
+      "community": 255,
       "file_type": "code",
       "id": "searchcatalog_mapskutocatalogresult",
       "label": "mapSkuToCatalogResult()",
@@ -69391,7 +69418,7 @@
       "source_location": "L34"
     },
     {
-      "community": 256,
+      "community": 255,
       "file_type": "code",
       "id": "searchcatalog_searchproducts",
       "label": "searchProducts()",
@@ -69400,7 +69427,7 @@
       "source_location": "L76"
     },
     {
-      "community": 257,
+      "community": 256,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_sessioncommandrepository_ts",
       "label": "sessionCommandRepository.ts",
@@ -69409,7 +69436,7 @@
       "source_location": "L1"
     },
     {
-      "community": 257,
+      "community": 256,
       "file_type": "code",
       "id": "sessioncommandrepository_collectsessionitemsfrompages",
       "label": "collectSessionItemsFromPages()",
@@ -69418,7 +69445,7 @@
       "source_location": "L159"
     },
     {
-      "community": 257,
+      "community": 256,
       "file_type": "code",
       "id": "sessioncommandrepository_createsessioncommandrepository",
       "label": "createSessionCommandRepository()",
@@ -69427,7 +69454,7 @@
       "source_location": "L56"
     },
     {
-      "community": 257,
+      "community": 256,
       "file_type": "code",
       "id": "sessioncommandrepository_scansessionitembyskuinpages",
       "label": "scanSessionItemBySkuInPages()",
@@ -69436,7 +69463,7 @@
       "source_location": "L177"
     },
     {
-      "community": 258,
+      "community": 257,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_transactions_test_ts",
       "label": "transactions.test.ts",
@@ -69445,7 +69472,7 @@
       "source_location": "L1"
     },
     {
-      "community": 258,
+      "community": 257,
       "file_type": "code",
       "id": "transactions_test_exportreturns",
       "label": "exportReturns()",
@@ -69454,7 +69481,7 @@
       "source_location": "L30"
     },
     {
-      "community": 258,
+      "community": 257,
       "file_type": "code",
       "id": "transactions_test_gethandler",
       "label": "getHandler()",
@@ -69463,7 +69490,7 @@
       "source_location": "L38"
     },
     {
-      "community": 258,
+      "community": 257,
       "file_type": "code",
       "id": "transactions_test_parsevalidator",
       "label": "parseValidator()",
@@ -69472,7 +69499,7 @@
       "source_location": "L34"
     },
     {
-      "community": 259,
+      "community": 258,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_replenishment_test_ts",
       "label": "replenishment.test.ts",
@@ -69481,7 +69508,7 @@
       "source_location": "L1"
     },
     {
-      "community": 259,
+      "community": 258,
       "file_type": "code",
       "id": "replenishment_test_createreplenishmentqueryctx",
       "label": "createReplenishmentQueryCtx()",
@@ -69490,7 +69517,7 @@
       "source_location": "L21"
     },
     {
-      "community": 259,
+      "community": 258,
       "file_type": "code",
       "id": "replenishment_test_getsource",
       "label": "getSource()",
@@ -69499,13 +69526,49 @@
       "source_location": "L7"
     },
     {
-      "community": 259,
+      "community": 258,
       "file_type": "code",
       "id": "replenishment_test_toasynciterable",
       "label": "toAsyncIterable()",
       "norm_label": "toasynciterable()",
       "source_file": "packages/athena-webapp/convex/stockOps/replenishment.test.ts",
       "source_location": "L11"
+    },
+    {
+      "community": 259,
+      "file_type": "code",
+      "id": "commercequeryindexes_test_expectindex",
+      "label": "expectIndex()",
+      "norm_label": "expectindex()",
+      "source_file": "packages/athena-webapp/convex/storeFront/commerceQueryIndexes.test.ts",
+      "source_location": "L19"
+    },
+    {
+      "community": 259,
+      "file_type": "code",
+      "id": "commercequeryindexes_test_getsource",
+      "label": "getSource()",
+      "norm_label": "getsource()",
+      "source_file": "packages/athena-webapp/convex/storeFront/commerceQueryIndexes.test.ts",
+      "source_location": "L26"
+    },
+    {
+      "community": 259,
+      "file_type": "code",
+      "id": "commercequeryindexes_test_gettableindexes",
+      "label": "getTableIndexes()",
+      "norm_label": "gettableindexes()",
+      "source_file": "packages/athena-webapp/convex/storeFront/commerceQueryIndexes.test.ts",
+      "source_location": "L12"
+    },
+    {
+      "community": 259,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_commercequeryindexes_test_ts",
+      "label": "commerceQueryIndexes.test.ts",
+      "norm_label": "commercequeryindexes.test.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/commerceQueryIndexes.test.ts",
+      "source_location": "L1"
     },
     {
       "community": 26,
@@ -69672,42 +69735,6 @@
     {
       "community": 260,
       "file_type": "code",
-      "id": "commercequeryindexes_test_expectindex",
-      "label": "expectIndex()",
-      "norm_label": "expectindex()",
-      "source_file": "packages/athena-webapp/convex/storeFront/commerceQueryIndexes.test.ts",
-      "source_location": "L19"
-    },
-    {
-      "community": 260,
-      "file_type": "code",
-      "id": "commercequeryindexes_test_getsource",
-      "label": "getSource()",
-      "norm_label": "getsource()",
-      "source_file": "packages/athena-webapp/convex/storeFront/commerceQueryIndexes.test.ts",
-      "source_location": "L26"
-    },
-    {
-      "community": 260,
-      "file_type": "code",
-      "id": "commercequeryindexes_test_gettableindexes",
-      "label": "getTableIndexes()",
-      "norm_label": "gettableindexes()",
-      "source_file": "packages/athena-webapp/convex/storeFront/commerceQueryIndexes.test.ts",
-      "source_location": "L12"
-    },
-    {
-      "community": 260,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_commercequeryindexes_test_ts",
-      "label": "commerceQueryIndexes.test.ts",
-      "norm_label": "commercequeryindexes.test.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/commerceQueryIndexes.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 261,
-      "file_type": "code",
       "id": "customerengagementevents_findexistingcustomerprofileid",
       "label": "findExistingCustomerProfileId()",
       "norm_label": "findexistingcustomerprofileid()",
@@ -69715,7 +69742,7 @@
       "source_location": "L21"
     },
     {
-      "community": 261,
+      "community": 260,
       "file_type": "code",
       "id": "customerengagementevents_getstoreorganizationid",
       "label": "getStoreOrganizationId()",
@@ -69724,7 +69751,7 @@
       "source_location": "L63"
     },
     {
-      "community": 261,
+      "community": 260,
       "file_type": "code",
       "id": "customerengagementevents_recordstorefrontcustomermilestone",
       "label": "recordStoreFrontCustomerMilestone()",
@@ -69733,7 +69760,7 @@
       "source_location": "L71"
     },
     {
-      "community": 261,
+      "community": 260,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_helpers_customerengagementevents_ts",
       "label": "customerEngagementEvents.ts",
@@ -69742,7 +69769,7 @@
       "source_location": "L1"
     },
     {
-      "community": 262,
+      "community": 261,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_returnexchangeoperations_test_ts",
       "label": "returnExchangeOperations.test.ts",
@@ -69751,7 +69778,7 @@
       "source_location": "L1"
     },
     {
-      "community": 262,
+      "community": 261,
       "file_type": "code",
       "id": "returnexchangeoperations_test_createorderitem",
       "label": "createOrderItem()",
@@ -69760,7 +69787,7 @@
       "source_location": "L13"
     },
     {
-      "community": 262,
+      "community": 261,
       "file_type": "code",
       "id": "returnexchangeoperations_test_createreplacement",
       "label": "createReplacement()",
@@ -69769,7 +69796,7 @@
       "source_location": "L31"
     },
     {
-      "community": 262,
+      "community": 261,
       "file_type": "code",
       "id": "returnexchangeoperations_test_getsource",
       "label": "getSource()",
@@ -69778,7 +69805,7 @@
       "source_location": "L9"
     },
     {
-      "community": 263,
+      "community": 262,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_staffdisplayname_ts",
       "label": "staffDisplayName.ts",
@@ -69787,7 +69814,7 @@
       "source_location": "L1"
     },
     {
-      "community": 263,
+      "community": 262,
       "file_type": "code",
       "id": "staffdisplayname_formatstaffdisplayname",
       "label": "formatStaffDisplayName()",
@@ -69796,7 +69823,7 @@
       "source_location": "L12"
     },
     {
-      "community": 263,
+      "community": 262,
       "file_type": "code",
       "id": "staffdisplayname_formatstaffdisplaynameorfallback",
       "label": "formatStaffDisplayNameOrFallback()",
@@ -69805,7 +69832,7 @@
       "source_location": "L46"
     },
     {
-      "community": 263,
+      "community": 262,
       "file_type": "code",
       "id": "staffdisplayname_normalizenamepart",
       "label": "normalizeNamePart()",
@@ -69814,7 +69841,7 @@
       "source_location": "L7"
     },
     {
-      "community": 264,
+      "community": 263,
       "file_type": "code",
       "id": "attributesmanager_attributesmanager",
       "label": "AttributesManager()",
@@ -69823,7 +69850,7 @@
       "source_location": "L227"
     },
     {
-      "community": 264,
+      "community": 263,
       "file_type": "code",
       "id": "attributesmanager_colormanager",
       "label": "ColorManager()",
@@ -69832,7 +69859,7 @@
       "source_location": "L46"
     },
     {
-      "community": 264,
+      "community": 263,
       "file_type": "code",
       "id": "attributesmanager_sidebar",
       "label": "Sidebar()",
@@ -69841,7 +69868,7 @@
       "source_location": "L27"
     },
     {
-      "community": 264,
+      "community": 263,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_attributesmanager_tsx",
       "label": "AttributesManager.tsx",
@@ -69850,7 +69877,7 @@
       "source_location": "L1"
     },
     {
-      "community": 265,
+      "community": 264,
       "file_type": "code",
       "id": "attributestable_getproductattribute",
       "label": "getProductAttribute()",
@@ -69859,7 +69886,7 @@
       "source_location": "L55"
     },
     {
-      "community": 265,
+      "community": 264,
       "file_type": "code",
       "id": "attributestable_handlechange",
       "label": "handleChange()",
@@ -69868,7 +69895,7 @@
       "source_location": "L32"
     },
     {
-      "community": 265,
+      "community": 264,
       "file_type": "code",
       "id": "attributestable_onsubmit",
       "label": "onSubmit()",
@@ -69877,7 +69904,7 @@
       "source_location": "L211"
     },
     {
-      "community": 265,
+      "community": 264,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_attributestable_tsx",
       "label": "AttributesTable.tsx",
@@ -69886,7 +69913,7 @@
       "source_location": "L1"
     },
     {
-      "community": 266,
+      "community": 265,
       "file_type": "code",
       "id": "categorysubcategorymanager_categorymanager",
       "label": "CategoryManager()",
@@ -69895,7 +69922,7 @@
       "source_location": "L52"
     },
     {
-      "community": 266,
+      "community": 265,
       "file_type": "code",
       "id": "categorysubcategorymanager_sidebar",
       "label": "Sidebar()",
@@ -69904,7 +69931,7 @@
       "source_location": "L27"
     },
     {
-      "community": 266,
+      "community": 265,
       "file_type": "code",
       "id": "categorysubcategorymanager_subcategorymanager",
       "label": "SubcategoryManager()",
@@ -69913,7 +69940,7 @@
       "source_location": "L288"
     },
     {
-      "community": 266,
+      "community": 265,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_categorysubcategorymanager_tsx",
       "label": "CategorySubcategoryManager.tsx",
@@ -69922,7 +69949,7 @@
       "source_location": "L1"
     },
     {
-      "community": 267,
+      "community": 266,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_storefrontobservabilitypanel_tsx",
       "label": "StorefrontObservabilityPanel.tsx",
@@ -69931,7 +69958,7 @@
       "source_location": "L1"
     },
     {
-      "community": 267,
+      "community": 266,
       "file_type": "code",
       "id": "storefrontobservabilitypanel_formatlabel",
       "label": "formatLabel()",
@@ -69940,7 +69967,7 @@
       "source_location": "L15"
     },
     {
-      "community": 267,
+      "community": 266,
       "file_type": "code",
       "id": "storefrontobservabilitypanel_gettrafficsourcebadge",
       "label": "getTrafficSourceBadge()",
@@ -69949,7 +69976,7 @@
       "source_location": "L32"
     },
     {
-      "community": 267,
+      "community": 266,
       "file_type": "code",
       "id": "storefrontobservabilitypanel_summarycard",
       "label": "SummaryCard()",
@@ -69958,7 +69985,7 @@
       "source_location": "L19"
     },
     {
-      "community": 268,
+      "community": 267,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_utils_ts",
       "label": "utils.ts",
@@ -69967,7 +69994,7 @@
       "source_location": "L1"
     },
     {
-      "community": 268,
+      "community": 267,
       "file_type": "code",
       "id": "utils_countgroupedanalytics",
       "label": "countGroupedAnalytics()",
@@ -69976,7 +70003,7 @@
       "source_location": "L52"
     },
     {
-      "community": 268,
+      "community": 267,
       "file_type": "code",
       "id": "utils_groupanalytics",
       "label": "groupAnalytics()",
@@ -69985,7 +70012,7 @@
       "source_location": "L3"
     },
     {
-      "community": 268,
+      "community": 267,
       "file_type": "code",
       "id": "utils_groupproductviewsbyday",
       "label": "groupProductViewsByDay()",
@@ -69994,7 +70021,7 @@
       "source_location": "L90"
     },
     {
-      "community": 269,
+      "community": 268,
       "file_type": "code",
       "id": "maintenancemessageeditor_getcountdownstatus",
       "label": "getCountdownStatus()",
@@ -70003,7 +70030,7 @@
       "source_location": "L86"
     },
     {
-      "community": 269,
+      "community": 268,
       "file_type": "code",
       "id": "maintenancemessageeditor_handlecountdownchange",
       "label": "handleCountdownChange()",
@@ -70012,7 +70039,7 @@
       "source_location": "L76"
     },
     {
-      "community": 269,
+      "community": 268,
       "file_type": "code",
       "id": "maintenancemessageeditor_handlesave",
       "label": "handleSave()",
@@ -70021,13 +70048,49 @@
       "source_location": "L52"
     },
     {
-      "community": 269,
+      "community": 268,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_maintenancemessageeditor_tsx",
       "label": "MaintenanceMessageEditor.tsx",
       "norm_label": "maintenancemessageeditor.tsx",
       "source_file": "packages/athena-webapp/src/components/homepage/MaintenanceMessageEditor.tsx",
       "source_location": "L1"
+    },
+    {
+      "community": 269,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_homepage_shoplook_tsx",
+      "label": "ShopLook.tsx",
+      "norm_label": "shoplook.tsx",
+      "source_file": "packages/athena-webapp/src/components/homepage/ShopLook.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 269,
+      "file_type": "code",
+      "id": "shoplook_handlehighlighteditem",
+      "label": "handleHighlightedItem()",
+      "norm_label": "handlehighlighteditem()",
+      "source_file": "packages/athena-webapp/src/components/homepage/ShopLook.tsx",
+      "source_location": "L67"
+    },
+    {
+      "community": 269,
+      "file_type": "code",
+      "id": "shoplook_handleimageupdate",
+      "label": "handleImageUpdate()",
+      "norm_label": "handleimageupdate()",
+      "source_file": "packages/athena-webapp/src/components/homepage/ShopLook.tsx",
+      "source_location": "L90"
+    },
+    {
+      "community": 269,
+      "file_type": "code",
+      "id": "shoplook_ondragend",
+      "label": "onDragEnd()",
+      "norm_label": "ondragend()",
+      "source_file": "packages/athena-webapp/src/components/homepage/ShopLook.tsx",
+      "source_location": "L73"
     },
     {
       "community": 27,
@@ -70194,42 +70257,6 @@
     {
       "community": 270,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_homepage_shoplook_tsx",
-      "label": "ShopLook.tsx",
-      "norm_label": "shoplook.tsx",
-      "source_file": "packages/athena-webapp/src/components/homepage/ShopLook.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 270,
-      "file_type": "code",
-      "id": "shoplook_handlehighlighteditem",
-      "label": "handleHighlightedItem()",
-      "norm_label": "handlehighlighteditem()",
-      "source_file": "packages/athena-webapp/src/components/homepage/ShopLook.tsx",
-      "source_location": "L67"
-    },
-    {
-      "community": 270,
-      "file_type": "code",
-      "id": "shoplook_handleimageupdate",
-      "label": "handleImageUpdate()",
-      "norm_label": "handleimageupdate()",
-      "source_file": "packages/athena-webapp/src/components/homepage/ShopLook.tsx",
-      "source_location": "L90"
-    },
-    {
-      "community": 270,
-      "file_type": "code",
-      "id": "shoplook_ondragend",
-      "label": "onDragEnd()",
-      "norm_label": "ondragend()",
-      "source_file": "packages/athena-webapp/src/components/homepage/ShopLook.tsx",
-      "source_location": "L73"
-    },
-    {
-      "community": 271,
-      "file_type": "code",
       "id": "commandapprovaldialog_getasyncresolution",
       "label": "getAsyncResolution()",
       "norm_label": "getasyncresolution()",
@@ -70237,7 +70264,7 @@
       "source_location": "L78"
     },
     {
-      "community": 271,
+      "community": 270,
       "file_type": "code",
       "id": "commandapprovaldialog_getinlinemanagerresolution",
       "label": "getInlineManagerResolution()",
@@ -70246,7 +70273,7 @@
       "source_location": "L67"
     },
     {
-      "community": 271,
+      "community": 270,
       "file_type": "code",
       "id": "commandapprovaldialog_tostaffauthenticationresult",
       "label": "toStaffAuthenticationResult()",
@@ -70255,7 +70282,7 @@
       "source_location": "L85"
     },
     {
-      "community": 271,
+      "community": 270,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_commandapprovaldialog_tsx",
       "label": "CommandApprovalDialog.tsx",
@@ -70264,7 +70291,7 @@
       "source_location": "L1"
     },
     {
-      "community": 272,
+      "community": 271,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_useapprovedcommand_tsx",
       "label": "useApprovedCommand.tsx",
@@ -70273,7 +70300,7 @@
       "source_location": "L1"
     },
     {
-      "community": 272,
+      "community": 271,
       "file_type": "code",
       "id": "useapprovedcommand_hasasyncapprovalrequest",
       "label": "hasAsyncApprovalRequest()",
@@ -70282,7 +70309,7 @@
       "source_location": "L67"
     },
     {
-      "community": 272,
+      "community": 271,
       "file_type": "code",
       "id": "useapprovedcommand_hasinlinemanagerproof",
       "label": "hasInlineManagerProof()",
@@ -70291,7 +70318,7 @@
       "source_location": "L61"
     },
     {
-      "community": 272,
+      "community": 271,
       "file_type": "code",
       "id": "useapprovedcommand_useapprovedcommand",
       "label": "useApprovedCommand()",
@@ -70300,7 +70327,7 @@
       "source_location": "L73"
     },
     {
-      "community": 273,
+      "community": 272,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_returnexchangeview_tsx",
       "label": "ReturnExchangeView.tsx",
@@ -70309,7 +70336,7 @@
       "source_location": "L1"
     },
     {
-      "community": 273,
+      "community": 272,
       "file_type": "code",
       "id": "returnexchangeview_handlesubmit",
       "label": "handleSubmit()",
@@ -70318,7 +70345,7 @@
       "source_location": "L105"
     },
     {
-      "community": 273,
+      "community": 272,
       "file_type": "code",
       "id": "returnexchangeview_resetreplacementfields",
       "label": "resetReplacementFields()",
@@ -70327,7 +70354,7 @@
       "source_location": "L97"
     },
     {
-      "community": 273,
+      "community": 272,
       "file_type": "code",
       "id": "returnexchangeview_toggleitem",
       "label": "toggleItem()",
@@ -70336,7 +70363,7 @@
       "source_location": "L83"
     },
     {
-      "community": 274,
+      "community": 273,
       "file_type": "code",
       "id": "newtransactionview_handlequickstart",
       "label": "handleQuickStart()",
@@ -70345,7 +70372,7 @@
       "source_location": "L91"
     },
     {
-      "community": 274,
+      "community": 273,
       "file_type": "code",
       "id": "newtransactionview_handlestarttransaction",
       "label": "handleStartTransaction()",
@@ -70354,7 +70381,7 @@
       "source_location": "L68"
     },
     {
-      "community": 274,
+      "community": 273,
       "file_type": "code",
       "id": "newtransactionview_navigation",
       "label": "Navigation()",
@@ -70363,7 +70390,7 @@
       "source_location": "L22"
     },
     {
-      "community": 274,
+      "community": 273,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_newtransactionview_tsx",
       "label": "NewTransactionView.tsx",
@@ -70372,7 +70399,7 @@
       "source_location": "L1"
     },
     {
-      "community": 275,
+      "community": 274,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_transactions_transactionview_test_tsx",
       "label": "TransactionView.test.tsx",
@@ -70381,7 +70408,7 @@
       "source_location": "L1"
     },
     {
-      "community": 275,
+      "community": 274,
       "file_type": "code",
       "id": "transactionview_test_async",
       "label": "async()",
@@ -70390,7 +70417,7 @@
       "source_location": "L164"
     },
     {
-      "community": 275,
+      "community": 274,
       "file_type": "code",
       "id": "transactionview_test_mocktransactionmutations",
       "label": "mockTransactionMutations()",
@@ -70399,7 +70426,7 @@
       "source_location": "L388"
     },
     {
-      "community": 275,
+      "community": 274,
       "file_type": "code",
       "id": "transactionview_test_paymentapprovalrequirement",
       "label": "paymentApprovalRequirement()",
@@ -70408,7 +70435,7 @@
       "source_location": "L347"
     },
     {
-      "community": 276,
+      "community": 275,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_transactions_transactionsview_tsx",
       "label": "TransactionsView.tsx",
@@ -70417,7 +70444,7 @@
       "source_location": "L1"
     },
     {
-      "community": 276,
+      "community": 275,
       "file_type": "code",
       "id": "transactionsview_formatpaymentmethod",
       "label": "formatPaymentMethod()",
@@ -70426,7 +70453,7 @@
       "source_location": "L22"
     },
     {
-      "community": 276,
+      "community": 275,
       "file_type": "code",
       "id": "transactionsview_formatregisterfilterlabel",
       "label": "formatRegisterFilterLabel()",
@@ -70435,7 +70462,7 @@
       "source_location": "L27"
     },
     {
-      "community": 276,
+      "community": 275,
       "file_type": "code",
       "id": "transactionsview_istoday",
       "label": "isToday()",
@@ -70444,7 +70471,7 @@
       "source_location": "L40"
     },
     {
-      "community": 277,
+      "community": 276,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_procurement_procurementview_test_tsx",
       "label": "ProcurementView.test.tsx",
@@ -70453,7 +70480,7 @@
       "source_location": "L1"
     },
     {
-      "community": 277,
+      "community": 276,
       "file_type": "code",
       "id": "procurementview_test_choosedraftvendor",
       "label": "chooseDraftVendor()",
@@ -70462,7 +70489,7 @@
       "source_location": "L324"
     },
     {
-      "community": 277,
+      "community": 276,
       "file_type": "code",
       "id": "procurementview_test_installmutationmocks",
       "label": "installMutationMocks()",
@@ -70471,7 +70498,7 @@
       "source_location": "L290"
     },
     {
-      "community": 277,
+      "community": 276,
       "file_type": "code",
       "id": "procurementview_test_makerecommendation",
       "label": "makeRecommendation()",
@@ -70480,7 +70507,7 @@
       "source_location": "L279"
     },
     {
-      "community": 278,
+      "community": 277,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_productstock_tsx",
       "label": "ProductStock.tsx",
@@ -70489,7 +70516,7 @@
       "source_location": "L1"
     },
     {
-      "community": 278,
+      "community": 277,
       "file_type": "code",
       "id": "productstock_lowstockstatus",
       "label": "LowStockStatus()",
@@ -70498,7 +70525,7 @@
       "source_location": "L63"
     },
     {
-      "community": 278,
+      "community": 277,
       "file_type": "code",
       "id": "productstock_outofstockstatus",
       "label": "OutOfStockStatus()",
@@ -70507,7 +70534,7 @@
       "source_location": "L54"
     },
     {
-      "community": 278,
+      "community": 277,
       "file_type": "code",
       "id": "productstock_productstockstatus",
       "label": "ProductStockStatus()",
@@ -70516,7 +70543,7 @@
       "source_location": "L11"
     },
     {
-      "community": 279,
+      "community": 278,
       "file_type": "code",
       "id": "complimentaryproductsview_body",
       "label": "Body()",
@@ -70525,7 +70552,7 @@
       "source_location": "L16"
     },
     {
-      "community": 279,
+      "community": 278,
       "file_type": "code",
       "id": "complimentaryproductsview_complimentaryproductsview",
       "label": "ComplimentaryProductsView()",
@@ -70534,7 +70561,7 @@
       "source_location": "L35"
     },
     {
-      "community": 279,
+      "community": 278,
       "file_type": "code",
       "id": "complimentaryproductsview_navigation",
       "label": "Navigation()",
@@ -70543,13 +70570,49 @@
       "source_location": "L6"
     },
     {
-      "community": 279,
+      "community": 278,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_complimentary_complimentaryproductsview_tsx",
       "label": "ComplimentaryProductsView.tsx",
       "norm_label": "complimentaryproductsview.tsx",
       "source_file": "packages/athena-webapp/src/components/products/complimentary/ComplimentaryProductsView.tsx",
       "source_location": "L1"
+    },
+    {
+      "community": 279,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_promocodemoney_ts",
+      "label": "promoCodeMoney.ts",
+      "norm_label": "promocodemoney.ts",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/promoCodeMoney.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 279,
+      "file_type": "code",
+      "id": "promocodemoney_parsepromodiscountinput",
+      "label": "parsePromoDiscountInput()",
+      "norm_label": "parsepromodiscountinput()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/promoCodeMoney.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 279,
+      "file_type": "code",
+      "id": "promocodemoney_promodiscountdisplaytext",
+      "label": "promoDiscountDisplayText()",
+      "norm_label": "promodiscountdisplaytext()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/promoCodeMoney.ts",
+      "source_location": "L30"
+    },
+    {
+      "community": 279,
+      "file_type": "code",
+      "id": "promocodemoney_promodiscountinputvalue",
+      "label": "promoDiscountInputValue()",
+      "norm_label": "promodiscountinputvalue()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/promoCodeMoney.ts",
+      "source_location": "L21"
     },
     {
       "community": 28,
@@ -70716,42 +70779,6 @@
     {
       "community": 280,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_promocodemoney_ts",
-      "label": "promoCodeMoney.ts",
-      "norm_label": "promocodemoney.ts",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/promoCodeMoney.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 280,
-      "file_type": "code",
-      "id": "promocodemoney_parsepromodiscountinput",
-      "label": "parsePromoDiscountInput()",
-      "norm_label": "parsepromodiscountinput()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/promoCodeMoney.ts",
-      "source_location": "L5"
-    },
-    {
-      "community": 280,
-      "file_type": "code",
-      "id": "promocodemoney_promodiscountdisplaytext",
-      "label": "promoDiscountDisplayText()",
-      "norm_label": "promodiscountdisplaytext()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/promoCodeMoney.ts",
-      "source_location": "L30"
-    },
-    {
-      "community": 280,
-      "file_type": "code",
-      "id": "promocodemoney_promodiscountinputvalue",
-      "label": "promoDiscountInputValue()",
-      "norm_label": "promodiscountinputvalue()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/promoCodeMoney.ts",
-      "source_location": "L21"
-    },
-    {
-      "community": 281,
-      "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_servicecasesview_tsx",
       "label": "ServiceCasesView.tsx",
       "norm_label": "servicecasesview.tsx",
@@ -70759,7 +70786,7 @@
       "source_location": "L1"
     },
     {
-      "community": 281,
+      "community": 280,
       "file_type": "code",
       "id": "servicecasesview_applycommandresult",
       "label": "applyCommandResult()",
@@ -70768,7 +70795,7 @@
       "source_location": "L178"
     },
     {
-      "community": 281,
+      "community": 280,
       "file_type": "code",
       "id": "servicecasesview_handlecreatecase",
       "label": "handleCreateCase()",
@@ -70777,7 +70804,7 @@
       "source_location": "L205"
     },
     {
-      "community": 281,
+      "community": 280,
       "file_type": "code",
       "id": "servicecasesview_withsavestate",
       "label": "withSaveState()",
@@ -70786,7 +70813,7 @@
       "source_location": "L806"
     },
     {
-      "community": 282,
+      "community": 281,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_traces_workflowtraceview_tsx",
       "label": "WorkflowTraceView.tsx",
@@ -70795,7 +70822,7 @@
       "source_location": "L1"
     },
     {
-      "community": 282,
+      "community": 281,
       "file_type": "code",
       "id": "workflowtraceview_formattracelabel",
       "label": "formatTraceLabel()",
@@ -70804,7 +70831,7 @@
       "source_location": "L41"
     },
     {
-      "community": 282,
+      "community": 281,
       "file_type": "code",
       "id": "workflowtraceview_getstatustone",
       "label": "getStatusTone()",
@@ -70813,7 +70840,7 @@
       "source_location": "L45"
     },
     {
-      "community": 282,
+      "community": 281,
       "file_type": "code",
       "id": "workflowtraceview_workflowtraceheader",
       "label": "WorkflowTraceHeader()",
@@ -70822,7 +70849,7 @@
       "source_location": "L65"
     },
     {
-      "community": 283,
+      "community": 282,
       "file_type": "code",
       "id": "engagementmetrics_formatlastactivity",
       "label": "formatLastActivity()",
@@ -70831,7 +70858,7 @@
       "source_location": "L75"
     },
     {
-      "community": 283,
+      "community": 282,
       "file_type": "code",
       "id": "engagementmetrics_getdeviceicon",
       "label": "getDeviceIcon()",
@@ -70840,7 +70867,7 @@
       "source_location": "L82"
     },
     {
-      "community": 283,
+      "community": 282,
       "file_type": "code",
       "id": "engagementmetrics_getdevicelabel",
       "label": "getDeviceLabel()",
@@ -70849,7 +70876,7 @@
       "source_location": "L93"
     },
     {
-      "community": 283,
+      "community": 282,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_engagementmetrics_tsx",
       "label": "EngagementMetrics.tsx",
@@ -70858,7 +70885,7 @@
       "source_location": "L1"
     },
     {
-      "community": 284,
+      "community": 283,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_riskindicators_tsx",
       "label": "RiskIndicators.tsx",
@@ -70867,7 +70894,7 @@
       "source_location": "L1"
     },
     {
-      "community": 284,
+      "community": 283,
       "file_type": "code",
       "id": "riskindicators_getriskicon",
       "label": "getRiskIcon()",
@@ -70876,7 +70903,7 @@
       "source_location": "L15"
     },
     {
-      "community": 284,
+      "community": 283,
       "file_type": "code",
       "id": "riskindicators_getriskstyles",
       "label": "getRiskStyles()",
@@ -70885,7 +70912,7 @@
       "source_location": "L28"
     },
     {
-      "community": 284,
+      "community": 283,
       "file_type": "code",
       "id": "riskindicators_riskindicators",
       "label": "RiskIndicators()",
@@ -70894,7 +70921,7 @@
       "source_location": "L54"
     },
     {
-      "community": 285,
+      "community": 284,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetproducts_ts",
       "label": "useGetProducts.ts",
@@ -70903,7 +70930,7 @@
       "source_location": "L1"
     },
     {
-      "community": 285,
+      "community": 284,
       "file_type": "code",
       "id": "usegetproducts_usegetarchivedproducts",
       "label": "useGetArchivedProducts()",
@@ -70912,7 +70939,7 @@
       "source_location": "L36"
     },
     {
-      "community": 285,
+      "community": 284,
       "file_type": "code",
       "id": "usegetproducts_usegetproducts",
       "label": "useGetProducts()",
@@ -70921,7 +70948,7 @@
       "source_location": "L7"
     },
     {
-      "community": 285,
+      "community": 284,
       "file_type": "code",
       "id": "usegetproducts_usegetunresolvedproducts",
       "label": "useGetUnresolvedProducts()",
@@ -70930,7 +70957,7 @@
       "source_location": "L40"
     },
     {
-      "community": 286,
+      "community": 285,
       "file_type": "code",
       "id": "customerobservabilitytimeline_formatobservabilitylabel",
       "label": "formatObservabilityLabel()",
@@ -70939,7 +70966,7 @@
       "source_location": "L66"
     },
     {
-      "community": 286,
+      "community": 285,
       "file_type": "code",
       "id": "customerobservabilitytimeline_getdeviceicon",
       "label": "getDeviceIcon()",
@@ -70948,7 +70975,7 @@
       "source_location": "L121"
     },
     {
-      "community": 286,
+      "community": 285,
       "file_type": "code",
       "id": "customerobservabilitytimeline_getobservabilitystatusstyles",
       "label": "getObservabilityStatusStyles()",
@@ -70957,7 +70984,7 @@
       "source_location": "L74"
     },
     {
-      "community": 286,
+      "community": 285,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_customerobservabilitytimeline_ts",
       "label": "customerObservabilityTimeline.ts",
@@ -70966,7 +70993,7 @@
       "source_location": "L1"
     },
     {
-      "community": 287,
+      "community": 286,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_runcommand_ts",
       "label": "runCommand.ts",
@@ -70975,7 +71002,7 @@
       "source_location": "L1"
     },
     {
-      "community": 287,
+      "community": 286,
       "file_type": "code",
       "id": "runcommand_extracttraceid",
       "label": "extractTraceId()",
@@ -70984,7 +71011,7 @@
       "source_location": "L34"
     },
     {
-      "community": 287,
+      "community": 286,
       "file_type": "code",
       "id": "runcommand_isapprovalrequiredresult",
       "label": "isApprovalRequiredResult()",
@@ -70993,7 +71020,7 @@
       "source_location": "L28"
     },
     {
-      "community": 287,
+      "community": 286,
       "file_type": "code",
       "id": "runcommand_runcommand",
       "label": "runCommand()",
@@ -71002,7 +71029,7 @@
       "source_location": "L48"
     },
     {
-      "community": 288,
+      "community": 287,
       "file_type": "code",
       "id": "barcodeutils_extractbarcodefrominput",
       "label": "extractBarcodeFromInput()",
@@ -71011,7 +71038,7 @@
       "source_location": "L51"
     },
     {
-      "community": 288,
+      "community": 287,
       "file_type": "code",
       "id": "barcodeutils_isurlorbarcode",
       "label": "isUrlOrBarcode()",
@@ -71020,7 +71047,7 @@
       "source_location": "L92"
     },
     {
-      "community": 288,
+      "community": 287,
       "file_type": "code",
       "id": "barcodeutils_isvalidconvexid",
       "label": "isValidConvexId()",
@@ -71029,7 +71056,7 @@
       "source_location": "L16"
     },
     {
-      "community": 288,
+      "community": 287,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_barcodeutils_ts",
       "label": "barcodeUtils.ts",
@@ -71038,7 +71065,7 @@
       "source_location": "L1"
     },
     {
-      "community": 289,
+      "community": 288,
       "file_type": "code",
       "id": "customergateway_useconvexposcustomercreate",
       "label": "useConvexPosCustomerCreate()",
@@ -71047,7 +71074,7 @@
       "source_location": "L22"
     },
     {
-      "community": 289,
+      "community": 288,
       "file_type": "code",
       "id": "customergateway_useconvexposcustomersearch",
       "label": "useConvexPosCustomerSearch()",
@@ -71056,7 +71083,7 @@
       "source_location": "L10"
     },
     {
-      "community": 289,
+      "community": 288,
       "file_type": "code",
       "id": "customergateway_useconvexposcustomerupdate",
       "label": "useConvexPosCustomerUpdate()",
@@ -71065,13 +71092,49 @@
       "source_location": "L57"
     },
     {
-      "community": 289,
+      "community": 288,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_customergateway_ts",
       "label": "customerGateway.ts",
       "norm_label": "customergateway.ts",
       "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/customerGateway.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 289,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_sessiongateway_mapper_ts",
+      "label": "sessionGateway.mapper.ts",
+      "norm_label": "sessiongateway.mapper.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/sessionGateway.mapper.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 289,
+      "file_type": "code",
+      "id": "sessiongateway_mapper_mapactivesessiondto",
+      "label": "mapActiveSessionDto()",
+      "norm_label": "mapactivesessiondto()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/sessionGateway.mapper.ts",
+      "source_location": "L83"
+    },
+    {
+      "community": 289,
+      "file_type": "code",
+      "id": "sessiongateway_mapper_mapheldsessionsdto",
+      "label": "mapHeldSessionsDto()",
+      "norm_label": "mapheldsessionsdto()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/sessionGateway.mapper.ts",
+      "source_location": "L100"
+    },
+    {
+      "community": 289,
+      "file_type": "code",
+      "id": "sessiongateway_mapper_normalizecartitems",
+      "label": "normalizeCartItems()",
+      "norm_label": "normalizecartitems()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/sessionGateway.mapper.ts",
+      "source_location": "L79"
     },
     {
       "community": 29,
@@ -71238,42 +71301,6 @@
     {
       "community": 290,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_sessiongateway_mapper_ts",
-      "label": "sessionGateway.mapper.ts",
-      "norm_label": "sessiongateway.mapper.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/sessionGateway.mapper.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 290,
-      "file_type": "code",
-      "id": "sessiongateway_mapper_mapactivesessiondto",
-      "label": "mapActiveSessionDto()",
-      "norm_label": "mapactivesessiondto()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/sessionGateway.mapper.ts",
-      "source_location": "L83"
-    },
-    {
-      "community": 290,
-      "file_type": "code",
-      "id": "sessiongateway_mapper_mapheldsessionsdto",
-      "label": "mapHeldSessionsDto()",
-      "norm_label": "mapheldsessionsdto()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/sessionGateway.mapper.ts",
-      "source_location": "L100"
-    },
-    {
-      "community": 290,
-      "file_type": "code",
-      "id": "sessiongateway_mapper_normalizecartitems",
-      "label": "normalizeCartItems()",
-      "norm_label": "normalizecartitems()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/sessionGateway.mapper.ts",
-      "source_location": "L79"
-    },
-    {
-      "community": 291,
-      "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_sessiongateway_ts",
       "label": "sessionGateway.ts",
       "norm_label": "sessiongateway.ts",
@@ -71281,7 +71308,7 @@
       "source_location": "L1"
     },
     {
-      "community": 291,
+      "community": 290,
       "file_type": "code",
       "id": "sessiongateway_useconvexactivesession",
       "label": "useConvexActiveSession()",
@@ -71290,7 +71317,7 @@
       "source_location": "L38"
     },
     {
-      "community": 291,
+      "community": 290,
       "file_type": "code",
       "id": "sessiongateway_useconvexheldsessions",
       "label": "useConvexHeldSessions()",
@@ -71299,7 +71326,7 @@
       "source_location": "L65"
     },
     {
-      "community": 291,
+      "community": 290,
       "file_type": "code",
       "id": "sessiongateway_useconvexsessionactions",
       "label": "useConvexSessionActions()",
@@ -71308,7 +71335,7 @@
       "source_location": "L91"
     },
     {
-      "community": 292,
+      "community": 291,
       "file_type": "code",
       "id": "fingerprint_isbrowserfingerprintresult",
       "label": "isBrowserFingerprintResult()",
@@ -71317,7 +71344,7 @@
       "source_location": "L4"
     },
     {
-      "community": 292,
+      "community": 291,
       "file_type": "code",
       "id": "fingerprint_readstoredterminalfingerprint",
       "label": "readStoredTerminalFingerprint()",
@@ -71326,7 +71353,7 @@
       "source_location": "L20"
     },
     {
-      "community": 292,
+      "community": 291,
       "file_type": "code",
       "id": "fingerprint_readstoredterminalfingerprinthash",
       "label": "readStoredTerminalFingerprintHash()",
@@ -71335,7 +71362,7 @@
       "source_location": "L42"
     },
     {
-      "community": 292,
+      "community": 291,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_terminal_fingerprint_ts",
       "label": "fingerprint.ts",
@@ -71344,7 +71371,7 @@
       "source_location": "L1"
     },
     {
-      "community": 293,
+      "community": 292,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_presentation_expense_useexpenseregisterviewmodel_ts",
       "label": "useExpenseRegisterViewModel.ts",
@@ -71353,7 +71380,7 @@
       "source_location": "L1"
     },
     {
-      "community": 293,
+      "community": 292,
       "file_type": "code",
       "id": "useexpenseregisterviewmodel_getcashierdisplayname",
       "label": "getCashierDisplayName()",
@@ -71362,7 +71389,7 @@
       "source_location": "L37"
     },
     {
-      "community": 293,
+      "community": 292,
       "file_type": "code",
       "id": "useexpenseregisterviewmodel_getexpensesessionloadkey",
       "label": "getExpenseSessionLoadKey()",
@@ -71371,7 +71398,7 @@
       "source_location": "L49"
     },
     {
-      "community": 293,
+      "community": 292,
       "file_type": "code",
       "id": "useexpenseregisterviewmodel_useexpenseregisterviewmodel",
       "label": "useExpenseRegisterViewModel()",
@@ -71380,7 +71407,7 @@
       "source_location": "L65"
     },
     {
-      "community": 294,
+      "community": 293,
       "file_type": "code",
       "id": "offers_getbaseurl",
       "label": "getBaseUrl()",
@@ -71389,7 +71416,7 @@
       "source_location": "L13"
     },
     {
-      "community": 294,
+      "community": 293,
       "file_type": "code",
       "id": "offers_getuserredeemedoffers",
       "label": "getUserRedeemedOffers()",
@@ -71398,7 +71425,7 @@
       "source_location": "L46"
     },
     {
-      "community": 294,
+      "community": 293,
       "file_type": "code",
       "id": "offers_submitoffer",
       "label": "submitOffer()",
@@ -71407,7 +71434,7 @@
       "source_location": "L21"
     },
     {
-      "community": 294,
+      "community": 293,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_offers_ts",
       "label": "offers.ts",
@@ -71416,7 +71443,7 @@
       "source_location": "L1"
     },
     {
-      "community": 295,
+      "community": 294,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_stores_ts",
       "label": "stores.ts",
@@ -71425,7 +71452,7 @@
       "source_location": "L1"
     },
     {
-      "community": 295,
+      "community": 294,
       "file_type": "code",
       "id": "stores_getallstores",
       "label": "getAllStores()",
@@ -71434,7 +71461,7 @@
       "source_location": "L8"
     },
     {
-      "community": 295,
+      "community": 294,
       "file_type": "code",
       "id": "stores_getbaseurl",
       "label": "getBaseUrl()",
@@ -71443,7 +71470,7 @@
       "source_location": "L5"
     },
     {
-      "community": 295,
+      "community": 294,
       "file_type": "code",
       "id": "stores_getstore",
       "label": "getStore()",
@@ -71452,7 +71479,7 @@
       "source_location": "L20"
     },
     {
-      "community": 296,
+      "community": 295,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_subcategory_ts",
       "label": "subcategory.ts",
@@ -71461,7 +71488,7 @@
       "source_location": "L1"
     },
     {
-      "community": 296,
+      "community": 295,
       "file_type": "code",
       "id": "subcategory_getallsubcategories",
       "label": "getAllSubcategories()",
@@ -71470,7 +71497,7 @@
       "source_location": "L11"
     },
     {
-      "community": 296,
+      "community": 295,
       "file_type": "code",
       "id": "subcategory_getbaseurl",
       "label": "getBaseUrl()",
@@ -71479,7 +71506,7 @@
       "source_location": "L9"
     },
     {
-      "community": 296,
+      "community": 295,
       "file_type": "code",
       "id": "subcategory_getsubategory",
       "label": "getSubategory()",
@@ -71488,7 +71515,7 @@
       "source_location": "L25"
     },
     {
-      "community": 297,
+      "community": 296,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_productactionbar_tsx",
       "label": "ProductActionBar.tsx",
@@ -71497,7 +71524,7 @@
       "source_location": "L1"
     },
     {
-      "community": 297,
+      "community": 296,
       "file_type": "code",
       "id": "productactionbar_checkscroll",
       "label": "checkScroll()",
@@ -71506,7 +71533,7 @@
       "source_location": "L50"
     },
     {
-      "community": 297,
+      "community": 296,
       "file_type": "code",
       "id": "productactionbar_handleaction",
       "label": "handleAction()",
@@ -71515,7 +71542,7 @@
       "source_location": "L92"
     },
     {
-      "community": 297,
+      "community": 296,
       "file_type": "code",
       "id": "productactionbar_handledismiss",
       "label": "handleDismiss()",
@@ -71524,7 +71551,7 @@
       "source_location": "L74"
     },
     {
-      "community": 298,
+      "community": 297,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_productreminderbar_tsx",
       "label": "ProductReminderBar.tsx",
@@ -71533,7 +71560,7 @@
       "source_location": "L1"
     },
     {
-      "community": 298,
+      "community": 297,
       "file_type": "code",
       "id": "productreminderbar_checkscroll",
       "label": "checkScroll()",
@@ -71542,7 +71569,7 @@
       "source_location": "L62"
     },
     {
-      "community": 298,
+      "community": 297,
       "file_type": "code",
       "id": "productreminderbar_handleaddtobag",
       "label": "handleAddToBag()",
@@ -71551,7 +71578,7 @@
       "source_location": "L109"
     },
     {
-      "community": 298,
+      "community": 297,
       "file_type": "code",
       "id": "productreminderbar_handledismiss",
       "label": "handleDismiss()",
@@ -71560,7 +71587,7 @@
       "source_location": "L177"
     },
     {
-      "community": 299,
+      "community": 298,
       "file_type": "code",
       "id": "billingdetailssection_clearform",
       "label": "clearForm()",
@@ -71569,7 +71596,7 @@
       "source_location": "L18"
     },
     {
-      "community": 299,
+      "community": 298,
       "file_type": "code",
       "id": "billingdetailssection_handleusebillingaddressonfile",
       "label": "handleUseBillingAddressOnFile()",
@@ -71578,7 +71605,7 @@
       "source_location": "L52"
     },
     {
-      "community": 299,
+      "community": 298,
       "file_type": "code",
       "id": "billingdetailssection_togglesameasdelivery",
       "label": "toggleSameAsDelivery()",
@@ -71587,12 +71614,48 @@
       "source_location": "L68"
     },
     {
-      "community": 299,
+      "community": 298,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_billingdetailssection_tsx",
       "label": "BillingDetailsSection.tsx",
       "norm_label": "billingdetailssection.tsx",
       "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetailsSection.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 299,
+      "file_type": "code",
+      "id": "hooks_usegetshopsearchparams",
+      "label": "useGetShopSearchParams()",
+      "norm_label": "usegetshopsearchparams()",
+      "source_file": "packages/storefront-webapp/src/components/navigation/hooks.ts",
+      "source_location": "L68"
+    },
+    {
+      "community": 299,
+      "file_type": "code",
+      "id": "hooks_usegetstorecategories",
+      "label": "useGetStoreCategories()",
+      "norm_label": "usegetstorecategories()",
+      "source_file": "packages/storefront-webapp/src/components/navigation/hooks.ts",
+      "source_location": "L26"
+    },
+    {
+      "community": 299,
+      "file_type": "code",
+      "id": "hooks_usegetstoresubcategories",
+      "label": "useGetStoreSubcategories()",
+      "norm_label": "usegetstoresubcategories()",
+      "source_file": "packages/storefront-webapp/src/components/navigation/hooks.ts",
+      "source_location": "L7"
+    },
+    {
+      "community": 299,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_navigation_hooks_ts",
+      "label": "hooks.ts",
+      "norm_label": "hooks.ts",
+      "source_file": "packages/storefront-webapp/src/components/navigation/hooks.ts",
       "source_location": "L1"
     },
     {
@@ -72057,42 +72120,6 @@
     {
       "community": 300,
       "file_type": "code",
-      "id": "hooks_usegetshopsearchparams",
-      "label": "useGetShopSearchParams()",
-      "norm_label": "usegetshopsearchparams()",
-      "source_file": "packages/storefront-webapp/src/components/navigation/hooks.ts",
-      "source_location": "L68"
-    },
-    {
-      "community": 300,
-      "file_type": "code",
-      "id": "hooks_usegetstorecategories",
-      "label": "useGetStoreCategories()",
-      "norm_label": "usegetstorecategories()",
-      "source_file": "packages/storefront-webapp/src/components/navigation/hooks.ts",
-      "source_location": "L26"
-    },
-    {
-      "community": 300,
-      "file_type": "code",
-      "id": "hooks_usegetstoresubcategories",
-      "label": "useGetStoreSubcategories()",
-      "norm_label": "usegetstoresubcategories()",
-      "source_file": "packages/storefront-webapp/src/components/navigation/hooks.ts",
-      "source_location": "L7"
-    },
-    {
-      "community": 300,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_navigation_hooks_ts",
-      "label": "hooks.ts",
-      "norm_label": "hooks.ts",
-      "source_file": "packages/storefront-webapp/src/components/navigation/hooks.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 301,
-      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productattribute_tsx",
       "label": "ProductAttribute.tsx",
       "norm_label": "productattribute.tsx",
@@ -72100,7 +72127,7 @@
       "source_location": "L1"
     },
     {
-      "community": 301,
+      "community": 300,
       "file_type": "code",
       "id": "productattribute_findsize",
       "label": "findSize()",
@@ -72109,7 +72136,7 @@
       "source_location": "L81"
     },
     {
-      "community": 301,
+      "community": 300,
       "file_type": "code",
       "id": "productattribute_handleclick",
       "label": "handleClick()",
@@ -72118,7 +72145,7 @@
       "source_location": "L85"
     },
     {
-      "community": 301,
+      "community": 300,
       "file_type": "code",
       "id": "productattribute_optionclassname",
       "label": "optionClassName()",
@@ -72127,7 +72154,7 @@
       "source_location": "L27"
     },
     {
-      "community": 302,
+      "community": 301,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productdetails_tsx",
       "label": "ProductDetails.tsx",
@@ -72136,7 +72163,7 @@
       "source_location": "L1"
     },
     {
-      "community": 302,
+      "community": 301,
       "file_type": "code",
       "id": "productdetails_bagproduct",
       "label": "BagProduct()",
@@ -72145,7 +72172,7 @@
       "source_location": "L43"
     },
     {
-      "community": 302,
+      "community": 301,
       "file_type": "code",
       "id": "productdetails_pickupdetails",
       "label": "PickupDetails()",
@@ -72154,7 +72181,7 @@
       "source_location": "L13"
     },
     {
-      "community": 302,
+      "community": 301,
       "file_type": "code",
       "id": "productdetails_shippingpolicy",
       "label": "ShippingPolicy()",
@@ -72163,7 +72190,7 @@
       "source_location": "L88"
     },
     {
-      "community": 303,
+      "community": 302,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_upsellmodal_tsx",
       "label": "UpsellModal.tsx",
@@ -72172,7 +72199,7 @@
       "source_location": "L1"
     },
     {
-      "community": 303,
+      "community": 302,
       "file_type": "code",
       "id": "upsellmodal_handleclose",
       "label": "handleClose()",
@@ -72181,7 +72208,7 @@
       "source_location": "L111"
     },
     {
-      "community": 303,
+      "community": 302,
       "file_type": "code",
       "id": "upsellmodal_handlescroll",
       "label": "handleScroll()",
@@ -72190,7 +72217,7 @@
       "source_location": "L66"
     },
     {
-      "community": 303,
+      "community": 302,
       "file_type": "code",
       "id": "upsellmodal_handlesuccess",
       "label": "handleSuccess()",
@@ -72199,7 +72226,7 @@
       "source_location": "L127"
     },
     {
-      "community": 304,
+      "community": 303,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_contexts_storecontext_tsx",
       "label": "StoreContext.tsx",
@@ -72208,7 +72235,7 @@
       "source_location": "L1"
     },
     {
-      "community": 304,
+      "community": 303,
       "file_type": "code",
       "id": "storecontext_storeprovider",
       "label": "StoreProvider()",
@@ -72217,7 +72244,7 @@
       "source_location": "L25"
     },
     {
-      "community": 304,
+      "community": 303,
       "file_type": "code",
       "id": "storecontext_useoptionalstorecontext",
       "label": "useOptionalStoreContext()",
@@ -72226,7 +72253,7 @@
       "source_location": "L90"
     },
     {
-      "community": 304,
+      "community": 303,
       "file_type": "code",
       "id": "storecontext_usestorecontext",
       "label": "useStoreContext()",
@@ -72235,7 +72262,7 @@
       "source_location": "L82"
     },
     {
-      "community": 305,
+      "community": 304,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_shoplayout_tsx",
       "label": "_shopLayout.tsx",
@@ -72244,7 +72271,7 @@
       "source_location": "L1"
     },
     {
-      "community": 305,
+      "community": 304,
       "file_type": "code",
       "id": "shoplayout_clearfilters",
       "label": "clearFilters()",
@@ -72253,7 +72280,7 @@
       "source_location": "L115"
     },
     {
-      "community": 305,
+      "community": 304,
       "file_type": "code",
       "id": "shoplayout_onclickonmobilefilters",
       "label": "onClickOnMobileFilters()",
@@ -72262,7 +72289,7 @@
       "source_location": "L105"
     },
     {
-      "community": 305,
+      "community": 304,
       "file_type": "code",
       "id": "shoplayout_onmobilefilterscloseclick",
       "label": "onMobileFiltersCloseClick()",
@@ -72271,7 +72298,7 @@
       "source_location": "L110"
     },
     {
-      "community": 306,
+      "community": 305,
       "file_type": "code",
       "id": "index_cancelorder",
       "label": "cancelOrder()",
@@ -72280,7 +72307,7 @@
       "source_location": "L121"
     },
     {
-      "community": 306,
+      "community": 305,
       "file_type": "code",
       "id": "index_geterrormessage",
       "label": "getErrorMessage()",
@@ -72289,7 +72316,7 @@
       "source_location": "L26"
     },
     {
-      "community": 306,
+      "community": 305,
       "file_type": "code",
       "id": "index_placeorder",
       "label": "placeOrder()",
@@ -72298,7 +72325,7 @@
       "source_location": "L71"
     },
     {
-      "community": 306,
+      "community": 305,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_index_tsx",
       "label": "index.tsx",
@@ -72307,7 +72334,7 @@
       "source_location": "L1"
     },
     {
-      "community": 307,
+      "community": 306,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_receipt_posreceiptpage_tsx",
       "label": "-PosReceiptPage.tsx",
@@ -72316,7 +72343,7 @@
       "source_location": "L1"
     },
     {
-      "community": 307,
+      "community": 306,
       "file_type": "code",
       "id": "posreceiptpage_money",
       "label": "money()",
@@ -72325,7 +72352,7 @@
       "source_location": "L51"
     },
     {
-      "community": 307,
+      "community": 306,
       "file_type": "code",
       "id": "posreceiptpage_paymentlabel",
       "label": "paymentLabel()",
@@ -72334,7 +72361,7 @@
       "source_location": "L13"
     },
     {
-      "community": 307,
+      "community": 306,
       "file_type": "code",
       "id": "posreceiptpage_shouldretryreceiptlookup",
       "label": "shouldRetryReceiptLookup()",
@@ -72343,7 +72370,7 @@
       "source_location": "L21"
     },
     {
-      "community": 308,
+      "community": 307,
       "file_type": "code",
       "id": "bootstrap_bootstrapcheckout",
       "label": "bootstrapCheckout()",
@@ -72352,7 +72379,7 @@
       "source_location": "L46"
     },
     {
-      "community": 308,
+      "community": 307,
       "file_type": "code",
       "id": "bootstrap_createbootstraptoken",
       "label": "createBootstrapToken()",
@@ -72361,7 +72388,7 @@
       "source_location": "L24"
     },
     {
-      "community": 308,
+      "community": 307,
       "file_type": "code",
       "id": "bootstrap_createmarker",
       "label": "createMarker()",
@@ -72370,7 +72397,7 @@
       "source_location": "L20"
     },
     {
-      "community": 308,
+      "community": 307,
       "file_type": "code",
       "id": "packages_storefront_webapp_tests_e2e_helpers_bootstrap_ts",
       "label": "bootstrap.ts",
@@ -72379,7 +72406,7 @@
       "source_location": "L1"
     },
     {
-      "community": 309,
+      "community": 308,
       "file_type": "code",
       "id": "graphify_check_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -72388,7 +72415,7 @@
       "source_location": "L17"
     },
     {
-      "community": 309,
+      "community": 308,
       "file_type": "code",
       "id": "graphify_check_test_write",
       "label": "write()",
@@ -72397,7 +72424,7 @@
       "source_location": "L11"
     },
     {
-      "community": 309,
+      "community": 308,
       "file_type": "code",
       "id": "graphify_check_test_writegraphifywikiartifacts",
       "label": "writeGraphifyWikiArtifacts()",
@@ -72406,12 +72433,48 @@
       "source_location": "L24"
     },
     {
-      "community": 309,
+      "community": 308,
       "file_type": "code",
       "id": "scripts_graphify_check_test_ts",
       "label": "graphify-check.test.ts",
       "norm_label": "graphify-check.test.ts",
       "source_file": "scripts/graphify-check.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 309,
+      "file_type": "code",
+      "id": "graphify_rebuild_test_createfixtureroot",
+      "label": "createFixtureRoot()",
+      "norm_label": "createfixtureroot()",
+      "source_file": "scripts/graphify-rebuild.test.ts",
+      "source_location": "L20"
+    },
+    {
+      "community": 309,
+      "file_type": "code",
+      "id": "graphify_rebuild_test_spawn",
+      "label": "spawn()",
+      "norm_label": "spawn()",
+      "source_file": "scripts/graphify-rebuild.test.ts",
+      "source_location": "L65"
+    },
+    {
+      "community": 309,
+      "file_type": "code",
+      "id": "graphify_rebuild_test_write",
+      "label": "write()",
+      "norm_label": "write()",
+      "source_file": "scripts/graphify-rebuild.test.ts",
+      "source_location": "L14"
+    },
+    {
+      "community": 309,
+      "file_type": "code",
+      "id": "scripts_graphify_rebuild_test_ts",
+      "label": "graphify-rebuild.test.ts",
+      "norm_label": "graphify-rebuild.test.ts",
+      "source_file": "scripts/graphify-rebuild.test.ts",
       "source_location": "L1"
     },
     {
@@ -72430,7 +72493,7 @@
       "label": "acquireInventoryHoldsBatch()",
       "norm_label": "acquireinventoryholdsbatch()",
       "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
-      "source_location": "L319"
+      "source_location": "L318"
     },
     {
       "community": 31,
@@ -72439,7 +72502,7 @@
       "label": "adjustInventoryHold()",
       "norm_label": "adjustinventoryhold()",
       "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
-      "source_location": "L242"
+      "source_location": "L241"
     },
     {
       "community": 31,
@@ -72448,7 +72511,7 @@
       "label": "consumeInventoryHoldsForSession()",
       "norm_label": "consumeinventoryholdsforsession()",
       "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
-      "source_location": "L446"
+      "source_location": "L445"
     },
     {
       "community": 31,
@@ -72457,7 +72520,7 @@
       "label": "getActiveHoldForSessionSku()",
       "norm_label": "getactiveholdforsessionsku()",
       "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
-      "source_location": "L580"
+      "source_location": "L579"
     },
     {
       "community": 31,
@@ -72466,7 +72529,7 @@
       "label": "listActiveSessionHolds()",
       "norm_label": "listactivesessionholds()",
       "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
-      "source_location": "L609"
+      "source_location": "L608"
     },
     {
       "community": 31,
@@ -72475,7 +72538,7 @@
       "label": "markHoldExpired()",
       "norm_label": "markholdexpired()",
       "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
-      "source_location": "L637"
+      "source_location": "L636"
     },
     {
       "community": 31,
@@ -72484,7 +72547,7 @@
       "label": "readActiveInventoryHoldDetailsForSession()",
       "norm_label": "readactiveinventoryholddetailsforsession()",
       "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
-      "source_location": "L517"
+      "source_location": "L516"
     },
     {
       "community": 31,
@@ -72493,7 +72556,7 @@
       "label": "readActiveInventoryHoldQuantitiesForSession()",
       "norm_label": "readactiveinventoryholdquantitiesforsession()",
       "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
-      "source_location": "L490"
+      "source_location": "L489"
     },
     {
       "community": 31,
@@ -72502,7 +72565,7 @@
       "label": "releaseActiveInventoryHoldsForSession()",
       "norm_label": "releaseactiveinventoryholdsforsession()",
       "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
-      "source_location": "L410"
+      "source_location": "L409"
     },
     {
       "community": 31,
@@ -72520,7 +72583,7 @@
       "label": "releaseInventoryHoldsBatch()",
       "norm_label": "releaseinventoryholdsbatch()",
       "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
-      "source_location": "L348"
+      "source_location": "L347"
     },
     {
       "community": 31,
@@ -72529,16 +72592,16 @@
       "label": "releaseInventoryHoldsForSession()",
       "norm_label": "releaseinventoryholdsforsession()",
       "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
-      "source_location": "L386"
+      "source_location": "L385"
     },
     {
       "community": 31,
       "file_type": "code",
-      "id": "inventoryholds_restorelegacyquantitypatchhold",
-      "label": "restoreLegacyQuantityPatchHold()",
-      "norm_label": "restorelegacyquantitypatchhold()",
+      "id": "inventoryholds_releaselegacyexpensequantitypatchholds",
+      "label": "releaseLegacyExpenseQuantityPatchHolds()",
+      "norm_label": "releaselegacyexpensequantitypatchholds()",
       "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
-      "source_location": "L649"
+      "source_location": "L367"
     },
     {
       "community": 31,
@@ -72547,7 +72610,7 @@
       "label": "sumActiveHeldQuantity()",
       "norm_label": "sumactiveheldquantity()",
       "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
-      "source_location": "L547"
+      "source_location": "L546"
     },
     {
       "community": 31,
@@ -72570,42 +72633,6 @@
     {
       "community": 310,
       "file_type": "code",
-      "id": "graphify_rebuild_test_createfixtureroot",
-      "label": "createFixtureRoot()",
-      "norm_label": "createfixtureroot()",
-      "source_file": "scripts/graphify-rebuild.test.ts",
-      "source_location": "L20"
-    },
-    {
-      "community": 310,
-      "file_type": "code",
-      "id": "graphify_rebuild_test_spawn",
-      "label": "spawn()",
-      "norm_label": "spawn()",
-      "source_file": "scripts/graphify-rebuild.test.ts",
-      "source_location": "L65"
-    },
-    {
-      "community": 310,
-      "file_type": "code",
-      "id": "graphify_rebuild_test_write",
-      "label": "write()",
-      "norm_label": "write()",
-      "source_file": "scripts/graphify-rebuild.test.ts",
-      "source_location": "L14"
-    },
-    {
-      "community": 310,
-      "file_type": "code",
-      "id": "scripts_graphify_rebuild_test_ts",
-      "label": "graphify-rebuild.test.ts",
-      "norm_label": "graphify-rebuild.test.ts",
-      "source_file": "scripts/graphify-rebuild.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 311,
-      "file_type": "code",
       "id": "harness_app_registry_buildharnessdocpaths",
       "label": "buildHarnessDocPaths()",
       "norm_label": "buildharnessdocpaths()",
@@ -72613,7 +72640,7 @@
       "source_location": "L126"
     },
     {
-      "community": 311,
+      "community": 310,
       "file_type": "code",
       "id": "harness_app_registry_buildharnessdocpathsforarchetype",
       "label": "buildHarnessDocPathsForArchetype()",
@@ -72622,7 +72649,7 @@
       "source_location": "L130"
     },
     {
-      "community": 311,
+      "community": 310,
       "file_type": "code",
       "id": "harness_app_registry_getharnesspackageregistration",
       "label": "getHarnessPackageRegistration()",
@@ -72631,7 +72658,7 @@
       "source_location": "L879"
     },
     {
-      "community": 311,
+      "community": 310,
       "file_type": "code",
       "id": "scripts_harness_app_registry_ts",
       "label": "harness-app-registry.ts",
@@ -72640,7 +72667,7 @@
       "source_location": "L1"
     },
     {
-      "community": 312,
+      "community": 311,
       "file_type": "code",
       "id": "scripts_harness_behavior_fixtures_valkey_runtime_app_ts",
       "label": "valkey-runtime-app.ts",
@@ -72649,7 +72676,7 @@
       "source_location": "L1"
     },
     {
-      "community": 312,
+      "community": 311,
       "file_type": "code",
       "id": "valkey_runtime_app_createvalkeyruntimeserver",
       "label": "createValkeyRuntimeServer()",
@@ -72658,7 +72685,7 @@
       "source_location": "L8"
     },
     {
-      "community": 312,
+      "community": 311,
       "file_type": "code",
       "id": "valkey_runtime_app_shutdown",
       "label": "shutdown()",
@@ -72667,7 +72694,7 @@
       "source_location": "L79"
     },
     {
-      "community": 312,
+      "community": 311,
       "file_type": "code",
       "id": "valkey_runtime_app_stopvalkeyruntimeserver",
       "label": "stopValkeyRuntimeServer()",
@@ -72676,7 +72703,7 @@
       "source_location": "L61"
     },
     {
-      "community": 313,
+      "community": 312,
       "file_type": "code",
       "id": "harness_scorecard_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -72685,7 +72712,7 @@
       "source_location": "L49"
     },
     {
-      "community": 313,
+      "community": 312,
       "file_type": "code",
       "id": "harness_scorecard_test_createinferentialartifact",
       "label": "createInferentialArtifact()",
@@ -72694,7 +72721,7 @@
       "source_location": "L17"
     },
     {
-      "community": 313,
+      "community": 312,
       "file_type": "code",
       "id": "harness_scorecard_test_write",
       "label": "write()",
@@ -72703,7 +72730,7 @@
       "source_location": "L11"
     },
     {
-      "community": 313,
+      "community": 312,
       "file_type": "code",
       "id": "scripts_harness_scorecard_test_ts",
       "label": "harness-scorecard.test.ts",
@@ -72712,7 +72739,7 @@
       "source_location": "L1"
     },
     {
-      "community": 314,
+      "community": 313,
       "file_type": "code",
       "id": "harness_test_collectharnesstesttargets",
       "label": "collectHarnessTestTargets()",
@@ -72721,7 +72748,7 @@
       "source_location": "L26"
     },
     {
-      "community": 314,
+      "community": 313,
       "file_type": "code",
       "id": "harness_test_parseharnesstestcliargs",
       "label": "parseHarnessTestCliArgs()",
@@ -72730,7 +72757,7 @@
       "source_location": "L72"
     },
     {
-      "community": 314,
+      "community": 313,
       "file_type": "code",
       "id": "harness_test_runharnesstest",
       "label": "runHarnessTest()",
@@ -72739,7 +72766,7 @@
       "source_location": "L36"
     },
     {
-      "community": 314,
+      "community": 313,
       "file_type": "code",
       "id": "scripts_harness_test_ts",
       "label": "harness-test.ts",
@@ -72748,7 +72775,7 @@
       "source_location": "L1"
     },
     {
-      "community": 315,
+      "community": 314,
       "file_type": "code",
       "id": "pre_push_review_test_error",
       "label": "error()",
@@ -72757,7 +72784,7 @@
       "source_location": "L96"
     },
     {
-      "community": 315,
+      "community": 314,
       "file_type": "code",
       "id": "pre_push_review_test_log",
       "label": "log()",
@@ -72766,7 +72793,7 @@
       "source_location": "L94"
     },
     {
-      "community": 315,
+      "community": 314,
       "file_type": "code",
       "id": "pre_push_review_test_warn",
       "label": "warn()",
@@ -72775,7 +72802,7 @@
       "source_location": "L95"
     },
     {
-      "community": 315,
+      "community": 314,
       "file_type": "code",
       "id": "scripts_pre_push_review_test_ts",
       "label": "pre-push-review.test.ts",
@@ -72784,7 +72811,7 @@
       "source_location": "L1"
     },
     {
-      "community": 316,
+      "community": 315,
       "file_type": "code",
       "id": "preview_worktree_test_makedir",
       "label": "makeDir()",
@@ -72793,7 +72820,7 @@
       "source_location": "L17"
     },
     {
-      "community": 316,
+      "community": 315,
       "file_type": "code",
       "id": "preview_worktree_test_previewoptions",
       "label": "previewOptions()",
@@ -72802,7 +72829,7 @@
       "source_location": "L23"
     },
     {
-      "community": 316,
+      "community": 315,
       "file_type": "code",
       "id": "preview_worktree_test_real",
       "label": "real()",
@@ -72811,7 +72838,7 @@
       "source_location": "L40"
     },
     {
-      "community": 316,
+      "community": 315,
       "file_type": "code",
       "id": "scripts_preview_worktree_test_ts",
       "label": "preview-worktree.test.ts",
@@ -72820,7 +72847,7 @@
       "source_location": "L1"
     },
     {
-      "community": 317,
+      "community": 316,
       "file_type": "code",
       "id": "closeouts_test_gethandler",
       "label": "getHandler()",
@@ -72829,7 +72856,7 @@
       "source_location": "L15"
     },
     {
-      "community": 317,
+      "community": 316,
       "file_type": "code",
       "id": "closeouts_test_getsource",
       "label": "getSource()",
@@ -72838,7 +72865,7 @@
       "source_location": "L11"
     },
     {
-      "community": 317,
+      "community": 316,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cashcontrols_closeouts_test_ts",
       "label": "closeouts.test.ts",
@@ -72847,7 +72874,7 @@
       "source_location": "L1"
     },
     {
-      "community": 318,
+      "community": 317,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_customermessaging_public_ts",
       "label": "public.ts",
@@ -72856,7 +72883,7 @@
       "source_location": "L1"
     },
     {
-      "community": 318,
+      "community": 317,
       "file_type": "code",
       "id": "public_resolverecipient",
       "label": "resolveRecipient()",
@@ -72865,7 +72892,7 @@
       "source_location": "L57"
     },
     {
-      "community": 318,
+      "community": 317,
       "file_type": "code",
       "id": "public_topublicreceipttransaction",
       "label": "toPublicReceiptTransaction()",
@@ -72874,7 +72901,7 @@
       "source_location": "L29"
     },
     {
-      "community": 319,
+      "community": 318,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_customermessaging_whatsappclient_ts",
       "label": "whatsappClient.ts",
@@ -72883,7 +72910,7 @@
       "source_location": "L1"
     },
     {
-      "community": 319,
+      "community": 318,
       "file_type": "code",
       "id": "whatsappclient_providererrorcategory",
       "label": "providerErrorCategory()",
@@ -72892,13 +72919,40 @@
       "source_location": "L20"
     },
     {
-      "community": 319,
+      "community": 318,
       "file_type": "code",
       "id": "whatsappclient_sendwhatsappreceipttemplate",
       "label": "sendWhatsAppReceiptTemplate()",
       "norm_label": "sendwhatsappreceipttemplate()",
       "source_file": "packages/athena-webapp/convex/customerMessaging/whatsappClient.ts",
       "source_location": "L27"
+    },
+    {
+      "community": 319,
+      "file_type": "code",
+      "id": "discountcode_chunkproducts",
+      "label": "chunkProducts()",
+      "norm_label": "chunkproducts()",
+      "source_file": "packages/athena-webapp/convex/emails/DiscountCode.tsx",
+      "source_location": "L98"
+    },
+    {
+      "community": 319,
+      "file_type": "code",
+      "id": "discountcode_productcard",
+      "label": "ProductCard()",
+      "norm_label": "productcard()",
+      "source_file": "packages/athena-webapp/convex/emails/DiscountCode.tsx",
+      "source_location": "L33"
+    },
+    {
+      "community": 319,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_emails_discountcode_tsx",
+      "label": "DiscountCode.tsx",
+      "norm_label": "discountcode.tsx",
+      "source_file": "packages/athena-webapp/convex/emails/DiscountCode.tsx",
+      "source_location": "L1"
     },
     {
       "community": 32,
@@ -73056,33 +73110,6 @@
     {
       "community": 320,
       "file_type": "code",
-      "id": "discountcode_chunkproducts",
-      "label": "chunkProducts()",
-      "norm_label": "chunkproducts()",
-      "source_file": "packages/athena-webapp/convex/emails/DiscountCode.tsx",
-      "source_location": "L98"
-    },
-    {
-      "community": 320,
-      "file_type": "code",
-      "id": "discountcode_productcard",
-      "label": "ProductCard()",
-      "norm_label": "productcard()",
-      "source_file": "packages/athena-webapp/convex/emails/DiscountCode.tsx",
-      "source_location": "L33"
-    },
-    {
-      "community": 320,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_emails_discountcode_tsx",
-      "label": "DiscountCode.tsx",
-      "norm_label": "discountcode.tsx",
-      "source_file": "packages/athena-webapp/convex/emails/DiscountCode.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 321,
-      "file_type": "code",
       "id": "discountreminder_chunkproducts",
       "label": "chunkProducts()",
       "norm_label": "chunkproducts()",
@@ -73090,7 +73117,7 @@
       "source_location": "L85"
     },
     {
-      "community": 321,
+      "community": 320,
       "file_type": "code",
       "id": "discountreminder_productcard",
       "label": "ProductCard()",
@@ -73099,7 +73126,7 @@
       "source_location": "L31"
     },
     {
-      "community": 321,
+      "community": 320,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_discountreminder_tsx",
       "label": "DiscountReminder.tsx",
@@ -73108,7 +73135,7 @@
       "source_location": "L1"
     },
     {
-      "community": 322,
+      "community": 321,
       "file_type": "code",
       "id": "categories_removestorefronthiddencategories",
       "label": "removeStorefrontHiddenCategories()",
@@ -73117,7 +73144,7 @@
       "source_location": "L12"
     },
     {
-      "community": 322,
+      "community": 321,
       "file_type": "code",
       "id": "categories_removestorefronthiddensubcategories",
       "label": "removeStorefrontHiddenSubcategories()",
@@ -73126,7 +73153,7 @@
       "source_location": "L21"
     },
     {
-      "community": 322,
+      "community": 321,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_core_routes_categories_ts",
       "label": "categories.ts",
@@ -73135,7 +73162,7 @@
       "source_location": "L1"
     },
     {
-      "community": 323,
+      "community": 322,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_utils_ts",
       "label": "utils.ts",
@@ -73144,7 +73171,7 @@
       "source_location": "L1"
     },
     {
-      "community": 323,
+      "community": 322,
       "file_type": "code",
       "id": "utils_getstoredatafromrequest",
       "label": "getStoreDataFromRequest()",
@@ -73153,7 +73180,7 @@
       "source_location": "L5"
     },
     {
-      "community": 323,
+      "community": 322,
       "file_type": "code",
       "id": "utils_getstorefrontuserfromrequest",
       "label": "getStorefrontUserFromRequest()",
@@ -73162,25 +73189,25 @@
       "source_location": "L12"
     },
     {
-      "community": 324,
+      "community": 323,
       "file_type": "code",
       "id": "inventoryholds_test_buildhold",
       "label": "buildHold()",
       "norm_label": "buildhold()",
       "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.test.ts",
-      "source_location": "L467"
+      "source_location": "L566"
     },
     {
-      "community": 324,
+      "community": 323,
       "file_type": "code",
       "id": "inventoryholds_test_createdb",
       "label": "createDb()",
       "norm_label": "createdb()",
       "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.test.ts",
-      "source_location": "L38"
+      "source_location": "L40"
     },
     {
-      "community": 324,
+      "community": 323,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_helpers_inventoryholds_test_ts",
       "label": "inventoryHolds.test.ts",
@@ -73189,7 +73216,7 @@
       "source_location": "L1"
     },
     {
-      "community": 325,
+      "community": 324,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_sessionqueryindexes_test_ts",
       "label": "sessionQueryIndexes.test.ts",
@@ -73198,7 +73225,7 @@
       "source_location": "L1"
     },
     {
-      "community": 325,
+      "community": 324,
       "file_type": "code",
       "id": "sessionqueryindexes_test_readprojectfile",
       "label": "readProjectFile()",
@@ -73207,7 +73234,7 @@
       "source_location": "L6"
     },
     {
-      "community": 325,
+      "community": 324,
       "file_type": "code",
       "id": "sessionqueryindexes_test_readsourceslice",
       "label": "readSourceSlice()",
@@ -73216,7 +73243,7 @@
       "source_location": "L9"
     },
     {
-      "community": 326,
+      "community": 325,
       "file_type": "code",
       "id": "analyticsutils_calculateactivitytrend",
       "label": "calculateActivityTrend()",
@@ -73225,7 +73252,7 @@
       "source_location": "L43"
     },
     {
-      "community": 326,
+      "community": 325,
       "file_type": "code",
       "id": "analyticsutils_calculatedevicedistribution",
       "label": "calculateDeviceDistribution()",
@@ -73234,7 +73261,7 @@
       "source_location": "L11"
     },
     {
-      "community": 326,
+      "community": 325,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_utils_analyticsutils_ts",
       "label": "analyticsUtils.ts",
@@ -73243,7 +73270,7 @@
       "source_location": "L1"
     },
     {
-      "community": 327,
+      "community": 326,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_staffcredentials_test_ts",
       "label": "staffCredentials.test.ts",
@@ -73252,7 +73279,7 @@
       "source_location": "L1"
     },
     {
-      "community": 327,
+      "community": 326,
       "file_type": "code",
       "id": "staffcredentials_test_createstaffcredentialsmutationctx",
       "label": "createStaffCredentialsMutationCtx()",
@@ -73261,7 +73288,7 @@
       "source_location": "L26"
     },
     {
-      "community": 327,
+      "community": 326,
       "file_type": "code",
       "id": "staffcredentials_test_gethandler",
       "label": "getHandler()",
@@ -73270,7 +73297,7 @@
       "source_location": "L118"
     },
     {
-      "community": 328,
+      "community": 327,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_staffprofiles_test_ts",
       "label": "staffProfiles.test.ts",
@@ -73279,7 +73306,7 @@
       "source_location": "L1"
     },
     {
-      "community": 328,
+      "community": 327,
       "file_type": "code",
       "id": "staffprofiles_test_createstaffprofilesmutationctx",
       "label": "createStaffProfilesMutationCtx()",
@@ -73288,7 +73315,7 @@
       "source_location": "L16"
     },
     {
-      "community": 328,
+      "community": 327,
       "file_type": "code",
       "id": "staffprofiles_test_gethandler",
       "label": "getHandler()",
@@ -73297,7 +73324,7 @@
       "source_location": "L92"
     },
     {
-      "community": 329,
+      "community": 328,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_staffroles_ts",
       "label": "staffRoles.ts",
@@ -73306,7 +73333,7 @@
       "source_location": "L1"
     },
     {
-      "community": 329,
+      "community": 328,
       "file_type": "code",
       "id": "staffroles_derivedefaultoperationalroles",
       "label": "deriveDefaultOperationalRoles()",
@@ -73315,13 +73342,40 @@
       "source_location": "L21"
     },
     {
-      "community": 329,
+      "community": 328,
       "file_type": "code",
       "id": "staffroles_uniqueoperationalroles",
       "label": "uniqueOperationalRoles()",
       "norm_label": "uniqueoperationalroles()",
       "source_file": "packages/athena-webapp/convex/operations/staffRoles.ts",
       "source_location": "L31"
+    },
+    {
+      "community": 329,
+      "file_type": "code",
+      "id": "index_listtransactions",
+      "label": "listTransactions()",
+      "norm_label": "listtransactions()",
+      "source_file": "packages/athena-webapp/convex/paystack/index.ts",
+      "source_location": "L7"
+    },
+    {
+      "community": 329,
+      "file_type": "code",
+      "id": "index_verifytransaction",
+      "label": "verifyTransaction()",
+      "norm_label": "verifytransaction()",
+      "source_file": "packages/athena-webapp/convex/paystack/index.ts",
+      "source_location": "L109"
+    },
+    {
+      "community": 329,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_paystack_index_ts",
+      "label": "index.ts",
+      "norm_label": "index.ts",
+      "source_file": "packages/athena-webapp/convex/paystack/index.ts",
+      "source_location": "L1"
     },
     {
       "community": 33,
@@ -73479,33 +73533,6 @@
     {
       "community": 330,
       "file_type": "code",
-      "id": "index_listtransactions",
-      "label": "listTransactions()",
-      "norm_label": "listtransactions()",
-      "source_file": "packages/athena-webapp/convex/paystack/index.ts",
-      "source_location": "L7"
-    },
-    {
-      "community": 330,
-      "file_type": "code",
-      "id": "index_verifytransaction",
-      "label": "verifyTransaction()",
-      "norm_label": "verifytransaction()",
-      "source_file": "packages/athena-webapp/convex/paystack/index.ts",
-      "source_location": "L109"
-    },
-    {
-      "community": 330,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_paystack_index_ts",
-      "label": "index.ts",
-      "norm_label": "index.ts",
-      "source_file": "packages/athena-webapp/convex/paystack/index.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 331,
-      "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_queries_terminals_ts",
       "label": "terminals.ts",
       "norm_label": "terminals.ts",
@@ -73513,7 +73540,7 @@
       "source_location": "L1"
     },
     {
-      "community": 331,
+      "community": 330,
       "file_type": "code",
       "id": "terminals_getterminalbyfingerprint",
       "label": "getTerminalByFingerprint()",
@@ -73522,7 +73549,7 @@
       "source_location": "L18"
     },
     {
-      "community": 331,
+      "community": 330,
       "file_type": "code",
       "id": "terminals_listterminals",
       "label": "listTerminals()",
@@ -73531,7 +73558,7 @@
       "source_location": "L9"
     },
     {
-      "community": 332,
+      "community": 331,
       "file_type": "code",
       "id": "errors_posservererror",
       "label": "PosServerError",
@@ -73540,7 +73567,7 @@
       "source_location": "L8"
     },
     {
-      "community": 332,
+      "community": 331,
       "file_type": "code",
       "id": "errors_posservererror_constructor",
       "label": ".constructor()",
@@ -73549,7 +73576,7 @@
       "source_location": "L9"
     },
     {
-      "community": 332,
+      "community": 331,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_domain_errors_ts",
       "label": "errors.ts",
@@ -73558,7 +73585,7 @@
       "source_location": "L1"
     },
     {
-      "community": 333,
+      "community": 332,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_domain_sessionrules_ts",
       "label": "sessionRules.ts",
@@ -73567,7 +73594,7 @@
       "source_location": "L1"
     },
     {
-      "community": 333,
+      "community": 332,
       "file_type": "code",
       "id": "sessionrules_deriveregisterphase",
       "label": "deriveRegisterPhase()",
@@ -73576,7 +73603,7 @@
       "source_location": "L7"
     },
     {
-      "community": 333,
+      "community": 332,
       "file_type": "code",
       "id": "sessionrules_selectresumablesession",
       "label": "selectResumableSession()",
@@ -73585,7 +73612,61 @@
       "source_location": "L29"
     },
     {
+      "community": 333,
+      "file_type": "code",
+      "id": "inventoryholdgateway_test_createctx",
+      "label": "createCtx()",
+      "norm_label": "createctx()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/integrations/inventoryHoldGateway.test.ts",
+      "source_location": "L16"
+    },
+    {
+      "community": 333,
+      "file_type": "code",
+      "id": "inventoryholdgateway_test_createlegacypatchctx",
+      "label": "createLegacyPatchCtx()",
+      "norm_label": "createlegacypatchctx()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/integrations/inventoryHoldGateway.test.ts",
+      "source_location": "L22"
+    },
+    {
+      "community": 333,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_infrastructure_integrations_inventoryholdgateway_test_ts",
+      "label": "inventoryHoldGateway.test.ts",
+      "norm_label": "inventoryholdgateway.test.ts",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/integrations/inventoryHoldGateway.test.ts",
+      "source_location": "L1"
+    },
+    {
       "community": 334,
+      "file_type": "code",
+      "id": "inventoryholdgateway_assertobjectshapedholdargs",
+      "label": "assertObjectShapedHoldArgs()",
+      "norm_label": "assertobjectshapedholdargs()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/integrations/inventoryHoldGateway.ts",
+      "source_location": "L43"
+    },
+    {
+      "community": 334,
+      "file_type": "code",
+      "id": "inventoryholdgateway_createinventoryholdgateway",
+      "label": "createInventoryHoldGateway()",
+      "norm_label": "createinventoryholdgateway()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/integrations/inventoryHoldGateway.ts",
+      "source_location": "L24"
+    },
+    {
+      "community": 334,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_infrastructure_integrations_inventoryholdgateway_ts",
+      "label": "inventoryHoldGateway.ts",
+      "norm_label": "inventoryholdgateway.ts",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/integrations/inventoryHoldGateway.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 335,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_integrations_paymentallocationservice_ts",
       "label": "paymentAllocationService.ts",
@@ -73594,7 +73675,7 @@
       "source_location": "L1"
     },
     {
-      "community": 334,
+      "community": 335,
       "file_type": "code",
       "id": "paymentallocationservice_recordretailsalepaymentallocations",
       "label": "recordRetailSalePaymentAllocations()",
@@ -73603,7 +73684,7 @@
       "source_location": "L13"
     },
     {
-      "community": 334,
+      "community": 335,
       "file_type": "code",
       "id": "paymentallocationservice_recordretailvoidpaymentallocations",
       "label": "recordRetailVoidPaymentAllocations()",
@@ -73612,7 +73693,7 @@
       "source_location": "L45"
     },
     {
-      "community": 335,
+      "community": 336,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_registersessionrepository_ts",
       "label": "registerSessionRepository.ts",
@@ -73621,7 +73702,7 @@
       "source_location": "L1"
     },
     {
-      "community": 335,
+      "community": 336,
       "file_type": "code",
       "id": "registersessionrepository_getactiveregistersessionforregisterstate",
       "label": "getActiveRegisterSessionForRegisterState()",
@@ -73630,7 +73711,7 @@
       "source_location": "L36"
     },
     {
-      "community": 335,
+      "community": 336,
       "file_type": "code",
       "id": "registersessionrepository_mapregistersessiontocashdrawersummary",
       "label": "mapRegisterSessionToCashDrawerSummary()",
@@ -73639,7 +73720,7 @@
       "source_location": "L13"
     },
     {
-      "community": 336,
+      "community": 337,
       "file_type": "code",
       "id": "appointments_buildserviceappointment",
       "label": "buildServiceAppointment()",
@@ -73648,7 +73729,7 @@
       "source_location": "L17"
     },
     {
-      "community": 336,
+      "community": 337,
       "file_type": "code",
       "id": "appointments_findoverlappingappointment",
       "label": "findOverlappingAppointment()",
@@ -73657,7 +73738,7 @@
       "source_location": "L61"
     },
     {
-      "community": 336,
+      "community": 337,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_serviceops_appointments_ts",
       "label": "appointments.ts",
@@ -73666,7 +73747,7 @@
       "source_location": "L1"
     },
     {
-      "community": 337,
+      "community": 338,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_serviceops_servicecases_test_ts",
       "label": "serviceCases.test.ts",
@@ -73675,7 +73756,7 @@
       "source_location": "L1"
     },
     {
-      "community": 337,
+      "community": 338,
       "file_type": "code",
       "id": "servicecases_test_expectindex",
       "label": "expectIndex()",
@@ -73684,7 +73765,7 @@
       "source_location": "L23"
     },
     {
-      "community": 337,
+      "community": 338,
       "file_type": "code",
       "id": "servicecases_test_gettableindexes",
       "label": "getTableIndexes()",
@@ -73693,7 +73774,7 @@
       "source_location": "L16"
     },
     {
-      "community": 338,
+      "community": 339,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_purchaseorders_test_ts",
       "label": "purchaseOrders.test.ts",
@@ -73702,7 +73783,7 @@
       "source_location": "L1"
     },
     {
-      "community": 338,
+      "community": 339,
       "file_type": "code",
       "id": "purchaseorders_test_createpurchaseordermutationctx",
       "label": "createPurchaseOrderMutationCtx()",
@@ -73711,40 +73792,13 @@
       "source_location": "L26"
     },
     {
-      "community": 338,
+      "community": 339,
       "file_type": "code",
       "id": "purchaseorders_test_getsource",
       "label": "getSource()",
       "norm_label": "getsource()",
       "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.test.ts",
       "source_location": "L22"
-    },
-    {
-      "community": 339,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_stockops_receiving_test_ts",
-      "label": "receiving.test.ts",
-      "norm_label": "receiving.test.ts",
-      "source_file": "packages/athena-webapp/convex/stockOps/receiving.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 339,
-      "file_type": "code",
-      "id": "receiving_test_createreceivingmutationctx",
-      "label": "createReceivingMutationCtx()",
-      "norm_label": "createreceivingmutationctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/receiving.test.ts",
-      "source_location": "L28"
-    },
-    {
-      "community": 339,
-      "file_type": "code",
-      "id": "receiving_test_getsource",
-      "label": "getSource()",
-      "norm_label": "getsource()",
-      "source_file": "packages/athena-webapp/convex/stockOps/receiving.test.ts",
-      "source_location": "L24"
     },
     {
       "community": 34,
@@ -73902,6 +73956,33 @@
     {
       "community": 340,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_stockops_receiving_test_ts",
+      "label": "receiving.test.ts",
+      "norm_label": "receiving.test.ts",
+      "source_file": "packages/athena-webapp/convex/stockOps/receiving.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 340,
+      "file_type": "code",
+      "id": "receiving_test_createreceivingmutationctx",
+      "label": "createReceivingMutationCtx()",
+      "norm_label": "createreceivingmutationctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/receiving.test.ts",
+      "source_location": "L28"
+    },
+    {
+      "community": 340,
+      "file_type": "code",
+      "id": "receiving_test_getsource",
+      "label": "getSource()",
+      "norm_label": "getsource()",
+      "source_file": "packages/athena-webapp/convex/stockOps/receiving.test.ts",
+      "source_location": "L24"
+    },
+    {
+      "community": 341,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_vendors_test_ts",
       "label": "vendors.test.ts",
       "norm_label": "vendors.test.ts",
@@ -73909,7 +73990,7 @@
       "source_location": "L1"
     },
     {
-      "community": 340,
+      "community": 341,
       "file_type": "code",
       "id": "vendors_test_createvendormutationctx",
       "label": "createVendorMutationCtx()",
@@ -73918,7 +73999,7 @@
       "source_location": "L24"
     },
     {
-      "community": 340,
+      "community": 341,
       "file_type": "code",
       "id": "vendors_test_getsource",
       "label": "getSource()",
@@ -73927,7 +74008,7 @@
       "source_location": "L20"
     },
     {
-      "community": 341,
+      "community": 342,
       "file_type": "code",
       "id": "errorfoundation_test_gethandler",
       "label": "getHandler()",
@@ -73936,7 +74017,7 @@
       "source_location": "L25"
     },
     {
-      "community": 341,
+      "community": 342,
       "file_type": "code",
       "id": "errorfoundation_test_getsource",
       "label": "getSource()",
@@ -73945,7 +74026,7 @@
       "source_location": "L21"
     },
     {
-      "community": 341,
+      "community": 342,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_errorfoundation_test_ts",
       "label": "errorFoundation.test.ts",
@@ -73954,7 +74035,7 @@
       "source_location": "L1"
     },
     {
-      "community": 342,
+      "community": 343,
       "file_type": "code",
       "id": "bag_listbagitems",
       "label": "listBagItems()",
@@ -73963,7 +74044,7 @@
       "source_location": "L7"
     },
     {
-      "community": 342,
+      "community": 343,
       "file_type": "code",
       "id": "bag_loadbagwithitems",
       "label": "loadBagWithItems()",
@@ -73972,7 +74053,7 @@
       "source_location": "L14"
     },
     {
-      "community": 342,
+      "community": 343,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_helpers_bag_ts",
       "label": "bag.ts",
@@ -73981,7 +74062,7 @@
       "source_location": "L1"
     },
     {
-      "community": 343,
+      "community": 344,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_adapters_registersession_ts",
       "label": "registerSession.ts",
@@ -73990,7 +74071,7 @@
       "source_location": "L1"
     },
     {
-      "community": 343,
+      "community": 344,
       "file_type": "code",
       "id": "registersession_buildregistersessiontraceseed",
       "label": "buildRegisterSessionTraceSeed()",
@@ -73999,7 +74080,7 @@
       "source_location": "L45"
     },
     {
-      "community": 343,
+      "community": 344,
       "file_type": "code",
       "id": "registersession_formatregistersessionlabel",
       "label": "formatRegisterSessionLabel()",
@@ -74008,7 +74089,7 @@
       "source_location": "L37"
     },
     {
-      "community": 344,
+      "community": 345,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_public_ts",
       "label": "public.ts",
@@ -74017,7 +74098,7 @@
       "source_location": "L1"
     },
     {
-      "community": 344,
+      "community": 345,
       "file_type": "code",
       "id": "public_getworkflowtraceviewbyidwithctx",
       "label": "getWorkflowTraceViewByIdWithCtx()",
@@ -74026,7 +74107,7 @@
       "source_location": "L10"
     },
     {
-      "community": 344,
+      "community": 345,
       "file_type": "code",
       "id": "public_getworkflowtraceviewbylookupwithctx",
       "label": "getWorkflowTraceViewByLookupWithCtx()",
@@ -74035,7 +74116,7 @@
       "source_location": "L44"
     },
     {
-      "community": 345,
+      "community": 346,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_queryusage_test_ts",
       "label": "queryUsage.test.ts",
@@ -74044,7 +74125,7 @@
       "source_location": "L1"
     },
     {
-      "community": 345,
+      "community": 346,
       "file_type": "code",
       "id": "queryusage_test_comparebyfields",
       "label": "compareByFields()",
@@ -74053,7 +74134,7 @@
       "source_location": "L84"
     },
     {
-      "community": 345,
+      "community": 346,
       "file_type": "code",
       "id": "queryusage_test_createtestctx",
       "label": "createTestCtx()",
@@ -74062,7 +74143,7 @@
       "source_location": "L100"
     },
     {
-      "community": 346,
+      "community": 347,
       "file_type": "code",
       "id": "currencyformatter_currencydisplaysymbol",
       "label": "currencyDisplaySymbol()",
@@ -74071,7 +74152,7 @@
       "source_location": "L5"
     },
     {
-      "community": 346,
+      "community": 347,
       "file_type": "code",
       "id": "currencyformatter_currencyformatter",
       "label": "currencyFormatter()",
@@ -74080,7 +74161,7 @@
       "source_location": "L25"
     },
     {
-      "community": 346,
+      "community": 347,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_currencyformatter_ts",
       "label": "currencyFormatter.ts",
@@ -74089,7 +74170,7 @@
       "source_location": "L1"
     },
     {
-      "community": 347,
+      "community": 348,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_workflowtrace_ts",
       "label": "workflowTrace.ts",
@@ -74098,7 +74179,7 @@
       "source_location": "L1"
     },
     {
-      "community": 347,
+      "community": 348,
       "file_type": "code",
       "id": "workflowtrace_createworkflowtraceid",
       "label": "createWorkflowTraceId()",
@@ -74107,7 +74188,7 @@
       "source_location": "L35"
     },
     {
-      "community": 347,
+      "community": 348,
       "file_type": "code",
       "id": "workflowtrace_normalizeworkflowtracelookupvalue",
       "label": "normalizeWorkflowTraceLookupValue()",
@@ -74116,7 +74197,7 @@
       "source_location": "L25"
     },
     {
-      "community": 348,
+      "community": 349,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_view_tsx",
       "label": "View.tsx",
@@ -74125,7 +74206,7 @@
       "source_location": "L1"
     },
     {
-      "community": 348,
+      "community": 349,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_view_tsx",
       "label": "View.tsx",
@@ -74134,40 +74215,13 @@
       "source_location": "L1"
     },
     {
-      "community": 348,
+      "community": 349,
       "file_type": "code",
       "id": "view_view",
       "label": "View()",
       "norm_label": "view()",
       "source_file": "packages/storefront-webapp/src/components/View.tsx",
       "source_location": "L4"
-    },
-    {
-      "community": 349,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_productavailability_tsx",
-      "label": "ProductAvailability.tsx",
-      "norm_label": "productavailability.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductAvailability.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 349,
-      "file_type": "code",
-      "id": "productavailability_productavailability",
-      "label": "ProductAvailability()",
-      "norm_label": "productavailability()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductAvailability.tsx",
-      "source_location": "L19"
-    },
-    {
-      "community": 349,
-      "file_type": "code",
-      "id": "productavailability_productavailabilityview",
-      "label": "ProductAvailabilityView()",
-      "norm_label": "productavailabilityview()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductAvailability.tsx",
-      "source_location": "L5"
     },
     {
       "community": 35,
@@ -74316,6 +74370,33 @@
     {
       "community": 350,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_productavailability_tsx",
+      "label": "ProductAvailability.tsx",
+      "norm_label": "productavailability.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductAvailability.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 350,
+      "file_type": "code",
+      "id": "productavailability_productavailability",
+      "label": "ProductAvailability()",
+      "norm_label": "productavailability()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductAvailability.tsx",
+      "source_location": "L19"
+    },
+    {
+      "community": 350,
+      "file_type": "code",
+      "id": "productavailability_productavailabilityview",
+      "label": "ProductAvailabilityView()",
+      "norm_label": "productavailabilityview()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductAvailability.tsx",
+      "source_location": "L5"
+    },
+    {
+      "community": 351,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_sheetprovider_tsx",
       "label": "SheetProvider.tsx",
       "norm_label": "sheetprovider.tsx",
@@ -74323,7 +74404,7 @@
       "source_location": "L1"
     },
     {
-      "community": 350,
+      "community": 351,
       "file_type": "code",
       "id": "sheetprovider_sheetprovider",
       "label": "SheetProvider()",
@@ -74332,7 +74413,7 @@
       "source_location": "L19"
     },
     {
-      "community": 350,
+      "community": 351,
       "file_type": "code",
       "id": "sheetprovider_usesheet",
       "label": "useSheet()",
@@ -74341,7 +74422,7 @@
       "source_location": "L11"
     },
     {
-      "community": 351,
+      "community": 352,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_wigtype_tsx",
       "label": "WigType.tsx",
@@ -74350,7 +74431,7 @@
       "source_location": "L1"
     },
     {
-      "community": 351,
+      "community": 352,
       "file_type": "code",
       "id": "wigtype_wigtype",
       "label": "WigType()",
@@ -74359,7 +74440,7 @@
       "source_location": "L22"
     },
     {
-      "community": 351,
+      "community": 352,
       "file_type": "code",
       "id": "wigtype_wigtypeview",
       "label": "WigTypeView()",
@@ -74368,7 +74449,7 @@
       "source_location": "L8"
     },
     {
-      "community": 352,
+      "community": 353,
       "file_type": "code",
       "id": "copyimagesprovider_copyimagesprovider",
       "label": "CopyImagesProvider()",
@@ -74377,7 +74458,7 @@
       "source_location": "L21"
     },
     {
-      "community": 352,
+      "community": 353,
       "file_type": "code",
       "id": "copyimagesprovider_usecopyimages",
       "label": "useCopyImages()",
@@ -74386,7 +74467,7 @@
       "source_location": "L13"
     },
     {
-      "community": 352,
+      "community": 353,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_copyimagesprovider_tsx",
       "label": "CopyImagesProvider.tsx",
@@ -74395,7 +74476,7 @@
       "source_location": "L1"
     },
     {
-      "community": 353,
+      "community": 354,
       "file_type": "code",
       "id": "analyticscombinedusers_analyticscombinedusers",
       "label": "AnalyticsCombinedUsers()",
@@ -74404,7 +74485,7 @@
       "source_location": "L100"
     },
     {
-      "community": 353,
+      "community": 354,
       "file_type": "code",
       "id": "analyticscombinedusers_processanalyticstousers",
       "label": "processAnalyticsToUsers()",
@@ -74413,7 +74494,7 @@
       "source_location": "L10"
     },
     {
-      "community": 353,
+      "community": 354,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticscombinedusers_tsx",
       "label": "AnalyticsCombinedUsers.tsx",
@@ -74422,7 +74503,7 @@
       "source_location": "L1"
     },
     {
-      "community": 354,
+      "community": 355,
       "file_type": "code",
       "id": "analyticstopusers_analyticstopusers",
       "label": "AnalyticsTopUsers()",
@@ -74431,7 +74512,7 @@
       "source_location": "L100"
     },
     {
-      "community": 354,
+      "community": 355,
       "file_type": "code",
       "id": "analyticstopusers_processanalyticstousers",
       "label": "processAnalyticsToUsers()",
@@ -74440,7 +74521,7 @@
       "source_location": "L10"
     },
     {
-      "community": 354,
+      "community": 355,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticstopusers_tsx",
       "label": "AnalyticsTopUsers.tsx",
@@ -74449,7 +74530,7 @@
       "source_location": "L1"
     },
     {
-      "community": 355,
+      "community": 356,
       "file_type": "code",
       "id": "log_items_provider_logitemsprovider",
       "label": "LogItemsProvider()",
@@ -74458,7 +74539,7 @@
       "source_location": "L15"
     },
     {
-      "community": 355,
+      "community": 356,
       "file_type": "code",
       "id": "log_items_provider_uselogitems",
       "label": "useLogItems()",
@@ -74467,7 +74548,7 @@
       "source_location": "L39"
     },
     {
-      "community": 355,
+      "community": 356,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_log_items_provider_tsx",
       "label": "log-items-provider.tsx",
@@ -74476,7 +74557,7 @@
       "source_location": "L1"
     },
     {
-      "community": 356,
+      "community": 357,
       "file_type": "code",
       "id": "fadein_fadein",
       "label": "FadeIn()",
@@ -74485,7 +74566,7 @@
       "source_location": "L3"
     },
     {
-      "community": 356,
+      "community": 357,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_common_fadein_tsx",
       "label": "FadeIn.tsx",
@@ -74494,7 +74575,7 @@
       "source_location": "L1"
     },
     {
-      "community": 356,
+      "community": 357,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_common_fadein_tsx",
       "label": "FadeIn.tsx",
@@ -74503,7 +74584,7 @@
       "source_location": "L1"
     },
     {
-      "community": 357,
+      "community": 358,
       "file_type": "code",
       "id": "bestsellers_handleremovebestseller",
       "label": "handleRemoveBestSeller()",
@@ -74512,7 +74593,7 @@
       "source_location": "L53"
     },
     {
-      "community": 357,
+      "community": 358,
       "file_type": "code",
       "id": "bestsellers_ondragend",
       "label": "onDragEnd()",
@@ -74521,7 +74602,7 @@
       "source_location": "L65"
     },
     {
-      "community": 357,
+      "community": 358,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_bestsellers_tsx",
       "label": "BestSellers.tsx",
@@ -74530,7 +74611,7 @@
       "source_location": "L1"
     },
     {
-      "community": 358,
+      "community": 359,
       "file_type": "code",
       "id": "featuredsection_handlehighlighteditem",
       "label": "handleHighlightedItem()",
@@ -74539,7 +74620,7 @@
       "source_location": "L47"
     },
     {
-      "community": 358,
+      "community": 359,
       "file_type": "code",
       "id": "featuredsection_ondragend",
       "label": "onDragEnd()",
@@ -74548,40 +74629,13 @@
       "source_location": "L53"
     },
     {
-      "community": 358,
+      "community": 359,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_featuredsection_tsx",
       "label": "FeaturedSection.tsx",
       "norm_label": "featuredsection.tsx",
       "source_file": "packages/athena-webapp/src/components/homepage/FeaturedSection.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 359,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_homepage_videoplayer_tsx",
-      "label": "VideoPlayer.tsx",
-      "norm_label": "videoplayer.tsx",
-      "source_file": "packages/athena-webapp/src/components/homepage/VideoPlayer.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 359,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_home_videoplayer_tsx",
-      "label": "VideoPlayer.tsx",
-      "norm_label": "videoplayer.tsx",
-      "source_file": "packages/storefront-webapp/src/components/home/VideoPlayer.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 359,
-      "file_type": "code",
-      "id": "videoplayer_videoplayer",
-      "label": "VideoPlayer()",
-      "norm_label": "videoplayer()",
-      "source_file": "packages/storefront-webapp/src/components/home/VideoPlayer.tsx",
-      "source_location": "L9"
     },
     {
       "community": 36,
@@ -74730,6 +74784,33 @@
     {
       "community": 360,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_homepage_videoplayer_tsx",
+      "label": "VideoPlayer.tsx",
+      "norm_label": "videoplayer.tsx",
+      "source_file": "packages/athena-webapp/src/components/homepage/VideoPlayer.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 360,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_home_videoplayer_tsx",
+      "label": "VideoPlayer.tsx",
+      "norm_label": "videoplayer.tsx",
+      "source_file": "packages/storefront-webapp/src/components/home/VideoPlayer.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 360,
+      "file_type": "code",
+      "id": "videoplayer_videoplayer",
+      "label": "VideoPlayer()",
+      "norm_label": "videoplayer()",
+      "source_file": "packages/storefront-webapp/src/components/home/VideoPlayer.tsx",
+      "source_location": "L9"
+    },
+    {
+      "community": 361,
+      "file_type": "code",
       "id": "orderview_handlerefundorder",
       "label": "handleRefundOrder()",
       "norm_label": "handlerefundorder()",
@@ -74737,7 +74818,7 @@
       "source_location": "L70"
     },
     {
-      "community": 360,
+      "community": 361,
       "file_type": "code",
       "id": "orderview_toast",
       "label": "toast()",
@@ -74746,7 +74827,7 @@
       "source_location": "L227"
     },
     {
-      "community": 360,
+      "community": 361,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orderview_tsx",
       "label": "OrderView.tsx",
@@ -74755,7 +74836,7 @@
       "source_location": "L1"
     },
     {
-      "community": 361,
+      "community": 362,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_pickupdetailsview_tsx",
       "label": "PickupDetailsView.tsx",
@@ -74764,7 +74845,7 @@
       "source_location": "L1"
     },
     {
-      "community": 361,
+      "community": 362,
       "file_type": "code",
       "id": "pickupdetailsview_deliverydetails",
       "label": "DeliveryDetails()",
@@ -74773,7 +74854,7 @@
       "source_location": "L71"
     },
     {
-      "community": 361,
+      "community": 362,
       "file_type": "code",
       "id": "pickupdetailsview_pickupdetailsview",
       "label": "PickupDetailsView()",
@@ -74782,7 +74863,7 @@
       "source_location": "L9"
     },
     {
-      "community": 362,
+      "community": 363,
       "file_type": "code",
       "id": "cashierauthdialog_cashierauthdialog",
       "label": "CashierAuthDialog()",
@@ -74791,7 +74872,7 @@
       "source_location": "L33"
     },
     {
-      "community": 362,
+      "community": 363,
       "file_type": "code",
       "id": "cashierauthdialog_getstaffdisplayname",
       "label": "getStaffDisplayName()",
@@ -74800,7 +74881,7 @@
       "source_location": "L24"
     },
     {
-      "community": 362,
+      "community": 363,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_cashierauthdialog_tsx",
       "label": "CashierAuthDialog.tsx",
@@ -74809,7 +74890,7 @@
       "source_location": "L1"
     },
     {
-      "community": 363,
+      "community": 364,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_searchresultssection_tsx",
       "label": "SearchResultsSection.tsx",
@@ -74818,7 +74899,7 @@
       "source_location": "L1"
     },
     {
-      "community": 363,
+      "community": 364,
       "file_type": "code",
       "id": "searchresultssection_handlequickaddproductshortcut",
       "label": "handleQuickAddProductShortcut()",
@@ -74827,7 +74908,7 @@
       "source_location": "L117"
     },
     {
-      "community": 363,
+      "community": 364,
       "file_type": "code",
       "id": "searchresultssection_handlequickaddvariantshortcut",
       "label": "handleQuickAddVariantShortcut()",
@@ -74836,7 +74917,7 @@
       "source_location": "L84"
     },
     {
-      "community": 364,
+      "community": 365,
       "file_type": "code",
       "id": "expensereportsview_istoday",
       "label": "isToday()",
@@ -74845,7 +74926,7 @@
       "source_location": "L28"
     },
     {
-      "community": 364,
+      "community": 365,
       "file_type": "code",
       "id": "expensereportsview_toexpensereportrows",
       "label": "toExpenseReportRows()",
@@ -74854,7 +74935,7 @@
       "source_location": "L34"
     },
     {
-      "community": 364,
+      "community": 365,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportsview_tsx",
       "label": "ExpenseReportsView.tsx",
@@ -74863,7 +74944,7 @@
       "source_location": "L1"
     },
     {
-      "community": 365,
+      "community": 366,
       "file_type": "code",
       "id": "heldsessionslist_getsessioncartitemscount",
       "label": "getSessionCartItemsCount()",
@@ -74872,7 +74953,7 @@
       "source_location": "L36"
     },
     {
-      "community": 365,
+      "community": 366,
       "file_type": "code",
       "id": "heldsessionslist_hasexpired",
       "label": "hasExpired()",
@@ -74881,7 +74962,7 @@
       "source_location": "L32"
     },
     {
-      "community": 365,
+      "community": 366,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_session_heldsessionslist_tsx",
       "label": "HeldSessionsList.tsx",
@@ -74890,7 +74971,7 @@
       "source_location": "L1"
     },
     {
-      "community": 366,
+      "community": 367,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_settings_possettingsview_tsx",
       "label": "POSSettingsView.tsx",
@@ -74899,7 +74980,7 @@
       "source_location": "L1"
     },
     {
-      "community": 366,
+      "community": 367,
       "file_type": "code",
       "id": "possettingsview_fingerprintregistrationcard",
       "label": "FingerprintRegistrationCard()",
@@ -74908,7 +74989,7 @@
       "source_location": "L53"
     },
     {
-      "community": 366,
+      "community": 367,
       "file_type": "code",
       "id": "possettingsview_possettingsview",
       "label": "POSSettingsView()",
@@ -74917,7 +74998,7 @@
       "source_location": "L180"
     },
     {
-      "community": 367,
+      "community": 368,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_productstatus_test_tsx",
       "label": "ProductStatus.test.tsx",
@@ -74926,7 +75007,7 @@
       "source_location": "L1"
     },
     {
-      "community": 367,
+      "community": 368,
       "file_type": "code",
       "id": "productstatus_test_makeproduct",
       "label": "makeProduct()",
@@ -74935,7 +75016,7 @@
       "source_location": "L8"
     },
     {
-      "community": 367,
+      "community": 368,
       "file_type": "code",
       "id": "productstatus_test_makevariant",
       "label": "makeVariant()",
@@ -74944,7 +75025,7 @@
       "source_location": "L18"
     },
     {
-      "community": 368,
+      "community": 369,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_productslistview_tsx",
       "label": "ProductsListView.tsx",
@@ -74953,7 +75034,7 @@
       "source_location": "L1"
     },
     {
-      "community": 368,
+      "community": 369,
       "file_type": "code",
       "id": "productslistview_handleclearcache",
       "label": "handleClearCache()",
@@ -74962,40 +75043,13 @@
       "source_location": "L65"
     },
     {
-      "community": 368,
+      "community": 369,
       "file_type": "code",
       "id": "productslistview_productactionstogglegroup",
       "label": "ProductActionsToggleGroup()",
       "norm_label": "productactionstogglegroup()",
       "source_file": "packages/athena-webapp/src/components/products/ProductsListView.tsx",
       "source_location": "L20"
-    },
-    {
-      "community": 369,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_productstablecontext_tsx",
-      "label": "ProductsTableContext.tsx",
-      "norm_label": "productstablecontext.tsx",
-      "source_file": "packages/athena-webapp/src/components/products/ProductsTableContext.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 369,
-      "file_type": "code",
-      "id": "productstablecontext_productstableprovider",
-      "label": "ProductsTableProvider()",
-      "norm_label": "productstableprovider()",
-      "source_file": "packages/athena-webapp/src/components/products/ProductsTableContext.tsx",
-      "source_location": "L16"
-    },
-    {
-      "community": 369,
-      "file_type": "code",
-      "id": "productstablecontext_useproductstablestate",
-      "label": "useProductsTableState()",
-      "norm_label": "useproductstablestate()",
-      "source_file": "packages/athena-webapp/src/components/products/ProductsTableContext.tsx",
-      "source_location": "L60"
     },
     {
       "community": 37,
@@ -75144,6 +75198,33 @@
     {
       "community": 370,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_products_productstablecontext_tsx",
+      "label": "ProductsTableContext.tsx",
+      "norm_label": "productstablecontext.tsx",
+      "source_file": "packages/athena-webapp/src/components/products/ProductsTableContext.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 370,
+      "file_type": "code",
+      "id": "productstablecontext_productstableprovider",
+      "label": "ProductsTableProvider()",
+      "norm_label": "productstableprovider()",
+      "source_file": "packages/athena-webapp/src/components/products/ProductsTableContext.tsx",
+      "source_location": "L16"
+    },
+    {
+      "community": 370,
+      "file_type": "code",
+      "id": "productstablecontext_useproductstablestate",
+      "label": "useProductsTableState()",
+      "norm_label": "useproductstablestate()",
+      "source_file": "packages/athena-webapp/src/components/products/ProductsTableContext.tsx",
+      "source_location": "L60"
+    },
+    {
+      "community": 371,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_storeproductsview_tsx",
       "label": "StoreProductsView.tsx",
       "norm_label": "storeproductsview.tsx",
@@ -75151,7 +75232,7 @@
       "source_location": "L1"
     },
     {
-      "community": 370,
+      "community": 371,
       "file_type": "code",
       "id": "storeproductsview_navigation",
       "label": "Navigation()",
@@ -75160,7 +75241,7 @@
       "source_location": "L45"
     },
     {
-      "community": 370,
+      "community": 371,
       "file_type": "code",
       "id": "storeproductsview_productactionstogglegroup",
       "label": "ProductActionsToggleGroup()",
@@ -75169,7 +75250,7 @@
       "source_location": "L19"
     },
     {
-      "community": 371,
+      "community": 372,
       "file_type": "code",
       "id": "addcomplimentaryproduct_addcomplimentaryproduct",
       "label": "AddComplimentaryProduct()",
@@ -75178,7 +75259,7 @@
       "source_location": "L128"
     },
     {
-      "community": 371,
+      "community": 372,
       "file_type": "code",
       "id": "addcomplimentaryproduct_handleaddcomplimentaryproducts",
       "label": "handleAddComplimentaryProducts()",
@@ -75187,7 +75268,7 @@
       "source_location": "L40"
     },
     {
-      "community": 371,
+      "community": 372,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_complimentary_addcomplimentaryproduct_tsx",
       "label": "AddComplimentaryProduct.tsx",
@@ -75196,7 +75277,7 @@
       "source_location": "L1"
     },
     {
-      "community": 372,
+      "community": 373,
       "file_type": "code",
       "id": "color_picker_handleblur",
       "label": "handleBlur()",
@@ -75205,7 +75286,7 @@
       "source_location": "L24"
     },
     {
-      "community": 372,
+      "community": 373,
       "file_type": "code",
       "id": "color_picker_handleinputchange",
       "label": "handleInputChange()",
@@ -75214,7 +75295,7 @@
       "source_location": "L20"
     },
     {
-      "community": 372,
+      "community": 373,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_modals_color_picker_tsx",
       "label": "color-picker.tsx",
@@ -75223,7 +75304,7 @@
       "source_location": "L1"
     },
     {
-      "community": 373,
+      "community": 374,
       "file_type": "code",
       "id": "currency_provider_currencyprovider",
       "label": "CurrencyProvider()",
@@ -75232,7 +75313,7 @@
       "source_location": "L25"
     },
     {
-      "community": 373,
+      "community": 374,
       "file_type": "code",
       "id": "currency_provider_usestorecurrency",
       "label": "useStoreCurrency()",
@@ -75241,7 +75322,7 @@
       "source_location": "L17"
     },
     {
-      "community": 373,
+      "community": 374,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_providers_currency_provider_tsx",
       "label": "currency-provider.tsx",
@@ -75250,7 +75331,7 @@
       "source_location": "L1"
     },
     {
-      "community": 374,
+      "community": 375,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_serviceappointmentsview_test_tsx",
       "label": "ServiceAppointmentsView.test.tsx",
@@ -75259,7 +75340,7 @@
       "source_location": "L1"
     },
     {
-      "community": 374,
+      "community": 375,
       "file_type": "code",
       "id": "serviceappointmentsview_test_choosedatetime",
       "label": "chooseDateTime()",
@@ -75268,7 +75349,7 @@
       "source_location": "L59"
     },
     {
-      "community": 374,
+      "community": 375,
       "file_type": "code",
       "id": "serviceappointmentsview_test_chooseselectoption",
       "label": "chooseSelectOption()",
@@ -75277,7 +75358,7 @@
       "source_location": "L50"
     },
     {
-      "community": 375,
+      "community": 376,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_serviceintakeview_tsx",
       "label": "ServiceIntakeView.tsx",
@@ -75286,7 +75367,7 @@
       "source_location": "L1"
     },
     {
-      "community": 375,
+      "community": 376,
       "file_type": "code",
       "id": "serviceintakeview_serviceintakeview",
       "label": "ServiceIntakeView()",
@@ -75295,7 +75376,7 @@
       "source_location": "L225"
     },
     {
-      "community": 375,
+      "community": 376,
       "file_type": "code",
       "id": "serviceintakeview_serviceintakeviewcontent",
       "label": "ServiceIntakeViewContent()",
@@ -75304,7 +75385,7 @@
       "source_location": "L80"
     },
     {
-      "community": 376,
+      "community": 377,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_staff_staffmanagement_test_tsx",
       "label": "StaffManagement.test.tsx",
@@ -75313,7 +75394,7 @@
       "source_location": "L1"
     },
     {
-      "community": 376,
+      "community": 377,
       "file_type": "code",
       "id": "staffmanagement_test_chooserole",
       "label": "chooseRole()",
@@ -75322,7 +75403,7 @@
       "source_location": "L163"
     },
     {
-      "community": 376,
+      "community": 377,
       "file_type": "code",
       "id": "staffmanagement_test_mockconvex",
       "label": "mockConvex()",
@@ -75331,7 +75412,7 @@
       "source_location": "L107"
     },
     {
-      "community": 377,
+      "community": 378,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_staff_auth_staffauthenticationdialog_tsx",
       "label": "StaffAuthenticationDialog.tsx",
@@ -75340,7 +75421,7 @@
       "source_location": "L1"
     },
     {
-      "community": 377,
+      "community": 378,
       "file_type": "code",
       "id": "staffauthenticationdialog_handlekeydown",
       "label": "handleKeyDown()",
@@ -75349,7 +75430,7 @@
       "source_location": "L168"
     },
     {
-      "community": 377,
+      "community": 378,
       "file_type": "code",
       "id": "staffauthenticationdialog_handlesubmit",
       "label": "handleSubmit()",
@@ -75358,7 +75439,7 @@
       "source_location": "L110"
     },
     {
-      "community": 378,
+      "community": 379,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_error_singlelineerror_tsx",
       "label": "SingleLineError.tsx",
@@ -75367,7 +75448,7 @@
       "source_location": "L1"
     },
     {
-      "community": 378,
+      "community": 379,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_error_singlelineerror_tsx",
       "label": "SingleLineError.tsx",
@@ -75376,40 +75457,13 @@
       "source_location": "L1"
     },
     {
-      "community": 378,
+      "community": 379,
       "file_type": "code",
       "id": "singlelineerror_singlelineerror",
       "label": "SingleLineError()",
       "norm_label": "singlelineerror()",
       "source_file": "packages/storefront-webapp/src/components/states/error/SingleLineError.tsx",
       "source_location": "L3"
-    },
-    {
-      "community": 379,
-      "file_type": "code",
-      "id": "index_errorpage",
-      "label": "ErrorPage()",
-      "norm_label": "errorpage()",
-      "source_file": "packages/storefront-webapp/src/components/states/error/index.tsx",
-      "source_location": "L9"
-    },
-    {
-      "community": 379,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_states_error_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/components/states/error/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 379,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_states_error_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/storefront-webapp/src/components/states/error/index.tsx",
-      "source_location": "L1"
     },
     {
       "community": 38,
@@ -75558,6 +75612,33 @@
     {
       "community": 380,
       "file_type": "code",
+      "id": "index_errorpage",
+      "label": "ErrorPage()",
+      "norm_label": "errorpage()",
+      "source_file": "packages/storefront-webapp/src/components/states/error/index.tsx",
+      "source_location": "L9"
+    },
+    {
+      "community": 380,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_states_error_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/components/states/error/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 380,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_states_error_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/storefront-webapp/src/components/states/error/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 381,
+      "file_type": "code",
       "id": "app_skeleton_appskeleton",
       "label": "AppSkeleton()",
       "norm_label": "appskeleton()",
@@ -75565,7 +75646,7 @@
       "source_location": "L3"
     },
     {
-      "community": 380,
+      "community": 381,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_loading_app_skeleton_tsx",
       "label": "app-skeleton.tsx",
@@ -75574,7 +75655,7 @@
       "source_location": "L1"
     },
     {
-      "community": 380,
+      "community": 381,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_loading_app_skeleton_tsx",
       "label": "app-skeleton.tsx",
@@ -75583,7 +75664,7 @@
       "source_location": "L1"
     },
     {
-      "community": 381,
+      "community": 382,
       "file_type": "code",
       "id": "dashboard_skeleton_dashboardskeleton",
       "label": "DashboardSkeleton()",
@@ -75592,7 +75673,7 @@
       "source_location": "L3"
     },
     {
-      "community": 381,
+      "community": 382,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_loading_dashboard_skeleton_tsx",
       "label": "dashboard-skeleton.tsx",
@@ -75601,7 +75682,7 @@
       "source_location": "L1"
     },
     {
-      "community": 381,
+      "community": 382,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_loading_dashboard_skeleton_tsx",
       "label": "dashboard-skeleton.tsx",
@@ -75610,7 +75691,7 @@
       "source_location": "L1"
     },
     {
-      "community": 382,
+      "community": 383,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_loading_table_skeleton_tsx",
       "label": "table-skeleton.tsx",
@@ -75619,7 +75700,7 @@
       "source_location": "L1"
     },
     {
-      "community": 382,
+      "community": 383,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_loading_table_skeleton_tsx",
       "label": "table-skeleton.tsx",
@@ -75628,7 +75709,7 @@
       "source_location": "L1"
     },
     {
-      "community": 382,
+      "community": 383,
       "file_type": "code",
       "id": "table_skeleton_tableskeleton",
       "label": "TableSkeleton()",
@@ -75637,7 +75718,7 @@
       "source_location": "L3"
     },
     {
-      "community": 383,
+      "community": 384,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_loading_transactions_skeleton_tsx",
       "label": "transactions-skeleton.tsx",
@@ -75646,7 +75727,7 @@
       "source_location": "L1"
     },
     {
-      "community": 383,
+      "community": 384,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_loading_transactions_skeleton_tsx",
       "label": "transactions-skeleton.tsx",
@@ -75655,7 +75736,7 @@
       "source_location": "L1"
     },
     {
-      "community": 383,
+      "community": 384,
       "file_type": "code",
       "id": "transactions_skeleton_transactionsskeleton",
       "label": "TransactionsSkeleton()",
@@ -75664,7 +75745,7 @@
       "source_location": "L3"
     },
     {
-      "community": 384,
+      "community": 385,
       "file_type": "code",
       "id": "notfound_notfound",
       "label": "NotFound()",
@@ -75673,7 +75754,7 @@
       "source_location": "L4"
     },
     {
-      "community": 384,
+      "community": 385,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_not_found_notfound_tsx",
       "label": "NotFound.tsx",
@@ -75682,7 +75763,7 @@
       "source_location": "L1"
     },
     {
-      "community": 384,
+      "community": 385,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_not_found_notfound_tsx",
       "label": "NotFound.tsx",
@@ -75691,7 +75772,7 @@
       "source_location": "L1"
     },
     {
-      "community": 385,
+      "community": 386,
       "file_type": "code",
       "id": "feesview_handletoggleallfees",
       "label": "handleToggleAllFees()",
@@ -75700,7 +75781,7 @@
       "source_location": "L120"
     },
     {
-      "community": 385,
+      "community": 386,
       "file_type": "code",
       "id": "feesview_handleupdatefees",
       "label": "handleUpdateFees()",
@@ -75709,7 +75790,7 @@
       "source_location": "L36"
     },
     {
-      "community": 385,
+      "community": 386,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_feesview_tsx",
       "label": "FeesView.tsx",
@@ -75718,7 +75799,7 @@
       "source_location": "L1"
     },
     {
-      "community": 386,
+      "community": 387,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_traces_workflowtraceroutelink_tsx",
       "label": "WorkflowTraceRouteLink.tsx",
@@ -75727,7 +75808,7 @@
       "source_location": "L1"
     },
     {
-      "community": 386,
+      "community": 387,
       "file_type": "code",
       "id": "workflowtraceroutelink_getworkflowtraceroutetarget",
       "label": "getWorkflowTraceRouteTarget()",
@@ -75736,7 +75817,7 @@
       "source_location": "L23"
     },
     {
-      "community": 386,
+      "community": 387,
       "file_type": "code",
       "id": "workflowtraceroutelink_workflowtraceroutelink",
       "label": "WorkflowTraceRouteLink()",
@@ -75745,7 +75826,7 @@
       "source_location": "L41"
     },
     {
-      "community": 387,
+      "community": 388,
       "file_type": "code",
       "id": "app_context_menu_appcontextmenu",
       "label": "AppContextMenu()",
@@ -75754,7 +75835,7 @@
       "source_location": "L20"
     },
     {
-      "community": 387,
+      "community": 388,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_app_context_menu_tsx",
       "label": "app-context-menu.tsx",
@@ -75763,7 +75844,7 @@
       "source_location": "L1"
     },
     {
-      "community": 387,
+      "community": 388,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_app_context_menu_tsx",
       "label": "app-context-menu.tsx",
@@ -75772,7 +75853,7 @@
       "source_location": "L1"
     },
     {
-      "community": 388,
+      "community": 389,
       "file_type": "code",
       "id": "badge_badge",
       "label": "Badge()",
@@ -75781,7 +75862,7 @@
       "source_location": "L30"
     },
     {
-      "community": 388,
+      "community": 389,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_badge_tsx",
       "label": "badge.tsx",
@@ -75790,39 +75871,12 @@
       "source_location": "L1"
     },
     {
-      "community": 388,
+      "community": 389,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_badge_tsx",
       "label": "badge.tsx",
       "norm_label": "badge.tsx",
       "source_file": "packages/storefront-webapp/src/components/ui/badge.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 389,
-      "file_type": "code",
-      "id": "loading_button_loadingbutton",
-      "label": "LoadingButton()",
-      "norm_label": "loadingbutton()",
-      "source_file": "packages/storefront-webapp/src/components/ui/loading-button.tsx",
-      "source_location": "L9"
-    },
-    {
-      "community": 389,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_loading_button_tsx",
-      "label": "loading-button.tsx",
-      "norm_label": "loading-button.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/loading-button.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 389,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_loading_button_tsx",
-      "label": "loading-button.tsx",
-      "norm_label": "loading-button.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/loading-button.tsx",
       "source_location": "L1"
     },
     {
@@ -75972,6 +76026,33 @@
     {
       "community": 390,
       "file_type": "code",
+      "id": "loading_button_loadingbutton",
+      "label": "LoadingButton()",
+      "norm_label": "loadingbutton()",
+      "source_file": "packages/storefront-webapp/src/components/ui/loading-button.tsx",
+      "source_location": "L9"
+    },
+    {
+      "community": 390,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_loading_button_tsx",
+      "label": "loading-button.tsx",
+      "norm_label": "loading-button.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/loading-button.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 390,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_loading_button_tsx",
+      "label": "loading-button.tsx",
+      "norm_label": "loading-button.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/loading-button.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 391,
+      "file_type": "code",
       "id": "modal_onchange",
       "label": "onChange()",
       "norm_label": "onchange()",
@@ -75979,7 +76060,7 @@
       "source_location": "L38"
     },
     {
-      "community": 390,
+      "community": 391,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modal_tsx",
       "label": "modal.tsx",
@@ -75988,7 +76069,7 @@
       "source_location": "L1"
     },
     {
-      "community": 390,
+      "community": 391,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modal_tsx",
       "label": "modal.tsx",
@@ -75997,7 +76078,7 @@
       "source_location": "L1"
     },
     {
-      "community": 391,
+      "community": 392,
       "file_type": "code",
       "id": "alert_modal_alertmodal",
       "label": "AlertModal()",
@@ -76006,7 +76087,7 @@
       "source_location": "L20"
     },
     {
-      "community": 391,
+      "community": 392,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_alert_modal_tsx",
       "label": "alert-modal.tsx",
@@ -76015,7 +76096,7 @@
       "source_location": "L1"
     },
     {
-      "community": 391,
+      "community": 392,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_alert_modal_tsx",
       "label": "alert-modal.tsx",
@@ -76024,7 +76105,7 @@
       "source_location": "L1"
     },
     {
-      "community": 392,
+      "community": 393,
       "file_type": "code",
       "id": "overlay_modal_overlaymodal",
       "label": "OverlayModal()",
@@ -76033,7 +76114,7 @@
       "source_location": "L12"
     },
     {
-      "community": 392,
+      "community": 393,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_overlay_modal_tsx",
       "label": "overlay-modal.tsx",
@@ -76042,7 +76123,7 @@
       "source_location": "L1"
     },
     {
-      "community": 392,
+      "community": 393,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_overlay_modal_tsx",
       "label": "overlay-modal.tsx",
@@ -76051,7 +76132,7 @@
       "source_location": "L1"
     },
     {
-      "community": 393,
+      "community": 394,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_skeleton_tsx",
       "label": "skeleton.tsx",
@@ -76060,7 +76141,7 @@
       "source_location": "L1"
     },
     {
-      "community": 393,
+      "community": 394,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_skeleton_tsx",
       "label": "skeleton.tsx",
@@ -76069,7 +76150,7 @@
       "source_location": "L1"
     },
     {
-      "community": 393,
+      "community": 394,
       "file_type": "code",
       "id": "skeleton_skeleton",
       "label": "Skeleton()",
@@ -76078,7 +76159,7 @@
       "source_location": "L3"
     },
     {
-      "community": 394,
+      "community": 395,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_sonner_tsx",
       "label": "sonner.tsx",
@@ -76087,7 +76168,7 @@
       "source_location": "L1"
     },
     {
-      "community": 394,
+      "community": 395,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_sonner_tsx",
       "label": "sonner.tsx",
@@ -76096,7 +76177,7 @@
       "source_location": "L1"
     },
     {
-      "community": 394,
+      "community": 395,
       "file_type": "code",
       "id": "sonner_toaster",
       "label": "Toaster()",
@@ -76105,7 +76186,7 @@
       "source_location": "L6"
     },
     {
-      "community": 395,
+      "community": 396,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_spinner_tsx",
       "label": "spinner.tsx",
@@ -76114,7 +76195,7 @@
       "source_location": "L1"
     },
     {
-      "community": 395,
+      "community": 396,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_spinner_tsx",
       "label": "spinner.tsx",
@@ -76123,7 +76204,7 @@
       "source_location": "L1"
     },
     {
-      "community": 395,
+      "community": 396,
       "file_type": "code",
       "id": "spinner_spinner",
       "label": "Spinner()",
@@ -76132,7 +76213,7 @@
       "source_location": "L3"
     },
     {
-      "community": 396,
+      "community": 397,
       "file_type": "code",
       "id": "activitysummarycards_activitysummarycards",
       "label": "ActivitySummaryCards()",
@@ -76141,7 +76222,7 @@
       "source_location": "L44"
     },
     {
-      "community": 396,
+      "community": 397,
       "file_type": "code",
       "id": "activitysummarycards_summarycard",
       "label": "SummaryCard()",
@@ -76150,7 +76231,7 @@
       "source_location": "L19"
     },
     {
-      "community": 396,
+      "community": 397,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_activitysummarycards_tsx",
       "label": "ActivitySummaryCards.tsx",
@@ -76159,7 +76240,7 @@
       "source_location": "L1"
     },
     {
-      "community": 397,
+      "community": 398,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_timelineeventcard_tsx",
       "label": "TimelineEventCard.tsx",
@@ -76168,7 +76249,7 @@
       "source_location": "L1"
     },
     {
-      "community": 397,
+      "community": 398,
       "file_type": "code",
       "id": "timelineeventcard_formatobservabilitylabel",
       "label": "formatObservabilityLabel()",
@@ -76177,7 +76258,7 @@
       "source_location": "L159"
     },
     {
-      "community": 397,
+      "community": 398,
       "file_type": "code",
       "id": "timelineeventcard_loadmore",
       "label": "loadMore()",
@@ -76186,7 +76267,7 @@
       "source_location": "L195"
     },
     {
-      "community": 398,
+      "community": 399,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_useractivity_tsx",
       "label": "UserActivity.tsx",
@@ -76195,7 +76276,7 @@
       "source_location": "L1"
     },
     {
-      "community": 398,
+      "community": 399,
       "file_type": "code",
       "id": "useractivity_activityheader",
       "label": "ActivityHeader()",
@@ -76204,40 +76285,13 @@
       "source_location": "L22"
     },
     {
-      "community": 398,
+      "community": 399,
       "file_type": "code",
       "id": "useractivity_useractivity",
       "label": "UserActivity()",
       "norm_label": "useractivity()",
       "source_file": "packages/athena-webapp/src/components/users/UserActivity.tsx",
       "source_location": "L45"
-    },
-    {
-      "community": 399,
-      "file_type": "code",
-      "id": "onlineordercontext_onlineorderprovider",
-      "label": "OnlineOrderProvider()",
-      "norm_label": "onlineorderprovider()",
-      "source_file": "packages/athena-webapp/src/contexts/OnlineOrderContext.tsx",
-      "source_location": "L24"
-    },
-    {
-      "community": 399,
-      "file_type": "code",
-      "id": "onlineordercontext_useonlineorder",
-      "label": "useOnlineOrder()",
-      "norm_label": "useonlineorder()",
-      "source_file": "packages/athena-webapp/src/contexts/OnlineOrderContext.tsx",
-      "source_location": "L38"
-    },
-    {
-      "community": 399,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_contexts_onlineordercontext_tsx",
-      "label": "OnlineOrderContext.tsx",
-      "norm_label": "onlineordercontext.tsx",
-      "source_file": "packages/athena-webapp/src/contexts/OnlineOrderContext.tsx",
-      "source_location": "L1"
     },
     {
       "community": 4,
@@ -76665,6 +76719,33 @@
     {
       "community": 400,
       "file_type": "code",
+      "id": "onlineordercontext_onlineorderprovider",
+      "label": "OnlineOrderProvider()",
+      "norm_label": "onlineorderprovider()",
+      "source_file": "packages/athena-webapp/src/contexts/OnlineOrderContext.tsx",
+      "source_location": "L24"
+    },
+    {
+      "community": 400,
+      "file_type": "code",
+      "id": "onlineordercontext_useonlineorder",
+      "label": "useOnlineOrder()",
+      "norm_label": "useonlineorder()",
+      "source_file": "packages/athena-webapp/src/contexts/OnlineOrderContext.tsx",
+      "source_location": "L38"
+    },
+    {
+      "community": 400,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_contexts_onlineordercontext_tsx",
+      "label": "OnlineOrderContext.tsx",
+      "norm_label": "onlineordercontext.tsx",
+      "source_file": "packages/athena-webapp/src/contexts/OnlineOrderContext.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 401,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_contexts_permissionscontext_tsx",
       "label": "PermissionsContext.tsx",
       "norm_label": "permissionscontext.tsx",
@@ -76672,7 +76753,7 @@
       "source_location": "L1"
     },
     {
-      "community": 400,
+      "community": 401,
       "file_type": "code",
       "id": "permissionscontext_permissionsprovider",
       "label": "PermissionsProvider()",
@@ -76681,7 +76762,7 @@
       "source_location": "L23"
     },
     {
-      "community": 400,
+      "community": 401,
       "file_type": "code",
       "id": "permissionscontext_usepermissionscontext",
       "label": "usePermissionsContext()",
@@ -76690,7 +76771,7 @@
       "source_location": "L51"
     },
     {
-      "community": 401,
+      "community": 402,
       "file_type": "code",
       "id": "packages_athena_webapp_src_contexts_productcontext_tsx",
       "label": "ProductContext.tsx",
@@ -76699,7 +76780,7 @@
       "source_location": "L1"
     },
     {
-      "community": 401,
+      "community": 402,
       "file_type": "code",
       "id": "productcontext_productprovider",
       "label": "ProductProvider()",
@@ -76708,7 +76789,7 @@
       "source_location": "L54"
     },
     {
-      "community": 401,
+      "community": 402,
       "file_type": "code",
       "id": "productcontext_useproduct",
       "label": "useProduct()",
@@ -76717,7 +76798,7 @@
       "source_location": "L282"
     },
     {
-      "community": 402,
+      "community": 403,
       "file_type": "code",
       "id": "packages_athena_webapp_src_contexts_usercontext_tsx",
       "label": "UserContext.tsx",
@@ -76726,7 +76807,7 @@
       "source_location": "L1"
     },
     {
-      "community": 402,
+      "community": 403,
       "file_type": "code",
       "id": "usercontext_userprovider",
       "label": "UserProvider()",
@@ -76735,7 +76816,7 @@
       "source_location": "L12"
     },
     {
-      "community": 402,
+      "community": 403,
       "file_type": "code",
       "id": "usercontext_useusercontext",
       "label": "useUserContext()",
@@ -76744,7 +76825,7 @@
       "source_location": "L37"
     },
     {
-      "community": 403,
+      "community": 404,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useauth_ts",
       "label": "useAuth.ts",
@@ -76753,7 +76834,7 @@
       "source_location": "L1"
     },
     {
-      "community": 403,
+      "community": 404,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useauth_ts",
       "label": "useAuth.ts",
@@ -76762,7 +76843,7 @@
       "source_location": "L1"
     },
     {
-      "community": 403,
+      "community": 404,
       "file_type": "code",
       "id": "useauth_useauth",
       "label": "useAuth()",
@@ -76771,7 +76852,7 @@
       "source_location": "L4"
     },
     {
-      "community": 404,
+      "community": 405,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetactivestore_ts",
       "label": "useGetActiveStore.ts",
@@ -76780,7 +76861,7 @@
       "source_location": "L1"
     },
     {
-      "community": 404,
+      "community": 405,
       "file_type": "code",
       "id": "usegetactivestore_usegetactivestore",
       "label": "useGetActiveStore()",
@@ -76789,7 +76870,7 @@
       "source_location": "L9"
     },
     {
-      "community": 404,
+      "community": 405,
       "file_type": "code",
       "id": "usegetactivestore_usegetstores",
       "label": "useGetStores()",
@@ -76798,7 +76879,7 @@
       "source_location": "L50"
     },
     {
-      "community": 405,
+      "community": 406,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetorganizations_ts",
       "label": "useGetOrganizations.ts",
@@ -76807,7 +76888,7 @@
       "source_location": "L1"
     },
     {
-      "community": 405,
+      "community": 406,
       "file_type": "code",
       "id": "usegetorganizations_usegetactiveorganization",
       "label": "useGetActiveOrganization()",
@@ -76816,7 +76897,7 @@
       "source_location": "L6"
     },
     {
-      "community": 405,
+      "community": 406,
       "file_type": "code",
       "id": "usegetorganizations_usegetorganizations",
       "label": "useGetOrganizations()",
@@ -76825,7 +76906,7 @@
       "source_location": "L31"
     },
     {
-      "community": 406,
+      "community": 407,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usesessionmanagementexpense_ts",
       "label": "useSessionManagementExpense.ts",
@@ -76834,7 +76915,7 @@
       "source_location": "L1"
     },
     {
-      "community": 406,
+      "community": 407,
       "file_type": "code",
       "id": "usesessionmanagementexpense_getcommanderrormessage",
       "label": "getCommandErrorMessage()",
@@ -76843,7 +76924,7 @@
       "source_location": "L19"
     },
     {
-      "community": 406,
+      "community": 407,
       "file_type": "code",
       "id": "usesessionmanagementexpense_usesessionmanagementexpense",
       "label": "useSessionManagementExpense()",
@@ -76852,7 +76933,7 @@
       "source_location": "L33"
     },
     {
-      "community": 407,
+      "community": 408,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_presentcommandtoast_ts",
       "label": "presentCommandToast.ts",
@@ -76861,7 +76942,7 @@
       "source_location": "L1"
     },
     {
-      "community": 407,
+      "community": 408,
       "file_type": "code",
       "id": "presentcommandtoast_getapprovalguidance",
       "label": "getApprovalGuidance()",
@@ -76870,7 +76951,7 @@
       "source_location": "L9"
     },
     {
-      "community": 407,
+      "community": 408,
       "file_type": "code",
       "id": "presentcommandtoast_presentcommandtoast",
       "label": "presentCommandToast()",
@@ -76879,7 +76960,7 @@
       "source_location": "L16"
     },
     {
-      "community": 408,
+      "community": 409,
       "file_type": "code",
       "id": "maintenanceutils_isinmaintenancemode",
       "label": "isInMaintenanceMode()",
@@ -76888,7 +76969,7 @@
       "source_location": "L7"
     },
     {
-      "community": 408,
+      "community": 409,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_maintenanceutils_ts",
       "label": "maintenanceUtils.ts",
@@ -76897,39 +76978,12 @@
       "source_location": "L1"
     },
     {
-      "community": 408,
+      "community": 409,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_maintenanceutils_ts",
       "label": "maintenanceUtils.ts",
       "norm_label": "maintenanceutils.ts",
       "source_file": "packages/storefront-webapp/src/lib/maintenanceUtils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 409,
-      "file_type": "code",
-      "id": "bootstrapregister_test_drawer",
-      "label": "drawer()",
-      "norm_label": "drawer()",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/bootstrapRegister.test.ts",
-      "source_location": "L9"
-    },
-    {
-      "community": 409,
-      "file_type": "code",
-      "id": "bootstrapregister_test_state",
-      "label": "state()",
-      "norm_label": "state()",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/bootstrapRegister.test.ts",
-      "source_location": "L23"
-    },
-    {
-      "community": 409,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_application_bootstrapregister_test_ts",
-      "label": "bootstrapRegister.test.ts",
-      "norm_label": "bootstrapregister.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/bootstrapRegister.test.ts",
       "source_location": "L1"
     },
     {
@@ -77070,6 +77124,33 @@
     {
       "community": 410,
       "file_type": "code",
+      "id": "bootstrapregister_test_drawer",
+      "label": "drawer()",
+      "norm_label": "drawer()",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/bootstrapRegister.test.ts",
+      "source_location": "L9"
+    },
+    {
+      "community": 410,
+      "file_type": "code",
+      "id": "bootstrapregister_test_state",
+      "label": "state()",
+      "norm_label": "state()",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/bootstrapRegister.test.ts",
+      "source_location": "L23"
+    },
+    {
+      "community": 410,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_application_bootstrapregister_test_ts",
+      "label": "bootstrapRegister.test.ts",
+      "norm_label": "bootstrapregister.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/bootstrapRegister.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 411,
+      "file_type": "code",
       "id": "displayamounts_formatstoredamount",
       "label": "formatStoredAmount()",
       "norm_label": "formatstoredamount()",
@@ -77077,7 +77158,7 @@
       "source_location": "L3"
     },
     {
-      "community": 410,
+      "community": 411,
       "file_type": "code",
       "id": "displayamounts_parsedisplayamountinput",
       "label": "parseDisplayAmountInput()",
@@ -77086,7 +77167,7 @@
       "source_location": "L10"
     },
     {
-      "community": 410,
+      "community": 411,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_displayamounts_ts",
       "label": "displayAmounts.ts",
@@ -77095,7 +77176,7 @@
       "source_location": "L1"
     },
     {
-      "community": 411,
+      "community": 412,
       "file_type": "code",
       "id": "commandgateway_useconvexcommandgateway",
       "label": "useConvexCommandGateway()",
@@ -77104,7 +77185,7 @@
       "source_location": "L18"
     },
     {
-      "community": 411,
+      "community": 412,
       "file_type": "code",
       "id": "commandgateway_useconvexdirecttransactionmutation",
       "label": "useConvexDirectTransactionMutation()",
@@ -77113,7 +77194,7 @@
       "source_location": "L60"
     },
     {
-      "community": 411,
+      "community": 412,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_commandgateway_ts",
       "label": "commandGateway.ts",
@@ -77122,7 +77203,7 @@
       "source_location": "L1"
     },
     {
-      "community": 412,
+      "community": 413,
       "file_type": "code",
       "id": "main_app",
       "label": "App()",
@@ -77131,7 +77212,7 @@
       "source_location": "L31"
     },
     {
-      "community": 412,
+      "community": 413,
       "file_type": "code",
       "id": "packages_athena_webapp_src_main_tsx",
       "label": "main.tsx",
@@ -77140,7 +77221,7 @@
       "source_location": "L1"
     },
     {
-      "community": 412,
+      "community": 413,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_main_tsx",
       "label": "main.tsx",
@@ -77149,7 +77230,7 @@
       "source_location": "L1"
     },
     {
-      "community": 413,
+      "community": 414,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routetree_browser_boundary_test_ts",
       "label": "routeTree.browser-boundary.test.ts",
@@ -77158,7 +77239,7 @@
       "source_location": "L1"
     },
     {
-      "community": 413,
+      "community": 414,
       "file_type": "code",
       "id": "routetree_browser_boundary_test_collectsourcefiles",
       "label": "collectSourceFiles()",
@@ -77167,7 +77248,7 @@
       "source_location": "L28"
     },
     {
-      "community": 413,
+      "community": 414,
       "file_type": "code",
       "id": "routetree_browser_boundary_test_findillegalconveximports",
       "label": "findIllegalConvexImports()",
@@ -77176,7 +77257,7 @@
       "source_location": "L46"
     },
     {
-      "community": 414,
+      "community": 415,
       "file_type": "code",
       "id": "actioncolorreview_stories_swatch",
       "label": "Swatch()",
@@ -77185,7 +77266,7 @@
       "source_location": "L179"
     },
     {
-      "community": 414,
+      "community": 415,
       "file_type": "code",
       "id": "actioncolorreview_stories_tokenscope",
       "label": "TokenScope()",
@@ -77194,7 +77275,7 @@
       "source_location": "L168"
     },
     {
-      "community": 414,
+      "community": 415,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_foundations_actioncolorreview_stories_tsx",
       "label": "ActionColorReview.stories.tsx",
@@ -77203,7 +77284,7 @@
       "source_location": "L1"
     },
     {
-      "community": 415,
+      "community": 416,
       "file_type": "code",
       "id": "admin_shell_patterns_patterncard",
       "label": "PatternCard()",
@@ -77212,7 +77293,7 @@
       "source_location": "L127"
     },
     {
-      "community": 415,
+      "community": 416,
       "file_type": "code",
       "id": "admin_shell_patterns_patternshell",
       "label": "PatternShell()",
@@ -77221,7 +77302,7 @@
       "source_location": "L106"
     },
     {
-      "community": 415,
+      "community": 416,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_patterns_admin_shell_patterns_tsx",
       "label": "admin-shell-patterns.tsx",
@@ -77230,7 +77311,7 @@
       "source_location": "L1"
     },
     {
-      "community": 416,
+      "community": 417,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_storybook_theme_decorator_tsx",
       "label": "storybook-theme-decorator.tsx",
@@ -77239,7 +77320,7 @@
       "source_location": "L1"
     },
     {
-      "community": 416,
+      "community": 417,
       "file_type": "code",
       "id": "storybook_theme_decorator_getathenadesigntokenstyle",
       "label": "getAthenaDesignTokenStyle()",
@@ -77248,7 +77329,7 @@
       "source_location": "L49"
     },
     {
-      "community": 416,
+      "community": 417,
       "file_type": "code",
       "id": "storybook_theme_decorator_withathenatheme",
       "label": "withAthenaTheme()",
@@ -77257,7 +77338,7 @@
       "source_location": "L62"
     },
     {
-      "community": 417,
+      "community": 418,
       "file_type": "code",
       "id": "inventoryvalidationlogic_test_mockgetsku",
       "label": "mockGetSku()",
@@ -77266,7 +77347,7 @@
       "source_location": "L66"
     },
     {
-      "community": 417,
+      "community": 418,
       "file_type": "code",
       "id": "inventoryvalidationlogic_test_validateinventoryfortransaction",
       "label": "validateInventoryForTransaction()",
@@ -77275,7 +77356,7 @@
       "source_location": "L20"
     },
     {
-      "community": 417,
+      "community": 418,
       "file_type": "code",
       "id": "packages_athena_webapp_src_tests_pos_inventoryvalidationlogic_test_ts",
       "label": "inventoryValidationLogic.test.ts",
@@ -77284,7 +77365,7 @@
       "source_location": "L1"
     },
     {
-      "community": 418,
+      "community": 419,
       "file_type": "code",
       "id": "index_hashpassword",
       "label": "hashPassword()",
@@ -77293,7 +77374,7 @@
       "source_location": "L1"
     },
     {
-      "community": 418,
+      "community": 419,
       "file_type": "code",
       "id": "packages_athena_webapp_src_utils_index_ts",
       "label": "index.ts",
@@ -77302,40 +77383,13 @@
       "source_location": "L1"
     },
     {
-      "community": 418,
+      "community": 419,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_utils_index_ts",
       "label": "index.ts",
       "norm_label": "index.ts",
       "source_file": "packages/storefront-webapp/src/utils/index.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 419,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_utils_versionchecker_ts",
-      "label": "versionChecker.ts",
-      "norm_label": "versionchecker.ts",
-      "source_file": "packages/athena-webapp/src/utils/versionChecker.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 419,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_utils_versionchecker_ts",
-      "label": "versionChecker.ts",
-      "norm_label": "versionchecker.ts",
-      "source_file": "packages/storefront-webapp/src/utils/versionChecker.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 419,
-      "file_type": "code",
-      "id": "versionchecker_createversionchecker",
-      "label": "createVersionChecker()",
-      "norm_label": "createversionchecker()",
-      "source_file": "packages/storefront-webapp/src/utils/versionChecker.ts",
-      "source_location": "L16"
     },
     {
       "community": 42,
@@ -77466,6 +77520,33 @@
     {
       "community": 420,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_utils_versionchecker_ts",
+      "label": "versionChecker.ts",
+      "norm_label": "versionchecker.ts",
+      "source_file": "packages/athena-webapp/src/utils/versionChecker.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 420,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_utils_versionchecker_ts",
+      "label": "versionChecker.ts",
+      "norm_label": "versionchecker.ts",
+      "source_file": "packages/storefront-webapp/src/utils/versionChecker.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 420,
+      "file_type": "code",
+      "id": "versionchecker_createversionchecker",
+      "label": "createVersionChecker()",
+      "norm_label": "createversionchecker()",
+      "source_file": "packages/storefront-webapp/src/utils/versionChecker.ts",
+      "source_location": "L16"
+    },
+    {
+      "community": 421,
+      "file_type": "code",
       "id": "packages_athena_webapp_vite_config_ts",
       "label": "vite.config.ts",
       "norm_label": "vite.config.ts",
@@ -77473,7 +77554,7 @@
       "source_location": "L1"
     },
     {
-      "community": 420,
+      "community": 421,
       "file_type": "code",
       "id": "packages_storefront_webapp_vite_config_ts",
       "label": "vite.config.ts",
@@ -77482,7 +77563,7 @@
       "source_location": "L1"
     },
     {
-      "community": 420,
+      "community": 421,
       "file_type": "code",
       "id": "vite_config_manualchunks",
       "label": "manualChunks()",
@@ -77491,7 +77572,7 @@
       "source_location": "L26"
     },
     {
-      "community": 421,
+      "community": 422,
       "file_type": "code",
       "id": "packages_athena_webapp_vitest_setup_ts",
       "label": "vitest.setup.ts",
@@ -77500,7 +77581,7 @@
       "source_location": "L1"
     },
     {
-      "community": 421,
+      "community": 422,
       "file_type": "code",
       "id": "vitest_setup_pointercapturestub",
       "label": "pointerCaptureStub()",
@@ -77509,7 +77590,7 @@
       "source_location": "L23"
     },
     {
-      "community": 421,
+      "community": 422,
       "file_type": "code",
       "id": "vitest_setup_pointerreleasestub",
       "label": "pointerReleaseStub()",
@@ -77518,7 +77599,7 @@
       "source_location": "L24"
     },
     {
-      "community": 422,
+      "community": 423,
       "file_type": "code",
       "id": "auth_logout",
       "label": "logout()",
@@ -77527,7 +77608,7 @@
       "source_location": "L32"
     },
     {
-      "community": 422,
+      "community": 423,
       "file_type": "code",
       "id": "auth_verifyuseraccount",
       "label": "verifyUserAccount()",
@@ -77536,7 +77617,7 @@
       "source_location": "L3"
     },
     {
-      "community": 422,
+      "community": 423,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_auth_ts",
       "label": "auth.ts",
@@ -77545,7 +77626,7 @@
       "source_location": "L1"
     },
     {
-      "community": 423,
+      "community": 424,
       "file_type": "code",
       "id": "color_getallcolors",
       "label": "getAllColors()",
@@ -77554,7 +77635,7 @@
       "source_location": "L7"
     },
     {
-      "community": 423,
+      "community": 424,
       "file_type": "code",
       "id": "color_getbaseurl",
       "label": "getBaseUrl()",
@@ -77563,7 +77644,7 @@
       "source_location": "L5"
     },
     {
-      "community": 423,
+      "community": 424,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_color_ts",
       "label": "color.ts",
@@ -77572,7 +77653,7 @@
       "source_location": "L1"
     },
     {
-      "community": 424,
+      "community": 425,
       "file_type": "code",
       "id": "organization_getallorganizations",
       "label": "getAllOrganizations()",
@@ -77581,7 +77662,7 @@
       "source_location": "L6"
     },
     {
-      "community": 424,
+      "community": 425,
       "file_type": "code",
       "id": "organization_getorganization",
       "label": "getOrganization()",
@@ -77590,7 +77671,7 @@
       "source_location": "L18"
     },
     {
-      "community": 424,
+      "community": 425,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_organization_ts",
       "label": "organization.ts",
@@ -77599,7 +77680,7 @@
       "source_location": "L1"
     },
     {
-      "community": 425,
+      "community": 426,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_upsells_ts",
       "label": "upsells.ts",
@@ -77608,7 +77689,7 @@
       "source_location": "L1"
     },
     {
-      "community": 425,
+      "community": 426,
       "file_type": "code",
       "id": "upsells_getbaseurl",
       "label": "getBaseUrl()",
@@ -77617,7 +77698,7 @@
       "source_location": "L3"
     },
     {
-      "community": 425,
+      "community": 426,
       "file_type": "code",
       "id": "upsells_getlastviewedproduct",
       "label": "getLastViewedProduct()",
@@ -77626,7 +77707,7 @@
       "source_location": "L5"
     },
     {
-      "community": 426,
+      "community": 427,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_useroffers_ts",
       "label": "userOffers.ts",
@@ -77635,7 +77716,7 @@
       "source_location": "L1"
     },
     {
-      "community": 426,
+      "community": 427,
       "file_type": "code",
       "id": "useroffers_getbaseurl",
       "label": "getBaseUrl()",
@@ -77644,7 +77725,7 @@
       "source_location": "L18"
     },
     {
-      "community": 426,
+      "community": 427,
       "file_type": "code",
       "id": "useroffers_getuserofferseligibility",
       "label": "getUserOffersEligibility()",
@@ -77653,7 +77734,7 @@
       "source_location": "L23"
     },
     {
-      "community": 427,
+      "community": 428,
       "file_type": "code",
       "id": "customerdetails_enteredcustomerdetails",
       "label": "EnteredCustomerDetails()",
@@ -77662,7 +77743,7 @@
       "source_location": "L22"
     },
     {
-      "community": 427,
+      "community": 428,
       "file_type": "code",
       "id": "customerdetails_onsubmit",
       "label": "onSubmit()",
@@ -77671,7 +77752,7 @@
       "source_location": "L55"
     },
     {
-      "community": 427,
+      "community": 428,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_customerdetails_tsx",
       "label": "CustomerDetails.tsx",
@@ -77680,7 +77761,7 @@
       "source_location": "L1"
     },
     {
-      "community": 428,
+      "community": 429,
       "file_type": "code",
       "id": "deliveryoptionsselector_handlechange",
       "label": "handleChange()",
@@ -77689,7 +77770,7 @@
       "source_location": "L77"
     },
     {
-      "community": 428,
+      "community": 429,
       "file_type": "code",
       "id": "deliveryoptionsselector_storeselector",
       "label": "StoreSelector()",
@@ -77698,39 +77779,12 @@
       "source_location": "L11"
     },
     {
-      "community": 428,
+      "community": 429,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_deliveryoptionsselector_tsx",
       "label": "DeliveryOptionsSelector.tsx",
       "norm_label": "deliveryoptionsselector.tsx",
       "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/DeliveryOptionsSelector.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 429,
-      "file_type": "code",
-      "id": "deliverysection_deliverydetails",
-      "label": "DeliveryDetails()",
-      "norm_label": "deliverydetails()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/DeliverySection.tsx",
-      "source_location": "L11"
-    },
-    {
-      "community": 429,
-      "file_type": "code",
-      "id": "deliverysection_deliveryoptions",
-      "label": "DeliveryOptions()",
-      "norm_label": "deliveryoptions()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/DeliverySection.tsx",
-      "source_location": "L22"
-    },
-    {
-      "community": 429,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_deliverysection_tsx",
-      "label": "DeliverySection.tsx",
-      "norm_label": "deliverysection.tsx",
-      "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/DeliverySection.tsx",
       "source_location": "L1"
     },
     {
@@ -77862,6 +77916,33 @@
     {
       "community": 430,
       "file_type": "code",
+      "id": "deliverysection_deliverydetails",
+      "label": "DeliveryDetails()",
+      "norm_label": "deliverydetails()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/DeliverySection.tsx",
+      "source_location": "L11"
+    },
+    {
+      "community": 430,
+      "file_type": "code",
+      "id": "deliverysection_deliveryoptions",
+      "label": "DeliveryOptions()",
+      "norm_label": "deliveryoptions()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/DeliverySection.tsx",
+      "source_location": "L22"
+    },
+    {
+      "community": 430,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_deliverysection_tsx",
+      "label": "DeliverySection.tsx",
+      "norm_label": "deliverysection.tsx",
+      "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/DeliverySection.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 431,
+      "file_type": "code",
       "id": "mobilebagsummary_handlekeydown",
       "label": "handleKeyDown()",
       "norm_label": "handlekeydown()",
@@ -77869,7 +77950,7 @@
       "source_location": "L110"
     },
     {
-      "community": 430,
+      "community": 431,
       "file_type": "code",
       "id": "mobilebagsummary_handleredeempromocode",
       "label": "handleRedeemPromoCode()",
@@ -77878,7 +77959,7 @@
       "source_location": "L89"
     },
     {
-      "community": 430,
+      "community": 431,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_mobilebagsummary_tsx",
       "label": "MobileBagSummary.tsx",
@@ -77887,7 +77968,7 @@
       "source_location": "L1"
     },
     {
-      "community": 431,
+      "community": 432,
       "file_type": "code",
       "id": "checkoutstorage_loadcheckoutstate",
       "label": "loadCheckoutState()",
@@ -77896,7 +77977,7 @@
       "source_location": "L4"
     },
     {
-      "community": 431,
+      "community": 432,
       "file_type": "code",
       "id": "checkoutstorage_savecheckoutstate",
       "label": "saveCheckoutState()",
@@ -77905,7 +77986,7 @@
       "source_location": "L24"
     },
     {
-      "community": 431,
+      "community": 432,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkoutstorage_ts",
       "label": "checkoutStorage.ts",
@@ -77914,7 +77995,7 @@
       "source_location": "L1"
     },
     {
-      "community": 432,
+      "community": 433,
       "file_type": "code",
       "id": "footer_enablecategories",
       "label": "enableCategories()",
@@ -77923,7 +78004,7 @@
       "source_location": "L131"
     },
     {
-      "community": 432,
+      "community": 433,
       "file_type": "code",
       "id": "footer_linkgroup",
       "label": "LinkGroup()",
@@ -77932,7 +78013,7 @@
       "source_location": "L12"
     },
     {
-      "community": 432,
+      "community": 433,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_footer_footer_tsx",
       "label": "Footer.tsx",
@@ -77941,7 +78022,7 @@
       "source_location": "L1"
     },
     {
-      "community": 433,
+      "community": 434,
       "file_type": "code",
       "id": "featuredproductssection_featuredproductssection",
       "label": "FeaturedProductsSection()",
@@ -77950,7 +78031,7 @@
       "source_location": "L20"
     },
     {
-      "community": 433,
+      "community": 434,
       "file_type": "code",
       "id": "featuredproductssection_featuredsection",
       "label": "FeaturedSection()",
@@ -77959,7 +78040,7 @@
       "source_location": "L46"
     },
     {
-      "community": 433,
+      "community": 434,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_featuredproductssection_tsx",
       "label": "FeaturedProductsSection.tsx",
@@ -77968,7 +78049,7 @@
       "source_location": "L1"
     },
     {
-      "community": 434,
+      "community": 435,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_promoalert_tsx",
       "label": "PromoAlert.tsx",
@@ -77977,7 +78058,7 @@
       "source_location": "L1"
     },
     {
-      "community": 434,
+      "community": 435,
       "file_type": "code",
       "id": "promoalert_getpromoalertcopy",
       "label": "getPromoAlertCopy()",
@@ -77986,7 +78067,7 @@
       "source_location": "L20"
     },
     {
-      "community": 434,
+      "community": 435,
       "file_type": "code",
       "id": "promoalert_promoalert",
       "label": "PromoAlert()",
@@ -77995,7 +78076,7 @@
       "source_location": "L59"
     },
     {
-      "community": 435,
+      "community": 436,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_rewardsalert_tsx",
       "label": "RewardsAlert.tsx",
@@ -78004,7 +78085,7 @@
       "source_location": "L1"
     },
     {
-      "community": 435,
+      "community": 436,
       "file_type": "code",
       "id": "rewardsalert_handleshopnow",
       "label": "handleShopNow()",
@@ -78013,7 +78094,7 @@
       "source_location": "L25"
     },
     {
-      "community": 435,
+      "community": 436,
       "file_type": "code",
       "id": "rewardsalert_onrewardsalertclose",
       "label": "onRewardsAlertClose()",
@@ -78022,7 +78103,7 @@
       "source_location": "L20"
     },
     {
-      "community": 436,
+      "community": 437,
       "file_type": "code",
       "id": "navigationbar_navigationbar",
       "label": "NavigationBar()",
@@ -78031,7 +78112,7 @@
       "source_location": "L30"
     },
     {
-      "community": 436,
+      "community": 437,
       "file_type": "code",
       "id": "navigationbar_storecategoriessubmenu",
       "label": "StoreCategoriesSubmenu()",
@@ -78040,7 +78121,7 @@
       "source_location": "L95"
     },
     {
-      "community": 436,
+      "community": 437,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_navigationbar_tsx",
       "label": "NavigationBar.tsx",
@@ -78049,7 +78130,7 @@
       "source_location": "L1"
     },
     {
-      "community": 437,
+      "community": 438,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_revieweditor_tsx",
       "label": "ReviewEditor.tsx",
@@ -78058,7 +78139,7 @@
       "source_location": "L1"
     },
     {
-      "community": 437,
+      "community": 438,
       "file_type": "code",
       "id": "revieweditor_handleformdatachange",
       "label": "handleFormDataChange()",
@@ -78067,7 +78148,7 @@
       "source_location": "L150"
     },
     {
-      "community": 437,
+      "community": 438,
       "file_type": "code",
       "id": "revieweditor_handlesubmit",
       "label": "handleSubmit()",
@@ -78076,7 +78157,7 @@
       "source_location": "L157"
     },
     {
-      "community": 438,
+      "community": 439,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_upsellmodalform_tsx",
       "label": "UpsellModalForm.tsx",
@@ -78085,7 +78166,7 @@
       "source_location": "L1"
     },
     {
-      "community": 438,
+      "community": 439,
       "file_type": "code",
       "id": "upsellmodalform_handleinputchange",
       "label": "handleInputChange()",
@@ -78094,40 +78175,13 @@
       "source_location": "L63"
     },
     {
-      "community": 438,
+      "community": 439,
       "file_type": "code",
       "id": "upsellmodalform_handlesubmit",
       "label": "handleSubmit()",
       "norm_label": "handlesubmit()",
       "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModalForm.tsx",
       "source_location": "L48"
-    },
-    {
-      "community": 439,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_modals_welcomebackmodal_tsx",
-      "label": "WelcomeBackModal.tsx",
-      "norm_label": "welcomebackmodal.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModal.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 439,
-      "file_type": "code",
-      "id": "welcomebackmodal_handleclose",
-      "label": "handleClose()",
-      "norm_label": "handleclose()",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModal.tsx",
-      "source_location": "L63"
-    },
-    {
-      "community": 439,
-      "file_type": "code",
-      "id": "welcomebackmodal_handlesuccess",
-      "label": "handleSuccess()",
-      "norm_label": "handlesuccess()",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModal.tsx",
-      "source_location": "L76"
     },
     {
       "community": 44,
@@ -78258,6 +78312,33 @@
     {
       "community": 440,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_modals_welcomebackmodal_tsx",
+      "label": "WelcomeBackModal.tsx",
+      "norm_label": "welcomebackmodal.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModal.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 440,
+      "file_type": "code",
+      "id": "welcomebackmodal_handleclose",
+      "label": "handleClose()",
+      "norm_label": "handleclose()",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModal.tsx",
+      "source_location": "L63"
+    },
+    {
+      "community": 440,
+      "file_type": "code",
+      "id": "welcomebackmodal_handlesuccess",
+      "label": "handleSuccess()",
+      "norm_label": "handlesuccess()",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModal.tsx",
+      "source_location": "L76"
+    },
+    {
+      "community": 441,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_welcomebackmodalform_tsx",
       "label": "WelcomeBackModalForm.tsx",
       "norm_label": "welcomebackmodalform.tsx",
@@ -78265,7 +78346,7 @@
       "source_location": "L1"
     },
     {
-      "community": 440,
+      "community": 441,
       "file_type": "code",
       "id": "welcomebackmodalform_handleinputchange",
       "label": "handleInputChange()",
@@ -78274,7 +78355,7 @@
       "source_location": "L51"
     },
     {
-      "community": 440,
+      "community": 441,
       "file_type": "code",
       "id": "welcomebackmodalform_handlesubmit",
       "label": "handleSubmit()",
@@ -78283,7 +78364,7 @@
       "source_location": "L36"
     },
     {
-      "community": 441,
+      "community": 442,
       "file_type": "code",
       "id": "navigationbarprovider_navigationbarprovider",
       "label": "NavigationBarProvider()",
@@ -78292,7 +78373,7 @@
       "source_location": "L16"
     },
     {
-      "community": 441,
+      "community": 442,
       "file_type": "code",
       "id": "navigationbarprovider_usenavigationbarcontext",
       "label": "useNavigationBarContext()",
@@ -78301,7 +78382,7 @@
       "source_location": "L39"
     },
     {
-      "community": 441,
+      "community": 442,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_contexts_navigationbarprovider_tsx",
       "label": "NavigationBarProvider.tsx",
@@ -78310,7 +78391,7 @@
       "source_location": "L1"
     },
     {
-      "community": 442,
+      "community": 443,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_contexts_storefrontobservabilityprovider_tsx",
       "label": "StorefrontObservabilityProvider.tsx",
@@ -78319,7 +78400,7 @@
       "source_location": "L1"
     },
     {
-      "community": 442,
+      "community": 443,
       "file_type": "code",
       "id": "storefrontobservabilityprovider_storefrontobservabilityprovider",
       "label": "StorefrontObservabilityProvider()",
@@ -78328,7 +78409,7 @@
       "source_location": "L20"
     },
     {
-      "community": 442,
+      "community": 443,
       "file_type": "code",
       "id": "storefrontobservabilityprovider_usestorefrontobservability",
       "label": "useStorefrontObservability()",
@@ -78337,7 +78418,7 @@
       "source_location": "L55"
     },
     {
-      "community": 443,
+      "community": 444,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useproductdiscount_ts",
       "label": "useProductDiscount.ts",
@@ -78346,7 +78427,7 @@
       "source_location": "L1"
     },
     {
-      "community": 443,
+      "community": 444,
       "file_type": "code",
       "id": "useproductdiscount_useproductdiscount",
       "label": "useProductDiscount()",
@@ -78355,7 +78436,7 @@
       "source_location": "L107"
     },
     {
-      "community": 443,
+      "community": 444,
       "file_type": "code",
       "id": "useproductdiscount_useproductdiscounts",
       "label": "useProductDiscounts()",
@@ -78364,7 +78445,7 @@
       "source_location": "L25"
     },
     {
-      "community": 444,
+      "community": 445,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useshoppingbag_ts",
       "label": "useShoppingBag.ts",
@@ -78373,7 +78454,7 @@
       "source_location": "L1"
     },
     {
-      "community": 444,
+      "community": 445,
       "file_type": "code",
       "id": "useshoppingbag_isunavailableproductlist",
       "label": "isUnavailableProductList()",
@@ -78382,7 +78463,7 @@
       "source_location": "L556"
     },
     {
-      "community": 444,
+      "community": 445,
       "file_type": "code",
       "id": "useshoppingbag_useshoppingbag",
       "label": "useShoppingBag()",
@@ -78391,7 +78472,7 @@
       "source_location": "L52"
     },
     {
-      "community": 445,
+      "community": 446,
       "file_type": "code",
       "id": "index_getordermessage",
       "label": "getOrderMessage()",
@@ -78400,7 +78481,7 @@
       "source_location": "L429"
     },
     {
-      "community": 445,
+      "community": 446,
       "file_type": "code",
       "id": "index_getpaymenttext",
       "label": "getPaymentText()",
@@ -78409,7 +78490,7 @@
       "source_location": "L102"
     },
     {
-      "community": 445,
+      "community": 446,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_orderid_index_tsx",
       "label": "index.tsx",
@@ -78418,7 +78499,7 @@
       "source_location": "L1"
     },
     {
-      "community": 446,
+      "community": 447,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_orderid_review_tsx",
       "label": "review.tsx",
@@ -78427,7 +78508,7 @@
       "source_location": "L1"
     },
     {
-      "community": 446,
+      "community": 447,
       "file_type": "code",
       "id": "review_getordermessage",
       "label": "getOrderMessage()",
@@ -78436,7 +78517,7 @@
       "source_location": "L250"
     },
     {
-      "community": 446,
+      "community": 447,
       "file_type": "code",
       "id": "review_ordernavigation",
       "label": "OrderNavigation()",
@@ -78445,7 +78526,7 @@
       "source_location": "L46"
     },
     {
-      "community": 447,
+      "community": 448,
       "file_type": "code",
       "id": "account_accountbeforeload",
       "label": "accountBeforeLoad()",
@@ -78454,7 +78535,7 @@
       "source_location": "L17"
     },
     {
-      "community": 447,
+      "community": 448,
       "file_type": "code",
       "id": "account_handleonsubmitform",
       "label": "handleOnSubmitForm()",
@@ -78463,7 +78544,7 @@
       "source_location": "L63"
     },
     {
-      "community": 447,
+      "community": 448,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_account_tsx",
       "label": "account.tsx",
@@ -78472,7 +78553,7 @@
       "source_location": "L1"
     },
     {
-      "community": 448,
+      "community": 449,
       "file_type": "code",
       "id": "login_loginbeforeload",
       "label": "loginBeforeLoad()",
@@ -78481,7 +78562,7 @@
       "source_location": "L47"
     },
     {
-      "community": 448,
+      "community": 449,
       "file_type": "code",
       "id": "login_onsubmit",
       "label": "onSubmit()",
@@ -78490,40 +78571,13 @@
       "source_location": "L141"
     },
     {
-      "community": 448,
+      "community": 449,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_login_tsx",
       "label": "login.tsx",
       "norm_label": "login.tsx",
       "source_file": "packages/storefront-webapp/src/routes/login.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 449,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_shop_checkout_verify_index_tsx",
-      "label": "verify.index.tsx",
-      "norm_label": "verify.index.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/verify.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 449,
-      "file_type": "code",
-      "id": "verify_index_verify",
-      "label": "Verify()",
-      "norm_label": "verify()",
-      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/verify.index.tsx",
-      "source_location": "L21"
-    },
-    {
-      "community": 449,
-      "file_type": "code",
-      "id": "verify_index_verifycheckoutsessionpayment",
-      "label": "VerifyCheckoutSessionPayment()",
-      "norm_label": "verifycheckoutsessionpayment()",
-      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/verify.index.tsx",
-      "source_location": "L107"
     },
     {
       "community": 45,
@@ -78654,6 +78708,33 @@
     {
       "community": 450,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_shop_checkout_verify_index_tsx",
+      "label": "verify.index.tsx",
+      "norm_label": "verify.index.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/verify.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 450,
+      "file_type": "code",
+      "id": "verify_index_verify",
+      "label": "Verify()",
+      "norm_label": "verify()",
+      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/verify.index.tsx",
+      "source_location": "L21"
+    },
+    {
+      "community": 450,
+      "file_type": "code",
+      "id": "verify_index_verifycheckoutsessionpayment",
+      "label": "VerifyCheckoutSessionPayment()",
+      "norm_label": "verifycheckoutsessionpayment()",
+      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/verify.index.tsx",
+      "source_location": "L107"
+    },
+    {
+      "community": 451,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_signup_tsx",
       "label": "signup.tsx",
       "norm_label": "signup.tsx",
@@ -78661,7 +78742,7 @@
       "source_location": "L1"
     },
     {
-      "community": 450,
+      "community": 451,
       "file_type": "code",
       "id": "signup_onsubmit",
       "label": "onSubmit()",
@@ -78670,7 +78751,7 @@
       "source_location": "L161"
     },
     {
-      "community": 450,
+      "community": 451,
       "file_type": "code",
       "id": "signup_signupbeforeload",
       "label": "signupBeforeLoad()",
@@ -78679,7 +78760,7 @@
       "source_location": "L66"
     },
     {
-      "community": 451,
+      "community": 452,
       "file_type": "code",
       "id": "env_optionalnumberenv",
       "label": "optionalNumberEnv()",
@@ -78688,7 +78769,7 @@
       "source_location": "L11"
     },
     {
-      "community": 451,
+      "community": 452,
       "file_type": "code",
       "id": "env_requireenv",
       "label": "requireEnv()",
@@ -78697,7 +78778,7 @@
       "source_location": "L1"
     },
     {
-      "community": 451,
+      "community": 452,
       "file_type": "code",
       "id": "packages_storefront_webapp_tests_e2e_helpers_env_ts",
       "label": "env.ts",
@@ -78706,7 +78787,7 @@
       "source_location": "L1"
     },
     {
-      "community": 452,
+      "community": 453,
       "file_type": "code",
       "id": "graphify_wiki_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -78715,7 +78796,7 @@
       "source_location": "L16"
     },
     {
-      "community": 452,
+      "community": 453,
       "file_type": "code",
       "id": "graphify_wiki_test_write",
       "label": "write()",
@@ -78724,7 +78805,7 @@
       "source_location": "L10"
     },
     {
-      "community": 452,
+      "community": 453,
       "file_type": "code",
       "id": "scripts_graphify_wiki_test_ts",
       "label": "graphify-wiki.test.ts",
@@ -78733,7 +78814,7 @@
       "source_location": "L1"
     },
     {
-      "community": 453,
+      "community": 454,
       "file_type": "code",
       "id": "harness_audit_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -78742,7 +78823,7 @@
       "source_location": "L17"
     },
     {
-      "community": 453,
+      "community": 454,
       "file_type": "code",
       "id": "harness_audit_test_write",
       "label": "write()",
@@ -78751,7 +78832,7 @@
       "source_location": "L11"
     },
     {
-      "community": 453,
+      "community": 454,
       "file_type": "code",
       "id": "scripts_harness_audit_test_ts",
       "label": "harness-audit.test.ts",
@@ -78760,7 +78841,7 @@
       "source_location": "L1"
     },
     {
-      "community": 454,
+      "community": 455,
       "file_type": "code",
       "id": "harness_check_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -78769,7 +78850,7 @@
       "source_location": "L48"
     },
     {
-      "community": 454,
+      "community": 455,
       "file_type": "code",
       "id": "harness_check_test_write",
       "label": "write()",
@@ -78778,7 +78859,7 @@
       "source_location": "L42"
     },
     {
-      "community": 454,
+      "community": 455,
       "file_type": "code",
       "id": "scripts_harness_check_test_ts",
       "label": "harness-check.test.ts",
@@ -78787,7 +78868,7 @@
       "source_location": "L1"
     },
     {
-      "community": 455,
+      "community": 456,
       "file_type": "code",
       "id": "harness_generate_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -78796,7 +78877,7 @@
       "source_location": "L16"
     },
     {
-      "community": 455,
+      "community": 456,
       "file_type": "code",
       "id": "harness_generate_test_write",
       "label": "write()",
@@ -78805,7 +78886,7 @@
       "source_location": "L10"
     },
     {
-      "community": 455,
+      "community": 456,
       "file_type": "code",
       "id": "scripts_harness_generate_test_ts",
       "label": "harness-generate.test.ts",
@@ -78814,7 +78895,7 @@
       "source_location": "L1"
     },
     {
-      "community": 456,
+      "community": 457,
       "file_type": "code",
       "id": "harness_inferential_review_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -78823,7 +78904,7 @@
       "source_location": "L19"
     },
     {
-      "community": 456,
+      "community": 457,
       "file_type": "code",
       "id": "harness_inferential_review_test_write",
       "label": "write()",
@@ -78832,7 +78913,7 @@
       "source_location": "L13"
     },
     {
-      "community": 456,
+      "community": 457,
       "file_type": "code",
       "id": "scripts_harness_inferential_review_test_ts",
       "label": "harness-inferential-review.test.ts",
@@ -78841,7 +78922,7 @@
       "source_location": "L1"
     },
     {
-      "community": 457,
+      "community": 458,
       "file_type": "code",
       "id": "harness_self_review_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -78850,7 +78931,7 @@
       "source_location": "L16"
     },
     {
-      "community": 457,
+      "community": 458,
       "file_type": "code",
       "id": "harness_self_review_test_write",
       "label": "write()",
@@ -78859,7 +78940,7 @@
       "source_location": "L10"
     },
     {
-      "community": 457,
+      "community": 458,
       "file_type": "code",
       "id": "scripts_harness_self_review_test_ts",
       "label": "harness-self-review.test.ts",
@@ -78868,7 +78949,7 @@
       "source_location": "L1"
     },
     {
-      "community": 458,
+      "community": 459,
       "file_type": "code",
       "id": "harness_test_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -78877,7 +78958,7 @@
       "source_location": "L20"
     },
     {
-      "community": 458,
+      "community": 459,
       "file_type": "code",
       "id": "harness_test_test_write",
       "label": "write()",
@@ -78886,39 +78967,12 @@
       "source_location": "L14"
     },
     {
-      "community": 458,
+      "community": 459,
       "file_type": "code",
       "id": "scripts_harness_test_test_ts",
       "label": "harness-test.test.ts",
       "norm_label": "harness-test.test.ts",
       "source_file": "scripts/harness-test.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 459,
-      "file_type": "code",
-      "id": "root_scripts_coverage_test_createfixtureroot",
-      "label": "createFixtureRoot()",
-      "norm_label": "createfixtureroot()",
-      "source_file": "scripts/root-scripts-coverage.test.ts",
-      "source_location": "L10"
-    },
-    {
-      "community": 459,
-      "file_type": "code",
-      "id": "root_scripts_coverage_test_write",
-      "label": "write()",
-      "norm_label": "write()",
-      "source_file": "scripts/root-scripts-coverage.test.ts",
-      "source_location": "L16"
-    },
-    {
-      "community": 459,
-      "file_type": "code",
-      "id": "scripts_root_scripts_coverage_test_ts",
-      "label": "root-scripts-coverage.test.ts",
-      "norm_label": "root-scripts-coverage.test.ts",
-      "source_file": "scripts/root-scripts-coverage.test.ts",
       "source_location": "L1"
     },
     {
@@ -79050,6 +79104,33 @@
     {
       "community": 460,
       "file_type": "code",
+      "id": "root_scripts_coverage_test_createfixtureroot",
+      "label": "createFixtureRoot()",
+      "norm_label": "createfixtureroot()",
+      "source_file": "scripts/root-scripts-coverage.test.ts",
+      "source_location": "L10"
+    },
+    {
+      "community": 460,
+      "file_type": "code",
+      "id": "root_scripts_coverage_test_write",
+      "label": "write()",
+      "norm_label": "write()",
+      "source_file": "scripts/root-scripts-coverage.test.ts",
+      "source_location": "L16"
+    },
+    {
+      "community": 460,
+      "file_type": "code",
+      "id": "scripts_root_scripts_coverage_test_ts",
+      "label": "root-scripts-coverage.test.ts",
+      "norm_label": "root-scripts-coverage.test.ts",
+      "source_file": "scripts/root-scripts-coverage.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 461,
+      "file_type": "code",
       "id": "root_scripts_coverage_collectrootscripttestfiles",
       "label": "collectRootScriptTestFiles()",
       "norm_label": "collectrootscripttestfiles()",
@@ -79057,7 +79138,7 @@
       "source_location": "L4"
     },
     {
-      "community": 460,
+      "community": 461,
       "file_type": "code",
       "id": "root_scripts_coverage_runrootscriptscoverage",
       "label": "runRootScriptsCoverage()",
@@ -79066,7 +79147,7 @@
       "source_location": "L13"
     },
     {
-      "community": 460,
+      "community": 461,
       "file_type": "code",
       "id": "scripts_root_scripts_coverage_ts",
       "label": "root-scripts-coverage.ts",
@@ -79075,7 +79156,7 @@
       "source_location": "L1"
     },
     {
-      "community": 461,
+      "community": 462,
       "file_type": "code",
       "id": "deposits_test_getsource",
       "label": "getSource()",
@@ -79084,7 +79165,7 @@
       "source_location": "L9"
     },
     {
-      "community": 461,
+      "community": 462,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cashcontrols_deposits_test_ts",
       "label": "deposits.test.ts",
@@ -79093,7 +79174,7 @@
       "source_location": "L1"
     },
     {
-      "community": 462,
+      "community": 463,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cashcontrols_paymentallocationattribution_test_ts",
       "label": "paymentAllocationAttribution.test.ts",
@@ -79102,7 +79183,7 @@
       "source_location": "L1"
     },
     {
-      "community": 462,
+      "community": 463,
       "file_type": "code",
       "id": "paymentallocationattribution_test_readprojectfile",
       "label": "readProjectFile()",
@@ -79111,7 +79192,7 @@
       "source_location": "L12"
     },
     {
-      "community": 463,
+      "community": 464,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cloudflare_stream_ts",
       "label": "stream.ts",
@@ -79120,7 +79201,7 @@
       "source_location": "L1"
     },
     {
-      "community": 463,
+      "community": 464,
       "file_type": "code",
       "id": "stream_getcloudflareconfig",
       "label": "getCloudflareConfig()",
@@ -79129,7 +79210,7 @@
       "source_location": "L8"
     },
     {
-      "community": 464,
+      "community": 465,
       "file_type": "code",
       "id": "convexauditscript_test_createcommandshimbin",
       "label": "createCommandShimBin()",
@@ -79138,7 +79219,7 @@
       "source_location": "L10"
     },
     {
-      "community": 464,
+      "community": 465,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_convexauditscript_test_ts",
       "label": "convexAuditScript.test.ts",
@@ -79147,7 +79228,7 @@
       "source_location": "L1"
     },
     {
-      "community": 465,
+      "community": 466,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_customermessaging_policy_ts",
       "label": "policy.ts",
@@ -79156,7 +79237,7 @@
       "source_location": "L1"
     },
     {
-      "community": 465,
+      "community": 466,
       "file_type": "code",
       "id": "policy_assertsupportedcustomermessagepolicy",
       "label": "assertSupportedCustomerMessagePolicy()",
@@ -79165,7 +79246,7 @@
       "source_location": "L8"
     },
     {
-      "community": 466,
+      "community": 467,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_customermessaging_repository_test_ts",
       "label": "repository.test.ts",
@@ -79174,7 +79255,7 @@
       "source_location": "L1"
     },
     {
-      "community": 466,
+      "community": 467,
       "file_type": "code",
       "id": "repository_test_queryresult",
       "label": "queryResult()",
@@ -79183,7 +79264,7 @@
       "source_location": "L12"
     },
     {
-      "community": 467,
+      "community": 468,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_customermessaging_webhooksecurity_test_ts",
       "label": "webhookSecurity.test.ts",
@@ -79192,7 +79273,7 @@
       "source_location": "L1"
     },
     {
-      "community": 467,
+      "community": 468,
       "file_type": "code",
       "id": "webhooksecurity_test_sign",
       "label": "sign()",
@@ -79201,7 +79282,7 @@
       "source_location": "L5"
     },
     {
-      "community": 468,
+      "community": 469,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_verificationcode_tsx",
       "label": "VerificationCode.tsx",
@@ -79210,31 +79291,13 @@
       "source_location": "L1"
     },
     {
-      "community": 468,
+      "community": 469,
       "file_type": "code",
       "id": "verificationcode_verificationcode",
       "label": "VerificationCode()",
       "norm_label": "verificationcode()",
       "source_file": "packages/athena-webapp/convex/emails/VerificationCode.tsx",
       "source_location": "L18"
-    },
-    {
-      "community": 469,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_core_routes_subcategories_ts",
-      "label": "subcategories.ts",
-      "norm_label": "subcategories.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/core/routes/subcategories.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 469,
-      "file_type": "code",
-      "id": "subcategories_removestorefronthiddensubcategorylist",
-      "label": "removeStorefrontHiddenSubcategoryList()",
-      "norm_label": "removestorefronthiddensubcategorylist()",
-      "source_file": "packages/athena-webapp/convex/http/domains/core/routes/subcategories.ts",
-      "source_location": "L10"
     },
     {
       "community": 47,
@@ -79365,6 +79428,24 @@
     {
       "community": 470,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_core_routes_subcategories_ts",
+      "label": "subcategories.ts",
+      "norm_label": "subcategories.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/core/routes/subcategories.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 470,
+      "file_type": "code",
+      "id": "subcategories_removestorefronthiddensubcategorylist",
+      "label": "removeStorefrontHiddenSubcategoryList()",
+      "norm_label": "removestorefronthiddensubcategorylist()",
+      "source_file": "packages/athena-webapp/convex/http/domains/core/routes/subcategories.ts",
+      "source_location": "L10"
+    },
+    {
+      "community": 471,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_storefrontcors_test_ts",
       "label": "storefrontCors.test.ts",
       "norm_label": "storefrontcors.test.ts",
@@ -79372,7 +79453,7 @@
       "source_location": "L1"
     },
     {
-      "community": 470,
+      "community": 471,
       "file_type": "code",
       "id": "storefrontcors_test_readroutefile",
       "label": "readRouteFile()",
@@ -79381,7 +79462,7 @@
       "source_location": "L6"
     },
     {
-      "community": 471,
+      "community": 472,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customermessaging_routes_whatsapp_ts",
       "label": "whatsapp.ts",
@@ -79390,7 +79471,7 @@
       "source_location": "L1"
     },
     {
-      "community": 471,
+      "community": 472,
       "file_type": "code",
       "id": "whatsapp_mapwebhookstatus",
       "label": "mapWebhookStatus()",
@@ -79399,7 +79480,7 @@
       "source_location": "L15"
     },
     {
-      "community": 472,
+      "community": 473,
       "file_type": "code",
       "id": "mtnmomo_handlecollectionnotification",
       "label": "handleCollectionNotification()",
@@ -79408,7 +79489,7 @@
       "source_location": "L10"
     },
     {
-      "community": 472,
+      "community": 473,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_moneymovement_routes_mtnmomo_ts",
       "label": "mtnMomo.ts",
@@ -79417,7 +79498,7 @@
       "source_location": "L1"
     },
     {
-      "community": 473,
+      "community": 474,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_routercomposition_test_ts",
       "label": "routerComposition.test.ts",
@@ -79426,7 +79507,7 @@
       "source_location": "L1"
     },
     {
-      "community": 473,
+      "community": 474,
       "file_type": "code",
       "id": "routercomposition_test_readprojectfile",
       "label": "readProjectFile()",
@@ -79435,7 +79516,7 @@
       "source_location": "L6"
     },
     {
-      "community": 474,
+      "community": 475,
       "file_type": "code",
       "id": "auth_mapathenaauthsyncerror",
       "label": "mapAthenaAuthSyncError()",
@@ -79444,7 +79525,7 @@
       "source_location": "L110"
     },
     {
-      "community": 474,
+      "community": 475,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_auth_ts",
       "label": "auth.ts",
@@ -79453,7 +79534,7 @@
       "source_location": "L1"
     },
     {
-      "community": 475,
+      "community": 476,
       "file_type": "code",
       "id": "bestseller_test_gethandler",
       "label": "getHandler()",
@@ -79462,7 +79543,7 @@
       "source_location": "L6"
     },
     {
-      "community": 475,
+      "community": 476,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_bestseller_test_ts",
       "label": "bestSeller.test.ts",
@@ -79471,7 +79552,7 @@
       "source_location": "L1"
     },
     {
-      "community": 476,
+      "community": 477,
       "file_type": "code",
       "id": "expensesessionitems_usererrorfromexpenseitemcommandfailure",
       "label": "userErrorFromExpenseItemCommandFailure()",
@@ -79480,7 +79561,7 @@
       "source_location": "L14"
     },
     {
-      "community": 476,
+      "community": 477,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_expensesessionitems_ts",
       "label": "expenseSessionItems.ts",
@@ -79489,7 +79570,7 @@
       "source_location": "L1"
     },
     {
-      "community": 477,
+      "community": 478,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_posquerycleanup_test_ts",
       "label": "posQueryCleanup.test.ts",
@@ -79498,7 +79579,7 @@
       "source_location": "L1"
     },
     {
-      "community": 477,
+      "community": 478,
       "file_type": "code",
       "id": "posquerycleanup_test_readprojectfile",
       "label": "readProjectFile()",
@@ -79507,7 +79588,7 @@
       "source_location": "L8"
     },
     {
-      "community": 478,
+      "community": 479,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_possessionitems_ts",
       "label": "posSessionItems.ts",
@@ -79516,31 +79597,13 @@
       "source_location": "L1"
     },
     {
-      "community": 478,
+      "community": 479,
       "file_type": "code",
       "id": "possessionitems_usererrorfromsessionitemfailure",
       "label": "userErrorFromSessionItemFailure()",
       "norm_label": "usererrorfromsessionitemfailure()",
       "source_file": "packages/athena-webapp/convex/inventory/posSessionItems.ts",
       "source_location": "L22"
-    },
-    {
-      "community": 479,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_productutil_ts",
-      "label": "productUtil.ts",
-      "norm_label": "productutil.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/productUtil.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 479,
-      "file_type": "code",
-      "id": "productutil_buildallproductscachekey",
-      "label": "buildAllProductsCacheKey()",
-      "norm_label": "buildallproductscachekey()",
-      "source_file": "packages/athena-webapp/convex/inventory/productUtil.ts",
-      "source_location": "L8"
     },
     {
       "community": 48,
@@ -79671,6 +79734,24 @@
     {
       "community": 480,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_productutil_ts",
+      "label": "productUtil.ts",
+      "norm_label": "productutil.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/productUtil.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 480,
+      "file_type": "code",
+      "id": "productutil_buildallproductscachekey",
+      "label": "buildAllProductsCacheKey()",
+      "norm_label": "buildallproductscachekey()",
+      "source_file": "packages/athena-webapp/convex/inventory/productUtil.ts",
+      "source_location": "L8"
+    },
+    {
+      "community": 481,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_stores_ts",
       "label": "stores.ts",
       "norm_label": "stores.ts",
@@ -79678,7 +79759,7 @@
       "source_location": "L1"
     },
     {
-      "community": 480,
+      "community": 481,
       "file_type": "code",
       "id": "stores_tov2onlyconfig",
       "label": "toV2OnlyConfig()",
@@ -79687,7 +79768,7 @@
       "source_location": "L29"
     },
     {
-      "community": 481,
+      "community": 482,
       "file_type": "code",
       "id": "commandresultvalidators_commandresultvalidator",
       "label": "commandResultValidator()",
@@ -79696,7 +79777,7 @@
       "source_location": "L73"
     },
     {
-      "community": 481,
+      "community": 482,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_lib_commandresultvalidators_ts",
       "label": "commandResultValidators.ts",
@@ -79705,7 +79786,7 @@
       "source_location": "L1"
     },
     {
-      "community": 482,
+      "community": 483,
       "file_type": "code",
       "id": "callllmprovider_callllmprovider",
       "label": "callLlmProvider()",
@@ -79714,7 +79795,7 @@
       "source_location": "L4"
     },
     {
-      "community": 482,
+      "community": 483,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_callllmprovider_ts",
       "label": "callLlmProvider.ts",
@@ -79723,7 +79804,7 @@
       "source_location": "L1"
     },
     {
-      "community": 483,
+      "community": 484,
       "file_type": "code",
       "id": "anthropic_callanthropic",
       "label": "callAnthropic()",
@@ -79732,7 +79813,7 @@
       "source_location": "L3"
     },
     {
-      "community": 483,
+      "community": 484,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_providers_anthropic_ts",
       "label": "anthropic.ts",
@@ -79741,7 +79822,7 @@
       "source_location": "L1"
     },
     {
-      "community": 484,
+      "community": 485,
       "file_type": "code",
       "id": "openai_callopenai",
       "label": "callOpenAi()",
@@ -79750,7 +79831,7 @@
       "source_location": "L3"
     },
     {
-      "community": 484,
+      "community": 485,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_providers_openai_ts",
       "label": "openai.ts",
@@ -79759,7 +79840,7 @@
       "source_location": "L1"
     },
     {
-      "community": 485,
+      "community": 486,
       "file_type": "code",
       "id": "foundation_test_readprojectfile",
       "label": "readProjectFile()",
@@ -79768,7 +79849,7 @@
       "source_location": "L6"
     },
     {
-      "community": 485,
+      "community": 486,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_foundation_test_ts",
       "label": "foundation.test.ts",
@@ -79777,7 +79858,7 @@
       "source_location": "L1"
     },
     {
-      "community": 486,
+      "community": 487,
       "file_type": "code",
       "id": "approvalactions_consumecommandapprovalproofwithctx",
       "label": "consumeCommandApprovalProofWithCtx()",
@@ -79786,7 +79867,7 @@
       "source_location": "L34"
     },
     {
-      "community": 486,
+      "community": 487,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_approvalactions_ts",
       "label": "approvalActions.ts",
@@ -79795,7 +79876,7 @@
       "source_location": "L1"
     },
     {
-      "community": 487,
+      "community": 488,
       "file_type": "code",
       "id": "approvalauditevents_test_createoperationaleventctx",
       "label": "createOperationalEventCtx()",
@@ -79804,7 +79885,7 @@
       "source_location": "L11"
     },
     {
-      "community": 487,
+      "community": 488,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_approvalauditevents_test_ts",
       "label": "approvalAuditEvents.test.ts",
@@ -79813,7 +79894,7 @@
       "source_location": "L1"
     },
     {
-      "community": 488,
+      "community": 489,
       "file_type": "code",
       "id": "approvalproofs_test_createapprovalproofmutationctx",
       "label": "createApprovalProofMutationCtx()",
@@ -79822,30 +79903,12 @@
       "source_location": "L11"
     },
     {
-      "community": 488,
+      "community": 489,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_approvalproofs_test_ts",
       "label": "approvalProofs.test.ts",
       "norm_label": "approvalproofs.test.ts",
       "source_file": "packages/athena-webapp/convex/operations/approvalProofs.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 489,
-      "file_type": "code",
-      "id": "approvalrequesthelpers_buildapprovalrequest",
-      "label": "buildApprovalRequest()",
-      "norm_label": "buildapprovalrequest()",
-      "source_file": "packages/athena-webapp/convex/operations/approvalRequestHelpers.ts",
-      "source_location": "L3"
-    },
-    {
-      "community": 489,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_approvalrequesthelpers_ts",
-      "label": "approvalRequestHelpers.ts",
-      "norm_label": "approvalrequesthelpers.ts",
-      "source_file": "packages/athena-webapp/convex/operations/approvalRequestHelpers.ts",
       "source_location": "L1"
     },
     {
@@ -79977,6 +80040,24 @@
     {
       "community": 490,
       "file_type": "code",
+      "id": "approvalrequesthelpers_buildapprovalrequest",
+      "label": "buildApprovalRequest()",
+      "norm_label": "buildapprovalrequest()",
+      "source_file": "packages/athena-webapp/convex/operations/approvalRequestHelpers.ts",
+      "source_location": "L3"
+    },
+    {
+      "community": 490,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_approvalrequesthelpers_ts",
+      "label": "approvalRequestHelpers.ts",
+      "norm_label": "approvalrequesthelpers.ts",
+      "source_file": "packages/athena-webapp/convex/operations/approvalRequestHelpers.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 491,
+      "file_type": "code",
       "id": "approvalrequests_test_createapprovalrequestmutationctx",
       "label": "createApprovalRequestMutationCtx()",
       "norm_label": "createapprovalrequestmutationctx()",
@@ -79984,7 +80065,7 @@
       "source_location": "L19"
     },
     {
-      "community": 490,
+      "community": 491,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_approvalrequests_test_ts",
       "label": "approvalRequests.test.ts",
@@ -79993,7 +80074,7 @@
       "source_location": "L1"
     },
     {
-      "community": 491,
+      "community": 492,
       "file_type": "code",
       "id": "eventbuilders_buildoperationaleventmessage",
       "label": "buildOperationalEventMessage()",
@@ -80002,7 +80083,7 @@
       "source_location": "L1"
     },
     {
-      "community": 491,
+      "community": 492,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_helpers_eventbuilders_ts",
       "label": "eventBuilders.ts",
@@ -80011,7 +80092,7 @@
       "source_location": "L1"
     },
     {
-      "community": 492,
+      "community": 493,
       "file_type": "code",
       "id": "emailotp_formatvalidtime",
       "label": "formatValidTime()",
@@ -80020,7 +80101,7 @@
       "source_location": "L9"
     },
     {
-      "community": 492,
+      "community": 493,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_otp_emailotp_ts",
       "label": "EmailOTP.ts",
@@ -80029,7 +80110,7 @@
       "source_location": "L1"
     },
     {
-      "community": 493,
+      "community": 494,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_commands_quickaddcatalogitem_test_ts",
       "label": "quickAddCatalogItem.test.ts",
@@ -80038,7 +80119,7 @@
       "source_location": "L1"
     },
     {
-      "community": 493,
+      "community": 494,
       "file_type": "code",
       "id": "quickaddcatalogitem_test_createquickaddctx",
       "label": "createQuickAddCtx()",
@@ -80047,7 +80128,7 @@
       "source_location": "L17"
     },
     {
-      "community": 494,
+      "community": 495,
       "file_type": "code",
       "id": "completetransaction_test_expectnocompletionsideeffects",
       "label": "expectNoCompletionSideEffects()",
@@ -80056,7 +80137,7 @@
       "source_location": "L82"
     },
     {
-      "community": 494,
+      "community": 495,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_completetransaction_test_ts",
       "label": "completeTransaction.test.ts",
@@ -80065,7 +80146,7 @@
       "source_location": "L1"
     },
     {
-      "community": 495,
+      "community": 496,
       "file_type": "code",
       "id": "correcttransactionpaymentmethod_test_createmutationctx",
       "label": "createMutationCtx()",
@@ -80074,7 +80155,7 @@
       "source_location": "L38"
     },
     {
-      "community": 495,
+      "community": 496,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_correcttransactionpaymentmethod_test_ts",
       "label": "correctTransactionPaymentMethod.test.ts",
@@ -80083,7 +80164,7 @@
       "source_location": "L1"
     },
     {
-      "community": 496,
+      "community": 497,
       "file_type": "code",
       "id": "correctionevents_buildcorrectionoperationalevent",
       "label": "buildCorrectionOperationalEvent()",
@@ -80092,7 +80173,7 @@
       "source_location": "L35"
     },
     {
-      "community": 496,
+      "community": 497,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_corrections_correctionevents_ts",
       "label": "correctionEvents.ts",
@@ -80101,7 +80182,7 @@
       "source_location": "L1"
     },
     {
-      "community": 497,
+      "community": 498,
       "file_type": "code",
       "id": "gettransactions_test_mockcorrectionhistorydb",
       "label": "mockCorrectionHistoryDb()",
@@ -80110,7 +80191,7 @@
       "source_location": "L33"
     },
     {
-      "community": 497,
+      "community": 498,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_gettransactions_test_ts",
       "label": "getTransactions.test.ts",
@@ -80119,7 +80200,7 @@
       "source_location": "L1"
     },
     {
-      "community": 498,
+      "community": 499,
       "file_type": "code",
       "id": "listregistercatalog_test_createregistercatalogctx",
       "label": "createRegisterCatalogCtx()",
@@ -80128,30 +80209,12 @@
       "source_location": "L22"
     },
     {
-      "community": 498,
+      "community": 499,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_queries_listregistercatalog_test_ts",
       "label": "listRegisterCatalog.test.ts",
       "norm_label": "listregistercatalog.test.ts",
       "source_file": "packages/athena-webapp/convex/pos/application/queries/listRegisterCatalog.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 499,
-      "file_type": "code",
-      "id": "inventoryholdgateway_test_createctx",
-      "label": "createCtx()",
-      "norm_label": "createctx()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/integrations/inventoryHoldGateway.test.ts",
-      "source_location": "L5"
-    },
-    {
-      "community": 499,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_infrastructure_integrations_inventoryholdgateway_test_ts",
-      "label": "inventoryHoldGateway.test.ts",
-      "norm_label": "inventoryholdgateway.test.ts",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/integrations/inventoryHoldGateway.test.ts",
       "source_location": "L1"
     },
     {
@@ -92896,7 +92959,7 @@
       "label": "buildItem()",
       "norm_label": "builditem()",
       "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L2404"
+      "source_location": "L2406"
     },
     {
       "community": 96,
@@ -92905,7 +92968,7 @@
       "label": "buildRegisterSession()",
       "norm_label": "buildregistersession()",
       "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L2398"
+      "source_location": "L2400"
     },
     {
       "community": 96,
@@ -92914,7 +92977,7 @@
       "label": "buildSession()",
       "norm_label": "buildsession()",
       "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L2394"
+      "source_location": "L2396"
     },
     {
       "community": 96,
@@ -92923,7 +92986,7 @@
       "label": "createCommandService()",
       "norm_label": "createcommandservice()",
       "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L2414"
+      "source_location": "L2416"
     },
     {
       "community": 96,
@@ -92932,7 +92995,7 @@
       "label": "createDependencies()",
       "norm_label": "createdependencies()",
       "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L2153"
+      "source_location": "L2155"
     },
     {
       "community": 96,
@@ -92941,7 +93004,7 @@
       "label": "createFakeRepository()",
       "norm_label": "createfakerepository()",
       "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L2250"
+      "source_location": "L2252"
     },
     {
       "community": 96,
@@ -92950,7 +93013,7 @@
       "label": "loadCommandService()",
       "norm_label": "loadcommandservice()",
       "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L2135"
+      "source_location": "L2137"
     },
     {
       "community": 960,

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,8 +8,8 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 1619
-- Graph nodes: 4570
-- Graph edges: 4366
+- Graph nodes: 4573
+- Graph edges: 4369
 - Communities: 1547
 
 ## Graph Hotspots

--- a/graphify-out/wiki/packages/athena-webapp.md
+++ b/graphify-out/wiki/packages/athena-webapp.md
@@ -20,8 +20,8 @@ Landing page for packages/athena-webapp. Use this page to orient around graph ho
 - `ProcurementView.tsx` (39 edges, Community 2) - [`packages/athena-webapp/src/components/procurement/ProcurementView.tsx`](../../../packages/athena-webapp/src/components/procurement/ProcurementView.tsx)
 - `RegisterSessionView.tsx` (27 edges, Community 7) - [`packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx`](../../../packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx)
 - `storeConfigV2.ts` (27 edges, Community 6) - [`packages/athena-webapp/convex/inventory/storeConfigV2.ts`](../../../packages/athena-webapp/convex/inventory/storeConfigV2.ts)
+- `expenseSessionCommands.ts` (23 edges, Community 12) - [`packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts`](../../../packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts)
 - `posSessions.ts` (23 edges, Community 11) - [`packages/athena-webapp/convex/inventory/posSessions.ts`](../../../packages/athena-webapp/convex/inventory/posSessions.ts)
-- `cycleCountDrafts.ts` (21 edges, Community 12) - [`packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts`](../../../packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts)
 
 ## Navigation
 - [wiki index](../index.md) - back to the wiki index

--- a/graphify-out/wiki/packages/storefront-webapp.md
+++ b/graphify-out/wiki/packages/storefront-webapp.md
@@ -19,9 +19,9 @@ Landing page for packages/storefront-webapp. Use this page to orient around grap
 ## Graph Hotspots
 - `storefrontJourneyEvents.ts` (45 edges, Community 1) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
 - `createJourneyEvent()` (40 edges, Community 1) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
-- `getStoreConfigV2()` (17 edges, Community 13) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)
+- `getStoreConfigV2()` (17 edges, Community 14) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)
 - `checkoutSession.ts` (14 edges, Community 38) - [`packages/storefront-webapp/src/api/checkoutSession.ts`](../../../packages/storefront-webapp/src/api/checkoutSession.ts)
-- `storeConfig.ts` (14 edges, Community 13) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)
+- `storeConfig.ts` (14 edges, Community 14) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)
 
 ## Navigation
 - [wiki index](../index.md) - back to the wiki index

--- a/packages/athena-webapp/convex/inventory/expenseSessions.test.ts
+++ b/packages/athena-webapp/convex/inventory/expenseSessions.test.ts
@@ -13,8 +13,10 @@ vi.mock("./expenseTransactions", () => ({
 import {
   completeExpenseSession,
   createExpenseSession,
+  releaseExpenseSessionItems,
   releaseExpenseSessionInventoryHoldsAndDeleteItems,
   updateExpenseSession,
+  voidExpenseSession,
 } from "./expenseSessions";
 
 afterEach(() => {
@@ -36,12 +38,28 @@ type SessionRecord = {
   workflowTraceId?: string;
 };
 
+type ExpenseItemRecord = {
+  _id: string;
+  sessionId: string;
+  productSkuId: string;
+  quantity: number;
+};
+
+type ProductSkuRecord = {
+  _id: string;
+  quantityAvailable: number;
+};
+
 function createMutationCtx(seed?: {
   latestSession?: SessionRecord;
   sessions?: SessionRecord[];
+  expenseItems?: ExpenseItemRecord[];
+  productSkus?: ProductSkuRecord[];
   terminals?: Array<{ _id: string; registerNumber?: string | null }>;
 }) {
   const sessions = [...(seed?.sessions ?? [])];
+  const expenseItems = [...(seed?.expenseItems ?? [])];
+  const productSkus = [...(seed?.productSkus ?? [])];
   const terminals = [...(seed?.terminals ?? [])];
   const workflowTraces: Array<Record<string, unknown>> = [];
   const workflowTraceLookups: Array<Record<string, unknown>> = [];
@@ -58,6 +76,10 @@ function createMutationCtx(seed?: {
 
       if (tableName === "posTerminal") {
         return terminals.find((terminal) => terminal._id === id) ?? null;
+      }
+
+      if (tableName === "productSku") {
+        return productSkus.find((sku) => sku._id === id) ?? null;
       }
 
       return null;
@@ -101,6 +123,12 @@ function createMutationCtx(seed?: {
     patch: vi.fn(
       async (tableName: string, id: string, patch: Record<string, unknown>) => {
         if (tableName !== "expenseSession") {
+          if (tableName === "productSku") {
+            const sku = productSkus.find((entry) => entry._id === id);
+            if (sku) {
+              Object.assign(sku, patch);
+            }
+          }
           return;
         }
 
@@ -113,35 +141,93 @@ function createMutationCtx(seed?: {
       },
     ),
     query: vi.fn((tableName: string) => ({
-      withIndex: vi.fn(() => ({
-        unique: vi.fn(async () => {
-          if (tableName === "workflowTrace") {
-            return workflowTraces[0] ?? null;
-          }
+      withIndex: vi.fn(
+        (
+          _indexName: string,
+          apply?: (builder: {
+            eq(field: string, value: unknown): unknown;
+            lt(field: string, value: unknown): unknown;
+          }) => void,
+        ) => {
+          const filters: Record<string, unknown> = {};
+          const builder = {
+            eq(field: string, value: unknown) {
+              filters[field] = value;
+              return builder;
+            },
+            lt(field: string, value: unknown) {
+              filters[`${field}:lt`] = value;
+              return builder;
+            },
+          };
+          apply?.(builder);
 
-          if (tableName === "workflowTraceLookup") {
-            return workflowTraceLookups[0] ?? null;
-          }
+          const filteredExpenseItems =
+            tableName === "expenseSessionItem"
+              ? expenseItems.filter((item) => {
+                  if (
+                    filters.sessionId &&
+                    item.sessionId !== filters.sessionId
+                  ) {
+                    return false;
+                  }
 
-          return null;
-        }),
-        first: vi.fn(async () => seed?.latestSession ?? null),
-        order: vi.fn(() => ({
-          first: vi.fn(async () => {
-            if (tableName === "workflowTraceEvent") {
-              return workflowTraceEvents.at(-1) ?? null;
-            }
+                  return true;
+                })
+              : [];
+          const filteredSessions =
+            tableName === "expenseSession"
+              ? sessions.filter((session) => {
+                  if (filters.status && session.status !== filters.status) {
+                    return false;
+                  }
+                  if (
+                    filters["expiresAt:lt"] &&
+                    session.expiresAt >= Number(filters["expiresAt:lt"])
+                  ) {
+                    return false;
+                  }
 
-            return seed?.latestSession ?? null;
-          }),
-        })),
-        take: vi.fn(async () => []),
-      })),
+                  return true;
+                })
+              : [];
+
+          return {
+            unique: vi.fn(async () => {
+              if (tableName === "workflowTrace") {
+                return workflowTraces[0] ?? null;
+              }
+
+              if (tableName === "workflowTraceLookup") {
+                return workflowTraceLookups[0] ?? null;
+              }
+
+              return null;
+            }),
+            first: vi.fn(async () => seed?.latestSession ?? null),
+            order: vi.fn(() => ({
+              first: vi.fn(async () => {
+                if (tableName === "workflowTraceEvent") {
+                  return workflowTraceEvents.at(-1) ?? null;
+                }
+
+                return seed?.latestSession ?? null;
+              }),
+            })),
+            take: vi.fn(async () =>
+              tableName === "expenseSessionItem"
+                ? filteredExpenseItems
+                : filteredSessions,
+            ),
+          };
+        },
+      ),
     })),
   };
 
   return {
     db,
+    productSkus,
     runMutation: vi.fn(),
   };
 }
@@ -312,6 +398,80 @@ describe("expense session command results", () => {
         code: "not_found",
         message: "Session not found",
       },
+    });
+  });
+
+  it("restores quantity-patch expense holds when voiding a session", async () => {
+    const ctx = createMutationCtx({
+      sessions: [buildSession({ _id: "expense-session-1" })],
+      expenseItems: [
+        {
+          _id: "expense-item-1",
+          sessionId: "expense-session-1",
+          productSkuId: "sku-1",
+          quantity: 2,
+        },
+        {
+          _id: "expense-item-2",
+          sessionId: "expense-session-1",
+          productSkuId: "sku-1",
+          quantity: 3,
+        },
+      ],
+      productSkus: [{ _id: "sku-1", quantityAvailable: 4 }],
+    });
+
+    const result = await getHandler(voidExpenseSession)(ctx as never, {
+      sessionId: "expense-session-1",
+    });
+
+    expect(result).toEqual({
+      kind: "ok",
+      data: { sessionId: "expense-session-1" },
+    });
+    expect(ctx.productSkus[0]).toEqual(
+      expect.objectContaining({ quantityAvailable: 9 }),
+    );
+    expect(ctx.db.patch).toHaveBeenCalledWith("productSku", "sku-1", {
+      quantityAvailable: 9,
+    });
+  });
+
+  it("restores quantity-patch expense holds when expiring sessions", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(2_000);
+    const ctx = createMutationCtx({
+      sessions: [
+        buildSession({
+          _id: "expense-session-1",
+          expiresAt: 1_000,
+          status: "active",
+        }),
+      ],
+      expenseItems: [
+        {
+          _id: "expense-item-1",
+          sessionId: "expense-session-1",
+          productSkuId: "sku-1",
+          quantity: 2,
+        },
+      ],
+      productSkus: [{ _id: "sku-1", quantityAvailable: 4 }],
+    });
+
+    const result = await getHandler(releaseExpenseSessionItems)(
+      ctx as never,
+      {},
+    );
+
+    expect(result).toEqual({
+      releasedCount: 1,
+      sessionIds: ["expense-session-1"],
+    });
+    expect(ctx.productSkus[0]).toEqual(
+      expect.objectContaining({ quantityAvailable: 6 }),
+    );
+    expect(ctx.db.patch).toHaveBeenCalledWith("productSku", "sku-1", {
+      quantityAvailable: 6,
     });
   });
 });

--- a/packages/athena-webapp/convex/inventory/expenseSessions.ts
+++ b/packages/athena-webapp/convex/inventory/expenseSessions.ts
@@ -7,7 +7,7 @@ import {
   QueryCtx,
 } from "../_generated/server";
 import type { Doc, Id } from "../_generated/dataModel";
-import { releaseInventoryHoldsBatch } from "./helpers/inventoryHolds";
+import { releaseLegacyExpenseQuantityPatchHolds } from "./helpers/inventoryHolds";
 import { validateExpenseSessionModifiable } from "./helpers/expenseSessionValidation";
 import { calculateExpenseSessionExpiration } from "./helpers/expenseSessionExpiration";
 import { commandResultValidator } from "../lib/commandResultValidators";
@@ -606,7 +606,7 @@ export const voidExpenseSession = mutation({
       }),
     );
 
-    await releaseInventoryHoldsBatch(ctx.db, releaseItems);
+    await releaseLegacyExpenseQuantityPatchHolds(ctx.db, releaseItems);
 
     // Mark session as void
     await ctx.db.patch("expenseSession", args.sessionId, {
@@ -777,7 +777,7 @@ export const releaseExpenseSessionItems = internalMutation({
           }),
         );
 
-        await releaseInventoryHoldsBatch(ctx.db, releaseItems);
+        await releaseLegacyExpenseQuantityPatchHolds(ctx.db, releaseItems);
         console.log(
           `[Expense] Released inventory holds for ${releaseItems.length} SKUs`,
         );

--- a/packages/athena-webapp/convex/inventory/helpers/inventoryHolds.test.ts
+++ b/packages/athena-webapp/convex/inventory/helpers/inventoryHolds.test.ts
@@ -7,6 +7,8 @@ import {
   consumeInventoryHoldsForSession,
   releaseActiveInventoryHoldsForSession,
   releaseInventoryHold,
+  releaseInventoryHoldsBatch,
+  releaseLegacyExpenseQuantityPatchHolds,
 } from "./inventoryHolds";
 
 type HoldStatus = "active" | "released" | "consumed" | "expired";
@@ -49,17 +51,23 @@ function createDb(seed: { sku: SkuRecord; holds?: HoldRecord[] }) {
       }
       return null;
     }),
-    insert: vi.fn(async (_tableName: string, input: Omit<HoldRecord, "_id">) => {
-      const hold = {
-        _id: `hold-${holds.length + 1}`,
-        ...input,
-      };
-      holds.push(hold);
-      insertedHolds.push(hold);
-      return hold._id;
-    }),
+    insert: vi.fn(
+      async (_tableName: string, input: Omit<HoldRecord, "_id">) => {
+        const hold = {
+          _id: `hold-${holds.length + 1}`,
+          ...input,
+        };
+        holds.push(hold);
+        insertedHolds.push(hold);
+        return hold._id;
+      },
+    ),
     patch: vi.fn(
-      async (tableNameOrId: string, idOrPatch: string | Record<string, unknown>, maybePatch?: Record<string, unknown>) => {
+      async (
+        tableNameOrId: string,
+        idOrPatch: string | Record<string, unknown>,
+        maybePatch?: Record<string, unknown>,
+      ) => {
         const tableName = maybePatch ? tableNameOrId : "productSku";
         const id = maybePatch ? String(idOrPatch) : tableNameOrId;
         const patch = maybePatch ?? (idOrPatch as Record<string, unknown>);
@@ -77,10 +85,13 @@ function createDb(seed: { sku: SkuRecord; holds?: HoldRecord[] }) {
       },
     ),
     query: vi.fn((tableName: string) => ({
-      withIndex(_indexName: string, apply: (builder: {
-        eq(field: string, value: unknown): unknown;
-        gt(field: string, value: unknown): unknown;
-      }) => void) {
+      withIndex(
+        _indexName: string,
+        apply: (builder: {
+          eq(field: string, value: unknown): unknown;
+          gt(field: string, value: unknown): unknown;
+        }) => void,
+      ) {
         const filters: Record<string, unknown> = {};
         const builder = {
           eq(field: string, value: unknown) {
@@ -285,13 +296,13 @@ describe("POS inventory hold ledger", () => {
     expect(productSkuPatches).toEqual([]);
   });
 
-  it("restores legacy quantity-patch holds when no ledger hold exists", async () => {
+  it("does not restore SKU availability when no ledger hold exists", async () => {
     const { db, productSkuPatches } = createDb({
       sku: {
         _id: "sku-1",
         storeId: "store-1",
         sku: "SKU-1",
-        quantityAvailable: 6,
+        quantityAvailable: 10,
         inventoryCount: 10,
       },
     });
@@ -304,6 +315,94 @@ describe("POS inventory hold ledger", () => {
     });
 
     expect(result).toMatchObject({ success: true });
+    expect(productSkuPatches).toEqual([]);
+  });
+
+  it("expires matching ledger holds without restoring SKU availability", async () => {
+    const { db, holds, productSkuPatches } = createDb({
+      sku: {
+        _id: "sku-1",
+        storeId: "store-1",
+        sku: "SKU-1",
+        quantityAvailable: 10,
+        inventoryCount: 10,
+      },
+      holds: [
+        buildHold({
+          _id: "hold-expired",
+          sourceSessionId: "session-1",
+          quantity: 2,
+          expiresAt: 500,
+        }),
+      ],
+    });
+
+    const result = await releaseInventoryHold(db as never, {
+      sessionId: "session-1" as Id<"posSession">,
+      skuId: "sku-1" as Id<"productSku">,
+      quantity: 2,
+      now: 1_000,
+    });
+
+    expect(result).toMatchObject({ success: true });
+    expect(holds[0]).toEqual(
+      expect.objectContaining({
+        status: "expired",
+        expiredAt: 1_000,
+      }),
+    );
+    expect(productSkuPatches).toEqual([]);
+  });
+
+  it("releases expired POS-session batch holds without restoring SKU availability", async () => {
+    const { db, holds, productSkuPatches } = createDb({
+      sku: {
+        _id: "sku-1",
+        storeId: "store-1",
+        sku: "SKU-1",
+        quantityAvailable: 10,
+        inventoryCount: 10,
+      },
+      holds: [
+        buildHold({
+          _id: "hold-expired",
+          sourceSessionId: "session-expired",
+          quantity: 4,
+          expiresAt: 500,
+        }),
+      ],
+    });
+
+    await releaseInventoryHoldsBatch(db as never, {
+      sessionId: "session-expired" as Id<"posSession">,
+      items: [{ skuId: "sku-1" as Id<"productSku">, quantity: 4 }],
+      now: 1_000,
+    });
+
+    expect(holds[0]).toEqual(
+      expect.objectContaining({
+        status: "expired",
+        expiredAt: 1_000,
+      }),
+    );
+    expect(productSkuPatches).toEqual([]);
+  });
+
+  it("restores explicit legacy expense quantity-patch holds", async () => {
+    const { db, productSkuPatches } = createDb({
+      sku: {
+        _id: "sku-1",
+        storeId: "store-1",
+        sku: "SKU-1",
+        quantityAvailable: 6,
+        inventoryCount: 10,
+      },
+    });
+
+    await releaseLegacyExpenseQuantityPatchHolds(db as never, [
+      { skuId: "sku-1" as Id<"productSku">, quantity: 2 },
+    ]);
+
     expect(productSkuPatches).toEqual([{ quantityAvailable: 8 }]);
   });
 

--- a/packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts
+++ b/packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts
@@ -202,6 +202,9 @@ export async function releaseInventoryHold(
   for (const hold of activeHolds) {
     if (hold.expiresAt <= now) {
       await markHoldExpired(db, hold._id, now);
+      if (remainingQuantity !== undefined) {
+        remainingQuantity = Math.max(0, remainingQuantity - hold.quantity);
+      }
       continue;
     }
 
@@ -227,10 +230,6 @@ export async function releaseInventoryHold(
       releasedAt: now,
       updatedAt: now,
     });
-  }
-
-  if (remainingQuantity && remainingQuantity > 0) {
-    await restoreLegacyQuantityPatchHold(db, args.skuId, remainingQuantity);
   }
 
   return {
@@ -347,30 +346,12 @@ export async function acquireInventoryHoldsBatch(
 
 export async function releaseInventoryHoldsBatch(
   db: DatabaseWriter,
-  input:
-    | {
-        sessionId: Id<"posSession">;
-        items: Array<{ skuId: Id<"productSku">; quantity: number }>;
-        now?: number;
-      }
-    | Array<{ skuId: Id<"productSku">; quantity: number }>,
+  input: {
+    sessionId: Id<"posSession">;
+    items: Array<{ skuId: Id<"productSku">; quantity: number }>;
+    now?: number;
+  },
 ): Promise<void> {
-  if (Array.isArray(input)) {
-    await Promise.all(
-      input.map(async (item) => {
-        const sku = await db.get("productSku", item.skuId);
-        if (!sku || typeof sku.quantityAvailable !== "number") {
-          return;
-        }
-
-        await db.patch("productSku", item.skuId, {
-          quantityAvailable: sku.quantityAvailable + item.quantity,
-        });
-      }),
-    );
-    return;
-  }
-
   await Promise.all(
     input.items.map((item) =>
       releaseInventoryHold(db, {
@@ -380,6 +361,24 @@ export async function releaseInventoryHoldsBatch(
         now: input.now,
       }),
     ),
+  );
+}
+
+export async function releaseLegacyExpenseQuantityPatchHolds(
+  db: DatabaseWriter,
+  items: Array<{ skuId: Id<"productSku">; quantity: number }>,
+): Promise<void> {
+  await Promise.all(
+    items.map(async (item) => {
+      const sku = await db.get("productSku", item.skuId);
+      if (!sku || typeof sku.quantityAvailable !== "number") {
+        return;
+      }
+
+      await db.patch("productSku", item.skuId, {
+        quantityAvailable: sku.quantityAvailable + item.quantity,
+      });
+    }),
   );
 }
 
@@ -643,20 +642,5 @@ async function markHoldExpired(
     status: "expired",
     expiredAt: now,
     updatedAt: now,
-  });
-}
-
-async function restoreLegacyQuantityPatchHold(
-  db: DatabaseWriter,
-  skuId: Id<"productSku">,
-  quantity: number,
-) {
-  const sku = await db.get("productSku", skuId);
-  if (!sku || typeof sku.quantityAvailable !== "number") {
-    return;
-  }
-
-  await db.patch("productSku", skuId, {
-    quantityAvailable: sku.quantityAvailable + quantity,
   });
 }

--- a/packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts
+++ b/packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts
@@ -3,10 +3,6 @@ import type { MutationCtx } from "../../../_generated/server";
 
 import { calculateExpenseSessionExpiration } from "../../../inventory/helpers/expenseSessionExpiration";
 import {
-  createInventoryHoldGateway,
-  type PosInventoryHoldGateway,
-} from "../../infrastructure/integrations/inventoryHoldGateway";
-import {
   createExpenseSessionCommandRepository,
   type ExpenseSessionCommandRepository,
 } from "../../infrastructure/repositories/expenseSessionCommandRepository";
@@ -129,9 +125,31 @@ type ExpenseSessionCommandDependencies = {
   now: () => number;
   calculateExpiration: (baseTime: number) => number;
   repository: ExpenseSessionCommandRepository;
-  inventory: PosInventoryHoldGateway;
+  inventory: ExpenseInventoryHoldGateway;
   traceRecorder?: ExpenseSessionTraceRecorder;
 };
+
+interface ExpenseInventoryHoldGatewayResult {
+  success: boolean;
+  message?: string;
+  available?: number;
+}
+
+interface ExpenseInventoryHoldGateway {
+  acquireHold(
+    skuId: Id<"productSku">,
+    quantity: number,
+  ): Promise<ExpenseInventoryHoldGatewayResult>;
+  adjustHold(
+    skuId: Id<"productSku">,
+    oldQuantity: number,
+    newQuantity: number,
+  ): Promise<ExpenseInventoryHoldGatewayResult>;
+  releaseHold(
+    skuId: Id<"productSku">,
+    quantity: number,
+  ): Promise<ExpenseInventoryHoldGatewayResult>;
+}
 
 export function createExpenseSessionCommandService(
   dependencies: ExpenseSessionCommandDependencies,
@@ -648,9 +666,88 @@ function createDefaultExpenseSessionCommandService(
     now: () => Date.now(),
     calculateExpiration: calculateExpenseSessionExpiration,
     repository: createExpenseSessionCommandRepository(ctx),
-    inventory: createInventoryHoldGateway(ctx),
+    inventory: createExpenseInventoryHoldGateway(ctx),
     traceRecorder: createExpenseSessionTraceRecorder(ctx),
   });
+}
+
+function createExpenseInventoryHoldGateway(
+  ctx: MutationCtx,
+): ExpenseInventoryHoldGateway {
+  return {
+    acquireHold(skuId, quantity) {
+      return acquireExpenseQuantityPatchHold(ctx, skuId, quantity);
+    },
+    adjustHold(skuId, oldQuantity, newQuantity) {
+      return adjustExpenseQuantityPatchHold(
+        ctx,
+        skuId,
+        oldQuantity,
+        newQuantity,
+      );
+    },
+    releaseHold(skuId, quantity) {
+      return releaseExpenseQuantityPatchHold(ctx, skuId, quantity);
+    },
+  };
+}
+
+async function acquireExpenseQuantityPatchHold(
+  ctx: MutationCtx,
+  skuId: Id<"productSku">,
+  quantity: number,
+): Promise<ExpenseInventoryHoldGatewayResult> {
+  const sku = await ctx.db.get("productSku", skuId);
+  if (!sku || typeof sku.quantityAvailable !== "number") {
+    return { success: false, message: "Product not found" };
+  }
+
+  if (sku.quantityAvailable < quantity) {
+    return {
+      success: false,
+      message: `Only ${sku.quantityAvailable} unit${sku.quantityAvailable !== 1 ? "s" : ""} available`,
+      available: sku.quantityAvailable,
+    };
+  }
+
+  await ctx.db.patch("productSku", skuId, {
+    quantityAvailable: sku.quantityAvailable - quantity,
+  });
+  return { success: true };
+}
+
+async function releaseExpenseQuantityPatchHold(
+  ctx: MutationCtx,
+  skuId: Id<"productSku">,
+  quantity: number,
+): Promise<ExpenseInventoryHoldGatewayResult> {
+  const sku = await ctx.db.get("productSku", skuId);
+  if (!sku || typeof sku.quantityAvailable !== "number") {
+    return { success: true };
+  }
+
+  await ctx.db.patch("productSku", skuId, {
+    quantityAvailable: sku.quantityAvailable + quantity,
+  });
+  return { success: true };
+}
+
+async function adjustExpenseQuantityPatchHold(
+  ctx: MutationCtx,
+  skuId: Id<"productSku">,
+  oldQuantity: number,
+  newQuantity: number,
+): Promise<ExpenseInventoryHoldGatewayResult> {
+  const quantityChange = newQuantity - oldQuantity;
+  if (quantityChange === 0) {
+    return { success: true };
+  }
+
+  if (quantityChange > 0) {
+    return acquireExpenseQuantityPatchHold(ctx, skuId, quantityChange);
+  }
+
+  return releaseExpenseQuantityPatchHold(ctx, skuId, Math.abs(quantityChange));
 }
 
 function buildNextSessionNumber(

--- a/packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts
+++ b/packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts
@@ -280,6 +280,7 @@ export function createPosSessionCommandService(
         terminalId: args.terminalId,
         registerNumber,
         registerSessionId: registerSessionBinding.data.registerSessionId,
+        inventoryHoldMode: "ledger",
         status: "active",
         createdAt: now,
         updatedAt: now,

--- a/packages/athena-webapp/convex/pos/application/sessionCommands.test.ts
+++ b/packages/athena-webapp/convex/pos/application/sessionCommands.test.ts
@@ -8,6 +8,7 @@ type SessionRecord = {
   staffProfileId?: string;
   registerNumber?: string;
   registerSessionId?: string;
+  inventoryHoldMode?: "ledger";
   status: "active" | "held" | "completed" | "void" | "expired";
   workflowTraceId?: string;
   expiresAt: number;
@@ -112,6 +113,7 @@ describe("createPosSessionCommandService", () => {
         staffProfileId: "cashier-1",
         registerNumber: "1",
         registerSessionId: "drawer-1",
+        inventoryHoldMode: "ledger",
         expiresAt: 61_000,
         workflowTraceId: "pos_session:session-1",
       }),

--- a/packages/athena-webapp/convex/pos/infrastructure/integrations/inventoryHoldGateway.test.ts
+++ b/packages/athena-webapp/convex/pos/infrastructure/integrations/inventoryHoldGateway.test.ts
@@ -1,77 +1,104 @@
 import { describe, expect, it, vi } from "vitest";
 
+import {
+  acquireInventoryHold,
+  adjustInventoryHold,
+  releaseInventoryHold,
+} from "../../../inventory/helpers/inventoryHolds";
 import { createInventoryHoldGateway } from "./inventoryHoldGateway";
 
-function createCtx(quantityAvailable = 5) {
-  const sku = {
-    _id: "sku-1",
-    quantityAvailable,
-  };
-  const patches: Array<Record<string, unknown>> = [];
+vi.mock("../../../inventory/helpers/inventoryHolds", () => ({
+  acquireInventoryHold: vi.fn(async () => ({ success: true })),
+  adjustInventoryHold: vi.fn(async () => ({ success: true })),
+  releaseInventoryHold: vi.fn(async () => ({ success: true })),
+}));
 
+function createCtx() {
   return {
-    ctx: {
-      db: {
-        get: vi.fn(async (tableName: string, id: string) =>
-          tableName === "productSku" && id === "sku-1" ? sku : null,
-        ),
-        patch: vi.fn(async (_tableName: string, _id: string, patch: Record<string, unknown>) => {
-          patches.push(patch);
-          Object.assign(sku, patch);
-        }),
-      },
-    },
-    patches,
-    sku,
+    db: {},
   };
 }
 
-describe("createInventoryHoldGateway legacy quantity-patch compatibility", () => {
-  it("subtracts availability for tuple acquire calls", async () => {
-    const { ctx, patches } = createCtx(5);
-    const gateway = createInventoryHoldGateway(ctx as never);
+function createLegacyPatchCtx() {
+  return {
+    db: {
+      get: vi.fn(async () => ({
+        _id: "sku-1",
+        quantityAvailable: 5,
+      })),
+      patch: vi.fn(async () => undefined),
+    },
+  };
+}
 
-    await expect(gateway.acquireHold("sku-1" as never, 2)).resolves.toEqual({
+describe("createInventoryHoldGateway", () => {
+  it("delegates acquire calls to the ledger helper with object-shaped args", async () => {
+    const ctx = createCtx();
+    const gateway = createInventoryHoldGateway(ctx as never);
+    const args = {
+      storeId: "store-1",
+      sessionId: "session-1",
+      skuId: "sku-1",
+      quantity: 2,
+      expiresAt: 1_000,
+      now: 500,
+    } as never;
+
+    await expect(gateway.acquireHold(args)).resolves.toEqual({
       success: true,
     });
 
-    expect(patches).toEqual([{ quantityAvailable: 3 }]);
+    expect(acquireInventoryHold).toHaveBeenCalledWith(ctx.db, args);
   });
 
-  it("restores availability for tuple release calls", async () => {
-    const { ctx, patches } = createCtx(3);
+  it("delegates adjust calls to the ledger helper with object-shaped args", async () => {
+    const ctx = createCtx();
     const gateway = createInventoryHoldGateway(ctx as never);
+    const args = {
+      storeId: "store-1",
+      sessionId: "session-1",
+      skuId: "sku-1",
+      oldQuantity: 2,
+      newQuantity: 5,
+      expiresAt: 1_000,
+      now: 500,
+    } as never;
 
-    await expect(gateway.releaseHold("sku-1" as never, 2)).resolves.toEqual({
+    await expect(gateway.adjustHold(args)).resolves.toEqual({
       success: true,
     });
 
-    expect(patches).toEqual([{ quantityAvailable: 5 }]);
+    expect(adjustInventoryHold).toHaveBeenCalledWith(ctx.db, args);
   });
 
-  it("adjusts tuple holds by patching only the quantity delta", async () => {
-    const { ctx, patches } = createCtx(3);
+  it("delegates release calls to the ledger helper with object-shaped args", async () => {
+    const ctx = createCtx();
+    const gateway = createInventoryHoldGateway(ctx as never);
+    const args = {
+      sessionId: "session-1",
+      skuId: "sku-1",
+      quantity: 2,
+      now: 500,
+    } as never;
+
+    await expect(gateway.releaseHold(args)).resolves.toEqual({
+      success: true,
+    });
+
+    expect(releaseInventoryHold).toHaveBeenCalledWith(ctx.db, args);
+  });
+
+  it("rejects tuple-shaped acquire calls instead of patching SKU availability", async () => {
+    const ctx = createLegacyPatchCtx();
     const gateway = createInventoryHoldGateway(ctx as never);
 
-    await expect(
-      gateway.adjustHold("sku-1" as never, 2, 5),
-    ).resolves.toEqual({
-      success: true,
-    });
-    await expect(
-      gateway.adjustHold("sku-1" as never, 5, 4),
-    ).resolves.toEqual({
-      success: true,
-    });
-    await expect(
-      gateway.adjustHold("sku-1" as never, 4, 4),
-    ).resolves.toEqual({
-      success: true,
-    });
+    expect(() =>
+      (gateway.acquireHold as never as (skuId: string, quantity: number) => unknown)(
+        "sku-1",
+        2,
+      ),
+    ).toThrow("object-shaped inventory hold arguments");
 
-    expect(patches).toEqual([
-      { quantityAvailable: 0 },
-      { quantityAvailable: 1 },
-    ]);
+    expect(ctx.db.patch).not.toHaveBeenCalled();
   });
 });

--- a/packages/athena-webapp/convex/pos/infrastructure/integrations/inventoryHoldGateway.ts
+++ b/packages/athena-webapp/convex/pos/infrastructure/integrations/inventoryHoldGateway.ts
@@ -1,4 +1,3 @@
-import type { Id } from "../../../_generated/dataModel";
 import type { MutationCtx } from "../../../_generated/server";
 import {
   acquireInventoryHold,
@@ -12,136 +11,39 @@ export interface InventoryHoldGatewayResult {
   available?: number;
 }
 
+type AcquireHoldArgs = Parameters<typeof acquireInventoryHold>[1];
+type AdjustHoldArgs = Parameters<typeof adjustInventoryHold>[1];
+type ReleaseHoldArgs = Parameters<typeof releaseInventoryHold>[1];
+
 export interface PosInventoryHoldGateway {
-  acquireHold(
-    ...args:
-      | [
-          {
-            storeId: Id<"store">;
-            sessionId: Id<"posSession">;
-            skuId: Id<"productSku">;
-            quantity: number;
-            expiresAt: number;
-            now?: number;
-          },
-        ]
-      | [skuId: Id<"productSku">, quantity: number]
-  ): Promise<InventoryHoldGatewayResult>;
-  adjustHold(
-    ...args:
-      | [
-          {
-            storeId: Id<"store">;
-            sessionId: Id<"posSession">;
-            skuId: Id<"productSku">;
-            oldQuantity: number;
-            newQuantity: number;
-            expiresAt: number;
-            now?: number;
-          },
-        ]
-      | [
-          skuId: Id<"productSku">,
-          oldQuantity: number,
-          newQuantity: number,
-        ]
-  ): Promise<InventoryHoldGatewayResult>;
-  releaseHold(
-    ...args:
-      | [
-          {
-            sessionId: Id<"posSession">;
-            skuId: Id<"productSku">;
-            quantity: number;
-            now?: number;
-          },
-        ]
-      | [skuId: Id<"productSku">, quantity: number]
-  ): Promise<InventoryHoldGatewayResult>;
+  acquireHold(args: AcquireHoldArgs): Promise<InventoryHoldGatewayResult>;
+  adjustHold(args: AdjustHoldArgs): Promise<InventoryHoldGatewayResult>;
+  releaseHold(args: ReleaseHoldArgs): Promise<InventoryHoldGatewayResult>;
 }
 
 export function createInventoryHoldGateway(
   ctx: MutationCtx,
 ): PosInventoryHoldGateway {
   return {
-    acquireHold(...args) {
-      if (typeof args[0] === "string") {
-        return acquireLegacyQuantityPatchHold(ctx, args[0], args[1]!);
-      }
-
-      return acquireInventoryHold(ctx.db, args[0]);
+    acquireHold(args) {
+      assertObjectShapedHoldArgs(args);
+      return acquireInventoryHold(ctx.db, args);
     },
-    adjustHold(...args) {
-      if (typeof args[0] === "string") {
-        return adjustLegacyQuantityPatchHold(ctx, args[0], args[1]!, args[2]!);
-      }
-
-      return adjustInventoryHold(ctx.db, args[0]);
+    adjustHold(args) {
+      assertObjectShapedHoldArgs(args);
+      return adjustInventoryHold(ctx.db, args);
     },
-    releaseHold(...args) {
-      if (typeof args[0] === "string") {
-        return releaseLegacyQuantityPatchHold(ctx, args[0], args[1]!);
-      }
-
-      return releaseInventoryHold(ctx.db, args[0]);
+    releaseHold(args) {
+      assertObjectShapedHoldArgs(args);
+      return releaseInventoryHold(ctx.db, args);
     },
   };
 }
 
-async function acquireLegacyQuantityPatchHold(
-  ctx: MutationCtx,
-  skuId: Id<"productSku">,
-  quantity: number,
-): Promise<InventoryHoldGatewayResult> {
-  const sku = await ctx.db.get("productSku", skuId);
-  if (!sku || typeof sku.quantityAvailable !== "number") {
-    return { success: false, message: "Product not found" };
+function assertObjectShapedHoldArgs(args: unknown): asserts args is object {
+  if (typeof args !== "object" || args === null) {
+    throw new TypeError(
+      "POS inventory hold gateway requires object-shaped inventory hold arguments",
+    );
   }
-
-  if (sku.quantityAvailable < quantity) {
-    return {
-      success: false,
-      message: `Only ${sku.quantityAvailable} unit${sku.quantityAvailable !== 1 ? "s" : ""} available`,
-      available: sku.quantityAvailable,
-    };
-  }
-
-  await ctx.db.patch("productSku", skuId, {
-    quantityAvailable: sku.quantityAvailable - quantity,
-  });
-  return { success: true };
-}
-
-async function releaseLegacyQuantityPatchHold(
-  ctx: MutationCtx,
-  skuId: Id<"productSku">,
-  quantity: number,
-): Promise<InventoryHoldGatewayResult> {
-  const sku = await ctx.db.get("productSku", skuId);
-  if (!sku || typeof sku.quantityAvailable !== "number") {
-    return { success: true };
-  }
-
-  await ctx.db.patch("productSku", skuId, {
-    quantityAvailable: sku.quantityAvailable + quantity,
-  });
-  return { success: true };
-}
-
-async function adjustLegacyQuantityPatchHold(
-  ctx: MutationCtx,
-  skuId: Id<"productSku">,
-  oldQuantity: number,
-  newQuantity: number,
-): Promise<InventoryHoldGatewayResult> {
-  const quantityChange = newQuantity - oldQuantity;
-  if (quantityChange === 0) {
-    return { success: true };
-  }
-
-  if (quantityChange > 0) {
-    return acquireLegacyQuantityPatchHold(ctx, skuId, quantityChange);
-  }
-
-  return releaseLegacyQuantityPatchHold(ctx, skuId, Math.abs(quantityChange));
 }

--- a/packages/athena-webapp/convex/schemas/pos/posSession.ts
+++ b/packages/athena-webapp/convex/schemas/pos/posSession.ts
@@ -12,9 +12,7 @@ export const posSessionSchema = v.object({
   transactionId: v.optional(v.id("posTransaction")), // Link to transaction created from this session
   workflowTraceId: v.optional(v.string()),
   terminalId: v.id("posTerminal"),
-  inventoryHoldMode: v.optional(
-    v.union(v.literal("legacyQuantityPatch"), v.literal("ledger"))
-  ),
+  inventoryHoldMode: v.optional(v.literal("ledger")),
 
   // Cart contents - now stored in separate posSessionItem table
   // Kept here for backward compatibility queries only


### PR DESCRIPTION
## Summary
- remove the POS legacy quantity-patch fallback from ledger hold release paths
- make POS inventory hold gateway object-shaped and ledger-only, with new sessions marked `inventoryHoldMode: "ledger"`
- keep expense quantity-patch compatibility behind explicit expense helpers/adapters
- add regression coverage for expired POS ledger holds, batch release, expense release compatibility, and gateway tuple rejection
- add the implementation plan, solution notes, and regenerated graphify artifacts

## Validation
- `bun run --filter '@athena/webapp' test -- convex/inventory/helpers/inventoryHolds.test.ts convex/inventory/expenseSessions.test.ts convex/pos/infrastructure/integrations/inventoryHoldGateway.test.ts convex/pos/application/sessionCommands.test.ts convex/pos/application/completeTransaction.test.ts convex/pos/application/expenseSessionCommands.test.ts convex/inventory/posSessions.trace.test.ts`\n- `bun run --filter '@athena/webapp' audit:convex`\n- `bunx tsc --noEmit -p packages/athena-webapp/tsconfig.json`\n- `bun run --filter '@athena/webapp' build`\n- `bun run pre-commit:generated-artifacts`\n- `bun run harness:review`\n- `git push` pre-push suite: graphify check, architecture check, harness review, inferential review\n\nRefs V26-496 V26-497 V26-498 V26-499