### PR TITLE
fix: correct daily close summary metadata

### DIFF
--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 4712 nodes · 4587 edges · 1557 communities detected
+- 4714 nodes · 4589 edges · 1557 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -1599,12 +1599,12 @@ Cohesion: 0.1
 Nodes (45): buildFinding(), buildHumanReport(), buildSemanticPrompt(), buildShadowSummary(), buildShellCommandPattern(), collectHarnessSafetySignalFindings(), collectHarnessScriptTestUpdateFindings(), createOutput() (+37 more)
 
 ### Community 1 - "Community 1"
-Cohesion: 0.09
-Nodes (45): compactContext(), createAuthEntryViewedEvent(), createAuthRequestStartedEvent(), createAuthVerificationSucceededEvent(), createAuthVerificationViewedEvent(), createBagAddSucceededEvent(), createBagMoveToSavedEvent(), createBagRemoveSucceededEvent() (+37 more)
-
-### Community 2 - "Community 2"
 Cohesion: 0.07
 Nodes (25): cn(), formatMetadataDisplayValue(), formatMetadataValue(), formatMoney(), formatTimestampMetadata(), getBucketCountClassName(), getCarryForwardWorkItemId(), getDisplayMetadataLabel() (+17 more)
+
+### Community 2 - "Community 2"
+Cohesion: 0.09
+Nodes (45): compactContext(), createAuthEntryViewedEvent(), createAuthRequestStartedEvent(), createAuthVerificationSucceededEvent(), createAuthVerificationViewedEvent(), createBagAddSucceededEvent(), createBagMoveToSavedEvent(), createBagRemoveSucceededEvent() (+37 more)
 
 ### Community 3 - "Community 3"
 Cohesion: 0.07
@@ -1735,12 +1735,12 @@ Cohesion: 0.23
 Nodes (14): acquireInventoryHold(), acquireInventoryHoldsBatch(), adjustInventoryHold(), consumeInventoryHoldsForSession(), getActiveHoldForSessionSku(), listActiveSessionHolds(), markHoldExpired(), readActiveInventoryHoldDetailsForSession() (+6 more)
 
 ### Community 35 - "Community 35"
-Cohesion: 0.25
-Nodes (14): buildCompleteTransactionResult(), calculateCanonicalTransactionTotals(), calculateTotalPaid(), completeTransaction(), createTransactionFromSessionHandler(), isUsableRegisterSession(), recordRegisterSessionSale(), recordRegisterSessionVoid() (+6 more)
-
-### Community 36 - "Community 36"
 Cohesion: 0.12
 Nodes (1): DataTableViewOptions()
+
+### Community 36 - "Community 36"
+Cohesion: 0.25
+Nodes (14): buildCompleteTransactionResult(), calculateCanonicalTransactionTotals(), calculateTotalPaid(), completeTransaction(), createTransactionFromSessionHandler(), isUsableRegisterSession(), recordRegisterSessionSale(), recordRegisterSessionVoid() (+6 more)
 
 ### Community 37 - "Community 37"
 Cohesion: 0.19
@@ -1968,39 +1968,39 @@ Nodes (6): findAthenaUserByEmailWithCtx(), getAuthenticatedAthenaUserWithCtx(), 
 
 ### Community 93 - "Community 93"
 Cohesion: 0.43
-Nodes (6): sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
-
-### Community 94 - "Community 94"
-Cohesion: 0.43
 Nodes (6): buildMtnCollectionsLookupPrefixes(), isTargetEnvironment(), readScopedValue(), resolveConfigForPrefix(), resolveMtnCollectionsConfigFromEnv(), toEnvSegment()
 
-### Community 95 - "Community 95"
+### Community 94 - "Community 94"
 Cohesion: 0.46
 Nodes (7): recordApprovalAuditEventWithCtx(), recordApprovalDecisionRecordedAuditEventWithCtx(), recordApprovalProofConsumedAuditEventWithCtx(), recordApprovalRequiredAuditEventWithCtx(), recordApprovedCommandAppliedAuditEventWithCtx(), recordAsyncApprovalRequestCreatedAuditEventWithCtx(), recordManagerApprovalGrantedAuditEventWithCtx()
 
-### Community 96 - "Community 96"
+### Community 95 - "Community 95"
 Cohesion: 0.5
 Nodes (7): buildApprovalDecisionRequirement(), buildApprovalDecisionSubject(), consumeApprovalDecisionProofWithCtx(), decideApprovalRequestAsAuthenticatedUserWithCtx(), decideApprovalRequestAsCommandWithCtx(), decideApprovalRequestWithCtx(), mapDecideApprovalRequestError()
 
-### Community 97 - "Community 97"
+### Community 96 - "Community 96"
 Cohesion: 0.36
 Nodes (5): buildPaymentAllocation(), correctSameAmountSinglePaymentAllocationWithCtx(), findSameAmountSinglePaymentAllocation(), listPaymentAllocationsForTargetWithCtx(), recordPaymentAllocationWithCtx()
 
-### Community 98 - "Community 98"
+### Community 97 - "Community 97"
 Cohesion: 0.43
 Nodes (6): buildPosSessionTraceEvent(), buildPosSessionTraceRecord(), buildTraceSummary(), formatPaymentMethod(), recordPosSessionTraceBestEffort(), safeTraceWrite()
 
-### Community 99 - "Community 99"
+### Community 98 - "Community 98"
 Cohesion: 0.5
 Nodes (7): findExistingSku(), findOrCreateQuickAddCategory(), findOrCreateQuickAddSubcategory(), generateSKU(), isBarcodeLike(), mapSkuToCatalogResult(), quickAddCatalogItem()
+
+### Community 99 - "Community 99"
+Cohesion: 0.25
+Nodes (0):
 
 ### Community 100 - "Community 100"
 Cohesion: 0.25
 Nodes (0):
 
 ### Community 101 - "Community 101"
-Cohesion: 0.25
-Nodes (0):
+Cohesion: 0.43
+Nodes (6): sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
 
 ### Community 102 - "Community 102"
 Cohesion: 0.25
@@ -2388,7 +2388,7 @@ Nodes (0):
 
 ### Community 198 - "Community 198"
 Cohesion: 0.4
-Nodes (1): Header()
+Nodes (0):
 
 ### Community 199 - "Community 199"
 Cohesion: 0.4
@@ -2403,12 +2403,12 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 202 - "Community 202"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 203 - "Community 203"
 Cohesion: 0.5
 Nodes (2): handleFileSelect(), validateFile()
+
+### Community 203 - "Community 203"
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 204 - "Community 204"
 Cohesion: 0.4
@@ -2420,7 +2420,7 @@ Nodes (0):
 
 ### Community 206 - "Community 206"
 Cohesion: 0.4
-Nodes (0):
+Nodes (1): Header()
 
 ### Community 207 - "Community 207"
 Cohesion: 0.5
@@ -10016,9 +10016,9 @@ _Questions this graph is uniquely positioned to answer:_
 - **Should `Community 0` be split into smaller, more focused modules?**
   _Cohesion score 0.1 - nodes in this community are weakly interconnected._
 - **Should `Community 1` be split into smaller, more focused modules?**
-  _Cohesion score 0.09 - nodes in this community are weakly interconnected._
-- **Should `Community 2` be split into smaller, more focused modules?**
   _Cohesion score 0.07 - nodes in this community are weakly interconnected._
+- **Should `Community 2` be split into smaller, more focused modules?**
+  _Cohesion score 0.09 - nodes in this community are weakly interconnected._
 - **Should `Community 3` be split into smaller, more focused modules?**
   _Cohesion score 0.07 - nodes in this community are weakly interconnected._
 - **Should `Community 4` be split into smaller, more focused modules?**

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -3527,7 +3527,7 @@
       "relation": "calls",
       "source": "dailyclose_formatpaymentmethodlabel",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L242",
+      "source_location": "L256",
       "target": "dailyclose_approvalrequesttypelabel",
       "weight": 1
     },
@@ -3539,7 +3539,7 @@
       "relation": "calls",
       "source": "dailyclose_buildpaymenttotals",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1185",
+      "source_location": "L1220",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -3551,7 +3551,7 @@
       "relation": "calls",
       "source": "dailyclose_buildreadiness",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1187",
+      "source_location": "L1222",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -3563,7 +3563,7 @@
       "relation": "calls",
       "source": "dailyclose_buildregistersessionsbyid",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L723",
+      "source_location": "L738",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -3575,7 +3575,7 @@
       "relation": "calls",
       "source": "dailyclose_buildstaffnamesbyid",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L738",
+      "source_location": "L753",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -3587,7 +3587,7 @@
       "relation": "calls",
       "source": "dailyclose_buildterminallabelsbyid",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L730",
+      "source_location": "L745",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -3599,7 +3599,7 @@
       "relation": "calls",
       "source": "dailyclose_cashdeltasbyregistersessionid",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L720",
+      "source_location": "L735",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -3611,7 +3611,7 @@
       "relation": "calls",
       "source": "dailyclose_emptysummary",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L671",
+      "source_location": "L686",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -3623,7 +3623,7 @@
       "relation": "calls",
       "source": "dailyclose_getdailyclosefordate",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L706",
+      "source_location": "L721",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -3635,7 +3635,7 @@
       "relation": "calls",
       "source": "dailyclose_getpriorcompleteddailyclose",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L707",
+      "source_location": "L722",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -3647,7 +3647,7 @@
       "relation": "calls",
       "source": "dailyclose_getstore",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L635",
+      "source_location": "L650",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -3659,7 +3659,7 @@
       "relation": "calls",
       "source": "dailyclose_listactiveregistersessions",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L689",
+      "source_location": "L704",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -3671,7 +3671,7 @@
       "relation": "calls",
       "source": "dailyclose_listclosedregistersessionsforday",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L690",
+      "source_location": "L705",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -3683,7 +3683,7 @@
       "relation": "calls",
       "source": "dailyclose_listdepositsforday",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L705",
+      "source_location": "L720",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -3695,7 +3695,7 @@
       "relation": "calls",
       "source": "dailyclose_listexpensesforday",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L704",
+      "source_location": "L719",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -3707,7 +3707,7 @@
       "relation": "calls",
       "source": "dailyclose_listopenoperationalworkitems",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L693",
+      "source_location": "L708",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -3719,7 +3719,7 @@
       "relation": "calls",
       "source": "dailyclose_listopenpossessions",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L692",
+      "source_location": "L707",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -3731,7 +3731,7 @@
       "relation": "calls",
       "source": "dailyclose_listpendingcloseoutapprovals",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L691",
+      "source_location": "L706",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -3743,7 +3743,7 @@
       "relation": "calls",
       "source": "dailyclose_listtransactionsforday",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L694",
+      "source_location": "L709",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -3755,7 +3755,7 @@
       "relation": "calls",
       "source": "dailyclose_resolveoperatingdaterange",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L634",
+      "source_location": "L649",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -3767,7 +3767,7 @@
       "relation": "calls",
       "source": "dailyclose_uniquesourcesubjects",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1231",
+      "source_location": "L1266",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -3779,7 +3779,7 @@
       "relation": "calls",
       "source": "dailyclose_builddailyclosesnapshotwithctx",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1368",
+      "source_location": "L1403",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -3791,7 +3791,7 @@
       "relation": "calls",
       "source": "dailyclose_createcarryforwardworkitems",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1430",
+      "source_location": "L1465",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -3803,7 +3803,7 @@
       "relation": "calls",
       "source": "dailyclose_getstore",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1343",
+      "source_location": "L1378",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -3815,7 +3815,7 @@
       "relation": "calls",
       "source": "dailyclose_markotherdailyclosesnotcurrent",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1489",
+      "source_location": "L1524",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -3827,7 +3827,7 @@
       "relation": "calls",
       "source": "dailyclose_resolveoperatingdaterange",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1359",
+      "source_location": "L1394",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -3839,7 +3839,7 @@
       "relation": "calls",
       "source": "dailyclose_trimoptional",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1471",
+      "source_location": "L1506",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -3851,7 +3851,7 @@
       "relation": "calls",
       "source": "dailyclose_validatecarryforwardworkitemids",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1418",
+      "source_location": "L1453",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -3863,7 +3863,7 @@
       "relation": "calls",
       "source": "dailyclose_trimoptional",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1277",
+      "source_location": "L1312",
       "target": "dailyclose_createcarryforwardworkitems",
       "weight": 1
     },
@@ -3875,7 +3875,7 @@
       "relation": "calls",
       "source": "dailyclose_getpriorcompleteddailyclose",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1554",
+      "source_location": "L1589",
       "target": "dailyclose_getdailycloseopeningcontextwithctx",
       "weight": 1
     },
@@ -3887,7 +3887,7 @@
       "relation": "calls",
       "source": "dailyclose_isvalidoperatingdaterange",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L179",
+      "source_location": "L180",
       "target": "dailyclose_resolveoperatingdaterange",
       "weight": 1
     },
@@ -3899,7 +3899,7 @@
       "relation": "calls",
       "source": "dailyclose_safeoperatingdaterange",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L173",
+      "source_location": "L174",
       "target": "dailyclose_resolveoperatingdaterange",
       "weight": 1
     },
@@ -3911,7 +3911,7 @@
       "relation": "calls",
       "source": "dailyclose_formatpaymentmethodlabel",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L221",
+      "source_location": "L235",
       "target": "dailyclose_transactionpaymentsummary",
       "weight": 1
     },
@@ -3923,7 +3923,7 @@
       "relation": "calls",
       "source": "dailycloseview_formatmetadatavalue",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L731",
+      "source_location": "L732",
       "target": "dailycloseview_formatmetadatadisplayvalue",
       "weight": 1
     },
@@ -3935,7 +3935,7 @@
       "relation": "calls",
       "source": "dailycloseview_getmetadatastringvalue",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L733",
+      "source_location": "L734",
       "target": "dailycloseview_formatmetadatadisplayvalue",
       "weight": 1
     },
@@ -3947,7 +3947,7 @@
       "relation": "calls",
       "source": "dailycloseview_getnumericmetadatavalue",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L757",
+      "source_location": "L758",
       "target": "dailycloseview_formatmetadatadisplayvalue",
       "weight": 1
     },
@@ -3959,7 +3959,7 @@
       "relation": "calls",
       "source": "dailycloseview_getvariancetone",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L762",
+      "source_location": "L763",
       "target": "dailycloseview_formatmetadatadisplayvalue",
       "weight": 1
     },
@@ -3971,7 +3971,7 @@
       "relation": "calls",
       "source": "dailycloseview_normalizemetadatalabel",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L736",
+      "source_location": "L737",
       "target": "dailycloseview_formatmetadatadisplayvalue",
       "weight": 1
     },
@@ -3983,7 +3983,7 @@
       "relation": "calls",
       "source": "dailycloseview_formatmoney",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L679",
+      "source_location": "L680",
       "target": "dailycloseview_formatmetadatavalue",
       "weight": 1
     },
@@ -3995,7 +3995,7 @@
       "relation": "calls",
       "source": "dailycloseview_formattimestampmetadata",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L675",
+      "source_location": "L676",
       "target": "dailycloseview_formatmetadatavalue",
       "weight": 1
     },
@@ -4007,7 +4007,7 @@
       "relation": "calls",
       "source": "dailycloseview_humanizemetadatalabel",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L703",
+      "source_location": "L704",
       "target": "dailycloseview_formatmetadatavalue",
       "weight": 1
     },
@@ -4019,7 +4019,7 @@
       "relation": "calls",
       "source": "dailycloseview_ismoneymetadatalabel",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L678",
+      "source_location": "L679",
       "target": "dailycloseview_formatmetadatavalue",
       "weight": 1
     },
@@ -4031,7 +4031,7 @@
       "relation": "calls",
       "source": "dailycloseview_istimestampmetadatalabel",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L674",
+      "source_location": "L675",
       "target": "dailycloseview_formatmetadatavalue",
       "weight": 1
     },
@@ -4043,7 +4043,7 @@
       "relation": "calls",
       "source": "dailycloseview_normalizemetadatalabel",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L667",
+      "source_location": "L668",
       "target": "dailycloseview_formatmetadatavalue",
       "weight": 1
     },
@@ -4055,7 +4055,7 @@
       "relation": "calls",
       "source": "dailycloseview_getbucketcountclassname",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L300",
+      "source_location": "L301",
       "target": "dailycloseview_cn",
       "weight": 1
     },
@@ -4067,7 +4067,7 @@
       "relation": "calls",
       "source": "dailycloseview_getitemid",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L415",
+      "source_location": "L416",
       "target": "dailycloseview_getcarryforwardworkitemid",
       "weight": 1
     },
@@ -4079,7 +4079,7 @@
       "relation": "calls",
       "source": "dailycloseview_humanizemetadatalabel",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L643",
+      "source_location": "L644",
       "target": "dailycloseview_getdisplaymetadatalabel",
       "weight": 1
     },
@@ -4091,7 +4091,7 @@
       "relation": "calls",
       "source": "dailycloseview_normalizemetadatalabel",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L636",
+      "source_location": "L637",
       "target": "dailycloseview_getdisplaymetadatalabel",
       "weight": 1
     },
@@ -4103,7 +4103,7 @@
       "relation": "calls",
       "source": "dailycloseview_getitemcontextlabel",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L428",
+      "source_location": "L429",
       "target": "dailycloseview_humanizemetadatalabel",
       "weight": 1
     },
@@ -4115,7 +4115,7 @@
       "relation": "calls",
       "source": "dailycloseview_getlocaloperatingdate",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L370",
+      "source_location": "L371",
       "target": "dailycloseview_getlocaloperatingdaterange",
       "weight": 1
     },
@@ -4127,7 +4127,7 @@
       "relation": "calls",
       "source": "dailycloseview_normalizemetadatalabel",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L781",
+      "source_location": "L782",
       "target": "dailycloseview_getmetadataentries",
       "weight": 1
     },
@@ -4139,7 +4139,7 @@
       "relation": "calls",
       "source": "dailycloseview_normalizemetadatalabel",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L657",
+      "source_location": "L658",
       "target": "dailycloseview_getmetadatavalue",
       "weight": 1
     },
@@ -4151,7 +4151,7 @@
       "relation": "calls",
       "source": "dailycloseview_getstatuslabelclassname",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L290",
+      "source_location": "L291",
       "target": "dailycloseview_cn",
       "weight": 1
     },
@@ -4163,7 +4163,7 @@
       "relation": "calls",
       "source": "dailycloseview_getsummaryamount",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L972",
+      "source_location": "L980",
       "target": "dailycloseview_getsummaryregistervariancecount",
       "weight": 1
     },
@@ -4175,7 +4175,7 @@
       "relation": "calls",
       "source": "dailycloseview_normalizemetadatalabel",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L581",
+      "source_location": "L582",
       "target": "dailycloseview_ismoneymetadatalabel",
       "weight": 1
     },
@@ -4187,7 +4187,7 @@
       "relation": "calls",
       "source": "dailycloseview_normalizemetadatalabel",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L585",
+      "source_location": "L586",
       "target": "dailycloseview_istimestampmetadatalabel",
       "weight": 1
     },
@@ -4199,7 +4199,7 @@
       "relation": "calls",
       "source": "dailycloseview_getnumericmetadatavalue",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L617",
+      "source_location": "L618",
       "target": "dailycloseview_shouldshowmetadataentry",
       "weight": 1
     },
@@ -4211,7 +4211,7 @@
       "relation": "calls",
       "source": "dailycloseview_normalizemetadatalabel",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L610",
+      "source_location": "L611",
       "target": "dailycloseview_shouldshowmetadataentry",
       "weight": 1
     },
@@ -14027,7 +14027,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L229",
+      "source_location": "L243",
       "target": "dailyclose_approvalrequesttypelabel",
       "weight": 1
     },
@@ -14039,7 +14039,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L305",
+      "source_location": "L319",
       "target": "dailyclose_ascarryforwarditem",
       "weight": 1
     },
@@ -14051,7 +14051,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L625",
+      "source_location": "L640",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -14063,7 +14063,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L526",
+      "source_location": "L540",
       "target": "dailyclose_buildpaymenttotals",
       "weight": 1
     },
@@ -14075,7 +14075,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L573",
+      "source_location": "L587",
       "target": "dailyclose_buildreadiness",
       "weight": 1
     },
@@ -14087,7 +14087,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L285",
+      "source_location": "L299",
       "target": "dailyclose_buildregistersessionsbyid",
       "weight": 1
     },
@@ -14099,7 +14099,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L265",
+      "source_location": "L279",
       "target": "dailyclose_buildstaffnamesbyid",
       "weight": 1
     },
@@ -14111,7 +14111,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L245",
+      "source_location": "L259",
       "target": "dailyclose_buildterminallabelsbyid",
       "weight": 1
     },
@@ -14123,7 +14123,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L555",
+      "source_location": "L569",
       "target": "dailyclose_cashdeltasbyregistersessionid",
       "weight": 1
     },
@@ -14135,7 +14135,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1339",
+      "source_location": "L1374",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -14147,7 +14147,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1263",
+      "source_location": "L1298",
       "target": "dailyclose_createcarryforwardworkitems",
       "weight": 1
     },
@@ -14159,7 +14159,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L603",
+      "source_location": "L617",
       "target": "dailyclose_emptysummary",
       "weight": 1
     },
@@ -14171,7 +14171,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L201",
+      "source_location": "L215",
       "target": "dailyclose_formatpaymentmethodlabel",
       "weight": 1
     },
@@ -14183,7 +14183,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L334",
+      "source_location": "L348",
       "target": "dailyclose_getdailyclosefordate",
       "weight": 1
     },
@@ -14195,7 +14195,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1547",
+      "source_location": "L1582",
       "target": "dailyclose_getdailycloseopeningcontextwithctx",
       "weight": 1
     },
@@ -14207,7 +14207,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L349",
+      "source_location": "L363",
       "target": "dailyclose_getpriorcompleteddailyclose",
       "weight": 1
     },
@@ -14219,7 +14219,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L327",
+      "source_location": "L341",
       "target": "dailyclose_getstore",
       "weight": 1
     },
@@ -14231,7 +14231,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L189",
+      "source_location": "L190",
       "target": "dailyclose_isinrange",
       "weight": 1
     },
@@ -14243,7 +14243,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L157",
+      "source_location": "L158",
       "target": "dailyclose_isvalidoperatingdaterange",
       "weight": 1
     },
@@ -14255,7 +14255,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L371",
+      "source_location": "L385",
       "target": "dailyclose_listactiveregistersessions",
       "weight": 1
     },
@@ -14267,7 +14267,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L389",
+      "source_location": "L403",
       "target": "dailyclose_listclosedregistersessionsforday",
       "weight": 1
     },
@@ -14279,7 +14279,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L504",
+      "source_location": "L518",
       "target": "dailyclose_listdepositsforday",
       "weight": 1
     },
@@ -14291,7 +14291,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L484",
+      "source_location": "L498",
       "target": "dailyclose_listexpensesforday",
       "weight": 1
     },
@@ -14303,7 +14303,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L449",
+      "source_location": "L463",
       "target": "dailyclose_listopenoperationalworkitems",
       "weight": 1
     },
@@ -14315,7 +14315,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L428",
+      "source_location": "L442",
       "target": "dailyclose_listopenpossessions",
       "weight": 1
     },
@@ -14327,7 +14327,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L409",
+      "source_location": "L423",
       "target": "dailyclose_listpendingcloseoutapprovals",
       "weight": 1
     },
@@ -14339,7 +14339,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L463",
+      "source_location": "L477",
       "target": "dailyclose_listtransactionsforday",
       "weight": 1
     },
@@ -14351,7 +14351,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1316",
+      "source_location": "L1351",
       "target": "dailyclose_markotherdailyclosesnotcurrent",
       "weight": 1
     },
@@ -14363,8 +14363,20 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L225",
+      "source_location": "L239",
       "target": "dailyclose_nonzerovariancemetadata",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_convex_operations_dailyclose_ts",
+      "_tgt": "dailyclose_registermetadatalabel",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
+      "source_location": "L202",
+      "target": "dailyclose_registermetadatalabel",
       "weight": 1
     },
     {
@@ -14375,7 +14387,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L193",
+      "source_location": "L194",
       "target": "dailyclose_registersessionlabel",
       "weight": 1
     },
@@ -14387,7 +14399,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L168",
+      "source_location": "L169",
       "target": "dailyclose_resolveoperatingdaterange",
       "weight": 1
     },
@@ -14399,7 +14411,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L140",
+      "source_location": "L141",
       "target": "dailyclose_safeoperatingdaterange",
       "weight": 1
     },
@@ -14411,7 +14423,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L544",
+      "source_location": "L558",
       "target": "dailyclose_transactioncashdelta",
       "weight": 1
     },
@@ -14423,7 +14435,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L207",
+      "source_location": "L221",
       "target": "dailyclose_transactionpaymentsummary",
       "weight": 1
     },
@@ -14435,7 +14447,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L135",
+      "source_location": "L136",
       "target": "dailyclose_trimoptional",
       "weight": 1
     },
@@ -14447,7 +14459,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L593",
+      "source_location": "L607",
       "target": "dailyclose_uniquesourcesubjects",
       "weight": 1
     },
@@ -14459,7 +14471,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1235",
+      "source_location": "L1270",
       "target": "dailyclose_validatecarryforwardworkitemids",
       "weight": 1
     },
@@ -25211,7 +25223,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1498",
+      "source_location": "L1518",
       "target": "dailycloseview_cn",
       "weight": 1
     },
@@ -25223,7 +25235,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L270",
+      "source_location": "L271",
       "target": "dailycloseview_formatcarriedoverregistercount",
       "weight": 1
     },
@@ -25235,7 +25247,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L253",
+      "source_location": "L254",
       "target": "dailycloseview_formatchecklistcount",
       "weight": 1
     },
@@ -25247,7 +25259,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L337",
+      "source_location": "L338",
       "target": "dailycloseview_formatcompletedat",
       "weight": 1
     },
@@ -25259,7 +25271,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L243",
+      "source_location": "L244",
       "target": "dailycloseview_formatentitycount",
       "weight": 1
     },
@@ -25271,7 +25283,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L716",
+      "source_location": "L717",
       "target": "dailycloseview_formatmetadatadisplayvalue",
       "weight": 1
     },
@@ -25283,7 +25295,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L664",
+      "source_location": "L665",
       "target": "dailycloseview_formatmetadatavalue",
       "weight": 1
     },
@@ -25295,7 +25307,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L317",
+      "source_location": "L318",
       "target": "dailycloseview_formatmoney",
       "weight": 1
     },
@@ -25307,7 +25319,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L323",
+      "source_location": "L324",
       "target": "dailycloseview_formatoperatingdate",
       "weight": 1
     },
@@ -25319,7 +25331,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L276",
+      "source_location": "L277",
       "target": "dailycloseview_formatregistervariancecount",
       "weight": 1
     },
@@ -25331,7 +25343,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L311",
+      "source_location": "L312",
       "target": "dailycloseview_formatstaffinvolvedcount",
       "weight": 1
     },
@@ -25343,7 +25355,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L624",
+      "source_location": "L625",
       "target": "dailycloseview_formattimestampmetadata",
       "weight": 1
     },
@@ -25355,7 +25367,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L264",
+      "source_location": "L265",
       "target": "dailycloseview_formattodaycashtransactioncount",
       "weight": 1
     },
@@ -25367,7 +25379,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L997",
+      "source_location": "L1017",
       "target": "dailycloseview_getbucketconfigs",
       "weight": 1
     },
@@ -25379,7 +25391,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L299",
+      "source_location": "L300",
       "target": "dailycloseview_getbucketcountclassname",
       "weight": 1
     },
@@ -25391,7 +25403,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L412",
+      "source_location": "L413",
       "target": "dailycloseview_getcarryforwardworkitemid",
       "weight": 1
     },
@@ -25403,7 +25415,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L418",
+      "source_location": "L419",
       "target": "dailycloseview_getcarryforwardworkitemids",
       "weight": 1
     },
@@ -25415,7 +25427,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L233",
+      "source_location": "L234",
       "target": "dailycloseview_getdailycloseapi",
       "weight": 1
     },
@@ -25427,7 +25439,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L386",
+      "source_location": "L387",
       "target": "dailycloseview_getdailyclosestatus",
       "weight": 1
     },
@@ -25439,7 +25451,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L980",
+      "source_location": "L1000",
       "target": "dailycloseview_getdefaultbucketvalue",
       "weight": 1
     },
@@ -25451,8 +25463,20 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L634",
+      "source_location": "L635",
       "target": "dailycloseview_getdisplaymetadatalabel",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
+      "_tgt": "dailycloseview_getexpensestaffcount",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
+      "source_location": "L988",
+      "target": "dailycloseview_getexpensestaffcount",
       "weight": 1
     },
     {
@@ -25463,7 +25487,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L426",
+      "source_location": "L427",
       "target": "dailycloseview_getitemcontextlabel",
       "weight": 1
     },
@@ -25475,7 +25499,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L422",
+      "source_location": "L423",
       "target": "dailycloseview_getitemdescription",
       "weight": 1
     },
@@ -25487,7 +25511,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L400",
+      "source_location": "L401",
       "target": "dailycloseview_getitemid",
       "weight": 1
     },
@@ -25499,7 +25523,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L349",
+      "source_location": "L350",
       "target": "dailycloseview_getlocaloperatingdate",
       "weight": 1
     },
@@ -25511,7 +25535,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L357",
+      "source_location": "L358",
       "target": "dailycloseview_getlocaloperatingdaterange",
       "weight": 1
     },
@@ -25523,7 +25547,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L773",
+      "source_location": "L774",
       "target": "dailycloseview_getmetadataentries",
       "weight": 1
     },
@@ -25535,7 +25559,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L646",
+      "source_location": "L647",
       "target": "dailycloseview_getmetadatastringvalue",
       "weight": 1
     },
@@ -25547,7 +25571,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L656",
+      "source_location": "L657",
       "target": "dailycloseview_getmetadatavalue",
       "weight": 1
     },
@@ -25559,7 +25583,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L596",
+      "source_location": "L597",
       "target": "dailycloseview_getnumericmetadatavalue",
       "weight": 1
     },
@@ -25571,7 +25595,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L408",
+      "source_location": "L409",
       "target": "dailycloseview_getrevieweditemkeys",
       "weight": 1
     },
@@ -25583,7 +25607,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L282",
+      "source_location": "L283",
       "target": "dailycloseview_getstatusicon",
       "weight": 1
     },
@@ -25595,7 +25619,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L289",
+      "source_location": "L290",
       "target": "dailycloseview_getstatuslabelclassname",
       "weight": 1
     },
@@ -25607,7 +25631,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L935",
+      "source_location": "L943",
       "target": "dailycloseview_getsummaryamount",
       "weight": 1
     },
@@ -25619,7 +25643,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L950",
+      "source_location": "L958",
       "target": "dailycloseview_getsummarycount",
       "weight": 1
     },
@@ -25631,7 +25655,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L965",
+      "source_location": "L973",
       "target": "dailycloseview_getsummaryregistervariancecount",
       "weight": 1
     },
@@ -25643,7 +25667,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L588",
+      "source_location": "L589",
       "target": "dailycloseview_getvariancetone",
       "weight": 1
     },
@@ -25655,7 +25679,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L434",
+      "source_location": "L435",
       "target": "dailycloseview_humanizemetadatalabel",
       "weight": 1
     },
@@ -25667,7 +25691,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L580",
+      "source_location": "L581",
       "target": "dailycloseview_ismoneymetadatalabel",
       "weight": 1
     },
@@ -25679,7 +25703,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L584",
+      "source_location": "L585",
       "target": "dailycloseview_istimestampmetadatalabel",
       "weight": 1
     },
@@ -25691,7 +25715,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L990",
+      "source_location": "L1010",
       "target": "dailycloseview_normalizebuckettab",
       "weight": 1
     },
@@ -25703,7 +25727,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L376",
+      "source_location": "L377",
       "target": "dailycloseview_normalizecommandmessage",
       "weight": 1
     },
@@ -25715,7 +25739,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L576",
+      "source_location": "L577",
       "target": "dailycloseview_normalizemetadatalabel",
       "weight": 1
     },
@@ -25727,7 +25751,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L609",
+      "source_location": "L610",
       "target": "dailycloseview_shouldshowmetadataentry",
       "weight": 1
     },
@@ -55476,416 +55500,416 @@
     {
       "community": 1,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_storefrontjourneyevents_ts",
-      "label": "storefrontJourneyEvents.ts",
-      "norm_label": "storefrontjourneyevents.ts",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
-      "source_location": "L1"
+      "id": "dailycloseview_cn",
+      "label": "cn()",
+      "norm_label": "cn()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
+      "source_location": "L1370"
     },
     {
       "community": 1,
       "file_type": "code",
-      "id": "storefrontjourneyevents_compactcontext",
-      "label": "compactContext()",
-      "norm_label": "compactcontext()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
-      "source_location": "L7"
+      "id": "dailycloseview_formatcarriedoverregistercount",
+      "label": "formatCarriedOverRegisterCount()",
+      "norm_label": "formatcarriedoverregistercount()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
+      "source_location": "L271"
     },
     {
       "community": 1,
       "file_type": "code",
-      "id": "storefrontjourneyevents_createauthentryviewedevent",
-      "label": "createAuthEntryViewedEvent()",
-      "norm_label": "createauthentryviewedevent()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
-      "source_location": "L315"
+      "id": "dailycloseview_formatchecklistcount",
+      "label": "formatChecklistCount()",
+      "norm_label": "formatchecklistcount()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
+      "source_location": "L254"
     },
     {
       "community": 1,
       "file_type": "code",
-      "id": "storefrontjourneyevents_createauthrequeststartedevent",
-      "label": "createAuthRequestStartedEvent()",
-      "norm_label": "createauthrequeststartedevent()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
-      "source_location": "L335"
+      "id": "dailycloseview_formatcompletedat",
+      "label": "formatCompletedAt()",
+      "norm_label": "formatcompletedat()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
+      "source_location": "L338"
     },
     {
       "community": 1,
       "file_type": "code",
-      "id": "storefrontjourneyevents_createauthverificationsucceededevent",
-      "label": "createAuthVerificationSucceededEvent()",
-      "norm_label": "createauthverificationsucceededevent()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
-      "source_location": "L370"
+      "id": "dailycloseview_formatentitycount",
+      "label": "formatEntityCount()",
+      "norm_label": "formatentitycount()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
+      "source_location": "L244"
     },
     {
       "community": 1,
       "file_type": "code",
-      "id": "storefrontjourneyevents_createauthverificationviewedevent",
-      "label": "createAuthVerificationViewedEvent()",
-      "norm_label": "createauthverificationviewedevent()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
-      "source_location": "L355"
+      "id": "dailycloseview_formatmetadatadisplayvalue",
+      "label": "formatMetadataDisplayValue()",
+      "norm_label": "formatmetadatadisplayvalue()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
+      "source_location": "L717"
     },
     {
       "community": 1,
       "file_type": "code",
-      "id": "storefrontjourneyevents_createbagaddsucceededevent",
-      "label": "createBagAddSucceededEvent()",
-      "norm_label": "createbagaddsucceededevent()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
-      "source_location": "L101"
+      "id": "dailycloseview_formatmetadatavalue",
+      "label": "formatMetadataValue()",
+      "norm_label": "formatmetadatavalue()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
+      "source_location": "L665"
     },
     {
       "community": 1,
       "file_type": "code",
-      "id": "storefrontjourneyevents_createbagmovetosavedevent",
-      "label": "createBagMoveToSavedEvent()",
-      "norm_label": "createbagmovetosavedevent()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
-      "source_location": "L726"
+      "id": "dailycloseview_formatmoney",
+      "label": "formatMoney()",
+      "norm_label": "formatmoney()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
+      "source_location": "L318"
     },
     {
       "community": 1,
       "file_type": "code",
-      "id": "storefrontjourneyevents_createbagremovesucceededevent",
-      "label": "createBagRemoveSucceededEvent()",
-      "norm_label": "createbagremovesucceededevent()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
-      "source_location": "L122"
+      "id": "dailycloseview_formatoperatingdate",
+      "label": "formatOperatingDate()",
+      "norm_label": "formatoperatingdate()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
+      "source_location": "L324"
     },
     {
       "community": 1,
       "file_type": "code",
-      "id": "storefrontjourneyevents_createbagviewedevent",
-      "label": "createBagViewedEvent()",
-      "norm_label": "createbagviewedevent()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
-      "source_location": "L83"
+      "id": "dailycloseview_formatregistervariancecount",
+      "label": "formatRegisterVarianceCount()",
+      "norm_label": "formatregistervariancecount()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
+      "source_location": "L277"
     },
     {
       "community": 1,
       "file_type": "code",
-      "id": "storefrontjourneyevents_createcategorybrowseviewedevent",
-      "label": "createCategoryBrowseViewedEvent()",
-      "norm_label": "createcategorybrowseviewedevent()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
-      "source_location": "L41"
+      "id": "dailycloseview_formatstaffinvolvedcount",
+      "label": "formatStaffInvolvedCount()",
+      "norm_label": "formatstaffinvolvedcount()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
+      "source_location": "L312"
     },
     {
       "community": 1,
       "file_type": "code",
-      "id": "storefrontjourneyevents_createcheckoutcompletionblockedevent",
-      "label": "createCheckoutCompletionBlockedEvent()",
-      "norm_label": "createcheckoutcompletionblockedevent()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
-      "source_location": "L273"
+      "id": "dailycloseview_formattimestampmetadata",
+      "label": "formatTimestampMetadata()",
+      "norm_label": "formattimestampmetadata()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
+      "source_location": "L625"
     },
     {
       "community": 1,
       "file_type": "code",
-      "id": "storefrontjourneyevents_createcheckoutcompletioncanceledevent",
-      "label": "createCheckoutCompletionCanceledEvent()",
-      "norm_label": "createcheckoutcompletioncanceledevent()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
-      "source_location": "L290"
+      "id": "dailycloseview_formattodaycashtransactioncount",
+      "label": "formatTodayCashTransactionCount()",
+      "norm_label": "formattodaycashtransactioncount()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
+      "source_location": "L265"
     },
     {
       "community": 1,
       "file_type": "code",
-      "id": "storefrontjourneyevents_createcheckoutcompletionevent",
-      "label": "createCheckoutCompletionEvent()",
-      "norm_label": "createcheckoutcompletionevent()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
-      "source_location": "L233"
+      "id": "dailycloseview_getbucketconfigs",
+      "label": "getBucketConfigs()",
+      "norm_label": "getbucketconfigs()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
+      "source_location": "L1017"
     },
     {
       "community": 1,
       "file_type": "code",
-      "id": "storefrontjourneyevents_createcheckoutcompletionsucceededevent",
-      "label": "createCheckoutCompletionSucceededEvent()",
-      "norm_label": "createcheckoutcompletionsucceededevent()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
-      "source_location": "L256"
+      "id": "dailycloseview_getbucketcountclassname",
+      "label": "getBucketCountClassName()",
+      "norm_label": "getbucketcountclassname()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
+      "source_location": "L300"
     },
     {
       "community": 1,
       "file_type": "code",
-      "id": "storefrontjourneyevents_createcheckoutdetailsviewedevent",
-      "label": "createCheckoutDetailsViewedEvent()",
-      "norm_label": "createcheckoutdetailsviewedevent()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
-      "source_location": "L164"
+      "id": "dailycloseview_getcarryforwardworkitemid",
+      "label": "getCarryForwardWorkItemId()",
+      "norm_label": "getcarryforwardworkitemid()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
+      "source_location": "L413"
     },
     {
       "community": 1,
       "file_type": "code",
-      "id": "storefrontjourneyevents_createcheckoutstartevent",
-      "label": "createCheckoutStartEvent()",
-      "norm_label": "createcheckoutstartevent()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
-      "source_location": "L143"
+      "id": "dailycloseview_getcarryforwardworkitemids",
+      "label": "getCarryForwardWorkItemIds()",
+      "norm_label": "getcarryforwardworkitemids()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
+      "source_location": "L419"
     },
     {
       "community": 1,
       "file_type": "code",
-      "id": "storefrontjourneyevents_creatediscountcodetriggerevent",
-      "label": "createDiscountCodeTriggerEvent()",
-      "norm_label": "creatediscountcodetriggerevent()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
-      "source_location": "L747"
+      "id": "dailycloseview_getdailycloseapi",
+      "label": "getDailyCloseApi()",
+      "norm_label": "getdailycloseapi()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
+      "source_location": "L234"
     },
     {
       "community": 1,
       "file_type": "code",
-      "id": "storefrontjourneyevents_createjourneyevent",
-      "label": "createJourneyEvent()",
-      "norm_label": "createjourneyevent()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
-      "source_location": "L19"
-    },
-    {
-      "community": 1,
-      "file_type": "code",
-      "id": "storefrontjourneyevents_createlandingpageviewedevent",
-      "label": "createLandingPageViewedEvent()",
-      "norm_label": "createlandingpageviewedevent()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
-      "source_location": "L33"
-    },
-    {
-      "community": 1,
-      "file_type": "code",
-      "id": "storefrontjourneyevents_createleavereviewmodaldismissedevent",
-      "label": "createLeaveReviewModalDismissedEvent()",
-      "norm_label": "createleavereviewmodaldismissedevent()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
-      "source_location": "L555"
-    },
-    {
-      "community": 1,
-      "file_type": "code",
-      "id": "storefrontjourneyevents_createleavereviewmodalviewedevent",
-      "label": "createLeaveReviewModalViewedEvent()",
-      "norm_label": "createleavereviewmodalviewedevent()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
-      "source_location": "L537"
-    },
-    {
-      "community": 1,
-      "file_type": "code",
-      "id": "storefrontjourneyevents_createorderreviewviewedevent",
-      "label": "createOrderReviewViewedEvent()",
-      "norm_label": "createorderreviewviewedevent()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
-      "source_location": "L179"
-    },
-    {
-      "community": 1,
-      "file_type": "code",
-      "id": "storefrontjourneyevents_createpaymentsubmissionstartedevent",
-      "label": "createPaymentSubmissionStartedEvent()",
-      "norm_label": "createpaymentsubmissionstartedevent()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
-      "source_location": "L194"
-    },
-    {
-      "community": 1,
-      "file_type": "code",
-      "id": "storefrontjourneyevents_createpaymentverificationstartedevent",
-      "label": "createPaymentVerificationStartedEvent()",
-      "norm_label": "createpaymentverificationstartedevent()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
-      "source_location": "L215"
-    },
-    {
-      "community": 1,
-      "file_type": "code",
-      "id": "storefrontjourneyevents_createproductdetailviewedevent",
-      "label": "createProductDetailViewedEvent()",
-      "norm_label": "createproductdetailviewedevent()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
-      "source_location": "L59"
-    },
-    {
-      "community": 1,
-      "file_type": "code",
-      "id": "storefrontjourneyevents_createpromoalertdismissedevent",
-      "label": "createPromoAlertDismissedEvent()",
-      "norm_label": "createpromoalertdismissedevent()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
-      "source_location": "L435"
-    },
-    {
-      "community": 1,
-      "file_type": "code",
-      "id": "storefrontjourneyevents_createpromoalertshopnowevent",
-      "label": "createPromoAlertShopNowEvent()",
-      "norm_label": "createpromoalertshopnowevent()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
-      "source_location": "L459"
-    },
-    {
-      "community": 1,
-      "file_type": "code",
-      "id": "storefrontjourneyevents_createpromoalertviewedevent",
-      "label": "createPromoAlertViewedEvent()",
-      "norm_label": "createpromoalertviewedevent()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
-      "source_location": "L411"
-    },
-    {
-      "community": 1,
-      "file_type": "code",
-      "id": "storefrontjourneyevents_createrevieweditorviewedevent",
-      "label": "createReviewEditorViewedEvent()",
-      "norm_label": "createrevieweditorviewedevent()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
-      "source_location": "L762"
-    },
-    {
-      "community": 1,
-      "file_type": "code",
-      "id": "storefrontjourneyevents_createreviewsubmittedevent",
-      "label": "createReviewSubmittedEvent()",
-      "norm_label": "createreviewsubmittedevent()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
-      "source_location": "L786"
-    },
-    {
-      "community": 1,
-      "file_type": "code",
-      "id": "storefrontjourneyevents_createrewardsalertdismissedevent",
-      "label": "createRewardsAlertDismissedEvent()",
-      "norm_label": "createrewardsalertdismissedevent()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
-      "source_location": "L395"
-    },
-    {
-      "community": 1,
-      "file_type": "code",
-      "id": "storefrontjourneyevents_createrewardsalertshopnowevent",
-      "label": "createRewardsAlertShopNowEvent()",
-      "norm_label": "createrewardsalertshopnowevent()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
-      "source_location": "L403"
-    },
-    {
-      "community": 1,
-      "file_type": "code",
-      "id": "storefrontjourneyevents_createrewardsalertviewedevent",
-      "label": "createRewardsAlertViewedEvent()",
-      "norm_label": "createrewardsalertviewedevent()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
+      "id": "dailycloseview_getdailyclosestatus",
+      "label": "getDailyCloseStatus()",
+      "norm_label": "getdailyclosestatus()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
       "source_location": "L387"
     },
     {
       "community": 1,
       "file_type": "code",
-      "id": "storefrontjourneyevents_createsavedbagmovetobagevent",
-      "label": "createSavedBagMoveToBagEvent()",
-      "norm_label": "createsavedbagmovetobagevent()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
-      "source_location": "L684"
+      "id": "dailycloseview_getdefaultbucketvalue",
+      "label": "getDefaultBucketValue()",
+      "norm_label": "getdefaultbucketvalue()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
+      "source_location": "L1000"
     },
     {
       "community": 1,
       "file_type": "code",
-      "id": "storefrontjourneyevents_createsavedbagremoveevent",
-      "label": "createSavedBagRemoveEvent()",
-      "norm_label": "createsavedbagremoveevent()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
-      "source_location": "L705"
+      "id": "dailycloseview_getdisplaymetadatalabel",
+      "label": "getDisplayMetadataLabel()",
+      "norm_label": "getdisplaymetadatalabel()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
+      "source_location": "L635"
     },
     {
       "community": 1,
       "file_type": "code",
-      "id": "storefrontjourneyevents_createsavedbagviewedevent",
-      "label": "createSavedBagViewedEvent()",
-      "norm_label": "createsavedbagviewedevent()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
-      "source_location": "L676"
+      "id": "dailycloseview_getexpensestaffcount",
+      "label": "getExpenseStaffCount()",
+      "norm_label": "getexpensestaffcount()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
+      "source_location": "L988"
     },
     {
       "community": 1,
       "file_type": "code",
-      "id": "storefrontjourneyevents_createupsellmodaladdtobagevent",
-      "label": "createUpsellModalAddToBagEvent()",
-      "norm_label": "createupsellmodaladdtobagevent()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
-      "source_location": "L654"
+      "id": "dailycloseview_getitemcontextlabel",
+      "label": "getItemContextLabel()",
+      "norm_label": "getitemcontextlabel()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
+      "source_location": "L427"
     },
     {
       "community": 1,
       "file_type": "code",
-      "id": "storefrontjourneyevents_createupsellmodaldismissedevent",
-      "label": "createUpsellModalDismissedEvent()",
-      "norm_label": "createupsellmodaldismissedevent()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
-      "source_location": "L600"
+      "id": "dailycloseview_getitemdescription",
+      "label": "getItemDescription()",
+      "norm_label": "getitemdescription()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
+      "source_location": "L423"
     },
     {
       "community": 1,
       "file_type": "code",
-      "id": "storefrontjourneyevents_createupsellmodalsubmittedevent",
-      "label": "createUpsellModalSubmittedEvent()",
-      "norm_label": "createupsellmodalsubmittedevent()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
-      "source_location": "L627"
+      "id": "dailycloseview_getitemid",
+      "label": "getItemId()",
+      "norm_label": "getitemid()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
+      "source_location": "L401"
     },
     {
       "community": 1,
       "file_type": "code",
-      "id": "storefrontjourneyevents_createupsellmodalviewedevent",
-      "label": "createUpsellModalViewedEvent()",
-      "norm_label": "createupsellmodalviewedevent()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
-      "source_location": "L573"
+      "id": "dailycloseview_getlocaloperatingdate",
+      "label": "getLocalOperatingDate()",
+      "norm_label": "getlocaloperatingdate()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
+      "source_location": "L350"
     },
     {
       "community": 1,
       "file_type": "code",
-      "id": "storefrontjourneyevents_createwelcomebackmodaldismissedevent",
-      "label": "createWelcomeBackModalDismissedEvent()",
-      "norm_label": "createwelcomebackmodaldismissedevent()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
-      "source_location": "L501"
+      "id": "dailycloseview_getlocaloperatingdaterange",
+      "label": "getLocalOperatingDateRange()",
+      "norm_label": "getlocaloperatingdaterange()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
+      "source_location": "L358"
     },
     {
       "community": 1,
       "file_type": "code",
-      "id": "storefrontjourneyevents_createwelcomebackmodalsubmittedevent",
-      "label": "createWelcomeBackModalSubmittedEvent()",
-      "norm_label": "createwelcomebackmodalsubmittedevent()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
-      "source_location": "L519"
+      "id": "dailycloseview_getmetadataentries",
+      "label": "getMetadataEntries()",
+      "norm_label": "getmetadataentries()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
+      "source_location": "L774"
     },
     {
       "community": 1,
       "file_type": "code",
-      "id": "storefrontjourneyevents_createwelcomebackmodalviewedevent",
-      "label": "createWelcomeBackModalViewedEvent()",
-      "norm_label": "createwelcomebackmodalviewedevent()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
-      "source_location": "L483"
+      "id": "dailycloseview_getmetadatastringvalue",
+      "label": "getMetadataStringValue()",
+      "norm_label": "getmetadatastringvalue()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
+      "source_location": "L647"
     },
     {
       "community": 1,
       "file_type": "code",
-      "id": "storefrontjourneyevents_getauthentrystep",
-      "label": "getAuthEntryStep()",
-      "norm_label": "getauthentrystep()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
-      "source_location": "L307"
+      "id": "dailycloseview_getmetadatavalue",
+      "label": "getMetadataValue()",
+      "norm_label": "getmetadatavalue()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
+      "source_location": "L657"
     },
     {
       "community": 1,
       "file_type": "code",
-      "id": "storefrontjourneyevents_getauthrequeststep",
-      "label": "getAuthRequestStep()",
-      "norm_label": "getauthrequeststep()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
-      "source_location": "L311"
+      "id": "dailycloseview_getnumericmetadatavalue",
+      "label": "getNumericMetadataValue()",
+      "norm_label": "getnumericmetadatavalue()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
+      "source_location": "L597"
+    },
+    {
+      "community": 1,
+      "file_type": "code",
+      "id": "dailycloseview_getrevieweditemkeys",
+      "label": "getReviewedItemKeys()",
+      "norm_label": "getrevieweditemkeys()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
+      "source_location": "L409"
+    },
+    {
+      "community": 1,
+      "file_type": "code",
+      "id": "dailycloseview_getstatusicon",
+      "label": "getStatusIcon()",
+      "norm_label": "getstatusicon()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
+      "source_location": "L283"
+    },
+    {
+      "community": 1,
+      "file_type": "code",
+      "id": "dailycloseview_getstatuslabelclassname",
+      "label": "getStatusLabelClassName()",
+      "norm_label": "getstatuslabelclassname()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
+      "source_location": "L290"
+    },
+    {
+      "community": 1,
+      "file_type": "code",
+      "id": "dailycloseview_getsummaryamount",
+      "label": "getSummaryAmount()",
+      "norm_label": "getsummaryamount()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
+      "source_location": "L943"
+    },
+    {
+      "community": 1,
+      "file_type": "code",
+      "id": "dailycloseview_getsummarycount",
+      "label": "getSummaryCount()",
+      "norm_label": "getsummarycount()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
+      "source_location": "L958"
+    },
+    {
+      "community": 1,
+      "file_type": "code",
+      "id": "dailycloseview_getsummaryregistervariancecount",
+      "label": "getSummaryRegisterVarianceCount()",
+      "norm_label": "getsummaryregistervariancecount()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
+      "source_location": "L973"
+    },
+    {
+      "community": 1,
+      "file_type": "code",
+      "id": "dailycloseview_getvariancetone",
+      "label": "getVarianceTone()",
+      "norm_label": "getvariancetone()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
+      "source_location": "L589"
+    },
+    {
+      "community": 1,
+      "file_type": "code",
+      "id": "dailycloseview_humanizemetadatalabel",
+      "label": "humanizeMetadataLabel()",
+      "norm_label": "humanizemetadatalabel()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
+      "source_location": "L435"
+    },
+    {
+      "community": 1,
+      "file_type": "code",
+      "id": "dailycloseview_ismoneymetadatalabel",
+      "label": "isMoneyMetadataLabel()",
+      "norm_label": "ismoneymetadatalabel()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
+      "source_location": "L581"
+    },
+    {
+      "community": 1,
+      "file_type": "code",
+      "id": "dailycloseview_istimestampmetadatalabel",
+      "label": "isTimestampMetadataLabel()",
+      "norm_label": "istimestampmetadatalabel()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
+      "source_location": "L585"
+    },
+    {
+      "community": 1,
+      "file_type": "code",
+      "id": "dailycloseview_normalizebuckettab",
+      "label": "normalizeBucketTab()",
+      "norm_label": "normalizebuckettab()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
+      "source_location": "L1010"
+    },
+    {
+      "community": 1,
+      "file_type": "code",
+      "id": "dailycloseview_normalizecommandmessage",
+      "label": "normalizeCommandMessage()",
+      "norm_label": "normalizecommandmessage()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
+      "source_location": "L377"
+    },
+    {
+      "community": 1,
+      "file_type": "code",
+      "id": "dailycloseview_normalizemetadatalabel",
+      "label": "normalizeMetadataLabel()",
+      "norm_label": "normalizemetadatalabel()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
+      "source_location": "L577"
+    },
+    {
+      "community": 1,
+      "file_type": "code",
+      "id": "dailycloseview_shouldshowmetadataentry",
+      "label": "shouldShowMetadataEntry()",
+      "norm_label": "shouldshowmetadataentry()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
+      "source_location": "L610"
+    },
+    {
+      "community": 1,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
+      "label": "DailyCloseView.tsx",
+      "norm_label": "dailycloseview.tsx",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
+      "source_location": "L1"
     },
     {
       "community": 10,
@@ -56142,74 +56166,74 @@
     {
       "community": 100,
       "file_type": "code",
-      "id": "expensesessioncommands_test_builditem",
+      "id": "packages_athena_webapp_convex_pos_application_sessioncommands_test_ts",
+      "label": "sessionCommands.test.ts",
+      "norm_label": "sessioncommands.test.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 100,
+      "file_type": "code",
+      "id": "sessioncommands_test_builditem",
       "label": "buildItem()",
       "norm_label": "builditem()",
-      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
-      "source_location": "L645"
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L2406"
     },
     {
       "community": 100,
       "file_type": "code",
-      "id": "expensesessioncommands_test_buildregistersession",
+      "id": "sessioncommands_test_buildregistersession",
       "label": "buildRegisterSession()",
       "norm_label": "buildregistersession()",
-      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
-      "source_location": "L639"
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L2400"
     },
     {
       "community": 100,
       "file_type": "code",
-      "id": "expensesessioncommands_test_buildsession",
+      "id": "sessioncommands_test_buildsession",
       "label": "buildSession()",
       "norm_label": "buildsession()",
-      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
-      "source_location": "L635"
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L2396"
     },
     {
       "community": 100,
       "file_type": "code",
-      "id": "expensesessioncommands_test_createcommandservice",
+      "id": "sessioncommands_test_createcommandservice",
       "label": "createCommandService()",
       "norm_label": "createcommandservice()",
-      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
-      "source_location": "L655"
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L2416"
     },
     {
       "community": 100,
       "file_type": "code",
-      "id": "expensesessioncommands_test_createdependencies",
+      "id": "sessioncommands_test_createdependencies",
       "label": "createDependencies()",
       "norm_label": "createdependencies()",
-      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
-      "source_location": "L424"
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L2155"
     },
     {
       "community": 100,
       "file_type": "code",
-      "id": "expensesessioncommands_test_createfakerepository",
+      "id": "sessioncommands_test_createfakerepository",
       "label": "createFakeRepository()",
       "norm_label": "createfakerepository()",
-      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
-      "source_location": "L492"
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L2252"
     },
     {
       "community": 100,
       "file_type": "code",
-      "id": "expensesessioncommands_test_loadcommandservice",
+      "id": "sessioncommands_test_loadcommandservice",
       "label": "loadCommandService()",
       "norm_label": "loadcommandservice()",
-      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
-      "source_location": "L404"
-    },
-    {
-      "community": 100,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_expensesessioncommands_test_ts",
-      "label": "expenseSessionCommands.test.ts",
-      "norm_label": "expensesessioncommands.test.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
-      "source_location": "L1"
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L2137"
     },
     {
       "community": 1000,
@@ -56304,74 +56328,74 @@
     {
       "community": 101,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_sessioncommands_test_ts",
-      "label": "sessionCommands.test.ts",
-      "norm_label": "sessioncommands.test.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "id": "index_senddiscountcodeemail",
+      "label": "sendDiscountCodeEmail()",
+      "norm_label": "senddiscountcodeemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L255"
+    },
+    {
+      "community": 101,
+      "file_type": "code",
+      "id": "index_senddiscountreminderemail",
+      "label": "sendDiscountReminderEmail()",
+      "norm_label": "senddiscountreminderemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L334"
+    },
+    {
+      "community": 101,
+      "file_type": "code",
+      "id": "index_sendfeedbackrequestemail",
+      "label": "sendFeedbackRequestEmail()",
+      "norm_label": "sendfeedbackrequestemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L167"
+    },
+    {
+      "community": 101,
+      "file_type": "code",
+      "id": "index_sendneworderemail",
+      "label": "sendNewOrderEmail()",
+      "norm_label": "sendneworderemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L117"
+    },
+    {
+      "community": 101,
+      "file_type": "code",
+      "id": "index_sendorderemail",
+      "label": "sendOrderEmail()",
+      "norm_label": "sendorderemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L43"
+    },
+    {
+      "community": 101,
+      "file_type": "code",
+      "id": "index_sendverificationcode",
+      "label": "sendVerificationCode()",
+      "norm_label": "sendverificationcode()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L3"
+    },
+    {
+      "community": 101,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_mailersend_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/convex/mailersend/index.tsx",
       "source_location": "L1"
     },
     {
       "community": 101,
       "file_type": "code",
-      "id": "sessioncommands_test_builditem",
-      "label": "buildItem()",
-      "norm_label": "builditem()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L2406"
-    },
-    {
-      "community": 101,
-      "file_type": "code",
-      "id": "sessioncommands_test_buildregistersession",
-      "label": "buildRegisterSession()",
-      "norm_label": "buildregistersession()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L2400"
-    },
-    {
-      "community": 101,
-      "file_type": "code",
-      "id": "sessioncommands_test_buildsession",
-      "label": "buildSession()",
-      "norm_label": "buildsession()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L2396"
-    },
-    {
-      "community": 101,
-      "file_type": "code",
-      "id": "sessioncommands_test_createcommandservice",
-      "label": "createCommandService()",
-      "norm_label": "createcommandservice()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L2416"
-    },
-    {
-      "community": 101,
-      "file_type": "code",
-      "id": "sessioncommands_test_createdependencies",
-      "label": "createDependencies()",
-      "norm_label": "createdependencies()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L2155"
-    },
-    {
-      "community": 101,
-      "file_type": "code",
-      "id": "sessioncommands_test_createfakerepository",
-      "label": "createFakeRepository()",
-      "norm_label": "createfakerepository()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L2252"
-    },
-    {
-      "community": 101,
-      "file_type": "code",
-      "id": "sessioncommands_test_loadcommandservice",
-      "label": "loadCommandService()",
-      "norm_label": "loadcommandservice()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L2137"
+      "id": "packages_athena_webapp_convex_sendgrid_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L1"
     },
     {
       "community": 1010,
@@ -68652,51 +68676,6 @@
     {
       "community": 198,
       "file_type": "code",
-      "id": "index_feesview",
-      "label": "FeesView()",
-      "norm_label": "feesview()",
-      "source_file": "packages/athena-webapp/src/components/assets/index.tsx",
-      "source_location": "L30"
-    },
-    {
-      "community": 198,
-      "file_type": "code",
-      "id": "index_header",
-      "label": "Header()",
-      "norm_label": "header()",
-      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
-      "source_location": "L43"
-    },
-    {
-      "community": 198,
-      "file_type": "code",
-      "id": "index_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
-      "source_location": "L106"
-    },
-    {
-      "community": 198,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_assets_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/components/assets/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 198,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 199,
-      "file_type": "code",
       "id": "cashcontrolsdashboard_cn",
       "label": "cn()",
       "norm_label": "cn()",
@@ -68704,7 +68683,7 @@
       "source_location": "L363"
     },
     {
-      "community": 199,
+      "community": 198,
       "file_type": "code",
       "id": "cashcontrolsdashboard_if",
       "label": "if()",
@@ -68713,7 +68692,7 @@
       "source_location": "L423"
     },
     {
-      "community": 199,
+      "community": 198,
       "file_type": "code",
       "id": "cashcontrolsdashboard_metriccardskeleton",
       "label": "MetricCardSkeleton()",
@@ -68722,7 +68701,7 @@
       "source_location": "L87"
     },
     {
-      "community": 199,
+      "community": 198,
       "file_type": "code",
       "id": "cashcontrolsdashboard_switch",
       "label": "switch()",
@@ -68731,7 +68710,7 @@
       "source_location": "L256"
     },
     {
-      "community": 199,
+      "community": 198,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_cashcontrolsdashboard_tsx",
       "label": "CashControlsDashboard.tsx",
@@ -68740,409 +68719,463 @@
       "source_location": "L1"
     },
     {
-      "community": 2,
+      "community": 199,
       "file_type": "code",
-      "id": "dailycloseview_cn",
-      "label": "cn()",
-      "norm_label": "cn()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1350"
+      "id": "packages_athena_webapp_src_components_common_pageheader_tsx",
+      "label": "PageHeader.tsx",
+      "norm_label": "pageheader.tsx",
+      "source_file": "packages/athena-webapp/src/components/common/PageHeader.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 199,
+      "file_type": "code",
+      "id": "pageheader_navigatebackbutton",
+      "label": "NavigateBackButton()",
+      "norm_label": "navigatebackbutton()",
+      "source_file": "packages/athena-webapp/src/components/common/PageHeader.tsx",
+      "source_location": "L30"
+    },
+    {
+      "community": 199,
+      "file_type": "code",
+      "id": "pageheader_pageheader",
+      "label": "PageHeader()",
+      "norm_label": "pageheader()",
+      "source_file": "packages/athena-webapp/src/components/common/PageHeader.tsx",
+      "source_location": "L8"
+    },
+    {
+      "community": 199,
+      "file_type": "code",
+      "id": "pageheader_simplepageheader",
+      "label": "SimplePageHeader()",
+      "norm_label": "simplepageheader()",
+      "source_file": "packages/athena-webapp/src/components/common/PageHeader.tsx",
+      "source_location": "L50"
+    },
+    {
+      "community": 199,
+      "file_type": "code",
+      "id": "pageheader_viewheader",
+      "label": "ViewHeader()",
+      "norm_label": "viewheader()",
+      "source_file": "packages/athena-webapp/src/components/common/PageHeader.tsx",
+      "source_location": "L67"
     },
     {
       "community": 2,
       "file_type": "code",
-      "id": "dailycloseview_formatcarriedoverregistercount",
-      "label": "formatCarriedOverRegisterCount()",
-      "norm_label": "formatcarriedoverregistercount()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L270"
+      "id": "packages_storefront_webapp_src_lib_storefrontjourneyevents_ts",
+      "label": "storefrontJourneyEvents.ts",
+      "norm_label": "storefrontjourneyevents.ts",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
+      "source_location": "L1"
     },
     {
       "community": 2,
       "file_type": "code",
-      "id": "dailycloseview_formatchecklistcount",
-      "label": "formatChecklistCount()",
-      "norm_label": "formatchecklistcount()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L253"
+      "id": "storefrontjourneyevents_compactcontext",
+      "label": "compactContext()",
+      "norm_label": "compactcontext()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
+      "source_location": "L7"
     },
     {
       "community": 2,
       "file_type": "code",
-      "id": "dailycloseview_formatcompletedat",
-      "label": "formatCompletedAt()",
-      "norm_label": "formatcompletedat()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L337"
+      "id": "storefrontjourneyevents_createauthentryviewedevent",
+      "label": "createAuthEntryViewedEvent()",
+      "norm_label": "createauthentryviewedevent()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
+      "source_location": "L315"
     },
     {
       "community": 2,
       "file_type": "code",
-      "id": "dailycloseview_formatentitycount",
-      "label": "formatEntityCount()",
-      "norm_label": "formatentitycount()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L243"
+      "id": "storefrontjourneyevents_createauthrequeststartedevent",
+      "label": "createAuthRequestStartedEvent()",
+      "norm_label": "createauthrequeststartedevent()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
+      "source_location": "L335"
     },
     {
       "community": 2,
       "file_type": "code",
-      "id": "dailycloseview_formatmetadatadisplayvalue",
-      "label": "formatMetadataDisplayValue()",
-      "norm_label": "formatmetadatadisplayvalue()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L716"
+      "id": "storefrontjourneyevents_createauthverificationsucceededevent",
+      "label": "createAuthVerificationSucceededEvent()",
+      "norm_label": "createauthverificationsucceededevent()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
+      "source_location": "L370"
     },
     {
       "community": 2,
       "file_type": "code",
-      "id": "dailycloseview_formatmetadatavalue",
-      "label": "formatMetadataValue()",
-      "norm_label": "formatmetadatavalue()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L664"
+      "id": "storefrontjourneyevents_createauthverificationviewedevent",
+      "label": "createAuthVerificationViewedEvent()",
+      "norm_label": "createauthverificationviewedevent()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
+      "source_location": "L355"
     },
     {
       "community": 2,
       "file_type": "code",
-      "id": "dailycloseview_formatmoney",
-      "label": "formatMoney()",
-      "norm_label": "formatmoney()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L317"
+      "id": "storefrontjourneyevents_createbagaddsucceededevent",
+      "label": "createBagAddSucceededEvent()",
+      "norm_label": "createbagaddsucceededevent()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
+      "source_location": "L101"
     },
     {
       "community": 2,
       "file_type": "code",
-      "id": "dailycloseview_formatoperatingdate",
-      "label": "formatOperatingDate()",
-      "norm_label": "formatoperatingdate()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L323"
+      "id": "storefrontjourneyevents_createbagmovetosavedevent",
+      "label": "createBagMoveToSavedEvent()",
+      "norm_label": "createbagmovetosavedevent()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
+      "source_location": "L726"
     },
     {
       "community": 2,
       "file_type": "code",
-      "id": "dailycloseview_formatregistervariancecount",
-      "label": "formatRegisterVarianceCount()",
-      "norm_label": "formatregistervariancecount()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L276"
+      "id": "storefrontjourneyevents_createbagremovesucceededevent",
+      "label": "createBagRemoveSucceededEvent()",
+      "norm_label": "createbagremovesucceededevent()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
+      "source_location": "L122"
     },
     {
       "community": 2,
       "file_type": "code",
-      "id": "dailycloseview_formatstaffinvolvedcount",
-      "label": "formatStaffInvolvedCount()",
-      "norm_label": "formatstaffinvolvedcount()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L311"
+      "id": "storefrontjourneyevents_createbagviewedevent",
+      "label": "createBagViewedEvent()",
+      "norm_label": "createbagviewedevent()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
+      "source_location": "L83"
     },
     {
       "community": 2,
       "file_type": "code",
-      "id": "dailycloseview_formattimestampmetadata",
-      "label": "formatTimestampMetadata()",
-      "norm_label": "formattimestampmetadata()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L624"
+      "id": "storefrontjourneyevents_createcategorybrowseviewedevent",
+      "label": "createCategoryBrowseViewedEvent()",
+      "norm_label": "createcategorybrowseviewedevent()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
+      "source_location": "L41"
     },
     {
       "community": 2,
       "file_type": "code",
-      "id": "dailycloseview_formattodaycashtransactioncount",
-      "label": "formatTodayCashTransactionCount()",
-      "norm_label": "formattodaycashtransactioncount()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L264"
+      "id": "storefrontjourneyevents_createcheckoutcompletionblockedevent",
+      "label": "createCheckoutCompletionBlockedEvent()",
+      "norm_label": "createcheckoutcompletionblockedevent()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
+      "source_location": "L273"
     },
     {
       "community": 2,
       "file_type": "code",
-      "id": "dailycloseview_getbucketconfigs",
-      "label": "getBucketConfigs()",
-      "norm_label": "getbucketconfigs()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L997"
+      "id": "storefrontjourneyevents_createcheckoutcompletioncanceledevent",
+      "label": "createCheckoutCompletionCanceledEvent()",
+      "norm_label": "createcheckoutcompletioncanceledevent()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
+      "source_location": "L290"
     },
     {
       "community": 2,
       "file_type": "code",
-      "id": "dailycloseview_getbucketcountclassname",
-      "label": "getBucketCountClassName()",
-      "norm_label": "getbucketcountclassname()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L299"
-    },
-    {
-      "community": 2,
-      "file_type": "code",
-      "id": "dailycloseview_getcarryforwardworkitemid",
-      "label": "getCarryForwardWorkItemId()",
-      "norm_label": "getcarryforwardworkitemid()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L412"
-    },
-    {
-      "community": 2,
-      "file_type": "code",
-      "id": "dailycloseview_getcarryforwardworkitemids",
-      "label": "getCarryForwardWorkItemIds()",
-      "norm_label": "getcarryforwardworkitemids()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L418"
-    },
-    {
-      "community": 2,
-      "file_type": "code",
-      "id": "dailycloseview_getdailycloseapi",
-      "label": "getDailyCloseApi()",
-      "norm_label": "getdailycloseapi()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
+      "id": "storefrontjourneyevents_createcheckoutcompletionevent",
+      "label": "createCheckoutCompletionEvent()",
+      "norm_label": "createcheckoutcompletionevent()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L233"
     },
     {
       "community": 2,
       "file_type": "code",
-      "id": "dailycloseview_getdailyclosestatus",
-      "label": "getDailyCloseStatus()",
-      "norm_label": "getdailyclosestatus()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L386"
+      "id": "storefrontjourneyevents_createcheckoutcompletionsucceededevent",
+      "label": "createCheckoutCompletionSucceededEvent()",
+      "norm_label": "createcheckoutcompletionsucceededevent()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
+      "source_location": "L256"
     },
     {
       "community": 2,
       "file_type": "code",
-      "id": "dailycloseview_getdefaultbucketvalue",
-      "label": "getDefaultBucketValue()",
-      "norm_label": "getdefaultbucketvalue()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L980"
+      "id": "storefrontjourneyevents_createcheckoutdetailsviewedevent",
+      "label": "createCheckoutDetailsViewedEvent()",
+      "norm_label": "createcheckoutdetailsviewedevent()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
+      "source_location": "L164"
     },
     {
       "community": 2,
       "file_type": "code",
-      "id": "dailycloseview_getdisplaymetadatalabel",
-      "label": "getDisplayMetadataLabel()",
-      "norm_label": "getdisplaymetadatalabel()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L634"
+      "id": "storefrontjourneyevents_createcheckoutstartevent",
+      "label": "createCheckoutStartEvent()",
+      "norm_label": "createcheckoutstartevent()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
+      "source_location": "L143"
     },
     {
       "community": 2,
       "file_type": "code",
-      "id": "dailycloseview_getitemcontextlabel",
-      "label": "getItemContextLabel()",
-      "norm_label": "getitemcontextlabel()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L426"
+      "id": "storefrontjourneyevents_creatediscountcodetriggerevent",
+      "label": "createDiscountCodeTriggerEvent()",
+      "norm_label": "creatediscountcodetriggerevent()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
+      "source_location": "L747"
     },
     {
       "community": 2,
       "file_type": "code",
-      "id": "dailycloseview_getitemdescription",
-      "label": "getItemDescription()",
-      "norm_label": "getitemdescription()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L422"
+      "id": "storefrontjourneyevents_createjourneyevent",
+      "label": "createJourneyEvent()",
+      "norm_label": "createjourneyevent()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
+      "source_location": "L19"
     },
     {
       "community": 2,
       "file_type": "code",
-      "id": "dailycloseview_getitemid",
-      "label": "getItemId()",
-      "norm_label": "getitemid()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L400"
+      "id": "storefrontjourneyevents_createlandingpageviewedevent",
+      "label": "createLandingPageViewedEvent()",
+      "norm_label": "createlandingpageviewedevent()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
+      "source_location": "L33"
     },
     {
       "community": 2,
       "file_type": "code",
-      "id": "dailycloseview_getlocaloperatingdate",
-      "label": "getLocalOperatingDate()",
-      "norm_label": "getlocaloperatingdate()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L349"
+      "id": "storefrontjourneyevents_createleavereviewmodaldismissedevent",
+      "label": "createLeaveReviewModalDismissedEvent()",
+      "norm_label": "createleavereviewmodaldismissedevent()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
+      "source_location": "L555"
     },
     {
       "community": 2,
       "file_type": "code",
-      "id": "dailycloseview_getlocaloperatingdaterange",
-      "label": "getLocalOperatingDateRange()",
-      "norm_label": "getlocaloperatingdaterange()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L357"
+      "id": "storefrontjourneyevents_createleavereviewmodalviewedevent",
+      "label": "createLeaveReviewModalViewedEvent()",
+      "norm_label": "createleavereviewmodalviewedevent()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
+      "source_location": "L537"
     },
     {
       "community": 2,
       "file_type": "code",
-      "id": "dailycloseview_getmetadataentries",
-      "label": "getMetadataEntries()",
-      "norm_label": "getmetadataentries()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L773"
+      "id": "storefrontjourneyevents_createorderreviewviewedevent",
+      "label": "createOrderReviewViewedEvent()",
+      "norm_label": "createorderreviewviewedevent()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
+      "source_location": "L179"
     },
     {
       "community": 2,
       "file_type": "code",
-      "id": "dailycloseview_getmetadatastringvalue",
-      "label": "getMetadataStringValue()",
-      "norm_label": "getmetadatastringvalue()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L646"
+      "id": "storefrontjourneyevents_createpaymentsubmissionstartedevent",
+      "label": "createPaymentSubmissionStartedEvent()",
+      "norm_label": "createpaymentsubmissionstartedevent()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
+      "source_location": "L194"
     },
     {
       "community": 2,
       "file_type": "code",
-      "id": "dailycloseview_getmetadatavalue",
-      "label": "getMetadataValue()",
-      "norm_label": "getmetadatavalue()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L656"
+      "id": "storefrontjourneyevents_createpaymentverificationstartedevent",
+      "label": "createPaymentVerificationStartedEvent()",
+      "norm_label": "createpaymentverificationstartedevent()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
+      "source_location": "L215"
     },
     {
       "community": 2,
       "file_type": "code",
-      "id": "dailycloseview_getnumericmetadatavalue",
-      "label": "getNumericMetadataValue()",
-      "norm_label": "getnumericmetadatavalue()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L596"
+      "id": "storefrontjourneyevents_createproductdetailviewedevent",
+      "label": "createProductDetailViewedEvent()",
+      "norm_label": "createproductdetailviewedevent()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
+      "source_location": "L59"
     },
     {
       "community": 2,
       "file_type": "code",
-      "id": "dailycloseview_getrevieweditemkeys",
-      "label": "getReviewedItemKeys()",
-      "norm_label": "getrevieweditemkeys()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L408"
+      "id": "storefrontjourneyevents_createpromoalertdismissedevent",
+      "label": "createPromoAlertDismissedEvent()",
+      "norm_label": "createpromoalertdismissedevent()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
+      "source_location": "L435"
     },
     {
       "community": 2,
       "file_type": "code",
-      "id": "dailycloseview_getstatusicon",
-      "label": "getStatusIcon()",
-      "norm_label": "getstatusicon()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L282"
+      "id": "storefrontjourneyevents_createpromoalertshopnowevent",
+      "label": "createPromoAlertShopNowEvent()",
+      "norm_label": "createpromoalertshopnowevent()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
+      "source_location": "L459"
     },
     {
       "community": 2,
       "file_type": "code",
-      "id": "dailycloseview_getstatuslabelclassname",
-      "label": "getStatusLabelClassName()",
-      "norm_label": "getstatuslabelclassname()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L289"
+      "id": "storefrontjourneyevents_createpromoalertviewedevent",
+      "label": "createPromoAlertViewedEvent()",
+      "norm_label": "createpromoalertviewedevent()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
+      "source_location": "L411"
     },
     {
       "community": 2,
       "file_type": "code",
-      "id": "dailycloseview_getsummaryamount",
-      "label": "getSummaryAmount()",
-      "norm_label": "getsummaryamount()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L935"
+      "id": "storefrontjourneyevents_createrevieweditorviewedevent",
+      "label": "createReviewEditorViewedEvent()",
+      "norm_label": "createrevieweditorviewedevent()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
+      "source_location": "L762"
     },
     {
       "community": 2,
       "file_type": "code",
-      "id": "dailycloseview_getsummarycount",
-      "label": "getSummaryCount()",
-      "norm_label": "getsummarycount()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L950"
+      "id": "storefrontjourneyevents_createreviewsubmittedevent",
+      "label": "createReviewSubmittedEvent()",
+      "norm_label": "createreviewsubmittedevent()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
+      "source_location": "L786"
     },
     {
       "community": 2,
       "file_type": "code",
-      "id": "dailycloseview_getsummaryregistervariancecount",
-      "label": "getSummaryRegisterVarianceCount()",
-      "norm_label": "getsummaryregistervariancecount()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L965"
+      "id": "storefrontjourneyevents_createrewardsalertdismissedevent",
+      "label": "createRewardsAlertDismissedEvent()",
+      "norm_label": "createrewardsalertdismissedevent()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
+      "source_location": "L395"
     },
     {
       "community": 2,
       "file_type": "code",
-      "id": "dailycloseview_getvariancetone",
-      "label": "getVarianceTone()",
-      "norm_label": "getvariancetone()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L588"
+      "id": "storefrontjourneyevents_createrewardsalertshopnowevent",
+      "label": "createRewardsAlertShopNowEvent()",
+      "norm_label": "createrewardsalertshopnowevent()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
+      "source_location": "L403"
     },
     {
       "community": 2,
       "file_type": "code",
-      "id": "dailycloseview_humanizemetadatalabel",
-      "label": "humanizeMetadataLabel()",
-      "norm_label": "humanizemetadatalabel()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L434"
+      "id": "storefrontjourneyevents_createrewardsalertviewedevent",
+      "label": "createRewardsAlertViewedEvent()",
+      "norm_label": "createrewardsalertviewedevent()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
+      "source_location": "L387"
     },
     {
       "community": 2,
       "file_type": "code",
-      "id": "dailycloseview_ismoneymetadatalabel",
-      "label": "isMoneyMetadataLabel()",
-      "norm_label": "ismoneymetadatalabel()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L580"
+      "id": "storefrontjourneyevents_createsavedbagmovetobagevent",
+      "label": "createSavedBagMoveToBagEvent()",
+      "norm_label": "createsavedbagmovetobagevent()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
+      "source_location": "L684"
     },
     {
       "community": 2,
       "file_type": "code",
-      "id": "dailycloseview_istimestampmetadatalabel",
-      "label": "isTimestampMetadataLabel()",
-      "norm_label": "istimestampmetadatalabel()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L584"
+      "id": "storefrontjourneyevents_createsavedbagremoveevent",
+      "label": "createSavedBagRemoveEvent()",
+      "norm_label": "createsavedbagremoveevent()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
+      "source_location": "L705"
     },
     {
       "community": 2,
       "file_type": "code",
-      "id": "dailycloseview_normalizebuckettab",
-      "label": "normalizeBucketTab()",
-      "norm_label": "normalizebuckettab()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L990"
+      "id": "storefrontjourneyevents_createsavedbagviewedevent",
+      "label": "createSavedBagViewedEvent()",
+      "norm_label": "createsavedbagviewedevent()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
+      "source_location": "L676"
     },
     {
       "community": 2,
       "file_type": "code",
-      "id": "dailycloseview_normalizecommandmessage",
-      "label": "normalizeCommandMessage()",
-      "norm_label": "normalizecommandmessage()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L376"
+      "id": "storefrontjourneyevents_createupsellmodaladdtobagevent",
+      "label": "createUpsellModalAddToBagEvent()",
+      "norm_label": "createupsellmodaladdtobagevent()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
+      "source_location": "L654"
     },
     {
       "community": 2,
       "file_type": "code",
-      "id": "dailycloseview_normalizemetadatalabel",
-      "label": "normalizeMetadataLabel()",
-      "norm_label": "normalizemetadatalabel()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L576"
+      "id": "storefrontjourneyevents_createupsellmodaldismissedevent",
+      "label": "createUpsellModalDismissedEvent()",
+      "norm_label": "createupsellmodaldismissedevent()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
+      "source_location": "L600"
     },
     {
       "community": 2,
       "file_type": "code",
-      "id": "dailycloseview_shouldshowmetadataentry",
-      "label": "shouldShowMetadataEntry()",
-      "norm_label": "shouldshowmetadataentry()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L609"
+      "id": "storefrontjourneyevents_createupsellmodalsubmittedevent",
+      "label": "createUpsellModalSubmittedEvent()",
+      "norm_label": "createupsellmodalsubmittedevent()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
+      "source_location": "L627"
     },
     {
       "community": 2,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
-      "label": "DailyCloseView.tsx",
-      "norm_label": "dailycloseview.tsx",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1"
+      "id": "storefrontjourneyevents_createupsellmodalviewedevent",
+      "label": "createUpsellModalViewedEvent()",
+      "norm_label": "createupsellmodalviewedevent()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
+      "source_location": "L573"
+    },
+    {
+      "community": 2,
+      "file_type": "code",
+      "id": "storefrontjourneyevents_createwelcomebackmodaldismissedevent",
+      "label": "createWelcomeBackModalDismissedEvent()",
+      "norm_label": "createwelcomebackmodaldismissedevent()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
+      "source_location": "L501"
+    },
+    {
+      "community": 2,
+      "file_type": "code",
+      "id": "storefrontjourneyevents_createwelcomebackmodalsubmittedevent",
+      "label": "createWelcomeBackModalSubmittedEvent()",
+      "norm_label": "createwelcomebackmodalsubmittedevent()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
+      "source_location": "L519"
+    },
+    {
+      "community": 2,
+      "file_type": "code",
+      "id": "storefrontjourneyevents_createwelcomebackmodalviewedevent",
+      "label": "createWelcomeBackModalViewedEvent()",
+      "norm_label": "createwelcomebackmodalviewedevent()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
+      "source_location": "L483"
+    },
+    {
+      "community": 2,
+      "file_type": "code",
+      "id": "storefrontjourneyevents_getauthentrystep",
+      "label": "getAuthEntryStep()",
+      "norm_label": "getauthentrystep()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
+      "source_location": "L307"
+    },
+    {
+      "community": 2,
+      "file_type": "code",
+      "id": "storefrontjourneyevents_getauthrequeststep",
+      "label": "getAuthRequestStep()",
+      "norm_label": "getauthrequeststep()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
+      "source_location": "L311"
     },
     {
       "community": 20,
@@ -69327,51 +69360,6 @@
     {
       "community": 200,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_common_pageheader_tsx",
-      "label": "PageHeader.tsx",
-      "norm_label": "pageheader.tsx",
-      "source_file": "packages/athena-webapp/src/components/common/PageHeader.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 200,
-      "file_type": "code",
-      "id": "pageheader_navigatebackbutton",
-      "label": "NavigateBackButton()",
-      "norm_label": "navigatebackbutton()",
-      "source_file": "packages/athena-webapp/src/components/common/PageHeader.tsx",
-      "source_location": "L30"
-    },
-    {
-      "community": 200,
-      "file_type": "code",
-      "id": "pageheader_pageheader",
-      "label": "PageHeader()",
-      "norm_label": "pageheader()",
-      "source_file": "packages/athena-webapp/src/components/common/PageHeader.tsx",
-      "source_location": "L8"
-    },
-    {
-      "community": 200,
-      "file_type": "code",
-      "id": "pageheader_simplepageheader",
-      "label": "SimplePageHeader()",
-      "norm_label": "simplepageheader()",
-      "source_file": "packages/athena-webapp/src/components/common/PageHeader.tsx",
-      "source_location": "L50"
-    },
-    {
-      "community": 200,
-      "file_type": "code",
-      "id": "pageheader_viewheader",
-      "label": "ViewHeader()",
-      "norm_label": "viewheader()",
-      "source_file": "packages/athena-webapp/src/components/common/PageHeader.tsx",
-      "source_location": "L67"
-    },
-    {
-      "community": 201,
-      "file_type": "code",
       "id": "dashboard_getperiodrange",
       "label": "getPeriodRange()",
       "norm_label": "getperiodrange()",
@@ -69379,7 +69367,7 @@
       "source_location": "L20"
     },
     {
-      "community": 201,
+      "community": 200,
       "file_type": "code",
       "id": "dashboard_loadingsection",
       "label": "LoadingSection()",
@@ -69388,7 +69376,7 @@
       "source_location": "L50"
     },
     {
-      "community": 201,
+      "community": 200,
       "file_type": "code",
       "id": "dashboard_renderproductssection",
       "label": "renderProductsSection()",
@@ -69397,7 +69385,7 @@
       "source_location": "L342"
     },
     {
-      "community": 201,
+      "community": 200,
       "file_type": "code",
       "id": "dashboard_rendersalessection",
       "label": "renderSalesSection()",
@@ -69406,7 +69394,7 @@
       "source_location": "L322"
     },
     {
-      "community": 201,
+      "community": 200,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_dashboard_dashboard_tsx",
       "label": "Dashboard.tsx",
@@ -69415,7 +69403,7 @@
       "source_location": "L1"
     },
     {
-      "community": 202,
+      "community": 201,
       "file_type": "code",
       "id": "herosectiontabs_handledisplaytypechange",
       "label": "handleDisplayTypeChange()",
@@ -69424,7 +69412,7 @@
       "source_location": "L61"
     },
     {
-      "community": 202,
+      "community": 201,
       "file_type": "code",
       "id": "herosectiontabs_handleimageupdate",
       "label": "handleImageUpdate()",
@@ -69433,7 +69421,7 @@
       "source_location": "L57"
     },
     {
-      "community": 202,
+      "community": 201,
       "file_type": "code",
       "id": "herosectiontabs_handleoverlaytoggle",
       "label": "handleOverlayToggle()",
@@ -69442,7 +69430,7 @@
       "source_location": "L98"
     },
     {
-      "community": 202,
+      "community": 201,
       "file_type": "code",
       "id": "herosectiontabs_handletexttoggle",
       "label": "handleTextToggle()",
@@ -69451,7 +69439,7 @@
       "source_location": "L134"
     },
     {
-      "community": 202,
+      "community": 201,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_herosectiontabs_tsx",
       "label": "HeroSectionTabs.tsx",
@@ -69460,7 +69448,7 @@
       "source_location": "L1"
     },
     {
-      "community": 203,
+      "community": 202,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_reeluploader_tsx",
       "label": "ReelUploader.tsx",
@@ -69469,7 +69457,7 @@
       "source_location": "L1"
     },
     {
-      "community": 203,
+      "community": 202,
       "file_type": "code",
       "id": "reeluploader_formatfilesize",
       "label": "formatFileSize()",
@@ -69478,7 +69466,7 @@
       "source_location": "L38"
     },
     {
-      "community": 203,
+      "community": 202,
       "file_type": "code",
       "id": "reeluploader_handlefileselect",
       "label": "handleFileSelect()",
@@ -69487,7 +69475,7 @@
       "source_location": "L64"
     },
     {
-      "community": 203,
+      "community": 202,
       "file_type": "code",
       "id": "reeluploader_handleupload",
       "label": "handleUpload()",
@@ -69496,7 +69484,7 @@
       "source_location": "L135"
     },
     {
-      "community": 203,
+      "community": 202,
       "file_type": "code",
       "id": "reeluploader_validatefile",
       "label": "validateFile()",
@@ -69505,7 +69493,7 @@
       "source_location": "L43"
     },
     {
-      "community": 204,
+      "community": 203,
       "file_type": "code",
       "id": "activityview_iscreatedaction",
       "label": "isCreatedAction()",
@@ -69514,7 +69502,7 @@
       "source_location": "L58"
     },
     {
-      "community": 204,
+      "community": 203,
       "file_type": "code",
       "id": "activityview_isfeedbackrequestaction",
       "label": "isFeedbackRequestAction()",
@@ -69523,7 +69511,7 @@
       "source_location": "L63"
     },
     {
-      "community": 204,
+      "community": 203,
       "file_type": "code",
       "id": "activityview_isrefundaction",
       "label": "isRefundAction()",
@@ -69532,7 +69520,7 @@
       "source_location": "L50"
     },
     {
-      "community": 204,
+      "community": 203,
       "file_type": "code",
       "id": "activityview_istransitionaction",
       "label": "isTransitionAction()",
@@ -69541,7 +69529,7 @@
       "source_location": "L53"
     },
     {
-      "community": 204,
+      "community": 203,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_activityview_tsx",
       "label": "ActivityView.tsx",
@@ -69550,7 +69538,7 @@
       "source_location": "L1"
     },
     {
-      "community": 205,
+      "community": 204,
       "file_type": "code",
       "id": "orderdetailsview_fetchtransactions",
       "label": "fetchTransactions()",
@@ -69559,7 +69547,7 @@
       "source_location": "L140"
     },
     {
-      "community": 205,
+      "community": 204,
       "file_type": "code",
       "id": "orderdetailsview_handlemarkasverified",
       "label": "handleMarkAsVerified()",
@@ -69568,7 +69556,7 @@
       "source_location": "L177"
     },
     {
-      "community": 205,
+      "community": 204,
       "file_type": "code",
       "id": "orderdetailsview_handlemarkpaymentcollected",
       "label": "handleMarkPaymentCollected()",
@@ -69577,7 +69565,7 @@
       "source_location": "L195"
     },
     {
-      "community": 205,
+      "community": 204,
       "file_type": "code",
       "id": "orderdetailsview_verifiedbadge",
       "label": "VerifiedBadge()",
@@ -69586,7 +69574,7 @@
       "source_location": "L45"
     },
     {
-      "community": 205,
+      "community": 204,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orderdetailsview_tsx",
       "label": "OrderDetailsView.tsx",
@@ -69595,7 +69583,7 @@
       "source_location": "L1"
     },
     {
-      "community": 206,
+      "community": 205,
       "file_type": "code",
       "id": "orderitemsview_handlerequestfeedback",
       "label": "handleRequestFeedback()",
@@ -69604,7 +69592,7 @@
       "source_location": "L92"
     },
     {
-      "community": 206,
+      "community": 205,
       "file_type": "code",
       "id": "orderitemsview_handlerestockall",
       "label": "handleRestockAll()",
@@ -69613,7 +69601,7 @@
       "source_location": "L307"
     },
     {
-      "community": 206,
+      "community": 205,
       "file_type": "code",
       "id": "orderitemsview_handlereturnitemtostock",
       "label": "handleReturnItemToStock()",
@@ -69622,7 +69610,7 @@
       "source_location": "L70"
     },
     {
-      "community": 206,
+      "community": 205,
       "file_type": "code",
       "id": "orderitemsview_handleupdateorderitem",
       "label": "handleUpdateOrderItem()",
@@ -69631,12 +69619,57 @@
       "source_location": "L50"
     },
     {
-      "community": 206,
+      "community": 205,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orderitemsview_tsx",
       "label": "OrderItemsView.tsx",
       "norm_label": "orderitemsview.tsx",
       "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 206,
+      "file_type": "code",
+      "id": "index_feesview",
+      "label": "FeesView()",
+      "norm_label": "feesview()",
+      "source_file": "packages/athena-webapp/src/components/assets/index.tsx",
+      "source_location": "L30"
+    },
+    {
+      "community": 206,
+      "file_type": "code",
+      "id": "index_header",
+      "label": "Header()",
+      "norm_label": "header()",
+      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
+      "source_location": "L43"
+    },
+    {
+      "community": 206,
+      "file_type": "code",
+      "id": "index_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
+      "source_location": "L106"
+    },
+    {
+      "community": 206,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_assets_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/components/assets/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 206,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_organization_members_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
       "source_location": "L1"
     },
     {
@@ -77490,154 +77523,154 @@
     {
       "community": 35,
       "file_type": "code",
-      "id": "completetransaction_buildcompletetransactionresult",
-      "label": "buildCompleteTransactionResult()",
-      "norm_label": "buildcompletetransactionresult()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L57"
+      "id": "data_table_view_options_datatableviewoptions",
+      "label": "DataTableViewOptions()",
+      "norm_label": "datatableviewoptions()",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-view-options.tsx",
+      "source_location": "L18"
     },
     {
       "community": 35,
       "file_type": "code",
-      "id": "completetransaction_calculatecanonicaltransactiontotals",
-      "label": "calculateCanonicalTransactionTotals()",
-      "norm_label": "calculatecanonicaltransactiontotals()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L86"
-    },
-    {
-      "community": 35,
-      "file_type": "code",
-      "id": "completetransaction_calculatetotalpaid",
-      "label": "calculateTotalPaid()",
-      "norm_label": "calculatetotalpaid()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L78"
-    },
-    {
-      "community": 35,
-      "file_type": "code",
-      "id": "completetransaction_completetransaction",
-      "label": "completeTransaction()",
-      "norm_label": "completetransaction()",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/useCases/completeTransaction.ts",
-      "source_location": "L5"
-    },
-    {
-      "community": 35,
-      "file_type": "code",
-      "id": "completetransaction_createtransactionfromsessionhandler",
-      "label": "createTransactionFromSessionHandler()",
-      "norm_label": "createtransactionfromsessionhandler()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L564"
-    },
-    {
-      "community": 35,
-      "file_type": "code",
-      "id": "completetransaction_isusableregistersession",
-      "label": "isUsableRegisterSession()",
-      "norm_label": "isusableregistersession()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L137"
-    },
-    {
-      "community": 35,
-      "file_type": "code",
-      "id": "completetransaction_recordregistersessionsale",
-      "label": "recordRegisterSessionSale()",
-      "norm_label": "recordregistersessionsale()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L191"
-    },
-    {
-      "community": 35,
-      "file_type": "code",
-      "id": "completetransaction_recordregistersessionvoid",
-      "label": "recordRegisterSessionVoid()",
-      "norm_label": "recordregistersessionvoid()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L216"
-    },
-    {
-      "community": 35,
-      "file_type": "code",
-      "id": "completetransaction_registersessionmatchesidentity",
-      "label": "registerSessionMatchesIdentity()",
-      "norm_label": "registersessionmatchesidentity()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L122"
-    },
-    {
-      "community": 35,
-      "file_type": "code",
-      "id": "completetransaction_resolvesessionregistersessionid",
-      "label": "resolveSessionRegisterSessionId()",
-      "norm_label": "resolvesessionregistersessionid()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L141"
-    },
-    {
-      "community": 35,
-      "file_type": "code",
-      "id": "completetransaction_roundstoredamount",
-      "label": "roundStoredAmount()",
-      "norm_label": "roundstoredamount()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L82"
-    },
-    {
-      "community": 35,
-      "file_type": "code",
-      "id": "completetransaction_stalesaletotalerror",
-      "label": "staleSaleTotalError()",
-      "norm_label": "stalesaletotalerror()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L115"
-    },
-    {
-      "community": 35,
-      "file_type": "code",
-      "id": "completetransaction_totalsmatch",
-      "label": "totalsMatch()",
-      "norm_label": "totalsmatch()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L104"
-    },
-    {
-      "community": 35,
-      "file_type": "code",
-      "id": "completetransaction_updateinventory",
-      "label": "updateInventory()",
-      "norm_label": "updateinventory()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L241"
-    },
-    {
-      "community": 35,
-      "file_type": "code",
-      "id": "completetransaction_voidtransaction",
-      "label": "voidTransaction()",
-      "norm_label": "voidtransaction()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L488"
-    },
-    {
-      "community": 35,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_commands_completetransaction_ts",
-      "label": "completeTransaction.ts",
-      "norm_label": "completetransaction.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
+      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table-view-options.tsx",
       "source_location": "L1"
     },
     {
       "community": 35,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_application_usecases_completetransaction_ts",
-      "label": "completeTransaction.ts",
-      "norm_label": "completetransaction.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/useCases/completeTransaction.ts",
+      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/data-table-view-options.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 35,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-products-table/data-table-view-options.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 35,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_table_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/table/data-table-view-options.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 35,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/data-table-view-options.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 35,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/assets/assets-table/data-table-view-options.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 35,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/data-table-view-options.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 35,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_base_table_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/base/table/data-table-view-options.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 35,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data-table-view-options.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 35,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table-view-options.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 35,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data-table-view-options.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 35,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/products/products-table/components/data-table-view-options.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 35,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/data-table-view-options.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 35,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/table/data-table-view-options.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 35,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_table_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-view-options.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 35,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-view-options.tsx",
       "source_location": "L1"
     },
     {
@@ -77913,154 +77946,154 @@
     {
       "community": 36,
       "file_type": "code",
-      "id": "data_table_view_options_datatableviewoptions",
-      "label": "DataTableViewOptions()",
-      "norm_label": "datatableviewoptions()",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-view-options.tsx",
-      "source_location": "L18"
+      "id": "completetransaction_buildcompletetransactionresult",
+      "label": "buildCompleteTransactionResult()",
+      "norm_label": "buildcompletetransactionresult()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
+      "source_location": "L57"
     },
     {
       "community": 36,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table-view-options.tsx",
+      "id": "completetransaction_calculatecanonicaltransactiontotals",
+      "label": "calculateCanonicalTransactionTotals()",
+      "norm_label": "calculatecanonicaltransactiontotals()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
+      "source_location": "L86"
+    },
+    {
+      "community": 36,
+      "file_type": "code",
+      "id": "completetransaction_calculatetotalpaid",
+      "label": "calculateTotalPaid()",
+      "norm_label": "calculatetotalpaid()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
+      "source_location": "L78"
+    },
+    {
+      "community": 36,
+      "file_type": "code",
+      "id": "completetransaction_completetransaction",
+      "label": "completeTransaction()",
+      "norm_label": "completetransaction()",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/useCases/completeTransaction.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 36,
+      "file_type": "code",
+      "id": "completetransaction_createtransactionfromsessionhandler",
+      "label": "createTransactionFromSessionHandler()",
+      "norm_label": "createtransactionfromsessionhandler()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
+      "source_location": "L564"
+    },
+    {
+      "community": 36,
+      "file_type": "code",
+      "id": "completetransaction_isusableregistersession",
+      "label": "isUsableRegisterSession()",
+      "norm_label": "isusableregistersession()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
+      "source_location": "L137"
+    },
+    {
+      "community": 36,
+      "file_type": "code",
+      "id": "completetransaction_recordregistersessionsale",
+      "label": "recordRegisterSessionSale()",
+      "norm_label": "recordregistersessionsale()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
+      "source_location": "L191"
+    },
+    {
+      "community": 36,
+      "file_type": "code",
+      "id": "completetransaction_recordregistersessionvoid",
+      "label": "recordRegisterSessionVoid()",
+      "norm_label": "recordregistersessionvoid()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
+      "source_location": "L216"
+    },
+    {
+      "community": 36,
+      "file_type": "code",
+      "id": "completetransaction_registersessionmatchesidentity",
+      "label": "registerSessionMatchesIdentity()",
+      "norm_label": "registersessionmatchesidentity()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
+      "source_location": "L122"
+    },
+    {
+      "community": 36,
+      "file_type": "code",
+      "id": "completetransaction_resolvesessionregistersessionid",
+      "label": "resolveSessionRegisterSessionId()",
+      "norm_label": "resolvesessionregistersessionid()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
+      "source_location": "L141"
+    },
+    {
+      "community": 36,
+      "file_type": "code",
+      "id": "completetransaction_roundstoredamount",
+      "label": "roundStoredAmount()",
+      "norm_label": "roundstoredamount()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
+      "source_location": "L82"
+    },
+    {
+      "community": 36,
+      "file_type": "code",
+      "id": "completetransaction_stalesaletotalerror",
+      "label": "staleSaleTotalError()",
+      "norm_label": "stalesaletotalerror()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
+      "source_location": "L115"
+    },
+    {
+      "community": 36,
+      "file_type": "code",
+      "id": "completetransaction_totalsmatch",
+      "label": "totalsMatch()",
+      "norm_label": "totalsmatch()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
+      "source_location": "L104"
+    },
+    {
+      "community": 36,
+      "file_type": "code",
+      "id": "completetransaction_updateinventory",
+      "label": "updateInventory()",
+      "norm_label": "updateinventory()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
+      "source_location": "L241"
+    },
+    {
+      "community": 36,
+      "file_type": "code",
+      "id": "completetransaction_voidtransaction",
+      "label": "voidTransaction()",
+      "norm_label": "voidtransaction()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
+      "source_location": "L488"
+    },
+    {
+      "community": 36,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_commands_completetransaction_ts",
+      "label": "completeTransaction.ts",
+      "norm_label": "completetransaction.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
       "source_location": "L1"
     },
     {
       "community": 36,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/data-table-view-options.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 36,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-products-table/data-table-view-options.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 36,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_table_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/table/data-table-view-options.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 36,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/data-table-view-options.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 36,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/assets/assets-table/data-table-view-options.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 36,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/data-table-view-options.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 36,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_base_table_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/base/table/data-table-view-options.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 36,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data-table-view-options.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 36,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table-view-options.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 36,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data-table-view-options.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 36,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/products/products-table/components/data-table-view-options.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 36,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/data-table-view-options.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 36,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/table/data-table-view-options.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 36,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_table_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-view-options.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 36,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-view-options.tsx",
+      "id": "packages_athena_webapp_src_lib_pos_application_usecases_completetransaction_ts",
+      "label": "completeTransaction.ts",
+      "norm_label": "completetransaction.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/useCases/completeTransaction.ts",
       "source_location": "L1"
     },
     {
@@ -79600,7 +79633,7 @@
       "label": "approvalRequestTypeLabel()",
       "norm_label": "approvalrequesttypelabel()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L229"
+      "source_location": "L243"
     },
     {
       "community": 4,
@@ -79609,7 +79642,7 @@
       "label": "asCarryForwardItem()",
       "norm_label": "ascarryforwarditem()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L305"
+      "source_location": "L319"
     },
     {
       "community": 4,
@@ -79618,7 +79651,7 @@
       "label": "buildDailyCloseSnapshotWithCtx()",
       "norm_label": "builddailyclosesnapshotwithctx()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L625"
+      "source_location": "L640"
     },
     {
       "community": 4,
@@ -79627,7 +79660,7 @@
       "label": "buildPaymentTotals()",
       "norm_label": "buildpaymenttotals()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L526"
+      "source_location": "L540"
     },
     {
       "community": 4,
@@ -79636,7 +79669,7 @@
       "label": "buildReadiness()",
       "norm_label": "buildreadiness()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L573"
+      "source_location": "L587"
     },
     {
       "community": 4,
@@ -79645,7 +79678,7 @@
       "label": "buildRegisterSessionsById()",
       "norm_label": "buildregistersessionsbyid()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L285"
+      "source_location": "L299"
     },
     {
       "community": 4,
@@ -79654,7 +79687,7 @@
       "label": "buildStaffNamesById()",
       "norm_label": "buildstaffnamesbyid()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L265"
+      "source_location": "L279"
     },
     {
       "community": 4,
@@ -79663,7 +79696,7 @@
       "label": "buildTerminalLabelsById()",
       "norm_label": "buildterminallabelsbyid()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L245"
+      "source_location": "L259"
     },
     {
       "community": 4,
@@ -79672,7 +79705,7 @@
       "label": "cashDeltasByRegisterSessionId()",
       "norm_label": "cashdeltasbyregistersessionid()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L555"
+      "source_location": "L569"
     },
     {
       "community": 4,
@@ -79681,7 +79714,7 @@
       "label": "completeDailyCloseWithCtx()",
       "norm_label": "completedailyclosewithctx()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1339"
+      "source_location": "L1374"
     },
     {
       "community": 4,
@@ -79690,7 +79723,7 @@
       "label": "createCarryForwardWorkItems()",
       "norm_label": "createcarryforwardworkitems()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1263"
+      "source_location": "L1298"
     },
     {
       "community": 4,
@@ -79699,7 +79732,7 @@
       "label": "emptySummary()",
       "norm_label": "emptysummary()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L603"
+      "source_location": "L617"
     },
     {
       "community": 4,
@@ -79708,7 +79741,7 @@
       "label": "formatPaymentMethodLabel()",
       "norm_label": "formatpaymentmethodlabel()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L201"
+      "source_location": "L215"
     },
     {
       "community": 4,
@@ -79717,7 +79750,7 @@
       "label": "getDailyCloseForDate()",
       "norm_label": "getdailyclosefordate()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L334"
+      "source_location": "L348"
     },
     {
       "community": 4,
@@ -79726,7 +79759,7 @@
       "label": "getDailyCloseOpeningContextWithCtx()",
       "norm_label": "getdailycloseopeningcontextwithctx()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1547"
+      "source_location": "L1582"
     },
     {
       "community": 4,
@@ -79735,7 +79768,7 @@
       "label": "getPriorCompletedDailyClose()",
       "norm_label": "getpriorcompleteddailyclose()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L349"
+      "source_location": "L363"
     },
     {
       "community": 4,
@@ -79744,7 +79777,7 @@
       "label": "getStore()",
       "norm_label": "getstore()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L327"
+      "source_location": "L341"
     },
     {
       "community": 4,
@@ -79753,7 +79786,7 @@
       "label": "isInRange()",
       "norm_label": "isinrange()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L189"
+      "source_location": "L190"
     },
     {
       "community": 4,
@@ -79762,7 +79795,7 @@
       "label": "isValidOperatingDateRange()",
       "norm_label": "isvalidoperatingdaterange()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L157"
+      "source_location": "L158"
     },
     {
       "community": 4,
@@ -79771,7 +79804,7 @@
       "label": "listActiveRegisterSessions()",
       "norm_label": "listactiveregistersessions()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L371"
+      "source_location": "L385"
     },
     {
       "community": 4,
@@ -79780,7 +79813,7 @@
       "label": "listClosedRegisterSessionsForDay()",
       "norm_label": "listclosedregistersessionsforday()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L389"
+      "source_location": "L403"
     },
     {
       "community": 4,
@@ -79789,7 +79822,7 @@
       "label": "listDepositsForDay()",
       "norm_label": "listdepositsforday()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L504"
+      "source_location": "L518"
     },
     {
       "community": 4,
@@ -79798,7 +79831,7 @@
       "label": "listExpensesForDay()",
       "norm_label": "listexpensesforday()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L484"
+      "source_location": "L498"
     },
     {
       "community": 4,
@@ -79807,7 +79840,7 @@
       "label": "listOpenOperationalWorkItems()",
       "norm_label": "listopenoperationalworkitems()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L449"
+      "source_location": "L463"
     },
     {
       "community": 4,
@@ -79816,7 +79849,7 @@
       "label": "listOpenPosSessions()",
       "norm_label": "listopenpossessions()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L428"
+      "source_location": "L442"
     },
     {
       "community": 4,
@@ -79825,7 +79858,7 @@
       "label": "listPendingCloseoutApprovals()",
       "norm_label": "listpendingcloseoutapprovals()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L409"
+      "source_location": "L423"
     },
     {
       "community": 4,
@@ -79834,7 +79867,7 @@
       "label": "listTransactionsForDay()",
       "norm_label": "listtransactionsforday()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L463"
+      "source_location": "L477"
     },
     {
       "community": 4,
@@ -79843,7 +79876,7 @@
       "label": "markOtherDailyClosesNotCurrent()",
       "norm_label": "markotherdailyclosesnotcurrent()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1316"
+      "source_location": "L1351"
     },
     {
       "community": 4,
@@ -79852,7 +79885,16 @@
       "label": "nonZeroVarianceMetadata()",
       "norm_label": "nonzerovariancemetadata()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L225"
+      "source_location": "L239"
+    },
+    {
+      "community": 4,
+      "file_type": "code",
+      "id": "dailyclose_registermetadatalabel",
+      "label": "registerMetadataLabel()",
+      "norm_label": "registermetadatalabel()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
+      "source_location": "L202"
     },
     {
       "community": 4,
@@ -79861,7 +79903,7 @@
       "label": "registerSessionLabel()",
       "norm_label": "registersessionlabel()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L193"
+      "source_location": "L194"
     },
     {
       "community": 4,
@@ -79870,7 +79912,7 @@
       "label": "resolveOperatingDateRange()",
       "norm_label": "resolveoperatingdaterange()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L168"
+      "source_location": "L169"
     },
     {
       "community": 4,
@@ -79879,7 +79921,7 @@
       "label": "safeOperatingDateRange()",
       "norm_label": "safeoperatingdaterange()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L140"
+      "source_location": "L141"
     },
     {
       "community": 4,
@@ -79888,7 +79930,7 @@
       "label": "transactionCashDelta()",
       "norm_label": "transactioncashdelta()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L544"
+      "source_location": "L558"
     },
     {
       "community": 4,
@@ -79897,7 +79939,7 @@
       "label": "transactionPaymentSummary()",
       "norm_label": "transactionpaymentsummary()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L207"
+      "source_location": "L221"
     },
     {
       "community": 4,
@@ -79906,7 +79948,7 @@
       "label": "trimOptional()",
       "norm_label": "trimoptional()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L135"
+      "source_location": "L136"
     },
     {
       "community": 4,
@@ -79915,7 +79957,7 @@
       "label": "uniqueSourceSubjects()",
       "norm_label": "uniquesourcesubjects()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L593"
+      "source_location": "L607"
     },
     {
       "community": 4,
@@ -79924,7 +79966,7 @@
       "label": "validateCarryForwardWorkItemIds()",
       "norm_label": "validatecarryforwardworkitemids()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1235"
+      "source_location": "L1270"
     },
     {
       "community": 4,
@@ -96327,73 +96369,73 @@
     {
       "community": 93,
       "file_type": "code",
-      "id": "index_senddiscountcodeemail",
-      "label": "sendDiscountCodeEmail()",
-      "norm_label": "senddiscountcodeemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L255"
+      "id": "config_buildmtncollectionscallbackurl",
+      "label": "buildMtnCollectionsCallbackUrl()",
+      "norm_label": "buildmtncollectionscallbackurl()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "source_location": "L135"
     },
     {
       "community": 93,
       "file_type": "code",
-      "id": "index_senddiscountreminderemail",
-      "label": "sendDiscountReminderEmail()",
-      "norm_label": "senddiscountreminderemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L334"
-    },
-    {
-      "community": 93,
-      "file_type": "code",
-      "id": "index_sendfeedbackrequestemail",
-      "label": "sendFeedbackRequestEmail()",
-      "norm_label": "sendfeedbackrequestemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L167"
-    },
-    {
-      "community": 93,
-      "file_type": "code",
-      "id": "index_sendneworderemail",
-      "label": "sendNewOrderEmail()",
-      "norm_label": "sendneworderemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L117"
-    },
-    {
-      "community": 93,
-      "file_type": "code",
-      "id": "index_sendorderemail",
-      "label": "sendOrderEmail()",
-      "norm_label": "sendorderemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "id": "config_buildmtncollectionslookupprefixes",
+      "label": "buildMtnCollectionsLookupPrefixes()",
+      "norm_label": "buildmtncollectionslookupprefixes()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
       "source_location": "L43"
     },
     {
       "community": 93,
       "file_type": "code",
-      "id": "index_sendverificationcode",
-      "label": "sendVerificationCode()",
-      "norm_label": "sendverificationcode()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L3"
+      "id": "config_istargetenvironment",
+      "label": "isTargetEnvironment()",
+      "norm_label": "istargetenvironment()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "source_location": "L67"
     },
     {
       "community": 93,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_mailersend_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/convex/mailersend/index.tsx",
-      "source_location": "L1"
+      "id": "config_readscopedvalue",
+      "label": "readScopedValue()",
+      "norm_label": "readscopedvalue()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "source_location": "L56"
     },
     {
       "community": 93,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_sendgrid_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "id": "config_resolveconfigforprefix",
+      "label": "resolveConfigForPrefix()",
+      "norm_label": "resolveconfigforprefix()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "source_location": "L73"
+    },
+    {
+      "community": 93,
+      "file_type": "code",
+      "id": "config_resolvemtncollectionsconfigfromenv",
+      "label": "resolveMtnCollectionsConfigFromEnv()",
+      "norm_label": "resolvemtncollectionsconfigfromenv()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "source_location": "L108"
+    },
+    {
+      "community": 93,
+      "file_type": "code",
+      "id": "config_toenvsegment",
+      "label": "toEnvSegment()",
+      "norm_label": "toenvsegment()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "source_location": "L29"
+    },
+    {
+      "community": 93,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_mtn_config_ts",
+      "label": "config.ts",
+      "norm_label": "config.ts",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
       "source_location": "L1"
     },
     {
@@ -96489,73 +96531,73 @@
     {
       "community": 94,
       "file_type": "code",
-      "id": "config_buildmtncollectionscallbackurl",
-      "label": "buildMtnCollectionsCallbackUrl()",
-      "norm_label": "buildmtncollectionscallbackurl()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
-      "source_location": "L135"
+      "id": "approvalauditevents_recordapprovalauditeventwithctx",
+      "label": "recordApprovalAuditEventWithCtx()",
+      "norm_label": "recordapprovalauditeventwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
+      "source_location": "L30"
     },
     {
       "community": 94,
       "file_type": "code",
-      "id": "config_buildmtncollectionslookupprefixes",
-      "label": "buildMtnCollectionsLookupPrefixes()",
-      "norm_label": "buildmtncollectionslookupprefixes()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
-      "source_location": "L43"
+      "id": "approvalauditevents_recordapprovaldecisionrecordedauditeventwithctx",
+      "label": "recordApprovalDecisionRecordedAuditEventWithCtx()",
+      "norm_label": "recordapprovaldecisionrecordedauditeventwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
+      "source_location": "L107"
     },
     {
       "community": 94,
       "file_type": "code",
-      "id": "config_istargetenvironment",
-      "label": "isTargetEnvironment()",
-      "norm_label": "istargetenvironment()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "id": "approvalauditevents_recordapprovalproofconsumedauditeventwithctx",
+      "label": "recordApprovalProofConsumedAuditEventWithCtx()",
+      "norm_label": "recordapprovalproofconsumedauditeventwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
+      "source_location": "L87"
+    },
+    {
+      "community": 94,
+      "file_type": "code",
+      "id": "approvalauditevents_recordapprovalrequiredauditeventwithctx",
+      "label": "recordApprovalRequiredAuditEventWithCtx()",
+      "norm_label": "recordapprovalrequiredauditeventwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
       "source_location": "L67"
     },
     {
       "community": 94,
       "file_type": "code",
-      "id": "config_readscopedvalue",
-      "label": "readScopedValue()",
-      "norm_label": "readscopedvalue()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
-      "source_location": "L56"
+      "id": "approvalauditevents_recordapprovedcommandappliedauditeventwithctx",
+      "label": "recordApprovedCommandAppliedAuditEventWithCtx()",
+      "norm_label": "recordapprovedcommandappliedauditeventwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
+      "source_location": "L117"
     },
     {
       "community": 94,
       "file_type": "code",
-      "id": "config_resolveconfigforprefix",
-      "label": "resolveConfigForPrefix()",
-      "norm_label": "resolveconfigforprefix()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
-      "source_location": "L73"
+      "id": "approvalauditevents_recordasyncapprovalrequestcreatedauditeventwithctx",
+      "label": "recordAsyncApprovalRequestCreatedAuditEventWithCtx()",
+      "norm_label": "recordasyncapprovalrequestcreatedauditeventwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
+      "source_location": "L97"
     },
     {
       "community": 94,
       "file_type": "code",
-      "id": "config_resolvemtncollectionsconfigfromenv",
-      "label": "resolveMtnCollectionsConfigFromEnv()",
-      "norm_label": "resolvemtncollectionsconfigfromenv()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
-      "source_location": "L108"
+      "id": "approvalauditevents_recordmanagerapprovalgrantedauditeventwithctx",
+      "label": "recordManagerApprovalGrantedAuditEventWithCtx()",
+      "norm_label": "recordmanagerapprovalgrantedauditeventwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
+      "source_location": "L77"
     },
     {
       "community": 94,
       "file_type": "code",
-      "id": "config_toenvsegment",
-      "label": "toEnvSegment()",
-      "norm_label": "toenvsegment()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
-      "source_location": "L29"
-    },
-    {
-      "community": 94,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_mtn_config_ts",
-      "label": "config.ts",
-      "norm_label": "config.ts",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "id": "packages_athena_webapp_convex_operations_approvalauditevents_ts",
+      "label": "approvalAuditEvents.ts",
+      "norm_label": "approvalauditevents.ts",
+      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
       "source_location": "L1"
     },
     {
@@ -96651,73 +96693,73 @@
     {
       "community": 95,
       "file_type": "code",
-      "id": "approvalauditevents_recordapprovalauditeventwithctx",
-      "label": "recordApprovalAuditEventWithCtx()",
-      "norm_label": "recordapprovalauditeventwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
-      "source_location": "L30"
+      "id": "approvalrequests_buildapprovaldecisionrequirement",
+      "label": "buildApprovalDecisionRequirement()",
+      "norm_label": "buildapprovaldecisionrequirement()",
+      "source_file": "packages/athena-webapp/convex/operations/approvalRequests.ts",
+      "source_location": "L54"
     },
     {
       "community": 95,
       "file_type": "code",
-      "id": "approvalauditevents_recordapprovaldecisionrecordedauditeventwithctx",
-      "label": "recordApprovalDecisionRecordedAuditEventWithCtx()",
-      "norm_label": "recordapprovaldecisionrecordedauditeventwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
-      "source_location": "L107"
+      "id": "approvalrequests_buildapprovaldecisionsubject",
+      "label": "buildApprovalDecisionSubject()",
+      "norm_label": "buildapprovaldecisionsubject()",
+      "source_file": "packages/athena-webapp/convex/operations/approvalRequests.ts",
+      "source_location": "L42"
     },
     {
       "community": 95,
       "file_type": "code",
-      "id": "approvalauditevents_recordapprovalproofconsumedauditeventwithctx",
-      "label": "recordApprovalProofConsumedAuditEventWithCtx()",
-      "norm_label": "recordapprovalproofconsumedauditeventwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
-      "source_location": "L87"
+      "id": "approvalrequests_consumeapprovaldecisionproofwithctx",
+      "label": "consumeApprovalDecisionProofWithCtx()",
+      "norm_label": "consumeapprovaldecisionproofwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/approvalRequests.ts",
+      "source_location": "L78"
     },
     {
       "community": 95,
       "file_type": "code",
-      "id": "approvalauditevents_recordapprovalrequiredauditeventwithctx",
-      "label": "recordApprovalRequiredAuditEventWithCtx()",
-      "norm_label": "recordapprovalrequiredauditeventwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
-      "source_location": "L67"
+      "id": "approvalrequests_decideapprovalrequestasauthenticateduserwithctx",
+      "label": "decideApprovalRequestAsAuthenticatedUserWithCtx()",
+      "norm_label": "decideapprovalrequestasauthenticateduserwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/approvalRequests.ts",
+      "source_location": "L167"
     },
     {
       "community": 95,
       "file_type": "code",
-      "id": "approvalauditevents_recordapprovedcommandappliedauditeventwithctx",
-      "label": "recordApprovedCommandAppliedAuditEventWithCtx()",
-      "norm_label": "recordapprovedcommandappliedauditeventwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
-      "source_location": "L117"
+      "id": "approvalrequests_decideapprovalrequestascommandwithctx",
+      "label": "decideApprovalRequestAsCommandWithCtx()",
+      "norm_label": "decideapprovalrequestascommandwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/approvalRequests.ts",
+      "source_location": "L283"
     },
     {
       "community": 95,
       "file_type": "code",
-      "id": "approvalauditevents_recordasyncapprovalrequestcreatedauditeventwithctx",
-      "label": "recordAsyncApprovalRequestCreatedAuditEventWithCtx()",
-      "norm_label": "recordasyncapprovalrequestcreatedauditeventwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
-      "source_location": "L97"
+      "id": "approvalrequests_decideapprovalrequestwithctx",
+      "label": "decideApprovalRequestWithCtx()",
+      "norm_label": "decideapprovalrequestwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/approvalRequests.ts",
+      "source_location": "L105"
     },
     {
       "community": 95,
       "file_type": "code",
-      "id": "approvalauditevents_recordmanagerapprovalgrantedauditeventwithctx",
-      "label": "recordManagerApprovalGrantedAuditEventWithCtx()",
-      "norm_label": "recordmanagerapprovalgrantedauditeventwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
-      "source_location": "L77"
+      "id": "approvalrequests_mapdecideapprovalrequesterror",
+      "label": "mapDecideApprovalRequestError()",
+      "norm_label": "mapdecideapprovalrequesterror()",
+      "source_file": "packages/athena-webapp/convex/operations/approvalRequests.ts",
+      "source_location": "L217"
     },
     {
       "community": 95,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_approvalauditevents_ts",
-      "label": "approvalAuditEvents.ts",
-      "norm_label": "approvalauditevents.ts",
-      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
+      "id": "packages_athena_webapp_convex_operations_approvalrequests_ts",
+      "label": "approvalRequests.ts",
+      "norm_label": "approvalrequests.ts",
+      "source_file": "packages/athena-webapp/convex/operations/approvalRequests.ts",
       "source_location": "L1"
     },
     {
@@ -96813,74 +96855,74 @@
     {
       "community": 96,
       "file_type": "code",
-      "id": "approvalrequests_buildapprovaldecisionrequirement",
-      "label": "buildApprovalDecisionRequirement()",
-      "norm_label": "buildapprovaldecisionrequirement()",
-      "source_file": "packages/athena-webapp/convex/operations/approvalRequests.ts",
-      "source_location": "L54"
-    },
-    {
-      "community": 96,
-      "file_type": "code",
-      "id": "approvalrequests_buildapprovaldecisionsubject",
-      "label": "buildApprovalDecisionSubject()",
-      "norm_label": "buildapprovaldecisionsubject()",
-      "source_file": "packages/athena-webapp/convex/operations/approvalRequests.ts",
-      "source_location": "L42"
-    },
-    {
-      "community": 96,
-      "file_type": "code",
-      "id": "approvalrequests_consumeapprovaldecisionproofwithctx",
-      "label": "consumeApprovalDecisionProofWithCtx()",
-      "norm_label": "consumeapprovaldecisionproofwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/approvalRequests.ts",
-      "source_location": "L78"
-    },
-    {
-      "community": 96,
-      "file_type": "code",
-      "id": "approvalrequests_decideapprovalrequestasauthenticateduserwithctx",
-      "label": "decideApprovalRequestAsAuthenticatedUserWithCtx()",
-      "norm_label": "decideapprovalrequestasauthenticateduserwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/approvalRequests.ts",
-      "source_location": "L167"
-    },
-    {
-      "community": 96,
-      "file_type": "code",
-      "id": "approvalrequests_decideapprovalrequestascommandwithctx",
-      "label": "decideApprovalRequestAsCommandWithCtx()",
-      "norm_label": "decideapprovalrequestascommandwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/approvalRequests.ts",
-      "source_location": "L283"
-    },
-    {
-      "community": 96,
-      "file_type": "code",
-      "id": "approvalrequests_decideapprovalrequestwithctx",
-      "label": "decideApprovalRequestWithCtx()",
-      "norm_label": "decideapprovalrequestwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/approvalRequests.ts",
-      "source_location": "L105"
-    },
-    {
-      "community": 96,
-      "file_type": "code",
-      "id": "approvalrequests_mapdecideapprovalrequesterror",
-      "label": "mapDecideApprovalRequestError()",
-      "norm_label": "mapdecideapprovalrequesterror()",
-      "source_file": "packages/athena-webapp/convex/operations/approvalRequests.ts",
-      "source_location": "L217"
-    },
-    {
-      "community": 96,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_approvalrequests_ts",
-      "label": "approvalRequests.ts",
-      "norm_label": "approvalrequests.ts",
-      "source_file": "packages/athena-webapp/convex/operations/approvalRequests.ts",
+      "id": "packages_athena_webapp_convex_operations_paymentallocations_ts",
+      "label": "paymentAllocations.ts",
+      "norm_label": "paymentallocations.ts",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 96,
+      "file_type": "code",
+      "id": "paymentallocations_buildpaymentallocation",
+      "label": "buildPaymentAllocation()",
+      "norm_label": "buildpaymentallocation()",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "source_location": "L27"
+    },
+    {
+      "community": 96,
+      "file_type": "code",
+      "id": "paymentallocations_correctsameamountsinglepaymentallocationwithctx",
+      "label": "correctSameAmountSinglePaymentAllocationWithCtx()",
+      "norm_label": "correctsameamountsinglepaymentallocationwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "source_location": "L153"
+    },
+    {
+      "community": 96,
+      "file_type": "code",
+      "id": "paymentallocations_findsameamountsinglepaymentallocation",
+      "label": "findSameAmountSinglePaymentAllocation()",
+      "norm_label": "findsameamountsinglepaymentallocation()",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "source_location": "L57"
+    },
+    {
+      "community": 96,
+      "file_type": "code",
+      "id": "paymentallocations_listpaymentallocationsfortargetwithctx",
+      "label": "listPaymentAllocationsForTargetWithCtx()",
+      "norm_label": "listpaymentallocationsfortargetwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "source_location": "L133"
+    },
+    {
+      "community": 96,
+      "file_type": "code",
+      "id": "paymentallocations_matchesexistingallocation",
+      "label": "matchesExistingAllocation()",
+      "norm_label": "matchesexistingallocation()",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "source_location": "L81"
+    },
+    {
+      "community": 96,
+      "file_type": "code",
+      "id": "paymentallocations_recordpaymentallocationwithctx",
+      "label": "recordPaymentAllocationWithCtx()",
+      "norm_label": "recordpaymentallocationwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "source_location": "L102"
+    },
+    {
+      "community": 96,
+      "file_type": "code",
+      "id": "paymentallocations_summarizepaymentallocations",
+      "label": "summarizePaymentAllocations()",
+      "norm_label": "summarizepaymentallocations()",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "source_location": "L41"
     },
     {
       "community": 960,
@@ -96975,74 +97017,74 @@
     {
       "community": 97,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_paymentallocations_ts",
-      "label": "paymentAllocations.ts",
-      "norm_label": "paymentallocations.ts",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "id": "packages_athena_webapp_convex_pos_application_commands_possessiontracing_ts",
+      "label": "posSessionTracing.ts",
+      "norm_label": "possessiontracing.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
       "source_location": "L1"
     },
     {
       "community": 97,
       "file_type": "code",
-      "id": "paymentallocations_buildpaymentallocation",
-      "label": "buildPaymentAllocation()",
-      "norm_label": "buildpaymentallocation()",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
-      "source_location": "L27"
+      "id": "possessiontracing_buildpossessiontraceevent",
+      "label": "buildPosSessionTraceEvent()",
+      "norm_label": "buildpossessiontraceevent()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L226"
     },
     {
       "community": 97,
       "file_type": "code",
-      "id": "paymentallocations_correctsameamountsinglepaymentallocationwithctx",
-      "label": "correctSameAmountSinglePaymentAllocationWithCtx()",
-      "norm_label": "correctsameamountsinglepaymentallocationwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
-      "source_location": "L153"
+      "id": "possessiontracing_buildpossessiontracerecord",
+      "label": "buildPosSessionTraceRecord()",
+      "norm_label": "buildpossessiontracerecord()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L142"
     },
     {
       "community": 97,
       "file_type": "code",
-      "id": "paymentallocations_findsameamountsinglepaymentallocation",
-      "label": "findSameAmountSinglePaymentAllocation()",
-      "norm_label": "findsameamountsinglepaymentallocation()",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
-      "source_location": "L57"
+      "id": "possessiontracing_buildtracesummary",
+      "label": "buildTraceSummary()",
+      "norm_label": "buildtracesummary()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L105"
     },
     {
       "community": 97,
       "file_type": "code",
-      "id": "paymentallocations_listpaymentallocationsfortargetwithctx",
-      "label": "listPaymentAllocationsForTargetWithCtx()",
-      "norm_label": "listpaymentallocationsfortargetwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
-      "source_location": "L133"
+      "id": "possessiontracing_createpossessiontracerecorder",
+      "label": "createPosSessionTraceRecorder()",
+      "norm_label": "createpossessiontracerecorder()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L559"
     },
     {
       "community": 97,
       "file_type": "code",
-      "id": "paymentallocations_matchesexistingallocation",
-      "label": "matchesExistingAllocation()",
-      "norm_label": "matchesexistingallocation()",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
-      "source_location": "L81"
+      "id": "possessiontracing_formatpaymentmethod",
+      "label": "formatPaymentMethod()",
+      "norm_label": "formatpaymentmethod()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L218"
     },
     {
       "community": 97,
       "file_type": "code",
-      "id": "paymentallocations_recordpaymentallocationwithctx",
-      "label": "recordPaymentAllocationWithCtx()",
-      "norm_label": "recordpaymentallocationwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
-      "source_location": "L102"
+      "id": "possessiontracing_recordpossessiontracebesteffort",
+      "label": "recordPosSessionTraceBestEffort()",
+      "norm_label": "recordpossessiontracebesteffort()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L532"
     },
     {
       "community": 97,
       "file_type": "code",
-      "id": "paymentallocations_summarizepaymentallocations",
-      "label": "summarizePaymentAllocations()",
-      "norm_label": "summarizepaymentallocations()",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
-      "source_location": "L41"
+      "id": "possessiontracing_safetracewrite",
+      "label": "safeTraceWrite()",
+      "norm_label": "safetracewrite()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L524"
     },
     {
       "community": 970,
@@ -97137,74 +97179,74 @@
     {
       "community": 98,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_commands_possessiontracing_ts",
-      "label": "posSessionTracing.ts",
-      "norm_label": "possessiontracing.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "id": "packages_athena_webapp_convex_pos_application_commands_quickaddcatalogitem_ts",
+      "label": "quickAddCatalogItem.ts",
+      "norm_label": "quickaddcatalogitem.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
       "source_location": "L1"
     },
     {
       "community": 98,
       "file_type": "code",
-      "id": "possessiontracing_buildpossessiontraceevent",
-      "label": "buildPosSessionTraceEvent()",
-      "norm_label": "buildpossessiontraceevent()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L226"
+      "id": "quickaddcatalogitem_findexistingsku",
+      "label": "findExistingSku()",
+      "norm_label": "findexistingsku()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
+      "source_location": "L125"
     },
     {
       "community": 98,
       "file_type": "code",
-      "id": "possessiontracing_buildpossessiontracerecord",
-      "label": "buildPosSessionTraceRecord()",
-      "norm_label": "buildpossessiontracerecord()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L142"
+      "id": "quickaddcatalogitem_findorcreatequickaddcategory",
+      "label": "findOrCreateQuickAddCategory()",
+      "norm_label": "findorcreatequickaddcategory()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
+      "source_location": "L29"
     },
     {
       "community": 98,
       "file_type": "code",
-      "id": "possessiontracing_buildtracesummary",
-      "label": "buildTraceSummary()",
-      "norm_label": "buildtracesummary()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L105"
+      "id": "quickaddcatalogitem_findorcreatequickaddsubcategory",
+      "label": "findOrCreateQuickAddSubcategory()",
+      "norm_label": "findorcreatequickaddsubcategory()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
+      "source_location": "L56"
     },
     {
       "community": 98,
       "file_type": "code",
-      "id": "possessiontracing_createpossessiontracerecorder",
-      "label": "createPosSessionTraceRecorder()",
-      "norm_label": "createpossessiontracerecorder()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L559"
+      "id": "quickaddcatalogitem_generatesku",
+      "label": "generateSKU()",
+      "norm_label": "generatesku()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
+      "source_location": "L153"
     },
     {
       "community": 98,
       "file_type": "code",
-      "id": "possessiontracing_formatpaymentmethod",
-      "label": "formatPaymentMethod()",
-      "norm_label": "formatpaymentmethod()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L218"
+      "id": "quickaddcatalogitem_isbarcodelike",
+      "label": "isBarcodeLike()",
+      "norm_label": "isbarcodelike()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
+      "source_location": "L149"
     },
     {
       "community": 98,
       "file_type": "code",
-      "id": "possessiontracing_recordpossessiontracebesteffort",
-      "label": "recordPosSessionTraceBestEffort()",
-      "norm_label": "recordpossessiontracebesteffort()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L532"
+      "id": "quickaddcatalogitem_mapskutocatalogresult",
+      "label": "mapSkuToCatalogResult()",
+      "norm_label": "mapskutocatalogresult()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
+      "source_location": "L88"
     },
     {
       "community": 98,
       "file_type": "code",
-      "id": "possessiontracing_safetracewrite",
-      "label": "safeTraceWrite()",
-      "norm_label": "safetracewrite()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L524"
+      "id": "quickaddcatalogitem_quickaddcatalogitem",
+      "label": "quickAddCatalogItem()",
+      "norm_label": "quickaddcatalogitem()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
+      "source_location": "L174"
     },
     {
       "community": 980,
@@ -97299,74 +97341,74 @@
     {
       "community": 99,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_commands_quickaddcatalogitem_ts",
-      "label": "quickAddCatalogItem.ts",
-      "norm_label": "quickaddcatalogitem.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
+      "id": "expensesessioncommands_test_builditem",
+      "label": "buildItem()",
+      "norm_label": "builditem()",
+      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
+      "source_location": "L645"
+    },
+    {
+      "community": 99,
+      "file_type": "code",
+      "id": "expensesessioncommands_test_buildregistersession",
+      "label": "buildRegisterSession()",
+      "norm_label": "buildregistersession()",
+      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
+      "source_location": "L639"
+    },
+    {
+      "community": 99,
+      "file_type": "code",
+      "id": "expensesessioncommands_test_buildsession",
+      "label": "buildSession()",
+      "norm_label": "buildsession()",
+      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
+      "source_location": "L635"
+    },
+    {
+      "community": 99,
+      "file_type": "code",
+      "id": "expensesessioncommands_test_createcommandservice",
+      "label": "createCommandService()",
+      "norm_label": "createcommandservice()",
+      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
+      "source_location": "L655"
+    },
+    {
+      "community": 99,
+      "file_type": "code",
+      "id": "expensesessioncommands_test_createdependencies",
+      "label": "createDependencies()",
+      "norm_label": "createdependencies()",
+      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
+      "source_location": "L424"
+    },
+    {
+      "community": 99,
+      "file_type": "code",
+      "id": "expensesessioncommands_test_createfakerepository",
+      "label": "createFakeRepository()",
+      "norm_label": "createfakerepository()",
+      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
+      "source_location": "L492"
+    },
+    {
+      "community": 99,
+      "file_type": "code",
+      "id": "expensesessioncommands_test_loadcommandservice",
+      "label": "loadCommandService()",
+      "norm_label": "loadcommandservice()",
+      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
+      "source_location": "L404"
+    },
+    {
+      "community": 99,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_expensesessioncommands_test_ts",
+      "label": "expenseSessionCommands.test.ts",
+      "norm_label": "expensesessioncommands.test.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 99,
-      "file_type": "code",
-      "id": "quickaddcatalogitem_findexistingsku",
-      "label": "findExistingSku()",
-      "norm_label": "findexistingsku()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
-      "source_location": "L125"
-    },
-    {
-      "community": 99,
-      "file_type": "code",
-      "id": "quickaddcatalogitem_findorcreatequickaddcategory",
-      "label": "findOrCreateQuickAddCategory()",
-      "norm_label": "findorcreatequickaddcategory()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
-      "source_location": "L29"
-    },
-    {
-      "community": 99,
-      "file_type": "code",
-      "id": "quickaddcatalogitem_findorcreatequickaddsubcategory",
-      "label": "findOrCreateQuickAddSubcategory()",
-      "norm_label": "findorcreatequickaddsubcategory()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
-      "source_location": "L56"
-    },
-    {
-      "community": 99,
-      "file_type": "code",
-      "id": "quickaddcatalogitem_generatesku",
-      "label": "generateSKU()",
-      "norm_label": "generatesku()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
-      "source_location": "L153"
-    },
-    {
-      "community": 99,
-      "file_type": "code",
-      "id": "quickaddcatalogitem_isbarcodelike",
-      "label": "isBarcodeLike()",
-      "norm_label": "isbarcodelike()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
-      "source_location": "L149"
-    },
-    {
-      "community": 99,
-      "file_type": "code",
-      "id": "quickaddcatalogitem_mapskutocatalogresult",
-      "label": "mapSkuToCatalogResult()",
-      "norm_label": "mapskutocatalogresult()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
-      "source_location": "L88"
-    },
-    {
-      "community": 99,
-      "file_type": "code",
-      "id": "quickaddcatalogitem_quickaddcatalogitem",
-      "label": "quickAddCatalogItem()",
-      "norm_label": "quickaddcatalogitem()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
-      "source_location": "L174"
     },
     {
       "community": 990,

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,17 +8,17 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 1629
-- Graph nodes: 4712
-- Graph edges: 4587
+- Graph nodes: 4714
+- Graph edges: 4589
 - Communities: 1557
 
 ## Graph Hotspots
 - `harness-inferential-review.ts` (46 edges, Community 0) - [`scripts/harness-inferential-review.ts`](../../scripts/harness-inferential-review.ts)
-- `storefrontJourneyEvents.ts` (45 edges, Community 1) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
-- `DailyCloseView.tsx` (44 edges, Community 2) - [`packages/athena-webapp/src/components/operations/DailyCloseView.tsx`](../../packages/athena-webapp/src/components/operations/DailyCloseView.tsx)
-- `createJourneyEvent()` (40 edges, Community 1) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
+- `DailyCloseView.tsx` (45 edges, Community 1) - [`packages/athena-webapp/src/components/operations/DailyCloseView.tsx`](../../packages/athena-webapp/src/components/operations/DailyCloseView.tsx)
+- `storefrontJourneyEvents.ts` (45 edges, Community 2) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
+- `createJourneyEvent()` (40 edges, Community 2) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
 - `ProcurementView.tsx` (39 edges, Community 3) - [`packages/athena-webapp/src/components/procurement/ProcurementView.tsx`](../../packages/athena-webapp/src/components/procurement/ProcurementView.tsx)
-- `dailyClose.ts` (37 edges, Community 4) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../packages/athena-webapp/convex/operations/dailyClose.ts)
+- `dailyClose.ts` (38 edges, Community 4) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../packages/athena-webapp/convex/operations/dailyClose.ts)
 - `harness-check.ts` (32 edges, Community 5) - [`scripts/harness-check.ts`](../../scripts/harness-check.ts)
 - `harness-behavior.ts` (30 edges, Community 6) - [`scripts/harness-behavior.ts`](../../scripts/harness-behavior.ts)
 

--- a/graphify-out/wiki/packages/athena-webapp.md
+++ b/graphify-out/wiki/packages/athena-webapp.md
@@ -17,9 +17,9 @@ Landing page for packages/athena-webapp. Use this page to orient around graph ho
 - [validation-map.json](../../../packages/athena-webapp/docs/agent/validation-map.json)
 
 ## Graph Hotspots
-- `DailyCloseView.tsx` (44 edges, Community 2) - [`packages/athena-webapp/src/components/operations/DailyCloseView.tsx`](../../../packages/athena-webapp/src/components/operations/DailyCloseView.tsx)
+- `DailyCloseView.tsx` (45 edges, Community 1) - [`packages/athena-webapp/src/components/operations/DailyCloseView.tsx`](../../../packages/athena-webapp/src/components/operations/DailyCloseView.tsx)
 - `ProcurementView.tsx` (39 edges, Community 3) - [`packages/athena-webapp/src/components/procurement/ProcurementView.tsx`](../../../packages/athena-webapp/src/components/procurement/ProcurementView.tsx)
-- `dailyClose.ts` (37 edges, Community 4) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../../packages/athena-webapp/convex/operations/dailyClose.ts)
+- `dailyClose.ts` (38 edges, Community 4) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../../packages/athena-webapp/convex/operations/dailyClose.ts)
 - `RegisterSessionView.tsx` (27 edges, Community 9) - [`packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx`](../../../packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx)
 - `storeConfigV2.ts` (27 edges, Community 8) - [`packages/athena-webapp/convex/inventory/storeConfigV2.ts`](../../../packages/athena-webapp/convex/inventory/storeConfigV2.ts)
 

--- a/graphify-out/wiki/packages/storefront-webapp.md
+++ b/graphify-out/wiki/packages/storefront-webapp.md
@@ -17,8 +17,8 @@ Landing page for packages/storefront-webapp. Use this page to orient around grap
 - [validation-map.json](../../../packages/storefront-webapp/docs/agent/validation-map.json)
 
 ## Graph Hotspots
-- `storefrontJourneyEvents.ts` (45 edges, Community 1) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
-- `createJourneyEvent()` (40 edges, Community 1) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
+- `storefrontJourneyEvents.ts` (45 edges, Community 2) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
+- `createJourneyEvent()` (40 edges, Community 2) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
 - `getStoreConfigV2()` (17 edges, Community 16) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)
 - `checkoutSession.ts` (14 edges, Community 42) - [`packages/storefront-webapp/src/api/checkoutSession.ts`](../../../packages/storefront-webapp/src/api/checkoutSession.ts)
 - `storeConfig.ts` (14 edges, Community 16) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)

--- a/packages/athena-webapp/convex/operations/dailyClose.test.ts
+++ b/packages/athena-webapp/convex/operations/dailyClose.test.ts
@@ -249,6 +249,38 @@ describe("daily close backend foundation", () => {
           type: "customer_follow_up",
         },
       ],
+      expenseTransaction: [
+        {
+          _id: "expense-1",
+          completedAt: Date.UTC(2026, 4, 7, 17),
+          sessionId: "expense-session-1",
+          staffProfileId: "staff-1",
+          status: "completed",
+          storeId: "store-1",
+          totalValue: 4500,
+          transactionNumber: "EXP-1",
+        },
+        {
+          _id: "expense-2",
+          completedAt: Date.UTC(2026, 4, 7, 18),
+          sessionId: "expense-session-2",
+          staffProfileId: "staff-1",
+          status: "completed",
+          storeId: "store-1",
+          totalValue: 2500,
+          transactionNumber: "EXP-2",
+        },
+        {
+          _id: "expense-prior-day",
+          completedAt: Date.UTC(2026, 4, 6, 18),
+          sessionId: "expense-session-prior",
+          staffProfileId: "staff-1",
+          status: "completed",
+          storeId: "store-1",
+          totalValue: 9000,
+          transactionNumber: "EXP-PRIOR",
+        },
+      ],
       paymentAllocation: [
         {
           _id: "deposit-1",
@@ -418,6 +450,7 @@ describe("daily close backend foundation", () => {
     expect(snapshot.blockers[0].metadata).toMatchObject({
       openedAt: Date.UTC(2026, 4, 6, 20),
       operatingScope: "Carried over from prior day",
+      register: "Register A1",
       terminal: "Front counter terminal",
     });
     expect(snapshot.blockers[1].metadata).toMatchObject({
@@ -426,6 +459,7 @@ describe("daily close backend foundation", () => {
       openedAt: Date.UTC(2026, 4, 7, 10),
       openedBy: "Kofi Mensah",
       operatingScope: "Opened today",
+      register: "Register A2",
       status: "closing",
       terminal: "Front counter terminal",
       variance: -2000,
@@ -478,6 +512,7 @@ describe("daily close backend foundation", () => {
       expectedCash: 10000,
       openedAt: Date.UTC(2026, 4, 7, 10),
       operatingScope: "Opened today",
+      register: "Register A3",
       status: "closed",
       terminal: "Front counter terminal",
       variance: -500,
@@ -527,6 +562,7 @@ describe("daily close backend foundation", () => {
       openedAt: Date.UTC(2026, 4, 7, 10),
       openedBy: "Kofi Mensah",
       operatingScope: "Opened today",
+      register: "Register A3",
       status: "closed",
       terminal: "Front counter terminal",
       variance: -500,
@@ -548,6 +584,8 @@ describe("daily close backend foundation", () => {
       currentDayCashTotal: 9500,
       currentDayCashTransactionCount: 1,
       expectedCashTotal: 39500,
+      expenseStaffCount: 1,
+      expenseTotal: 7000,
       netCashVariance: -2500,
       openWorkItemCount: 1,
       pendingApprovalCount: 1,
@@ -560,6 +598,51 @@ describe("daily close backend foundation", () => {
     expect(snapshot.readyItems.map((item) => item.key)).not.toContain(
       "pos_transaction:txn-prior-day:completed",
     );
+  });
+
+  it("does not repeat the register when the terminal label already includes it", async () => {
+    const { db } = createDb({
+      posTerminal: [
+        {
+          _id: "terminal-codex",
+          displayName: "Codex / Register 3",
+          storeId: "store-1",
+        },
+      ],
+      registerSession: [
+        {
+          _id: "register-3",
+          closedAt: Date.UTC(2026, 4, 8, 1),
+          countedCash: 39099,
+          expectedCash: 39099,
+          openedAt: Date.UTC(2026, 4, 6, 4, 42),
+          openingFloat: 10000,
+          registerNumber: "3",
+          status: "closed",
+          storeId: "store-1",
+          terminalId: "terminal-codex",
+        },
+      ],
+      store: [store],
+    });
+
+    const snapshot = await buildDailyCloseSnapshotWithCtx(
+      { db } as unknown as QueryCtx,
+      {
+        endAt: Date.UTC(2026, 4, 8, 4),
+        operatingDate: "2026-05-07",
+        startAt: Date.UTC(2026, 4, 7, 4),
+        storeId: "store-1" as Id<"store">,
+      },
+    );
+    const metadata = snapshot.readyItems.find(
+      (item) => item.key === "register_session:register-3:closed",
+    )?.metadata;
+
+    expect(metadata).toMatchObject({
+      terminal: "Codex / Register 3",
+    });
+    expect(metadata).not.toHaveProperty("register");
   });
 
   it("uses the supplied operating-day range for same-local-day transactions after UTC midnight", async () => {

--- a/packages/athena-webapp/convex/operations/dailyClose.ts
+++ b/packages/athena-webapp/convex/operations/dailyClose.ts
@@ -61,6 +61,7 @@ type DailyCloseSummary = {
   currentDayCashTotal: number;
   currentDayCashTransactionCount: number;
   expectedCashTotal: number;
+  expenseStaffCount: number;
   expenseTotal: number;
   netCashVariance: number;
   openWorkItemCount: number;
@@ -196,6 +197,19 @@ function registerSessionLabel(
   return session.registerNumber
     ? `Register ${session.registerNumber}`
     : "Register";
+}
+
+function registerMetadataLabel(
+  terminalLabel: string | undefined,
+  registerLabel: string | undefined,
+) {
+  if (!registerLabel) return undefined;
+
+  return terminalLabel
+    ?.toLocaleLowerCase()
+    .includes(registerLabel.toLocaleLowerCase())
+    ? undefined
+    : registerLabel;
 }
 
 function formatPaymentMethodLabel(method: string) {
@@ -609,6 +623,7 @@ function emptySummary(): DailyCloseSummary {
     currentDayCashTotal: 0,
     currentDayCashTransactionCount: 0,
     expectedCashTotal: 0,
+    expenseStaffCount: 0,
     expenseTotal: 0,
     netCashVariance: 0,
     openWorkItemCount: 0,
@@ -756,6 +771,13 @@ export async function buildDailyCloseSnapshotWithCtx(
     const terminalLabel = session.terminalId
       ? terminalLabelsById.get(session.terminalId)
       : undefined;
+    const registerLabel = trimOptional(session.registerNumber)
+      ? registerSessionLabel(session)
+      : undefined;
+    const registerMetadata = registerMetadataLabel(
+      terminalLabel,
+      registerLabel,
+    );
     const openedBy = session.openedByStaffProfileId
       ? staffNamesById.get(session.openedByStaffProfileId)
       : undefined;
@@ -790,6 +812,7 @@ export async function buildDailyCloseSnapshotWithCtx(
       },
       metadata: {
         ...(terminalLabel ? { terminal: terminalLabel } : {}),
+        ...(registerMetadata ? { register: registerMetadata } : {}),
         operatingScope: isCarriedOver
           ? "Carried over from prior day"
           : "Opened today",
@@ -947,6 +970,13 @@ export async function buildDailyCloseSnapshotWithCtx(
     const terminalLabel = session.terminalId
       ? terminalLabelsById.get(session.terminalId)
       : undefined;
+    const registerLabel = trimOptional(session.registerNumber)
+      ? registerSessionLabel(session)
+      : undefined;
+    const registerMetadata = registerMetadataLabel(
+      terminalLabel,
+      registerLabel,
+    );
     const openedBy = session.openedByStaffProfileId
       ? staffNamesById.get(session.openedByStaffProfileId)
       : undefined;
@@ -973,6 +1003,7 @@ export async function buildDailyCloseSnapshotWithCtx(
       },
       metadata: {
         ...(terminalLabel ? { terminal: terminalLabel } : {}),
+        ...(registerMetadata ? { register: registerMetadata } : {}),
         operatingScope: isCarriedOver
           ? "Carried over from prior day"
           : "Opened today",
@@ -1010,6 +1041,7 @@ export async function buildDailyCloseSnapshotWithCtx(
         },
         metadata: {
           ...(terminalLabel ? { terminal: terminalLabel } : {}),
+          ...(registerMetadata ? { register: registerMetadata } : {}),
           operatingScope: isCarriedOver
             ? "Carried over from prior day"
             : "Opened today",
@@ -1166,6 +1198,9 @@ export async function buildDailyCloseSnapshotWithCtx(
       (sum, transaction) => sum + transaction.totalValue,
       0,
     ),
+    expenseStaffCount: new Set(
+      expenseTransactions.map((transaction) => transaction.staffProfileId),
+    ).size,
     netCashVariance: relevantRegisterSessions.reduce(
       (sum, session) => sum + (session.variance ?? 0),
       0,

--- a/packages/athena-webapp/src/components/operations/DailyCloseView.test.tsx
+++ b/packages/athena-webapp/src/components/operations/DailyCloseView.test.tsx
@@ -388,6 +388,32 @@ describe("DailyCloseViewContent", () => {
     ).toBeEnabled();
   });
 
+  it("uses explicit register metadata instead of also appending the subject register", () => {
+    renderContent({
+      ...readySnapshot,
+      readyItems: [
+        {
+          ...readySnapshot.readyItems[0],
+          metadata: {
+            ...readySnapshot.readyItems[0].metadata,
+            register: "Register 3",
+            terminal: "Codex",
+          },
+          subject: {
+            id: "session-3",
+            label: "Register 3",
+            type: "register_session",
+          },
+        },
+      ],
+    });
+
+    expect(screen.getByText("Codex / Register 3")).toBeInTheDocument();
+    expect(
+      screen.queryByText("Codex / Register 3 / Register 3"),
+    ).not.toBeInTheDocument();
+  });
+
   it("uses natural count grammar in summary helpers", () => {
     renderContent({
       ...readySnapshot,
@@ -407,6 +433,24 @@ describe("DailyCloseViewContent", () => {
     expect(screen.getByText("1 register from a prior day")).toBeInTheDocument();
     expect(screen.getByText("1 register variance")).toBeInTheDocument();
     expect(screen.getByText("1 staff member involved")).toBeInTheDocument();
+  });
+
+  it("does not use pending approvals as the expenses staff count", () => {
+    renderContent({
+      ...readySnapshot,
+      summary: {
+        ...baseSummary,
+        expenseStaffCount: undefined,
+        expenseTotal: 0,
+        pendingApprovalCount: 1,
+        staffCount: undefined,
+      },
+    });
+
+    expect(screen.getByText("No staff involved")).toBeInTheDocument();
+    expect(
+      screen.queryByText("1 staff member involved"),
+    ).not.toBeInTheDocument();
   });
 
   it("keeps review context available from the ready state", () => {

--- a/packages/athena-webapp/src/components/operations/DailyCloseView.tsx
+++ b/packages/athena-webapp/src/components/operations/DailyCloseView.tsx
@@ -130,6 +130,7 @@ export type DailyCloseSnapshot = {
     currentDayCashTransactionCount?: number | null;
     currentDayCashTotal?: number | null;
     expectedCashTotal?: number | null;
+    expenseStaffCount?: number | null;
     expenseTotal?: number | null;
     netCashVariance?: number | null;
     openWorkItemCount?: number | null;
@@ -812,9 +813,20 @@ function getMetadataEntries(
       value: ReactNode;
     }>,
   ) => {
+    const hasExplicitRegister = entries.some(
+      (entry) => normalizeMetadataLabel(entry.label) === "register",
+    );
+    const appendRegister = (value: ReactNode, nextRegisterLabel: ReactNode) => (
+      <>
+        {value} / {nextRegisterLabel}
+      </>
+    );
+
     let combinedEntries = entries.map((entry) =>
-      registerLabel && normalizeMetadataLabel(entry.label) === "terminal"
-        ? { ...entry, value: `${entry.value} / ${registerLabel}` }
+      registerLabel &&
+      normalizeMetadataLabel(entry.label) === "terminal" &&
+      !hasExplicitRegister
+        ? { ...entry, value: appendRegister(entry.value, registerLabel) }
         : entry,
     );
     const terminalEntry = combinedEntries.find(
@@ -832,11 +844,7 @@ function getMetadataEntries(
           return [
             {
               ...entry,
-              value: (
-                <>
-                  {entry.value} / {registerEntry.value}
-                </>
-              ),
+              value: appendRegister(entry.value, registerEntry.value),
             },
           ];
         }
@@ -975,6 +983,18 @@ function getSummaryRegisterVarianceCount(
     "netCashVariance",
   );
   return variance === 0 ? 0 : 1;
+}
+
+function getExpenseStaffCount(summary: DailyCloseSnapshot["summary"]) {
+  if (typeof summary.expenseStaffCount === "number") {
+    return summary.expenseStaffCount;
+  }
+
+  if (summary.expenseTotal === 0) {
+    return 0;
+  }
+
+  return typeof summary.staffCount === "number" ? summary.staffCount : 0;
 }
 
 function getDefaultBucketValue(
@@ -1791,11 +1811,7 @@ export function DailyCloseViewContent({
                   />
                   <SummaryMetric
                     helper={formatStaffInvolvedCount(
-                      getSummaryCount(
-                        snapshot.summary,
-                        "staffCount",
-                        "pendingApprovalCount",
-                      ),
+                      getExpenseStaffCount(snapshot.summary),
                     )}
                     label="Expenses"
                     value={formatMoney(currency, snapshot.summary.expenseTotal)}


### PR DESCRIPTION
## Summary

Fixes two Daily Close summary/detail issues found during browser iteration:

- adds an expense-specific staff count to the Daily Close backend summary so the Expenses card no longer falls back to pending approval counts
- makes register-session detail metadata carry register labels explicitly, while the UI renderer treats explicit register metadata as the source of truth instead of appending the subject label again
- refreshes tracked graphify artifacts for the changed code graph

## Validation

- `bun run --filter '@athena/webapp' test -- convex/operations/dailyClose.test.ts`
- `bun run --filter '@athena/webapp' test -- src/components/operations/DailyCloseView.test.tsx`
- `bun run --filter '@athena/webapp' lint:frontend:changed`
- `git diff --check`
- `bun run pr:athena`
