### PR TITLE
fix(harness): reuse pr athena proof after commit

### DIFF
--- a/docs/solutions/harness/repo-validation-rerun-policy-2026-05-07.md
+++ b/docs/solutions/harness/repo-validation-rerun-policy-2026-05-07.md
@@ -39,11 +39,13 @@ ran. It passes `--repo-validation-provided-by pr:athena` into
 `harness:review`; standalone `harness:review` still selects and runs the full
 repo validation command set for repo-owned changes.
 
-After a clean `pr:athena`, the repo records a git-private proof under the current
-worktree's git metadata. `pre-push:review` may reuse that proof only when all of
+After a clean or staged-only `pr:athena`, the repo records a git-private proof
+under the current worktree's git metadata. A staged-only run is valid because
+`pre-commit:generated-artifacts` stages the exact index tree that the next
+commit will contain. `pre-push:review` may reuse that proof only when all of
 these still match:
 
-- branch `HEAD`
+- validated tree SHA
 - `origin/main` SHA
 - clean tracked and untracked working tree status
 - Bun version
@@ -52,7 +54,9 @@ these still match:
 
 If any field is missing or stale, pre-push prints the reason and runs normally.
 Generated-doc and graphify auto-repair still block for review and commit instead
-of reusing a stale proof.
+of reusing a stale proof. Proof recording refuses mixed states with unstaged or
+untracked files, because those files were not guaranteed to become the pushed
+commit tree.
 
 ## Prevention
 
@@ -62,8 +66,11 @@ of reusing a stale proof.
   state into tracked files or shared temp paths.
 - Include command wiring, hooks, harness scripts, coverage scripts, graphify
   scripts, package metadata, and lock/runtime inputs in the proof fingerprint.
-- Reject proof reuse on dirty status, rebases, advanced `origin/main`, missing
-  proof, unsupported proof shape, changed Bun version, or changed validation
-  wiring.
+- Reject proof reuse on dirty status at push time, rebases, advanced
+  `origin/main`, missing proof, unsupported proof shape, changed Bun version, or
+  changed validation wiring.
+- When recording proof before commit, allow staged-only changes by proving the
+  staged index tree; refuse proof recording if any unstaged or untracked files
+  are present.
 - When repeated validation feels noisy, add a characterization test before
   removing any command from the ladder.

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 4667 nodes · 4502 edges · 1556 communities detected
+- 4668 nodes · 4504 edges · 1556 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -1838,16 +1838,16 @@ Cohesion: 0.26
 Nodes (11): collectConvexSourceModules(), collectConvexSourceModulesFromDir(), readCommandStdout(), readGeneratedConvexApiModules(), refreshAthenaConvexGeneratedApi(), resolveSupportedConvexNodeBin(), runPreCommitGeneratedArtifacts(), stageTrackedGeneratedArtifacts() (+3 more)
 
 ### Community 61 - "Community 61"
+Cohesion: 0.31
+Nodes (12): collectFilesUnder(), collectProofSnapshot(), collectValidationFingerprintPaths(), evaluatePrePushValidationProof(), hashValidationWiring(), normalizeRepoPath(), readPrAthenaScript(), recordPrePushValidationProof() (+4 more)
+
+### Community 62 - "Community 62"
 Cohesion: 0.21
 Nodes (4): hasCustomerDetails(), mapCatalogRowToProduct(), trimOptional(), useRegisterViewModel()
 
-### Community 62 - "Community 62"
+### Community 63 - "Community 63"
 Cohesion: 0.18
 Nodes (2): formatBlockerList(), runPrePushReview()
-
-### Community 63 - "Community 63"
-Cohesion: 0.33
-Nodes (11): collectFilesUnder(), collectProofSnapshot(), collectValidationFingerprintPaths(), evaluatePrePushValidationProof(), hashValidationWiring(), normalizeRepoPath(), readPrAthenaScript(), recordPrePushValidationProof() (+3 more)
 
 ### Community 64 - "Community 64"
 Cohesion: 0.29
@@ -2387,7 +2387,7 @@ Nodes (0):
 
 ### Community 198 - "Community 198"
 Cohesion: 0.4
-Nodes (0):
+Nodes (1): Header()
 
 ### Community 199 - "Community 199"
 Cohesion: 0.4
@@ -2402,12 +2402,12 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 202 - "Community 202"
-Cohesion: 0.5
-Nodes (2): handleFileSelect(), validateFile()
-
-### Community 203 - "Community 203"
 Cohesion: 0.4
 Nodes (0):
+
+### Community 203 - "Community 203"
+Cohesion: 0.5
+Nodes (2): handleFileSelect(), validateFile()
 
 ### Community 204 - "Community 204"
 Cohesion: 0.4
@@ -2419,7 +2419,7 @@ Nodes (0):
 
 ### Community 206 - "Community 206"
 Cohesion: 0.4
-Nodes (1): Header()
+Nodes (0):
 
 ### Community 207 - "Community 207"
 Cohesion: 0.5

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -42011,7 +42011,7 @@
       "relation": "calls",
       "source": "pre_push_validation_proof_normalizerepopath",
       "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L109",
+      "source_location": "L131",
       "target": "pre_push_validation_proof_collectfilesunder",
       "weight": 1
     },
@@ -42023,7 +42023,7 @@
       "relation": "calls",
       "source": "pre_push_validation_proof_hashvalidationwiring",
       "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L206",
+      "source_location": "L235",
       "target": "pre_push_validation_proof_collectproofsnapshot",
       "weight": 1
     },
@@ -42035,7 +42035,7 @@
       "relation": "calls",
       "source": "pre_push_validation_proof_readprathenascript",
       "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L205",
+      "source_location": "L234",
       "target": "pre_push_validation_proof_collectproofsnapshot",
       "weight": 1
     },
@@ -42047,7 +42047,19 @@
       "relation": "calls",
       "source": "pre_push_validation_proof_runcommand",
       "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L196",
+      "source_location": "L222",
+      "target": "pre_push_validation_proof_collectproofsnapshot",
+      "weight": 1
+    },
+    {
+      "_src": "pre_push_validation_proof_collectproofsnapshot",
+      "_tgt": "pre_push_validation_proof_runexitcodecommand",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "pre_push_validation_proof_runexitcodecommand",
+      "source_file": "scripts/pre-push-validation-proof.ts",
+      "source_location": "L246",
       "target": "pre_push_validation_proof_collectproofsnapshot",
       "weight": 1
     },
@@ -42059,7 +42071,7 @@
       "relation": "calls",
       "source": "pre_push_validation_proof_collectfilesunder",
       "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L140",
+      "source_location": "L162",
       "target": "pre_push_validation_proof_collectvalidationfingerprintpaths",
       "weight": 1
     },
@@ -42071,7 +42083,7 @@
       "relation": "calls",
       "source": "pre_push_validation_proof_sortuniquepaths",
       "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L128",
+      "source_location": "L150",
       "target": "pre_push_validation_proof_collectvalidationfingerprintpaths",
       "weight": 1
     },
@@ -42083,7 +42095,7 @@
       "relation": "calls",
       "source": "pre_push_validation_proof_collectproofsnapshot",
       "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L250",
+      "source_location": "L309",
       "target": "pre_push_validation_proof_evaluateprepushvalidationproof",
       "weight": 1
     },
@@ -42095,7 +42107,7 @@
       "relation": "calls",
       "source": "pre_push_validation_proof_validateproofshape",
       "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L268",
+      "source_location": "L327",
       "target": "pre_push_validation_proof_evaluateprepushvalidationproof",
       "weight": 1
     },
@@ -42107,7 +42119,7 @@
       "relation": "calls",
       "source": "pre_push_validation_proof_collectvalidationfingerprintpaths",
       "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L154",
+      "source_location": "L176",
       "target": "pre_push_validation_proof_hashvalidationwiring",
       "weight": 1
     },
@@ -42119,7 +42131,7 @@
       "relation": "calls",
       "source": "pre_push_validation_proof_collectproofsnapshot",
       "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L308",
+      "source_location": "L367",
       "target": "pre_push_validation_proof_recordprepushvalidationproof",
       "weight": 1
     },
@@ -42131,7 +42143,7 @@
       "relation": "calls",
       "source": "pre_push_validation_proof_runcommand",
       "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L323",
+      "source_location": "L382",
       "target": "pre_push_validation_proof_recordprepushvalidationproof",
       "weight": 1
     },
@@ -49931,7 +49943,7 @@
       "relation": "contains",
       "source": "scripts_pre_push_review_test_ts",
       "source_file": "scripts/pre-push-review.test.ts",
-      "source_location": "L756",
+      "source_location": "L757",
       "target": "pre_push_review_test_error",
       "weight": 1
     },
@@ -49943,7 +49955,7 @@
       "relation": "contains",
       "source": "scripts_pre_push_review_test_ts",
       "source_file": "scripts/pre-push-review.test.ts",
-      "source_location": "L754",
+      "source_location": "L755",
       "target": "pre_push_review_test_log",
       "weight": 1
     },
@@ -49955,7 +49967,7 @@
       "relation": "contains",
       "source": "scripts_pre_push_review_test_ts",
       "source_file": "scripts/pre-push-review.test.ts",
-      "source_location": "L755",
+      "source_location": "L756",
       "target": "pre_push_review_test_warn",
       "weight": 1
     },
@@ -50123,7 +50135,7 @@
       "relation": "contains",
       "source": "scripts_pre_push_validation_proof_test_ts",
       "source_file": "scripts/pre-push-validation-proof.test.ts",
-      "source_location": "L155",
+      "source_location": "L278",
       "target": "pre_push_validation_proof_test_log",
       "weight": 1
     },
@@ -50135,7 +50147,7 @@
       "relation": "contains",
       "source": "scripts_pre_push_validation_proof_test_ts",
       "source_file": "scripts/pre-push-validation-proof.test.ts",
-      "source_location": "L155",
+      "source_location": "L278",
       "target": "pre_push_validation_proof_test_warn",
       "weight": 1
     },
@@ -50159,7 +50171,7 @@
       "relation": "contains",
       "source": "scripts_pre_push_validation_proof_ts",
       "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L88",
+      "source_location": "L110",
       "target": "pre_push_validation_proof_collectfilesunder",
       "weight": 1
     },
@@ -50171,7 +50183,7 @@
       "relation": "contains",
       "source": "scripts_pre_push_validation_proof_ts",
       "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L182",
+      "source_location": "L204",
       "target": "pre_push_validation_proof_collectproofsnapshot",
       "weight": 1
     },
@@ -50183,7 +50195,7 @@
       "relation": "contains",
       "source": "scripts_pre_push_validation_proof_ts",
       "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L124",
+      "source_location": "L146",
       "target": "pre_push_validation_proof_collectvalidationfingerprintpaths",
       "weight": 1
     },
@@ -50195,7 +50207,7 @@
       "relation": "contains",
       "source": "scripts_pre_push_validation_proof_ts",
       "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L244",
+      "source_location": "L303",
       "target": "pre_push_validation_proof_evaluateprepushvalidationproof",
       "weight": 1
     },
@@ -50207,7 +50219,7 @@
       "relation": "contains",
       "source": "scripts_pre_push_validation_proof_ts",
       "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L147",
+      "source_location": "L169",
       "target": "pre_push_validation_proof_hashvalidationwiring",
       "weight": 1
     },
@@ -50219,7 +50231,7 @@
       "relation": "contains",
       "source": "scripts_pre_push_validation_proof_ts",
       "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L55",
+      "source_location": "L58",
       "target": "pre_push_validation_proof_normalizerepopath",
       "weight": 1
     },
@@ -50231,7 +50243,7 @@
       "relation": "contains",
       "source": "scripts_pre_push_validation_proof_ts",
       "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L168",
+      "source_location": "L190",
       "target": "pre_push_validation_proof_readprathenascript",
       "weight": 1
     },
@@ -50243,7 +50255,7 @@
       "relation": "contains",
       "source": "scripts_pre_push_validation_proof_ts",
       "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L301",
+      "source_location": "L360",
       "target": "pre_push_validation_proof_recordprepushvalidationproof",
       "weight": 1
     },
@@ -50255,8 +50267,20 @@
       "relation": "contains",
       "source": "scripts_pre_push_validation_proof_ts",
       "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L65",
+      "source_location": "L68",
       "target": "pre_push_validation_proof_runcommand",
+      "weight": 1
+    },
+    {
+      "_src": "scripts_pre_push_validation_proof_ts",
+      "_tgt": "pre_push_validation_proof_runexitcodecommand",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "scripts_pre_push_validation_proof_ts",
+      "source_file": "scripts/pre-push-validation-proof.ts",
+      "source_location": "L91",
+      "target": "pre_push_validation_proof_runexitcodecommand",
       "weight": 1
     },
     {
@@ -50267,7 +50291,7 @@
       "relation": "contains",
       "source": "scripts_pre_push_validation_proof_ts",
       "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L59",
+      "source_location": "L62",
       "target": "pre_push_validation_proof_sortuniquepaths",
       "weight": 1
     },
@@ -50279,7 +50303,7 @@
       "relation": "contains",
       "source": "scripts_pre_push_validation_proof_ts",
       "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L226",
+      "source_location": "L283",
       "target": "pre_push_validation_proof_validateproofshape",
       "weight": 1
     },
@@ -66619,7 +66643,7 @@
       "label": "log()",
       "norm_label": "log()",
       "source_file": "scripts/pre-push-validation-proof.test.ts",
-      "source_location": "L121"
+      "source_location": "L187"
     },
     {
       "community": 181,
@@ -66628,7 +66652,7 @@
       "label": "warn()",
       "norm_label": "warn()",
       "source_file": "scripts/pre-push-validation-proof.test.ts",
-      "source_location": "L121"
+      "source_location": "L187"
     },
     {
       "community": 181,
@@ -67551,6 +67575,51 @@
     {
       "community": 198,
       "file_type": "code",
+      "id": "index_feesview",
+      "label": "FeesView()",
+      "norm_label": "feesview()",
+      "source_file": "packages/athena-webapp/src/components/assets/index.tsx",
+      "source_location": "L30"
+    },
+    {
+      "community": 198,
+      "file_type": "code",
+      "id": "index_header",
+      "label": "Header()",
+      "norm_label": "header()",
+      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
+      "source_location": "L43"
+    },
+    {
+      "community": 198,
+      "file_type": "code",
+      "id": "index_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
+      "source_location": "L106"
+    },
+    {
+      "community": 198,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_assets_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/components/assets/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 198,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_organization_members_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 199,
+      "file_type": "code",
       "id": "cashcontrolsdashboard_cn",
       "label": "cn()",
       "norm_label": "cn()",
@@ -67558,7 +67627,7 @@
       "source_location": "L363"
     },
     {
-      "community": 198,
+      "community": 199,
       "file_type": "code",
       "id": "cashcontrolsdashboard_if",
       "label": "if()",
@@ -67567,7 +67636,7 @@
       "source_location": "L423"
     },
     {
-      "community": 198,
+      "community": 199,
       "file_type": "code",
       "id": "cashcontrolsdashboard_metriccardskeleton",
       "label": "MetricCardSkeleton()",
@@ -67576,7 +67645,7 @@
       "source_location": "L87"
     },
     {
-      "community": 198,
+      "community": 199,
       "file_type": "code",
       "id": "cashcontrolsdashboard_switch",
       "label": "switch()",
@@ -67585,58 +67654,13 @@
       "source_location": "L256"
     },
     {
-      "community": 198,
+      "community": 199,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_cashcontrolsdashboard_tsx",
       "label": "CashControlsDashboard.tsx",
       "norm_label": "cashcontrolsdashboard.tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 199,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_common_pageheader_tsx",
-      "label": "PageHeader.tsx",
-      "norm_label": "pageheader.tsx",
-      "source_file": "packages/athena-webapp/src/components/common/PageHeader.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 199,
-      "file_type": "code",
-      "id": "pageheader_navigatebackbutton",
-      "label": "NavigateBackButton()",
-      "norm_label": "navigatebackbutton()",
-      "source_file": "packages/athena-webapp/src/components/common/PageHeader.tsx",
-      "source_location": "L30"
-    },
-    {
-      "community": 199,
-      "file_type": "code",
-      "id": "pageheader_pageheader",
-      "label": "PageHeader()",
-      "norm_label": "pageheader()",
-      "source_file": "packages/athena-webapp/src/components/common/PageHeader.tsx",
-      "source_location": "L8"
-    },
-    {
-      "community": 199,
-      "file_type": "code",
-      "id": "pageheader_simplepageheader",
-      "label": "SimplePageHeader()",
-      "norm_label": "simplepageheader()",
-      "source_file": "packages/athena-webapp/src/components/common/PageHeader.tsx",
-      "source_location": "L50"
-    },
-    {
-      "community": 199,
-      "file_type": "code",
-      "id": "pageheader_viewheader",
-      "label": "ViewHeader()",
-      "norm_label": "viewheader()",
-      "source_file": "packages/athena-webapp/src/components/common/PageHeader.tsx",
-      "source_location": "L67"
     },
     {
       "community": 2,
@@ -68181,6 +68205,51 @@
     {
       "community": 200,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_common_pageheader_tsx",
+      "label": "PageHeader.tsx",
+      "norm_label": "pageheader.tsx",
+      "source_file": "packages/athena-webapp/src/components/common/PageHeader.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 200,
+      "file_type": "code",
+      "id": "pageheader_navigatebackbutton",
+      "label": "NavigateBackButton()",
+      "norm_label": "navigatebackbutton()",
+      "source_file": "packages/athena-webapp/src/components/common/PageHeader.tsx",
+      "source_location": "L30"
+    },
+    {
+      "community": 200,
+      "file_type": "code",
+      "id": "pageheader_pageheader",
+      "label": "PageHeader()",
+      "norm_label": "pageheader()",
+      "source_file": "packages/athena-webapp/src/components/common/PageHeader.tsx",
+      "source_location": "L8"
+    },
+    {
+      "community": 200,
+      "file_type": "code",
+      "id": "pageheader_simplepageheader",
+      "label": "SimplePageHeader()",
+      "norm_label": "simplepageheader()",
+      "source_file": "packages/athena-webapp/src/components/common/PageHeader.tsx",
+      "source_location": "L50"
+    },
+    {
+      "community": 200,
+      "file_type": "code",
+      "id": "pageheader_viewheader",
+      "label": "ViewHeader()",
+      "norm_label": "viewheader()",
+      "source_file": "packages/athena-webapp/src/components/common/PageHeader.tsx",
+      "source_location": "L67"
+    },
+    {
+      "community": 201,
+      "file_type": "code",
       "id": "dashboard_getperiodrange",
       "label": "getPeriodRange()",
       "norm_label": "getperiodrange()",
@@ -68188,7 +68257,7 @@
       "source_location": "L20"
     },
     {
-      "community": 200,
+      "community": 201,
       "file_type": "code",
       "id": "dashboard_loadingsection",
       "label": "LoadingSection()",
@@ -68197,7 +68266,7 @@
       "source_location": "L50"
     },
     {
-      "community": 200,
+      "community": 201,
       "file_type": "code",
       "id": "dashboard_renderproductssection",
       "label": "renderProductsSection()",
@@ -68206,7 +68275,7 @@
       "source_location": "L342"
     },
     {
-      "community": 200,
+      "community": 201,
       "file_type": "code",
       "id": "dashboard_rendersalessection",
       "label": "renderSalesSection()",
@@ -68215,7 +68284,7 @@
       "source_location": "L322"
     },
     {
-      "community": 200,
+      "community": 201,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_dashboard_dashboard_tsx",
       "label": "Dashboard.tsx",
@@ -68224,7 +68293,7 @@
       "source_location": "L1"
     },
     {
-      "community": 201,
+      "community": 202,
       "file_type": "code",
       "id": "herosectiontabs_handledisplaytypechange",
       "label": "handleDisplayTypeChange()",
@@ -68233,7 +68302,7 @@
       "source_location": "L61"
     },
     {
-      "community": 201,
+      "community": 202,
       "file_type": "code",
       "id": "herosectiontabs_handleimageupdate",
       "label": "handleImageUpdate()",
@@ -68242,7 +68311,7 @@
       "source_location": "L57"
     },
     {
-      "community": 201,
+      "community": 202,
       "file_type": "code",
       "id": "herosectiontabs_handleoverlaytoggle",
       "label": "handleOverlayToggle()",
@@ -68251,7 +68320,7 @@
       "source_location": "L98"
     },
     {
-      "community": 201,
+      "community": 202,
       "file_type": "code",
       "id": "herosectiontabs_handletexttoggle",
       "label": "handleTextToggle()",
@@ -68260,7 +68329,7 @@
       "source_location": "L134"
     },
     {
-      "community": 201,
+      "community": 202,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_herosectiontabs_tsx",
       "label": "HeroSectionTabs.tsx",
@@ -68269,7 +68338,7 @@
       "source_location": "L1"
     },
     {
-      "community": 202,
+      "community": 203,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_reeluploader_tsx",
       "label": "ReelUploader.tsx",
@@ -68278,7 +68347,7 @@
       "source_location": "L1"
     },
     {
-      "community": 202,
+      "community": 203,
       "file_type": "code",
       "id": "reeluploader_formatfilesize",
       "label": "formatFileSize()",
@@ -68287,7 +68356,7 @@
       "source_location": "L38"
     },
     {
-      "community": 202,
+      "community": 203,
       "file_type": "code",
       "id": "reeluploader_handlefileselect",
       "label": "handleFileSelect()",
@@ -68296,7 +68365,7 @@
       "source_location": "L64"
     },
     {
-      "community": 202,
+      "community": 203,
       "file_type": "code",
       "id": "reeluploader_handleupload",
       "label": "handleUpload()",
@@ -68305,7 +68374,7 @@
       "source_location": "L135"
     },
     {
-      "community": 202,
+      "community": 203,
       "file_type": "code",
       "id": "reeluploader_validatefile",
       "label": "validateFile()",
@@ -68314,7 +68383,7 @@
       "source_location": "L43"
     },
     {
-      "community": 203,
+      "community": 204,
       "file_type": "code",
       "id": "activityview_iscreatedaction",
       "label": "isCreatedAction()",
@@ -68323,7 +68392,7 @@
       "source_location": "L58"
     },
     {
-      "community": 203,
+      "community": 204,
       "file_type": "code",
       "id": "activityview_isfeedbackrequestaction",
       "label": "isFeedbackRequestAction()",
@@ -68332,7 +68401,7 @@
       "source_location": "L63"
     },
     {
-      "community": 203,
+      "community": 204,
       "file_type": "code",
       "id": "activityview_isrefundaction",
       "label": "isRefundAction()",
@@ -68341,7 +68410,7 @@
       "source_location": "L50"
     },
     {
-      "community": 203,
+      "community": 204,
       "file_type": "code",
       "id": "activityview_istransitionaction",
       "label": "isTransitionAction()",
@@ -68350,7 +68419,7 @@
       "source_location": "L53"
     },
     {
-      "community": 203,
+      "community": 204,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_activityview_tsx",
       "label": "ActivityView.tsx",
@@ -68359,7 +68428,7 @@
       "source_location": "L1"
     },
     {
-      "community": 204,
+      "community": 205,
       "file_type": "code",
       "id": "orderdetailsview_fetchtransactions",
       "label": "fetchTransactions()",
@@ -68368,7 +68437,7 @@
       "source_location": "L140"
     },
     {
-      "community": 204,
+      "community": 205,
       "file_type": "code",
       "id": "orderdetailsview_handlemarkasverified",
       "label": "handleMarkAsVerified()",
@@ -68377,7 +68446,7 @@
       "source_location": "L177"
     },
     {
-      "community": 204,
+      "community": 205,
       "file_type": "code",
       "id": "orderdetailsview_handlemarkpaymentcollected",
       "label": "handleMarkPaymentCollected()",
@@ -68386,7 +68455,7 @@
       "source_location": "L195"
     },
     {
-      "community": 204,
+      "community": 205,
       "file_type": "code",
       "id": "orderdetailsview_verifiedbadge",
       "label": "VerifiedBadge()",
@@ -68395,7 +68464,7 @@
       "source_location": "L45"
     },
     {
-      "community": 204,
+      "community": 205,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orderdetailsview_tsx",
       "label": "OrderDetailsView.tsx",
@@ -68404,7 +68473,7 @@
       "source_location": "L1"
     },
     {
-      "community": 205,
+      "community": 206,
       "file_type": "code",
       "id": "orderitemsview_handlerequestfeedback",
       "label": "handleRequestFeedback()",
@@ -68413,7 +68482,7 @@
       "source_location": "L92"
     },
     {
-      "community": 205,
+      "community": 206,
       "file_type": "code",
       "id": "orderitemsview_handlerestockall",
       "label": "handleRestockAll()",
@@ -68422,7 +68491,7 @@
       "source_location": "L307"
     },
     {
-      "community": 205,
+      "community": 206,
       "file_type": "code",
       "id": "orderitemsview_handlereturnitemtostock",
       "label": "handleReturnItemToStock()",
@@ -68431,7 +68500,7 @@
       "source_location": "L70"
     },
     {
-      "community": 205,
+      "community": 206,
       "file_type": "code",
       "id": "orderitemsview_handleupdateorderitem",
       "label": "handleUpdateOrderItem()",
@@ -68440,57 +68509,12 @@
       "source_location": "L50"
     },
     {
-      "community": 205,
+      "community": 206,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orderitemsview_tsx",
       "label": "OrderItemsView.tsx",
       "norm_label": "orderitemsview.tsx",
       "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 206,
-      "file_type": "code",
-      "id": "index_feesview",
-      "label": "FeesView()",
-      "norm_label": "feesview()",
-      "source_file": "packages/athena-webapp/src/components/assets/index.tsx",
-      "source_location": "L30"
-    },
-    {
-      "community": 206,
-      "file_type": "code",
-      "id": "index_header",
-      "label": "Header()",
-      "norm_label": "header()",
-      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
-      "source_location": "L43"
-    },
-    {
-      "community": 206,
-      "file_type": "code",
-      "id": "index_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
-      "source_location": "L106"
-    },
-    {
-      "community": 206,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_assets_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/components/assets/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 206,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
       "source_location": "L1"
     },
     {
@@ -86199,110 +86223,119 @@
     {
       "community": 61,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_presentation_register_useregisterviewmodel_ts",
-      "label": "useRegisterViewModel.ts",
-      "norm_label": "useregisterviewmodel.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
-      "source_location": "L1"
+      "id": "pre_push_validation_proof_collectfilesunder",
+      "label": "collectFilesUnder()",
+      "norm_label": "collectfilesunder()",
+      "source_file": "scripts/pre-push-validation-proof.ts",
+      "source_location": "L110"
     },
     {
       "community": 61,
       "file_type": "code",
-      "id": "useregisterviewmodel_canoperateregister",
-      "label": "canOperateRegister()",
-      "norm_label": "canoperateregister()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
-      "source_location": "L209"
+      "id": "pre_push_validation_proof_collectproofsnapshot",
+      "label": "collectProofSnapshot()",
+      "norm_label": "collectproofsnapshot()",
+      "source_file": "scripts/pre-push-validation-proof.ts",
+      "source_location": "L204"
     },
     {
       "community": 61,
       "file_type": "code",
-      "id": "useregisterviewmodel_combinepaymentsbymethod",
-      "label": "combinePaymentsByMethod()",
-      "norm_label": "combinepaymentsbymethod()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
-      "source_location": "L99"
+      "id": "pre_push_validation_proof_collectvalidationfingerprintpaths",
+      "label": "collectValidationFingerprintPaths()",
+      "norm_label": "collectvalidationfingerprintpaths()",
+      "source_file": "scripts/pre-push-validation-proof.ts",
+      "source_location": "L146"
     },
     {
       "community": 61,
       "file_type": "code",
-      "id": "useregisterviewmodel_createpaymentid",
-      "label": "createPaymentId()",
-      "norm_label": "createpaymentid()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
-      "source_location": "L119"
+      "id": "pre_push_validation_proof_evaluateprepushvalidationproof",
+      "label": "evaluatePrePushValidationProof()",
+      "norm_label": "evaluateprepushvalidationproof()",
+      "source_file": "scripts/pre-push-validation-proof.ts",
+      "source_location": "L303"
     },
     {
       "community": 61,
       "file_type": "code",
-      "id": "useregisterviewmodel_hascustomerdetails",
-      "label": "hasCustomerDetails()",
-      "norm_label": "hascustomerdetails()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
-      "source_location": "L71"
-    },
-    {
-      "community": 61,
-      "file_type": "code",
-      "id": "useregisterviewmodel_mapcatalogrowtoproduct",
-      "label": "mapCatalogRowToProduct()",
-      "norm_label": "mapcatalogrowtoproduct()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
-      "source_location": "L140"
-    },
-    {
-      "community": 61,
-      "file_type": "code",
-      "id": "useregisterviewmodel_mapproducttooptimisticcartitem",
-      "label": "mapProductToOptimisticCartItem()",
-      "norm_label": "mapproducttooptimisticcartitem()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
+      "id": "pre_push_validation_proof_hashvalidationwiring",
+      "label": "hashValidationWiring()",
+      "norm_label": "hashvalidationwiring()",
+      "source_file": "scripts/pre-push-validation-proof.ts",
       "source_location": "L169"
     },
     {
       "community": 61,
       "file_type": "code",
-      "id": "useregisterviewmodel_mapsessioncustomer",
-      "label": "mapSessionCustomer()",
-      "norm_label": "mapsessioncustomer()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
-      "source_location": "L86"
+      "id": "pre_push_validation_proof_normalizerepopath",
+      "label": "normalizeRepoPath()",
+      "norm_label": "normalizerepopath()",
+      "source_file": "scripts/pre-push-validation-proof.ts",
+      "source_location": "L58"
     },
     {
       "community": 61,
       "file_type": "code",
-      "id": "useregisterviewmodel_normalizeexactinput",
-      "label": "normalizeExactInput()",
-      "norm_label": "normalizeexactinput()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
+      "id": "pre_push_validation_proof_readprathenascript",
+      "label": "readPrAthenaScript()",
+      "norm_label": "readprathenascript()",
+      "source_file": "scripts/pre-push-validation-proof.ts",
       "source_location": "L190"
     },
     {
       "community": 61,
       "file_type": "code",
-      "id": "useregisterviewmodel_presentoperatorerror",
-      "label": "presentOperatorError()",
-      "norm_label": "presentoperatorerror()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
-      "source_location": "L131"
+      "id": "pre_push_validation_proof_recordprepushvalidationproof",
+      "label": "recordPrePushValidationProof()",
+      "norm_label": "recordprepushvalidationproof()",
+      "source_file": "scripts/pre-push-validation-proof.ts",
+      "source_location": "L360"
     },
     {
       "community": 61,
       "file_type": "code",
-      "id": "useregisterviewmodel_trimoptional",
-      "label": "trimOptional()",
-      "norm_label": "trimoptional()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
-      "source_location": "L126"
+      "id": "pre_push_validation_proof_runcommand",
+      "label": "runCommand()",
+      "norm_label": "runcommand()",
+      "source_file": "scripts/pre-push-validation-proof.ts",
+      "source_location": "L68"
     },
     {
       "community": 61,
       "file_type": "code",
-      "id": "useregisterviewmodel_useregisterviewmodel",
-      "label": "useRegisterViewModel()",
-      "norm_label": "useregisterviewmodel()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
-      "source_location": "L218"
+      "id": "pre_push_validation_proof_runexitcodecommand",
+      "label": "runExitCodeCommand()",
+      "norm_label": "runexitcodecommand()",
+      "source_file": "scripts/pre-push-validation-proof.ts",
+      "source_location": "L91"
+    },
+    {
+      "community": 61,
+      "file_type": "code",
+      "id": "pre_push_validation_proof_sortuniquepaths",
+      "label": "sortUniquePaths()",
+      "norm_label": "sortuniquepaths()",
+      "source_file": "scripts/pre-push-validation-proof.ts",
+      "source_location": "L62"
+    },
+    {
+      "community": 61,
+      "file_type": "code",
+      "id": "pre_push_validation_proof_validateproofshape",
+      "label": "validateProofShape()",
+      "norm_label": "validateproofshape()",
+      "source_file": "scripts/pre-push-validation-proof.ts",
+      "source_location": "L283"
+    },
+    {
+      "community": 61,
+      "file_type": "code",
+      "id": "scripts_pre_push_validation_proof_ts",
+      "label": "pre-push-validation-proof.ts",
+      "norm_label": "pre-push-validation-proof.ts",
+      "source_file": "scripts/pre-push-validation-proof.ts",
+      "source_location": "L1"
     },
     {
       "community": 610,
@@ -86487,110 +86520,110 @@
     {
       "community": 62,
       "file_type": "code",
-      "id": "pre_push_review_collectrepairableharnessdocerrors",
-      "label": "collectRepairableHarnessDocErrors()",
-      "norm_label": "collectrepairableharnessdocerrors()",
-      "source_file": "scripts/pre-push-review.ts",
-      "source_location": "L161"
-    },
-    {
-      "community": 62,
-      "file_type": "code",
-      "id": "pre_push_review_formatblockerlist",
-      "label": "formatBlockerList()",
-      "norm_label": "formatblockerlist()",
-      "source_file": "scripts/pre-push-review.ts",
-      "source_location": "L193"
-    },
-    {
-      "community": 62,
-      "file_type": "code",
-      "id": "pre_push_review_getchangedfilesvsoriginmain",
-      "label": "getChangedFilesVsOriginMain()",
-      "norm_label": "getchangedfilesvsoriginmain()",
-      "source_file": "scripts/pre-push-review.ts",
-      "source_location": "L74"
-    },
-    {
-      "community": 62,
-      "file_type": "code",
-      "id": "pre_push_review_isrepairablegraphifydrift",
-      "label": "isRepairableGraphifyDrift()",
-      "norm_label": "isrepairablegraphifydrift()",
-      "source_file": "scripts/pre-push-review.ts",
-      "source_location": "L197"
-    },
-    {
-      "community": 62,
-      "file_type": "code",
-      "id": "pre_push_review_normalizerepopath",
-      "label": "normalizeRepoPath()",
-      "norm_label": "normalizerepopath()",
-      "source_file": "scripts/pre-push-review.ts",
-      "source_location": "L70"
-    },
-    {
-      "community": 62,
-      "file_type": "code",
-      "id": "pre_push_review_runarchitecturecheck",
-      "label": "runArchitectureCheck()",
-      "norm_label": "runarchitecturecheck()",
-      "source_file": "scripts/pre-push-review.ts",
-      "source_location": "L115"
-    },
-    {
-      "community": 62,
-      "file_type": "code",
-      "id": "pre_push_review_runharnessgenerate",
-      "label": "runHarnessGenerate()",
-      "norm_label": "runharnessgenerate()",
-      "source_file": "scripts/pre-push-review.ts",
-      "source_location": "L133"
-    },
-    {
-      "community": 62,
-      "file_type": "code",
-      "id": "pre_push_review_runharnessimplementationtests",
-      "label": "runHarnessImplementationTests()",
-      "norm_label": "runharnessimplementationtests()",
-      "source_file": "scripts/pre-push-review.ts",
-      "source_location": "L137"
-    },
-    {
-      "community": 62,
-      "file_type": "code",
-      "id": "pre_push_review_runharnessinferentialreview",
-      "label": "runHarnessInferentialReview()",
-      "norm_label": "runharnessinferentialreview()",
-      "source_file": "scripts/pre-push-review.ts",
-      "source_location": "L149"
-    },
-    {
-      "community": 62,
-      "file_type": "code",
-      "id": "pre_push_review_runharnessselfreview",
-      "label": "runHarnessSelfReview()",
-      "norm_label": "runharnessselfreview()",
-      "source_file": "scripts/pre-push-review.ts",
-      "source_location": "L127"
-    },
-    {
-      "community": 62,
-      "file_type": "code",
-      "id": "pre_push_review_runprepushreview",
-      "label": "runPrePushReview()",
-      "norm_label": "runprepushreview()",
-      "source_file": "scripts/pre-push-review.ts",
-      "source_location": "L205"
-    },
-    {
-      "community": 62,
-      "file_type": "code",
-      "id": "scripts_pre_push_review_ts",
-      "label": "pre-push-review.ts",
-      "norm_label": "pre-push-review.ts",
-      "source_file": "scripts/pre-push-review.ts",
+      "id": "packages_athena_webapp_src_lib_pos_presentation_register_useregisterviewmodel_ts",
+      "label": "useRegisterViewModel.ts",
+      "norm_label": "useregisterviewmodel.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 62,
+      "file_type": "code",
+      "id": "useregisterviewmodel_canoperateregister",
+      "label": "canOperateRegister()",
+      "norm_label": "canoperateregister()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
+      "source_location": "L209"
+    },
+    {
+      "community": 62,
+      "file_type": "code",
+      "id": "useregisterviewmodel_combinepaymentsbymethod",
+      "label": "combinePaymentsByMethod()",
+      "norm_label": "combinepaymentsbymethod()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
+      "source_location": "L99"
+    },
+    {
+      "community": 62,
+      "file_type": "code",
+      "id": "useregisterviewmodel_createpaymentid",
+      "label": "createPaymentId()",
+      "norm_label": "createpaymentid()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
+      "source_location": "L119"
+    },
+    {
+      "community": 62,
+      "file_type": "code",
+      "id": "useregisterviewmodel_hascustomerdetails",
+      "label": "hasCustomerDetails()",
+      "norm_label": "hascustomerdetails()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
+      "source_location": "L71"
+    },
+    {
+      "community": 62,
+      "file_type": "code",
+      "id": "useregisterviewmodel_mapcatalogrowtoproduct",
+      "label": "mapCatalogRowToProduct()",
+      "norm_label": "mapcatalogrowtoproduct()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
+      "source_location": "L140"
+    },
+    {
+      "community": 62,
+      "file_type": "code",
+      "id": "useregisterviewmodel_mapproducttooptimisticcartitem",
+      "label": "mapProductToOptimisticCartItem()",
+      "norm_label": "mapproducttooptimisticcartitem()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
+      "source_location": "L169"
+    },
+    {
+      "community": 62,
+      "file_type": "code",
+      "id": "useregisterviewmodel_mapsessioncustomer",
+      "label": "mapSessionCustomer()",
+      "norm_label": "mapsessioncustomer()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
+      "source_location": "L86"
+    },
+    {
+      "community": 62,
+      "file_type": "code",
+      "id": "useregisterviewmodel_normalizeexactinput",
+      "label": "normalizeExactInput()",
+      "norm_label": "normalizeexactinput()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
+      "source_location": "L190"
+    },
+    {
+      "community": 62,
+      "file_type": "code",
+      "id": "useregisterviewmodel_presentoperatorerror",
+      "label": "presentOperatorError()",
+      "norm_label": "presentoperatorerror()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
+      "source_location": "L131"
+    },
+    {
+      "community": 62,
+      "file_type": "code",
+      "id": "useregisterviewmodel_trimoptional",
+      "label": "trimOptional()",
+      "norm_label": "trimoptional()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
+      "source_location": "L126"
+    },
+    {
+      "community": 62,
+      "file_type": "code",
+      "id": "useregisterviewmodel_useregisterviewmodel",
+      "label": "useRegisterViewModel()",
+      "norm_label": "useregisterviewmodel()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts",
+      "source_location": "L218"
     },
     {
       "community": 620,
@@ -86775,109 +86808,109 @@
     {
       "community": 63,
       "file_type": "code",
-      "id": "pre_push_validation_proof_collectfilesunder",
-      "label": "collectFilesUnder()",
-      "norm_label": "collectfilesunder()",
-      "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L88"
+      "id": "pre_push_review_collectrepairableharnessdocerrors",
+      "label": "collectRepairableHarnessDocErrors()",
+      "norm_label": "collectrepairableharnessdocerrors()",
+      "source_file": "scripts/pre-push-review.ts",
+      "source_location": "L161"
     },
     {
       "community": 63,
       "file_type": "code",
-      "id": "pre_push_validation_proof_collectproofsnapshot",
-      "label": "collectProofSnapshot()",
-      "norm_label": "collectproofsnapshot()",
-      "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L182"
+      "id": "pre_push_review_formatblockerlist",
+      "label": "formatBlockerList()",
+      "norm_label": "formatblockerlist()",
+      "source_file": "scripts/pre-push-review.ts",
+      "source_location": "L193"
     },
     {
       "community": 63,
       "file_type": "code",
-      "id": "pre_push_validation_proof_collectvalidationfingerprintpaths",
-      "label": "collectValidationFingerprintPaths()",
-      "norm_label": "collectvalidationfingerprintpaths()",
-      "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L124"
+      "id": "pre_push_review_getchangedfilesvsoriginmain",
+      "label": "getChangedFilesVsOriginMain()",
+      "norm_label": "getchangedfilesvsoriginmain()",
+      "source_file": "scripts/pre-push-review.ts",
+      "source_location": "L74"
     },
     {
       "community": 63,
       "file_type": "code",
-      "id": "pre_push_validation_proof_evaluateprepushvalidationproof",
-      "label": "evaluatePrePushValidationProof()",
-      "norm_label": "evaluateprepushvalidationproof()",
-      "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L244"
+      "id": "pre_push_review_isrepairablegraphifydrift",
+      "label": "isRepairableGraphifyDrift()",
+      "norm_label": "isrepairablegraphifydrift()",
+      "source_file": "scripts/pre-push-review.ts",
+      "source_location": "L197"
     },
     {
       "community": 63,
       "file_type": "code",
-      "id": "pre_push_validation_proof_hashvalidationwiring",
-      "label": "hashValidationWiring()",
-      "norm_label": "hashvalidationwiring()",
-      "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L147"
-    },
-    {
-      "community": 63,
-      "file_type": "code",
-      "id": "pre_push_validation_proof_normalizerepopath",
+      "id": "pre_push_review_normalizerepopath",
       "label": "normalizeRepoPath()",
       "norm_label": "normalizerepopath()",
-      "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L55"
+      "source_file": "scripts/pre-push-review.ts",
+      "source_location": "L70"
     },
     {
       "community": 63,
       "file_type": "code",
-      "id": "pre_push_validation_proof_readprathenascript",
-      "label": "readPrAthenaScript()",
-      "norm_label": "readprathenascript()",
-      "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L168"
+      "id": "pre_push_review_runarchitecturecheck",
+      "label": "runArchitectureCheck()",
+      "norm_label": "runarchitecturecheck()",
+      "source_file": "scripts/pre-push-review.ts",
+      "source_location": "L115"
     },
     {
       "community": 63,
       "file_type": "code",
-      "id": "pre_push_validation_proof_recordprepushvalidationproof",
-      "label": "recordPrePushValidationProof()",
-      "norm_label": "recordprepushvalidationproof()",
-      "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L301"
+      "id": "pre_push_review_runharnessgenerate",
+      "label": "runHarnessGenerate()",
+      "norm_label": "runharnessgenerate()",
+      "source_file": "scripts/pre-push-review.ts",
+      "source_location": "L133"
     },
     {
       "community": 63,
       "file_type": "code",
-      "id": "pre_push_validation_proof_runcommand",
-      "label": "runCommand()",
-      "norm_label": "runcommand()",
-      "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L65"
+      "id": "pre_push_review_runharnessimplementationtests",
+      "label": "runHarnessImplementationTests()",
+      "norm_label": "runharnessimplementationtests()",
+      "source_file": "scripts/pre-push-review.ts",
+      "source_location": "L137"
     },
     {
       "community": 63,
       "file_type": "code",
-      "id": "pre_push_validation_proof_sortuniquepaths",
-      "label": "sortUniquePaths()",
-      "norm_label": "sortuniquepaths()",
-      "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L59"
+      "id": "pre_push_review_runharnessinferentialreview",
+      "label": "runHarnessInferentialReview()",
+      "norm_label": "runharnessinferentialreview()",
+      "source_file": "scripts/pre-push-review.ts",
+      "source_location": "L149"
     },
     {
       "community": 63,
       "file_type": "code",
-      "id": "pre_push_validation_proof_validateproofshape",
-      "label": "validateProofShape()",
-      "norm_label": "validateproofshape()",
-      "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L226"
+      "id": "pre_push_review_runharnessselfreview",
+      "label": "runHarnessSelfReview()",
+      "norm_label": "runharnessselfreview()",
+      "source_file": "scripts/pre-push-review.ts",
+      "source_location": "L127"
     },
     {
       "community": 63,
       "file_type": "code",
-      "id": "scripts_pre_push_validation_proof_ts",
-      "label": "pre-push-validation-proof.ts",
-      "norm_label": "pre-push-validation-proof.ts",
-      "source_file": "scripts/pre-push-validation-proof.ts",
+      "id": "pre_push_review_runprepushreview",
+      "label": "runPrePushReview()",
+      "norm_label": "runprepushreview()",
+      "source_file": "scripts/pre-push-review.ts",
+      "source_location": "L205"
+    },
+    {
+      "community": 63,
+      "file_type": "code",
+      "id": "scripts_pre_push_review_ts",
+      "label": "pre-push-review.ts",
+      "norm_label": "pre-push-review.ts",
+      "source_file": "scripts/pre-push-review.ts",
       "source_location": "L1"
     },
     {

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,8 +8,8 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 1628
-- Graph nodes: 4667
-- Graph edges: 4502
+- Graph nodes: 4668
+- Graph edges: 4504
 - Communities: 1556
 
 ## Graph Hotspots

--- a/scripts/pre-push-review.test.ts
+++ b/scripts/pre-push-review.test.ts
@@ -116,11 +116,12 @@ describe("pre-push review wiring", () => {
         reusable: true,
         proofPath: "/tmp/proof.json",
         proof: {
-          schemaVersion: 1,
-          headSha: "head-sha",
+          schemaVersion: 2,
+          recordedHeadSha: "head-sha",
+          validatedTreeSha: "tree-sha",
+          recordedStatusMode: "clean",
           baseRef: "origin/main",
           baseSha: "base-sha",
-          cleanStatus: "",
           bunVersion: "1.1.29",
           prAthenaScript: "bun run pr:athena",
           validationFingerprint: "fingerprint",
@@ -152,7 +153,7 @@ describe("pre-push review wiring", () => {
 
     expect(steps).toEqual([]);
     expect(logs).toContain(
-      "[pre-push] Reusing current pr:athena validation proof for head-sha."
+      "[pre-push] Reusing current pr:athena validation proof for tree tree-sha."
     );
   });
 

--- a/scripts/pre-push-review.ts
+++ b/scripts/pre-push-review.ts
@@ -238,7 +238,7 @@ export async function runPrePushReview(
   const proofEvaluation = await evaluateValidationProof(rootDir);
   if (proofEvaluation.reusable) {
     logger.log(
-      `[pre-push] Reusing current pr:athena validation proof for ${proofEvaluation.proof.headSha}.`
+      `[pre-push] Reusing current pr:athena validation proof for tree ${proofEvaluation.proof.validatedTreeSha}.`
     );
     logger.log("[pre-push] All checks passed.");
     return;

--- a/scripts/pre-push-validation-proof.test.ts
+++ b/scripts/pre-push-validation-proof.test.ts
@@ -49,14 +49,22 @@ async function createFixtureRoot() {
 
 function createSpawn(outputs: {
   headSha?: string;
+  headTreeSha?: string;
+  indexTreeSha?: string;
   baseSha?: string;
   status?: string;
+  untrackedFiles?: string;
+  unstagedDiffExitCode?: number;
   bunVersion?: string;
 }) {
   const next = {
     headSha: "head-a",
+    headTreeSha: "tree-a",
+    indexTreeSha: "tree-a",
     baseSha: "base-a",
     status: "",
+    untrackedFiles: "",
+    unstagedDiffExitCode: 0,
     bunVersion: "1.1.29",
     ...outputs,
   };
@@ -67,12 +75,24 @@ function createSpawn(outputs: {
       output = "proof.json";
     } else if (command.join(" ") === "git rev-parse --verify HEAD") {
       output = next.headSha;
+    } else if (command.join(" ") === "git rev-parse --verify HEAD^{tree}") {
+      output = next.headTreeSha;
+    } else if (command.join(" ") === "git write-tree") {
+      output = next.indexTreeSha;
     } else if (command.join(" ") === "git rev-parse --verify origin/main") {
       output = next.baseSha;
     } else if (
       command.join(" ") === "git status --porcelain --untracked-files=all"
     ) {
       output = next.status;
+    } else if (command.join(" ") === "git ls-files --others --exclude-standard") {
+      output = next.untrackedFiles;
+    } else if (command.join(" ") === "git diff --quiet") {
+      return {
+        exited: Promise.resolve(next.unstagedDiffExitCode),
+        stdout: new Response("").body,
+        stderr: new Response("").body,
+      };
     } else if (command.join(" ") === "bun --version") {
       output = next.bunVersion;
     } else {
@@ -107,10 +127,87 @@ describe("pre-push validation proof", () => {
     ).resolves.toMatchObject({
       reusable: true,
       proof: {
-        headSha: "head-a",
+        recordedHeadSha: "head-a",
         baseSha: "base-a",
-        cleanStatus: "",
+        validatedTreeSha: "tree-a",
+        recordedStatusMode: "clean",
       },
+    });
+  });
+
+  it("records staged-only pr:athena proof and reuses it after commit creates the same tree", async () => {
+    const rootDir = await createFixtureRoot();
+    const recorded = await recordPrePushValidationProof(rootDir, {
+      spawn: createSpawn({
+        headSha: "head-before",
+        headTreeSha: "tree-before",
+        indexTreeSha: "tree-after",
+        status: "M  scripts/pre-push-review.ts",
+      }),
+      logger: { log() {}, warn() {} },
+    });
+    expect(recorded).toMatchObject({
+      recorded: true,
+      proof: {
+        recordedHeadSha: "head-before",
+        validatedTreeSha: "tree-after",
+        recordedStatusMode: "staged-index",
+      },
+    });
+
+    await expect(
+      evaluatePrePushValidationProof(rootDir, {
+        spawn: createSpawn({
+          headSha: "head-after",
+          headTreeSha: "tree-after",
+          indexTreeSha: "tree-after",
+        }),
+      })
+    ).resolves.toMatchObject({
+      reusable: true,
+      proof: {
+        recordedHeadSha: "head-before",
+        validatedTreeSha: "tree-after",
+        recordedStatusMode: "staged-index",
+      },
+    });
+  });
+
+  it("does not record staged proof when unstaged files are also present", async () => {
+    const rootDir = await createFixtureRoot();
+
+    await expect(
+      recordPrePushValidationProof(rootDir, {
+        spawn: createSpawn({
+          headTreeSha: "tree-before",
+          indexTreeSha: "tree-after",
+          status: "MM scripts/pre-push-review.ts",
+          unstagedDiffExitCode: 1,
+        }),
+        logger: { log() {}, warn() {} },
+      })
+    ).resolves.toMatchObject({
+      recorded: false,
+      reason: "working tree has unstaged or untracked changes",
+    });
+  });
+
+  it("does not record staged proof when untracked files are present", async () => {
+    const rootDir = await createFixtureRoot();
+
+    await expect(
+      recordPrePushValidationProof(rootDir, {
+        spawn: createSpawn({
+          headTreeSha: "tree-before",
+          indexTreeSha: "tree-after",
+          status: "M  scripts/pre-push-review.ts\n?? tmp.txt",
+          untrackedFiles: "tmp.txt",
+        }),
+        logger: { log() {}, warn() {} },
+      })
+    ).resolves.toMatchObject({
+      recorded: false,
+      reason: "working tree has unstaged or untracked changes",
     });
   });
 
@@ -128,6 +225,32 @@ describe("pre-push validation proof", () => {
     ).resolves.toMatchObject({
       reusable: false,
       reason: "working tree is not clean",
+    });
+  });
+
+  it("reruns pre-push when HEAD tree differs from the recorded staged proof", async () => {
+    const rootDir = await createFixtureRoot();
+    await recordPrePushValidationProof(rootDir, {
+      spawn: createSpawn({
+        headSha: "head-before",
+        headTreeSha: "tree-before",
+        indexTreeSha: "tree-after",
+        status: "M  scripts/pre-push-review.ts",
+      }),
+      logger: { log() {}, warn() {} },
+    });
+
+    await expect(
+      evaluatePrePushValidationProof(rootDir, {
+        spawn: createSpawn({
+          headSha: "head-after",
+          headTreeSha: "tree-other",
+          indexTreeSha: "tree-other",
+        }),
+      })
+    ).resolves.toMatchObject({
+      reusable: false,
+      reason: "HEAD tree changed since pr:athena recorded its proof",
     });
   });
 

--- a/scripts/pre-push-validation-proof.ts
+++ b/scripts/pre-push-validation-proof.ts
@@ -2,7 +2,7 @@ import { createHash } from "node:crypto";
 import { mkdir, readFile, readdir, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
 
-export const PRE_PUSH_VALIDATION_PROOF_SCHEMA_VERSION = 1;
+export const PRE_PUSH_VALIDATION_PROOF_SCHEMA_VERSION = 2;
 export const PR_ATHENA_PROOF_BASE_REF = "origin/main";
 const PROOF_GIT_PATH = "codex/pre-push-pr-athena-proof.json";
 
@@ -21,10 +21,11 @@ type ProofLogger = Pick<Console, "log" | "warn">;
 
 export type PrePushValidationProof = {
   schemaVersion: typeof PRE_PUSH_VALIDATION_PROOF_SCHEMA_VERSION;
-  headSha: string;
+  recordedHeadSha: string;
+  validatedTreeSha: string;
+  recordedStatusMode: "clean" | "staged-index";
   baseRef: typeof PR_ATHENA_PROOF_BASE_REF;
   baseSha: string;
-  cleanStatus: "";
   bunVersion: string;
   prAthenaScript: string;
   validationFingerprint: string;
@@ -51,6 +52,8 @@ type ProofRuntimeOptions = {
   readFile?: typeof readFile;
   readdir?: typeof readdir;
 };
+
+type ProofSnapshotMode = "evaluate" | "record";
 
 function normalizeRepoPath(repoPath: string) {
   return repoPath.replaceAll("\\", "/").replace(/^\.\//, "");
@@ -83,6 +86,25 @@ async function runCommand(
   }
 
   return stdout.trim();
+}
+
+async function runExitCodeCommand(
+  rootDir: string,
+  command: string[],
+  spawn: CommandRunner = Bun.spawn
+) {
+  const proc = spawn(command, {
+    cwd: rootDir,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+
+  return { stdout: stdout.trim(), stderr: stderr.trim(), exitCode };
 }
 
 async function collectFilesUnder(
@@ -181,42 +203,77 @@ async function readPrAthenaScript(rootDir: string, options: ProofRuntimeOptions 
 
 async function collectProofSnapshot(
   rootDir: string,
-  options: ProofRuntimeOptions = {}
+  options: ProofRuntimeOptions = {},
+  mode: ProofSnapshotMode = "evaluate"
 ): Promise<ProofSnapshot> {
   const spawn = options.spawn ?? Bun.spawn;
   const [
     proofPath,
-    headSha,
+    recordedHeadSha,
+    headTreeSha,
+    indexTreeSha,
     baseSha,
     status,
+    untrackedFiles,
     bunVersion,
     prAthenaScript,
     validationFingerprint,
   ] = await Promise.all([
     runCommand(rootDir, ["git", "rev-parse", "--git-path", PROOF_GIT_PATH], spawn),
     runCommand(rootDir, ["git", "rev-parse", "--verify", "HEAD"], spawn),
+    runCommand(rootDir, ["git", "rev-parse", "--verify", "HEAD^{tree}"], spawn),
+    runCommand(rootDir, ["git", "write-tree"], spawn),
     runCommand(rootDir, ["git", "rev-parse", "--verify", PR_ATHENA_PROOF_BASE_REF], spawn),
     runCommand(
       rootDir,
       ["git", "status", "--porcelain", "--untracked-files=all"],
       spawn
     ),
+    runCommand(rootDir, ["git", "ls-files", "--others", "--exclude-standard"], spawn),
     runCommand(rootDir, ["bun", "--version"], spawn),
     readPrAthenaScript(rootDir, options),
     hashValidationWiring(rootDir, options),
   ]);
 
+  let recordedStatusMode: PrePushValidationProof["recordedStatusMode"] = "clean";
+  let validatedTreeSha = headTreeSha;
+
   if (status.trim()) {
-    throw new Error("working tree is not clean");
+    if (mode !== "record") {
+      throw new Error("working tree is not clean");
+    }
+
+    const unstagedDiff = await runExitCodeCommand(
+      rootDir,
+      ["git", "diff", "--quiet"],
+      spawn
+    );
+    if (unstagedDiff.exitCode > 1) {
+      throw new Error(
+        unstagedDiff.stderr || unstagedDiff.stdout || "git diff --quiet failed"
+      );
+    }
+
+    if (unstagedDiff.exitCode !== 0 || untrackedFiles.trim()) {
+      throw new Error("working tree has unstaged or untracked changes");
+    }
+
+    if (indexTreeSha === headTreeSha) {
+      throw new Error("working tree is not clean");
+    }
+
+    recordedStatusMode = "staged-index";
+    validatedTreeSha = indexTreeSha;
   }
 
   return {
     proofPath: path.resolve(rootDir, proofPath),
     schemaVersion: PRE_PUSH_VALIDATION_PROOF_SCHEMA_VERSION,
-    headSha,
+    recordedHeadSha,
+    validatedTreeSha,
+    recordedStatusMode,
     baseRef: PR_ATHENA_PROOF_BASE_REF,
     baseSha,
-    cleanStatus: "",
     bunVersion,
     prAthenaScript,
     validationFingerprint,
@@ -231,10 +288,12 @@ function validateProofShape(value: unknown): value is PrePushValidationProof {
   const proof = value as Record<string, unknown>;
   return (
     proof.schemaVersion === PRE_PUSH_VALIDATION_PROOF_SCHEMA_VERSION &&
-    typeof proof.headSha === "string" &&
+    typeof proof.recordedHeadSha === "string" &&
+    typeof proof.validatedTreeSha === "string" &&
+    (proof.recordedStatusMode === "clean" ||
+      proof.recordedStatusMode === "staged-index") &&
     proof.baseRef === PR_ATHENA_PROOF_BASE_REF &&
     typeof proof.baseSha === "string" &&
-    proof.cleanStatus === "" &&
     typeof proof.bunVersion === "string" &&
     typeof proof.prAthenaScript === "string" &&
     typeof proof.validationFingerprint === "string"
@@ -274,7 +333,7 @@ export async function evaluatePrePushValidationProof(
   }
 
   const comparisons: Array<[keyof PrePushValidationProof, string]> = [
-    ["headSha", "HEAD changed since pr:athena recorded its proof"],
+    ["validatedTreeSha", "HEAD tree changed since pr:athena recorded its proof"],
     ["baseSha", `${PR_ATHENA_PROOF_BASE_REF} changed since pr:athena recorded its proof`],
     ["bunVersion", "Bun version changed since pr:athena recorded its proof"],
     ["prAthenaScript", "pr:athena command changed since proof recording"],
@@ -305,7 +364,7 @@ export async function recordPrePushValidationProof(
   const logger = options.logger ?? console;
 
   try {
-    const snapshot = await collectProofSnapshot(rootDir, options);
+    const snapshot = await collectProofSnapshot(rootDir, options, "record");
     const { proofPath, ...proof } = snapshot;
     await mkdir(path.dirname(proofPath), { recursive: true });
     await writeFile(proofPath, `${JSON.stringify(proof, null, 2)}\n`, "utf8");


### PR DESCRIPTION
## Summary
- Let `pr:athena` record validation proof for staged-only worktrees by storing the validated index tree SHA.
- Let pre-push reuse that proof after commit when `HEAD^{tree}` matches the validated tree.
- Continue refusing proof recording for mixed unstaged or untracked changes.
- Update the repo validation rerun solution note and regression tests for the staged-index proof path.

## Root Cause
`pr:athena` runs before the commit in the normal delivery loop, after `pre-commit:generated-artifacts` has staged the exact tree that will become the next commit. The old proof schema only accepted a clean worktree and compared against the pre-commit `HEAD`, so a valid local validation run could not be reused by the push hook.

## Validation
- `bun test scripts/pre-push-validation-proof.test.ts scripts/pre-push-review.test.ts`
- `bun scripts/compound-solution-check.ts --base origin/main`
- `bun run graphify:rebuild`
- `bun run pr:athena`
- `git push -u origin HEAD` reused the recorded proof instead of rerunning pre-push validation
