### PR TITLE
[V26-495]: Close lint coverage gap for changed POS register view-model files

### DIFF
--- a/docs/solutions/harness/frontend-changed-lint-2026-05-06.md
+++ b/docs/solutions/harness/frontend-changed-lint-2026-05-06.md
@@ -1,0 +1,61 @@
+---
+title: Athena PR Validation Lints Changed Frontend Source Files
+date: 2026-05-06
+category: harness
+module: repo
+problem_type: missing_guardrail
+component: pr-validation
+symptoms:
+  - "Frontend TypeScript files could be changed without running ESLint in the normal PR gate"
+  - "Direct ESLint runs on POS register view-model files found issues that pr:athena did not catch"
+root_cause: missing_validation
+resolution_type: guardrail
+severity: medium
+tags:
+  - eslint
+  - frontend
+  - pr-validation
+  - changed-files
+---
+
+# Athena PR Validation Lints Changed Frontend Source Files
+
+## Problem
+
+Athena had a changed-file lint command for Convex code, but no equivalent gate
+for changed browser-facing source files. A branch could touch
+`packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts`
+and pass the normal PR path while direct ESLint still reported unused variables
+or React hook dependency warnings.
+
+That made frontend lint depend on agents remembering an ad hoc file-level
+command instead of a repo-owned sensor.
+
+## Solution
+
+`@athena/webapp` now has `lint:frontend:changed`, backed by
+`packages/athena-webapp/scripts/frontend-lint-changed.sh`. The command compares
+changed `src`, `shared`, and `types.ts` files against `origin/main`, also
+including local tracked and untracked worktree changes, then runs ESLint only on
+changed `.ts` and `.tsx` frontend files.
+
+The root `pr:athena` command runs `lint:frontend:changed` after the Convex
+changed-file lint. The harness registry also maps changed frontend source files
+to this command, and generated Athena agent docs expose the surface through the
+validation map and guide.
+
+The POS register view-model file is clean under direct ESLint, so the new gate
+can be trusted for the original failure class instead of inheriting known local
+lint debt.
+
+## Prevention
+
+- Keep `bun run --filter '@athena/webapp' lint:frontend:changed` in
+  `pr:athena`.
+- When adding new browser-facing source roots outside `src`, `shared`, or
+  `types.ts`, update `frontend-lint-changed.sh` and the harness registry
+  scenario together.
+- Exclude generated files from changed-file lint at the script boundary rather
+  than hiding real frontend lint failures with broad ESLint ignores.
+- Use a temporary unused symbol in a changed frontend file as a negative proof
+  when changing this gate: the command should fail before the probe is removed.

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -7259,7 +7259,7 @@
       "relation": "calls",
       "source": "harness_review_test_rungit",
       "source_file": "scripts/harness-review.test.ts",
-      "source_location": "L260",
+      "source_location": "L261",
       "target": "harness_review_test_initializegithistory",
       "weight": 1
     },
@@ -44531,7 +44531,7 @@
       "relation": "contains",
       "source": "scripts_harness_app_registry_ts",
       "source_file": "scripts/harness-app-registry.ts",
-      "source_location": "L879",
+      "source_location": "L887",
       "target": "harness_app_registry_getharnesspackageregistration",
       "weight": 1
     },
@@ -47099,7 +47099,7 @@
       "relation": "contains",
       "source": "scripts_harness_review_test_ts",
       "source_file": "scripts/harness-review.test.ts",
-      "source_location": "L1005",
+      "source_location": "L1006",
       "target": "harness_review_test_error",
       "weight": 1
     },
@@ -47111,7 +47111,7 @@
       "relation": "contains",
       "source": "scripts_harness_review_test_ts",
       "source_file": "scripts/harness-review.test.ts",
-      "source_location": "L259",
+      "source_location": "L260",
       "target": "harness_review_test_initializegithistory",
       "weight": 1
     },
@@ -47123,7 +47123,7 @@
       "relation": "contains",
       "source": "scripts_harness_review_test_ts",
       "source_file": "scripts/harness-review.test.ts",
-      "source_location": "L1004",
+      "source_location": "L1005",
       "target": "harness_review_test_log",
       "weight": 1
     },
@@ -47135,7 +47135,7 @@
       "relation": "contains",
       "source": "scripts_harness_review_test_ts",
       "source_file": "scripts/harness-review.test.ts",
-      "source_location": "L245",
+      "source_location": "L246",
       "target": "harness_review_test_rungit",
       "weight": 1
     },
@@ -52067,7 +52067,7 @@
       "relation": "calls",
       "source": "useregisterviewmodel_hascustomerdetails",
       "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
-      "source_location": "L556",
+      "source_location": "L559",
       "target": "useregisterviewmodel_useregisterviewmodel",
       "weight": 1
     },
@@ -59569,7 +59569,7 @@
       "label": "error()",
       "norm_label": "error()",
       "source_file": "scripts/harness-review.test.ts",
-      "source_location": "L290"
+      "source_location": "L291"
     },
     {
       "community": 135,
@@ -59578,7 +59578,7 @@
       "label": "initializeGitHistory()",
       "norm_label": "initializegithistory()",
       "source_file": "scripts/harness-review.test.ts",
-      "source_location": "L259"
+      "source_location": "L260"
     },
     {
       "community": 135,
@@ -59587,7 +59587,7 @@
       "label": "log()",
       "norm_label": "log()",
       "source_file": "scripts/harness-review.test.ts",
-      "source_location": "L289"
+      "source_location": "L290"
     },
     {
       "community": 135,
@@ -59596,7 +59596,7 @@
       "label": "runGit()",
       "norm_label": "rungit()",
       "source_file": "scripts/harness-review.test.ts",
-      "source_location": "L245"
+      "source_location": "L246"
     },
     {
       "community": 135,
@@ -72655,7 +72655,7 @@
       "label": "getHarnessPackageRegistration()",
       "norm_label": "getharnesspackageregistration()",
       "source_file": "scripts/harness-app-registry.ts",
-      "source_location": "L879"
+      "source_location": "L887"
     },
     {
       "community": 310,

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "github:pr-merge": "bun scripts/github-pr-merge.ts",
     "pre-commit:generated-artifacts": "bun scripts/pre-commit-generated-artifacts.ts",
     "pre-push:review": "bun scripts/pre-push-review.ts",
-    "pr:athena": "bun run pre-commit:generated-artifacts && bun run compound:check && bun run --filter '@athena/webapp' audit:convex && bun run --filter '@athena/webapp' lint:convex:changed && bun run architecture:check && bun run test:coverage && bun run harness:test && bun run harness:check && bun run harness:review --base origin/main && bun run harness:inferential-review && bun run harness:audit && bun run harness:scorecard && bun run graphify:check",
+    "pr:athena": "bun run pre-commit:generated-artifacts && bun run compound:check && bun run --filter '@athena/webapp' audit:convex && bun run --filter '@athena/webapp' lint:convex:changed && bun run --filter '@athena/webapp' lint:frontend:changed && bun run architecture:check && bun run test:coverage && bun run harness:test && bun run harness:check && bun run harness:review --base origin/main && bun run harness:inferential-review && bun run harness:audit && bun run harness:scorecard && bun run graphify:check",
     "test": "bun run --filter '@athena/webapp' test && bun run --filter '@athena/storefront-webapp' test",
     "test:coverage:scripts": "bun scripts/root-scripts-coverage.ts",
     "test:coverage": "bun scripts/coverage-toolchain-parity.ts --repair && bun run --filter '@athena/webapp' test:coverage && bun run --filter '@athena/storefront-webapp' test:coverage && bun run test:coverage:scripts && bun scripts/coverage-summary.ts"

--- a/packages/athena-webapp/docs/agent/validation-guide.md
+++ b/packages/athena-webapp/docs/agent/validation-guide.md
@@ -15,6 +15,16 @@ Run:
 
 Use this for authenticated dashboard flows, service-management screens, route trees, and UI behavior changes that stay inside the frontend shell.
 
+## Changed frontend source lint
+
+Touched surfaces: `src`, `shared`, `types.ts`
+
+Run:
+
+- `bun run --filter '@athena/webapp' lint:frontend:changed`
+
+Run this for changed browser-facing TypeScript or TSX files so introduced ESLint failures are caught before PR handoff.
+
 ## Stock-ops procurement and receiving edits
 
 Touched surfaces: `convex/stockOps`, `convex/operations/approvalRequests.ts`, `src/components/operations/OperationsQueueView.tsx`, `src/components/operations/StockAdjustmentWorkspace.tsx`, `src/components/procurement`, `src/components/app-sidebar.tsx`, `src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/operations`, `src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/procurement.index.tsx`
@@ -206,7 +216,7 @@ Run these when bootstrap, generated router state, or package build configuration
 
 ## Storybook and frontend tooling edits
 
-Touched surfaces: `.storybook`, `index.html`, `src/stories`, `src/index.css`, `src/design-system-build-config.test.ts`, `tailwind.config.js`, `postcss.config.js`, `package.json`, `README.md`, `eslint.config.js`, `.gitignore`
+Touched surfaces: `.storybook`, `index.html`, `src/stories`, `src/index.css`, `src/design-system-build-config.test.ts`, `tailwind.config.js`, `postcss.config.js`, `package.json`, `README.md`, `eslint.config.js`, `scripts/frontend-lint-changed.sh`, `.gitignore`
 
 Run:
 

--- a/packages/athena-webapp/docs/agent/validation-map.json
+++ b/packages/athena-webapp/docs/agent/validation-map.json
@@ -27,6 +27,21 @@
       "behaviorScenarios": []
     },
     {
+      "name": "changed-frontend-source-lint",
+      "pathPrefixes": [
+        "packages/athena-webapp/src",
+        "packages/athena-webapp/shared",
+        "packages/athena-webapp/types.ts"
+      ],
+      "commands": [
+        {
+          "kind": "script",
+          "script": "lint:frontend:changed"
+        }
+      ],
+      "behaviorScenarios": []
+    },
+    {
       "name": "stock-ops-procurement-and-receiving-edits",
       "pathPrefixes": [
         "packages/athena-webapp/convex/stockOps",
@@ -450,6 +465,7 @@
         "packages/athena-webapp/package.json",
         "packages/athena-webapp/README.md",
         "packages/athena-webapp/eslint.config.js",
+        "packages/athena-webapp/scripts/frontend-lint-changed.sh",
         "packages/athena-webapp/.gitignore"
       ],
       "commands": [

--- a/packages/athena-webapp/package.json
+++ b/packages/athena-webapp/package.json
@@ -10,6 +10,7 @@
     "typecheck": "tsc --noEmit",
     "lint:architecture": "bun ../../scripts/architecture-boundary-check.ts athena-webapp",
     "lint": "bash ./scripts/convex-lint-changed.sh",
+    "lint:frontend:changed": "bash ./scripts/frontend-lint-changed.sh",
     "lint:convex": "eslint convex && python3 scripts/convexPaginationAntiPatternCheck.py .",
     "lint:convex:changed": "bash ./scripts/convex-lint-changed.sh",
     "audit:convex": "bash ./scripts/convex-audit.sh",

--- a/packages/athena-webapp/scripts/frontend-lint-changed.sh
+++ b/packages/athena-webapp/scripts/frontend-lint-changed.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REPO_ROOT="$(git -C "$ROOT_DIR" rev-parse --show-toplevel)"
+
+resolve_base_ref() {
+  local candidate
+
+  for candidate in \
+    "${FRONTEND_LINT_BASE_REF:-origin/main}" \
+    "origin/main" \
+    "main"
+  do
+    if git -C "$REPO_ROOT" rev-parse --verify "$candidate" >/dev/null 2>&1; then
+      echo "$candidate"
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+if ! BASE_REF="$(resolve_base_ref)"; then
+  echo "Unable to resolve a base ref for frontend changed-file linting." >&2
+  echo "Set FRONTEND_LINT_BASE_REF or fetch origin/main before running this script." >&2
+  exit 1
+fi
+
+MERGE_BASE="$(git -C "$REPO_ROOT" merge-base HEAD "$BASE_REF")"
+
+changed_files=()
+
+collect_changed_frontend_files() {
+  {
+    git -C "$REPO_ROOT" diff --name-only --diff-filter=ACMR "$MERGE_BASE"...HEAD -- \
+      packages/athena-webapp/src \
+      packages/athena-webapp/shared \
+      packages/athena-webapp/types.ts
+    git -C "$REPO_ROOT" diff --name-only --diff-filter=ACMR -- \
+      packages/athena-webapp/src \
+      packages/athena-webapp/shared \
+      packages/athena-webapp/types.ts
+    git -C "$REPO_ROOT" diff --cached --name-only --diff-filter=ACMR -- \
+      packages/athena-webapp/src \
+      packages/athena-webapp/shared \
+      packages/athena-webapp/types.ts
+    git -C "$REPO_ROOT" ls-files --others --exclude-standard -- \
+      packages/athena-webapp/src \
+      packages/athena-webapp/shared \
+      packages/athena-webapp/types.ts
+  } | sort -u
+}
+
+while IFS= read -r file; do
+  case "$file" in
+    packages/athena-webapp/src/routeTree.gen.ts | \
+    packages/athena-webapp/**/*.d.ts)
+      continue
+      ;;
+  esac
+
+  changed_files+=("${file#packages/athena-webapp/}")
+done < <(collect_changed_frontend_files | grep -E '\.(ts|tsx)$' || true)
+
+if [ "${#changed_files[@]}" -eq 0 ]; then
+  echo "No changed frontend files to lint against $BASE_REF."
+  exit 0
+fi
+
+echo "Linting changed frontend files against $BASE_REF"
+printf ' - %s\n' "${changed_files[@]}"
+
+cd "$ROOT_DIR"
+eslint "${changed_files[@]}"

--- a/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts
@@ -476,7 +476,10 @@ export function useRegisterViewModel(): RegisterViewModel {
   const voidSessionRef = useRef<typeof voidSession>(voidSession);
 
   const operableActiveSession = activeSession;
-  const serverCartItems = operableActiveSession?.cartItems ?? [];
+  const serverCartItems = useMemo(
+    () => operableActiveSession?.cartItems ?? [],
+    [operableActiveSession?.cartItems],
+  );
   const activeCartItems = useMemo(() => {
     const cartItems = serverCartItems
       .map((item) => {
@@ -644,16 +647,6 @@ export function useRegisterViewModel(): RegisterViewModel {
     return true;
   }, [activeSessionConflict]);
 
-  const resetDrawerWorkflowState = useCallback(() => {
-    setIsCloseoutRequested(false);
-    setIsOpeningFloatCorrectionRequested(false);
-    setCloseoutCountedCash("");
-    setCloseoutNotes("");
-    setCorrectedOpeningFloat("");
-    setOpeningFloatCorrectionReason("");
-    setDrawerErrorMessage(null);
-  }, []);
-
   const resetDraftState = useCallback(
     (options?: {
       keepCashier?: boolean;
@@ -683,7 +676,7 @@ export function useRegisterViewModel(): RegisterViewModel {
   }, []);
 
   useEffect(() => {
-    if (!registerState?.activeRegisterSession) {
+    if (!activeRegisterSessionId) {
       return;
     }
 
@@ -691,7 +684,7 @@ export function useRegisterViewModel(): RegisterViewModel {
     setDrawerNotes("");
     setDrawerErrorMessage(null);
     setIsOpeningDrawer(false);
-  }, [registerState?.activeRegisterSession?._id]);
+  }, [activeRegisterSessionId]);
 
   useEffect(() => {
     return () => {
@@ -962,7 +955,11 @@ export function useRegisterViewModel(): RegisterViewModel {
         sessionId: operableActiveSession._id as Id<"posSession">,
         staffProfileId,
         checkoutStateVersion: args.checkoutStateVersion,
-        payments: args.nextPayments.map(({ id, ...payment }) => payment),
+        payments: args.nextPayments.map(({ method, amount, timestamp }) => ({
+          method,
+          amount,
+          timestamp,
+        })),
         stage: args.stage,
         paymentMethod: args.paymentMethod,
         amount: args.amount,
@@ -1183,7 +1180,6 @@ export function useRegisterViewModel(): RegisterViewModel {
     activeRegisterSessionId,
     activeStore?._id,
     staffProfileId,
-    customerInfo,
     guardActiveSessionConflict,
     holdCurrentSession,
     registerNumber,
@@ -2076,7 +2072,6 @@ export function useRegisterViewModel(): RegisterViewModel {
     resetDraftState();
   }, [
     operableActiveSession,
-    customerInfo,
     holdCurrentSession,
     resetDraftState,
     voidCurrentSession,
@@ -2152,6 +2147,7 @@ export function useRegisterViewModel(): RegisterViewModel {
     customerInfo,
     persistSessionMetadata,
     registerNumber,
+    staffProfileId,
   ]);
 
   const handleStartNewTransaction = useCallback(() => {

--- a/scripts/harness-app-registry.test.ts
+++ b/scripts/harness-app-registry.test.ts
@@ -168,6 +168,22 @@ describe("HARNESS_APP_REGISTRY", () => {
     });
   });
 
+  it("covers changed Athena frontend source files with changed-file lint", () => {
+    const athena = HARNESS_APP_REGISTRY.find(
+      (entry) => entry.appName === "athena-webapp"
+    );
+    const frontendLintScenario = athena?.validationScenarios.find(
+      (scenario) => scenario.title === "Changed frontend source lint"
+    );
+
+    expect(frontendLintScenario).toMatchObject({
+      touchedPaths: ["src", "shared", "types.ts"],
+      commands: [{ kind: "script", script: "lint:frontend:changed" }],
+      note:
+        "Run this for changed browser-facing TypeScript or TSX files so introduced ESLint failures are caught before PR handoff.",
+    });
+  });
+
   it("runs the Athena browser-boundary regression for route runtime changes", () => {
     const athena = HARNESS_APP_REGISTRY.find(
       (entry) => entry.appName === "athena-webapp"
@@ -692,6 +708,7 @@ describe("HARNESS_APP_REGISTRY", () => {
         "package.json",
         "README.md",
         "eslint.config.js",
+        "scripts/frontend-lint-changed.sh",
         ".gitignore",
       ],
       commands: [

--- a/scripts/harness-app-registry.ts
+++ b/scripts/harness-app-registry.ts
@@ -284,6 +284,13 @@ export const HARNESS_APP_REGISTRY = [
           "Use this for authenticated dashboard flows, service-management screens, route trees, and UI behavior changes that stay inside the frontend shell.",
       },
       {
+        title: "Changed frontend source lint",
+        touchedPaths: ["src", "shared", "types.ts"],
+        commands: [{ kind: "script", script: "lint:frontend:changed" }],
+        note:
+          "Run this for changed browser-facing TypeScript or TSX files so introduced ESLint failures are caught before PR handoff.",
+      },
+      {
         title: "Stock-ops procurement and receiving edits",
         touchedPaths: [
           "convex/stockOps",
@@ -646,6 +653,7 @@ export const HARNESS_APP_REGISTRY = [
           "package.json",
           "README.md",
           "eslint.config.js",
+          "scripts/frontend-lint-changed.sh",
           ".gitignore",
         ],
         commands: [

--- a/scripts/harness-audit.test.ts
+++ b/scripts/harness-audit.test.ts
@@ -88,6 +88,7 @@ async function createFixtureRepo() {
           "storybook:build": "echo storybook",
           "lint:architecture": "echo architecture",
           "lint:convex:changed": "echo lint",
+          "lint:frontend:changed": "echo lint frontend",
           test: "echo test",
         },
       },
@@ -1030,6 +1031,11 @@ async function createFixtureRepo() {
   );
   await write(
     "packages/athena-webapp/scripts/convex-lint-changed.sh",
+    "#!/usr/bin/env bash\nexit 0\n",
+    rootDir
+  );
+  await write(
+    "packages/athena-webapp/scripts/frontend-lint-changed.sh",
     "#!/usr/bin/env bash\nexit 0\n",
     rootDir
   );

--- a/scripts/harness-check.test.ts
+++ b/scripts/harness-check.test.ts
@@ -119,6 +119,7 @@ async function createFixtureRepo() {
             test: "vitest run",
             "audit:convex": "bash ./scripts/convex-audit.sh",
             "lint:convex:changed": "bash ./scripts/convex-lint-changed.sh",
+            "lint:frontend:changed": "bash ./scripts/frontend-lint-changed.sh",
             "lint:architecture": "bun ../../scripts/architecture-boundary-check.ts athena-webapp",
             build: "vite build && tsc --noEmit",
             "storybook:build": "storybook build",

--- a/scripts/harness-generate.test.ts
+++ b/scripts/harness-generate.test.ts
@@ -26,6 +26,7 @@ async function createFixtureRepo() {
           test: "vitest run",
           "audit:convex": "bash ./scripts/convex-audit.sh",
           "lint:convex:changed": "bash ./scripts/convex-lint-changed.sh",
+          "lint:frontend:changed": "bash ./scripts/frontend-lint-changed.sh",
           build: "vite build && tsc --noEmit",
           "storybook:build": "storybook build",
           "lint:architecture": "bun ../../scripts/architecture-boundary-check.ts athena-webapp",

--- a/scripts/harness-review.test.ts
+++ b/scripts/harness-review.test.ts
@@ -32,6 +32,7 @@ async function createFixtureRepo() {
         scripts: {
           "audit:convex": "echo audit",
           "lint:convex:changed": "echo lint",
+          "lint:frontend:changed": "echo lint frontend",
           "storybook:build": "echo storybook",
           test: "echo test",
         },

--- a/scripts/pre-push-review.test.ts
+++ b/scripts/pre-push-review.test.ts
@@ -774,6 +774,9 @@ describe("repo harness ergonomics", () => {
     expect(packageJson.scripts?.["pr:athena"]).toContain(
       "bun run harness:review --base origin/main"
     );
+    expect(packageJson.scripts?.["pr:athena"]).toContain(
+      "bun run --filter '@athena/webapp' lint:frontend:changed"
+    );
     expect(packageJson.scripts?.["pr:athena"]).toContain("bun run harness:audit");
     expect(packageJson.scripts?.["pr:athena"]).toContain(
       "bun run harness:inferential-review"


### PR DESCRIPTION
## Summary
- Add `@athena/webapp` changed frontend source linting and wire it into `pr:athena`.
- Map changed frontend source files into the Athena harness validation docs and registry.
- Clean direct ESLint issues in the POS register view-model so the new gate starts from a clean target.

## Why
The existing PR path only linted changed Convex files. That let browser-facing TypeScript changes, including the POS register view-model, pass normal validation while direct ESLint still reported introduced issues.

## Validation
- Characterized the gap by proving `lint:convex:changed` ignored a temporary frontend lint failure.
- Confirmed `lint:frontend:changed` fails on a temporary unused-symbol probe, then passes after removal.
- `bun run --filter '@athena/webapp' lint:frontend:changed`
- `bun test scripts/harness-app-registry.test.ts scripts/pre-push-review.test.ts scripts/harness-generate.test.ts scripts/harness-check.test.ts scripts/harness-audit.test.ts scripts/harness-review.test.ts`
- `bun run graphify:rebuild`
- `bun run pre-commit:generated-artifacts`
- `bun run pr:athena`
- `git push` pre-push validation suite

Linear: https://linear.app/athenian/issue/V26-495/close-lint-coverage-gap-for-changed-pos-register-view-model-files
