### PR TITLE
fix(analytics): resolve mixed storefront actor ids

### DIFF
--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 4666 nodes · 4501 edges · 1556 communities detected
+- 4667 nodes · 4502 edges · 1556 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -1967,39 +1967,39 @@ Nodes (6): findAthenaUserByEmailWithCtx(), getAuthenticatedAthenaUserWithCtx(), 
 
 ### Community 93 - "Community 93"
 Cohesion: 0.43
-Nodes (6): buildMtnCollectionsLookupPrefixes(), isTargetEnvironment(), readScopedValue(), resolveConfigForPrefix(), resolveMtnCollectionsConfigFromEnv(), toEnvSegment()
+Nodes (6): sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
 
 ### Community 94 - "Community 94"
+Cohesion: 0.43
+Nodes (6): buildMtnCollectionsLookupPrefixes(), isTargetEnvironment(), readScopedValue(), resolveConfigForPrefix(), resolveMtnCollectionsConfigFromEnv(), toEnvSegment()
+
+### Community 95 - "Community 95"
 Cohesion: 0.46
 Nodes (7): recordApprovalAuditEventWithCtx(), recordApprovalDecisionRecordedAuditEventWithCtx(), recordApprovalProofConsumedAuditEventWithCtx(), recordApprovalRequiredAuditEventWithCtx(), recordApprovedCommandAppliedAuditEventWithCtx(), recordAsyncApprovalRequestCreatedAuditEventWithCtx(), recordManagerApprovalGrantedAuditEventWithCtx()
 
-### Community 95 - "Community 95"
+### Community 96 - "Community 96"
 Cohesion: 0.5
 Nodes (7): buildApprovalDecisionRequirement(), buildApprovalDecisionSubject(), consumeApprovalDecisionProofWithCtx(), decideApprovalRequestAsAuthenticatedUserWithCtx(), decideApprovalRequestAsCommandWithCtx(), decideApprovalRequestWithCtx(), mapDecideApprovalRequestError()
 
-### Community 96 - "Community 96"
+### Community 97 - "Community 97"
 Cohesion: 0.36
 Nodes (5): buildPaymentAllocation(), correctSameAmountSinglePaymentAllocationWithCtx(), findSameAmountSinglePaymentAllocation(), listPaymentAllocationsForTargetWithCtx(), recordPaymentAllocationWithCtx()
 
-### Community 97 - "Community 97"
+### Community 98 - "Community 98"
 Cohesion: 0.43
 Nodes (6): buildPosSessionTraceEvent(), buildPosSessionTraceRecord(), buildTraceSummary(), formatPaymentMethod(), recordPosSessionTraceBestEffort(), safeTraceWrite()
 
-### Community 98 - "Community 98"
+### Community 99 - "Community 99"
 Cohesion: 0.5
 Nodes (7): findExistingSku(), findOrCreateQuickAddCategory(), findOrCreateQuickAddSubcategory(), generateSKU(), isBarcodeLike(), mapSkuToCatalogResult(), quickAddCatalogItem()
-
-### Community 99 - "Community 99"
-Cohesion: 0.25
-Nodes (0):
 
 ### Community 100 - "Community 100"
 Cohesion: 0.25
 Nodes (0):
 
 ### Community 101 - "Community 101"
-Cohesion: 0.43
-Nodes (6): sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
+Cohesion: 0.25
+Nodes (0):
 
 ### Community 102 - "Community 102"
 Cohesion: 0.25
@@ -2078,52 +2078,52 @@ Cohesion: 0.48
 Nodes (5): getActiveSessionForRegisterState(), listHeldSessionsForRegisterState(), querySessionsByStatus(), selectRegisterStateLookupStrategy(), summarizeRegisterStateSessions()
 
 ### Community 121 - "Community 121"
+Cohesion: 0.29
+Nodes (0):
+
+### Community 122 - "Community 122"
 Cohesion: 0.33
 Nodes (2): getCustomerOperationalTimelineEvents(), resolveCustomerProfileIdForTimeline()
 
-### Community 122 - "Community 122"
+### Community 123 - "Community 123"
 Cohesion: 0.38
 Nodes (3): clearBagItems(), createOrderFromCheckoutSession(), generateOrderNumber()
 
-### Community 123 - "Community 123"
+### Community 124 - "Community 124"
 Cohesion: 0.57
 Nodes (5): getDeliveryAddress(), getLocationDetails(), getPickupLocation(), handleOrderStatusUpdate(), processOrderUpdateEmail()
 
-### Community 124 - "Community 124"
+### Community 125 - "Community 125"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 125 - "Community 125"
+### Community 126 - "Community 126"
 Cohesion: 0.33
 Nodes (2): appendTransition(), applyOnlineOrderUpdate()
 
-### Community 126 - "Community 126"
+### Community 127 - "Community 127"
 Cohesion: 0.38
 Nodes (3): createWorkflowTraceWithCtx(), getWorkflowTraceByIdWithCtx(), getWorkflowTraceByLookupWithCtx()
 
-### Community 127 - "Community 127"
+### Community 128 - "Community 128"
 Cohesion: 0.38
 Nodes (4): calculateCycleCountQuantityDelta(), hasHighStockAdjustmentVariance(), requiresStockAdjustmentApproval(), resolveStockAdjustmentQuantityDelta()
 
-### Community 128 - "Community 128"
+### Community 129 - "Community 129"
 Cohesion: 0.33
 Nodes (2): handleKeypadPress(), setAmountFromTouch()
 
-### Community 129 - "Community 129"
+### Community 130 - "Community 130"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 130 - "Community 130"
+### Community 131 - "Community 131"
 Cohesion: 0.48
 Nodes (4): applyCommandResult(), async(), handleSubmit(), parseDateTimeLocal()
 
-### Community 131 - "Community 131"
+### Community 132 - "Community 132"
 Cohesion: 0.52
 Nodes (6): deriveRegisterPhase(), hasActiveRegisterSession(), hasResumableRegisterSession(), isRegisterReadyToStart(), requiresCashier(), requiresTerminal()
-
-### Community 132 - "Community 132"
-Cohesion: 0.29
-Nodes (0):
 
 ### Community 133 - "Community 133"
 Cohesion: 0.29
@@ -2134,52 +2134,52 @@ Cohesion: 0.29
 Nodes (0):
 
 ### Community 135 - "Community 135"
+Cohesion: 0.29
+Nodes (0):
+
+### Community 136 - "Community 136"
 Cohesion: 0.52
 Nodes (6): addItemToSavedBag(), getActiveSavedBag(), getBaseUrl(), removeItemFromSavedBag(), updateSavedBagItem(), updateSavedBagOwner()
 
-### Community 136 - "Community 136"
+### Community 137 - "Community 137"
 Cohesion: 0.33
 Nodes (2): getProductName(), sortProduct()
 
-### Community 137 - "Community 137"
+### Community 138 - "Community 138"
 Cohesion: 0.43
 Nodes (4): createFixtureRepo(), gitEnv(), runGit(), write()
 
-### Community 138 - "Community 138"
+### Community 139 - "Community 139"
 Cohesion: 0.52
 Nodes (5): emitSignal(), handleCheckoutSessionFetch(), handleCheckoutSessionUpdate(), jsonResponse(), withCorsHeaders()
 
-### Community 139 - "Community 139"
+### Community 140 - "Community 140"
 Cohesion: 0.33
 Nodes (2): overwriteFreshGraphifyArtifacts(), write()
 
-### Community 140 - "Community 140"
+### Community 141 - "Community 141"
 Cohesion: 0.38
 Nodes (4): createFixtureRepo(), initializeGitHistory(), runGit(), write()
 
-### Community 141 - "Community 141"
+### Community 142 - "Community 142"
 Cohesion: 0.33
 Nodes (1): ValkeyClient
 
-### Community 142 - "Community 142"
+### Community 143 - "Community 143"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 143 - "Community 143"
+### Community 144 - "Community 144"
 Cohesion: 0.53
 Nodes (4): listRegisterCatalog(), mapSkuToRegisterCatalogRow(), readCategoryName(), readColorName()
 
-### Community 144 - "Community 144"
+### Community 145 - "Community 145"
 Cohesion: 0.73
 Nodes (5): buildOrderStatusMessage(), buildPickupDetails(), sendPaymentVerificationEmails(), sendPODOrderEmails(), shouldSendToAdmins()
 
-### Community 145 - "Community 145"
+### Community 146 - "Community 146"
 Cohesion: 0.6
 Nodes (5): createVendorCommandWithCtx(), createVendorWithCtx(), mapCreateVendorError(), normalizeVendorLookupKey(), trimOptional()
-
-### Community 146 - "Community 146"
-Cohesion: 0.33
-Nodes (0):
 
 ### Community 147 - "Community 147"
 Cohesion: 0.6
@@ -2198,12 +2198,12 @@ Cohesion: 0.33
 Nodes (1): DataTableToolbar()
 
 ### Community 151 - "Community 151"
-Cohesion: 0.4
-Nodes (2): handlePinChange(), normalizeOtpCode()
-
-### Community 152 - "Community 152"
 Cohesion: 0.53
 Nodes (2): SelectedProductsProvider(), useSelectedProducts()
+
+### Community 152 - "Community 152"
+Cohesion: 0.4
+Nodes (2): handlePinChange(), normalizeOtpCode()
 
 ### Community 153 - "Community 153"
 Cohesion: 0.33
@@ -2226,16 +2226,16 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 158 - "Community 158"
-Cohesion: 0.47
-Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
-
-### Community 159 - "Community 159"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 160 - "Community 160"
+### Community 159 - "Community 159"
 Cohesion: 0.4
 Nodes (2): useBulkOperations(), validateOperationValue()
+
+### Community 160 - "Community 160"
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 161 - "Community 161"
 Cohesion: 0.33
@@ -2250,12 +2250,12 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 164 - "Community 164"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 165 - "Community 165"
 Cohesion: 0.53
 Nodes (4): calculatePosChange(), calculatePosRemainingDue(), calculatePosTotalPaid(), roundPosAmount()
+
+### Community 165 - "Community 165"
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 166 - "Community 166"
 Cohesion: 0.33
@@ -2266,40 +2266,40 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 168 - "Community 168"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 169 - "Community 169"
 Cohesion: 0.4
 Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 170 - "Community 170"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
-
-### Community 171 - "Community 171"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 172 - "Community 172"
+### Community 171 - "Community 171"
 Cohesion: 0.47
 Nodes (4): fetchPosTransaction(), getBaseUrl(), getPosTransactionByReceiptToken(), PosTransactionReceiptError
 
-### Community 173 - "Community 173"
+### Community 172 - "Community 172"
 Cohesion: 0.47
 Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
 
-### Community 174 - "Community 174"
+### Community 173 - "Community 173"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 175 - "Community 175"
+### Community 174 - "Community 174"
 Cohesion: 0.4
 Nodes (2): handleConfirm(), handlePrimaryAction()
 
-### Community 176 - "Community 176"
+### Community 175 - "Community 175"
 Cohesion: 0.33
 Nodes (0):
+
+### Community 176 - "Community 176"
+Cohesion: 0.47
+Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
 
 ### Community 177 - "Community 177"
 Cohesion: 0.53

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -19739,7 +19739,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_storefront_analytics_ts",
       "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
-      "source_location": "L25",
+      "source_location": "L48",
       "target": "analytics_extractpromocodeid",
       "weight": 1
     },
@@ -19751,7 +19751,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_storefront_analytics_ts",
       "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
-      "source_location": "L130",
+      "source_location": "L153",
       "target": "analytics_getanalyticsbystoreandactionquery",
       "weight": 1
     },
@@ -19763,7 +19763,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_storefront_analytics_ts",
       "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
-      "source_location": "L35",
+      "source_location": "L58",
       "target": "analytics_getanalyticsbystorequery",
       "weight": 1
     },
@@ -19775,7 +19775,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_storefront_analytics_ts",
       "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
-      "source_location": "L83",
+      "source_location": "L106",
       "target": "analytics_getcompletedordersquery",
       "weight": 1
     },
@@ -19787,8 +19787,20 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_storefront_analytics_ts",
       "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
-      "source_location": "L188",
+      "source_location": "L211",
       "target": "analytics_getskumapforproducts",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_convex_storefront_analytics_ts",
+      "_tgt": "analytics_getstorefrontactor",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_convex_storefront_analytics_ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
+      "source_location": "L29",
+      "target": "analytics_getstorefrontactor",
       "weight": 1
     },
     {
@@ -55083,74 +55095,74 @@
     {
       "community": 100,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_sessioncommands_test_ts",
-      "label": "sessionCommands.test.ts",
-      "norm_label": "sessioncommands.test.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 100,
-      "file_type": "code",
-      "id": "sessioncommands_test_builditem",
+      "id": "expensesessioncommands_test_builditem",
       "label": "buildItem()",
       "norm_label": "builditem()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L2406"
+      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
+      "source_location": "L645"
     },
     {
       "community": 100,
       "file_type": "code",
-      "id": "sessioncommands_test_buildregistersession",
+      "id": "expensesessioncommands_test_buildregistersession",
       "label": "buildRegisterSession()",
       "norm_label": "buildregistersession()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L2400"
+      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
+      "source_location": "L639"
     },
     {
       "community": 100,
       "file_type": "code",
-      "id": "sessioncommands_test_buildsession",
+      "id": "expensesessioncommands_test_buildsession",
       "label": "buildSession()",
       "norm_label": "buildsession()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L2396"
+      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
+      "source_location": "L635"
     },
     {
       "community": 100,
       "file_type": "code",
-      "id": "sessioncommands_test_createcommandservice",
+      "id": "expensesessioncommands_test_createcommandservice",
       "label": "createCommandService()",
       "norm_label": "createcommandservice()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L2416"
+      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
+      "source_location": "L655"
     },
     {
       "community": 100,
       "file_type": "code",
-      "id": "sessioncommands_test_createdependencies",
+      "id": "expensesessioncommands_test_createdependencies",
       "label": "createDependencies()",
       "norm_label": "createdependencies()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L2155"
+      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
+      "source_location": "L424"
     },
     {
       "community": 100,
       "file_type": "code",
-      "id": "sessioncommands_test_createfakerepository",
+      "id": "expensesessioncommands_test_createfakerepository",
       "label": "createFakeRepository()",
       "norm_label": "createfakerepository()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L2252"
+      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
+      "source_location": "L492"
     },
     {
       "community": 100,
       "file_type": "code",
-      "id": "sessioncommands_test_loadcommandservice",
+      "id": "expensesessioncommands_test_loadcommandservice",
       "label": "loadCommandService()",
       "norm_label": "loadcommandservice()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L2137"
+      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
+      "source_location": "L404"
+    },
+    {
+      "community": 100,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_expensesessioncommands_test_ts",
+      "label": "expenseSessionCommands.test.ts",
+      "norm_label": "expensesessioncommands.test.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
+      "source_location": "L1"
     },
     {
       "community": 1000,
@@ -55245,74 +55257,74 @@
     {
       "community": 101,
       "file_type": "code",
-      "id": "index_senddiscountcodeemail",
-      "label": "sendDiscountCodeEmail()",
-      "norm_label": "senddiscountcodeemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L255"
-    },
-    {
-      "community": 101,
-      "file_type": "code",
-      "id": "index_senddiscountreminderemail",
-      "label": "sendDiscountReminderEmail()",
-      "norm_label": "senddiscountreminderemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L334"
-    },
-    {
-      "community": 101,
-      "file_type": "code",
-      "id": "index_sendfeedbackrequestemail",
-      "label": "sendFeedbackRequestEmail()",
-      "norm_label": "sendfeedbackrequestemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L167"
-    },
-    {
-      "community": 101,
-      "file_type": "code",
-      "id": "index_sendneworderemail",
-      "label": "sendNewOrderEmail()",
-      "norm_label": "sendneworderemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L117"
-    },
-    {
-      "community": 101,
-      "file_type": "code",
-      "id": "index_sendorderemail",
-      "label": "sendOrderEmail()",
-      "norm_label": "sendorderemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L43"
-    },
-    {
-      "community": 101,
-      "file_type": "code",
-      "id": "index_sendverificationcode",
-      "label": "sendVerificationCode()",
-      "norm_label": "sendverificationcode()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L3"
-    },
-    {
-      "community": 101,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_mailersend_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/convex/mailersend/index.tsx",
+      "id": "packages_athena_webapp_convex_pos_application_sessioncommands_test_ts",
+      "label": "sessionCommands.test.ts",
+      "norm_label": "sessioncommands.test.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
       "source_location": "L1"
     },
     {
       "community": 101,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_sendgrid_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L1"
+      "id": "sessioncommands_test_builditem",
+      "label": "buildItem()",
+      "norm_label": "builditem()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L2406"
+    },
+    {
+      "community": 101,
+      "file_type": "code",
+      "id": "sessioncommands_test_buildregistersession",
+      "label": "buildRegisterSession()",
+      "norm_label": "buildregistersession()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L2400"
+    },
+    {
+      "community": 101,
+      "file_type": "code",
+      "id": "sessioncommands_test_buildsession",
+      "label": "buildSession()",
+      "norm_label": "buildsession()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L2396"
+    },
+    {
+      "community": 101,
+      "file_type": "code",
+      "id": "sessioncommands_test_createcommandservice",
+      "label": "createCommandService()",
+      "norm_label": "createcommandservice()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L2416"
+    },
+    {
+      "community": 101,
+      "file_type": "code",
+      "id": "sessioncommands_test_createdependencies",
+      "label": "createDependencies()",
+      "norm_label": "createdependencies()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L2155"
+    },
+    {
+      "community": 101,
+      "file_type": "code",
+      "id": "sessioncommands_test_createfakerepository",
+      "label": "createFakeRepository()",
+      "norm_label": "createfakerepository()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L2252"
+    },
+    {
+      "community": 101,
+      "file_type": "code",
+      "id": "sessioncommands_test_loadcommandservice",
+      "label": "loadCommandService()",
+      "norm_label": "loadcommandservice()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L2137"
     },
     {
       "community": 1010,
@@ -58854,64 +58866,64 @@
     {
       "community": 121,
       "file_type": "code",
-      "id": "customerbehaviortimeline_getcustomeranalyticsquery",
-      "label": "getCustomerAnalyticsQuery()",
-      "norm_label": "getcustomeranalyticsquery()",
-      "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
-      "source_location": "L27"
+      "id": "analytics_extractpromocodeid",
+      "label": "extractPromoCodeId()",
+      "norm_label": "extractpromocodeid()",
+      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
+      "source_location": "L48"
     },
     {
       "community": 121,
       "file_type": "code",
-      "id": "customerbehaviortimeline_getcustomeroperationaltimelineevents",
-      "label": "getCustomerOperationalTimelineEvents()",
-      "norm_label": "getcustomeroperationaltimelineevents()",
-      "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
+      "id": "analytics_getanalyticsbystoreandactionquery",
+      "label": "getAnalyticsByStoreAndActionQuery()",
+      "norm_label": "getanalyticsbystoreandactionquery()",
+      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
       "source_location": "L153"
     },
     {
       "community": 121,
       "file_type": "code",
-      "id": "customerbehaviortimeline_getproductinfomaps",
-      "label": "getProductInfoMaps()",
-      "norm_label": "getproductinfomaps()",
-      "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
-      "source_location": "L71"
+      "id": "analytics_getanalyticsbystorequery",
+      "label": "getAnalyticsByStoreQuery()",
+      "norm_label": "getanalyticsbystorequery()",
+      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
+      "source_location": "L58"
     },
     {
       "community": 121,
       "file_type": "code",
-      "id": "customerbehaviortimeline_gettimefilterforrange",
-      "label": "getTimeFilterForRange()",
-      "norm_label": "gettimefilterforrange()",
-      "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
-      "source_location": "L12"
+      "id": "analytics_getcompletedordersquery",
+      "label": "getCompletedOrdersQuery()",
+      "norm_label": "getcompletedordersquery()",
+      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
+      "source_location": "L106"
     },
     {
       "community": 121,
       "file_type": "code",
-      "id": "customerbehaviortimeline_gettimelineuserdata",
-      "label": "getTimelineUserData()",
-      "norm_label": "gettimelineuserdata()",
-      "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
-      "source_location": "L47"
+      "id": "analytics_getskumapforproducts",
+      "label": "getSkuMapForProducts()",
+      "norm_label": "getskumapforproducts()",
+      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
+      "source_location": "L211"
     },
     {
       "community": 121,
       "file_type": "code",
-      "id": "customerbehaviortimeline_resolvecustomerprofileidfortimeline",
-      "label": "resolveCustomerProfileIdForTimeline()",
-      "norm_label": "resolvecustomerprofileidfortimeline()",
-      "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
-      "source_location": "L115"
+      "id": "analytics_getstorefrontactor",
+      "label": "getStoreFrontActor()",
+      "norm_label": "getstorefrontactor()",
+      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
+      "source_location": "L29"
     },
     {
       "community": 121,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_customerbehaviortimeline_ts",
-      "label": "customerBehaviorTimeline.ts",
-      "norm_label": "customerbehaviortimeline.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
+      "id": "packages_athena_webapp_convex_storefront_analytics_ts",
+      "label": "analytics.ts",
+      "norm_label": "analytics.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
       "source_location": "L1"
     },
     {
@@ -59007,64 +59019,64 @@
     {
       "community": 122,
       "file_type": "code",
-      "id": "onlineorder_clearbagitems",
-      "label": "clearBagItems()",
-      "norm_label": "clearbagitems()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
-      "source_location": "L45"
+      "id": "customerbehaviortimeline_getcustomeranalyticsquery",
+      "label": "getCustomerAnalyticsQuery()",
+      "norm_label": "getcustomeranalyticsquery()",
+      "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
+      "source_location": "L27"
     },
     {
       "community": 122,
       "file_type": "code",
-      "id": "onlineorder_createorderfromcheckoutsession",
-      "label": "createOrderFromCheckoutSession()",
-      "norm_label": "createorderfromcheckoutsession()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
-      "source_location": "L104"
+      "id": "customerbehaviortimeline_getcustomeroperationaltimelineevents",
+      "label": "getCustomerOperationalTimelineEvents()",
+      "norm_label": "getcustomeroperationaltimelineevents()",
+      "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
+      "source_location": "L153"
     },
     {
       "community": 122,
       "file_type": "code",
-      "id": "onlineorder_findorderbyexternalreference",
-      "label": "findOrderByExternalReference()",
-      "norm_label": "findorderbyexternalreference()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
-      "source_location": "L21"
+      "id": "customerbehaviortimeline_getproductinfomaps",
+      "label": "getProductInfoMaps()",
+      "norm_label": "getproductinfomaps()",
+      "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
+      "source_location": "L71"
     },
     {
       "community": 122,
       "file_type": "code",
-      "id": "onlineorder_findorderbyexternaltransactionid",
-      "label": "findOrderByExternalTransactionId()",
-      "norm_label": "findorderbyexternaltransactionid()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
-      "source_location": "L33"
+      "id": "customerbehaviortimeline_gettimefilterforrange",
+      "label": "getTimeFilterForRange()",
+      "norm_label": "gettimefilterforrange()",
+      "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
+      "source_location": "L12"
     },
     {
       "community": 122,
       "file_type": "code",
-      "id": "onlineorder_generateordernumber",
-      "label": "generateOrderNumber()",
-      "norm_label": "generateordernumber()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
-      "source_location": "L14"
+      "id": "customerbehaviortimeline_gettimelineuserdata",
+      "label": "getTimelineUserData()",
+      "norm_label": "gettimelineuserdata()",
+      "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
+      "source_location": "L47"
     },
     {
       "community": 122,
       "file_type": "code",
-      "id": "onlineorder_returnorderitemstostock",
-      "label": "returnOrderItemsToStock()",
-      "norm_label": "returnorderitemstostock()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
-      "source_location": "L57"
+      "id": "customerbehaviortimeline_resolvecustomerprofileidfortimeline",
+      "label": "resolveCustomerProfileIdForTimeline()",
+      "norm_label": "resolvecustomerprofileidfortimeline()",
+      "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
+      "source_location": "L115"
     },
     {
       "community": 122,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_helpers_onlineorder_ts",
-      "label": "onlineOrder.ts",
-      "norm_label": "onlineorder.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
+      "id": "packages_athena_webapp_convex_storefront_customerbehaviortimeline_ts",
+      "label": "customerBehaviorTimeline.ts",
+      "norm_label": "customerbehaviortimeline.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
       "source_location": "L1"
     },
     {
@@ -59160,64 +59172,64 @@
     {
       "community": 123,
       "file_type": "code",
-      "id": "orderupdateemails_formatorderitems",
-      "label": "formatOrderItems()",
-      "norm_label": "formatorderitems()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
-      "source_location": "L64"
+      "id": "onlineorder_clearbagitems",
+      "label": "clearBagItems()",
+      "norm_label": "clearbagitems()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
+      "source_location": "L45"
     },
     {
       "community": 123,
       "file_type": "code",
-      "id": "orderupdateemails_getdeliveryaddress",
-      "label": "getDeliveryAddress()",
-      "norm_label": "getdeliveryaddress()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
-      "source_location": "L55"
+      "id": "onlineorder_createorderfromcheckoutsession",
+      "label": "createOrderFromCheckoutSession()",
+      "norm_label": "createorderfromcheckoutsession()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
+      "source_location": "L104"
     },
     {
       "community": 123,
       "file_type": "code",
-      "id": "orderupdateemails_getlocationdetails",
-      "label": "getLocationDetails()",
-      "norm_label": "getlocationdetails()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
-      "source_location": "L58"
+      "id": "onlineorder_findorderbyexternalreference",
+      "label": "findOrderByExternalReference()",
+      "norm_label": "findorderbyexternalreference()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
+      "source_location": "L21"
     },
     {
       "community": 123,
       "file_type": "code",
-      "id": "orderupdateemails_getpickuplocation",
-      "label": "getPickupLocation()",
-      "norm_label": "getpickuplocation()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
-      "source_location": "L52"
+      "id": "onlineorder_findorderbyexternaltransactionid",
+      "label": "findOrderByExternalTransactionId()",
+      "norm_label": "findorderbyexternaltransactionid()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
+      "source_location": "L33"
     },
     {
       "community": 123,
       "file_type": "code",
-      "id": "orderupdateemails_handleorderstatusupdate",
-      "label": "handleOrderStatusUpdate()",
-      "norm_label": "handleorderstatusupdate()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
-      "source_location": "L118"
+      "id": "onlineorder_generateordernumber",
+      "label": "generateOrderNumber()",
+      "norm_label": "generateordernumber()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
+      "source_location": "L14"
     },
     {
       "community": 123,
       "file_type": "code",
-      "id": "orderupdateemails_processorderupdateemail",
-      "label": "processOrderUpdateEmail()",
-      "norm_label": "processorderupdateemail()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
-      "source_location": "L293"
+      "id": "onlineorder_returnorderitemstostock",
+      "label": "returnOrderItemsToStock()",
+      "norm_label": "returnorderitemstostock()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
+      "source_location": "L57"
     },
     {
       "community": 123,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_helpers_orderupdateemails_ts",
-      "label": "orderUpdateEmails.ts",
-      "norm_label": "orderupdateemails.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
+      "id": "packages_athena_webapp_convex_storefront_helpers_onlineorder_ts",
+      "label": "onlineOrder.ts",
+      "norm_label": "onlineorder.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
       "source_location": "L1"
     },
     {
@@ -59313,65 +59325,65 @@
     {
       "community": 124,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_helpers_paymenthelpers_ts",
-      "label": "paymentHelpers.ts",
-      "norm_label": "paymenthelpers.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
+      "id": "orderupdateemails_formatorderitems",
+      "label": "formatOrderItems()",
+      "norm_label": "formatorderitems()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
+      "source_location": "L64"
+    },
+    {
+      "community": 124,
+      "file_type": "code",
+      "id": "orderupdateemails_getdeliveryaddress",
+      "label": "getDeliveryAddress()",
+      "norm_label": "getdeliveryaddress()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
+      "source_location": "L55"
+    },
+    {
+      "community": 124,
+      "file_type": "code",
+      "id": "orderupdateemails_getlocationdetails",
+      "label": "getLocationDetails()",
+      "norm_label": "getlocationdetails()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
+      "source_location": "L58"
+    },
+    {
+      "community": 124,
+      "file_type": "code",
+      "id": "orderupdateemails_getpickuplocation",
+      "label": "getPickupLocation()",
+      "norm_label": "getpickuplocation()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
+      "source_location": "L52"
+    },
+    {
+      "community": 124,
+      "file_type": "code",
+      "id": "orderupdateemails_handleorderstatusupdate",
+      "label": "handleOrderStatusUpdate()",
+      "norm_label": "handleorderstatusupdate()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
+      "source_location": "L118"
+    },
+    {
+      "community": 124,
+      "file_type": "code",
+      "id": "orderupdateemails_processorderupdateemail",
+      "label": "processOrderUpdateEmail()",
+      "norm_label": "processorderupdateemail()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
+      "source_location": "L293"
+    },
+    {
+      "community": 124,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_helpers_orderupdateemails_ts",
+      "label": "orderUpdateEmails.ts",
+      "norm_label": "orderupdateemails.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 124,
-      "file_type": "code",
-      "id": "paymenthelpers_calculateorderamount",
-      "label": "calculateOrderAmount()",
-      "norm_label": "calculateorderamount()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
-      "source_location": "L35"
-    },
-    {
-      "community": 124,
-      "file_type": "code",
-      "id": "paymenthelpers_calculaterewardpoints",
-      "label": "calculateRewardPoints()",
-      "norm_label": "calculaterewardpoints()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
-      "source_location": "L53"
-    },
-    {
-      "community": 124,
-      "file_type": "code",
-      "id": "paymenthelpers_extractorderitems",
-      "label": "extractOrderItems()",
-      "norm_label": "extractorderitems()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
-      "source_location": "L18"
-    },
-    {
-      "community": 124,
-      "file_type": "code",
-      "id": "paymenthelpers_generatepodreference",
-      "label": "generatePODReference()",
-      "norm_label": "generatepodreference()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
-      "source_location": "L9"
-    },
-    {
-      "community": 124,
-      "file_type": "code",
-      "id": "paymenthelpers_getorderdiscountvalue",
-      "label": "getOrderDiscountValue()",
-      "norm_label": "getorderdiscountvalue()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
-      "source_location": "L75"
-    },
-    {
-      "community": 124,
-      "file_type": "code",
-      "id": "paymenthelpers_validatepaymentamount",
-      "label": "validatePaymentAmount()",
-      "norm_label": "validatepaymentamount()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
-      "source_location": "L61"
     },
     {
       "community": 1240,
@@ -59466,65 +59478,65 @@
     {
       "community": 125,
       "file_type": "code",
-      "id": "onlineorder_appendtransition",
-      "label": "appendTransition()",
-      "norm_label": "appendtransition()",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
-      "source_location": "L61"
-    },
-    {
-      "community": 125,
-      "file_type": "code",
-      "id": "onlineorder_applyonlineorderupdate",
-      "label": "applyOnlineOrderUpdate()",
-      "norm_label": "applyonlineorderupdate()",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
-      "source_location": "L85"
-    },
-    {
-      "community": 125,
-      "file_type": "code",
-      "id": "onlineorder_buildreturnexchangereplacementsourceid",
-      "label": "buildReturnExchangeReplacementSourceId()",
-      "norm_label": "buildreturnexchangereplacementsourceid()",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
-      "source_location": "L206"
-    },
-    {
-      "community": 125,
-      "file_type": "code",
-      "id": "onlineorder_buildreturnexchangereturnsourceid",
-      "label": "buildReturnExchangeReturnSourceId()",
-      "norm_label": "buildreturnexchangereturnsourceid()",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
-      "source_location": "L214"
-    },
-    {
-      "community": 125,
-      "file_type": "code",
-      "id": "onlineorder_listorderitems",
-      "label": "listOrderItems()",
-      "norm_label": "listorderitems()",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
-      "source_location": "L51"
-    },
-    {
-      "community": 125,
-      "file_type": "code",
-      "id": "onlineorder_mapupdateordererror",
-      "label": "mapUpdateOrderError()",
-      "norm_label": "mapupdateordererror()",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
-      "source_location": "L221"
-    },
-    {
-      "community": 125,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_onlineorder_ts",
-      "label": "onlineOrder.ts",
-      "norm_label": "onlineorder.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
+      "id": "packages_athena_webapp_convex_storefront_helpers_paymenthelpers_ts",
+      "label": "paymentHelpers.ts",
+      "norm_label": "paymenthelpers.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 125,
+      "file_type": "code",
+      "id": "paymenthelpers_calculateorderamount",
+      "label": "calculateOrderAmount()",
+      "norm_label": "calculateorderamount()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
+      "source_location": "L35"
+    },
+    {
+      "community": 125,
+      "file_type": "code",
+      "id": "paymenthelpers_calculaterewardpoints",
+      "label": "calculateRewardPoints()",
+      "norm_label": "calculaterewardpoints()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
+      "source_location": "L53"
+    },
+    {
+      "community": 125,
+      "file_type": "code",
+      "id": "paymenthelpers_extractorderitems",
+      "label": "extractOrderItems()",
+      "norm_label": "extractorderitems()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
+      "source_location": "L18"
+    },
+    {
+      "community": 125,
+      "file_type": "code",
+      "id": "paymenthelpers_generatepodreference",
+      "label": "generatePODReference()",
+      "norm_label": "generatepodreference()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
+      "source_location": "L9"
+    },
+    {
+      "community": 125,
+      "file_type": "code",
+      "id": "paymenthelpers_getorderdiscountvalue",
+      "label": "getOrderDiscountValue()",
+      "norm_label": "getorderdiscountvalue()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
+      "source_location": "L75"
+    },
+    {
+      "community": 125,
+      "file_type": "code",
+      "id": "paymenthelpers_validatepaymentamount",
+      "label": "validatePaymentAmount()",
+      "norm_label": "validatepaymentamount()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
+      "source_location": "L61"
     },
     {
       "community": 1250,
@@ -59619,64 +59631,64 @@
     {
       "community": 126,
       "file_type": "code",
-      "id": "core_appendworkflowtraceeventwithctx",
-      "label": "appendWorkflowTraceEventWithCtx()",
-      "norm_label": "appendworkflowtraceeventwithctx()",
-      "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
-      "source_location": "L134"
+      "id": "onlineorder_appendtransition",
+      "label": "appendTransition()",
+      "norm_label": "appendtransition()",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
+      "source_location": "L61"
     },
     {
       "community": 126,
       "file_type": "code",
-      "id": "core_createworkflowtracewithctx",
-      "label": "createWorkflowTraceWithCtx()",
-      "norm_label": "createworkflowtracewithctx()",
-      "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
-      "source_location": "L81"
+      "id": "onlineorder_applyonlineorderupdate",
+      "label": "applyOnlineOrderUpdate()",
+      "norm_label": "applyonlineorderupdate()",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
+      "source_location": "L85"
     },
     {
       "community": 126,
       "file_type": "code",
-      "id": "core_getworkflowtracebyidwithctx",
-      "label": "getWorkflowTraceByIdWithCtx()",
-      "norm_label": "getworkflowtracebyidwithctx()",
-      "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
-      "source_location": "L17"
+      "id": "onlineorder_buildreturnexchangereplacementsourceid",
+      "label": "buildReturnExchangeReplacementSourceId()",
+      "norm_label": "buildreturnexchangereplacementsourceid()",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
+      "source_location": "L206"
     },
     {
       "community": 126,
       "file_type": "code",
-      "id": "core_getworkflowtracebylookupwithctx",
-      "label": "getWorkflowTraceByLookupWithCtx()",
-      "norm_label": "getworkflowtracebylookupwithctx()",
-      "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
-      "source_location": "L32"
+      "id": "onlineorder_buildreturnexchangereturnsourceid",
+      "label": "buildReturnExchangeReturnSourceId()",
+      "norm_label": "buildreturnexchangereturnsourceid()",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
+      "source_location": "L214"
     },
     {
       "community": 126,
       "file_type": "code",
-      "id": "core_listworkflowtraceeventswithctx",
-      "label": "listWorkflowTraceEventsWithCtx()",
-      "norm_label": "listworkflowtraceeventswithctx()",
-      "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
-      "source_location": "L65"
+      "id": "onlineorder_listorderitems",
+      "label": "listOrderItems()",
+      "norm_label": "listorderitems()",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
+      "source_location": "L51"
     },
     {
       "community": 126,
       "file_type": "code",
-      "id": "core_registerworkflowtracelookupwithctx",
-      "label": "registerWorkflowTraceLookupWithCtx()",
-      "norm_label": "registerworkflowtracelookupwithctx()",
-      "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
-      "source_location": "L104"
+      "id": "onlineorder_mapupdateordererror",
+      "label": "mapUpdateOrderError()",
+      "norm_label": "mapupdateordererror()",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
+      "source_location": "L221"
     },
     {
       "community": 126,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_workflowtraces_core_ts",
-      "label": "core.ts",
-      "norm_label": "core.ts",
-      "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
+      "id": "packages_athena_webapp_convex_storefront_onlineorder_ts",
+      "label": "onlineOrder.ts",
+      "norm_label": "onlineorder.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
       "source_location": "L1"
     },
     {
@@ -59772,65 +59784,65 @@
     {
       "community": 127,
       "file_type": "code",
-      "id": "packages_athena_webapp_shared_stockadjustment_ts",
-      "label": "stockAdjustment.ts",
-      "norm_label": "stockadjustment.ts",
-      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
+      "id": "core_appendworkflowtraceeventwithctx",
+      "label": "appendWorkflowTraceEventWithCtx()",
+      "norm_label": "appendworkflowtraceeventwithctx()",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
+      "source_location": "L134"
+    },
+    {
+      "community": 127,
+      "file_type": "code",
+      "id": "core_createworkflowtracewithctx",
+      "label": "createWorkflowTraceWithCtx()",
+      "norm_label": "createworkflowtracewithctx()",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
+      "source_location": "L81"
+    },
+    {
+      "community": 127,
+      "file_type": "code",
+      "id": "core_getworkflowtracebyidwithctx",
+      "label": "getWorkflowTraceByIdWithCtx()",
+      "norm_label": "getworkflowtracebyidwithctx()",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
+      "source_location": "L17"
+    },
+    {
+      "community": 127,
+      "file_type": "code",
+      "id": "core_getworkflowtracebylookupwithctx",
+      "label": "getWorkflowTraceByLookupWithCtx()",
+      "norm_label": "getworkflowtracebylookupwithctx()",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
+      "source_location": "L32"
+    },
+    {
+      "community": 127,
+      "file_type": "code",
+      "id": "core_listworkflowtraceeventswithctx",
+      "label": "listWorkflowTraceEventsWithCtx()",
+      "norm_label": "listworkflowtraceeventswithctx()",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
+      "source_location": "L65"
+    },
+    {
+      "community": 127,
+      "file_type": "code",
+      "id": "core_registerworkflowtracelookupwithctx",
+      "label": "registerWorkflowTraceLookupWithCtx()",
+      "norm_label": "registerworkflowtracelookupwithctx()",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
+      "source_location": "L104"
+    },
+    {
+      "community": 127,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_workflowtraces_core_ts",
+      "label": "core.ts",
+      "norm_label": "core.ts",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 127,
-      "file_type": "code",
-      "id": "stockadjustment_assertstockadjustmentreasoncode",
-      "label": "assertStockAdjustmentReasonCode()",
-      "norm_label": "assertstockadjustmentreasoncode()",
-      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
-      "source_location": "L25"
-    },
-    {
-      "community": 127,
-      "file_type": "code",
-      "id": "stockadjustment_calculatecyclecountquantitydelta",
-      "label": "calculateCycleCountQuantityDelta()",
-      "norm_label": "calculatecyclecountquantitydelta()",
-      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
-      "source_location": "L14"
-    },
-    {
-      "community": 127,
-      "file_type": "code",
-      "id": "stockadjustment_hashighstockadjustmentvariance",
-      "label": "hasHighStockAdjustmentVariance()",
-      "norm_label": "hashighstockadjustmentvariance()",
-      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
-      "source_location": "L96"
-    },
-    {
-      "community": 127,
-      "file_type": "code",
-      "id": "stockadjustment_requiresstockadjustmentapproval",
-      "label": "requiresStockAdjustmentApproval()",
-      "norm_label": "requiresstockadjustmentapproval()",
-      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
-      "source_location": "L102"
-    },
-    {
-      "community": 127,
-      "file_type": "code",
-      "id": "stockadjustment_resolvestockadjustmentquantitydelta",
-      "label": "resolveStockAdjustmentQuantityDelta()",
-      "norm_label": "resolvestockadjustmentquantitydelta()",
-      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
-      "source_location": "L45"
-    },
-    {
-      "community": 127,
-      "file_type": "code",
-      "id": "stockadjustment_summarizestockadjustmentlineitems",
-      "label": "summarizeStockAdjustmentLineItems()",
-      "norm_label": "summarizestockadjustmentlineitems()",
-      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
-      "source_location": "L76"
     },
     {
       "community": 1270,
@@ -59925,65 +59937,65 @@
     {
       "community": 128,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_paymentview_tsx",
-      "label": "PaymentView.tsx",
-      "norm_label": "paymentview.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
+      "id": "packages_athena_webapp_shared_stockadjustment_ts",
+      "label": "stockAdjustment.ts",
+      "norm_label": "stockadjustment.ts",
+      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
       "source_location": "L1"
     },
     {
       "community": 128,
       "file_type": "code",
-      "id": "paymentview_cn",
-      "label": "cn()",
-      "norm_label": "cn()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
-      "source_location": "L404"
+      "id": "stockadjustment_assertstockadjustmentreasoncode",
+      "label": "assertStockAdjustmentReasonCode()",
+      "norm_label": "assertstockadjustmentreasoncode()",
+      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
+      "source_location": "L25"
     },
     {
       "community": 128,
       "file_type": "code",
-      "id": "paymentview_handleaddpayment",
-      "label": "handleAddPayment()",
-      "norm_label": "handleaddpayment()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
-      "source_location": "L181"
+      "id": "stockadjustment_calculatecyclecountquantitydelta",
+      "label": "calculateCycleCountQuantityDelta()",
+      "norm_label": "calculatecyclecountquantitydelta()",
+      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
+      "source_location": "L14"
     },
     {
       "community": 128,
       "file_type": "code",
-      "id": "paymentview_handleamountblur",
-      "label": "handleAmountBlur()",
-      "norm_label": "handleamountblur()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
-      "source_location": "L253"
+      "id": "stockadjustment_hashighstockadjustmentvariance",
+      "label": "hasHighStockAdjustmentVariance()",
+      "norm_label": "hashighstockadjustmentvariance()",
+      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
+      "source_location": "L96"
     },
     {
       "community": 128,
       "file_type": "code",
-      "id": "paymentview_handleamountchange",
-      "label": "handleAmountChange()",
-      "norm_label": "handleamountchange()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
-      "source_location": "L231"
+      "id": "stockadjustment_requiresstockadjustmentapproval",
+      "label": "requiresStockAdjustmentApproval()",
+      "norm_label": "requiresstockadjustmentapproval()",
+      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
+      "source_location": "L102"
     },
     {
       "community": 128,
       "file_type": "code",
-      "id": "paymentview_handlekeypadpress",
-      "label": "handleKeypadPress()",
-      "norm_label": "handlekeypadpress()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
-      "source_location": "L275"
+      "id": "stockadjustment_resolvestockadjustmentquantitydelta",
+      "label": "resolveStockAdjustmentQuantityDelta()",
+      "norm_label": "resolvestockadjustmentquantitydelta()",
+      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
+      "source_location": "L45"
     },
     {
       "community": 128,
       "file_type": "code",
-      "id": "paymentview_setamountfromtouch",
-      "label": "setAmountFromTouch()",
-      "norm_label": "setamountfromtouch()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
-      "source_location": "L259"
+      "id": "stockadjustment_summarizestockadjustmentlineitems",
+      "label": "summarizeStockAdjustmentLineItems()",
+      "norm_label": "summarizestockadjustmentlineitems()",
+      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
+      "source_location": "L76"
     },
     {
       "community": 1280,
@@ -60078,65 +60090,65 @@
     {
       "community": 129,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_register_posregisterview_tsx",
-      "label": "POSRegisterView.tsx",
-      "norm_label": "posregisterview.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
+      "id": "packages_athena_webapp_src_components_pos_paymentview_tsx",
+      "label": "PaymentView.tsx",
+      "norm_label": "paymentview.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
       "source_location": "L1"
     },
     {
       "community": 129,
       "file_type": "code",
-      "id": "posregisterview_cartcountsummary",
-      "label": "CartCountSummary()",
-      "norm_label": "cartcountsummary()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
-      "source_location": "L152"
+      "id": "paymentview_cn",
+      "label": "cn()",
+      "norm_label": "cn()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
+      "source_location": "L404"
     },
     {
       "community": 129,
       "file_type": "code",
-      "id": "posregisterview_cashierauthworkspace",
-      "label": "CashierAuthWorkspace()",
-      "norm_label": "cashierauthworkspace()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
-      "source_location": "L114"
+      "id": "paymentview_handleaddpayment",
+      "label": "handleAddPayment()",
+      "norm_label": "handleaddpayment()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
+      "source_location": "L181"
     },
     {
       "community": 129,
       "file_type": "code",
-      "id": "posregisterview_handlecmdk",
-      "label": "handleCmdK()",
-      "norm_label": "handlecmdk()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
-      "source_location": "L431"
+      "id": "paymentview_handleamountblur",
+      "label": "handleAmountBlur()",
+      "norm_label": "handleamountblur()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
+      "source_location": "L253"
     },
     {
       "community": 129,
       "file_type": "code",
-      "id": "posregisterview_productlookupemptystate",
-      "label": "ProductLookupEmptyState()",
-      "norm_label": "productlookupemptystate()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
-      "source_location": "L73"
+      "id": "paymentview_handleamountchange",
+      "label": "handleAmountChange()",
+      "norm_label": "handleamountchange()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
+      "source_location": "L231"
     },
     {
       "community": 129,
       "file_type": "code",
-      "id": "posregisterview_registersetupresolvingworkspace",
-      "label": "RegisterSetupResolvingWorkspace()",
-      "norm_label": "registersetupresolvingworkspace()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
-      "source_location": "L146"
+      "id": "paymentview_handlekeypadpress",
+      "label": "handleKeypadPress()",
+      "norm_label": "handlekeypadpress()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
+      "source_location": "L275"
     },
     {
       "community": 129,
       "file_type": "code",
-      "id": "posregisterview_usecollapsesidebarforposflow",
-      "label": "useCollapseSidebarForPosFlow()",
-      "norm_label": "usecollapsesidebarforposflow()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
-      "source_location": "L41"
+      "id": "paymentview_setamountfromtouch",
+      "label": "setAmountFromTouch()",
+      "norm_label": "setamountfromtouch()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
+      "source_location": "L259"
     },
     {
       "community": 1290,
@@ -60447,65 +60459,65 @@
     {
       "community": 130,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_services_serviceappointmentsview_tsx",
-      "label": "ServiceAppointmentsView.tsx",
-      "norm_label": "serviceappointmentsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
+      "id": "packages_athena_webapp_src_components_pos_register_posregisterview_tsx",
+      "label": "POSRegisterView.tsx",
+      "norm_label": "posregisterview.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
       "source_location": "L1"
     },
     {
       "community": 130,
       "file_type": "code",
-      "id": "serviceappointmentsview_applycommandresult",
-      "label": "applyCommandResult()",
-      "norm_label": "applycommandresult()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
-      "source_location": "L129"
+      "id": "posregisterview_cartcountsummary",
+      "label": "CartCountSummary()",
+      "norm_label": "cartcountsummary()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
+      "source_location": "L152"
     },
     {
       "community": 130,
       "file_type": "code",
-      "id": "serviceappointmentsview_async",
-      "label": "async()",
-      "norm_label": "async()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
-      "source_location": "L393"
+      "id": "posregisterview_cashierauthworkspace",
+      "label": "CashierAuthWorkspace()",
+      "norm_label": "cashierauthworkspace()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
+      "source_location": "L114"
     },
     {
       "community": 130,
       "file_type": "code",
-      "id": "serviceappointmentsview_formatdatetimelocal",
-      "label": "formatDateTimeLocal()",
-      "norm_label": "formatdatetimelocal()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
-      "source_location": "L102"
+      "id": "posregisterview_handlecmdk",
+      "label": "handleCmdK()",
+      "norm_label": "handlecmdk()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
+      "source_location": "L431"
     },
     {
       "community": 130,
       "file_type": "code",
-      "id": "serviceappointmentsview_handlesubmit",
-      "label": "handleSubmit()",
-      "norm_label": "handlesubmit()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
-      "source_location": "L153"
+      "id": "posregisterview_productlookupemptystate",
+      "label": "ProductLookupEmptyState()",
+      "norm_label": "productlookupemptystate()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
+      "source_location": "L73"
     },
     {
       "community": 130,
       "file_type": "code",
-      "id": "serviceappointmentsview_parsedatetimelocal",
-      "label": "parseDateTimeLocal()",
-      "norm_label": "parsedatetimelocal()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
-      "source_location": "L97"
+      "id": "posregisterview_registersetupresolvingworkspace",
+      "label": "RegisterSetupResolvingWorkspace()",
+      "norm_label": "registersetupresolvingworkspace()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
+      "source_location": "L146"
     },
     {
       "community": 130,
       "file_type": "code",
-      "id": "serviceappointmentsview_withsavestate",
-      "label": "withSaveState()",
-      "norm_label": "withsavestate()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
-      "source_location": "L521"
+      "id": "posregisterview_usecollapsesidebarforposflow",
+      "label": "useCollapseSidebarForPosFlow()",
+      "norm_label": "usecollapsesidebarforposflow()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
+      "source_location": "L41"
     },
     {
       "community": 1300,
@@ -60600,65 +60612,65 @@
     {
       "community": 131,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_domain_session_ts",
-      "label": "session.ts",
-      "norm_label": "session.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
+      "id": "packages_athena_webapp_src_components_services_serviceappointmentsview_tsx",
+      "label": "ServiceAppointmentsView.tsx",
+      "norm_label": "serviceappointmentsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
       "source_location": "L1"
     },
     {
       "community": 131,
       "file_type": "code",
-      "id": "session_deriveregisterphase",
-      "label": "deriveRegisterPhase()",
-      "norm_label": "deriveregisterphase()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
-      "source_location": "L3"
+      "id": "serviceappointmentsview_applycommandresult",
+      "label": "applyCommandResult()",
+      "norm_label": "applycommandresult()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
+      "source_location": "L129"
     },
     {
       "community": 131,
       "file_type": "code",
-      "id": "session_hasactiveregistersession",
-      "label": "hasActiveRegisterSession()",
-      "norm_label": "hasactiveregistersession()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
-      "source_location": "L33"
+      "id": "serviceappointmentsview_async",
+      "label": "async()",
+      "norm_label": "async()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
+      "source_location": "L393"
     },
     {
       "community": 131,
       "file_type": "code",
-      "id": "session_hasresumableregistersession",
-      "label": "hasResumableRegisterSession()",
-      "norm_label": "hasresumableregistersession()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
-      "source_location": "L39"
+      "id": "serviceappointmentsview_formatdatetimelocal",
+      "label": "formatDateTimeLocal()",
+      "norm_label": "formatdatetimelocal()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
+      "source_location": "L102"
     },
     {
       "community": 131,
       "file_type": "code",
-      "id": "session_isregisterreadytostart",
-      "label": "isRegisterReadyToStart()",
-      "norm_label": "isregisterreadytostart()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
-      "source_location": "L45"
+      "id": "serviceappointmentsview_handlesubmit",
+      "label": "handleSubmit()",
+      "norm_label": "handlesubmit()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
+      "source_location": "L153"
     },
     {
       "community": 131,
       "file_type": "code",
-      "id": "session_requirescashier",
-      "label": "requiresCashier()",
-      "norm_label": "requirescashier()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
-      "source_location": "L29"
+      "id": "serviceappointmentsview_parsedatetimelocal",
+      "label": "parseDateTimeLocal()",
+      "norm_label": "parsedatetimelocal()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
+      "source_location": "L97"
     },
     {
       "community": 131,
       "file_type": "code",
-      "id": "session_requiresterminal",
-      "label": "requiresTerminal()",
-      "norm_label": "requiresterminal()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
-      "source_location": "L25"
+      "id": "serviceappointmentsview_withsavestate",
+      "label": "withSaveState()",
+      "norm_label": "withsavestate()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
+      "source_location": "L521"
     },
     {
       "community": 1310,
@@ -60753,65 +60765,65 @@
     {
       "community": 132,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_presentation_register_useregisterviewmodel_test_ts",
-      "label": "useRegisterViewModel.test.ts",
-      "norm_label": "useregisterviewmodel.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts",
+      "id": "packages_athena_webapp_src_lib_pos_domain_session_ts",
+      "label": "session.ts",
+      "norm_label": "session.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
       "source_location": "L1"
     },
     {
       "community": 132,
       "file_type": "code",
-      "id": "useregisterviewmodel_test_buildregistercatalogavailabilityrow",
-      "label": "buildRegisterCatalogAvailabilityRow()",
-      "norm_label": "buildregistercatalogavailabilityrow()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts",
-      "source_location": "L251"
+      "id": "session_deriveregisterphase",
+      "label": "deriveRegisterPhase()",
+      "norm_label": "deriveregisterphase()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
+      "source_location": "L3"
     },
     {
       "community": 132,
       "file_type": "code",
-      "id": "useregisterviewmodel_test_buildregistercatalogrow",
-      "label": "buildRegisterCatalogRow()",
-      "norm_label": "buildregistercatalogrow()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts",
-      "source_location": "L228"
+      "id": "session_hasactiveregistersession",
+      "label": "hasActiveRegisterSession()",
+      "norm_label": "hasactiveregistersession()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
+      "source_location": "L33"
     },
     {
       "community": 132,
       "file_type": "code",
-      "id": "useregisterviewmodel_test_deferred",
-      "label": "deferred()",
-      "norm_label": "deferred()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts",
-      "source_location": "L219"
+      "id": "session_hasresumableregistersession",
+      "label": "hasResumableRegisterSession()",
+      "norm_label": "hasresumableregistersession()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
+      "source_location": "L39"
     },
     {
       "community": 132,
       "file_type": "code",
-      "id": "useregisterviewmodel_test_resolveadditem",
-      "label": "resolveAddItem()",
-      "norm_label": "resolveadditem()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts",
-      "source_location": "L2176"
+      "id": "session_isregisterreadytostart",
+      "label": "isRegisterReadyToStart()",
+      "norm_label": "isregisterreadytostart()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
+      "source_location": "L45"
     },
     {
       "community": 132,
       "file_type": "code",
-      "id": "useregisterviewmodel_test_resolveclearcart",
-      "label": "resolveClearCart()",
-      "norm_label": "resolveclearcart()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts",
-      "source_location": "L2614"
+      "id": "session_requirescashier",
+      "label": "requiresCashier()",
+      "norm_label": "requirescashier()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
+      "source_location": "L29"
     },
     {
       "community": 132,
       "file_type": "code",
-      "id": "useregisterviewmodel_test_resolveremoveitem",
-      "label": "resolveRemoveItem()",
-      "norm_label": "resolveremoveitem()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts",
-      "source_location": "L2491"
+      "id": "session_requiresterminal",
+      "label": "requiresTerminal()",
+      "norm_label": "requiresterminal()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
+      "source_location": "L25"
     },
     {
       "community": 1320,
@@ -60906,65 +60918,65 @@
     {
       "community": 133,
       "file_type": "code",
-      "id": "calculationservice_calculatecarttotals",
-      "label": "calculateCartTotals()",
-      "norm_label": "calculatecarttotals()",
-      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
-      "source_location": "L28"
-    },
-    {
-      "community": 133,
-      "file_type": "code",
-      "id": "calculationservice_calculatechange",
-      "label": "calculateChange()",
-      "norm_label": "calculatechange()",
-      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
-      "source_location": "L42"
-    },
-    {
-      "community": 133,
-      "file_type": "code",
-      "id": "calculationservice_calculateitemtotal",
-      "label": "calculateItemTotal()",
-      "norm_label": "calculateitemtotal()",
-      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
-      "source_location": "L35"
-    },
-    {
-      "community": 133,
-      "file_type": "code",
-      "id": "calculationservice_formatcurrency",
-      "label": "formatCurrency()",
-      "norm_label": "formatcurrency()",
-      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
-      "source_location": "L49"
-    },
-    {
-      "community": 133,
-      "file_type": "code",
-      "id": "calculationservice_geteffectiveprice",
-      "label": "getEffectivePrice()",
-      "norm_label": "geteffectiveprice()",
-      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
-      "source_location": "L70"
-    },
-    {
-      "community": 133,
-      "file_type": "code",
-      "id": "calculationservice_ispaymentsufficient",
-      "label": "isPaymentSufficient()",
-      "norm_label": "ispaymentsufficient()",
-      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
-      "source_location": "L59"
-    },
-    {
-      "community": 133,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_services_calculationservice_ts",
-      "label": "calculationService.ts",
-      "norm_label": "calculationservice.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
+      "id": "packages_athena_webapp_src_lib_pos_presentation_register_useregisterviewmodel_test_ts",
+      "label": "useRegisterViewModel.test.ts",
+      "norm_label": "useregisterviewmodel.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 133,
+      "file_type": "code",
+      "id": "useregisterviewmodel_test_buildregistercatalogavailabilityrow",
+      "label": "buildRegisterCatalogAvailabilityRow()",
+      "norm_label": "buildregistercatalogavailabilityrow()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts",
+      "source_location": "L251"
+    },
+    {
+      "community": 133,
+      "file_type": "code",
+      "id": "useregisterviewmodel_test_buildregistercatalogrow",
+      "label": "buildRegisterCatalogRow()",
+      "norm_label": "buildregistercatalogrow()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts",
+      "source_location": "L228"
+    },
+    {
+      "community": 133,
+      "file_type": "code",
+      "id": "useregisterviewmodel_test_deferred",
+      "label": "deferred()",
+      "norm_label": "deferred()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts",
+      "source_location": "L219"
+    },
+    {
+      "community": 133,
+      "file_type": "code",
+      "id": "useregisterviewmodel_test_resolveadditem",
+      "label": "resolveAddItem()",
+      "norm_label": "resolveadditem()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts",
+      "source_location": "L2176"
+    },
+    {
+      "community": 133,
+      "file_type": "code",
+      "id": "useregisterviewmodel_test_resolveclearcart",
+      "label": "resolveClearCart()",
+      "norm_label": "resolveclearcart()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts",
+      "source_location": "L2614"
+    },
+    {
+      "community": 133,
+      "file_type": "code",
+      "id": "useregisterviewmodel_test_resolveremoveitem",
+      "label": "resolveRemoveItem()",
+      "norm_label": "resolveremoveitem()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts",
+      "source_location": "L2491"
     },
     {
       "community": 1330,
@@ -61059,65 +61071,65 @@
     {
       "community": 134,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_templates_reference_fixtures_tsx",
-      "label": "reference-fixtures.tsx",
-      "norm_label": "reference-fixtures.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "id": "calculationservice_calculatecarttotals",
+      "label": "calculateCartTotals()",
+      "norm_label": "calculatecarttotals()",
+      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
+      "source_location": "L28"
+    },
+    {
+      "community": 134,
+      "file_type": "code",
+      "id": "calculationservice_calculatechange",
+      "label": "calculateChange()",
+      "norm_label": "calculatechange()",
+      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
+      "source_location": "L42"
+    },
+    {
+      "community": 134,
+      "file_type": "code",
+      "id": "calculationservice_calculateitemtotal",
+      "label": "calculateItemTotal()",
+      "norm_label": "calculateitemtotal()",
+      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
+      "source_location": "L35"
+    },
+    {
+      "community": 134,
+      "file_type": "code",
+      "id": "calculationservice_formatcurrency",
+      "label": "formatCurrency()",
+      "norm_label": "formatcurrency()",
+      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
+      "source_location": "L49"
+    },
+    {
+      "community": 134,
+      "file_type": "code",
+      "id": "calculationservice_geteffectiveprice",
+      "label": "getEffectivePrice()",
+      "norm_label": "geteffectiveprice()",
+      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
+      "source_location": "L70"
+    },
+    {
+      "community": 134,
+      "file_type": "code",
+      "id": "calculationservice_ispaymentsufficient",
+      "label": "isPaymentSufficient()",
+      "norm_label": "ispaymentsufficient()",
+      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
+      "source_location": "L59"
+    },
+    {
+      "community": 134,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_services_calculationservice_ts",
+      "label": "calculationService.ts",
+      "norm_label": "calculationservice.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 134,
-      "file_type": "code",
-      "id": "reference_fixtures_compacttable",
-      "label": "CompactTable()",
-      "norm_label": "compacttable()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L263"
-    },
-    {
-      "community": 134,
-      "file_type": "code",
-      "id": "reference_fixtures_framecard",
-      "label": "FrameCard()",
-      "norm_label": "framecard()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L163"
-    },
-    {
-      "community": 134,
-      "file_type": "code",
-      "id": "reference_fixtures_lanecard",
-      "label": "LaneCard()",
-      "norm_label": "lanecard()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L213"
-    },
-    {
-      "community": 134,
-      "file_type": "code",
-      "id": "reference_fixtures_metrictile",
-      "label": "MetricTile()",
-      "norm_label": "metrictile()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L194"
-    },
-    {
-      "community": 134,
-      "file_type": "code",
-      "id": "reference_fixtures_minitrendchart",
-      "label": "MiniTrendChart()",
-      "norm_label": "minitrendchart()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L240"
-    },
-    {
-      "community": 134,
-      "file_type": "code",
-      "id": "reference_fixtures_referencepageshell",
-      "label": "ReferencePageShell()",
-      "norm_label": "referencepageshell()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L145"
     },
     {
       "community": 1340,
@@ -61212,65 +61224,65 @@
     {
       "community": 135,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_savedbag_ts",
-      "label": "savedBag.ts",
-      "norm_label": "savedbag.ts",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "id": "packages_athena_webapp_src_stories_templates_reference_fixtures_tsx",
+      "label": "reference-fixtures.tsx",
+      "norm_label": "reference-fixtures.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
       "source_location": "L1"
     },
     {
       "community": 135,
       "file_type": "code",
-      "id": "savedbag_additemtosavedbag",
-      "label": "addItemToSavedBag()",
-      "norm_label": "additemtosavedbag()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L25"
+      "id": "reference_fixtures_compacttable",
+      "label": "CompactTable()",
+      "norm_label": "compacttable()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L263"
     },
     {
       "community": 135,
       "file_type": "code",
-      "id": "savedbag_getactivesavedbag",
-      "label": "getActiveSavedBag()",
-      "norm_label": "getactivesavedbag()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L10"
+      "id": "reference_fixtures_framecard",
+      "label": "FrameCard()",
+      "norm_label": "framecard()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L163"
     },
     {
       "community": 135,
       "file_type": "code",
-      "id": "savedbag_getbaseurl",
-      "label": "getBaseUrl()",
-      "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L8"
+      "id": "reference_fixtures_lanecard",
+      "label": "LaneCard()",
+      "norm_label": "lanecard()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L213"
     },
     {
       "community": 135,
       "file_type": "code",
-      "id": "savedbag_removeitemfromsavedbag",
-      "label": "removeItemFromSavedBag()",
-      "norm_label": "removeitemfromsavedbag()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L91"
+      "id": "reference_fixtures_metrictile",
+      "label": "MetricTile()",
+      "norm_label": "metrictile()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L194"
     },
     {
       "community": 135,
       "file_type": "code",
-      "id": "savedbag_updatesavedbagitem",
-      "label": "updateSavedBagItem()",
-      "norm_label": "updatesavedbagitem()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L61"
+      "id": "reference_fixtures_minitrendchart",
+      "label": "MiniTrendChart()",
+      "norm_label": "minitrendchart()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L240"
     },
     {
       "community": 135,
       "file_type": "code",
-      "id": "savedbag_updatesavedbagowner",
-      "label": "updateSavedBagOwner()",
-      "norm_label": "updatesavedbagowner()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L109"
+      "id": "reference_fixtures_referencepageshell",
+      "label": "ReferencePageShell()",
+      "norm_label": "referencepageshell()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L145"
     },
     {
       "community": 1350,
@@ -61365,65 +61377,65 @@
     {
       "community": 136,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_productutils_ts",
-      "label": "productUtils.ts",
-      "norm_label": "productutils.ts",
-      "source_file": "packages/athena-webapp/src/lib/productUtils.ts",
+      "id": "packages_storefront_webapp_src_api_savedbag_ts",
+      "label": "savedBag.ts",
+      "norm_label": "savedbag.ts",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
       "source_location": "L1"
     },
     {
       "community": 136,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_productutils_ts",
-      "label": "productUtils.ts",
-      "norm_label": "productutils.ts",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L1"
+      "id": "savedbag_additemtosavedbag",
+      "label": "addItemToSavedBag()",
+      "norm_label": "additemtosavedbag()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L25"
     },
     {
       "community": 136,
       "file_type": "code",
-      "id": "productutils_getproductname",
-      "label": "getProductName()",
-      "norm_label": "getproductname()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L18"
+      "id": "savedbag_getactivesavedbag",
+      "label": "getActiveSavedBag()",
+      "norm_label": "getactivesavedbag()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L10"
     },
     {
       "community": 136,
       "file_type": "code",
-      "id": "productutils_haslowstock",
-      "label": "hasLowStock()",
-      "norm_label": "haslowstock()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L52"
+      "id": "savedbag_getbaseurl",
+      "label": "getBaseUrl()",
+      "norm_label": "getbaseurl()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L8"
     },
     {
       "community": 136,
       "file_type": "code",
-      "id": "productutils_issoldout",
-      "label": "isSoldOut()",
-      "norm_label": "issoldout()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L45"
+      "id": "savedbag_removeitemfromsavedbag",
+      "label": "removeItemFromSavedBag()",
+      "norm_label": "removeitemfromsavedbag()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L91"
     },
     {
       "community": 136,
       "file_type": "code",
-      "id": "productutils_sortproduct",
-      "label": "sortProduct()",
-      "norm_label": "sortproduct()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L66"
+      "id": "savedbag_updatesavedbagitem",
+      "label": "updateSavedBagItem()",
+      "norm_label": "updatesavedbagitem()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L61"
     },
     {
       "community": 136,
       "file_type": "code",
-      "id": "productutils_sortskusbylength",
-      "label": "sortSkusByLength()",
-      "norm_label": "sortskusbylength()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L62"
+      "id": "savedbag_updatesavedbagowner",
+      "label": "updateSavedBagOwner()",
+      "norm_label": "updatesavedbagowner()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L109"
     },
     {
       "community": 1360,
@@ -61518,65 +61530,65 @@
     {
       "community": 137,
       "file_type": "code",
-      "id": "compound_solution_check_test_createfixturerepo",
-      "label": "createFixtureRepo()",
-      "norm_label": "createfixturerepo()",
-      "source_file": "scripts/compound-solution-check.test.ts",
-      "source_location": "L15"
+      "id": "packages_athena_webapp_src_lib_productutils_ts",
+      "label": "productUtils.ts",
+      "norm_label": "productutils.ts",
+      "source_file": "packages/athena-webapp/src/lib/productUtils.ts",
+      "source_location": "L1"
     },
     {
       "community": 137,
       "file_type": "code",
-      "id": "compound_solution_check_test_gitenv",
-      "label": "gitEnv()",
-      "norm_label": "gitenv()",
-      "source_file": "scripts/compound-solution-check.test.ts",
-      "source_location": "L50"
+      "id": "packages_storefront_webapp_src_lib_productutils_ts",
+      "label": "productUtils.ts",
+      "norm_label": "productutils.ts",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L1"
     },
     {
       "community": 137,
       "file_type": "code",
-      "id": "compound_solution_check_test_linechanges",
-      "label": "lineChanges()",
-      "norm_label": "linechanges()",
-      "source_file": "scripts/compound-solution-check.test.ts",
+      "id": "productutils_getproductname",
+      "label": "getProductName()",
+      "norm_label": "getproductname()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L18"
+    },
+    {
+      "community": 137,
+      "file_type": "code",
+      "id": "productutils_haslowstock",
+      "label": "hasLowStock()",
+      "norm_label": "haslowstock()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L52"
+    },
+    {
+      "community": 137,
+      "file_type": "code",
+      "id": "productutils_issoldout",
+      "label": "isSoldOut()",
+      "norm_label": "issoldout()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L45"
+    },
+    {
+      "community": 137,
+      "file_type": "code",
+      "id": "productutils_sortproduct",
+      "label": "sortProduct()",
+      "norm_label": "sortproduct()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
       "source_location": "L66"
     },
     {
       "community": 137,
       "file_type": "code",
-      "id": "compound_solution_check_test_rungit",
-      "label": "runGit()",
-      "norm_label": "rungit()",
-      "source_file": "scripts/compound-solution-check.test.ts",
-      "source_location": "L35"
-    },
-    {
-      "community": 137,
-      "file_type": "code",
-      "id": "compound_solution_check_test_solutionnote",
-      "label": "solutionNote()",
-      "norm_label": "solutionnote()",
-      "source_file": "scripts/compound-solution-check.test.ts",
-      "source_location": "L75"
-    },
-    {
-      "community": 137,
-      "file_type": "code",
-      "id": "compound_solution_check_test_write",
-      "label": "write()",
-      "norm_label": "write()",
-      "source_file": "scripts/compound-solution-check.test.ts",
-      "source_location": "L29"
-    },
-    {
-      "community": 137,
-      "file_type": "code",
-      "id": "scripts_compound_solution_check_test_ts",
-      "label": "compound-solution-check.test.ts",
-      "norm_label": "compound-solution-check.test.ts",
-      "source_file": "scripts/compound-solution-check.test.ts",
-      "source_location": "L1"
+      "id": "productutils_sortskusbylength",
+      "label": "sortSkusByLength()",
+      "norm_label": "sortskusbylength()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L62"
     },
     {
       "community": 1370,
@@ -61671,65 +61683,65 @@
     {
       "community": 138,
       "file_type": "code",
-      "id": "scripts_harness_behavior_fixtures_storefront_runtime_api_ts",
-      "label": "storefront-runtime-api.ts",
-      "norm_label": "storefront-runtime-api.ts",
-      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
+      "id": "compound_solution_check_test_createfixturerepo",
+      "label": "createFixtureRepo()",
+      "norm_label": "createfixturerepo()",
+      "source_file": "scripts/compound-solution-check.test.ts",
+      "source_location": "L15"
+    },
+    {
+      "community": 138,
+      "file_type": "code",
+      "id": "compound_solution_check_test_gitenv",
+      "label": "gitEnv()",
+      "norm_label": "gitenv()",
+      "source_file": "scripts/compound-solution-check.test.ts",
+      "source_location": "L50"
+    },
+    {
+      "community": 138,
+      "file_type": "code",
+      "id": "compound_solution_check_test_linechanges",
+      "label": "lineChanges()",
+      "norm_label": "linechanges()",
+      "source_file": "scripts/compound-solution-check.test.ts",
+      "source_location": "L66"
+    },
+    {
+      "community": 138,
+      "file_type": "code",
+      "id": "compound_solution_check_test_rungit",
+      "label": "runGit()",
+      "norm_label": "rungit()",
+      "source_file": "scripts/compound-solution-check.test.ts",
+      "source_location": "L35"
+    },
+    {
+      "community": 138,
+      "file_type": "code",
+      "id": "compound_solution_check_test_solutionnote",
+      "label": "solutionNote()",
+      "norm_label": "solutionnote()",
+      "source_file": "scripts/compound-solution-check.test.ts",
+      "source_location": "L75"
+    },
+    {
+      "community": 138,
+      "file_type": "code",
+      "id": "compound_solution_check_test_write",
+      "label": "write()",
+      "norm_label": "write()",
+      "source_file": "scripts/compound-solution-check.test.ts",
+      "source_location": "L29"
+    },
+    {
+      "community": 138,
+      "file_type": "code",
+      "id": "scripts_compound_solution_check_test_ts",
+      "label": "compound-solution-check.test.ts",
+      "norm_label": "compound-solution-check.test.ts",
+      "source_file": "scripts/compound-solution-check.test.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 138,
-      "file_type": "code",
-      "id": "storefront_runtime_api_emitsignal",
-      "label": "emitSignal()",
-      "norm_label": "emitsignal()",
-      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
-      "source_location": "L210"
-    },
-    {
-      "community": 138,
-      "file_type": "code",
-      "id": "storefront_runtime_api_handlecheckoutsessionfetch",
-      "label": "handleCheckoutSessionFetch()",
-      "norm_label": "handlecheckoutsessionfetch()",
-      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
-      "source_location": "L214"
-    },
-    {
-      "community": 138,
-      "file_type": "code",
-      "id": "storefront_runtime_api_handlecheckoutsessionupdate",
-      "label": "handleCheckoutSessionUpdate()",
-      "norm_label": "handlecheckoutsessionupdate()",
-      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
-      "source_location": "L236"
-    },
-    {
-      "community": 138,
-      "file_type": "code",
-      "id": "storefront_runtime_api_jsonresponse",
-      "label": "jsonResponse()",
-      "norm_label": "jsonresponse()",
-      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
-      "source_location": "L201"
-    },
-    {
-      "community": 138,
-      "file_type": "code",
-      "id": "storefront_runtime_api_shutdown",
-      "label": "shutdown()",
-      "norm_label": "shutdown()",
-      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
-      "source_location": "L421"
-    },
-    {
-      "community": 138,
-      "file_type": "code",
-      "id": "storefront_runtime_api_withcorsheaders",
-      "label": "withCorsHeaders()",
-      "norm_label": "withcorsheaders()",
-      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
-      "source_location": "L186"
     },
     {
       "community": 1380,
@@ -61824,65 +61836,65 @@
     {
       "community": 139,
       "file_type": "code",
-      "id": "harness_janitor_test_createfixtureroot",
-      "label": "createFixtureRoot()",
-      "norm_label": "createfixtureroot()",
-      "source_file": "scripts/harness-janitor.test.ts",
-      "source_location": "L29"
-    },
-    {
-      "community": 139,
-      "file_type": "code",
-      "id": "harness_janitor_test_overwritefreshgenerateddocs",
-      "label": "overwriteFreshGeneratedDocs()",
-      "norm_label": "overwritefreshgenerateddocs()",
-      "source_file": "scripts/harness-janitor.test.ts",
-      "source_location": "L46"
-    },
-    {
-      "community": 139,
-      "file_type": "code",
-      "id": "harness_janitor_test_overwritefreshgraphifyartifacts",
-      "label": "overwriteFreshGraphifyArtifacts()",
-      "norm_label": "overwritefreshgraphifyartifacts()",
-      "source_file": "scripts/harness-janitor.test.ts",
-      "source_location": "L54"
-    },
-    {
-      "community": 139,
-      "file_type": "code",
-      "id": "harness_janitor_test_seedartifacts",
-      "label": "seedArtifacts()",
-      "norm_label": "seedartifacts()",
-      "source_file": "scripts/harness-janitor.test.ts",
-      "source_location": "L35"
-    },
-    {
-      "community": 139,
-      "file_type": "code",
-      "id": "harness_janitor_test_sortpaths",
-      "label": "sortPaths()",
-      "norm_label": "sortpaths()",
-      "source_file": "scripts/harness-janitor.test.ts",
-      "source_location": "L61"
-    },
-    {
-      "community": 139,
-      "file_type": "code",
-      "id": "harness_janitor_test_write",
-      "label": "write()",
-      "norm_label": "write()",
-      "source_file": "scripts/harness-janitor.test.ts",
-      "source_location": "L23"
-    },
-    {
-      "community": 139,
-      "file_type": "code",
-      "id": "scripts_harness_janitor_test_ts",
-      "label": "harness-janitor.test.ts",
-      "norm_label": "harness-janitor.test.ts",
-      "source_file": "scripts/harness-janitor.test.ts",
+      "id": "scripts_harness_behavior_fixtures_storefront_runtime_api_ts",
+      "label": "storefront-runtime-api.ts",
+      "norm_label": "storefront-runtime-api.ts",
+      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 139,
+      "file_type": "code",
+      "id": "storefront_runtime_api_emitsignal",
+      "label": "emitSignal()",
+      "norm_label": "emitsignal()",
+      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
+      "source_location": "L210"
+    },
+    {
+      "community": 139,
+      "file_type": "code",
+      "id": "storefront_runtime_api_handlecheckoutsessionfetch",
+      "label": "handleCheckoutSessionFetch()",
+      "norm_label": "handlecheckoutsessionfetch()",
+      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
+      "source_location": "L214"
+    },
+    {
+      "community": 139,
+      "file_type": "code",
+      "id": "storefront_runtime_api_handlecheckoutsessionupdate",
+      "label": "handleCheckoutSessionUpdate()",
+      "norm_label": "handlecheckoutsessionupdate()",
+      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
+      "source_location": "L236"
+    },
+    {
+      "community": 139,
+      "file_type": "code",
+      "id": "storefront_runtime_api_jsonresponse",
+      "label": "jsonResponse()",
+      "norm_label": "jsonresponse()",
+      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
+      "source_location": "L201"
+    },
+    {
+      "community": 139,
+      "file_type": "code",
+      "id": "storefront_runtime_api_shutdown",
+      "label": "shutdown()",
+      "norm_label": "shutdown()",
+      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
+      "source_location": "L421"
+    },
+    {
+      "community": 139,
+      "file_type": "code",
+      "id": "storefront_runtime_api_withcorsheaders",
+      "label": "withCorsHeaders()",
+      "norm_label": "withcorsheaders()",
+      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
+      "source_location": "L186"
     },
     {
       "community": 1390,
@@ -62175,64 +62187,64 @@
     {
       "community": 140,
       "file_type": "code",
-      "id": "harness_review_test_createfixturerepo",
-      "label": "createFixtureRepo()",
-      "norm_label": "createfixturerepo()",
-      "source_file": "scripts/harness-review.test.ts",
+      "id": "harness_janitor_test_createfixtureroot",
+      "label": "createFixtureRoot()",
+      "norm_label": "createfixtureroot()",
+      "source_file": "scripts/harness-janitor.test.ts",
+      "source_location": "L29"
+    },
+    {
+      "community": 140,
+      "file_type": "code",
+      "id": "harness_janitor_test_overwritefreshgenerateddocs",
+      "label": "overwriteFreshGeneratedDocs()",
+      "norm_label": "overwritefreshgenerateddocs()",
+      "source_file": "scripts/harness-janitor.test.ts",
+      "source_location": "L46"
+    },
+    {
+      "community": 140,
+      "file_type": "code",
+      "id": "harness_janitor_test_overwritefreshgraphifyartifacts",
+      "label": "overwriteFreshGraphifyArtifacts()",
+      "norm_label": "overwritefreshgraphifyartifacts()",
+      "source_file": "scripts/harness-janitor.test.ts",
+      "source_location": "L54"
+    },
+    {
+      "community": 140,
+      "file_type": "code",
+      "id": "harness_janitor_test_seedartifacts",
+      "label": "seedArtifacts()",
+      "norm_label": "seedartifacts()",
+      "source_file": "scripts/harness-janitor.test.ts",
+      "source_location": "L35"
+    },
+    {
+      "community": 140,
+      "file_type": "code",
+      "id": "harness_janitor_test_sortpaths",
+      "label": "sortPaths()",
+      "norm_label": "sortpaths()",
+      "source_file": "scripts/harness-janitor.test.ts",
+      "source_location": "L61"
+    },
+    {
+      "community": 140,
+      "file_type": "code",
+      "id": "harness_janitor_test_write",
+      "label": "write()",
+      "norm_label": "write()",
+      "source_file": "scripts/harness-janitor.test.ts",
       "source_location": "L23"
     },
     {
       "community": 140,
       "file_type": "code",
-      "id": "harness_review_test_error",
-      "label": "error()",
-      "norm_label": "error()",
-      "source_file": "scripts/harness-review.test.ts",
-      "source_location": "L291"
-    },
-    {
-      "community": 140,
-      "file_type": "code",
-      "id": "harness_review_test_initializegithistory",
-      "label": "initializeGitHistory()",
-      "norm_label": "initializegithistory()",
-      "source_file": "scripts/harness-review.test.ts",
-      "source_location": "L260"
-    },
-    {
-      "community": 140,
-      "file_type": "code",
-      "id": "harness_review_test_log",
-      "label": "log()",
-      "norm_label": "log()",
-      "source_file": "scripts/harness-review.test.ts",
-      "source_location": "L290"
-    },
-    {
-      "community": 140,
-      "file_type": "code",
-      "id": "harness_review_test_rungit",
-      "label": "runGit()",
-      "norm_label": "rungit()",
-      "source_file": "scripts/harness-review.test.ts",
-      "source_location": "L246"
-    },
-    {
-      "community": 140,
-      "file_type": "code",
-      "id": "harness_review_test_write",
-      "label": "write()",
-      "norm_label": "write()",
-      "source_file": "scripts/harness-review.test.ts",
-      "source_location": "L17"
-    },
-    {
-      "community": 140,
-      "file_type": "code",
-      "id": "scripts_harness_review_test_ts",
-      "label": "harness-review.test.ts",
-      "norm_label": "harness-review.test.ts",
-      "source_file": "scripts/harness-review.test.ts",
+      "id": "scripts_harness_janitor_test_ts",
+      "label": "harness-janitor.test.ts",
+      "norm_label": "harness-janitor.test.ts",
+      "source_file": "scripts/harness-janitor.test.ts",
       "source_location": "L1"
     },
     {
@@ -62328,55 +62340,64 @@
     {
       "community": 141,
       "file_type": "code",
-      "id": "index_valkeyclient",
-      "label": "ValkeyClient",
-      "norm_label": "valkeyclient",
-      "source_file": "packages/athena-webapp/convex/cache/index.ts",
-      "source_location": "L4"
+      "id": "harness_review_test_createfixturerepo",
+      "label": "createFixtureRepo()",
+      "norm_label": "createfixturerepo()",
+      "source_file": "scripts/harness-review.test.ts",
+      "source_location": "L23"
     },
     {
       "community": 141,
       "file_type": "code",
-      "id": "index_valkeyclient_constructor",
-      "label": ".constructor()",
-      "norm_label": ".constructor()",
-      "source_file": "packages/athena-webapp/convex/cache/index.ts",
-      "source_location": "L11"
+      "id": "harness_review_test_error",
+      "label": "error()",
+      "norm_label": "error()",
+      "source_file": "scripts/harness-review.test.ts",
+      "source_location": "L291"
     },
     {
       "community": 141,
       "file_type": "code",
-      "id": "index_valkeyclient_get",
-      "label": ".get()",
-      "norm_label": ".get()",
-      "source_file": "packages/athena-webapp/convex/cache/index.ts",
-      "source_location": "L20"
+      "id": "harness_review_test_initializegithistory",
+      "label": "initializeGitHistory()",
+      "norm_label": "initializegithistory()",
+      "source_file": "scripts/harness-review.test.ts",
+      "source_location": "L260"
     },
     {
       "community": 141,
       "file_type": "code",
-      "id": "index_valkeyclient_invalidate",
-      "label": ".invalidate()",
-      "norm_label": ".invalidate()",
-      "source_file": "packages/athena-webapp/convex/cache/index.ts",
-      "source_location": "L75"
+      "id": "harness_review_test_log",
+      "label": "log()",
+      "norm_label": "log()",
+      "source_file": "scripts/harness-review.test.ts",
+      "source_location": "L290"
     },
     {
       "community": 141,
       "file_type": "code",
-      "id": "index_valkeyclient_set",
-      "label": ".set()",
-      "norm_label": ".set()",
-      "source_file": "packages/athena-webapp/convex/cache/index.ts",
-      "source_location": "L48"
+      "id": "harness_review_test_rungit",
+      "label": "runGit()",
+      "norm_label": "rungit()",
+      "source_file": "scripts/harness-review.test.ts",
+      "source_location": "L246"
     },
     {
       "community": 141,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_cache_index_ts",
-      "label": "index.ts",
-      "norm_label": "index.ts",
-      "source_file": "packages/athena-webapp/convex/cache/index.ts",
+      "id": "harness_review_test_write",
+      "label": "write()",
+      "norm_label": "write()",
+      "source_file": "scripts/harness-review.test.ts",
+      "source_location": "L17"
+    },
+    {
+      "community": 141,
+      "file_type": "code",
+      "id": "scripts_harness_review_test_ts",
+      "label": "harness-review.test.ts",
+      "norm_label": "harness-review.test.ts",
+      "source_file": "scripts/harness-review.test.ts",
       "source_location": "L1"
     },
     {
@@ -62472,56 +62493,56 @@
     {
       "community": 142,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_security_ts",
-      "label": "security.ts",
-      "norm_label": "security.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/security.ts",
+      "id": "index_valkeyclient",
+      "label": "ValkeyClient",
+      "norm_label": "valkeyclient",
+      "source_file": "packages/athena-webapp/convex/cache/index.ts",
+      "source_location": "L4"
+    },
+    {
+      "community": 142,
+      "file_type": "code",
+      "id": "index_valkeyclient_constructor",
+      "label": ".constructor()",
+      "norm_label": ".constructor()",
+      "source_file": "packages/athena-webapp/convex/cache/index.ts",
+      "source_location": "L11"
+    },
+    {
+      "community": 142,
+      "file_type": "code",
+      "id": "index_valkeyclient_get",
+      "label": ".get()",
+      "norm_label": ".get()",
+      "source_file": "packages/athena-webapp/convex/cache/index.ts",
+      "source_location": "L20"
+    },
+    {
+      "community": 142,
+      "file_type": "code",
+      "id": "index_valkeyclient_invalidate",
+      "label": ".invalidate()",
+      "norm_label": ".invalidate()",
+      "source_file": "packages/athena-webapp/convex/cache/index.ts",
+      "source_location": "L75"
+    },
+    {
+      "community": 142,
+      "file_type": "code",
+      "id": "index_valkeyclient_set",
+      "label": ".set()",
+      "norm_label": ".set()",
+      "source_file": "packages/athena-webapp/convex/cache/index.ts",
+      "source_location": "L48"
+    },
+    {
+      "community": 142,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_cache_index_ts",
+      "label": "index.ts",
+      "norm_label": "index.ts",
+      "source_file": "packages/athena-webapp/convex/cache/index.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 142,
-      "file_type": "code",
-      "id": "security_buildcanonicalcheckoutproducts",
-      "label": "buildCanonicalCheckoutProducts()",
-      "norm_label": "buildcanonicalcheckoutproducts()",
-      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/security.ts",
-      "source_location": "L42"
-    },
-    {
-      "community": 142,
-      "file_type": "code",
-      "id": "security_hasvalidpositivequantity",
-      "label": "hasValidPositiveQuantity()",
-      "norm_label": "hasvalidpositivequantity()",
-      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/security.ts",
-      "source_location": "L27"
-    },
-    {
-      "community": 142,
-      "file_type": "code",
-      "id": "security_isamounttampered",
-      "label": "isAmountTampered()",
-      "norm_label": "isamounttampered()",
-      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/security.ts",
-      "source_location": "L65"
-    },
-    {
-      "community": 142,
-      "file_type": "code",
-      "id": "security_isauthorizedresourceowner",
-      "label": "isAuthorizedResourceOwner()",
-      "norm_label": "isauthorizedresourceowner()",
-      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/security.ts",
-      "source_location": "L31"
-    },
-    {
-      "community": 142,
-      "file_type": "code",
-      "id": "security_isduplicatechargesuccess",
-      "label": "isDuplicateChargeSuccess()",
-      "norm_label": "isduplicatechargesuccess()",
-      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/security.ts",
-      "source_location": "L76"
     },
     {
       "community": 1420,
@@ -62616,56 +62637,56 @@
     {
       "community": 143,
       "file_type": "code",
-      "id": "listregistercatalog_listregistercatalog",
-      "label": "listRegisterCatalog()",
-      "norm_label": "listregistercatalog()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/listRegisterCatalog.ts",
-      "source_location": "L95"
-    },
-    {
-      "community": 143,
-      "file_type": "code",
-      "id": "listregistercatalog_listregistercatalogavailability",
-      "label": "listRegisterCatalogAvailability()",
-      "norm_label": "listregistercatalogavailability()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/listRegisterCatalog.ts",
-      "source_location": "L137"
-    },
-    {
-      "community": 143,
-      "file_type": "code",
-      "id": "listregistercatalog_mapskutoregistercatalogrow",
-      "label": "mapSkuToRegisterCatalogRow()",
-      "norm_label": "mapskutoregistercatalogrow()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/listRegisterCatalog.ts",
-      "source_location": "L70"
-    },
-    {
-      "community": 143,
-      "file_type": "code",
-      "id": "listregistercatalog_readcategoryname",
-      "label": "readCategoryName()",
-      "norm_label": "readcategoryname()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/listRegisterCatalog.ts",
-      "source_location": "L32"
-    },
-    {
-      "community": 143,
-      "file_type": "code",
-      "id": "listregistercatalog_readcolorname",
-      "label": "readColorName()",
-      "norm_label": "readcolorname()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/listRegisterCatalog.ts",
-      "source_location": "L49"
-    },
-    {
-      "community": 143,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_queries_listregistercatalog_ts",
-      "label": "listRegisterCatalog.ts",
-      "norm_label": "listregistercatalog.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/listRegisterCatalog.ts",
+      "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_security_ts",
+      "label": "security.ts",
+      "norm_label": "security.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/security.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 143,
+      "file_type": "code",
+      "id": "security_buildcanonicalcheckoutproducts",
+      "label": "buildCanonicalCheckoutProducts()",
+      "norm_label": "buildcanonicalcheckoutproducts()",
+      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/security.ts",
+      "source_location": "L42"
+    },
+    {
+      "community": 143,
+      "file_type": "code",
+      "id": "security_hasvalidpositivequantity",
+      "label": "hasValidPositiveQuantity()",
+      "norm_label": "hasvalidpositivequantity()",
+      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/security.ts",
+      "source_location": "L27"
+    },
+    {
+      "community": 143,
+      "file_type": "code",
+      "id": "security_isamounttampered",
+      "label": "isAmountTampered()",
+      "norm_label": "isamounttampered()",
+      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/security.ts",
+      "source_location": "L65"
+    },
+    {
+      "community": 143,
+      "file_type": "code",
+      "id": "security_isauthorizedresourceowner",
+      "label": "isAuthorizedResourceOwner()",
+      "norm_label": "isauthorizedresourceowner()",
+      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/security.ts",
+      "source_location": "L31"
+    },
+    {
+      "community": 143,
+      "file_type": "code",
+      "id": "security_isduplicatechargesuccess",
+      "label": "isDuplicateChargeSuccess()",
+      "norm_label": "isduplicatechargesuccess()",
+      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/security.ts",
+      "source_location": "L76"
     },
     {
       "community": 1430,
@@ -62760,55 +62781,55 @@
     {
       "community": 144,
       "file_type": "code",
-      "id": "orderemailservice_buildorderstatusmessage",
-      "label": "buildOrderStatusMessage()",
-      "norm_label": "buildorderstatusmessage()",
-      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
+      "id": "listregistercatalog_listregistercatalog",
+      "label": "listRegisterCatalog()",
+      "norm_label": "listregistercatalog()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/listRegisterCatalog.ts",
+      "source_location": "L95"
+    },
+    {
+      "community": 144,
+      "file_type": "code",
+      "id": "listregistercatalog_listregistercatalogavailability",
+      "label": "listRegisterCatalogAvailability()",
+      "norm_label": "listregistercatalogavailability()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/listRegisterCatalog.ts",
+      "source_location": "L137"
+    },
+    {
+      "community": 144,
+      "file_type": "code",
+      "id": "listregistercatalog_mapskutoregistercatalogrow",
+      "label": "mapSkuToRegisterCatalogRow()",
+      "norm_label": "mapskutoregistercatalogrow()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/listRegisterCatalog.ts",
+      "source_location": "L70"
+    },
+    {
+      "community": 144,
+      "file_type": "code",
+      "id": "listregistercatalog_readcategoryname",
+      "label": "readCategoryName()",
+      "norm_label": "readcategoryname()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/listRegisterCatalog.ts",
+      "source_location": "L32"
+    },
+    {
+      "community": 144,
+      "file_type": "code",
+      "id": "listregistercatalog_readcolorname",
+      "label": "readColorName()",
+      "norm_label": "readcolorname()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/listRegisterCatalog.ts",
       "source_location": "L49"
     },
     {
       "community": 144,
       "file_type": "code",
-      "id": "orderemailservice_buildpickupdetails",
-      "label": "buildPickupDetails()",
-      "norm_label": "buildpickupdetails()",
-      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
-      "source_location": "L77"
-    },
-    {
-      "community": 144,
-      "file_type": "code",
-      "id": "orderemailservice_sendpaymentverificationemails",
-      "label": "sendPaymentVerificationEmails()",
-      "norm_label": "sendpaymentverificationemails()",
-      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
-      "source_location": "L217"
-    },
-    {
-      "community": 144,
-      "file_type": "code",
-      "id": "orderemailservice_sendpodorderemails",
-      "label": "sendPODOrderEmails()",
-      "norm_label": "sendpodorderemails()",
-      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
-      "source_location": "L96"
-    },
-    {
-      "community": 144,
-      "file_type": "code",
-      "id": "orderemailservice_shouldsendtoadmins",
-      "label": "shouldSendToAdmins()",
-      "norm_label": "shouldsendtoadmins()",
-      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
-      "source_location": "L42"
-    },
-    {
-      "community": 144,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_services_orderemailservice_ts",
-      "label": "orderEmailService.ts",
-      "norm_label": "orderemailservice.ts",
-      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
+      "id": "packages_athena_webapp_convex_pos_application_queries_listregistercatalog_ts",
+      "label": "listRegisterCatalog.ts",
+      "norm_label": "listregistercatalog.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/listRegisterCatalog.ts",
       "source_location": "L1"
     },
     {
@@ -62904,56 +62925,56 @@
     {
       "community": 145,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_stockops_vendors_ts",
-      "label": "vendors.ts",
-      "norm_label": "vendors.ts",
-      "source_file": "packages/athena-webapp/convex/stockOps/vendors.ts",
+      "id": "orderemailservice_buildorderstatusmessage",
+      "label": "buildOrderStatusMessage()",
+      "norm_label": "buildorderstatusmessage()",
+      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
+      "source_location": "L49"
+    },
+    {
+      "community": 145,
+      "file_type": "code",
+      "id": "orderemailservice_buildpickupdetails",
+      "label": "buildPickupDetails()",
+      "norm_label": "buildpickupdetails()",
+      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
+      "source_location": "L77"
+    },
+    {
+      "community": 145,
+      "file_type": "code",
+      "id": "orderemailservice_sendpaymentverificationemails",
+      "label": "sendPaymentVerificationEmails()",
+      "norm_label": "sendpaymentverificationemails()",
+      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
+      "source_location": "L217"
+    },
+    {
+      "community": 145,
+      "file_type": "code",
+      "id": "orderemailservice_sendpodorderemails",
+      "label": "sendPODOrderEmails()",
+      "norm_label": "sendpodorderemails()",
+      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
+      "source_location": "L96"
+    },
+    {
+      "community": 145,
+      "file_type": "code",
+      "id": "orderemailservice_shouldsendtoadmins",
+      "label": "shouldSendToAdmins()",
+      "norm_label": "shouldsendtoadmins()",
+      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
+      "source_location": "L42"
+    },
+    {
+      "community": 145,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_services_orderemailservice_ts",
+      "label": "orderEmailService.ts",
+      "norm_label": "orderemailservice.ts",
+      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 145,
-      "file_type": "code",
-      "id": "vendors_createvendorcommandwithctx",
-      "label": "createVendorCommandWithCtx()",
-      "norm_label": "createvendorcommandwithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/vendors.ts",
-      "source_location": "L118"
-    },
-    {
-      "community": 145,
-      "file_type": "code",
-      "id": "vendors_createvendorwithctx",
-      "label": "createVendorWithCtx()",
-      "norm_label": "createvendorwithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/vendors.ts",
-      "source_location": "L74"
-    },
-    {
-      "community": 145,
-      "file_type": "code",
-      "id": "vendors_mapcreatevendorerror",
-      "label": "mapCreateVendorError()",
-      "norm_label": "mapcreatevendorerror()",
-      "source_file": "packages/athena-webapp/convex/stockOps/vendors.ts",
-      "source_location": "L45"
-    },
-    {
-      "community": 145,
-      "file_type": "code",
-      "id": "vendors_normalizevendorlookupkey",
-      "label": "normalizeVendorLookupKey()",
-      "norm_label": "normalizevendorlookupkey()",
-      "source_file": "packages/athena-webapp/convex/stockOps/vendors.ts",
-      "source_location": "L37"
-    },
-    {
-      "community": 145,
-      "file_type": "code",
-      "id": "vendors_trimoptional",
-      "label": "trimOptional()",
-      "norm_label": "trimoptional()",
-      "source_file": "packages/athena-webapp/convex/stockOps/vendors.ts",
-      "source_location": "L32"
     },
     {
       "community": 1450,
@@ -63048,56 +63069,56 @@
     {
       "community": 146,
       "file_type": "code",
-      "id": "analytics_extractpromocodeid",
-      "label": "extractPromoCodeId()",
-      "norm_label": "extractpromocodeid()",
-      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
-      "source_location": "L25"
-    },
-    {
-      "community": 146,
-      "file_type": "code",
-      "id": "analytics_getanalyticsbystoreandactionquery",
-      "label": "getAnalyticsByStoreAndActionQuery()",
-      "norm_label": "getanalyticsbystoreandactionquery()",
-      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
-      "source_location": "L130"
-    },
-    {
-      "community": 146,
-      "file_type": "code",
-      "id": "analytics_getanalyticsbystorequery",
-      "label": "getAnalyticsByStoreQuery()",
-      "norm_label": "getanalyticsbystorequery()",
-      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
-      "source_location": "L35"
-    },
-    {
-      "community": 146,
-      "file_type": "code",
-      "id": "analytics_getcompletedordersquery",
-      "label": "getCompletedOrdersQuery()",
-      "norm_label": "getcompletedordersquery()",
-      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
-      "source_location": "L83"
-    },
-    {
-      "community": 146,
-      "file_type": "code",
-      "id": "analytics_getskumapforproducts",
-      "label": "getSkuMapForProducts()",
-      "norm_label": "getskumapforproducts()",
-      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
-      "source_location": "L188"
-    },
-    {
-      "community": 146,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_analytics_ts",
-      "label": "analytics.ts",
-      "norm_label": "analytics.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
+      "id": "packages_athena_webapp_convex_stockops_vendors_ts",
+      "label": "vendors.ts",
+      "norm_label": "vendors.ts",
+      "source_file": "packages/athena-webapp/convex/stockOps/vendors.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 146,
+      "file_type": "code",
+      "id": "vendors_createvendorcommandwithctx",
+      "label": "createVendorCommandWithCtx()",
+      "norm_label": "createvendorcommandwithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/vendors.ts",
+      "source_location": "L118"
+    },
+    {
+      "community": 146,
+      "file_type": "code",
+      "id": "vendors_createvendorwithctx",
+      "label": "createVendorWithCtx()",
+      "norm_label": "createvendorwithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/vendors.ts",
+      "source_location": "L74"
+    },
+    {
+      "community": 146,
+      "file_type": "code",
+      "id": "vendors_mapcreatevendorerror",
+      "label": "mapCreateVendorError()",
+      "norm_label": "mapcreatevendorerror()",
+      "source_file": "packages/athena-webapp/convex/stockOps/vendors.ts",
+      "source_location": "L45"
+    },
+    {
+      "community": 146,
+      "file_type": "code",
+      "id": "vendors_normalizevendorlookupkey",
+      "label": "normalizeVendorLookupKey()",
+      "norm_label": "normalizevendorlookupkey()",
+      "source_file": "packages/athena-webapp/convex/stockOps/vendors.ts",
+      "source_location": "L37"
+    },
+    {
+      "community": 146,
+      "file_type": "code",
+      "id": "vendors_trimoptional",
+      "label": "trimOptional()",
+      "norm_label": "trimoptional()",
+      "source_file": "packages/athena-webapp/convex/stockOps/vendors.ts",
+      "source_location": "L32"
     },
     {
       "community": 1460,
@@ -63966,56 +63987,56 @@
     {
       "community": 151,
       "file_type": "code",
-      "id": "inputotp_formatrequestdelay",
-      "label": "formatRequestDelay()",
-      "norm_label": "formatrequestdelay()",
-      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
-      "source_location": "L46"
-    },
-    {
-      "community": 151,
-      "file_type": "code",
-      "id": "inputotp_handlepinchange",
-      "label": "handlePinChange()",
-      "norm_label": "handlepinchange()",
-      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
-      "source_location": "L95"
-    },
-    {
-      "community": 151,
-      "file_type": "code",
-      "id": "inputotp_handlerequestnewcode",
-      "label": "handleRequestNewCode()",
-      "norm_label": "handlerequestnewcode()",
-      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
-      "source_location": "L143"
-    },
-    {
-      "community": 151,
-      "file_type": "code",
-      "id": "inputotp_normalizeotpcode",
-      "label": "normalizeOtpCode()",
-      "norm_label": "normalizeotpcode()",
-      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
-      "source_location": "L30"
-    },
-    {
-      "community": 151,
-      "file_type": "code",
-      "id": "inputotp_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
-      "source_location": "L105"
-    },
-    {
-      "community": 151,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_auth_login_inputotp_tsx",
-      "label": "InputOTP.tsx",
-      "norm_label": "inputotp.tsx",
-      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
+      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_selectable_data_provider_tsx",
+      "label": "selectable-data-provider.tsx",
+      "norm_label": "selectable-data-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/selectable-data-provider.tsx",
       "source_location": "L1"
+    },
+    {
+      "community": 151,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_base_selectable_products_table_selectable_data_provider_tsx",
+      "label": "selectable-data-provider.tsx",
+      "norm_label": "selectable-data-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/selectable-data-provider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 151,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_selectable_data_provider_tsx",
+      "label": "selectable-data-provider.tsx",
+      "norm_label": "selectable-data-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/selectable-data-provider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 151,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_selectable_data_provider_tsx",
+      "label": "selectable-data-provider.tsx",
+      "norm_label": "selectable-data-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/selectable-data-provider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 151,
+      "file_type": "code",
+      "id": "selectable_data_provider_selectedproductsprovider",
+      "label": "SelectedProductsProvider()",
+      "norm_label": "selectedproductsprovider()",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/selectable-data-provider.tsx",
+      "source_location": "L16"
+    },
+    {
+      "community": 151,
+      "file_type": "code",
+      "id": "selectable_data_provider_useselectedproducts",
+      "label": "useSelectedProducts()",
+      "norm_label": "useselectedproducts()",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/selectable-data-provider.tsx",
+      "source_location": "L37"
     },
     {
       "community": 1510,
@@ -64110,56 +64131,56 @@
     {
       "community": 152,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_selectable_data_provider_tsx",
-      "label": "selectable-data-provider.tsx",
-      "norm_label": "selectable-data-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/selectable-data-provider.tsx",
+      "id": "inputotp_formatrequestdelay",
+      "label": "formatRequestDelay()",
+      "norm_label": "formatrequestdelay()",
+      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
+      "source_location": "L46"
+    },
+    {
+      "community": 152,
+      "file_type": "code",
+      "id": "inputotp_handlepinchange",
+      "label": "handlePinChange()",
+      "norm_label": "handlepinchange()",
+      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
+      "source_location": "L95"
+    },
+    {
+      "community": 152,
+      "file_type": "code",
+      "id": "inputotp_handlerequestnewcode",
+      "label": "handleRequestNewCode()",
+      "norm_label": "handlerequestnewcode()",
+      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
+      "source_location": "L143"
+    },
+    {
+      "community": 152,
+      "file_type": "code",
+      "id": "inputotp_normalizeotpcode",
+      "label": "normalizeOtpCode()",
+      "norm_label": "normalizeotpcode()",
+      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
+      "source_location": "L30"
+    },
+    {
+      "community": 152,
+      "file_type": "code",
+      "id": "inputotp_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
+      "source_location": "L105"
+    },
+    {
+      "community": 152,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_auth_login_inputotp_tsx",
+      "label": "InputOTP.tsx",
+      "norm_label": "inputotp.tsx",
+      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 152,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_base_selectable_products_table_selectable_data_provider_tsx",
-      "label": "selectable-data-provider.tsx",
-      "norm_label": "selectable-data-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/selectable-data-provider.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 152,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_selectable_data_provider_tsx",
-      "label": "selectable-data-provider.tsx",
-      "norm_label": "selectable-data-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/selectable-data-provider.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 152,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_selectable_data_provider_tsx",
-      "label": "selectable-data-provider.tsx",
-      "norm_label": "selectable-data-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/selectable-data-provider.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 152,
-      "file_type": "code",
-      "id": "selectable_data_provider_selectedproductsprovider",
-      "label": "SelectedProductsProvider()",
-      "norm_label": "selectedproductsprovider()",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/selectable-data-provider.tsx",
-      "source_location": "L16"
-    },
-    {
-      "community": 152,
-      "file_type": "code",
-      "id": "selectable_data_provider_useselectedproducts",
-      "label": "useSelectedProducts()",
-      "norm_label": "useselectedproducts()",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/selectable-data-provider.tsx",
-      "source_location": "L37"
     },
     {
       "community": 1520,
@@ -64758,60 +64779,6 @@
     {
       "community": 158,
       "file_type": "code",
-      "id": "image_uploader_ondragend",
-      "label": "onDragEnd()",
-      "norm_label": "ondragend()",
-      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L100"
-    },
-    {
-      "community": 158,
-      "file_type": "code",
-      "id": "image_uploader_ondrop",
-      "label": "onDrop()",
-      "norm_label": "ondrop()",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L20"
-    },
-    {
-      "community": 158,
-      "file_type": "code",
-      "id": "image_uploader_removeimage",
-      "label": "removeImage()",
-      "norm_label": "removeimage()",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L31"
-    },
-    {
-      "community": 158,
-      "file_type": "code",
-      "id": "image_uploader_unmarkfordeletion",
-      "label": "unmarkForDeletion()",
-      "norm_label": "unmarkfordeletion()",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L46"
-    },
-    {
-      "community": 158,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_image_uploader_tsx",
-      "label": "image-uploader.tsx",
-      "norm_label": "image-uploader.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 158,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_image_uploader_tsx",
-      "label": "image-uploader.tsx",
-      "norm_label": "image-uploader.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 159,
-      "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_sidebar_tsx",
       "label": "sidebar.tsx",
       "norm_label": "sidebar.tsx",
@@ -64819,7 +64786,7 @@
       "source_location": "L1"
     },
     {
-      "community": 159,
+      "community": 158,
       "file_type": "code",
       "id": "sidebar_cn",
       "label": "cn()",
@@ -64828,7 +64795,7 @@
       "source_location": "L147"
     },
     {
-      "community": 159,
+      "community": 158,
       "file_type": "code",
       "id": "sidebar_handlekeydown",
       "label": "handleKeyDown()",
@@ -64837,7 +64804,7 @@
       "source_location": "L105"
     },
     {
-      "community": 159,
+      "community": 158,
       "file_type": "code",
       "id": "sidebar_handleonhover",
       "label": "handleOnHover()",
@@ -64846,7 +64813,7 @@
       "source_location": "L224"
     },
     {
-      "community": 159,
+      "community": 158,
       "file_type": "code",
       "id": "sidebar_handleonmouseleave",
       "label": "handleOnMouseLeave()",
@@ -64855,13 +64822,67 @@
       "source_location": "L228"
     },
     {
-      "community": 159,
+      "community": 158,
       "file_type": "code",
       "id": "sidebar_usesidebar",
       "label": "useSidebar()",
       "norm_label": "usesidebar()",
       "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
       "source_location": "L45"
+    },
+    {
+      "community": 159,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_usebulkoperations_ts",
+      "label": "useBulkOperations.ts",
+      "norm_label": "usebulkoperations.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 159,
+      "file_type": "code",
+      "id": "usebulkoperations_applyoperation",
+      "label": "applyOperation()",
+      "norm_label": "applyoperation()",
+      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
+      "source_location": "L56"
+    },
+    {
+      "community": 159,
+      "file_type": "code",
+      "id": "usebulkoperations_calculatepricewithfee",
+      "label": "calculatePriceWithFee()",
+      "norm_label": "calculatepricewithfee()",
+      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
+      "source_location": "L87"
+    },
+    {
+      "community": 159,
+      "file_type": "code",
+      "id": "usebulkoperations_computepreview",
+      "label": "computePreview()",
+      "norm_label": "computepreview()",
+      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
+      "source_location": "L101"
+    },
+    {
+      "community": 159,
+      "file_type": "code",
+      "id": "usebulkoperations_usebulkoperations",
+      "label": "useBulkOperations()",
+      "norm_label": "usebulkoperations()",
+      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
+      "source_location": "L158"
+    },
+    {
+      "community": 159,
+      "file_type": "code",
+      "id": "usebulkoperations_validateoperationvalue",
+      "label": "validateOperationValue()",
+      "norm_label": "validateoperationvalue()",
+      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
+      "source_location": "L139"
     },
     {
       "community": 16,
@@ -65064,60 +65085,6 @@
     {
       "community": 160,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_usebulkoperations_ts",
-      "label": "useBulkOperations.ts",
-      "norm_label": "usebulkoperations.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 160,
-      "file_type": "code",
-      "id": "usebulkoperations_applyoperation",
-      "label": "applyOperation()",
-      "norm_label": "applyoperation()",
-      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
-      "source_location": "L56"
-    },
-    {
-      "community": 160,
-      "file_type": "code",
-      "id": "usebulkoperations_calculatepricewithfee",
-      "label": "calculatePriceWithFee()",
-      "norm_label": "calculatepricewithfee()",
-      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
-      "source_location": "L87"
-    },
-    {
-      "community": 160,
-      "file_type": "code",
-      "id": "usebulkoperations_computepreview",
-      "label": "computePreview()",
-      "norm_label": "computepreview()",
-      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
-      "source_location": "L101"
-    },
-    {
-      "community": 160,
-      "file_type": "code",
-      "id": "usebulkoperations_usebulkoperations",
-      "label": "useBulkOperations()",
-      "norm_label": "usebulkoperations()",
-      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
-      "source_location": "L158"
-    },
-    {
-      "community": 160,
-      "file_type": "code",
-      "id": "usebulkoperations_validateoperationvalue",
-      "label": "validateOperationValue()",
-      "norm_label": "validateoperationvalue()",
-      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
-      "source_location": "L139"
-    },
-    {
-      "community": 161,
-      "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useexpensesessions_ts",
       "label": "useExpenseSessions.ts",
       "norm_label": "useexpensesessions.ts",
@@ -65125,7 +65092,7 @@
       "source_location": "L1"
     },
     {
-      "community": 161,
+      "community": 160,
       "file_type": "code",
       "id": "useexpensesessions_useexpenseactivesession",
       "label": "useExpenseActiveSession()",
@@ -65134,7 +65101,7 @@
       "source_location": "L42"
     },
     {
-      "community": 161,
+      "community": 160,
       "file_type": "code",
       "id": "useexpensesessions_useexpensesession",
       "label": "useExpenseSession()",
@@ -65143,7 +65110,7 @@
       "source_location": "L32"
     },
     {
-      "community": 161,
+      "community": 160,
       "file_type": "code",
       "id": "useexpensesessions_useexpensesessioncreate",
       "label": "useExpenseSessionCreate()",
@@ -65152,7 +65119,7 @@
       "source_location": "L62"
     },
     {
-      "community": 161,
+      "community": 160,
       "file_type": "code",
       "id": "useexpensesessions_useexpensesessionupdate",
       "label": "useExpenseSessionUpdate()",
@@ -65161,7 +65128,7 @@
       "source_location": "L101"
     },
     {
-      "community": 161,
+      "community": 160,
       "file_type": "code",
       "id": "useexpensesessions_useexpensestoresessions",
       "label": "useExpenseStoreSessions()",
@@ -65170,7 +65137,7 @@
       "source_location": "L10"
     },
     {
-      "community": 162,
+      "community": 161,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useposproducts_ts",
       "label": "usePOSProducts.ts",
@@ -65179,7 +65146,7 @@
       "source_location": "L1"
     },
     {
-      "community": 162,
+      "community": 161,
       "file_type": "code",
       "id": "useposproducts_useposbarcodesearch",
       "label": "usePOSBarcodeSearch()",
@@ -65188,7 +65155,7 @@
       "source_location": "L17"
     },
     {
-      "community": 162,
+      "community": 161,
       "file_type": "code",
       "id": "useposproducts_useposproductidsearch",
       "label": "usePOSProductIdSearch()",
@@ -65197,7 +65164,7 @@
       "source_location": "L24"
     },
     {
-      "community": 162,
+      "community": 161,
       "file_type": "code",
       "id": "useposproducts_useposproductsearch",
       "label": "usePOSProductSearch()",
@@ -65206,7 +65173,7 @@
       "source_location": "L10"
     },
     {
-      "community": 162,
+      "community": 161,
       "file_type": "code",
       "id": "useposproducts_useposquickaddproductsku",
       "label": "usePOSQuickAddProductSku()",
@@ -65215,7 +65182,7 @@
       "source_location": "L33"
     },
     {
-      "community": 162,
+      "community": 161,
       "file_type": "code",
       "id": "useposproducts_usepostransactioncomplete",
       "label": "usePOSTransactionComplete()",
@@ -65224,7 +65191,7 @@
       "source_location": "L31"
     },
     {
-      "community": 163,
+      "community": 162,
       "file_type": "code",
       "id": "behaviorutils_calculateengagementmetrics",
       "label": "calculateEngagementMetrics()",
@@ -65233,7 +65200,7 @@
       "source_location": "L173"
     },
     {
-      "community": 163,
+      "community": 162,
       "file_type": "code",
       "id": "behaviorutils_calculateriskindicators",
       "label": "calculateRiskIndicators()",
@@ -65242,7 +65209,7 @@
       "source_location": "L71"
     },
     {
-      "community": 163,
+      "community": 162,
       "file_type": "code",
       "id": "behaviorutils_getactivitypriority",
       "label": "getActivityPriority()",
@@ -65251,7 +65218,7 @@
       "source_location": "L251"
     },
     {
-      "community": 163,
+      "community": 162,
       "file_type": "code",
       "id": "behaviorutils_getcustomerjourneystage",
       "label": "getCustomerJourneyStage()",
@@ -65260,7 +65227,7 @@
       "source_location": "L36"
     },
     {
-      "community": 163,
+      "community": 162,
       "file_type": "code",
       "id": "behaviorutils_getjourneystageinfo",
       "label": "getJourneyStageInfo()",
@@ -65269,7 +65236,7 @@
       "source_location": "L277"
     },
     {
-      "community": 163,
+      "community": 162,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_behaviorutils_ts",
       "label": "behaviorUtils.ts",
@@ -65278,7 +65245,7 @@
       "source_location": "L1"
     },
     {
-      "community": 164,
+      "community": 163,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_results_ts",
       "label": "results.ts",
@@ -65287,7 +65254,7 @@
       "source_location": "L1"
     },
     {
-      "community": 164,
+      "community": 163,
       "file_type": "code",
       "id": "results_isposusecasesuccess",
       "label": "isPosUseCaseSuccess()",
@@ -65296,7 +65263,7 @@
       "source_location": "L122"
     },
     {
-      "community": 164,
+      "community": 163,
       "file_type": "code",
       "id": "results_mapcommandoutcome",
       "label": "mapCommandOutcome()",
@@ -65305,7 +65272,7 @@
       "source_location": "L68"
     },
     {
-      "community": 164,
+      "community": 163,
       "file_type": "code",
       "id": "results_mapcommandresult",
       "label": "mapCommandResult()",
@@ -65314,7 +65281,7 @@
       "source_location": "L85"
     },
     {
-      "community": 164,
+      "community": 163,
       "file_type": "code",
       "id": "results_maplegacymutationresult",
       "label": "mapLegacyMutationResult()",
@@ -65323,7 +65290,7 @@
       "source_location": "L51"
     },
     {
-      "community": 164,
+      "community": 163,
       "file_type": "code",
       "id": "results_mapthrownerror",
       "label": "mapThrownError()",
@@ -65332,7 +65299,7 @@
       "source_location": "L102"
     },
     {
-      "community": 165,
+      "community": 164,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_domain_payments_ts",
       "label": "payments.ts",
@@ -65341,7 +65308,7 @@
       "source_location": "L1"
     },
     {
-      "community": 165,
+      "community": 164,
       "file_type": "code",
       "id": "payments_calculateposchange",
       "label": "calculatePosChange()",
@@ -65350,7 +65317,7 @@
       "source_location": "L3"
     },
     {
-      "community": 165,
+      "community": 164,
       "file_type": "code",
       "id": "payments_calculateposremainingdue",
       "label": "calculatePosRemainingDue()",
@@ -65359,7 +65326,7 @@
       "source_location": "L20"
     },
     {
-      "community": 165,
+      "community": 164,
       "file_type": "code",
       "id": "payments_calculatepostotalpaid",
       "label": "calculatePosTotalPaid()",
@@ -65368,7 +65335,7 @@
       "source_location": "L14"
     },
     {
-      "community": 165,
+      "community": 164,
       "file_type": "code",
       "id": "payments_ispospaymentsufficient",
       "label": "isPosPaymentSufficient()",
@@ -65377,7 +65344,7 @@
       "source_location": "L7"
     },
     {
-      "community": 165,
+      "community": 164,
       "file_type": "code",
       "id": "payments_roundposamount",
       "label": "roundPosAmount()",
@@ -65386,7 +65353,7 @@
       "source_location": "L27"
     },
     {
-      "community": 166,
+      "community": 165,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_presentation_register_selectors_ts",
       "label": "selectors.ts",
@@ -65395,7 +65362,7 @@
       "source_location": "L1"
     },
     {
-      "community": 166,
+      "community": 165,
       "file_type": "code",
       "id": "selectors_buildregisterheaderstate",
       "label": "buildRegisterHeaderState()",
@@ -65404,7 +65371,7 @@
       "source_location": "L28"
     },
     {
-      "community": 166,
+      "community": 165,
       "file_type": "code",
       "id": "selectors_buildregisterinfostate",
       "label": "buildRegisterInfoState()",
@@ -65413,7 +65380,7 @@
       "source_location": "L37"
     },
     {
-      "community": 166,
+      "community": 165,
       "file_type": "code",
       "id": "selectors_getcashierdisplayname",
       "label": "getCashierDisplayName()",
@@ -65422,7 +65389,7 @@
       "source_location": "L12"
     },
     {
-      "community": 166,
+      "community": 165,
       "file_type": "code",
       "id": "selectors_getregistercustomerinfo",
       "label": "getRegisterCustomerInfo()",
@@ -65431,7 +65398,7 @@
       "source_location": "L6"
     },
     {
-      "community": 166,
+      "community": 165,
       "file_type": "code",
       "id": "selectors_isregistersessionactive",
       "label": "isRegisterSessionActive()",
@@ -65440,7 +65407,7 @@
       "source_location": "L49"
     },
     {
-      "community": 167,
+      "community": 166,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_toastservice_ts",
       "label": "toastService.ts",
@@ -65449,7 +65416,7 @@
       "source_location": "L1"
     },
     {
-      "community": 167,
+      "community": 166,
       "file_type": "code",
       "id": "toastservice_handleposoperation",
       "label": "handlePOSOperation()",
@@ -65458,7 +65425,7 @@
       "source_location": "L171"
     },
     {
-      "community": 167,
+      "community": 166,
       "file_type": "code",
       "id": "toastservice_showinventoryerror",
       "label": "showInventoryError()",
@@ -65467,7 +65434,7 @@
       "source_location": "L302"
     },
     {
-      "community": 167,
+      "community": 166,
       "file_type": "code",
       "id": "toastservice_shownoactivesessionerror",
       "label": "showNoActiveSessionError()",
@@ -65476,7 +65443,7 @@
       "source_location": "L319"
     },
     {
-      "community": 167,
+      "community": 166,
       "file_type": "code",
       "id": "toastservice_showsessionexpirederror",
       "label": "showSessionExpiredError()",
@@ -65485,7 +65452,7 @@
       "source_location": "L312"
     },
     {
-      "community": 167,
+      "community": 166,
       "file_type": "code",
       "id": "toastservice_showvalidationerror",
       "label": "showValidationError()",
@@ -65494,7 +65461,7 @@
       "source_location": "L293"
     },
     {
-      "community": 168,
+      "community": 167,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_traces_traceid_tsx",
       "label": "$traceId.tsx",
@@ -65503,7 +65470,7 @@
       "source_location": "L1"
     },
     {
-      "community": 168,
+      "community": 167,
       "file_type": "code",
       "id": "traceid_hasorgnotfoundpayload",
       "label": "hasOrgNotFoundPayload()",
@@ -65512,7 +65479,7 @@
       "source_location": "L12"
     },
     {
-      "community": 168,
+      "community": 167,
       "file_type": "code",
       "id": "traceid_workflowtraceloadingstate",
       "label": "WorkflowTraceLoadingState()",
@@ -65521,7 +65488,7 @@
       "source_location": "L21"
     },
     {
-      "community": 168,
+      "community": 167,
       "file_type": "code",
       "id": "traceid_workflowtraceroute",
       "label": "WorkflowTraceRoute()",
@@ -65530,7 +65497,7 @@
       "source_location": "L101"
     },
     {
-      "community": 168,
+      "community": 167,
       "file_type": "code",
       "id": "traceid_workflowtraceroutecontent",
       "label": "WorkflowTraceRouteContent()",
@@ -65539,7 +65506,7 @@
       "source_location": "L35"
     },
     {
-      "community": 168,
+      "community": 167,
       "file_type": "code",
       "id": "traceid_workflowtracerouteshell",
       "label": "WorkflowTraceRouteShell()",
@@ -65548,7 +65515,7 @@
       "source_location": "L66"
     },
     {
-      "community": 169,
+      "community": 168,
       "file_type": "code",
       "id": "organizationsettingsview_handledeletestore",
       "label": "handleDeleteStore()",
@@ -65557,7 +65524,7 @@
       "source_location": "L155"
     },
     {
-      "community": 169,
+      "community": 168,
       "file_type": "code",
       "id": "organizationsettingsview_navigation",
       "label": "Navigation()",
@@ -65566,7 +65533,7 @@
       "source_location": "L197"
     },
     {
-      "community": 169,
+      "community": 168,
       "file_type": "code",
       "id": "organizationsettingsview_onsubmit",
       "label": "onSubmit()",
@@ -65575,7 +65542,7 @@
       "source_location": "L104"
     },
     {
-      "community": 169,
+      "community": 168,
       "file_type": "code",
       "id": "organizationsettingsview_organizationsettings",
       "label": "OrganizationSettings()",
@@ -65584,7 +65551,7 @@
       "source_location": "L25"
     },
     {
-      "community": 169,
+      "community": 168,
       "file_type": "code",
       "id": "organizationsettingsview_savestorechanges",
       "label": "saveStoreChanges()",
@@ -65593,13 +65560,67 @@
       "source_location": "L72"
     },
     {
-      "community": 169,
+      "community": 168,
       "file_type": "code",
       "id": "packages_athena_webapp_src_settings_organization_components_organizationsettingsview_tsx",
       "label": "OrganizationSettingsView.tsx",
       "norm_label": "organizationsettingsview.tsx",
       "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
       "source_location": "L1"
+    },
+    {
+      "community": 169,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_settings_store_storesettingsview_tsx",
+      "label": "StoreSettingsView.tsx",
+      "norm_label": "storesettingsview.tsx",
+      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 169,
+      "file_type": "code",
+      "id": "storesettingsview_handledeleteallproductsinstore",
+      "label": "handleDeleteAllProductsInStore()",
+      "norm_label": "handledeleteallproductsinstore()",
+      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
+      "source_location": "L231"
+    },
+    {
+      "community": 169,
+      "file_type": "code",
+      "id": "storesettingsview_handledeletestore",
+      "label": "handleDeleteStore()",
+      "norm_label": "handledeletestore()",
+      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
+      "source_location": "L167"
+    },
+    {
+      "community": 169,
+      "file_type": "code",
+      "id": "storesettingsview_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
+      "source_location": "L116"
+    },
+    {
+      "community": 169,
+      "file_type": "code",
+      "id": "storesettingsview_savestorechanges",
+      "label": "saveStoreChanges()",
+      "norm_label": "savestorechanges()",
+      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
+      "source_location": "L83"
+    },
+    {
+      "community": 169,
+      "file_type": "code",
+      "id": "storesettingsview_storesettings",
+      "label": "StoreSettings()",
+      "norm_label": "storesettings()",
+      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
+      "source_location": "L29"
     },
     {
       "community": 17,
@@ -65793,60 +65814,6 @@
     {
       "community": 170,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_settings_store_storesettingsview_tsx",
-      "label": "StoreSettingsView.tsx",
-      "norm_label": "storesettingsview.tsx",
-      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 170,
-      "file_type": "code",
-      "id": "storesettingsview_handledeleteallproductsinstore",
-      "label": "handleDeleteAllProductsInStore()",
-      "norm_label": "handledeleteallproductsinstore()",
-      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
-      "source_location": "L231"
-    },
-    {
-      "community": 170,
-      "file_type": "code",
-      "id": "storesettingsview_handledeletestore",
-      "label": "handleDeleteStore()",
-      "norm_label": "handledeletestore()",
-      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
-      "source_location": "L167"
-    },
-    {
-      "community": 170,
-      "file_type": "code",
-      "id": "storesettingsview_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
-      "source_location": "L116"
-    },
-    {
-      "community": 170,
-      "file_type": "code",
-      "id": "storesettingsview_savestorechanges",
-      "label": "saveStoreChanges()",
-      "norm_label": "savestorechanges()",
-      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
-      "source_location": "L83"
-    },
-    {
-      "community": 170,
-      "file_type": "code",
-      "id": "storesettingsview_storesettings",
-      "label": "StoreSettings()",
-      "norm_label": "storesettings()",
-      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
-      "source_location": "L29"
-    },
-    {
-      "community": 171,
-      "file_type": "code",
       "id": "packages_athena_webapp_src_stories_storybook_shell_tsx",
       "label": "storybook-shell.tsx",
       "norm_label": "storybook-shell.tsx",
@@ -65854,7 +65821,7 @@
       "source_location": "L1"
     },
     {
-      "community": 171,
+      "community": 170,
       "file_type": "code",
       "id": "storybook_shell_storybookcallout",
       "label": "StorybookCallout()",
@@ -65863,7 +65830,7 @@
       "source_location": "L76"
     },
     {
-      "community": 171,
+      "community": 170,
       "file_type": "code",
       "id": "storybook_shell_storybooklist",
       "label": "StorybookList()",
@@ -65872,7 +65839,7 @@
       "source_location": "L55"
     },
     {
-      "community": 171,
+      "community": 170,
       "file_type": "code",
       "id": "storybook_shell_storybookpillrow",
       "label": "StorybookPillRow()",
@@ -65881,7 +65848,7 @@
       "source_location": "L88"
     },
     {
-      "community": 171,
+      "community": 170,
       "file_type": "code",
       "id": "storybook_shell_storybooksection",
       "label": "StorybookSection()",
@@ -65890,7 +65857,7 @@
       "source_location": "L34"
     },
     {
-      "community": 171,
+      "community": 170,
       "file_type": "code",
       "id": "storybook_shell_storybookshell",
       "label": "StorybookShell()",
@@ -65899,7 +65866,7 @@
       "source_location": "L13"
     },
     {
-      "community": 172,
+      "community": 171,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_postransaction_ts",
       "label": "posTransaction.ts",
@@ -65908,7 +65875,7 @@
       "source_location": "L1"
     },
     {
-      "community": 172,
+      "community": 171,
       "file_type": "code",
       "id": "postransaction_fetchpostransaction",
       "label": "fetchPosTransaction()",
@@ -65917,7 +65884,7 @@
       "source_location": "L69"
     },
     {
-      "community": 172,
+      "community": 171,
       "file_type": "code",
       "id": "postransaction_getbaseurl",
       "label": "getBaseUrl()",
@@ -65926,7 +65893,7 @@
       "source_location": "L57"
     },
     {
-      "community": 172,
+      "community": 171,
       "file_type": "code",
       "id": "postransaction_getpostransactionbyreceipttoken",
       "label": "getPosTransactionByReceiptToken()",
@@ -65935,7 +65902,7 @@
       "source_location": "L90"
     },
     {
-      "community": 172,
+      "community": 171,
       "file_type": "code",
       "id": "postransaction_postransactionreceipterror",
       "label": "PosTransactionReceiptError",
@@ -65944,7 +65911,7 @@
       "source_location": "L59"
     },
     {
-      "community": 172,
+      "community": 171,
       "file_type": "code",
       "id": "postransaction_postransactionreceipterror_constructor",
       "label": ".constructor()",
@@ -65953,7 +65920,7 @@
       "source_location": "L62"
     },
     {
-      "community": 173,
+      "community": 172,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_promocodes_ts",
       "label": "promoCodes.ts",
@@ -65962,7 +65929,7 @@
       "source_location": "L1"
     },
     {
-      "community": 173,
+      "community": 172,
       "file_type": "code",
       "id": "promocodes_getbaseurl",
       "label": "getBaseUrl()",
@@ -65971,7 +65938,7 @@
       "source_location": "L4"
     },
     {
-      "community": 173,
+      "community": 172,
       "file_type": "code",
       "id": "promocodes_getpromocodeitems",
       "label": "getPromoCodeItems()",
@@ -65980,7 +65947,7 @@
       "source_location": "L49"
     },
     {
-      "community": 173,
+      "community": 172,
       "file_type": "code",
       "id": "promocodes_getpromocodes",
       "label": "getPromoCodes()",
@@ -65989,7 +65956,7 @@
       "source_location": "L34"
     },
     {
-      "community": 173,
+      "community": 172,
       "file_type": "code",
       "id": "promocodes_getredeemedpromocodes",
       "label": "getRedeemedPromoCodes()",
@@ -65998,7 +65965,7 @@
       "source_location": "L74"
     },
     {
-      "community": 173,
+      "community": 172,
       "file_type": "code",
       "id": "promocodes_redeempromocode",
       "label": "redeemPromoCode()",
@@ -66007,7 +65974,7 @@
       "source_location": "L6"
     },
     {
-      "community": 174,
+      "community": 173,
       "file_type": "code",
       "id": "billingdetails_clearform",
       "label": "clearForm()",
@@ -66016,7 +65983,7 @@
       "source_location": "L173"
     },
     {
-      "community": 174,
+      "community": 173,
       "file_type": "code",
       "id": "billingdetails_enteredbillingaddressdetails",
       "label": "EnteredBillingAddressDetails()",
@@ -66025,7 +65992,7 @@
       "source_location": "L102"
     },
     {
-      "community": 174,
+      "community": 173,
       "file_type": "code",
       "id": "billingdetails_handleusebillingaddressonfile",
       "label": "handleUseBillingAddressOnFile()",
@@ -66034,7 +66001,7 @@
       "source_location": "L201"
     },
     {
-      "community": 174,
+      "community": 173,
       "file_type": "code",
       "id": "billingdetails_onsubmit",
       "label": "onSubmit()",
@@ -66043,7 +66010,7 @@
       "source_location": "L150"
     },
     {
-      "community": 174,
+      "community": 173,
       "file_type": "code",
       "id": "billingdetails_togglesameasdelivery",
       "label": "toggleSameAsDelivery()",
@@ -66052,7 +66019,7 @@
       "source_location": "L155"
     },
     {
-      "community": 174,
+      "community": 173,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_billingdetails_tsx",
       "label": "BillingDetails.tsx",
@@ -66061,7 +66028,7 @@
       "source_location": "L1"
     },
     {
-      "community": 175,
+      "community": 174,
       "file_type": "code",
       "id": "mobileproductactions_collapseonpageclick",
       "label": "collapseOnPageClick()",
@@ -66070,7 +66037,7 @@
       "source_location": "L76"
     },
     {
-      "community": 175,
+      "community": 174,
       "file_type": "code",
       "id": "mobileproductactions_handleconfirm",
       "label": "handleConfirm()",
@@ -66079,7 +66046,7 @@
       "source_location": "L120"
     },
     {
-      "community": 175,
+      "community": 174,
       "file_type": "code",
       "id": "mobileproductactions_handleprimaryaction",
       "label": "handlePrimaryAction()",
@@ -66088,7 +66055,7 @@
       "source_location": "L129"
     },
     {
-      "community": 175,
+      "community": 174,
       "file_type": "code",
       "id": "mobileproductactions_handlesecondaryaction",
       "label": "handleSecondaryAction()",
@@ -66097,7 +66064,7 @@
       "source_location": "L133"
     },
     {
-      "community": 175,
+      "community": 174,
       "file_type": "code",
       "id": "mobileproductactions_updateposition",
       "label": "updatePosition()",
@@ -66106,7 +66073,7 @@
       "source_location": "L44"
     },
     {
-      "community": 175,
+      "community": 174,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_mobileproductactions_tsx",
       "label": "MobileProductActions.tsx",
@@ -66115,7 +66082,7 @@
       "source_location": "L1"
     },
     {
-      "community": 176,
+      "community": 175,
       "file_type": "code",
       "id": "checkoutexpired_checkoutexpired",
       "label": "CheckoutExpired()",
@@ -66124,7 +66091,7 @@
       "source_location": "L9"
     },
     {
-      "community": 176,
+      "community": 175,
       "file_type": "code",
       "id": "checkoutexpired_checkoutsessiongeneric",
       "label": "CheckoutSessionGeneric()",
@@ -66133,7 +66100,7 @@
       "source_location": "L73"
     },
     {
-      "community": 176,
+      "community": 175,
       "file_type": "code",
       "id": "checkoutexpired_checkoutsessionnotfound",
       "label": "CheckoutSessionNotFound()",
@@ -66142,7 +66109,7 @@
       "source_location": "L54"
     },
     {
-      "community": 176,
+      "community": 175,
       "file_type": "code",
       "id": "checkoutexpired_handlesendemail",
       "label": "handleSendEmail()",
@@ -66151,7 +66118,7 @@
       "source_location": "L98"
     },
     {
-      "community": 176,
+      "community": 175,
       "file_type": "code",
       "id": "checkoutexpired_nocheckoutsession",
       "label": "NoCheckoutSession()",
@@ -66160,12 +66127,66 @@
       "source_location": "L33"
     },
     {
-      "community": 176,
+      "community": 175,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_checkout_expired_checkoutexpired_tsx",
       "label": "CheckoutExpired.tsx",
       "norm_label": "checkoutexpired.tsx",
       "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 176,
+      "file_type": "code",
+      "id": "image_uploader_ondragend",
+      "label": "onDragEnd()",
+      "norm_label": "ondragend()",
+      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L100"
+    },
+    {
+      "community": 176,
+      "file_type": "code",
+      "id": "image_uploader_ondrop",
+      "label": "onDrop()",
+      "norm_label": "ondrop()",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L20"
+    },
+    {
+      "community": 176,
+      "file_type": "code",
+      "id": "image_uploader_removeimage",
+      "label": "removeImage()",
+      "norm_label": "removeimage()",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L31"
+    },
+    {
+      "community": 176,
+      "file_type": "code",
+      "id": "image_uploader_unmarkfordeletion",
+      "label": "unmarkForDeletion()",
+      "norm_label": "unmarkfordeletion()",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L46"
+    },
+    {
+      "community": 176,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_image_uploader_tsx",
+      "label": "image-uploader.tsx",
+      "norm_label": "image-uploader.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 176,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_image_uploader_tsx",
+      "label": "image-uploader.tsx",
+      "norm_label": "image-uploader.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
       "source_location": "L1"
     },
     {
@@ -94881,73 +94902,73 @@
     {
       "community": 93,
       "file_type": "code",
-      "id": "config_buildmtncollectionscallbackurl",
-      "label": "buildMtnCollectionsCallbackUrl()",
-      "norm_label": "buildmtncollectionscallbackurl()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
-      "source_location": "L135"
+      "id": "index_senddiscountcodeemail",
+      "label": "sendDiscountCodeEmail()",
+      "norm_label": "senddiscountcodeemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L255"
     },
     {
       "community": 93,
       "file_type": "code",
-      "id": "config_buildmtncollectionslookupprefixes",
-      "label": "buildMtnCollectionsLookupPrefixes()",
-      "norm_label": "buildmtncollectionslookupprefixes()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "id": "index_senddiscountreminderemail",
+      "label": "sendDiscountReminderEmail()",
+      "norm_label": "senddiscountreminderemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L334"
+    },
+    {
+      "community": 93,
+      "file_type": "code",
+      "id": "index_sendfeedbackrequestemail",
+      "label": "sendFeedbackRequestEmail()",
+      "norm_label": "sendfeedbackrequestemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L167"
+    },
+    {
+      "community": 93,
+      "file_type": "code",
+      "id": "index_sendneworderemail",
+      "label": "sendNewOrderEmail()",
+      "norm_label": "sendneworderemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L117"
+    },
+    {
+      "community": 93,
+      "file_type": "code",
+      "id": "index_sendorderemail",
+      "label": "sendOrderEmail()",
+      "norm_label": "sendorderemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
       "source_location": "L43"
     },
     {
       "community": 93,
       "file_type": "code",
-      "id": "config_istargetenvironment",
-      "label": "isTargetEnvironment()",
-      "norm_label": "istargetenvironment()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
-      "source_location": "L67"
+      "id": "index_sendverificationcode",
+      "label": "sendVerificationCode()",
+      "norm_label": "sendverificationcode()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L3"
     },
     {
       "community": 93,
       "file_type": "code",
-      "id": "config_readscopedvalue",
-      "label": "readScopedValue()",
-      "norm_label": "readscopedvalue()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
-      "source_location": "L56"
+      "id": "packages_athena_webapp_convex_mailersend_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/convex/mailersend/index.tsx",
+      "source_location": "L1"
     },
     {
       "community": 93,
       "file_type": "code",
-      "id": "config_resolveconfigforprefix",
-      "label": "resolveConfigForPrefix()",
-      "norm_label": "resolveconfigforprefix()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
-      "source_location": "L73"
-    },
-    {
-      "community": 93,
-      "file_type": "code",
-      "id": "config_resolvemtncollectionsconfigfromenv",
-      "label": "resolveMtnCollectionsConfigFromEnv()",
-      "norm_label": "resolvemtncollectionsconfigfromenv()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
-      "source_location": "L108"
-    },
-    {
-      "community": 93,
-      "file_type": "code",
-      "id": "config_toenvsegment",
-      "label": "toEnvSegment()",
-      "norm_label": "toenvsegment()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
-      "source_location": "L29"
-    },
-    {
-      "community": 93,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_mtn_config_ts",
-      "label": "config.ts",
-      "norm_label": "config.ts",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "id": "packages_athena_webapp_convex_sendgrid_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
       "source_location": "L1"
     },
     {
@@ -95043,73 +95064,73 @@
     {
       "community": 94,
       "file_type": "code",
-      "id": "approvalauditevents_recordapprovalauditeventwithctx",
-      "label": "recordApprovalAuditEventWithCtx()",
-      "norm_label": "recordapprovalauditeventwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
-      "source_location": "L30"
+      "id": "config_buildmtncollectionscallbackurl",
+      "label": "buildMtnCollectionsCallbackUrl()",
+      "norm_label": "buildmtncollectionscallbackurl()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "source_location": "L135"
     },
     {
       "community": 94,
       "file_type": "code",
-      "id": "approvalauditevents_recordapprovaldecisionrecordedauditeventwithctx",
-      "label": "recordApprovalDecisionRecordedAuditEventWithCtx()",
-      "norm_label": "recordapprovaldecisionrecordedauditeventwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
-      "source_location": "L107"
+      "id": "config_buildmtncollectionslookupprefixes",
+      "label": "buildMtnCollectionsLookupPrefixes()",
+      "norm_label": "buildmtncollectionslookupprefixes()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "source_location": "L43"
     },
     {
       "community": 94,
       "file_type": "code",
-      "id": "approvalauditevents_recordapprovalproofconsumedauditeventwithctx",
-      "label": "recordApprovalProofConsumedAuditEventWithCtx()",
-      "norm_label": "recordapprovalproofconsumedauditeventwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
-      "source_location": "L87"
-    },
-    {
-      "community": 94,
-      "file_type": "code",
-      "id": "approvalauditevents_recordapprovalrequiredauditeventwithctx",
-      "label": "recordApprovalRequiredAuditEventWithCtx()",
-      "norm_label": "recordapprovalrequiredauditeventwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
+      "id": "config_istargetenvironment",
+      "label": "isTargetEnvironment()",
+      "norm_label": "istargetenvironment()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
       "source_location": "L67"
     },
     {
       "community": 94,
       "file_type": "code",
-      "id": "approvalauditevents_recordapprovedcommandappliedauditeventwithctx",
-      "label": "recordApprovedCommandAppliedAuditEventWithCtx()",
-      "norm_label": "recordapprovedcommandappliedauditeventwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
-      "source_location": "L117"
+      "id": "config_readscopedvalue",
+      "label": "readScopedValue()",
+      "norm_label": "readscopedvalue()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "source_location": "L56"
     },
     {
       "community": 94,
       "file_type": "code",
-      "id": "approvalauditevents_recordasyncapprovalrequestcreatedauditeventwithctx",
-      "label": "recordAsyncApprovalRequestCreatedAuditEventWithCtx()",
-      "norm_label": "recordasyncapprovalrequestcreatedauditeventwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
-      "source_location": "L97"
+      "id": "config_resolveconfigforprefix",
+      "label": "resolveConfigForPrefix()",
+      "norm_label": "resolveconfigforprefix()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "source_location": "L73"
     },
     {
       "community": 94,
       "file_type": "code",
-      "id": "approvalauditevents_recordmanagerapprovalgrantedauditeventwithctx",
-      "label": "recordManagerApprovalGrantedAuditEventWithCtx()",
-      "norm_label": "recordmanagerapprovalgrantedauditeventwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
-      "source_location": "L77"
+      "id": "config_resolvemtncollectionsconfigfromenv",
+      "label": "resolveMtnCollectionsConfigFromEnv()",
+      "norm_label": "resolvemtncollectionsconfigfromenv()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "source_location": "L108"
     },
     {
       "community": 94,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_approvalauditevents_ts",
-      "label": "approvalAuditEvents.ts",
-      "norm_label": "approvalauditevents.ts",
-      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
+      "id": "config_toenvsegment",
+      "label": "toEnvSegment()",
+      "norm_label": "toenvsegment()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "source_location": "L29"
+    },
+    {
+      "community": 94,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_mtn_config_ts",
+      "label": "config.ts",
+      "norm_label": "config.ts",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
       "source_location": "L1"
     },
     {
@@ -95205,73 +95226,73 @@
     {
       "community": 95,
       "file_type": "code",
-      "id": "approvalrequests_buildapprovaldecisionrequirement",
-      "label": "buildApprovalDecisionRequirement()",
-      "norm_label": "buildapprovaldecisionrequirement()",
-      "source_file": "packages/athena-webapp/convex/operations/approvalRequests.ts",
-      "source_location": "L54"
+      "id": "approvalauditevents_recordapprovalauditeventwithctx",
+      "label": "recordApprovalAuditEventWithCtx()",
+      "norm_label": "recordapprovalauditeventwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
+      "source_location": "L30"
     },
     {
       "community": 95,
       "file_type": "code",
-      "id": "approvalrequests_buildapprovaldecisionsubject",
-      "label": "buildApprovalDecisionSubject()",
-      "norm_label": "buildapprovaldecisionsubject()",
-      "source_file": "packages/athena-webapp/convex/operations/approvalRequests.ts",
-      "source_location": "L42"
+      "id": "approvalauditevents_recordapprovaldecisionrecordedauditeventwithctx",
+      "label": "recordApprovalDecisionRecordedAuditEventWithCtx()",
+      "norm_label": "recordapprovaldecisionrecordedauditeventwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
+      "source_location": "L107"
     },
     {
       "community": 95,
       "file_type": "code",
-      "id": "approvalrequests_consumeapprovaldecisionproofwithctx",
-      "label": "consumeApprovalDecisionProofWithCtx()",
-      "norm_label": "consumeapprovaldecisionproofwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/approvalRequests.ts",
-      "source_location": "L78"
+      "id": "approvalauditevents_recordapprovalproofconsumedauditeventwithctx",
+      "label": "recordApprovalProofConsumedAuditEventWithCtx()",
+      "norm_label": "recordapprovalproofconsumedauditeventwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
+      "source_location": "L87"
     },
     {
       "community": 95,
       "file_type": "code",
-      "id": "approvalrequests_decideapprovalrequestasauthenticateduserwithctx",
-      "label": "decideApprovalRequestAsAuthenticatedUserWithCtx()",
-      "norm_label": "decideapprovalrequestasauthenticateduserwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/approvalRequests.ts",
-      "source_location": "L167"
+      "id": "approvalauditevents_recordapprovalrequiredauditeventwithctx",
+      "label": "recordApprovalRequiredAuditEventWithCtx()",
+      "norm_label": "recordapprovalrequiredauditeventwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
+      "source_location": "L67"
     },
     {
       "community": 95,
       "file_type": "code",
-      "id": "approvalrequests_decideapprovalrequestascommandwithctx",
-      "label": "decideApprovalRequestAsCommandWithCtx()",
-      "norm_label": "decideapprovalrequestascommandwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/approvalRequests.ts",
-      "source_location": "L283"
+      "id": "approvalauditevents_recordapprovedcommandappliedauditeventwithctx",
+      "label": "recordApprovedCommandAppliedAuditEventWithCtx()",
+      "norm_label": "recordapprovedcommandappliedauditeventwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
+      "source_location": "L117"
     },
     {
       "community": 95,
       "file_type": "code",
-      "id": "approvalrequests_decideapprovalrequestwithctx",
-      "label": "decideApprovalRequestWithCtx()",
-      "norm_label": "decideapprovalrequestwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/approvalRequests.ts",
-      "source_location": "L105"
+      "id": "approvalauditevents_recordasyncapprovalrequestcreatedauditeventwithctx",
+      "label": "recordAsyncApprovalRequestCreatedAuditEventWithCtx()",
+      "norm_label": "recordasyncapprovalrequestcreatedauditeventwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
+      "source_location": "L97"
     },
     {
       "community": 95,
       "file_type": "code",
-      "id": "approvalrequests_mapdecideapprovalrequesterror",
-      "label": "mapDecideApprovalRequestError()",
-      "norm_label": "mapdecideapprovalrequesterror()",
-      "source_file": "packages/athena-webapp/convex/operations/approvalRequests.ts",
-      "source_location": "L217"
+      "id": "approvalauditevents_recordmanagerapprovalgrantedauditeventwithctx",
+      "label": "recordManagerApprovalGrantedAuditEventWithCtx()",
+      "norm_label": "recordmanagerapprovalgrantedauditeventwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
+      "source_location": "L77"
     },
     {
       "community": 95,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_approvalrequests_ts",
-      "label": "approvalRequests.ts",
-      "norm_label": "approvalrequests.ts",
-      "source_file": "packages/athena-webapp/convex/operations/approvalRequests.ts",
+      "id": "packages_athena_webapp_convex_operations_approvalauditevents_ts",
+      "label": "approvalAuditEvents.ts",
+      "norm_label": "approvalauditevents.ts",
+      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
       "source_location": "L1"
     },
     {
@@ -95367,74 +95388,74 @@
     {
       "community": 96,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_paymentallocations_ts",
-      "label": "paymentAllocations.ts",
-      "norm_label": "paymentallocations.ts",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "id": "approvalrequests_buildapprovaldecisionrequirement",
+      "label": "buildApprovalDecisionRequirement()",
+      "norm_label": "buildapprovaldecisionrequirement()",
+      "source_file": "packages/athena-webapp/convex/operations/approvalRequests.ts",
+      "source_location": "L54"
+    },
+    {
+      "community": 96,
+      "file_type": "code",
+      "id": "approvalrequests_buildapprovaldecisionsubject",
+      "label": "buildApprovalDecisionSubject()",
+      "norm_label": "buildapprovaldecisionsubject()",
+      "source_file": "packages/athena-webapp/convex/operations/approvalRequests.ts",
+      "source_location": "L42"
+    },
+    {
+      "community": 96,
+      "file_type": "code",
+      "id": "approvalrequests_consumeapprovaldecisionproofwithctx",
+      "label": "consumeApprovalDecisionProofWithCtx()",
+      "norm_label": "consumeapprovaldecisionproofwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/approvalRequests.ts",
+      "source_location": "L78"
+    },
+    {
+      "community": 96,
+      "file_type": "code",
+      "id": "approvalrequests_decideapprovalrequestasauthenticateduserwithctx",
+      "label": "decideApprovalRequestAsAuthenticatedUserWithCtx()",
+      "norm_label": "decideapprovalrequestasauthenticateduserwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/approvalRequests.ts",
+      "source_location": "L167"
+    },
+    {
+      "community": 96,
+      "file_type": "code",
+      "id": "approvalrequests_decideapprovalrequestascommandwithctx",
+      "label": "decideApprovalRequestAsCommandWithCtx()",
+      "norm_label": "decideapprovalrequestascommandwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/approvalRequests.ts",
+      "source_location": "L283"
+    },
+    {
+      "community": 96,
+      "file_type": "code",
+      "id": "approvalrequests_decideapprovalrequestwithctx",
+      "label": "decideApprovalRequestWithCtx()",
+      "norm_label": "decideapprovalrequestwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/approvalRequests.ts",
+      "source_location": "L105"
+    },
+    {
+      "community": 96,
+      "file_type": "code",
+      "id": "approvalrequests_mapdecideapprovalrequesterror",
+      "label": "mapDecideApprovalRequestError()",
+      "norm_label": "mapdecideapprovalrequesterror()",
+      "source_file": "packages/athena-webapp/convex/operations/approvalRequests.ts",
+      "source_location": "L217"
+    },
+    {
+      "community": 96,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_approvalrequests_ts",
+      "label": "approvalRequests.ts",
+      "norm_label": "approvalrequests.ts",
+      "source_file": "packages/athena-webapp/convex/operations/approvalRequests.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 96,
-      "file_type": "code",
-      "id": "paymentallocations_buildpaymentallocation",
-      "label": "buildPaymentAllocation()",
-      "norm_label": "buildpaymentallocation()",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
-      "source_location": "L27"
-    },
-    {
-      "community": 96,
-      "file_type": "code",
-      "id": "paymentallocations_correctsameamountsinglepaymentallocationwithctx",
-      "label": "correctSameAmountSinglePaymentAllocationWithCtx()",
-      "norm_label": "correctsameamountsinglepaymentallocationwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
-      "source_location": "L153"
-    },
-    {
-      "community": 96,
-      "file_type": "code",
-      "id": "paymentallocations_findsameamountsinglepaymentallocation",
-      "label": "findSameAmountSinglePaymentAllocation()",
-      "norm_label": "findsameamountsinglepaymentallocation()",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
-      "source_location": "L57"
-    },
-    {
-      "community": 96,
-      "file_type": "code",
-      "id": "paymentallocations_listpaymentallocationsfortargetwithctx",
-      "label": "listPaymentAllocationsForTargetWithCtx()",
-      "norm_label": "listpaymentallocationsfortargetwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
-      "source_location": "L133"
-    },
-    {
-      "community": 96,
-      "file_type": "code",
-      "id": "paymentallocations_matchesexistingallocation",
-      "label": "matchesExistingAllocation()",
-      "norm_label": "matchesexistingallocation()",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
-      "source_location": "L81"
-    },
-    {
-      "community": 96,
-      "file_type": "code",
-      "id": "paymentallocations_recordpaymentallocationwithctx",
-      "label": "recordPaymentAllocationWithCtx()",
-      "norm_label": "recordpaymentallocationwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
-      "source_location": "L102"
-    },
-    {
-      "community": 96,
-      "file_type": "code",
-      "id": "paymentallocations_summarizepaymentallocations",
-      "label": "summarizePaymentAllocations()",
-      "norm_label": "summarizepaymentallocations()",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
-      "source_location": "L41"
     },
     {
       "community": 960,
@@ -95529,74 +95550,74 @@
     {
       "community": 97,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_commands_possessiontracing_ts",
-      "label": "posSessionTracing.ts",
-      "norm_label": "possessiontracing.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "id": "packages_athena_webapp_convex_operations_paymentallocations_ts",
+      "label": "paymentAllocations.ts",
+      "norm_label": "paymentallocations.ts",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
       "source_location": "L1"
     },
     {
       "community": 97,
       "file_type": "code",
-      "id": "possessiontracing_buildpossessiontraceevent",
-      "label": "buildPosSessionTraceEvent()",
-      "norm_label": "buildpossessiontraceevent()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L226"
+      "id": "paymentallocations_buildpaymentallocation",
+      "label": "buildPaymentAllocation()",
+      "norm_label": "buildpaymentallocation()",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "source_location": "L27"
     },
     {
       "community": 97,
       "file_type": "code",
-      "id": "possessiontracing_buildpossessiontracerecord",
-      "label": "buildPosSessionTraceRecord()",
-      "norm_label": "buildpossessiontracerecord()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L142"
+      "id": "paymentallocations_correctsameamountsinglepaymentallocationwithctx",
+      "label": "correctSameAmountSinglePaymentAllocationWithCtx()",
+      "norm_label": "correctsameamountsinglepaymentallocationwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "source_location": "L153"
     },
     {
       "community": 97,
       "file_type": "code",
-      "id": "possessiontracing_buildtracesummary",
-      "label": "buildTraceSummary()",
-      "norm_label": "buildtracesummary()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L105"
+      "id": "paymentallocations_findsameamountsinglepaymentallocation",
+      "label": "findSameAmountSinglePaymentAllocation()",
+      "norm_label": "findsameamountsinglepaymentallocation()",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "source_location": "L57"
     },
     {
       "community": 97,
       "file_type": "code",
-      "id": "possessiontracing_createpossessiontracerecorder",
-      "label": "createPosSessionTraceRecorder()",
-      "norm_label": "createpossessiontracerecorder()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L559"
+      "id": "paymentallocations_listpaymentallocationsfortargetwithctx",
+      "label": "listPaymentAllocationsForTargetWithCtx()",
+      "norm_label": "listpaymentallocationsfortargetwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "source_location": "L133"
     },
     {
       "community": 97,
       "file_type": "code",
-      "id": "possessiontracing_formatpaymentmethod",
-      "label": "formatPaymentMethod()",
-      "norm_label": "formatpaymentmethod()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L218"
+      "id": "paymentallocations_matchesexistingallocation",
+      "label": "matchesExistingAllocation()",
+      "norm_label": "matchesexistingallocation()",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "source_location": "L81"
     },
     {
       "community": 97,
       "file_type": "code",
-      "id": "possessiontracing_recordpossessiontracebesteffort",
-      "label": "recordPosSessionTraceBestEffort()",
-      "norm_label": "recordpossessiontracebesteffort()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L532"
+      "id": "paymentallocations_recordpaymentallocationwithctx",
+      "label": "recordPaymentAllocationWithCtx()",
+      "norm_label": "recordpaymentallocationwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "source_location": "L102"
     },
     {
       "community": 97,
       "file_type": "code",
-      "id": "possessiontracing_safetracewrite",
-      "label": "safeTraceWrite()",
-      "norm_label": "safetracewrite()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L524"
+      "id": "paymentallocations_summarizepaymentallocations",
+      "label": "summarizePaymentAllocations()",
+      "norm_label": "summarizepaymentallocations()",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "source_location": "L41"
     },
     {
       "community": 970,
@@ -95691,74 +95712,74 @@
     {
       "community": 98,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_commands_quickaddcatalogitem_ts",
-      "label": "quickAddCatalogItem.ts",
-      "norm_label": "quickaddcatalogitem.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
+      "id": "packages_athena_webapp_convex_pos_application_commands_possessiontracing_ts",
+      "label": "posSessionTracing.ts",
+      "norm_label": "possessiontracing.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
       "source_location": "L1"
     },
     {
       "community": 98,
       "file_type": "code",
-      "id": "quickaddcatalogitem_findexistingsku",
-      "label": "findExistingSku()",
-      "norm_label": "findexistingsku()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
-      "source_location": "L125"
+      "id": "possessiontracing_buildpossessiontraceevent",
+      "label": "buildPosSessionTraceEvent()",
+      "norm_label": "buildpossessiontraceevent()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L226"
     },
     {
       "community": 98,
       "file_type": "code",
-      "id": "quickaddcatalogitem_findorcreatequickaddcategory",
-      "label": "findOrCreateQuickAddCategory()",
-      "norm_label": "findorcreatequickaddcategory()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
-      "source_location": "L29"
+      "id": "possessiontracing_buildpossessiontracerecord",
+      "label": "buildPosSessionTraceRecord()",
+      "norm_label": "buildpossessiontracerecord()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L142"
     },
     {
       "community": 98,
       "file_type": "code",
-      "id": "quickaddcatalogitem_findorcreatequickaddsubcategory",
-      "label": "findOrCreateQuickAddSubcategory()",
-      "norm_label": "findorcreatequickaddsubcategory()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
-      "source_location": "L56"
+      "id": "possessiontracing_buildtracesummary",
+      "label": "buildTraceSummary()",
+      "norm_label": "buildtracesummary()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L105"
     },
     {
       "community": 98,
       "file_type": "code",
-      "id": "quickaddcatalogitem_generatesku",
-      "label": "generateSKU()",
-      "norm_label": "generatesku()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
-      "source_location": "L153"
+      "id": "possessiontracing_createpossessiontracerecorder",
+      "label": "createPosSessionTraceRecorder()",
+      "norm_label": "createpossessiontracerecorder()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L559"
     },
     {
       "community": 98,
       "file_type": "code",
-      "id": "quickaddcatalogitem_isbarcodelike",
-      "label": "isBarcodeLike()",
-      "norm_label": "isbarcodelike()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
-      "source_location": "L149"
+      "id": "possessiontracing_formatpaymentmethod",
+      "label": "formatPaymentMethod()",
+      "norm_label": "formatpaymentmethod()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L218"
     },
     {
       "community": 98,
       "file_type": "code",
-      "id": "quickaddcatalogitem_mapskutocatalogresult",
-      "label": "mapSkuToCatalogResult()",
-      "norm_label": "mapskutocatalogresult()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
-      "source_location": "L88"
+      "id": "possessiontracing_recordpossessiontracebesteffort",
+      "label": "recordPosSessionTraceBestEffort()",
+      "norm_label": "recordpossessiontracebesteffort()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L532"
     },
     {
       "community": 98,
       "file_type": "code",
-      "id": "quickaddcatalogitem_quickaddcatalogitem",
-      "label": "quickAddCatalogItem()",
-      "norm_label": "quickaddcatalogitem()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
-      "source_location": "L174"
+      "id": "possessiontracing_safetracewrite",
+      "label": "safeTraceWrite()",
+      "norm_label": "safetracewrite()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L524"
     },
     {
       "community": 980,
@@ -95853,74 +95874,74 @@
     {
       "community": 99,
       "file_type": "code",
-      "id": "expensesessioncommands_test_builditem",
-      "label": "buildItem()",
-      "norm_label": "builditem()",
-      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
-      "source_location": "L645"
-    },
-    {
-      "community": 99,
-      "file_type": "code",
-      "id": "expensesessioncommands_test_buildregistersession",
-      "label": "buildRegisterSession()",
-      "norm_label": "buildregistersession()",
-      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
-      "source_location": "L639"
-    },
-    {
-      "community": 99,
-      "file_type": "code",
-      "id": "expensesessioncommands_test_buildsession",
-      "label": "buildSession()",
-      "norm_label": "buildsession()",
-      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
-      "source_location": "L635"
-    },
-    {
-      "community": 99,
-      "file_type": "code",
-      "id": "expensesessioncommands_test_createcommandservice",
-      "label": "createCommandService()",
-      "norm_label": "createcommandservice()",
-      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
-      "source_location": "L655"
-    },
-    {
-      "community": 99,
-      "file_type": "code",
-      "id": "expensesessioncommands_test_createdependencies",
-      "label": "createDependencies()",
-      "norm_label": "createdependencies()",
-      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
-      "source_location": "L424"
-    },
-    {
-      "community": 99,
-      "file_type": "code",
-      "id": "expensesessioncommands_test_createfakerepository",
-      "label": "createFakeRepository()",
-      "norm_label": "createfakerepository()",
-      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
-      "source_location": "L492"
-    },
-    {
-      "community": 99,
-      "file_type": "code",
-      "id": "expensesessioncommands_test_loadcommandservice",
-      "label": "loadCommandService()",
-      "norm_label": "loadcommandservice()",
-      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
-      "source_location": "L404"
-    },
-    {
-      "community": 99,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_expensesessioncommands_test_ts",
-      "label": "expenseSessionCommands.test.ts",
-      "norm_label": "expensesessioncommands.test.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
+      "id": "packages_athena_webapp_convex_pos_application_commands_quickaddcatalogitem_ts",
+      "label": "quickAddCatalogItem.ts",
+      "norm_label": "quickaddcatalogitem.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 99,
+      "file_type": "code",
+      "id": "quickaddcatalogitem_findexistingsku",
+      "label": "findExistingSku()",
+      "norm_label": "findexistingsku()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
+      "source_location": "L125"
+    },
+    {
+      "community": 99,
+      "file_type": "code",
+      "id": "quickaddcatalogitem_findorcreatequickaddcategory",
+      "label": "findOrCreateQuickAddCategory()",
+      "norm_label": "findorcreatequickaddcategory()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
+      "source_location": "L29"
+    },
+    {
+      "community": 99,
+      "file_type": "code",
+      "id": "quickaddcatalogitem_findorcreatequickaddsubcategory",
+      "label": "findOrCreateQuickAddSubcategory()",
+      "norm_label": "findorcreatequickaddsubcategory()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
+      "source_location": "L56"
+    },
+    {
+      "community": 99,
+      "file_type": "code",
+      "id": "quickaddcatalogitem_generatesku",
+      "label": "generateSKU()",
+      "norm_label": "generatesku()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
+      "source_location": "L153"
+    },
+    {
+      "community": 99,
+      "file_type": "code",
+      "id": "quickaddcatalogitem_isbarcodelike",
+      "label": "isBarcodeLike()",
+      "norm_label": "isbarcodelike()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
+      "source_location": "L149"
+    },
+    {
+      "community": 99,
+      "file_type": "code",
+      "id": "quickaddcatalogitem_mapskutocatalogresult",
+      "label": "mapSkuToCatalogResult()",
+      "norm_label": "mapskutocatalogresult()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
+      "source_location": "L88"
+    },
+    {
+      "community": 99,
+      "file_type": "code",
+      "id": "quickaddcatalogitem_quickaddcatalogitem",
+      "label": "quickAddCatalogItem()",
+      "norm_label": "quickaddcatalogitem()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
+      "source_location": "L174"
     },
     {
       "community": 990,

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,8 +8,8 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 1628
-- Graph nodes: 4666
-- Graph edges: 4501
+- Graph nodes: 4667
+- Graph edges: 4502
 - Communities: 1556
 
 ## Graph Hotspots

--- a/packages/athena-webapp/convex/storeFront/analytics.ts
+++ b/packages/athena-webapp/convex/storeFront/analytics.ts
@@ -22,6 +22,29 @@ const MAX_ANALYTICS_WORKSPACE_PRODUCTS = 10;
 const MAX_ANALYTICS_WORKSPACE_RECENT_EVENTS = 8;
 const MAX_ACTIVE_CHECKOUT_SESSIONS = 500;
 
+type StoreFrontActor =
+  | { kind: "registered"; doc: Doc<"storeFrontUser"> }
+  | { kind: "guest"; doc: Doc<"guest"> };
+
+async function getStoreFrontActor(
+  ctx: QueryCtx,
+  actorId: Id<"storeFrontUser"> | Id<"guest">,
+): Promise<StoreFrontActor | null> {
+  const storeFrontUserId = ctx.db.normalizeId("storeFrontUser", actorId);
+  if (storeFrontUserId) {
+    const doc = await ctx.db.get("storeFrontUser", storeFrontUserId);
+    return doc ? { kind: "registered", doc } : null;
+  }
+
+  const guestId = ctx.db.normalizeId("guest", actorId);
+  if (guestId) {
+    const doc = await ctx.db.get("guest", guestId);
+    return doc ? { kind: "guest", doc } : null;
+  }
+
+  return null;
+}
+
 function extractPromoCodeId(
   data: Record<string, any>,
 ): Id<"promoCode"> | undefined {
@@ -385,9 +408,9 @@ export const getWorkspaceSummary = query({
       todayAnalytics.map((item) => item.storeFrontUserId),
     );
     const shoppers = new Map<
-      string,
+      Id<"storeFrontUser"> | Id<"guest">,
       {
-        userId: string;
+        userId: Id<"storeFrontUser"> | Id<"guest">;
         totalActions: number;
         lastActive: number;
         firstSeen: number;
@@ -465,32 +488,24 @@ export const getWorkspaceSummary = query({
     const topShopperMetrics = [...shoppers.values()]
       .sort((a, b) => b.lastActive - a.lastActive)
       .slice(0, MAX_ANALYTICS_WORKSPACE_USERS);
-    const shopperDocs = await Promise.all(
-      topShopperMetrics.map(async (shopper) => {
-        const storeFrontUser = await ctx.db.get(
-          "storeFrontUser",
-          shopper.userId as Id<"storeFrontUser">,
-        );
-
-        if (storeFrontUser) {
-          return storeFrontUser;
-        }
-
-        return ctx.db.get("guest", shopper.userId as Id<"guest">);
-      }),
+    const shopperActors = await Promise.all(
+      topShopperMetrics.map((shopper) =>
+        getStoreFrontActor(ctx, shopper.userId),
+      ),
     );
 
     const topUsers = topShopperMetrics.map((shopper, index) => {
-      const user = shopperDocs[index];
+      const actor = shopperActors[index];
+      const user = actor?.doc;
       const devicePreference =
         Object.entries(shopper.deviceCounts).sort(([, a], [, b]) => b - a)[0]
           ?.[0] ?? "unknown";
 
       return {
         userId: shopper.userId,
-        email: user && "email" in user ? user.email : undefined,
+        email: user?.email,
         userType:
-          user && "storeId" in user && "email" in user
+          actor?.kind === "registered"
             ? ("Registered" as const)
             : ("Guest" as const),
         isNewUser: user ? user._creationTime > sevenDaysAgo : false,

--- a/packages/athena-webapp/src/components/analytics/analyticsWorkspaceEfficiency.test.ts
+++ b/packages/athena-webapp/src/components/analytics/analyticsWorkspaceEfficiency.test.ts
@@ -29,10 +29,15 @@ describe("analytics workspace query efficiency", () => {
     const schemaSource = readSource("convex/schema.ts");
 
     expect(analyticsSource).toContain("export const getWorkspaceSummary");
+    expect(analyticsSource).toContain('ctx.db.normalizeId("storeFrontUser"');
+    expect(analyticsSource).toContain('ctx.db.normalizeId("guest"');
     expect(analyticsSource).toContain(
       '.withIndex("by_storeId_hasCompletedCheckoutSession"',
     );
     expect(analyticsSource).not.toContain('ctx.db.get(shopper.userId as');
+    expect(analyticsSource).not.toContain(
+      'shopper.userId as Id<"storeFrontUser">',
+    );
     expect(schemaSource).toContain(
       '.index("by_storeId_hasCompletedCheckoutSession"',
     );


### PR DESCRIPTION
## Summary
- Fix `analytics.getWorkspaceSummary` so mixed `storeFrontUser`/`guest` analytics actor IDs are normalized to the correct Convex table before `db.get`.
- Keep top shopper aggregation typed as the actor ID union instead of widening to `string`.
- Extend the analytics workspace efficiency regression to require `db.normalizeId` for both actor tables and reject the unsafe cast pattern.

## Root Cause
Convex validates the table embedded in an ID before `db.get` can return `null`. The summary query cast every analytics actor ID to `Id<"storeFrontUser">` first, so guest analytics rows threw before the guest fallback could run.

## Validation
- `bun run --filter '@athena/webapp' test -- analyticsWorkspaceEfficiency`
- `bunx eslint convex/storeFront/analytics.ts src/components/analytics/analyticsWorkspaceEfficiency.test.ts`
- `bun run --filter '@athena/webapp' typecheck`
- `bun run graphify:rebuild`
- `bun run graphify:check`
- `bun run pr:athena`
- pre-push validation hook passed during `git push`
