### PR TITLE
Refine store operations opening workflow

### DIFF
--- a/docs/solutions/logic-errors/athena-daily-opening-readiness-gate-2026-05-08.md
+++ b/docs/solutions/logic-errors/athena-daily-opening-readiness-gate-2026-05-08.md
@@ -9,6 +9,7 @@ symptoms:
   - "Opening can drift into a second drawer-open or register-session flow instead of a store-day acknowledgement"
   - "Operators need the prior close handoff, carry-forward work, and pending approval state in one place before starting the day"
   - "Frontend acknowledgement can become stale if the command trusts the client snapshot"
+  - "Started Opening states can show technical record language or miss the staff profile name if the snapshot returns only raw ids"
 root_cause: missing_workflow_record
 resolution_type: design_pattern
 severity: medium
@@ -42,6 +43,14 @@ evidence:
 - The persisted `dailyOpening` record stores the operating date, local range,
   prior close reference, readiness counts, source subjects, carry-forward work
   item ids, acknowledged keys, actor ids, and notes.
+- Start-day confirmation should use the shared manager approval dialog rather
+  than bespoke staff-auth UI. The approval proof's approved manager staff
+  profile becomes the opening actor, preserving the command boundary while
+  giving the store-day record a real staff identity.
+- Started snapshots should hydrate display fields from stored ids. In
+  particular, `startedOpening.startedByStaffName` should be derived from
+  `actorStaffProfileId` server-side so the UI does not guess from raw ids or
+  show "staff unavailable" for valid openings.
 - Opening records an operational event but does not mutate register sessions,
   drawers, or the carry-forward work item status.
 - The operator view should treat Opening as a review-and-confirm workspace with
@@ -60,6 +69,9 @@ review, and store-day analytics without changing the POS drawer lifecycle.
 - Include operating-date range fields in the backend contract when the frontend
   sends local store-day bounds, even if the first slice only keys records by
   `operatingDate`.
+- Use operational copy and labeled details for completed states. Avoid phrases
+  like "saved record" in the UI; present who completed the handoff and when as
+  separate facts.
 - Add a lifecycle harness scenario when Daily Opening, Daily Close, or their
   route wiring changes so readiness gates, generated Convex API refs, and
   operator views are validated together.

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 4788 nodes · 4695 edges · 1564 communities detected
+- 4795 nodes · 4708 edges · 1564 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -1580,7 +1580,7 @@
 2. `buildDailyCloseSnapshotWithCtx()` - 22 edges
 3. `getStoreConfigV2()` - 17 edges
 4. `DataTableViewOptions()` - 16 edges
-5. `buildDailyOpeningSnapshotWithCtx()` - 14 edges
+5. `buildDailyOpeningSnapshotWithCtx()` - 15 edges
 6. `toV2Config()` - 13 edges
 7. `validateHarnessDocs()` - 13 edges
 8. `runHarnessInferentialReview()` - 13 edges
@@ -1626,48 +1626,48 @@ Cohesion: 0.15
 Nodes (31): collectHarnessOnboardingErrors(), collectMarkdownLinkErrors(), collectMissingRequiredLinkErrors(), collectPackageGuideLinkErrors(), collectPackagesRouterLinkErrors(), collectReadmeLinkErrors(), collectReferencedPathErrors(), collectRuntimeScenarioDocSyncErrors() (+23 more)
 
 ### Community 6 - "Community 6"
+Cohesion: 0.09
+Nodes (18): cn(), formatMetadataValue(), formatOperatingDate(), getAcknowledgementKey(), getBucketCountClassName(), getItemContextLabel(), getItemId(), getLocalOperatingDate() (+10 more)
+
+### Community 7 - "Community 7"
 Cohesion: 0.12
 Nodes (28): asRegExp(), collectLatencyDiagnostics(), collectRuntimeSignalDiagnostics(), collectRuntimeSignalMatches(), consumeLines(), escapeRegExp(), formatAssertionDiagnostics(), formatError() (+20 more)
 
-### Community 7 - "Community 7"
+### Community 8 - "Community 8"
 Cohesion: 0.15
 Nodes (27): buildDiscoveryIndex(), buildGeneratedDoc(), buildKeyFolderIndex(), buildTestIndex(), buildValidationGuide(), buildValidationMap(), collectFolderFacts(), collectRouteGroups() (+19 more)
 
-### Community 8 - "Community 8"
+### Community 9 - "Community 9"
 Cohesion: 0.16
 Nodes (25): asArray(), asBoolean(), asMtnMomoSetupStatus(), asNumber(), asOptionalArray(), asRecord(), assignOrDelete(), asString() (+17 more)
 
-### Community 9 - "Community 9"
+### Community 10 - "Community 10"
 Cohesion: 0.1
 Nodes (17): applyCloseoutCommandResult(), applyCommandResult(), buildDepositSubmissionKey(), formatRegisterHeaderName(), formatRegisterName(), handleAuthenticatedCloseoutStaff(), handleOpeningFloatApprovalApproved(), handleRecordDeposit() (+9 more)
-
-### Community 10 - "Community 10"
-Cohesion: 0.09
-Nodes (13): cn(), getAcknowledgementKey(), getBucketCountClassName(), getItemContextLabel(), getItemId(), getLocalOperatingDate(), getLocalOperatingDateRange(), getStatusLabelClassName() (+5 more)
 
 ### Community 11 - "Community 11"
 Cohesion: 0.15
 Nodes (22): buildDocumentationStatus(), buildEmptyHistoryMetric(), buildGraphifyStatus(), buildInferentialSummaryNote(), buildSummary(), collectHarnessScorecard(), countMissingSnippets(), createFileSystem() (+14 more)
 
 ### Community 12 - "Community 12"
+Cohesion: 0.16
+Nodes (21): buildDailyOpeningSnapshotWithCtx(), buildReadiness(), getDailyOpeningForDate(), getMissingCarryForwardItems(), getStaffDisplayName(), getStartedDailyOpeningForDate(), getStore(), hydrateStartedOpening() (+13 more)
+
+### Community 13 - "Community 13"
 Cohesion: 0.19
 Nodes (23): assertCompoundSolutionCheck(), collectChangedFiles(), collectCompoundSolutionFindings(), collectExistingFiles(), collectMarkdownContents(), collectSourceLineChanges(), countFileLines(), extractFrontmatter() (+15 more)
 
-### Community 13 - "Community 13"
+### Community 14 - "Community 14"
 Cohesion: 0.15
 Nodes (19): appendListSection(), buildMarkdownBundle(), collectCoverage(), evaluateGraphifyFreshness(), fileExists(), formatValidationCommand(), getChangedFilesFromGit(), isLocalGeneratedArtifactPath() (+11 more)
 
-### Community 14 - "Community 14"
+### Community 15 - "Community 15"
 Cohesion: 0.13
 Nodes (18): buildCartSummary(), buildSessionOperationsRow(), expirePosSessionNow(), hasCustomerSnapshotValue(), isUsableRegisterSession(), loadPosSessionItems(), loadSessionCustomer(), loadSessionOperator() (+10 more)
 
-### Community 15 - "Community 15"
+### Community 16 - "Community 16"
 Cohesion: 0.15
 Nodes (19): acquireExpenseQuantityPatchHold(), adjustExpenseQuantityPatchHold(), createDefaultExpenseSessionCommandService(), createExpenseInventoryHoldGateway(), createExpenseSessionCommandService(), failure(), isActiveRegisterSession(), isSessionExpired() (+11 more)
-
-### Community 16 - "Community 16"
-Cohesion: 0.17
-Nodes (19): buildDailyOpeningSnapshotWithCtx(), buildReadiness(), getDailyOpeningForDate(), getMissingCarryForwardItems(), getStartedDailyOpeningForDate(), getStore(), invalidOperatingDateItem(), isValidOperatingDate() (+11 more)
 
 ### Community 17 - "Community 17"
 Cohesion: 0.25
@@ -1983,39 +1983,39 @@ Nodes (6): findAthenaUserByEmailWithCtx(), getAuthenticatedAthenaUserWithCtx(), 
 
 ### Community 95 - "Community 95"
 Cohesion: 0.43
-Nodes (6): sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
-
-### Community 96 - "Community 96"
-Cohesion: 0.43
 Nodes (6): buildMtnCollectionsLookupPrefixes(), isTargetEnvironment(), readScopedValue(), resolveConfigForPrefix(), resolveMtnCollectionsConfigFromEnv(), toEnvSegment()
 
-### Community 97 - "Community 97"
+### Community 96 - "Community 96"
 Cohesion: 0.46
 Nodes (7): recordApprovalAuditEventWithCtx(), recordApprovalDecisionRecordedAuditEventWithCtx(), recordApprovalProofConsumedAuditEventWithCtx(), recordApprovalRequiredAuditEventWithCtx(), recordApprovedCommandAppliedAuditEventWithCtx(), recordAsyncApprovalRequestCreatedAuditEventWithCtx(), recordManagerApprovalGrantedAuditEventWithCtx()
 
-### Community 98 - "Community 98"
+### Community 97 - "Community 97"
 Cohesion: 0.5
 Nodes (7): buildApprovalDecisionRequirement(), buildApprovalDecisionSubject(), consumeApprovalDecisionProofWithCtx(), decideApprovalRequestAsAuthenticatedUserWithCtx(), decideApprovalRequestAsCommandWithCtx(), decideApprovalRequestWithCtx(), mapDecideApprovalRequestError()
 
-### Community 99 - "Community 99"
+### Community 98 - "Community 98"
 Cohesion: 0.36
 Nodes (5): buildPaymentAllocation(), correctSameAmountSinglePaymentAllocationWithCtx(), findSameAmountSinglePaymentAllocation(), listPaymentAllocationsForTargetWithCtx(), recordPaymentAllocationWithCtx()
 
-### Community 100 - "Community 100"
+### Community 99 - "Community 99"
 Cohesion: 0.43
 Nodes (6): buildPosSessionTraceEvent(), buildPosSessionTraceRecord(), buildTraceSummary(), formatPaymentMethod(), recordPosSessionTraceBestEffort(), safeTraceWrite()
 
-### Community 101 - "Community 101"
+### Community 100 - "Community 100"
 Cohesion: 0.5
 Nodes (7): findExistingSku(), findOrCreateQuickAddCategory(), findOrCreateQuickAddSubcategory(), generateSKU(), isBarcodeLike(), mapSkuToCatalogResult(), quickAddCatalogItem()
+
+### Community 101 - "Community 101"
+Cohesion: 0.25
+Nodes (0):
 
 ### Community 102 - "Community 102"
 Cohesion: 0.25
 Nodes (0):
 
 ### Community 103 - "Community 103"
-Cohesion: 0.25
-Nodes (0):
+Cohesion: 0.43
+Nodes (6): sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
 
 ### Community 104 - "Community 104"
 Cohesion: 0.25
@@ -2403,7 +2403,7 @@ Nodes (0):
 
 ### Community 200 - "Community 200"
 Cohesion: 0.4
-Nodes (0):
+Nodes (1): Header()
 
 ### Community 201 - "Community 201"
 Cohesion: 0.4
@@ -2418,12 +2418,12 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 204 - "Community 204"
-Cohesion: 0.5
-Nodes (2): handleFileSelect(), validateFile()
-
-### Community 205 - "Community 205"
 Cohesion: 0.4
 Nodes (0):
+
+### Community 205 - "Community 205"
+Cohesion: 0.5
+Nodes (2): handleFileSelect(), validateFile()
 
 ### Community 206 - "Community 206"
 Cohesion: 0.4
@@ -2435,23 +2435,23 @@ Nodes (0):
 
 ### Community 208 - "Community 208"
 Cohesion: 0.4
-Nodes (1): Header()
+Nodes (0):
 
 ### Community 209 - "Community 209"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 210 - "Community 210"
 Cohesion: 0.5
 Nodes (2): getBalanceDueLabel(), getBalanceDuePanel()
 
-### Community 210 - "Community 210"
+### Community 211 - "Community 211"
 Cohesion: 0.6
 Nodes (3): getSummaryAmount(), getSummaryLabel(), getSummaryPanel()
 
-### Community 211 - "Community 211"
+### Community 212 - "Community 212"
 Cohesion: 0.6
 Nodes (3): handleClearSearch(), handleQuickAddSubmit(), resetQuickAddForm()
-
-### Community 212 - "Community 212"
-Cohesion: 0.4
-Nodes (0):
 
 ### Community 213 - "Community 213"
 Cohesion: 0.4
@@ -2466,32 +2466,32 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 216 - "Community 216"
-Cohesion: 0.7
-Nodes (4): getRuntimeOrigin(), isLocalHost(), resolveStoreFrontUrl(), trimTrailingSlash()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 217 - "Community 217"
 Cohesion: 0.7
-Nodes (4): bufferToHex(), collectBrowserInfo(), generateBrowserFingerprint(), hashFingerprintSource()
+Nodes (4): getRuntimeOrigin(), isLocalHost(), resolveStoreFrontUrl(), trimTrailingSlash()
 
 ### Community 218 - "Community 218"
-Cohesion: 0.4
-Nodes (1): MockImage
+Cohesion: 0.7
+Nodes (4): bufferToHex(), collectBrowserInfo(), generateBrowserFingerprint(), hashFingerprintSource()
 
 ### Community 219 - "Community 219"
 Cohesion: 0.4
-Nodes (0):
+Nodes (1): MockImage
 
 ### Community 220 - "Community 220"
-Cohesion: 0.6
-Nodes (3): calculatePosCartTotals(), calculatePosItemTotal(), roundPosAmount()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 221 - "Community 221"
 Cohesion: 0.6
-Nodes (4): mapRegisterStateDto(), mapTerminalDto(), useConvexRegisterState(), useConvexTerminalByFingerprint()
+Nodes (3): calculatePosCartTotals(), calculatePosItemTotal(), roundPosAmount()
 
 ### Community 222 - "Community 222"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.6
+Nodes (4): mapRegisterStateDto(), mapTerminalDto(), useConvexRegisterState(), useConvexTerminalByFingerprint()
 
 ### Community 223 - "Community 223"
 Cohesion: 0.4
@@ -2506,84 +2506,84 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 226 - "Community 226"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 227 - "Community 227"
 Cohesion: 0.5
 Nodes (2): completePendingAuthSync(), sleep()
 
-### Community 227 - "Community 227"
+### Community 228 - "Community 228"
 Cohesion: 0.4
 Nodes (0):
-
-### Community 228 - "Community 228"
-Cohesion: 0.7
-Nodes (4): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory()
 
 ### Community 229 - "Community 229"
 Cohesion: 0.7
-Nodes (4): getBaseUrl(), getOrder(), getOrders(), updateOrdersOwner()
+Nodes (4): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory()
 
 ### Community 230 - "Community 230"
 Cohesion: 0.7
-Nodes (4): getActiveUser(), getBaseUrl(), getGuest(), updateUser()
+Nodes (4): getBaseUrl(), getOrder(), getOrders(), updateOrdersOwner()
 
 ### Community 231 - "Community 231"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.7
+Nodes (4): getActiveUser(), getBaseUrl(), getGuest(), updateUser()
 
 ### Community 232 - "Community 232"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 233 - "Community 233"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 234 - "Community 234"
 Cohesion: 0.7
 Nodes (4): createStorefrontFailureEvent(), emitStorefrontFailure(), inferStorefrontJourneyFromRoute(), normalizeStorefrontError()
 
-### Community 234 - "Community 234"
+### Community 235 - "Community 235"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 235 - "Community 235"
+### Community 236 - "Community 236"
 Cohesion: 0.6
 Nodes (4): collectHarnessRepoValidationSelection(), matchesHarnessRepoValidationPath(), normalizeRepoPath(), sortUniquePaths()
 
-### Community 236 - "Community 236"
+### Community 237 - "Community 237"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 237 - "Community 237"
+### Community 238 - "Community 238"
 Cohesion: 0.7
 Nodes (4): createFixtureRepo(), fixtureEnv(), runGit(), runWorktreeManager()
 
-### Community 238 - "Community 238"
+### Community 239 - "Community 239"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 239 - "Community 239"
+### Community 240 - "Community 240"
 Cohesion: 0.67
 Nodes (2): maskReceiptPhone(), normalizeReceiptPhone()
 
-### Community 240 - "Community 240"
+### Community 241 - "Community 241"
 Cohesion: 0.83
 Nodes (3): createReceiptShareToken(), hashReceiptShareToken(), toHex()
 
-### Community 241 - "Community 241"
+### Community 242 - "Community 242"
 Cohesion: 0.83
 Nodes (3): timingSafeEqual(), toHex(), verifyMetaWebhookSignature()
-
-### Community 242 - "Community 242"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 243 - "Community 243"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 244 - "Community 244"
-Cohesion: 0.67
-Nodes (2): createExpenseTransactionFromSessionHandler(), expenseTransactionError()
-
-### Community 245 - "Community 245"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 245 - "Community 245"
+Cohesion: 0.67
+Nodes (2): createExpenseTransactionFromSessionHandler(), expenseTransactionError()
 
 ### Community 246 - "Community 246"
 Cohesion: 0.5
@@ -2594,68 +2594,68 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 248 - "Community 248"
-Cohesion: 0.67
-Nodes (2): createProductsQueryCtx(), createSkuMutationCtx()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 249 - "Community 249"
 Cohesion: 0.67
-Nodes (2): toDisplayAmount(), toPesewas()
+Nodes (2): createProductsQueryCtx(), createSkuMutationCtx()
 
 ### Community 250 - "Community 250"
+Cohesion: 0.67
+Nodes (2): toDisplayAmount(), toPesewas()
+
+### Community 251 - "Community 251"
 Cohesion: 0.83
 Nodes (3): getCachedTokenRecord(), resolveAccessTokenForStore(), resolveConfigForStore()
 
-### Community 251 - "Community 251"
+### Community 252 - "Community 252"
 Cohesion: 0.67
 Nodes (2): maskMtnPartyId(), normalizeCollectionsTransaction()
 
-### Community 252 - "Community 252"
+### Community 253 - "Community 253"
 Cohesion: 0.67
 Nodes (2): consumeApprovalProofWithCtx(), invalidApprovalProofResult()
 
-### Community 253 - "Community 253"
+### Community 254 - "Community 254"
 Cohesion: 0.67
 Nodes (2): buildOperationalEvent(), recordOperationalEventWithCtx()
 
-### Community 254 - "Community 254"
+### Community 255 - "Community 255"
 Cohesion: 0.67
 Nodes (2): buildOperationalWorkItem(), createOperationalWorkItemWithCtx()
 
-### Community 255 - "Community 255"
+### Community 256 - "Community 256"
 Cohesion: 0.67
 Nodes (2): expectIndex(), getTableIndexes()
-
-### Community 256 - "Community 256"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 257 - "Community 257"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 258 - "Community 258"
-Cohesion: 0.83
-Nodes (3): resolveServiceIntakeCustomerProfile(), splitFullName(), trimOptional()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 259 - "Community 259"
 Cohesion: 0.83
-Nodes (3): mapOpenDrawerUserError(), normalizeRegisterNumber(), openDrawer()
+Nodes (3): resolveServiceIntakeCustomerProfile(), splitFullName(), trimOptional()
 
 ### Community 260 - "Community 260"
 Cohesion: 0.83
-Nodes (3): createDbGetMock(), createDbMock(), createDbQueryMock()
+Nodes (3): mapOpenDrawerUserError(), normalizeRegisterNumber(), openDrawer()
 
 ### Community 261 - "Community 261"
 Cohesion: 0.83
-Nodes (3): buildRegisterState(), getActiveSessionConflictForRegisterState(), getRegisterState()
+Nodes (3): createDbGetMock(), createDbMock(), createDbQueryMock()
 
 ### Community 262 - "Community 262"
-Cohesion: 0.67
-Nodes (2): lookupByBarcode(), mapSkuToCatalogResult()
+Cohesion: 0.83
+Nodes (3): buildRegisterState(), getActiveSessionConflictForRegisterState(), getRegisterState()
 
 ### Community 263 - "Community 263"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): lookupByBarcode(), mapSkuToCatalogResult()
 
 ### Community 264 - "Community 264"
 Cohesion: 0.5
@@ -2666,24 +2666,24 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 266 - "Community 266"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 267 - "Community 267"
 Cohesion: 0.67
 Nodes (2): expectIndex(), getTableIndexes()
 
-### Community 267 - "Community 267"
+### Community 268 - "Community 268"
 Cohesion: 0.83
 Nodes (3): findExistingCustomerProfileId(), getStoreOrganizationId(), recordStoreFrontCustomerMilestone()
 
-### Community 268 - "Community 268"
+### Community 269 - "Community 269"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 269 - "Community 269"
-Cohesion: 0.83
-Nodes (3): formatStaffDisplayName(), formatStaffDisplayNameOrFallback(), normalizeNamePart()
 
 ### Community 270 - "Community 270"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): formatStaffDisplayName(), formatStaffDisplayNameOrFallback(), normalizeNamePart()
 
 ### Community 271 - "Community 271"
 Cohesion: 0.5
@@ -2698,12 +2698,12 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 274 - "Community 274"
-Cohesion: 0.67
-Nodes (2): countGroupedAnalytics(), groupAnalytics()
-
-### Community 275 - "Community 275"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 275 - "Community 275"
+Cohesion: 0.67
+Nodes (2): countGroupedAnalytics(), groupAnalytics()
 
 ### Community 276 - "Community 276"
 Cohesion: 0.5
@@ -10057,4 +10057,4 @@ _Questions this graph is uniquely positioned to answer:_
 - **Should `Community 4` be split into smaller, more focused modules?**
   _Cohesion score 0.07 - nodes in this community are weakly interconnected._
 - **Should `Community 6` be split into smaller, more focused modules?**
-  _Cohesion score 0.12 - nodes in this community are weakly interconnected._
+  _Cohesion score 0.09 - nodes in this community are weakly interconnected._

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -4355,7 +4355,7 @@
       "relation": "calls",
       "source": "dailyopening_buildreadiness",
       "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L551",
+      "source_location": "L580",
       "target": "dailyopening_builddailyopeningsnapshotwithctx",
       "weight": 1
     },
@@ -4367,7 +4367,7 @@
       "relation": "calls",
       "source": "dailyopening_getdailyopeningfordate",
       "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L486",
+      "source_location": "L514",
       "target": "dailyopening_builddailyopeningsnapshotwithctx",
       "weight": 1
     },
@@ -4379,7 +4379,7 @@
       "relation": "calls",
       "source": "dailyopening_getmissingcarryforwarditems",
       "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L529",
+      "source_location": "L558",
       "target": "dailyopening_builddailyopeningsnapshotwithctx",
       "weight": 1
     },
@@ -4391,7 +4391,19 @@
       "relation": "calls",
       "source": "dailyopening_getstore",
       "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L485",
+      "source_location": "L513",
+      "target": "dailyopening_builddailyopeningsnapshotwithctx",
+      "weight": 1
+    },
+    {
+      "_src": "dailyopening_builddailyopeningsnapshotwithctx",
+      "_tgt": "dailyopening_hydratestartedopening",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "dailyopening_hydratestartedopening",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
+      "source_location": "L515",
       "target": "dailyopening_builddailyopeningsnapshotwithctx",
       "weight": 1
     },
@@ -4403,7 +4415,7 @@
       "relation": "calls",
       "source": "dailyopening_invalidoperatingdateitem",
       "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L490",
+      "source_location": "L519",
       "target": "dailyopening_builddailyopeningsnapshotwithctx",
       "weight": 1
     },
@@ -4415,7 +4427,7 @@
       "relation": "calls",
       "source": "dailyopening_isvalidoperatingdate",
       "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L489",
+      "source_location": "L518",
       "target": "dailyopening_builddailyopeningsnapshotwithctx",
       "weight": 1
     },
@@ -4427,19 +4439,19 @@
       "relation": "calls",
       "source": "dailyopening_listpendingopeningblockerapprovals",
       "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L525",
+      "source_location": "L554",
       "target": "dailyopening_builddailyopeningsnapshotwithctx",
       "weight": 1
     },
     {
       "_src": "dailyopening_builddailyopeningsnapshotwithctx",
-      "_tgt": "dailyopening_missingpriorcloseitem",
+      "_tgt": "dailyopening_missingpriorclosereviewitem",
       "confidence": "EXTRACTED",
       "confidence_score": 1,
       "relation": "calls",
-      "source": "dailyopening_missingpriorcloseitem",
+      "source": "dailyopening_missingpriorclosereviewitem",
       "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L546",
+      "source_location": "L575",
       "target": "dailyopening_builddailyopeningsnapshotwithctx",
       "weight": 1
     },
@@ -4451,7 +4463,7 @@
       "relation": "calls",
       "source": "dailyopening_priorclosenotesitem",
       "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L540",
+      "source_location": "L569",
       "target": "dailyopening_builddailyopeningsnapshotwithctx",
       "weight": 1
     },
@@ -4463,7 +4475,7 @@
       "relation": "calls",
       "source": "dailyopening_priorclosereadyitem",
       "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L538",
+      "source_location": "L567",
       "target": "dailyopening_builddailyopeningsnapshotwithctx",
       "weight": 1
     },
@@ -4475,7 +4487,7 @@
       "relation": "calls",
       "source": "dailyopening_resolveoperatingdaterange",
       "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L487",
+      "source_location": "L516",
       "target": "dailyopening_builddailyopeningsnapshotwithctx",
       "weight": 1
     },
@@ -4487,8 +4499,20 @@
       "relation": "calls",
       "source": "dailyopening_uniquesourcesubjects",
       "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L579",
+      "source_location": "L608",
       "target": "dailyopening_builddailyopeningsnapshotwithctx",
+      "weight": 1
+    },
+    {
+      "_src": "dailyopening_hydratestartedopening",
+      "_tgt": "dailyopening_getstaffdisplayname",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "dailyopening_getstaffdisplayname",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
+      "source_location": "L212",
+      "target": "dailyopening_hydratestartedopening",
       "weight": 1
     },
     {
@@ -4499,7 +4523,7 @@
       "relation": "calls",
       "source": "dailyopening_trimoptional",
       "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L322",
+      "source_location": "L350",
       "target": "dailyopening_priorclosenotesitem",
       "weight": 1
     },
@@ -4511,7 +4535,7 @@
       "relation": "calls",
       "source": "dailyopening_isvalidoperatingdaterange",
       "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L141",
+      "source_location": "L143",
       "target": "dailyopening_resolveoperatingdaterange",
       "weight": 1
     },
@@ -4523,7 +4547,7 @@
       "relation": "calls",
       "source": "dailyopening_safeoperatingdaterange",
       "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L139",
+      "source_location": "L141",
       "target": "dailyopening_resolveoperatingdaterange",
       "weight": 1
     },
@@ -4535,7 +4559,7 @@
       "relation": "calls",
       "source": "dailyopening_isvalidoperatingdate",
       "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L111",
+      "source_location": "L113",
       "target": "dailyopening_safeoperatingdaterange",
       "weight": 1
     },
@@ -4547,7 +4571,7 @@
       "relation": "calls",
       "source": "dailyopening_builddailyopeningsnapshotwithctx",
       "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L618",
+      "source_location": "L647",
       "target": "dailyopening_startstoredaywithctx",
       "weight": 1
     },
@@ -4559,7 +4583,7 @@
       "relation": "calls",
       "source": "dailyopening_getstarteddailyopeningfordate",
       "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L609",
+      "source_location": "L638",
       "target": "dailyopening_startstoredaywithctx",
       "weight": 1
     },
@@ -4571,7 +4595,7 @@
       "relation": "calls",
       "source": "dailyopening_getstore",
       "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L593",
+      "source_location": "L622",
       "target": "dailyopening_startstoredaywithctx",
       "weight": 1
     },
@@ -4583,7 +4607,7 @@
       "relation": "calls",
       "source": "dailyopening_resolveopeningactor",
       "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L650",
+      "source_location": "L679",
       "target": "dailyopening_startstoredaywithctx",
       "weight": 1
     },
@@ -4595,7 +4619,7 @@
       "relation": "calls",
       "source": "dailyopening_trimoptional",
       "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L672",
+      "source_location": "L701",
       "target": "dailyopening_startstoredaywithctx",
       "weight": 1
     },
@@ -4607,7 +4631,7 @@
       "relation": "calls",
       "source": "dailyopeningview_getitemid",
       "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L299",
+      "source_location": "L305",
       "target": "dailyopeningview_getacknowledgementkey",
       "weight": 1
     },
@@ -4619,7 +4643,7 @@
       "relation": "calls",
       "source": "dailyopeningview_getbucketcountclassname",
       "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L406",
+      "source_location": "L434",
       "target": "dailyopeningview_cn",
       "weight": 1
     },
@@ -4631,7 +4655,7 @@
       "relation": "calls",
       "source": "dailyopeningview_humanizemetadatalabel",
       "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L315",
+      "source_location": "L321",
       "target": "dailyopeningview_getitemcontextlabel",
       "weight": 1
     },
@@ -4643,8 +4667,44 @@
       "relation": "calls",
       "source": "dailyopeningview_getlocaloperatingdate",
       "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L239",
+      "source_location": "L242",
       "target": "dailyopeningview_getlocaloperatingdaterange",
+      "weight": 1
+    },
+    {
+      "_src": "dailyopeningview_getmetadatalabel",
+      "_tgt": "dailyopeningview_humanizemetadatalabel",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "dailyopeningview_humanizemetadatalabel",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
+      "source_location": "L349",
+      "target": "dailyopeningview_getmetadatalabel",
+      "weight": 1
+    },
+    {
+      "_src": "dailyopeningview_getmetadatavalue",
+      "_tgt": "dailyopeningview_formatmetadatavalue",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "dailyopeningview_formatmetadatavalue",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
+      "source_location": "L357",
+      "target": "dailyopeningview_getmetadatavalue",
+      "weight": 1
+    },
+    {
+      "_src": "dailyopeningview_getmetadatavalue",
+      "_tgt": "dailyopeningview_formatoperatingdate",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "dailyopeningview_formatoperatingdate",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
+      "source_location": "L354",
+      "target": "dailyopeningview_getmetadatavalue",
       "weight": 1
     },
     {
@@ -4655,7 +4715,7 @@
       "relation": "calls",
       "source": "dailyopeningview_getstatuslabelclassname",
       "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L380",
+      "source_location": "L408",
       "target": "dailyopeningview_cn",
       "weight": 1
     },
@@ -4667,7 +4727,7 @@
       "relation": "calls",
       "source": "dailyopeningview_getstatusrailbadgeclassname",
       "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L398",
+      "source_location": "L426",
       "target": "dailyopeningview_cn",
       "weight": 1
     },
@@ -4679,20 +4739,32 @@
       "relation": "calls",
       "source": "dailyopeningview_getstatusrailiconclassname",
       "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L389",
+      "source_location": "L417",
       "target": "dailyopeningview_cn",
       "weight": 1
     },
     {
       "_src": "dailyopeningview_handlestartday",
+      "_tgt": "dailyopeningview_submitstartday",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "dailyopeningview_submitstartday",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
+      "source_location": "L1256",
+      "target": "dailyopeningview_handlestartday",
+      "weight": 1
+    },
+    {
+      "_src": "dailyopeningview_submitstartday",
       "_tgt": "dailyopeningview_normalizecommandmessage",
       "confidence": "EXTRACTED",
       "confidence_score": 1,
       "relation": "calls",
       "source": "dailyopeningview_normalizecommandmessage",
       "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L1187",
-      "target": "dailyopeningview_handlestartday",
+      "source_location": "L1245",
+      "target": "dailyopeningview_submitstartday",
       "weight": 1
     },
     {
@@ -15023,7 +15095,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyopening_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L476",
+      "source_location": "L504",
       "target": "dailyopening_builddailyopeningsnapshotwithctx",
       "weight": 1
     },
@@ -15035,7 +15107,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyopening_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L373",
+      "source_location": "L401",
       "target": "dailyopening_buildreadiness",
       "weight": 1
     },
@@ -15047,7 +15119,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyopening_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L346",
+      "source_location": "L374",
       "target": "dailyopening_carryforwarditem",
       "weight": 1
     },
@@ -15059,7 +15131,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyopening_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L155",
+      "source_location": "L157",
       "target": "dailyopening_getdailyopeningfordate",
       "weight": 1
     },
@@ -15071,8 +15143,20 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyopening_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L403",
+      "source_location": "L431",
       "target": "dailyopening_getmissingcarryforwarditems",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_convex_operations_dailyopening_ts",
+      "_tgt": "dailyopening_getstaffdisplayname",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_convex_operations_dailyopening_ts",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
+      "source_location": "L190",
+      "target": "dailyopening_getstaffdisplayname",
       "weight": 1
     },
     {
@@ -15083,7 +15167,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyopening_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L170",
+      "source_location": "L172",
       "target": "dailyopening_getstarteddailyopeningfordate",
       "weight": 1
     },
@@ -15095,8 +15179,20 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyopening_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L148",
+      "source_location": "L150",
       "target": "dailyopening_getstore",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_convex_operations_dailyopening_ts",
+      "_tgt": "dailyopening_hydratestartedopening",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_convex_operations_dailyopening_ts",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
+      "source_location": "L200",
+      "target": "dailyopening_hydratestartedopening",
       "weight": 1
     },
     {
@@ -15107,7 +15203,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyopening_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L261",
+      "source_location": "L289",
       "target": "dailyopening_invalidoperatingdateitem",
       "weight": 1
     },
@@ -15119,7 +15215,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyopening_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L96",
+      "source_location": "L98",
       "target": "dailyopening_isvalidoperatingdate",
       "weight": 1
     },
@@ -15131,7 +15227,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyopening_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L123",
+      "source_location": "L125",
       "target": "dailyopening_isvalidoperatingdaterange",
       "weight": 1
     },
@@ -15143,7 +15239,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyopening_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L188",
+      "source_location": "L216",
       "target": "dailyopening_listpendingopeningblockerapprovals",
       "weight": 1
     },
@@ -15155,20 +15251,20 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyopening_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L275",
+      "source_location": "L303",
       "target": "dailyopening_missingcarryforwarditem",
       "weight": 1
     },
     {
       "_src": "packages_athena_webapp_convex_operations_dailyopening_ts",
-      "_tgt": "dailyopening_missingpriorcloseitem",
+      "_tgt": "dailyopening_missingpriorclosereviewitem",
       "confidence": "EXTRACTED",
       "confidence_score": 1,
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyopening_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L235",
-      "target": "dailyopening_missingpriorcloseitem",
+      "source_location": "L263",
+      "target": "dailyopening_missingpriorclosereviewitem",
       "weight": 1
     },
     {
@@ -15179,7 +15275,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyopening_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L207",
+      "source_location": "L235",
       "target": "dailyopening_pendingapprovalitem",
       "weight": 1
     },
@@ -15191,7 +15287,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyopening_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L321",
+      "source_location": "L349",
       "target": "dailyopening_priorclosenotesitem",
       "weight": 1
     },
@@ -15203,7 +15299,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyopening_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L298",
+      "source_location": "L326",
       "target": "dailyopening_priorclosereadyitem",
       "weight": 1
     },
@@ -15215,7 +15311,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyopening_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L419",
+      "source_location": "L447",
       "target": "dailyopening_resolveopeningactor",
       "weight": 1
     },
@@ -15227,7 +15323,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyopening_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L134",
+      "source_location": "L136",
       "target": "dailyopening_resolveoperatingdaterange",
       "weight": 1
     },
@@ -15239,7 +15335,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyopening_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L110",
+      "source_location": "L112",
       "target": "dailyopening_safeoperatingdaterange",
       "weight": 1
     },
@@ -15251,7 +15347,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyopening_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L589",
+      "source_location": "L618",
       "target": "dailyopening_startstoredaywithctx",
       "weight": 1
     },
@@ -15263,7 +15359,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyopening_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L91",
+      "source_location": "L93",
       "target": "dailyopening_trimoptional",
       "weight": 1
     },
@@ -15275,7 +15371,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyopening_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L393",
+      "source_location": "L421",
       "target": "dailyopening_uniquesourcesubjects",
       "weight": 1
     },
@@ -26645,13 +26741,25 @@
     },
     {
       "_src": "packages_athena_webapp_src_components_operations_dailyopeningview_test_tsx",
+      "_tgt": "dailyopeningview_test_async",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_components_operations_dailyopeningview_test_tsx",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.test.tsx",
+      "source_location": "L118",
+      "target": "dailyopeningview_test_async",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_components_operations_dailyopeningview_test_tsx",
       "_tgt": "dailyopeningview_test_disconnect",
       "confidence": "EXTRACTED",
       "confidence_score": 1,
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailyopeningview_test_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.test.tsx",
-      "source_location": "L202",
+      "source_location": "L275",
       "target": "dailyopeningview_test_disconnect",
       "weight": 1
     },
@@ -26663,7 +26771,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailyopeningview_test_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.test.tsx",
-      "source_location": "L203",
+      "source_location": "L276",
       "target": "dailyopeningview_test_observe",
       "weight": 1
     },
@@ -26675,7 +26783,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailyopeningview_test_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.test.tsx",
-      "source_location": "L204",
+      "source_location": "L277",
       "target": "dailyopeningview_test_unobserve",
       "weight": 1
     },
@@ -26687,7 +26795,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailyopeningview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L937",
+      "source_location": "L956",
       "target": "dailyopeningview_cn",
       "weight": 1
     },
@@ -26699,7 +26807,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailyopeningview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L417",
+      "source_location": "L445",
       "target": "dailyopeningview_formatcount",
       "weight": 1
     },
@@ -26711,7 +26819,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailyopeningview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L321",
+      "source_location": "L327",
       "target": "dailyopeningview_formatmetadatavalue",
       "weight": 1
     },
@@ -26723,7 +26831,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailyopeningview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L244",
+      "source_location": "L247",
       "target": "dailyopeningview_formatoperatingdate",
       "weight": 1
     },
@@ -26735,7 +26843,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailyopeningview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L260",
+      "source_location": "L263",
       "target": "dailyopeningview_formattimestamp",
       "weight": 1
     },
@@ -26747,7 +26855,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailyopeningview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L298",
+      "source_location": "L304",
       "target": "dailyopeningview_getacknowledgementkey",
       "weight": 1
     },
@@ -26759,7 +26867,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailyopeningview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L447",
+      "source_location": "L475",
       "target": "dailyopeningview_getbucketconfigs",
       "weight": 1
     },
@@ -26771,7 +26879,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailyopeningview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L405",
+      "source_location": "L433",
       "target": "dailyopeningview_getbucketcountclassname",
       "weight": 1
     },
@@ -26783,7 +26891,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailyopeningview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L207",
+      "source_location": "L210",
       "target": "dailyopeningview_getdailyopeningapi",
       "weight": 1
     },
@@ -26795,7 +26903,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailyopeningview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L428",
+      "source_location": "L456",
       "target": "dailyopeningview_getdefaultbucketvalue",
       "weight": 1
     },
@@ -26807,7 +26915,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailyopeningview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L313",
+      "source_location": "L319",
       "target": "dailyopeningview_getitemcontextlabel",
       "weight": 1
     },
@@ -26819,7 +26927,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailyopeningview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L309",
+      "source_location": "L315",
       "target": "dailyopeningview_getitemdescription",
       "weight": 1
     },
@@ -26831,7 +26939,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailyopeningview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L290",
+      "source_location": "L296",
       "target": "dailyopeningview_getitemid",
       "weight": 1
     },
@@ -26843,7 +26951,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailyopeningview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L217",
+      "source_location": "L220",
       "target": "dailyopeningview_getlocaloperatingdate",
       "weight": 1
     },
@@ -26855,7 +26963,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailyopeningview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L225",
+      "source_location": "L228",
       "target": "dailyopeningview_getlocaloperatingdaterange",
       "weight": 1
     },
@@ -26867,8 +26975,32 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailyopeningview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L334",
+      "source_location": "L360",
       "target": "dailyopeningview_getmetadataentries",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_components_operations_dailyopeningview_tsx",
+      "_tgt": "dailyopeningview_getmetadatalabel",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_components_operations_dailyopeningview_tsx",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
+      "source_location": "L340",
+      "target": "dailyopeningview_getmetadatalabel",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_components_operations_dailyopeningview_tsx",
+      "_tgt": "dailyopeningview_getmetadatavalue",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_components_operations_dailyopeningview_tsx",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
+      "source_location": "L352",
+      "target": "dailyopeningview_getmetadatavalue",
       "weight": 1
     },
     {
@@ -26879,7 +27011,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailyopeningview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L279",
+      "source_location": "L282",
       "target": "dailyopeningview_getopeningstatus",
       "weight": 1
     },
@@ -26891,7 +27023,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailyopeningview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L302",
+      "source_location": "L308",
       "target": "dailyopeningview_getrequiredacknowledgementkeys",
       "weight": 1
     },
@@ -26903,7 +27035,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailyopeningview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L372",
+      "source_location": "L400",
       "target": "dailyopeningview_getstatusicon",
       "weight": 1
     },
@@ -26915,7 +27047,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailyopeningview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L379",
+      "source_location": "L407",
       "target": "dailyopeningview_getstatuslabelclassname",
       "weight": 1
     },
@@ -26927,7 +27059,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailyopeningview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L397",
+      "source_location": "L425",
       "target": "dailyopeningview_getstatusrailbadgeclassname",
       "weight": 1
     },
@@ -26939,8 +27071,20 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailyopeningview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L388",
+      "source_location": "L416",
       "target": "dailyopeningview_getstatusrailiconclassname",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_components_operations_dailyopeningview_tsx",
+      "_tgt": "dailyopeningview_handleauthenticateforapproval",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_components_operations_dailyopeningview_tsx",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
+      "source_location": "L1456",
+      "target": "dailyopeningview_handleauthenticateforapproval",
       "weight": 1
     },
     {
@@ -26951,7 +27095,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailyopeningview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L1191",
+      "source_location": "L1259",
       "target": "dailyopeningview_handlebucketvaluechange",
       "weight": 1
     },
@@ -26963,7 +27107,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailyopeningview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L1371",
+      "source_location": "L1495",
       "target": "dailyopeningview_handlestartday",
       "weight": 1
     },
@@ -26975,7 +27119,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailyopeningview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L272",
+      "source_location": "L275",
       "target": "dailyopeningview_humanizemetadatalabel",
       "weight": 1
     },
@@ -26987,7 +27131,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailyopeningview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L440",
+      "source_location": "L468",
       "target": "dailyopeningview_normalizebuckettab",
       "weight": 1
     },
@@ -26999,8 +27143,20 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailyopeningview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L352",
+      "source_location": "L380",
       "target": "dailyopeningview_normalizecommandmessage",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_components_operations_dailyopeningview_tsx",
+      "_tgt": "dailyopeningview_submitstartday",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_components_operations_dailyopeningview_tsx",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
+      "source_location": "L1216",
+      "target": "dailyopeningview_submitstartday",
       "weight": 1
     },
     {
@@ -29867,7 +30023,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_procurement_procurementview_tsx",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L853",
+      "source_location": "L845",
       "target": "procurementview_addrecommendationtodraft",
       "weight": 1
     },
@@ -29879,7 +30035,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_procurement_procurementview_tsx",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L512",
+      "source_location": "L499",
       "target": "procurementview_buildvendoroptions",
       "weight": 1
     },
@@ -29891,7 +30047,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_procurement_procurementview_tsx",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L492",
+      "source_location": "L479",
       "target": "procurementview_canreceivepurchaseorder",
       "weight": 1
     },
@@ -29903,7 +30059,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_procurement_procurementview_tsx",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L1719",
+      "source_location": "L1711",
       "target": "procurementview_cn",
       "weight": 1
     },
@@ -29915,7 +30071,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_procurement_procurementview_tsx",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L411",
+      "source_location": "L406",
       "target": "procurementview_countrecommendationsformode",
       "weight": 1
     },
@@ -29927,7 +30083,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_procurement_procurementview_tsx",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L1746",
+      "source_location": "L1738",
       "target": "procurementview_formatlinecount",
       "weight": 1
     },
@@ -29939,7 +30095,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_procurement_procurementview_tsx",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L185",
+      "source_location": "L184",
       "target": "procurementview_formatoptionaldate",
       "weight": 1
     },
@@ -29951,7 +30107,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_procurement_procurementview_tsx",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L1309",
+      "source_location": "L1301",
       "target": "procurementview_formatpurchaseordercount",
       "weight": 1
     },
@@ -29963,7 +30119,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_procurement_procurementview_tsx",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L196",
+      "source_location": "L195",
       "target": "procurementview_formatstatus",
       "weight": 1
     },
@@ -29975,7 +30131,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_procurement_procurementview_tsx",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L1421",
+      "source_location": "L1413",
       "target": "procurementview_formatunitcount",
       "weight": 1
     },
@@ -29987,7 +30143,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_procurement_procurementview_tsx",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L202",
+      "source_location": "L201",
       "target": "procurementview_getcontinuitystatecopy",
       "weight": 1
     },
@@ -29999,7 +30155,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_procurement_procurementview_tsx",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L420",
+      "source_location": "L415",
       "target": "procurementview_getmodeemptystatecopy",
       "weight": 1
     },
@@ -30011,7 +30167,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_procurement_procurementview_tsx",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L475",
+      "source_location": "L462",
       "target": "procurementview_getnextlifecycleactions",
       "weight": 1
     },
@@ -30023,7 +30179,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_procurement_procurementview_tsx",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L496",
+      "source_location": "L483",
       "target": "procurementview_getpurchaseordermode",
       "weight": 1
     },
@@ -30035,7 +30191,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_procurement_procurementview_tsx",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L455",
+      "source_location": "L444",
       "target": "procurementview_getrecommendationcountcopy",
       "weight": 1
     },
@@ -30047,7 +30203,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_procurement_procurementview_tsx",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L789",
+      "source_location": "L778",
       "target": "procurementview_getrecommendationforpurchaseorder",
       "weight": 1
     },
@@ -30059,7 +30215,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_procurement_procurementview_tsx",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L339",
+      "source_location": "L338",
       "target": "procurementview_getrecommendationstatenote",
       "weight": 1
     },
@@ -30071,7 +30227,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_procurement_procurementview_tsx",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L547",
+      "source_location": "L534",
       "target": "procurementview_getrecommendationurlsku",
       "weight": 1
     },
@@ -30083,7 +30239,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_procurement_procurementview_tsx",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L273",
+      "source_location": "L272",
       "target": "procurementview_getuniquepurchaseorderreferences",
       "weight": 1
     },
@@ -30095,7 +30251,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_procurement_procurementview_tsx",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L292",
+      "source_location": "L291",
       "target": "procurementview_getuniquevendorcount",
       "weight": 1
     },
@@ -30107,7 +30263,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_procurement_procurementview_tsx",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L1067",
+      "source_location": "L1059",
       "target": "procurementview_handleadvancepurchaseordertoordered",
       "weight": 1
     },
@@ -30119,7 +30275,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_procurement_procurementview_tsx",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L948",
+      "source_location": "L940",
       "target": "procurementview_handlecreatedraftpurchaseorders",
       "weight": 1
     },
@@ -30131,7 +30287,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_procurement_procurementview_tsx",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L650",
+      "source_location": "L637",
       "target": "procurementview_handlemodechange",
       "weight": 1
     },
@@ -30143,7 +30299,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_procurement_procurementview_tsx",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L799",
+      "source_location": "L788",
       "target": "procurementview_handlepurchaseordersummaryclick",
       "weight": 1
     },
@@ -30155,7 +30311,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_procurement_procurementview_tsx",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L896",
+      "source_location": "L888",
       "target": "procurementview_handlequickaddvendor",
       "weight": 1
     },
@@ -30167,7 +30323,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_procurement_procurementview_tsx",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L659",
+      "source_location": "L646",
       "target": "procurementview_handlerecommendationpagechange",
       "weight": 1
     },
@@ -30179,7 +30335,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_procurement_procurementview_tsx",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L1040",
+      "source_location": "L1032",
       "target": "procurementview_handleupdatepurchaseorderstatus",
       "weight": 1
     },
@@ -30191,7 +30347,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_procurement_procurementview_tsx",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L312",
+      "source_location": "L311",
       "target": "procurementview_hasinboundpurchaseordercover",
       "weight": 1
     },
@@ -30203,7 +30359,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_procurement_procurementview_tsx",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L324",
+      "source_location": "L323",
       "target": "procurementview_hasmixedpurchaseordercover",
       "weight": 1
     },
@@ -30215,7 +30371,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_procurement_procurementview_tsx",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L300",
+      "source_location": "L299",
       "target": "procurementview_hasplannedpurchaseordercover",
       "weight": 1
     },
@@ -30227,7 +30383,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_procurement_procurementview_tsx",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L1279",
+      "source_location": "L1271",
       "target": "procurementview_if",
       "weight": 1
     },
@@ -30239,7 +30395,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_procurement_procurementview_tsx",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L369",
+      "source_location": "L368",
       "target": "procurementview_isrecommendationvisible",
       "weight": 1
     },
@@ -30251,7 +30407,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_procurement_procurementview_tsx",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L551",
+      "source_location": "L538",
       "target": "procurementview_matchesrecommendationsku",
       "weight": 1
     },
@@ -30263,7 +30419,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_procurement_procurementview_tsx",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L537",
+      "source_location": "L524",
       "target": "procurementview_parsedraftlinequantity",
       "weight": 1
     },
@@ -30275,7 +30431,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_procurement_procurementview_tsx",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L890",
+      "source_location": "L882",
       "target": "procurementview_removedraftline",
       "weight": 1
     },
@@ -30287,7 +30443,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_procurement_procurementview_tsx",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L527",
+      "source_location": "L514",
       "target": "procurementview_sanitizedraftquantityinput",
       "weight": 1
     },
@@ -30299,7 +30455,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_procurement_procurementview_tsx",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L643",
+      "source_location": "L630",
       "target": "procurementview_selectproductsku",
       "weight": 1
     },
@@ -30311,7 +30467,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_procurement_procurementview_tsx",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L636",
+      "source_location": "L623",
       "target": "procurementview_setactiverecommendationpage",
       "weight": 1
     },
@@ -30323,7 +30479,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_procurement_procurementview_tsx",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L879",
+      "source_location": "L871",
       "target": "procurementview_updatedraftline",
       "weight": 1
     },
@@ -36623,7 +36779,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_procurement_index_tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/procurement.index.tsx",
-      "source_location": "L13",
+      "source_location": "L16",
       "target": "procurement_index_getnextprocurementmodesearch",
       "weight": 1
     },
@@ -36635,7 +36791,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_procurement_index_tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/procurement.index.tsx",
-      "source_location": "L31",
+      "source_location": "L34",
       "target": "procurement_index_getnextprocurementpagesearch",
       "weight": 1
     },
@@ -36647,7 +36803,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_procurement_index_tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/procurement.index.tsx",
-      "source_location": "L41",
+      "source_location": "L44",
       "target": "procurement_index_getnextprocurementselectedskusearch",
       "weight": 1
     },
@@ -36659,7 +36815,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_procurement_index_tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/procurement.index.tsx",
-      "source_location": "L67",
+      "source_location": "L70",
       "target": "procurement_index_procurementroute",
       "weight": 1
     },
@@ -44723,7 +44879,7 @@
       "relation": "calls",
       "source": "procurementview_formatunitcount",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L347",
+      "source_location": "L346",
       "target": "procurementview_getrecommendationstatenote",
       "weight": 1
     },
@@ -44735,7 +44891,7 @@
       "relation": "calls",
       "source": "procurementview_hasmixedpurchaseordercover",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L346",
+      "source_location": "L345",
       "target": "procurementview_getrecommendationstatenote",
       "weight": 1
     },
@@ -44747,7 +44903,7 @@
       "relation": "calls",
       "source": "procurementview_handlemodechange",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L1087",
+      "source_location": "L1079",
       "target": "procurementview_handleadvancepurchaseordertoordered",
       "weight": 1
     },
@@ -44759,7 +44915,7 @@
       "relation": "calls",
       "source": "procurementview_handlemodechange",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L1033",
+      "source_location": "L1025",
       "target": "procurementview_handlecreatedraftpurchaseorders",
       "weight": 1
     },
@@ -44771,7 +44927,7 @@
       "relation": "calls",
       "source": "procurementview_setactiverecommendationpage",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L651",
+      "source_location": "L638",
       "target": "procurementview_handlemodechange",
       "weight": 1
     },
@@ -44783,7 +44939,7 @@
       "relation": "calls",
       "source": "procurementview_getpurchaseordermode",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L803",
+      "source_location": "L792",
       "target": "procurementview_handlepurchaseordersummaryclick",
       "weight": 1
     },
@@ -44795,7 +44951,7 @@
       "relation": "calls",
       "source": "procurementview_getrecommendationforpurchaseorder",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L802",
+      "source_location": "L791",
       "target": "procurementview_handlepurchaseordersummaryclick",
       "weight": 1
     },
@@ -44807,7 +44963,7 @@
       "relation": "calls",
       "source": "procurementview_handlemodechange",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L810",
+      "source_location": "L802",
       "target": "procurementview_handlepurchaseordersummaryclick",
       "weight": 1
     },
@@ -44819,7 +44975,7 @@
       "relation": "calls",
       "source": "procurementview_selectproductsku",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L807",
+      "source_location": "L796",
       "target": "procurementview_handlepurchaseordersummaryclick",
       "weight": 1
     },
@@ -44831,7 +44987,7 @@
       "relation": "calls",
       "source": "procurementview_setactiverecommendationpage",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L821",
+      "source_location": "L813",
       "target": "procurementview_handlepurchaseordersummaryclick",
       "weight": 1
     },
@@ -44843,7 +44999,7 @@
       "relation": "calls",
       "source": "procurementview_setactiverecommendationpage",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L665",
+      "source_location": "L652",
       "target": "procurementview_handlerecommendationpagechange",
       "weight": 1
     },
@@ -44855,7 +45011,7 @@
       "relation": "calls",
       "source": "procurementview_formatstatus",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L1060",
+      "source_location": "L1052",
       "target": "procurementview_handleupdatepurchaseorderstatus",
       "weight": 1
     },
@@ -44867,7 +45023,7 @@
       "relation": "calls",
       "source": "procurementview_hasinboundpurchaseordercover",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L335",
+      "source_location": "L334",
       "target": "procurementview_hasmixedpurchaseordercover",
       "weight": 1
     },
@@ -44879,7 +45035,7 @@
       "relation": "calls",
       "source": "procurementview_hasplannedpurchaseordercover",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L334",
+      "source_location": "L333",
       "target": "procurementview_hasmixedpurchaseordercover",
       "weight": 1
     },
@@ -44891,7 +45047,7 @@
       "relation": "calls",
       "source": "procurementview_hasinboundpurchaseordercover",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L391",
+      "source_location": "L390",
       "target": "procurementview_isrecommendationvisible",
       "weight": 1
     },
@@ -44903,7 +45059,7 @@
       "relation": "calls",
       "source": "procurementview_hasplannedpurchaseordercover",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L384",
+      "source_location": "L383",
       "target": "procurementview_isrecommendationvisible",
       "weight": 1
     },
@@ -44915,7 +45071,7 @@
       "relation": "calls",
       "source": "procurementview_getrecommendationurlsku",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L646",
+      "source_location": "L633",
       "target": "procurementview_selectproductsku",
       "weight": 1
     },
@@ -57222,326 +57378,326 @@
     {
       "community": 10,
       "file_type": "code",
-      "id": "dailyopeningview_cn",
-      "label": "cn()",
-      "norm_label": "cn()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L766"
+      "id": "packages_athena_webapp_src_components_cash_controls_registersessionview_tsx",
+      "label": "RegisterSessionView.tsx",
+      "norm_label": "registersessionview.tsx",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L1"
     },
     {
       "community": 10,
       "file_type": "code",
-      "id": "dailyopeningview_formatcount",
-      "label": "formatCount()",
-      "norm_label": "formatcount()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L417"
+      "id": "registersessionview_applycloseoutcommandresult",
+      "label": "applyCloseoutCommandResult()",
+      "norm_label": "applycloseoutcommandresult()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L521"
     },
     {
       "community": 10,
       "file_type": "code",
-      "id": "dailyopeningview_formatmetadatavalue",
-      "label": "formatMetadataValue()",
-      "norm_label": "formatmetadatavalue()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L321"
+      "id": "registersessionview_applycommandresult",
+      "label": "applyCommandResult()",
+      "norm_label": "applycommandresult()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L511"
     },
     {
       "community": 10,
       "file_type": "code",
-      "id": "dailyopeningview_formatoperatingdate",
-      "label": "formatOperatingDate()",
-      "norm_label": "formatoperatingdate()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L244"
+      "id": "registersessionview_builddepositsubmissionkey",
+      "label": "buildDepositSubmissionKey()",
+      "norm_label": "builddepositsubmissionkey()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L276"
     },
     {
       "community": 10,
       "file_type": "code",
-      "id": "dailyopeningview_formattimestamp",
+      "id": "registersessionview_errormessage",
+      "label": "errorMessage()",
+      "norm_label": "errormessage()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L2141"
+    },
+    {
+      "community": 10,
+      "file_type": "code",
+      "id": "registersessionview_formatcurrency",
+      "label": "formatCurrency()",
+      "norm_label": "formatcurrency()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L280"
+    },
+    {
+      "community": 10,
+      "file_type": "code",
+      "id": "registersessionview_formatpaymentmethod",
+      "label": "formatPaymentMethod()",
+      "norm_label": "formatpaymentmethod()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L329"
+    },
+    {
+      "community": 10,
+      "file_type": "code",
+      "id": "registersessionview_formatregisterheadername",
+      "label": "formatRegisterHeaderName()",
+      "norm_label": "formatregisterheadername()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L342"
+    },
+    {
+      "community": 10,
+      "file_type": "code",
+      "id": "registersessionview_formatregistername",
+      "label": "formatRegisterName()",
+      "norm_label": "formatregistername()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L337"
+    },
+    {
+      "community": 10,
+      "file_type": "code",
+      "id": "registersessionview_formatsessioncode",
+      "label": "formatSessionCode()",
+      "norm_label": "formatsessioncode()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L356"
+    },
+    {
+      "community": 10,
+      "file_type": "code",
+      "id": "registersessionview_formatstatuslabel",
+      "label": "formatStatusLabel()",
+      "norm_label": "formatstatuslabel()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L299"
+    },
+    {
+      "community": 10,
+      "file_type": "code",
+      "id": "registersessionview_formatstoredamountforinput",
+      "label": "formatStoredAmountForInput()",
+      "norm_label": "formatstoredamountforinput()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L288"
+    },
+    {
+      "community": 10,
+      "file_type": "code",
+      "id": "registersessionview_formattimestamp",
       "label": "formatTimestamp()",
       "norm_label": "formattimestamp()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L260"
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L292"
     },
     {
       "community": 10,
       "file_type": "code",
-      "id": "dailyopeningview_getacknowledgementkey",
-      "label": "getAcknowledgementKey()",
-      "norm_label": "getacknowledgementkey()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L298"
+      "id": "registersessionview_getnumericeventmetadata",
+      "label": "getNumericEventMetadata()",
+      "norm_label": "getnumericeventmetadata()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L314"
     },
     {
       "community": 10,
       "file_type": "code",
-      "id": "dailyopeningview_getbucketconfigs",
-      "label": "getBucketConfigs()",
-      "norm_label": "getbucketconfigs()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L447"
+      "id": "registersessionview_getpaymentmethodicon",
+      "label": "getPaymentMethodIcon()",
+      "norm_label": "getpaymentmethodicon()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L368"
     },
     {
       "community": 10,
       "file_type": "code",
-      "id": "dailyopeningview_getbucketcountclassname",
-      "label": "getBucketCountClassName()",
-      "norm_label": "getbucketcountclassname()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L405"
+      "id": "registersessionview_getvariancetone",
+      "label": "getVarianceTone()",
+      "norm_label": "getvariancetone()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L360"
     },
     {
       "community": 10,
       "file_type": "code",
-      "id": "dailyopeningview_getdailyopeningapi",
-      "label": "getDailyOpeningApi()",
-      "norm_label": "getdailyopeningapi()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L207"
+      "id": "registersessionview_handleauthenticatedcloseoutstaff",
+      "label": "handleAuthenticatedCloseoutStaff()",
+      "norm_label": "handleauthenticatedcloseoutstaff()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L691"
     },
     {
       "community": 10,
       "file_type": "code",
-      "id": "dailyopeningview_getdefaultbucketvalue",
-      "label": "getDefaultBucketValue()",
-      "norm_label": "getdefaultbucketvalue()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L428"
+      "id": "registersessionview_handleopeningfloatapprovalapproved",
+      "label": "handleOpeningFloatApprovalApproved()",
+      "norm_label": "handleopeningfloatapprovalapproved()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L805"
     },
     {
       "community": 10,
       "file_type": "code",
-      "id": "dailyopeningview_getitemcontextlabel",
-      "label": "getItemContextLabel()",
-      "norm_label": "getitemcontextlabel()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L313"
+      "id": "registersessionview_handlerecorddeposit",
+      "label": "handleRecordDeposit()",
+      "norm_label": "handlerecorddeposit()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L538"
     },
     {
       "community": 10,
       "file_type": "code",
-      "id": "dailyopeningview_getitemdescription",
-      "label": "getItemDescription()",
-      "norm_label": "getitemdescription()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L309"
+      "id": "registersessionview_handlereviewcloseout",
+      "label": "handleReviewCloseout()",
+      "norm_label": "handlereviewcloseout()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L618"
     },
     {
       "community": 10,
       "file_type": "code",
-      "id": "dailyopeningview_getitemid",
-      "label": "getItemId()",
-      "norm_label": "getitemid()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L290"
+      "id": "registersessionview_handlesubmitcloseout",
+      "label": "handleSubmitCloseout()",
+      "norm_label": "handlesubmitcloseout()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L581"
     },
     {
       "community": 10,
       "file_type": "code",
-      "id": "dailyopeningview_getlocaloperatingdate",
-      "label": "getLocalOperatingDate()",
-      "norm_label": "getlocaloperatingdate()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L217"
+      "id": "registersessionview_handlesubmitopeningfloatcorrection",
+      "label": "handleSubmitOpeningFloatCorrection()",
+      "norm_label": "handlesubmitopeningfloatcorrection()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L635"
     },
     {
       "community": 10,
       "file_type": "code",
-      "id": "dailyopeningview_getlocaloperatingdaterange",
-      "label": "getLocalOperatingDateRange()",
-      "norm_label": "getlocaloperatingdaterange()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L225"
+      "id": "registersessionview_iscloseoutrejectionevent",
+      "label": "isCloseoutRejectionEvent()",
+      "norm_label": "iscloseoutrejectionevent()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L303"
     },
     {
       "community": 10,
       "file_type": "code",
-      "id": "dailyopeningview_getmetadataentries",
-      "label": "getMetadataEntries()",
-      "norm_label": "getmetadataentries()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L334"
-    },
-    {
-      "community": 10,
-      "file_type": "code",
-      "id": "dailyopeningview_getopeningstatus",
-      "label": "getOpeningStatus()",
-      "norm_label": "getopeningstatus()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L279"
-    },
-    {
-      "community": 10,
-      "file_type": "code",
-      "id": "dailyopeningview_getrequiredacknowledgementkeys",
-      "label": "getRequiredAcknowledgementKeys()",
-      "norm_label": "getrequiredacknowledgementkeys()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L302"
-    },
-    {
-      "community": 10,
-      "file_type": "code",
-      "id": "dailyopeningview_getstatusicon",
-      "label": "getStatusIcon()",
-      "norm_label": "getstatusicon()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L372"
-    },
-    {
-      "community": 10,
-      "file_type": "code",
-      "id": "dailyopeningview_getstatuslabelclassname",
-      "label": "getStatusLabelClassName()",
-      "norm_label": "getstatuslabelclassname()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L379"
-    },
-    {
-      "community": 10,
-      "file_type": "code",
-      "id": "dailyopeningview_getstatusrailbadgeclassname",
-      "label": "getStatusRailBadgeClassName()",
-      "norm_label": "getstatusrailbadgeclassname()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L397"
-    },
-    {
-      "community": 10,
-      "file_type": "code",
-      "id": "dailyopeningview_getstatusrailiconclassname",
-      "label": "getStatusRailIconClassName()",
-      "norm_label": "getstatusrailiconclassname()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L388"
-    },
-    {
-      "community": 10,
-      "file_type": "code",
-      "id": "dailyopeningview_handlebucketvaluechange",
-      "label": "handleBucketValueChange()",
-      "norm_label": "handlebucketvaluechange()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L1191"
-    },
-    {
-      "community": 10,
-      "file_type": "code",
-      "id": "dailyopeningview_handlestartday",
-      "label": "handleStartDay()",
-      "norm_label": "handlestartday()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L1159"
-    },
-    {
-      "community": 10,
-      "file_type": "code",
-      "id": "dailyopeningview_humanizemetadatalabel",
-      "label": "humanizeMetadataLabel()",
-      "norm_label": "humanizemetadatalabel()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
+      "id": "registersessionview_ismanagerstaff",
+      "label": "isManagerStaff()",
+      "norm_label": "ismanagerstaff()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
       "source_location": "L272"
     },
     {
       "community": 10,
       "file_type": "code",
-      "id": "dailyopeningview_normalizebuckettab",
-      "label": "normalizeBucketTab()",
-      "norm_label": "normalizebuckettab()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L440"
+      "id": "registersessionview_isopeningfloatcorrectionevent",
+      "label": "isOpeningFloatCorrectionEvent()",
+      "norm_label": "isopeningfloatcorrectionevent()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L307"
     },
     {
       "community": 10,
       "file_type": "code",
-      "id": "dailyopeningview_normalizecommandmessage",
-      "label": "normalizeCommandMessage()",
-      "norm_label": "normalizecommandmessage()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L352"
+      "id": "registersessionview_isregistersessioncorrectionevent",
+      "label": "isRegisterSessionCorrectionEvent()",
+      "norm_label": "isregistersessioncorrectionevent()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L323"
     },
     {
       "community": 10,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_operations_dailyopeningview_tsx",
-      "label": "DailyOpeningView.tsx",
-      "norm_label": "dailyopeningview.tsx",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
+      "id": "registersessionview_runopeningfloatcorrection",
+      "label": "runOpeningFloatCorrection()",
+      "norm_label": "runopeningfloatcorrection()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L759"
+    },
+    {
+      "community": 10,
+      "file_type": "code",
+      "id": "registersessionview_trimoptional",
+      "label": "trimOptional()",
+      "norm_label": "trimoptional()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L267"
+    },
+    {
+      "community": 100,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_commands_quickaddcatalogitem_ts",
+      "label": "quickAddCatalogItem.ts",
+      "norm_label": "quickaddcatalogitem.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
       "source_location": "L1"
     },
     {
       "community": 100,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_commands_possessiontracing_ts",
-      "label": "posSessionTracing.ts",
-      "norm_label": "possessiontracing.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L1"
+      "id": "quickaddcatalogitem_findexistingsku",
+      "label": "findExistingSku()",
+      "norm_label": "findexistingsku()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
+      "source_location": "L125"
     },
     {
       "community": 100,
       "file_type": "code",
-      "id": "possessiontracing_buildpossessiontraceevent",
-      "label": "buildPosSessionTraceEvent()",
-      "norm_label": "buildpossessiontraceevent()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L226"
+      "id": "quickaddcatalogitem_findorcreatequickaddcategory",
+      "label": "findOrCreateQuickAddCategory()",
+      "norm_label": "findorcreatequickaddcategory()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
+      "source_location": "L29"
     },
     {
       "community": 100,
       "file_type": "code",
-      "id": "possessiontracing_buildpossessiontracerecord",
-      "label": "buildPosSessionTraceRecord()",
-      "norm_label": "buildpossessiontracerecord()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L142"
+      "id": "quickaddcatalogitem_findorcreatequickaddsubcategory",
+      "label": "findOrCreateQuickAddSubcategory()",
+      "norm_label": "findorcreatequickaddsubcategory()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
+      "source_location": "L56"
     },
     {
       "community": 100,
       "file_type": "code",
-      "id": "possessiontracing_buildtracesummary",
-      "label": "buildTraceSummary()",
-      "norm_label": "buildtracesummary()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L105"
+      "id": "quickaddcatalogitem_generatesku",
+      "label": "generateSKU()",
+      "norm_label": "generatesku()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
+      "source_location": "L153"
     },
     {
       "community": 100,
       "file_type": "code",
-      "id": "possessiontracing_createpossessiontracerecorder",
-      "label": "createPosSessionTraceRecorder()",
-      "norm_label": "createpossessiontracerecorder()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L559"
+      "id": "quickaddcatalogitem_isbarcodelike",
+      "label": "isBarcodeLike()",
+      "norm_label": "isbarcodelike()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
+      "source_location": "L149"
     },
     {
       "community": 100,
       "file_type": "code",
-      "id": "possessiontracing_formatpaymentmethod",
-      "label": "formatPaymentMethod()",
-      "norm_label": "formatpaymentmethod()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L218"
+      "id": "quickaddcatalogitem_mapskutocatalogresult",
+      "label": "mapSkuToCatalogResult()",
+      "norm_label": "mapskutocatalogresult()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
+      "source_location": "L88"
     },
     {
       "community": 100,
       "file_type": "code",
-      "id": "possessiontracing_recordpossessiontracebesteffort",
-      "label": "recordPosSessionTraceBestEffort()",
-      "norm_label": "recordpossessiontracebesteffort()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L532"
-    },
-    {
-      "community": 100,
-      "file_type": "code",
-      "id": "possessiontracing_safetracewrite",
-      "label": "safeTraceWrite()",
-      "norm_label": "safetracewrite()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L524"
+      "id": "quickaddcatalogitem_quickaddcatalogitem",
+      "label": "quickAddCatalogItem()",
+      "norm_label": "quickaddcatalogitem()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
+      "source_location": "L174"
     },
     {
       "community": 1000,
@@ -57636,74 +57792,74 @@
     {
       "community": 101,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_commands_quickaddcatalogitem_ts",
-      "label": "quickAddCatalogItem.ts",
-      "norm_label": "quickaddcatalogitem.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
+      "id": "expensesessioncommands_test_builditem",
+      "label": "buildItem()",
+      "norm_label": "builditem()",
+      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
+      "source_location": "L645"
+    },
+    {
+      "community": 101,
+      "file_type": "code",
+      "id": "expensesessioncommands_test_buildregistersession",
+      "label": "buildRegisterSession()",
+      "norm_label": "buildregistersession()",
+      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
+      "source_location": "L639"
+    },
+    {
+      "community": 101,
+      "file_type": "code",
+      "id": "expensesessioncommands_test_buildsession",
+      "label": "buildSession()",
+      "norm_label": "buildsession()",
+      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
+      "source_location": "L635"
+    },
+    {
+      "community": 101,
+      "file_type": "code",
+      "id": "expensesessioncommands_test_createcommandservice",
+      "label": "createCommandService()",
+      "norm_label": "createcommandservice()",
+      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
+      "source_location": "L655"
+    },
+    {
+      "community": 101,
+      "file_type": "code",
+      "id": "expensesessioncommands_test_createdependencies",
+      "label": "createDependencies()",
+      "norm_label": "createdependencies()",
+      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
+      "source_location": "L424"
+    },
+    {
+      "community": 101,
+      "file_type": "code",
+      "id": "expensesessioncommands_test_createfakerepository",
+      "label": "createFakeRepository()",
+      "norm_label": "createfakerepository()",
+      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
+      "source_location": "L492"
+    },
+    {
+      "community": 101,
+      "file_type": "code",
+      "id": "expensesessioncommands_test_loadcommandservice",
+      "label": "loadCommandService()",
+      "norm_label": "loadcommandservice()",
+      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
+      "source_location": "L404"
+    },
+    {
+      "community": 101,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_expensesessioncommands_test_ts",
+      "label": "expenseSessionCommands.test.ts",
+      "norm_label": "expensesessioncommands.test.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 101,
-      "file_type": "code",
-      "id": "quickaddcatalogitem_findexistingsku",
-      "label": "findExistingSku()",
-      "norm_label": "findexistingsku()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
-      "source_location": "L125"
-    },
-    {
-      "community": 101,
-      "file_type": "code",
-      "id": "quickaddcatalogitem_findorcreatequickaddcategory",
-      "label": "findOrCreateQuickAddCategory()",
-      "norm_label": "findorcreatequickaddcategory()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
-      "source_location": "L29"
-    },
-    {
-      "community": 101,
-      "file_type": "code",
-      "id": "quickaddcatalogitem_findorcreatequickaddsubcategory",
-      "label": "findOrCreateQuickAddSubcategory()",
-      "norm_label": "findorcreatequickaddsubcategory()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
-      "source_location": "L56"
-    },
-    {
-      "community": 101,
-      "file_type": "code",
-      "id": "quickaddcatalogitem_generatesku",
-      "label": "generateSKU()",
-      "norm_label": "generatesku()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
-      "source_location": "L153"
-    },
-    {
-      "community": 101,
-      "file_type": "code",
-      "id": "quickaddcatalogitem_isbarcodelike",
-      "label": "isBarcodeLike()",
-      "norm_label": "isbarcodelike()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
-      "source_location": "L149"
-    },
-    {
-      "community": 101,
-      "file_type": "code",
-      "id": "quickaddcatalogitem_mapskutocatalogresult",
-      "label": "mapSkuToCatalogResult()",
-      "norm_label": "mapskutocatalogresult()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
-      "source_location": "L88"
-    },
-    {
-      "community": 101,
-      "file_type": "code",
-      "id": "quickaddcatalogitem_quickaddcatalogitem",
-      "label": "quickAddCatalogItem()",
-      "norm_label": "quickaddcatalogitem()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
-      "source_location": "L174"
     },
     {
       "community": 1010,
@@ -57798,74 +57954,74 @@
     {
       "community": 102,
       "file_type": "code",
-      "id": "expensesessioncommands_test_builditem",
+      "id": "packages_athena_webapp_convex_pos_application_sessioncommands_test_ts",
+      "label": "sessionCommands.test.ts",
+      "norm_label": "sessioncommands.test.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 102,
+      "file_type": "code",
+      "id": "sessioncommands_test_builditem",
       "label": "buildItem()",
       "norm_label": "builditem()",
-      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
-      "source_location": "L645"
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L2406"
     },
     {
       "community": 102,
       "file_type": "code",
-      "id": "expensesessioncommands_test_buildregistersession",
+      "id": "sessioncommands_test_buildregistersession",
       "label": "buildRegisterSession()",
       "norm_label": "buildregistersession()",
-      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
-      "source_location": "L639"
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L2400"
     },
     {
       "community": 102,
       "file_type": "code",
-      "id": "expensesessioncommands_test_buildsession",
+      "id": "sessioncommands_test_buildsession",
       "label": "buildSession()",
       "norm_label": "buildsession()",
-      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
-      "source_location": "L635"
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L2396"
     },
     {
       "community": 102,
       "file_type": "code",
-      "id": "expensesessioncommands_test_createcommandservice",
+      "id": "sessioncommands_test_createcommandservice",
       "label": "createCommandService()",
       "norm_label": "createcommandservice()",
-      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
-      "source_location": "L655"
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L2416"
     },
     {
       "community": 102,
       "file_type": "code",
-      "id": "expensesessioncommands_test_createdependencies",
+      "id": "sessioncommands_test_createdependencies",
       "label": "createDependencies()",
       "norm_label": "createdependencies()",
-      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
-      "source_location": "L424"
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L2155"
     },
     {
       "community": 102,
       "file_type": "code",
-      "id": "expensesessioncommands_test_createfakerepository",
+      "id": "sessioncommands_test_createfakerepository",
       "label": "createFakeRepository()",
       "norm_label": "createfakerepository()",
-      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
-      "source_location": "L492"
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L2252"
     },
     {
       "community": 102,
       "file_type": "code",
-      "id": "expensesessioncommands_test_loadcommandservice",
+      "id": "sessioncommands_test_loadcommandservice",
       "label": "loadCommandService()",
       "norm_label": "loadcommandservice()",
-      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
-      "source_location": "L404"
-    },
-    {
-      "community": 102,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_expensesessioncommands_test_ts",
-      "label": "expenseSessionCommands.test.ts",
-      "norm_label": "expensesessioncommands.test.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
-      "source_location": "L1"
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L2137"
     },
     {
       "community": 1020,
@@ -57960,74 +58116,74 @@
     {
       "community": 103,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_sessioncommands_test_ts",
-      "label": "sessionCommands.test.ts",
-      "norm_label": "sessioncommands.test.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "id": "index_senddiscountcodeemail",
+      "label": "sendDiscountCodeEmail()",
+      "norm_label": "senddiscountcodeemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L255"
+    },
+    {
+      "community": 103,
+      "file_type": "code",
+      "id": "index_senddiscountreminderemail",
+      "label": "sendDiscountReminderEmail()",
+      "norm_label": "senddiscountreminderemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L334"
+    },
+    {
+      "community": 103,
+      "file_type": "code",
+      "id": "index_sendfeedbackrequestemail",
+      "label": "sendFeedbackRequestEmail()",
+      "norm_label": "sendfeedbackrequestemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L167"
+    },
+    {
+      "community": 103,
+      "file_type": "code",
+      "id": "index_sendneworderemail",
+      "label": "sendNewOrderEmail()",
+      "norm_label": "sendneworderemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L117"
+    },
+    {
+      "community": 103,
+      "file_type": "code",
+      "id": "index_sendorderemail",
+      "label": "sendOrderEmail()",
+      "norm_label": "sendorderemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L43"
+    },
+    {
+      "community": 103,
+      "file_type": "code",
+      "id": "index_sendverificationcode",
+      "label": "sendVerificationCode()",
+      "norm_label": "sendverificationcode()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L3"
+    },
+    {
+      "community": 103,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_mailersend_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/convex/mailersend/index.tsx",
       "source_location": "L1"
     },
     {
       "community": 103,
       "file_type": "code",
-      "id": "sessioncommands_test_builditem",
-      "label": "buildItem()",
-      "norm_label": "builditem()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L2406"
-    },
-    {
-      "community": 103,
-      "file_type": "code",
-      "id": "sessioncommands_test_buildregistersession",
-      "label": "buildRegisterSession()",
-      "norm_label": "buildregistersession()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L2400"
-    },
-    {
-      "community": 103,
-      "file_type": "code",
-      "id": "sessioncommands_test_buildsession",
-      "label": "buildSession()",
-      "norm_label": "buildsession()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L2396"
-    },
-    {
-      "community": 103,
-      "file_type": "code",
-      "id": "sessioncommands_test_createcommandservice",
-      "label": "createCommandService()",
-      "norm_label": "createcommandservice()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L2416"
-    },
-    {
-      "community": 103,
-      "file_type": "code",
-      "id": "sessioncommands_test_createdependencies",
-      "label": "createDependencies()",
-      "norm_label": "createdependencies()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L2155"
-    },
-    {
-      "community": 103,
-      "file_type": "code",
-      "id": "sessioncommands_test_createfakerepository",
-      "label": "createFakeRepository()",
-      "norm_label": "createfakerepository()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L2252"
-    },
-    {
-      "community": 103,
-      "file_type": "code",
-      "id": "sessioncommands_test_loadcommandservice",
-      "label": "loadCommandService()",
-      "norm_label": "loadcommandservice()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L2137"
+      "id": "packages_athena_webapp_convex_sendgrid_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L1"
     },
     {
       "community": 1030,
@@ -60921,226 +61077,226 @@
     {
       "community": 12,
       "file_type": "code",
-      "id": "compound_solution_check_assertcompoundsolutioncheck",
-      "label": "assertCompoundSolutionCheck()",
-      "norm_label": "assertcompoundsolutioncheck()",
-      "source_file": "scripts/compound-solution-check.ts",
-      "source_location": "L391"
+      "id": "dailyopening_builddailyopeningsnapshotwithctx",
+      "label": "buildDailyOpeningSnapshotWithCtx()",
+      "norm_label": "builddailyopeningsnapshotwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
+      "source_location": "L504"
     },
     {
       "community": 12,
       "file_type": "code",
-      "id": "compound_solution_check_collectchangedfiles",
-      "label": "collectChangedFiles()",
-      "norm_label": "collectchangedfiles()",
-      "source_file": "scripts/compound-solution-check.ts",
-      "source_location": "L288"
+      "id": "dailyopening_buildreadiness",
+      "label": "buildReadiness()",
+      "norm_label": "buildreadiness()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
+      "source_location": "L401"
     },
     {
       "community": 12,
       "file_type": "code",
-      "id": "compound_solution_check_collectcompoundsolutionfindings",
-      "label": "collectCompoundSolutionFindings()",
-      "norm_label": "collectcompoundsolutionfindings()",
-      "source_file": "scripts/compound-solution-check.ts",
+      "id": "dailyopening_carryforwarditem",
+      "label": "carryForwardItem()",
+      "norm_label": "carryforwarditem()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
+      "source_location": "L374"
+    },
+    {
+      "community": 12,
+      "file_type": "code",
+      "id": "dailyopening_getdailyopeningfordate",
+      "label": "getDailyOpeningForDate()",
+      "norm_label": "getdailyopeningfordate()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
+      "source_location": "L157"
+    },
+    {
+      "community": 12,
+      "file_type": "code",
+      "id": "dailyopening_getmissingcarryforwarditems",
+      "label": "getMissingCarryForwardItems()",
+      "norm_label": "getmissingcarryforwarditems()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
+      "source_location": "L431"
+    },
+    {
+      "community": 12,
+      "file_type": "code",
+      "id": "dailyopening_getstaffdisplayname",
+      "label": "getStaffDisplayName()",
+      "norm_label": "getstaffdisplayname()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
+      "source_location": "L190"
+    },
+    {
+      "community": 12,
+      "file_type": "code",
+      "id": "dailyopening_getstarteddailyopeningfordate",
+      "label": "getStartedDailyOpeningForDate()",
+      "norm_label": "getstarteddailyopeningfordate()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
+      "source_location": "L172"
+    },
+    {
+      "community": 12,
+      "file_type": "code",
+      "id": "dailyopening_getstore",
+      "label": "getStore()",
+      "norm_label": "getstore()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
       "source_location": "L150"
     },
     {
       "community": 12,
       "file_type": "code",
-      "id": "compound_solution_check_collectexistingfiles",
-      "label": "collectExistingFiles()",
-      "norm_label": "collectexistingfiles()",
-      "source_file": "scripts/compound-solution-check.ts",
-      "source_location": "L350"
+      "id": "dailyopening_hydratestartedopening",
+      "label": "hydrateStartedOpening()",
+      "norm_label": "hydratestartedopening()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
+      "source_location": "L200"
     },
     {
       "community": 12,
       "file_type": "code",
-      "id": "compound_solution_check_collectmarkdowncontents",
-      "label": "collectMarkdownContents()",
-      "norm_label": "collectmarkdowncontents()",
-      "source_file": "scripts/compound-solution-check.ts",
-      "source_location": "L333"
+      "id": "dailyopening_invalidoperatingdateitem",
+      "label": "invalidOperatingDateItem()",
+      "norm_label": "invalidoperatingdateitem()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
+      "source_location": "L289"
     },
     {
       "community": 12,
       "file_type": "code",
-      "id": "compound_solution_check_collectsourcelinechanges",
-      "label": "collectSourceLineChanges()",
-      "norm_label": "collectsourcelinechanges()",
-      "source_file": "scripts/compound-solution-check.ts",
-      "source_location": "L297"
+      "id": "dailyopening_isvalidoperatingdate",
+      "label": "isValidOperatingDate()",
+      "norm_label": "isvalidoperatingdate()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
+      "source_location": "L98"
     },
     {
       "community": 12,
       "file_type": "code",
-      "id": "compound_solution_check_countfilelines",
-      "label": "countFileLines()",
-      "norm_label": "countfilelines()",
-      "source_file": "scripts/compound-solution-check.ts",
-      "source_location": "L284"
+      "id": "dailyopening_isvalidoperatingdaterange",
+      "label": "isValidOperatingDateRange()",
+      "norm_label": "isvalidoperatingdaterange()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
+      "source_location": "L125"
     },
     {
       "community": 12,
       "file_type": "code",
-      "id": "compound_solution_check_extractfrontmatter",
-      "label": "extractFrontmatter()",
-      "norm_label": "extractfrontmatter()",
-      "source_file": "scripts/compound-solution-check.ts",
-      "source_location": "L107"
+      "id": "dailyopening_listpendingopeningblockerapprovals",
+      "label": "listPendingOpeningBlockerApprovals()",
+      "norm_label": "listpendingopeningblockerapprovals()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
+      "source_location": "L216"
     },
     {
       "community": 12,
       "file_type": "code",
-      "id": "compound_solution_check_extractsolutionreferences",
-      "label": "extractSolutionReferences()",
-      "norm_label": "extractsolutionreferences()",
-      "source_file": "scripts/compound-solution-check.ts",
-      "source_location": "L101"
+      "id": "dailyopening_missingcarryforwarditem",
+      "label": "missingCarryForwardItem()",
+      "norm_label": "missingcarryforwarditem()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
+      "source_location": "L303"
     },
     {
       "community": 12,
       "file_type": "code",
-      "id": "compound_solution_check_gitenv",
-      "label": "gitEnv()",
-      "norm_label": "gitenv()",
-      "source_file": "scripts/compound-solution-check.ts",
-      "source_location": "L238"
+      "id": "dailyopening_missingpriorclosereviewitem",
+      "label": "missingPriorCloseReviewItem()",
+      "norm_label": "missingpriorclosereviewitem()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
+      "source_location": "L263"
     },
     {
       "community": 12,
       "file_type": "code",
-      "id": "compound_solution_check_iscompoundsensitiveworkflowpath",
-      "label": "isCompoundSensitiveWorkflowPath()",
-      "norm_label": "iscompoundsensitiveworkflowpath()",
-      "source_file": "scripts/compound-solution-check.ts",
-      "source_location": "L86"
+      "id": "dailyopening_pendingapprovalitem",
+      "label": "pendingApprovalItem()",
+      "norm_label": "pendingapprovalitem()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
+      "source_location": "L235"
     },
     {
       "community": 12,
       "file_type": "code",
-      "id": "compound_solution_check_isconsiderablesourcepath",
-      "label": "isConsiderableSourcePath()",
-      "norm_label": "isconsiderablesourcepath()",
-      "source_file": "scripts/compound-solution-check.ts",
-      "source_location": "L71"
+      "id": "dailyopening_priorclosenotesitem",
+      "label": "priorCloseNotesItem()",
+      "norm_label": "priorclosenotesitem()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
+      "source_location": "L349"
     },
     {
       "community": 12,
       "file_type": "code",
-      "id": "compound_solution_check_ismarkdowndocpath",
-      "label": "isMarkdownDocPath()",
-      "norm_label": "ismarkdowndocpath()",
-      "source_file": "scripts/compound-solution-check.ts",
-      "source_location": "L67"
+      "id": "dailyopening_priorclosereadyitem",
+      "label": "priorCloseReadyItem()",
+      "norm_label": "priorclosereadyitem()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
+      "source_location": "L326"
     },
     {
       "community": 12,
       "file_type": "code",
-      "id": "compound_solution_check_issolutiondocpath",
-      "label": "isSolutionDocPath()",
-      "norm_label": "issolutiondocpath()",
-      "source_file": "scripts/compound-solution-check.ts",
-      "source_location": "L63"
+      "id": "dailyopening_resolveopeningactor",
+      "label": "resolveOpeningActor()",
+      "norm_label": "resolveopeningactor()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
+      "source_location": "L447"
     },
     {
       "community": 12,
       "file_type": "code",
-      "id": "compound_solution_check_mergelinechanges",
-      "label": "mergeLineChanges()",
-      "norm_label": "mergelinechanges()",
-      "source_file": "scripts/compound-solution-check.ts",
-      "source_location": "L274"
+      "id": "dailyopening_resolveoperatingdaterange",
+      "label": "resolveOperatingDateRange()",
+      "norm_label": "resolveoperatingdaterange()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
+      "source_location": "L136"
     },
     {
       "community": 12,
       "file_type": "code",
-      "id": "compound_solution_check_missingsolutionfrontmatterfields",
-      "label": "missingSolutionFrontmatterFields()",
-      "norm_label": "missingsolutionfrontmatterfields()",
-      "source_file": "scripts/compound-solution-check.ts",
-      "source_location": "L120"
+      "id": "dailyopening_safeoperatingdaterange",
+      "label": "safeOperatingDateRange()",
+      "norm_label": "safeoperatingdaterange()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
+      "source_location": "L112"
     },
     {
       "community": 12,
       "file_type": "code",
-      "id": "compound_solution_check_missingsolutionsections",
-      "label": "missingSolutionSections()",
-      "norm_label": "missingsolutionsections()",
-      "source_file": "scripts/compound-solution-check.ts",
-      "source_location": "L128"
+      "id": "dailyopening_startstoredaywithctx",
+      "label": "startStoreDayWithCtx()",
+      "norm_label": "startstoredaywithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
+      "source_location": "L618"
     },
     {
       "community": 12,
       "file_type": "code",
-      "id": "compound_solution_check_normalizerepopath",
-      "label": "normalizeRepoPath()",
-      "norm_label": "normalizerepopath()",
-      "source_file": "scripts/compound-solution-check.ts",
-      "source_location": "L53"
+      "id": "dailyopening_trimoptional",
+      "label": "trimOptional()",
+      "norm_label": "trimoptional()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
+      "source_location": "L93"
     },
     {
       "community": 12,
       "file_type": "code",
-      "id": "compound_solution_check_parseargs",
-      "label": "parseArgs()",
-      "norm_label": "parseargs()",
-      "source_file": "scripts/compound-solution-check.ts",
-      "source_location": "L358"
+      "id": "dailyopening_uniquesourcesubjects",
+      "label": "uniqueSourceSubjects()",
+      "norm_label": "uniquesourcesubjects()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
+      "source_location": "L421"
     },
     {
       "community": 12,
       "file_type": "code",
-      "id": "compound_solution_check_parsechangedfiles",
-      "label": "parseChangedFiles()",
-      "norm_label": "parsechangedfiles()",
-      "source_file": "scripts/compound-solution-check.ts",
-      "source_location": "L246"
-    },
-    {
-      "community": 12,
-      "file_type": "code",
-      "id": "compound_solution_check_parsenumstat",
-      "label": "parseNumstat()",
-      "norm_label": "parsenumstat()",
-      "source_file": "scripts/compound-solution-check.ts",
-      "source_location": "L253"
-    },
-    {
-      "community": 12,
-      "file_type": "code",
-      "id": "compound_solution_check_rungit",
-      "label": "runGit()",
-      "norm_label": "rungit()",
-      "source_file": "scripts/compound-solution-check.ts",
-      "source_location": "L221"
-    },
-    {
-      "community": 12,
-      "file_type": "code",
-      "id": "compound_solution_check_sortuniquepaths",
-      "label": "sortUniquePaths()",
-      "norm_label": "sortuniquepaths()",
-      "source_file": "scripts/compound-solution-check.ts",
-      "source_location": "L57"
-    },
-    {
-      "community": 12,
-      "file_type": "code",
-      "id": "compound_solution_check_totalconsiderablesourcelinechanges",
-      "label": "totalConsiderableSourceLineChanges()",
-      "norm_label": "totalconsiderablesourcelinechanges()",
-      "source_file": "scripts/compound-solution-check.ts",
-      "source_location": "L134"
-    },
-    {
-      "community": 12,
-      "file_type": "code",
-      "id": "scripts_compound_solution_check_ts",
-      "label": "compound-solution-check.ts",
-      "norm_label": "compound-solution-check.ts",
-      "source_file": "scripts/compound-solution-check.ts",
+      "id": "packages_athena_webapp_convex_operations_dailyopening_ts",
+      "label": "dailyOpening.ts",
+      "norm_label": "dailyopening.ts",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
       "source_location": "L1"
     },
     {
@@ -62676,226 +62832,226 @@
     {
       "community": 13,
       "file_type": "code",
-      "id": "harness_self_review_appendlistsection",
-      "label": "appendListSection()",
-      "norm_label": "appendlistsection()",
-      "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L609"
+      "id": "compound_solution_check_assertcompoundsolutioncheck",
+      "label": "assertCompoundSolutionCheck()",
+      "norm_label": "assertcompoundsolutioncheck()",
+      "source_file": "scripts/compound-solution-check.ts",
+      "source_location": "L391"
     },
     {
       "community": 13,
       "file_type": "code",
-      "id": "harness_self_review_buildmarkdownbundle",
-      "label": "buildMarkdownBundle()",
-      "norm_label": "buildmarkdownbundle()",
-      "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L628"
+      "id": "compound_solution_check_collectchangedfiles",
+      "label": "collectChangedFiles()",
+      "norm_label": "collectchangedfiles()",
+      "source_file": "scripts/compound-solution-check.ts",
+      "source_location": "L288"
     },
     {
       "community": 13,
       "file_type": "code",
-      "id": "harness_self_review_collectcoverage",
-      "label": "collectCoverage()",
-      "norm_label": "collectcoverage()",
-      "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L398"
+      "id": "compound_solution_check_collectcompoundsolutionfindings",
+      "label": "collectCompoundSolutionFindings()",
+      "norm_label": "collectcompoundsolutionfindings()",
+      "source_file": "scripts/compound-solution-check.ts",
+      "source_location": "L150"
     },
     {
       "community": 13,
       "file_type": "code",
-      "id": "harness_self_review_evaluategraphifyfreshness",
-      "label": "evaluateGraphifyFreshness()",
-      "norm_label": "evaluategraphifyfreshness()",
-      "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L532"
+      "id": "compound_solution_check_collectexistingfiles",
+      "label": "collectExistingFiles()",
+      "norm_label": "collectexistingfiles()",
+      "source_file": "scripts/compound-solution-check.ts",
+      "source_location": "L350"
     },
     {
       "community": 13,
       "file_type": "code",
-      "id": "harness_self_review_fileexists",
-      "label": "fileExists()",
-      "norm_label": "fileexists()",
-      "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L144"
+      "id": "compound_solution_check_collectmarkdowncontents",
+      "label": "collectMarkdownContents()",
+      "norm_label": "collectmarkdowncontents()",
+      "source_file": "scripts/compound-solution-check.ts",
+      "source_location": "L333"
     },
     {
       "community": 13,
       "file_type": "code",
-      "id": "harness_self_review_formatvalidationcommand",
-      "label": "formatValidationCommand()",
-      "norm_label": "formatvalidationcommand()",
-      "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L132"
+      "id": "compound_solution_check_collectsourcelinechanges",
+      "label": "collectSourceLineChanges()",
+      "norm_label": "collectsourcelinechanges()",
+      "source_file": "scripts/compound-solution-check.ts",
+      "source_location": "L297"
     },
     {
       "community": 13,
       "file_type": "code",
-      "id": "harness_self_review_getchangedfilesfromgit",
-      "label": "getChangedFilesFromGit()",
-      "norm_label": "getchangedfilesfromgit()",
-      "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L177"
+      "id": "compound_solution_check_countfilelines",
+      "label": "countFileLines()",
+      "norm_label": "countfilelines()",
+      "source_file": "scripts/compound-solution-check.ts",
+      "source_location": "L284"
     },
     {
       "community": 13,
       "file_type": "code",
-      "id": "harness_self_review_islikelycodeorconfig",
-      "label": "isLikelyCodeOrConfig()",
-      "norm_label": "islikelycodeorconfig()",
-      "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L493"
+      "id": "compound_solution_check_extractfrontmatter",
+      "label": "extractFrontmatter()",
+      "norm_label": "extractfrontmatter()",
+      "source_file": "scripts/compound-solution-check.ts",
+      "source_location": "L107"
     },
     {
       "community": 13,
       "file_type": "code",
-      "id": "harness_self_review_islocalgeneratedartifactpath",
-      "label": "isLocalGeneratedArtifactPath()",
-      "norm_label": "islocalgeneratedartifactpath()",
-      "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L523"
+      "id": "compound_solution_check_extractsolutionreferences",
+      "label": "extractSolutionReferences()",
+      "norm_label": "extractsolutionreferences()",
+      "source_file": "scripts/compound-solution-check.ts",
+      "source_location": "L101"
     },
     {
       "community": 13,
       "file_type": "code",
-      "id": "harness_self_review_isworktreemetadatapath",
-      "label": "isWorktreeMetadataPath()",
-      "norm_label": "isworktreemetadatapath()",
-      "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L514"
+      "id": "compound_solution_check_gitenv",
+      "label": "gitEnv()",
+      "norm_label": "gitenv()",
+      "source_file": "scripts/compound-solution-check.ts",
+      "source_location": "L238"
     },
     {
       "community": 13,
       "file_type": "code",
-      "id": "harness_self_review_loadselfreviewtarget",
-      "label": "loadSelfReviewTarget()",
-      "norm_label": "loadselfreviewtarget()",
-      "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L247"
+      "id": "compound_solution_check_iscompoundsensitiveworkflowpath",
+      "label": "isCompoundSensitiveWorkflowPath()",
+      "norm_label": "iscompoundsensitiveworkflowpath()",
+      "source_file": "scripts/compound-solution-check.ts",
+      "source_location": "L86"
     },
     {
       "community": 13,
       "file_type": "code",
-      "id": "harness_self_review_loadselfreviewtargets",
-      "label": "loadSelfReviewTargets()",
-      "norm_label": "loadselfreviewtargets()",
-      "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L379"
+      "id": "compound_solution_check_isconsiderablesourcepath",
+      "label": "isConsiderableSourcePath()",
+      "norm_label": "isconsiderablesourcepath()",
+      "source_file": "scripts/compound-solution-check.ts",
+      "source_location": "L71"
     },
     {
       "community": 13,
       "file_type": "code",
-      "id": "harness_self_review_matchespathprefix",
-      "label": "matchesPathPrefix()",
-      "norm_label": "matchespathprefix()",
-      "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L106"
+      "id": "compound_solution_check_ismarkdowndocpath",
+      "label": "isMarkdownDocPath()",
+      "norm_label": "ismarkdowndocpath()",
+      "source_file": "scripts/compound-solution-check.ts",
+      "source_location": "L67"
     },
     {
       "community": 13,
       "file_type": "code",
-      "id": "harness_self_review_normalizebehaviorscenarioname",
-      "label": "normalizeBehaviorScenarioName()",
-      "norm_label": "normalizebehaviorscenarioname()",
-      "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L128"
+      "id": "compound_solution_check_issolutiondocpath",
+      "label": "isSolutionDocPath()",
+      "norm_label": "issolutiondocpath()",
+      "source_file": "scripts/compound-solution-check.ts",
+      "source_location": "L63"
     },
     {
       "community": 13,
       "file_type": "code",
-      "id": "harness_self_review_normalizerepopath",
-      "label": "normalizeRepoPath()",
-      "norm_label": "normalizerepopath()",
-      "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L96"
+      "id": "compound_solution_check_mergelinechanges",
+      "label": "mergeLineChanges()",
+      "norm_label": "mergelinechanges()",
+      "source_file": "scripts/compound-solution-check.ts",
+      "source_location": "L274"
     },
     {
       "community": 13,
       "file_type": "code",
-      "id": "harness_self_review_normalizevalidationcommand",
-      "label": "normalizeValidationCommand()",
-      "norm_label": "normalizevalidationcommand()",
-      "source_file": "scripts/harness-self-review.ts",
+      "id": "compound_solution_check_missingsolutionfrontmatterfields",
+      "label": "missingSolutionFrontmatterFields()",
+      "norm_label": "missingsolutionfrontmatterfields()",
+      "source_file": "scripts/compound-solution-check.ts",
       "source_location": "L120"
     },
     {
       "community": 13,
       "file_type": "code",
-      "id": "harness_self_review_parsecliarguments",
-      "label": "parseCliArguments()",
-      "norm_label": "parsecliarguments()",
-      "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L801"
+      "id": "compound_solution_check_missingsolutionsections",
+      "label": "missingSolutionSections()",
+      "norm_label": "missingsolutionsections()",
+      "source_file": "scripts/compound-solution-check.ts",
+      "source_location": "L128"
     },
     {
       "community": 13,
       "file_type": "code",
-      "id": "harness_self_review_parseruntimescenarios",
-      "label": "parseRuntimeScenarios()",
-      "norm_label": "parseruntimescenarios()",
-      "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L241"
+      "id": "compound_solution_check_normalizerepopath",
+      "label": "normalizeRepoPath()",
+      "norm_label": "normalizerepopath()",
+      "source_file": "scripts/compound-solution-check.ts",
+      "source_location": "L53"
     },
     {
       "community": 13,
       "file_type": "code",
-      "id": "harness_self_review_quotecode",
-      "label": "quoteCode()",
-      "norm_label": "quotecode()",
-      "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L140"
+      "id": "compound_solution_check_parseargs",
+      "label": "parseArgs()",
+      "norm_label": "parseargs()",
+      "source_file": "scripts/compound-solution-check.ts",
+      "source_location": "L358"
     },
     {
       "community": 13,
       "file_type": "code",
-      "id": "harness_self_review_readjsonfile",
-      "label": "readJsonFile()",
-      "norm_label": "readjsonfile()",
-      "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L153"
+      "id": "compound_solution_check_parsechangedfiles",
+      "label": "parseChangedFiles()",
+      "norm_label": "parsechangedfiles()",
+      "source_file": "scripts/compound-solution-check.ts",
+      "source_location": "L246"
     },
     {
       "community": 13,
       "file_type": "code",
-      "id": "harness_self_review_runcommand",
-      "label": "runCommand()",
-      "norm_label": "runcommand()",
-      "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L157"
+      "id": "compound_solution_check_parsenumstat",
+      "label": "parseNumstat()",
+      "norm_label": "parsenumstat()",
+      "source_file": "scripts/compound-solution-check.ts",
+      "source_location": "L253"
     },
     {
       "community": 13,
       "file_type": "code",
-      "id": "harness_self_review_runharnessselfreview",
-      "label": "runHarnessSelfReview()",
-      "norm_label": "runharnessselfreview()",
-      "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L850"
+      "id": "compound_solution_check_rungit",
+      "label": "runGit()",
+      "norm_label": "rungit()",
+      "source_file": "scripts/compound-solution-check.ts",
+      "source_location": "L221"
     },
     {
       "community": 13,
       "file_type": "code",
-      "id": "harness_self_review_runquietharnesscheck",
-      "label": "runQuietHarnessCheck()",
-      "norm_label": "runquietharnesscheck()",
-      "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L600"
-    },
-    {
-      "community": 13,
-      "file_type": "code",
-      "id": "harness_self_review_sortuniquepaths",
+      "id": "compound_solution_check_sortuniquepaths",
       "label": "sortUniquePaths()",
       "norm_label": "sortuniquepaths()",
-      "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L100"
+      "source_file": "scripts/compound-solution-check.ts",
+      "source_location": "L57"
     },
     {
       "community": 13,
       "file_type": "code",
-      "id": "scripts_harness_self_review_ts",
-      "label": "harness-self-review.ts",
-      "norm_label": "harness-self-review.ts",
-      "source_file": "scripts/harness-self-review.ts",
+      "id": "compound_solution_check_totalconsiderablesourcelinechanges",
+      "label": "totalConsiderableSourceLineChanges()",
+      "norm_label": "totalconsiderablesourcelinechanges()",
+      "source_file": "scripts/compound-solution-check.ts",
+      "source_location": "L134"
+    },
+    {
+      "community": 13,
+      "file_type": "code",
+      "id": "scripts_compound_solution_check_ts",
+      "label": "compound-solution-check.ts",
+      "norm_label": "compound-solution-check.ts",
+      "source_file": "scripts/compound-solution-check.ts",
       "source_location": "L1"
     },
     {
@@ -64431,218 +64587,227 @@
     {
       "community": 14,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_possessions_ts",
-      "label": "posSessions.ts",
-      "norm_label": "possessions.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "id": "harness_self_review_appendlistsection",
+      "label": "appendListSection()",
+      "norm_label": "appendlistsection()",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L609"
+    },
+    {
+      "community": 14,
+      "file_type": "code",
+      "id": "harness_self_review_buildmarkdownbundle",
+      "label": "buildMarkdownBundle()",
+      "norm_label": "buildmarkdownbundle()",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L628"
+    },
+    {
+      "community": 14,
+      "file_type": "code",
+      "id": "harness_self_review_collectcoverage",
+      "label": "collectCoverage()",
+      "norm_label": "collectcoverage()",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L398"
+    },
+    {
+      "community": 14,
+      "file_type": "code",
+      "id": "harness_self_review_evaluategraphifyfreshness",
+      "label": "evaluateGraphifyFreshness()",
+      "norm_label": "evaluategraphifyfreshness()",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L532"
+    },
+    {
+      "community": 14,
+      "file_type": "code",
+      "id": "harness_self_review_fileexists",
+      "label": "fileExists()",
+      "norm_label": "fileexists()",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L144"
+    },
+    {
+      "community": 14,
+      "file_type": "code",
+      "id": "harness_self_review_formatvalidationcommand",
+      "label": "formatValidationCommand()",
+      "norm_label": "formatvalidationcommand()",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L132"
+    },
+    {
+      "community": 14,
+      "file_type": "code",
+      "id": "harness_self_review_getchangedfilesfromgit",
+      "label": "getChangedFilesFromGit()",
+      "norm_label": "getchangedfilesfromgit()",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L177"
+    },
+    {
+      "community": 14,
+      "file_type": "code",
+      "id": "harness_self_review_islikelycodeorconfig",
+      "label": "isLikelyCodeOrConfig()",
+      "norm_label": "islikelycodeorconfig()",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L493"
+    },
+    {
+      "community": 14,
+      "file_type": "code",
+      "id": "harness_self_review_islocalgeneratedartifactpath",
+      "label": "isLocalGeneratedArtifactPath()",
+      "norm_label": "islocalgeneratedartifactpath()",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L523"
+    },
+    {
+      "community": 14,
+      "file_type": "code",
+      "id": "harness_self_review_isworktreemetadatapath",
+      "label": "isWorktreeMetadataPath()",
+      "norm_label": "isworktreemetadatapath()",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L514"
+    },
+    {
+      "community": 14,
+      "file_type": "code",
+      "id": "harness_self_review_loadselfreviewtarget",
+      "label": "loadSelfReviewTarget()",
+      "norm_label": "loadselfreviewtarget()",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L247"
+    },
+    {
+      "community": 14,
+      "file_type": "code",
+      "id": "harness_self_review_loadselfreviewtargets",
+      "label": "loadSelfReviewTargets()",
+      "norm_label": "loadselfreviewtargets()",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L379"
+    },
+    {
+      "community": 14,
+      "file_type": "code",
+      "id": "harness_self_review_matchespathprefix",
+      "label": "matchesPathPrefix()",
+      "norm_label": "matchespathprefix()",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L106"
+    },
+    {
+      "community": 14,
+      "file_type": "code",
+      "id": "harness_self_review_normalizebehaviorscenarioname",
+      "label": "normalizeBehaviorScenarioName()",
+      "norm_label": "normalizebehaviorscenarioname()",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L128"
+    },
+    {
+      "community": 14,
+      "file_type": "code",
+      "id": "harness_self_review_normalizerepopath",
+      "label": "normalizeRepoPath()",
+      "norm_label": "normalizerepopath()",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L96"
+    },
+    {
+      "community": 14,
+      "file_type": "code",
+      "id": "harness_self_review_normalizevalidationcommand",
+      "label": "normalizeValidationCommand()",
+      "norm_label": "normalizevalidationcommand()",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L120"
+    },
+    {
+      "community": 14,
+      "file_type": "code",
+      "id": "harness_self_review_parsecliarguments",
+      "label": "parseCliArguments()",
+      "norm_label": "parsecliarguments()",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L801"
+    },
+    {
+      "community": 14,
+      "file_type": "code",
+      "id": "harness_self_review_parseruntimescenarios",
+      "label": "parseRuntimeScenarios()",
+      "norm_label": "parseruntimescenarios()",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L241"
+    },
+    {
+      "community": 14,
+      "file_type": "code",
+      "id": "harness_self_review_quotecode",
+      "label": "quoteCode()",
+      "norm_label": "quotecode()",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L140"
+    },
+    {
+      "community": 14,
+      "file_type": "code",
+      "id": "harness_self_review_readjsonfile",
+      "label": "readJsonFile()",
+      "norm_label": "readjsonfile()",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L153"
+    },
+    {
+      "community": 14,
+      "file_type": "code",
+      "id": "harness_self_review_runcommand",
+      "label": "runCommand()",
+      "norm_label": "runcommand()",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L157"
+    },
+    {
+      "community": 14,
+      "file_type": "code",
+      "id": "harness_self_review_runharnessselfreview",
+      "label": "runHarnessSelfReview()",
+      "norm_label": "runharnessselfreview()",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L850"
+    },
+    {
+      "community": 14,
+      "file_type": "code",
+      "id": "harness_self_review_runquietharnesscheck",
+      "label": "runQuietHarnessCheck()",
+      "norm_label": "runquietharnesscheck()",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L600"
+    },
+    {
+      "community": 14,
+      "file_type": "code",
+      "id": "harness_self_review_sortuniquepaths",
+      "label": "sortUniquePaths()",
+      "norm_label": "sortuniquepaths()",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L100"
+    },
+    {
+      "community": 14,
+      "file_type": "code",
+      "id": "scripts_harness_self_review_ts",
+      "label": "harness-self-review.ts",
+      "norm_label": "harness-self-review.ts",
+      "source_file": "scripts/harness-self-review.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 14,
-      "file_type": "code",
-      "id": "possessions_buildcartsummary",
-      "label": "buildCartSummary()",
-      "norm_label": "buildcartsummary()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L547"
-    },
-    {
-      "community": 14,
-      "file_type": "code",
-      "id": "possessions_buildsessionoperationsrow",
-      "label": "buildSessionOperationsRow()",
-      "norm_label": "buildsessionoperationsrow()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L590"
-    },
-    {
-      "community": 14,
-      "file_type": "code",
-      "id": "possessions_expirepossessionnow",
-      "label": "expirePosSessionNow()",
-      "norm_label": "expirepossessionnow()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L251"
-    },
-    {
-      "community": 14,
-      "file_type": "code",
-      "id": "possessions_hascustomersnapshotvalue",
-      "label": "hasCustomerSnapshotValue()",
-      "norm_label": "hascustomersnapshotvalue()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L386"
-    },
-    {
-      "community": 14,
-      "file_type": "code",
-      "id": "possessions_isusableregistersession",
-      "label": "isUsableRegisterSession()",
-      "norm_label": "isusableregistersession()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L115"
-    },
-    {
-      "community": 14,
-      "file_type": "code",
-      "id": "possessions_listpossessionsbystatusbefore",
-      "label": "listPosSessionsByStatusBefore()",
-      "norm_label": "listpossessionsbystatusbefore()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L203"
-    },
-    {
-      "community": 14,
-      "file_type": "code",
-      "id": "possessions_listpossessionsforstorestatus",
-      "label": "listPosSessionsForStoreStatus()",
-      "norm_label": "listpossessionsforstorestatus()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L225"
-    },
-    {
-      "community": 14,
-      "file_type": "code",
-      "id": "possessions_liststoresessionsforoperationsstatus",
-      "label": "listStoreSessionsForOperationsStatus()",
-      "norm_label": "liststoresessionsforoperationsstatus()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L571"
-    },
-    {
-      "community": 14,
-      "file_type": "code",
-      "id": "possessions_loadpossessionitems",
-      "label": "loadPosSessionItems()",
-      "norm_label": "loadpossessionitems()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L181"
-    },
-    {
-      "community": 14,
-      "file_type": "code",
-      "id": "possessions_loadsessioncustomer",
-      "label": "loadSessionCustomer()",
-      "norm_label": "loadsessioncustomer()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L440"
-    },
-    {
-      "community": 14,
-      "file_type": "code",
-      "id": "possessions_loadsessionoperator",
-      "label": "loadSessionOperator()",
-      "norm_label": "loadsessionoperator()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L472"
-    },
-    {
-      "community": 14,
-      "file_type": "code",
-      "id": "possessions_loadsessionregister",
-      "label": "loadSessionRegister()",
-      "norm_label": "loadsessionregister()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L518"
-    },
-    {
-      "community": 14,
-      "file_type": "code",
-      "id": "possessions_loadsessionterminal",
-      "label": "loadSessionTerminal()",
-      "norm_label": "loadsessionterminal()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L496"
-    },
-    {
-      "community": 14,
-      "file_type": "code",
-      "id": "possessions_normalizecustomersnapshot",
-      "label": "normalizeCustomerSnapshot()",
-      "norm_label": "normalizecustomersnapshot()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L371"
-    },
-    {
-      "community": 14,
-      "file_type": "code",
-      "id": "possessions_persistsessionworkflowtraceidbesteffort",
-      "label": "persistSessionWorkflowTraceIdBestEffort()",
-      "norm_label": "persistsessionworkflowtraceidbesteffort()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L307"
-    },
-    {
-      "community": 14,
-      "file_type": "code",
-      "id": "possessions_recordsessionlifecycletracebesteffort",
-      "label": "recordSessionLifecycleTraceBestEffort()",
-      "norm_label": "recordsessionlifecycletracebesteffort()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L328"
-    },
-    {
-      "community": 14,
-      "file_type": "code",
-      "id": "possessions_registersessionmatchesidentity",
-      "label": "registerSessionMatchesIdentity()",
-      "norm_label": "registersessionmatchesidentity()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L119"
-    },
-    {
-      "community": 14,
-      "file_type": "code",
-      "id": "possessions_resolvecustomertracestage",
-      "label": "resolveCustomerTraceStage()",
-      "norm_label": "resolvecustomertracestage()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L397"
-    },
-    {
-      "community": 14,
-      "file_type": "code",
-      "id": "possessions_usererrorfromsessioncommandfailure",
-      "label": "userErrorFromSessionCommandFailure()",
-      "norm_label": "usererrorfromsessioncommandfailure()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L73"
-    },
-    {
-      "community": 14,
-      "file_type": "code",
-      "id": "possessions_usererrorfromvalidationmessage",
-      "label": "userErrorFromValidationMessage()",
-      "norm_label": "usererrorfromvalidationmessage()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L101"
-    },
-    {
-      "community": 14,
-      "file_type": "code",
-      "id": "possessions_validateoperationsactor",
-      "label": "validateOperationsActor()",
-      "norm_label": "validateoperationsactor()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L692"
-    },
-    {
-      "community": 14,
-      "file_type": "code",
-      "id": "possessions_validateoperationsmanager",
-      "label": "validateOperationsManager()",
-      "norm_label": "validateoperationsmanager()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L646"
-    },
-    {
-      "community": 14,
-      "file_type": "code",
-      "id": "possessions_validatesessiondrawerbinding",
-      "label": "validateSessionDrawerBinding()",
-      "norm_label": "validatesessiondrawerbinding()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
-      "source_location": "L145"
     },
     {
       "community": 140,
@@ -66123,218 +66288,218 @@
     {
       "community": 15,
       "file_type": "code",
-      "id": "expensesessioncommands_acquireexpensequantitypatchhold",
-      "label": "acquireExpenseQuantityPatchHold()",
-      "norm_label": "acquireexpensequantitypatchhold()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
-      "source_location": "L695"
+      "id": "packages_athena_webapp_convex_inventory_possessions_ts",
+      "label": "posSessions.ts",
+      "norm_label": "possessions.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L1"
     },
     {
       "community": 15,
       "file_type": "code",
-      "id": "expensesessioncommands_adjustexpensequantitypatchhold",
-      "label": "adjustExpenseQuantityPatchHold()",
-      "norm_label": "adjustexpensequantitypatchhold()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
-      "source_location": "L735"
+      "id": "possessions_buildcartsummary",
+      "label": "buildCartSummary()",
+      "norm_label": "buildcartsummary()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L547"
     },
     {
       "community": 15,
       "file_type": "code",
-      "id": "expensesessioncommands_buildnextsessionnumber",
-      "label": "buildNextSessionNumber()",
-      "norm_label": "buildnextsessionnumber()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
-      "source_location": "L753"
+      "id": "possessions_buildsessionoperationsrow",
+      "label": "buildSessionOperationsRow()",
+      "norm_label": "buildsessionoperationsrow()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L590"
     },
     {
       "community": 15,
       "file_type": "code",
-      "id": "expensesessioncommands_createdefaultexpensesessioncommandservice",
-      "label": "createDefaultExpenseSessionCommandService()",
-      "norm_label": "createdefaultexpensesessioncommandservice()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
-      "source_location": "L662"
+      "id": "possessions_expirepossessionnow",
+      "label": "expirePosSessionNow()",
+      "norm_label": "expirepossessionnow()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L251"
     },
     {
       "community": 15,
       "file_type": "code",
-      "id": "expensesessioncommands_createexpenseinventoryholdgateway",
-      "label": "createExpenseInventoryHoldGateway()",
-      "norm_label": "createexpenseinventoryholdgateway()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
-      "source_location": "L674"
+      "id": "possessions_hascustomersnapshotvalue",
+      "label": "hasCustomerSnapshotValue()",
+      "norm_label": "hascustomersnapshotvalue()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L386"
     },
     {
       "community": 15,
       "file_type": "code",
-      "id": "expensesessioncommands_createexpensesessioncommandservice",
-      "label": "createExpenseSessionCommandService()",
-      "norm_label": "createexpensesessioncommandservice()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
-      "source_location": "L154"
+      "id": "possessions_isusableregistersession",
+      "label": "isUsableRegisterSession()",
+      "norm_label": "isusableregistersession()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L115"
     },
     {
       "community": 15,
       "file_type": "code",
-      "id": "expensesessioncommands_failure",
-      "label": "failure()",
-      "norm_label": "failure()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
-      "source_location": "L926"
+      "id": "possessions_listpossessionsbystatusbefore",
+      "label": "listPosSessionsByStatusBefore()",
+      "norm_label": "listpossessionsbystatusbefore()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L203"
     },
     {
       "community": 15,
       "file_type": "code",
-      "id": "expensesessioncommands_isactiveregistersession",
-      "label": "isActiveRegisterSession()",
-      "norm_label": "isactiveregistersession()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
-      "source_location": "L764"
+      "id": "possessions_listpossessionsforstorestatus",
+      "label": "listPosSessionsForStoreStatus()",
+      "norm_label": "listpossessionsforstorestatus()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L225"
     },
     {
       "community": 15,
       "file_type": "code",
-      "id": "expensesessioncommands_issessionexpired",
-      "label": "isSessionExpired()",
-      "norm_label": "issessionexpired()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
-      "source_location": "L835"
+      "id": "possessions_liststoresessionsforoperationsstatus",
+      "label": "listStoreSessionsForOperationsStatus()",
+      "norm_label": "liststoresessionsforoperationsstatus()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L571"
     },
     {
       "community": 15,
       "file_type": "code",
-      "id": "expensesessioncommands_normalizeregisternumber",
-      "label": "normalizeRegisterNumber()",
-      "norm_label": "normalizeregisternumber()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
-      "source_location": "L24"
+      "id": "possessions_loadpossessionitems",
+      "label": "loadPosSessionItems()",
+      "norm_label": "loadpossessionitems()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L181"
     },
     {
       "community": 15,
       "file_type": "code",
-      "id": "expensesessioncommands_recordsessiontrace",
-      "label": "recordSessionTrace()",
-      "norm_label": "recordsessiontrace()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
-      "source_location": "L568"
+      "id": "possessions_loadsessioncustomer",
+      "label": "loadSessionCustomer()",
+      "norm_label": "loadsessioncustomer()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L440"
     },
     {
       "community": 15,
       "file_type": "code",
-      "id": "expensesessioncommands_registersessionmatchesidentity",
+      "id": "possessions_loadsessionoperator",
+      "label": "loadSessionOperator()",
+      "norm_label": "loadsessionoperator()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L472"
+    },
+    {
+      "community": 15,
+      "file_type": "code",
+      "id": "possessions_loadsessionregister",
+      "label": "loadSessionRegister()",
+      "norm_label": "loadsessionregister()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L518"
+    },
+    {
+      "community": 15,
+      "file_type": "code",
+      "id": "possessions_loadsessionterminal",
+      "label": "loadSessionTerminal()",
+      "norm_label": "loadsessionterminal()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L496"
+    },
+    {
+      "community": 15,
+      "file_type": "code",
+      "id": "possessions_normalizecustomersnapshot",
+      "label": "normalizeCustomerSnapshot()",
+      "norm_label": "normalizecustomersnapshot()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L371"
+    },
+    {
+      "community": 15,
+      "file_type": "code",
+      "id": "possessions_persistsessionworkflowtraceidbesteffort",
+      "label": "persistSessionWorkflowTraceIdBestEffort()",
+      "norm_label": "persistsessionworkflowtraceidbesteffort()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L307"
+    },
+    {
+      "community": 15,
+      "file_type": "code",
+      "id": "possessions_recordsessionlifecycletracebesteffort",
+      "label": "recordSessionLifecycleTraceBestEffort()",
+      "norm_label": "recordsessionlifecycletracebesteffort()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L328"
+    },
+    {
+      "community": 15,
+      "file_type": "code",
+      "id": "possessions_registersessionmatchesidentity",
       "label": "registerSessionMatchesIdentity()",
       "norm_label": "registersessionmatchesidentity()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
-      "source_location": "L770"
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L119"
     },
     {
       "community": 15,
       "file_type": "code",
-      "id": "expensesessioncommands_releaseexpensequantitypatchhold",
-      "label": "releaseExpenseQuantityPatchHold()",
-      "norm_label": "releaseexpensequantitypatchhold()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
-      "source_location": "L719"
+      "id": "possessions_resolvecustomertracestage",
+      "label": "resolveCustomerTraceStage()",
+      "norm_label": "resolvecustomertracestage()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L397"
     },
     {
       "community": 15,
       "file_type": "code",
-      "id": "expensesessioncommands_resolveregistersessionbinding",
-      "label": "resolveRegisterSessionBinding()",
-      "norm_label": "resolveregistersessionbinding()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
-      "source_location": "L799"
+      "id": "possessions_usererrorfromsessioncommandfailure",
+      "label": "userErrorFromSessionCommandFailure()",
+      "norm_label": "usererrorfromsessioncommandfailure()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L73"
     },
     {
       "community": 15,
       "file_type": "code",
-      "id": "expensesessioncommands_runbindexpensesessiontoregistersessioncommand",
-      "label": "runBindExpenseSessionToRegisterSessionCommand()",
-      "norm_label": "runbindexpensesessiontoregistersessioncommand()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
-      "source_location": "L632"
+      "id": "possessions_usererrorfromvalidationmessage",
+      "label": "userErrorFromValidationMessage()",
+      "norm_label": "usererrorfromvalidationmessage()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L101"
     },
     {
       "community": 15,
       "file_type": "code",
-      "id": "expensesessioncommands_runclearexpensesessionitemscommand",
-      "label": "runClearExpenseSessionItemsCommand()",
-      "norm_label": "runclearexpensesessionitemscommand()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
-      "source_location": "L655"
+      "id": "possessions_validateoperationsactor",
+      "label": "validateOperationsActor()",
+      "norm_label": "validateoperationsactor()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L692"
     },
     {
       "community": 15,
       "file_type": "code",
-      "id": "expensesessioncommands_runremoveexpensesessionitemcommand",
-      "label": "runRemoveExpenseSessionItemCommand()",
-      "norm_label": "runremoveexpensesessionitemcommand()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
-      "source_location": "L648"
+      "id": "possessions_validateoperationsmanager",
+      "label": "validateOperationsManager()",
+      "norm_label": "validateoperationsmanager()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L646"
     },
     {
       "community": 15,
       "file_type": "code",
-      "id": "expensesessioncommands_runresumeexpensesessioncommand",
-      "label": "runResumeExpenseSessionCommand()",
-      "norm_label": "runresumeexpensesessioncommand()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
-      "source_location": "L625"
-    },
-    {
-      "community": 15,
-      "file_type": "code",
-      "id": "expensesessioncommands_runstartexpensesessioncommand",
-      "label": "runStartExpenseSessionCommand()",
-      "norm_label": "runstartexpensesessioncommand()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
-      "source_location": "L606"
-    },
-    {
-      "community": 15,
-      "file_type": "code",
-      "id": "expensesessioncommands_runupsertexpensesessionitemcommand",
-      "label": "runUpsertExpenseSessionItemCommand()",
-      "norm_label": "runupsertexpensesessionitemcommand()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
-      "source_location": "L641"
-    },
-    {
-      "community": 15,
-      "file_type": "code",
-      "id": "expensesessioncommands_success",
-      "label": "success()",
-      "norm_label": "success()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
-      "source_location": "L919"
-    },
-    {
-      "community": 15,
-      "file_type": "code",
-      "id": "expensesessioncommands_validateactivesession",
-      "label": "validateActiveSession()",
-      "norm_label": "validateactivesession()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
-      "source_location": "L842"
-    },
-    {
-      "community": 15,
-      "file_type": "code",
-      "id": "expensesessioncommands_validatemodifiablesession",
-      "label": "validateModifiableSession()",
-      "norm_label": "validatemodifiablesession()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
-      "source_location": "L886"
-    },
-    {
-      "community": 15,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_commands_expensesessioncommands_ts",
-      "label": "expenseSessionCommands.ts",
-      "norm_label": "expensesessioncommands.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
-      "source_location": "L1"
+      "id": "possessions_validatesessiondrawerbinding",
+      "label": "validateSessionDrawerBinding()",
+      "norm_label": "validatesessiondrawerbinding()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
+      "source_location": "L145"
     },
     {
       "community": 150,
@@ -67455,208 +67620,217 @@
     {
       "community": 16,
       "file_type": "code",
-      "id": "dailyopening_builddailyopeningsnapshotwithctx",
-      "label": "buildDailyOpeningSnapshotWithCtx()",
-      "norm_label": "builddailyopeningsnapshotwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L476"
+      "id": "expensesessioncommands_acquireexpensequantitypatchhold",
+      "label": "acquireExpenseQuantityPatchHold()",
+      "norm_label": "acquireexpensequantitypatchhold()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
+      "source_location": "L695"
     },
     {
       "community": 16,
       "file_type": "code",
-      "id": "dailyopening_buildreadiness",
-      "label": "buildReadiness()",
-      "norm_label": "buildreadiness()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L373"
+      "id": "expensesessioncommands_adjustexpensequantitypatchhold",
+      "label": "adjustExpenseQuantityPatchHold()",
+      "norm_label": "adjustexpensequantitypatchhold()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
+      "source_location": "L735"
     },
     {
       "community": 16,
       "file_type": "code",
-      "id": "dailyopening_carryforwarditem",
-      "label": "carryForwardItem()",
-      "norm_label": "carryforwarditem()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L346"
+      "id": "expensesessioncommands_buildnextsessionnumber",
+      "label": "buildNextSessionNumber()",
+      "norm_label": "buildnextsessionnumber()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
+      "source_location": "L753"
     },
     {
       "community": 16,
       "file_type": "code",
-      "id": "dailyopening_getdailyopeningfordate",
-      "label": "getDailyOpeningForDate()",
-      "norm_label": "getdailyopeningfordate()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L155"
+      "id": "expensesessioncommands_createdefaultexpensesessioncommandservice",
+      "label": "createDefaultExpenseSessionCommandService()",
+      "norm_label": "createdefaultexpensesessioncommandservice()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
+      "source_location": "L662"
     },
     {
       "community": 16,
       "file_type": "code",
-      "id": "dailyopening_getmissingcarryforwarditems",
-      "label": "getMissingCarryForwardItems()",
-      "norm_label": "getmissingcarryforwarditems()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L403"
+      "id": "expensesessioncommands_createexpenseinventoryholdgateway",
+      "label": "createExpenseInventoryHoldGateway()",
+      "norm_label": "createexpenseinventoryholdgateway()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
+      "source_location": "L674"
     },
     {
       "community": 16,
       "file_type": "code",
-      "id": "dailyopening_getstarteddailyopeningfordate",
-      "label": "getStartedDailyOpeningForDate()",
-      "norm_label": "getstarteddailyopeningfordate()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L170"
+      "id": "expensesessioncommands_createexpensesessioncommandservice",
+      "label": "createExpenseSessionCommandService()",
+      "norm_label": "createexpensesessioncommandservice()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
+      "source_location": "L154"
     },
     {
       "community": 16,
       "file_type": "code",
-      "id": "dailyopening_getstore",
-      "label": "getStore()",
-      "norm_label": "getstore()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L148"
+      "id": "expensesessioncommands_failure",
+      "label": "failure()",
+      "norm_label": "failure()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
+      "source_location": "L926"
     },
     {
       "community": 16,
       "file_type": "code",
-      "id": "dailyopening_invalidoperatingdateitem",
-      "label": "invalidOperatingDateItem()",
-      "norm_label": "invalidoperatingdateitem()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L261"
+      "id": "expensesessioncommands_isactiveregistersession",
+      "label": "isActiveRegisterSession()",
+      "norm_label": "isactiveregistersession()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
+      "source_location": "L764"
     },
     {
       "community": 16,
       "file_type": "code",
-      "id": "dailyopening_isvalidoperatingdate",
-      "label": "isValidOperatingDate()",
-      "norm_label": "isvalidoperatingdate()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L96"
+      "id": "expensesessioncommands_issessionexpired",
+      "label": "isSessionExpired()",
+      "norm_label": "issessionexpired()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
+      "source_location": "L835"
     },
     {
       "community": 16,
       "file_type": "code",
-      "id": "dailyopening_isvalidoperatingdaterange",
-      "label": "isValidOperatingDateRange()",
-      "norm_label": "isvalidoperatingdaterange()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L123"
+      "id": "expensesessioncommands_normalizeregisternumber",
+      "label": "normalizeRegisterNumber()",
+      "norm_label": "normalizeregisternumber()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
+      "source_location": "L24"
     },
     {
       "community": 16,
       "file_type": "code",
-      "id": "dailyopening_listpendingopeningblockerapprovals",
-      "label": "listPendingOpeningBlockerApprovals()",
-      "norm_label": "listpendingopeningblockerapprovals()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L188"
+      "id": "expensesessioncommands_recordsessiontrace",
+      "label": "recordSessionTrace()",
+      "norm_label": "recordsessiontrace()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
+      "source_location": "L568"
     },
     {
       "community": 16,
       "file_type": "code",
-      "id": "dailyopening_missingcarryforwarditem",
-      "label": "missingCarryForwardItem()",
-      "norm_label": "missingcarryforwarditem()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L275"
+      "id": "expensesessioncommands_registersessionmatchesidentity",
+      "label": "registerSessionMatchesIdentity()",
+      "norm_label": "registersessionmatchesidentity()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
+      "source_location": "L770"
     },
     {
       "community": 16,
       "file_type": "code",
-      "id": "dailyopening_missingpriorcloseitem",
-      "label": "missingPriorCloseItem()",
-      "norm_label": "missingpriorcloseitem()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L235"
+      "id": "expensesessioncommands_releaseexpensequantitypatchhold",
+      "label": "releaseExpenseQuantityPatchHold()",
+      "norm_label": "releaseexpensequantitypatchhold()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
+      "source_location": "L719"
     },
     {
       "community": 16,
       "file_type": "code",
-      "id": "dailyopening_pendingapprovalitem",
-      "label": "pendingApprovalItem()",
-      "norm_label": "pendingapprovalitem()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L207"
+      "id": "expensesessioncommands_resolveregistersessionbinding",
+      "label": "resolveRegisterSessionBinding()",
+      "norm_label": "resolveregistersessionbinding()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
+      "source_location": "L799"
     },
     {
       "community": 16,
       "file_type": "code",
-      "id": "dailyopening_priorclosenotesitem",
-      "label": "priorCloseNotesItem()",
-      "norm_label": "priorclosenotesitem()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L321"
+      "id": "expensesessioncommands_runbindexpensesessiontoregistersessioncommand",
+      "label": "runBindExpenseSessionToRegisterSessionCommand()",
+      "norm_label": "runbindexpensesessiontoregistersessioncommand()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
+      "source_location": "L632"
     },
     {
       "community": 16,
       "file_type": "code",
-      "id": "dailyopening_priorclosereadyitem",
-      "label": "priorCloseReadyItem()",
-      "norm_label": "priorclosereadyitem()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L298"
+      "id": "expensesessioncommands_runclearexpensesessionitemscommand",
+      "label": "runClearExpenseSessionItemsCommand()",
+      "norm_label": "runclearexpensesessionitemscommand()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
+      "source_location": "L655"
     },
     {
       "community": 16,
       "file_type": "code",
-      "id": "dailyopening_resolveopeningactor",
-      "label": "resolveOpeningActor()",
-      "norm_label": "resolveopeningactor()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L419"
+      "id": "expensesessioncommands_runremoveexpensesessionitemcommand",
+      "label": "runRemoveExpenseSessionItemCommand()",
+      "norm_label": "runremoveexpensesessionitemcommand()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
+      "source_location": "L648"
     },
     {
       "community": 16,
       "file_type": "code",
-      "id": "dailyopening_resolveoperatingdaterange",
-      "label": "resolveOperatingDateRange()",
-      "norm_label": "resolveoperatingdaterange()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L134"
+      "id": "expensesessioncommands_runresumeexpensesessioncommand",
+      "label": "runResumeExpenseSessionCommand()",
+      "norm_label": "runresumeexpensesessioncommand()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
+      "source_location": "L625"
     },
     {
       "community": 16,
       "file_type": "code",
-      "id": "dailyopening_safeoperatingdaterange",
-      "label": "safeOperatingDateRange()",
-      "norm_label": "safeoperatingdaterange()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L110"
+      "id": "expensesessioncommands_runstartexpensesessioncommand",
+      "label": "runStartExpenseSessionCommand()",
+      "norm_label": "runstartexpensesessioncommand()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
+      "source_location": "L606"
     },
     {
       "community": 16,
       "file_type": "code",
-      "id": "dailyopening_startstoredaywithctx",
-      "label": "startStoreDayWithCtx()",
-      "norm_label": "startstoredaywithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L589"
+      "id": "expensesessioncommands_runupsertexpensesessionitemcommand",
+      "label": "runUpsertExpenseSessionItemCommand()",
+      "norm_label": "runupsertexpensesessionitemcommand()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
+      "source_location": "L641"
     },
     {
       "community": 16,
       "file_type": "code",
-      "id": "dailyopening_trimoptional",
-      "label": "trimOptional()",
-      "norm_label": "trimoptional()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L91"
+      "id": "expensesessioncommands_success",
+      "label": "success()",
+      "norm_label": "success()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
+      "source_location": "L919"
     },
     {
       "community": 16,
       "file_type": "code",
-      "id": "dailyopening_uniquesourcesubjects",
-      "label": "uniqueSourceSubjects()",
-      "norm_label": "uniquesourcesubjects()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L393"
+      "id": "expensesessioncommands_validateactivesession",
+      "label": "validateActiveSession()",
+      "norm_label": "validateactivesession()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
+      "source_location": "L842"
     },
     {
       "community": 16,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_dailyopening_ts",
-      "label": "dailyOpening.ts",
-      "norm_label": "dailyopening.ts",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
+      "id": "expensesessioncommands_validatemodifiablesession",
+      "label": "validateModifiableSession()",
+      "norm_label": "validatemodifiablesession()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
+      "source_location": "L886"
+    },
+    {
+      "community": 16,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_commands_expensesessioncommands_ts",
+      "label": "expenseSessionCommands.ts",
+      "norm_label": "expensesessioncommands.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts",
       "source_location": "L1"
     },
     {
@@ -70875,366 +71049,6 @@
     {
       "community": 200,
       "file_type": "code",
-      "id": "cashcontrolsdashboard_cn",
-      "label": "cn()",
-      "norm_label": "cn()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
-      "source_location": "L363"
-    },
-    {
-      "community": 200,
-      "file_type": "code",
-      "id": "cashcontrolsdashboard_if",
-      "label": "if()",
-      "norm_label": "if()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
-      "source_location": "L423"
-    },
-    {
-      "community": 200,
-      "file_type": "code",
-      "id": "cashcontrolsdashboard_metriccardskeleton",
-      "label": "MetricCardSkeleton()",
-      "norm_label": "metriccardskeleton()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
-      "source_location": "L87"
-    },
-    {
-      "community": 200,
-      "file_type": "code",
-      "id": "cashcontrolsdashboard_switch",
-      "label": "switch()",
-      "norm_label": "switch()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
-      "source_location": "L256"
-    },
-    {
-      "community": 200,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_cash_controls_cashcontrolsdashboard_tsx",
-      "label": "CashControlsDashboard.tsx",
-      "norm_label": "cashcontrolsdashboard.tsx",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 201,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_common_pageheader_tsx",
-      "label": "PageHeader.tsx",
-      "norm_label": "pageheader.tsx",
-      "source_file": "packages/athena-webapp/src/components/common/PageHeader.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 201,
-      "file_type": "code",
-      "id": "pageheader_navigatebackbutton",
-      "label": "NavigateBackButton()",
-      "norm_label": "navigatebackbutton()",
-      "source_file": "packages/athena-webapp/src/components/common/PageHeader.tsx",
-      "source_location": "L30"
-    },
-    {
-      "community": 201,
-      "file_type": "code",
-      "id": "pageheader_pageheader",
-      "label": "PageHeader()",
-      "norm_label": "pageheader()",
-      "source_file": "packages/athena-webapp/src/components/common/PageHeader.tsx",
-      "source_location": "L8"
-    },
-    {
-      "community": 201,
-      "file_type": "code",
-      "id": "pageheader_simplepageheader",
-      "label": "SimplePageHeader()",
-      "norm_label": "simplepageheader()",
-      "source_file": "packages/athena-webapp/src/components/common/PageHeader.tsx",
-      "source_location": "L50"
-    },
-    {
-      "community": 201,
-      "file_type": "code",
-      "id": "pageheader_viewheader",
-      "label": "ViewHeader()",
-      "norm_label": "viewheader()",
-      "source_file": "packages/athena-webapp/src/components/common/PageHeader.tsx",
-      "source_location": "L67"
-    },
-    {
-      "community": 202,
-      "file_type": "code",
-      "id": "dashboard_getperiodrange",
-      "label": "getPeriodRange()",
-      "norm_label": "getperiodrange()",
-      "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
-      "source_location": "L20"
-    },
-    {
-      "community": 202,
-      "file_type": "code",
-      "id": "dashboard_loadingsection",
-      "label": "LoadingSection()",
-      "norm_label": "loadingsection()",
-      "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
-      "source_location": "L50"
-    },
-    {
-      "community": 202,
-      "file_type": "code",
-      "id": "dashboard_renderproductssection",
-      "label": "renderProductsSection()",
-      "norm_label": "renderproductssection()",
-      "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
-      "source_location": "L342"
-    },
-    {
-      "community": 202,
-      "file_type": "code",
-      "id": "dashboard_rendersalessection",
-      "label": "renderSalesSection()",
-      "norm_label": "rendersalessection()",
-      "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
-      "source_location": "L322"
-    },
-    {
-      "community": 202,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_dashboard_dashboard_tsx",
-      "label": "Dashboard.tsx",
-      "norm_label": "dashboard.tsx",
-      "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 203,
-      "file_type": "code",
-      "id": "herosectiontabs_handledisplaytypechange",
-      "label": "handleDisplayTypeChange()",
-      "norm_label": "handledisplaytypechange()",
-      "source_file": "packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx",
-      "source_location": "L61"
-    },
-    {
-      "community": 203,
-      "file_type": "code",
-      "id": "herosectiontabs_handleimageupdate",
-      "label": "handleImageUpdate()",
-      "norm_label": "handleimageupdate()",
-      "source_file": "packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx",
-      "source_location": "L57"
-    },
-    {
-      "community": 203,
-      "file_type": "code",
-      "id": "herosectiontabs_handleoverlaytoggle",
-      "label": "handleOverlayToggle()",
-      "norm_label": "handleoverlaytoggle()",
-      "source_file": "packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx",
-      "source_location": "L98"
-    },
-    {
-      "community": 203,
-      "file_type": "code",
-      "id": "herosectiontabs_handletexttoggle",
-      "label": "handleTextToggle()",
-      "norm_label": "handletexttoggle()",
-      "source_file": "packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx",
-      "source_location": "L134"
-    },
-    {
-      "community": 203,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_homepage_herosectiontabs_tsx",
-      "label": "HeroSectionTabs.tsx",
-      "norm_label": "herosectiontabs.tsx",
-      "source_file": "packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 204,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_homepage_reeluploader_tsx",
-      "label": "ReelUploader.tsx",
-      "norm_label": "reeluploader.tsx",
-      "source_file": "packages/athena-webapp/src/components/homepage/ReelUploader.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 204,
-      "file_type": "code",
-      "id": "reeluploader_formatfilesize",
-      "label": "formatFileSize()",
-      "norm_label": "formatfilesize()",
-      "source_file": "packages/athena-webapp/src/components/homepage/ReelUploader.tsx",
-      "source_location": "L38"
-    },
-    {
-      "community": 204,
-      "file_type": "code",
-      "id": "reeluploader_handlefileselect",
-      "label": "handleFileSelect()",
-      "norm_label": "handlefileselect()",
-      "source_file": "packages/athena-webapp/src/components/homepage/ReelUploader.tsx",
-      "source_location": "L64"
-    },
-    {
-      "community": 204,
-      "file_type": "code",
-      "id": "reeluploader_handleupload",
-      "label": "handleUpload()",
-      "norm_label": "handleupload()",
-      "source_file": "packages/athena-webapp/src/components/homepage/ReelUploader.tsx",
-      "source_location": "L135"
-    },
-    {
-      "community": 204,
-      "file_type": "code",
-      "id": "reeluploader_validatefile",
-      "label": "validateFile()",
-      "norm_label": "validatefile()",
-      "source_file": "packages/athena-webapp/src/components/homepage/ReelUploader.tsx",
-      "source_location": "L43"
-    },
-    {
-      "community": 205,
-      "file_type": "code",
-      "id": "activityview_iscreatedaction",
-      "label": "isCreatedAction()",
-      "norm_label": "iscreatedaction()",
-      "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
-      "source_location": "L58"
-    },
-    {
-      "community": 205,
-      "file_type": "code",
-      "id": "activityview_isfeedbackrequestaction",
-      "label": "isFeedbackRequestAction()",
-      "norm_label": "isfeedbackrequestaction()",
-      "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
-      "source_location": "L63"
-    },
-    {
-      "community": 205,
-      "file_type": "code",
-      "id": "activityview_isrefundaction",
-      "label": "isRefundAction()",
-      "norm_label": "isrefundaction()",
-      "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
-      "source_location": "L50"
-    },
-    {
-      "community": 205,
-      "file_type": "code",
-      "id": "activityview_istransitionaction",
-      "label": "isTransitionAction()",
-      "norm_label": "istransitionaction()",
-      "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
-      "source_location": "L53"
-    },
-    {
-      "community": 205,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_activityview_tsx",
-      "label": "ActivityView.tsx",
-      "norm_label": "activityview.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 206,
-      "file_type": "code",
-      "id": "orderdetailsview_fetchtransactions",
-      "label": "fetchTransactions()",
-      "norm_label": "fetchtransactions()",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
-      "source_location": "L140"
-    },
-    {
-      "community": 206,
-      "file_type": "code",
-      "id": "orderdetailsview_handlemarkasverified",
-      "label": "handleMarkAsVerified()",
-      "norm_label": "handlemarkasverified()",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
-      "source_location": "L177"
-    },
-    {
-      "community": 206,
-      "file_type": "code",
-      "id": "orderdetailsview_handlemarkpaymentcollected",
-      "label": "handleMarkPaymentCollected()",
-      "norm_label": "handlemarkpaymentcollected()",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
-      "source_location": "L195"
-    },
-    {
-      "community": 206,
-      "file_type": "code",
-      "id": "orderdetailsview_verifiedbadge",
-      "label": "VerifiedBadge()",
-      "norm_label": "verifiedbadge()",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
-      "source_location": "L45"
-    },
-    {
-      "community": 206,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_orderdetailsview_tsx",
-      "label": "OrderDetailsView.tsx",
-      "norm_label": "orderdetailsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 207,
-      "file_type": "code",
-      "id": "orderitemsview_handlerequestfeedback",
-      "label": "handleRequestFeedback()",
-      "norm_label": "handlerequestfeedback()",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
-      "source_location": "L92"
-    },
-    {
-      "community": 207,
-      "file_type": "code",
-      "id": "orderitemsview_handlerestockall",
-      "label": "handleRestockAll()",
-      "norm_label": "handlerestockall()",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
-      "source_location": "L307"
-    },
-    {
-      "community": 207,
-      "file_type": "code",
-      "id": "orderitemsview_handlereturnitemtostock",
-      "label": "handleReturnItemToStock()",
-      "norm_label": "handlereturnitemtostock()",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
-      "source_location": "L70"
-    },
-    {
-      "community": 207,
-      "file_type": "code",
-      "id": "orderitemsview_handleupdateorderitem",
-      "label": "handleUpdateOrderItem()",
-      "norm_label": "handleupdateorderitem()",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
-      "source_location": "L50"
-    },
-    {
-      "community": 207,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_orderitemsview_tsx",
-      "label": "OrderItemsView.tsx",
-      "norm_label": "orderitemsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 208,
-      "file_type": "code",
       "id": "index_feesview",
       "label": "FeesView()",
       "norm_label": "feesview()",
@@ -71242,7 +71056,7 @@
       "source_location": "L30"
     },
     {
-      "community": 208,
+      "community": 200,
       "file_type": "code",
       "id": "index_header",
       "label": "Header()",
@@ -71251,7 +71065,7 @@
       "source_location": "L43"
     },
     {
-      "community": 208,
+      "community": 200,
       "file_type": "code",
       "id": "index_onsubmit",
       "label": "onSubmit()",
@@ -71260,7 +71074,7 @@
       "source_location": "L106"
     },
     {
-      "community": 208,
+      "community": 200,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_index_tsx",
       "label": "index.tsx",
@@ -71269,7 +71083,7 @@
       "source_location": "L1"
     },
     {
-      "community": 208,
+      "community": 200,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_index_tsx",
       "label": "index.tsx",
@@ -71278,48 +71092,408 @@
       "source_location": "L1"
     },
     {
-      "community": 209,
+      "community": 201,
       "file_type": "code",
-      "id": "ordersummary_test_getbalancedueamount",
-      "label": "getBalanceDueAmount()",
-      "norm_label": "getbalancedueamount()",
-      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.test.tsx",
-      "source_location": "L40"
+      "id": "cashcontrolsdashboard_cn",
+      "label": "cn()",
+      "norm_label": "cn()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
+      "source_location": "L363"
     },
     {
-      "community": 209,
+      "community": 201,
       "file_type": "code",
-      "id": "ordersummary_test_getbalanceduelabel",
-      "label": "getBalanceDueLabel()",
-      "norm_label": "getbalanceduelabel()",
-      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.test.tsx",
+      "id": "cashcontrolsdashboard_if",
+      "label": "if()",
+      "norm_label": "if()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
+      "source_location": "L423"
+    },
+    {
+      "community": 201,
+      "file_type": "code",
+      "id": "cashcontrolsdashboard_metriccardskeleton",
+      "label": "MetricCardSkeleton()",
+      "norm_label": "metriccardskeleton()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
+      "source_location": "L87"
+    },
+    {
+      "community": 201,
+      "file_type": "code",
+      "id": "cashcontrolsdashboard_switch",
+      "label": "switch()",
+      "norm_label": "switch()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
+      "source_location": "L256"
+    },
+    {
+      "community": 201,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_cash_controls_cashcontrolsdashboard_tsx",
+      "label": "CashControlsDashboard.tsx",
+      "norm_label": "cashcontrolsdashboard.tsx",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 202,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_common_pageheader_tsx",
+      "label": "PageHeader.tsx",
+      "norm_label": "pageheader.tsx",
+      "source_file": "packages/athena-webapp/src/components/common/PageHeader.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 202,
+      "file_type": "code",
+      "id": "pageheader_navigatebackbutton",
+      "label": "NavigateBackButton()",
+      "norm_label": "navigatebackbutton()",
+      "source_file": "packages/athena-webapp/src/components/common/PageHeader.tsx",
+      "source_location": "L30"
+    },
+    {
+      "community": 202,
+      "file_type": "code",
+      "id": "pageheader_pageheader",
+      "label": "PageHeader()",
+      "norm_label": "pageheader()",
+      "source_file": "packages/athena-webapp/src/components/common/PageHeader.tsx",
+      "source_location": "L8"
+    },
+    {
+      "community": 202,
+      "file_type": "code",
+      "id": "pageheader_simplepageheader",
+      "label": "SimplePageHeader()",
+      "norm_label": "simplepageheader()",
+      "source_file": "packages/athena-webapp/src/components/common/PageHeader.tsx",
+      "source_location": "L50"
+    },
+    {
+      "community": 202,
+      "file_type": "code",
+      "id": "pageheader_viewheader",
+      "label": "ViewHeader()",
+      "norm_label": "viewheader()",
+      "source_file": "packages/athena-webapp/src/components/common/PageHeader.tsx",
+      "source_location": "L67"
+    },
+    {
+      "community": 203,
+      "file_type": "code",
+      "id": "dashboard_getperiodrange",
+      "label": "getPeriodRange()",
+      "norm_label": "getperiodrange()",
+      "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
+      "source_location": "L20"
+    },
+    {
+      "community": 203,
+      "file_type": "code",
+      "id": "dashboard_loadingsection",
+      "label": "LoadingSection()",
+      "norm_label": "loadingsection()",
+      "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
+      "source_location": "L50"
+    },
+    {
+      "community": 203,
+      "file_type": "code",
+      "id": "dashboard_renderproductssection",
+      "label": "renderProductsSection()",
+      "norm_label": "renderproductssection()",
+      "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
+      "source_location": "L342"
+    },
+    {
+      "community": 203,
+      "file_type": "code",
+      "id": "dashboard_rendersalessection",
+      "label": "renderSalesSection()",
+      "norm_label": "rendersalessection()",
+      "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
+      "source_location": "L322"
+    },
+    {
+      "community": 203,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_dashboard_dashboard_tsx",
+      "label": "Dashboard.tsx",
+      "norm_label": "dashboard.tsx",
+      "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 204,
+      "file_type": "code",
+      "id": "herosectiontabs_handledisplaytypechange",
+      "label": "handleDisplayTypeChange()",
+      "norm_label": "handledisplaytypechange()",
+      "source_file": "packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx",
+      "source_location": "L61"
+    },
+    {
+      "community": 204,
+      "file_type": "code",
+      "id": "herosectiontabs_handleimageupdate",
+      "label": "handleImageUpdate()",
+      "norm_label": "handleimageupdate()",
+      "source_file": "packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx",
       "source_location": "L57"
     },
     {
-      "community": 209,
+      "community": 204,
       "file_type": "code",
-      "id": "ordersummary_test_getbalanceduepanel",
-      "label": "getBalanceDuePanel()",
-      "norm_label": "getbalanceduepanel()",
-      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.test.tsx",
-      "source_location": "L66"
+      "id": "herosectiontabs_handleoverlaytoggle",
+      "label": "handleOverlayToggle()",
+      "norm_label": "handleoverlaytoggle()",
+      "source_file": "packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx",
+      "source_location": "L98"
+    },
+    {
+      "community": 204,
+      "file_type": "code",
+      "id": "herosectiontabs_handletexttoggle",
+      "label": "handleTextToggle()",
+      "norm_label": "handletexttoggle()",
+      "source_file": "packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx",
+      "source_location": "L134"
+    },
+    {
+      "community": 204,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_homepage_herosectiontabs_tsx",
+      "label": "HeroSectionTabs.tsx",
+      "norm_label": "herosectiontabs.tsx",
+      "source_file": "packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 205,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_homepage_reeluploader_tsx",
+      "label": "ReelUploader.tsx",
+      "norm_label": "reeluploader.tsx",
+      "source_file": "packages/athena-webapp/src/components/homepage/ReelUploader.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 205,
+      "file_type": "code",
+      "id": "reeluploader_formatfilesize",
+      "label": "formatFileSize()",
+      "norm_label": "formatfilesize()",
+      "source_file": "packages/athena-webapp/src/components/homepage/ReelUploader.tsx",
+      "source_location": "L38"
+    },
+    {
+      "community": 205,
+      "file_type": "code",
+      "id": "reeluploader_handlefileselect",
+      "label": "handleFileSelect()",
+      "norm_label": "handlefileselect()",
+      "source_file": "packages/athena-webapp/src/components/homepage/ReelUploader.tsx",
+      "source_location": "L64"
+    },
+    {
+      "community": 205,
+      "file_type": "code",
+      "id": "reeluploader_handleupload",
+      "label": "handleUpload()",
+      "norm_label": "handleupload()",
+      "source_file": "packages/athena-webapp/src/components/homepage/ReelUploader.tsx",
+      "source_location": "L135"
+    },
+    {
+      "community": 205,
+      "file_type": "code",
+      "id": "reeluploader_validatefile",
+      "label": "validateFile()",
+      "norm_label": "validatefile()",
+      "source_file": "packages/athena-webapp/src/components/homepage/ReelUploader.tsx",
+      "source_location": "L43"
+    },
+    {
+      "community": 206,
+      "file_type": "code",
+      "id": "dailyopeningview_test_async",
+      "label": "async()",
+      "norm_label": "async()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.test.tsx",
+      "source_location": "L118"
+    },
+    {
+      "community": 206,
+      "file_type": "code",
+      "id": "dailyopeningview_test_disconnect",
+      "label": "disconnect()",
+      "norm_label": "disconnect()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.test.tsx",
+      "source_location": "L275"
+    },
+    {
+      "community": 206,
+      "file_type": "code",
+      "id": "dailyopeningview_test_observe",
+      "label": "observe()",
+      "norm_label": "observe()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.test.tsx",
+      "source_location": "L276"
+    },
+    {
+      "community": 206,
+      "file_type": "code",
+      "id": "dailyopeningview_test_unobserve",
+      "label": "unobserve()",
+      "norm_label": "unobserve()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.test.tsx",
+      "source_location": "L277"
+    },
+    {
+      "community": 206,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_operations_dailyopeningview_test_tsx",
+      "label": "DailyOpeningView.test.tsx",
+      "norm_label": "dailyopeningview.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 207,
+      "file_type": "code",
+      "id": "activityview_iscreatedaction",
+      "label": "isCreatedAction()",
+      "norm_label": "iscreatedaction()",
+      "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
+      "source_location": "L58"
+    },
+    {
+      "community": 207,
+      "file_type": "code",
+      "id": "activityview_isfeedbackrequestaction",
+      "label": "isFeedbackRequestAction()",
+      "norm_label": "isfeedbackrequestaction()",
+      "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
+      "source_location": "L63"
+    },
+    {
+      "community": 207,
+      "file_type": "code",
+      "id": "activityview_isrefundaction",
+      "label": "isRefundAction()",
+      "norm_label": "isrefundaction()",
+      "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
+      "source_location": "L50"
+    },
+    {
+      "community": 207,
+      "file_type": "code",
+      "id": "activityview_istransitionaction",
+      "label": "isTransitionAction()",
+      "norm_label": "istransitionaction()",
+      "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
+      "source_location": "L53"
+    },
+    {
+      "community": 207,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_activityview_tsx",
+      "label": "ActivityView.tsx",
+      "norm_label": "activityview.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 208,
+      "file_type": "code",
+      "id": "orderdetailsview_fetchtransactions",
+      "label": "fetchTransactions()",
+      "norm_label": "fetchtransactions()",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
+      "source_location": "L140"
+    },
+    {
+      "community": 208,
+      "file_type": "code",
+      "id": "orderdetailsview_handlemarkasverified",
+      "label": "handleMarkAsVerified()",
+      "norm_label": "handlemarkasverified()",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
+      "source_location": "L177"
+    },
+    {
+      "community": 208,
+      "file_type": "code",
+      "id": "orderdetailsview_handlemarkpaymentcollected",
+      "label": "handleMarkPaymentCollected()",
+      "norm_label": "handlemarkpaymentcollected()",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
+      "source_location": "L195"
+    },
+    {
+      "community": 208,
+      "file_type": "code",
+      "id": "orderdetailsview_verifiedbadge",
+      "label": "VerifiedBadge()",
+      "norm_label": "verifiedbadge()",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
+      "source_location": "L45"
+    },
+    {
+      "community": 208,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_orderdetailsview_tsx",
+      "label": "OrderDetailsView.tsx",
+      "norm_label": "orderdetailsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
+      "source_location": "L1"
     },
     {
       "community": 209,
       "file_type": "code",
-      "id": "ordersummary_test_stripwhitespace",
-      "label": "stripWhitespace()",
-      "norm_label": "stripwhitespace()",
-      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.test.tsx",
-      "source_location": "L36"
+      "id": "orderitemsview_handlerequestfeedback",
+      "label": "handleRequestFeedback()",
+      "norm_label": "handlerequestfeedback()",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
+      "source_location": "L92"
     },
     {
       "community": 209,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_ordersummary_test_tsx",
-      "label": "OrderSummary.test.tsx",
-      "norm_label": "ordersummary.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.test.tsx",
+      "id": "orderitemsview_handlerestockall",
+      "label": "handleRestockAll()",
+      "norm_label": "handlerestockall()",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
+      "source_location": "L307"
+    },
+    {
+      "community": 209,
+      "file_type": "code",
+      "id": "orderitemsview_handlereturnitemtostock",
+      "label": "handleReturnItemToStock()",
+      "norm_label": "handlereturnitemtostock()",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
+      "source_location": "L70"
+    },
+    {
+      "community": 209,
+      "file_type": "code",
+      "id": "orderitemsview_handleupdateorderitem",
+      "label": "handleUpdateOrderItem()",
+      "norm_label": "handleupdateorderitem()",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
+      "source_location": "L50"
+    },
+    {
+      "community": 209,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_orderitemsview_tsx",
+      "label": "OrderItemsView.tsx",
+      "norm_label": "orderitemsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
       "source_location": "L1"
     },
     {
@@ -71514,6 +71688,51 @@
     {
       "community": 210,
       "file_type": "code",
+      "id": "ordersummary_test_getbalancedueamount",
+      "label": "getBalanceDueAmount()",
+      "norm_label": "getbalancedueamount()",
+      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.test.tsx",
+      "source_location": "L40"
+    },
+    {
+      "community": 210,
+      "file_type": "code",
+      "id": "ordersummary_test_getbalanceduelabel",
+      "label": "getBalanceDueLabel()",
+      "norm_label": "getbalanceduelabel()",
+      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.test.tsx",
+      "source_location": "L57"
+    },
+    {
+      "community": 210,
+      "file_type": "code",
+      "id": "ordersummary_test_getbalanceduepanel",
+      "label": "getBalanceDuePanel()",
+      "norm_label": "getbalanceduepanel()",
+      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.test.tsx",
+      "source_location": "L66"
+    },
+    {
+      "community": 210,
+      "file_type": "code",
+      "id": "ordersummary_test_stripwhitespace",
+      "label": "stripWhitespace()",
+      "norm_label": "stripwhitespace()",
+      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.test.tsx",
+      "source_location": "L36"
+    },
+    {
+      "community": 210,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_ordersummary_test_tsx",
+      "label": "OrderSummary.test.tsx",
+      "norm_label": "ordersummary.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 211,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_paymentsaddedlist_test_tsx",
       "label": "PaymentsAddedList.test.tsx",
       "norm_label": "paymentsaddedlist.test.tsx",
@@ -71521,7 +71740,7 @@
       "source_location": "L1"
     },
     {
-      "community": 210,
+      "community": 211,
       "file_type": "code",
       "id": "paymentsaddedlist_test_getsummaryamount",
       "label": "getSummaryAmount()",
@@ -71530,7 +71749,7 @@
       "source_location": "L27"
     },
     {
-      "community": 210,
+      "community": 211,
       "file_type": "code",
       "id": "paymentsaddedlist_test_getsummarylabel",
       "label": "getSummaryLabel()",
@@ -71539,7 +71758,7 @@
       "source_location": "L18"
     },
     {
-      "community": 210,
+      "community": 211,
       "file_type": "code",
       "id": "paymentsaddedlist_test_getsummarypanel",
       "label": "getSummaryPanel()",
@@ -71548,7 +71767,7 @@
       "source_location": "L40"
     },
     {
-      "community": 210,
+      "community": 211,
       "file_type": "code",
       "id": "paymentsaddedlist_test_stripwhitespace",
       "label": "stripWhitespace()",
@@ -71557,7 +71776,7 @@
       "source_location": "L14"
     },
     {
-      "community": 211,
+      "community": 212,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_productentry_tsx",
       "label": "ProductEntry.tsx",
@@ -71566,7 +71785,7 @@
       "source_location": "L1"
     },
     {
-      "community": 211,
+      "community": 212,
       "file_type": "code",
       "id": "productentry_handleclearsearch",
       "label": "handleClearSearch()",
@@ -71575,7 +71794,7 @@
       "source_location": "L234"
     },
     {
-      "community": 211,
+      "community": 212,
       "file_type": "code",
       "id": "productentry_handleopenquickadd",
       "label": "handleOpenQuickAdd()",
@@ -71584,7 +71803,7 @@
       "source_location": "L239"
     },
     {
-      "community": 211,
+      "community": 212,
       "file_type": "code",
       "id": "productentry_handlequickaddsubmit",
       "label": "handleQuickAddSubmit()",
@@ -71593,7 +71812,7 @@
       "source_location": "L272"
     },
     {
-      "community": 211,
+      "community": 212,
       "file_type": "code",
       "id": "productentry_resetquickaddform",
       "label": "resetQuickAddForm()",
@@ -71602,7 +71821,7 @@
       "source_location": "L263"
     },
     {
-      "community": 212,
+      "community": 213,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_registerdrawergate_tsx",
       "label": "RegisterDrawerGate.tsx",
@@ -71611,7 +71830,7 @@
       "source_location": "L1"
     },
     {
-      "community": 212,
+      "community": 213,
       "file_type": "code",
       "id": "registerdrawergate_handlecloseoutsubmit",
       "label": "handleCloseoutSubmit()",
@@ -71620,7 +71839,7 @@
       "source_location": "L80"
     },
     {
-      "community": 212,
+      "community": 213,
       "file_type": "code",
       "id": "registerdrawergate_handleopeningfloatcorrectionsubmit",
       "label": "handleOpeningFloatCorrectionSubmit()",
@@ -71629,7 +71848,7 @@
       "source_location": "L84"
     },
     {
-      "community": 212,
+      "community": 213,
       "file_type": "code",
       "id": "registerdrawergate_handlesubmit",
       "label": "handleSubmit()",
@@ -71638,7 +71857,7 @@
       "source_location": "L73"
     },
     {
-      "community": 212,
+      "community": 213,
       "file_type": "code",
       "id": "registerdrawergate_if",
       "label": "if()",
@@ -71647,7 +71866,7 @@
       "source_location": "L61"
     },
     {
-      "community": 213,
+      "community": 214,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodeview_tsx",
       "label": "PromoCodeView.tsx",
@@ -71656,7 +71875,7 @@
       "source_location": "L1"
     },
     {
-      "community": 213,
+      "community": 214,
       "file_type": "code",
       "id": "promocodeview_handleaddpromocode",
       "label": "handleAddPromoCode()",
@@ -71665,7 +71884,7 @@
       "source_location": "L157"
     },
     {
-      "community": 213,
+      "community": 214,
       "file_type": "code",
       "id": "promocodeview_handleupdatepromocode",
       "label": "handleUpdatePromoCode()",
@@ -71674,7 +71893,7 @@
       "source_location": "L230"
     },
     {
-      "community": 213,
+      "community": 214,
       "file_type": "code",
       "id": "promocodeview_updatehomepagediscountcode",
       "label": "updateHomepageDiscountCode()",
@@ -71683,7 +71902,7 @@
       "source_location": "L322"
     },
     {
-      "community": 213,
+      "community": 214,
       "file_type": "code",
       "id": "promocodeview_updateleaveareviewdiscountcode",
       "label": "updateLeaveAReviewDiscountCode()",
@@ -71692,7 +71911,7 @@
       "source_location": "L377"
     },
     {
-      "community": 214,
+      "community": 215,
       "file_type": "code",
       "id": "date_time_picker_handleclear",
       "label": "handleClear()",
@@ -71701,7 +71920,7 @@
       "source_location": "L99"
     },
     {
-      "community": 214,
+      "community": 215,
       "file_type": "code",
       "id": "date_time_picker_handledateselect",
       "label": "handleDateSelect()",
@@ -71710,7 +71929,7 @@
       "source_location": "L53"
     },
     {
-      "community": 214,
+      "community": 215,
       "file_type": "code",
       "id": "date_time_picker_handletimeblur",
       "label": "handleTimeBlur()",
@@ -71719,7 +71938,7 @@
       "source_location": "L75"
     },
     {
-      "community": 214,
+      "community": 215,
       "file_type": "code",
       "id": "date_time_picker_handletimechange",
       "label": "handleTimeChange()",
@@ -71728,7 +71947,7 @@
       "source_location": "L63"
     },
     {
-      "community": 214,
+      "community": 215,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_date_time_picker_tsx",
       "label": "date-time-picker.tsx",
@@ -71737,7 +71956,7 @@
       "source_location": "L1"
     },
     {
-      "community": 215,
+      "community": 216,
       "file_type": "code",
       "id": "custom_modal_example_basicmodalexample",
       "label": "BasicModalExample()",
@@ -71746,7 +71965,7 @@
       "source_location": "L7"
     },
     {
-      "community": 215,
+      "community": 216,
       "file_type": "code",
       "id": "custom_modal_example_customclosebuttonexample",
       "label": "CustomCloseButtonExample()",
@@ -71755,7 +71974,7 @@
       "source_location": "L69"
     },
     {
-      "community": 215,
+      "community": 216,
       "file_type": "code",
       "id": "custom_modal_example_custompositionmodalexample",
       "label": "CustomPositionModalExample()",
@@ -71764,7 +71983,7 @@
       "source_location": "L44"
     },
     {
-      "community": 215,
+      "community": 216,
       "file_type": "code",
       "id": "custom_modal_example_fullscreenmodalexample",
       "label": "FullScreenModalExample()",
@@ -71773,7 +71992,7 @@
       "source_location": "L103"
     },
     {
-      "community": 215,
+      "community": 216,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_custom_modal_example_tsx",
       "label": "custom-modal-example.tsx",
@@ -71782,7 +72001,7 @@
       "source_location": "L1"
     },
     {
-      "community": 216,
+      "community": 217,
       "file_type": "code",
       "id": "config_getruntimeorigin",
       "label": "getRuntimeOrigin()",
@@ -71791,7 +72010,7 @@
       "source_location": "L12"
     },
     {
-      "community": 216,
+      "community": 217,
       "file_type": "code",
       "id": "config_islocalhost",
       "label": "isLocalHost()",
@@ -71800,7 +72019,7 @@
       "source_location": "L20"
     },
     {
-      "community": 216,
+      "community": 217,
       "file_type": "code",
       "id": "config_resolvestorefronturl",
       "label": "resolveStoreFrontUrl()",
@@ -71809,7 +72028,7 @@
       "source_location": "L24"
     },
     {
-      "community": 216,
+      "community": 217,
       "file_type": "code",
       "id": "config_trimtrailingslash",
       "label": "trimTrailingSlash()",
@@ -71818,7 +72037,7 @@
       "source_location": "L8"
     },
     {
-      "community": 216,
+      "community": 217,
       "file_type": "code",
       "id": "packages_athena_webapp_src_config_ts",
       "label": "config.ts",
@@ -71827,7 +72046,7 @@
       "source_location": "L1"
     },
     {
-      "community": 217,
+      "community": 218,
       "file_type": "code",
       "id": "browserfingerprint_buffertohex",
       "label": "bufferToHex()",
@@ -71836,7 +72055,7 @@
       "source_location": "L18"
     },
     {
-      "community": 217,
+      "community": 218,
       "file_type": "code",
       "id": "browserfingerprint_collectbrowserinfo",
       "label": "collectBrowserInfo()",
@@ -71845,7 +72064,7 @@
       "source_location": "L23"
     },
     {
-      "community": 217,
+      "community": 218,
       "file_type": "code",
       "id": "browserfingerprint_generatebrowserfingerprint",
       "label": "generateBrowserFingerprint()",
@@ -71854,7 +72073,7 @@
       "source_location": "L65"
     },
     {
-      "community": 217,
+      "community": 218,
       "file_type": "code",
       "id": "browserfingerprint_hashfingerprintsource",
       "label": "hashFingerprintSource()",
@@ -71863,7 +72082,7 @@
       "source_location": "L45"
     },
     {
-      "community": 217,
+      "community": 218,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_browserfingerprint_ts",
       "label": "browserFingerprint.ts",
@@ -71872,7 +72091,7 @@
       "source_location": "L1"
     },
     {
-      "community": 218,
+      "community": 219,
       "file_type": "code",
       "id": "imageutils_test_arraybuffer",
       "label": "arrayBuffer()",
@@ -71881,7 +72100,7 @@
       "source_location": "L78"
     },
     {
-      "community": 218,
+      "community": 219,
       "file_type": "code",
       "id": "imageutils_test_constructor",
       "label": "constructor()",
@@ -71890,7 +72109,7 @@
       "source_location": "L74"
     },
     {
-      "community": 218,
+      "community": 219,
       "file_type": "code",
       "id": "imageutils_test_mockimage",
       "label": "MockImage",
@@ -71899,7 +72118,7 @@
       "source_location": "L103"
     },
     {
-      "community": 218,
+      "community": 219,
       "file_type": "code",
       "id": "imageutils_test_mockimage_src",
       "label": ".src()",
@@ -71908,57 +72127,12 @@
       "source_location": "L109"
     },
     {
-      "community": 218,
+      "community": 219,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_imageutils_test_ts",
       "label": "imageUtils.test.ts",
       "norm_label": "imageutils.test.ts",
       "source_file": "packages/athena-webapp/src/lib/imageUtils.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 219,
-      "file_type": "code",
-      "id": "imageutils_convertimagestojpg",
-      "label": "convertImagesToJpg()",
-      "norm_label": "convertimagestojpg()",
-      "source_file": "packages/athena-webapp/src/lib/imageUtils.ts",
-      "source_location": "L75"
-    },
-    {
-      "community": 219,
-      "file_type": "code",
-      "id": "imageutils_convertimagestowebp",
-      "label": "convertImagesToWebp()",
-      "norm_label": "convertimagestowebp()",
-      "source_file": "packages/athena-webapp/src/lib/imageUtils.ts",
-      "source_location": "L26"
-    },
-    {
-      "community": 219,
-      "file_type": "code",
-      "id": "imageutils_converttojpg",
-      "label": "convertToJpg()",
-      "norm_label": "converttojpg()",
-      "source_file": "packages/athena-webapp/src/lib/imageUtils.ts",
-      "source_location": "L38"
-    },
-    {
-      "community": 219,
-      "file_type": "code",
-      "id": "imageutils_getuploadimagesdata",
-      "label": "getUploadImagesData()",
-      "norm_label": "getuploadimagesdata()",
-      "source_file": "packages/athena-webapp/src/lib/imageUtils.ts",
-      "source_location": "L4"
-    },
-    {
-      "community": 219,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_imageutils_ts",
-      "label": "imageUtils.ts",
-      "norm_label": "imageutils.ts",
-      "source_file": "packages/athena-webapp/src/lib/imageUtils.ts",
       "source_location": "L1"
     },
     {
@@ -72144,6 +72318,51 @@
     {
       "community": 220,
       "file_type": "code",
+      "id": "imageutils_convertimagestojpg",
+      "label": "convertImagesToJpg()",
+      "norm_label": "convertimagestojpg()",
+      "source_file": "packages/athena-webapp/src/lib/imageUtils.ts",
+      "source_location": "L75"
+    },
+    {
+      "community": 220,
+      "file_type": "code",
+      "id": "imageutils_convertimagestowebp",
+      "label": "convertImagesToWebp()",
+      "norm_label": "convertimagestowebp()",
+      "source_file": "packages/athena-webapp/src/lib/imageUtils.ts",
+      "source_location": "L26"
+    },
+    {
+      "community": 220,
+      "file_type": "code",
+      "id": "imageutils_converttojpg",
+      "label": "convertToJpg()",
+      "norm_label": "converttojpg()",
+      "source_file": "packages/athena-webapp/src/lib/imageUtils.ts",
+      "source_location": "L38"
+    },
+    {
+      "community": 220,
+      "file_type": "code",
+      "id": "imageutils_getuploadimagesdata",
+      "label": "getUploadImagesData()",
+      "norm_label": "getuploadimagesdata()",
+      "source_file": "packages/athena-webapp/src/lib/imageUtils.ts",
+      "source_location": "L4"
+    },
+    {
+      "community": 220,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_imageutils_ts",
+      "label": "imageUtils.ts",
+      "norm_label": "imageutils.ts",
+      "source_file": "packages/athena-webapp/src/lib/imageUtils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 221,
+      "file_type": "code",
       "id": "cart_calculateposcarttotals",
       "label": "calculatePosCartTotals()",
       "norm_label": "calculateposcarttotals()",
@@ -72151,7 +72370,7 @@
       "source_location": "L3"
     },
     {
-      "community": 220,
+      "community": 221,
       "file_type": "code",
       "id": "cart_calculatepositemtotal",
       "label": "calculatePosItemTotal()",
@@ -72160,7 +72379,7 @@
       "source_location": "L29"
     },
     {
-      "community": 220,
+      "community": 221,
       "file_type": "code",
       "id": "cart_getposeffectiveprice",
       "label": "getPosEffectivePrice()",
@@ -72169,7 +72388,7 @@
       "source_location": "L33"
     },
     {
-      "community": 220,
+      "community": 221,
       "file_type": "code",
       "id": "cart_roundposamount",
       "label": "roundPosAmount()",
@@ -72178,7 +72397,7 @@
       "source_location": "L40"
     },
     {
-      "community": 220,
+      "community": 221,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_domain_cart_ts",
       "label": "cart.ts",
@@ -72187,7 +72406,7 @@
       "source_location": "L1"
     },
     {
-      "community": 221,
+      "community": 222,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_registergateway_ts",
       "label": "registerGateway.ts",
@@ -72196,7 +72415,7 @@
       "source_location": "L1"
     },
     {
-      "community": 221,
+      "community": 222,
       "file_type": "code",
       "id": "registergateway_mapregisterstatedto",
       "label": "mapRegisterStateDto()",
@@ -72205,7 +72424,7 @@
       "source_location": "L12"
     },
     {
-      "community": 221,
+      "community": 222,
       "file_type": "code",
       "id": "registergateway_mapterminaldto",
       "label": "mapTerminalDto()",
@@ -72214,7 +72433,7 @@
       "source_location": "L30"
     },
     {
-      "community": 221,
+      "community": 222,
       "file_type": "code",
       "id": "registergateway_useconvexregisterstate",
       "label": "useConvexRegisterState()",
@@ -72223,7 +72442,7 @@
       "source_location": "L36"
     },
     {
-      "community": 221,
+      "community": 222,
       "file_type": "code",
       "id": "registergateway_useconvexterminalbyfingerprint",
       "label": "useConvexTerminalByFingerprint()",
@@ -72232,7 +72451,7 @@
       "source_location": "L58"
     },
     {
-      "community": 222,
+      "community": 223,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_transactionutils_ts",
       "label": "transactionUtils.ts",
@@ -72241,7 +72460,7 @@
       "source_location": "L1"
     },
     {
-      "community": 222,
+      "community": 223,
       "file_type": "code",
       "id": "transactionutils_calculatechange",
       "label": "calculateChange()",
@@ -72250,7 +72469,7 @@
       "source_location": "L42"
     },
     {
-      "community": 222,
+      "community": 223,
       "file_type": "code",
       "id": "transactionutils_formatcurrency",
       "label": "formatCurrency()",
@@ -72259,7 +72478,7 @@
       "source_location": "L29"
     },
     {
-      "community": 222,
+      "community": 223,
       "file_type": "code",
       "id": "transactionutils_formattimestamp",
       "label": "formatTimestamp()",
@@ -72268,7 +72487,7 @@
       "source_location": "L49"
     },
     {
-      "community": 222,
+      "community": 223,
       "file_type": "code",
       "id": "transactionutils_generatetransactionnumber",
       "label": "generateTransactionNumber()",
@@ -72277,7 +72496,7 @@
       "source_location": "L14"
     },
     {
-      "community": 223,
+      "community": 224,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_timelineutils_ts",
       "label": "timelineUtils.ts",
@@ -72286,7 +72505,7 @@
       "source_location": "L1"
     },
     {
-      "community": 223,
+      "community": 224,
       "file_type": "code",
       "id": "timelineutils_enrichtimelineevent",
       "label": "enrichTimelineEvent()",
@@ -72295,7 +72514,7 @@
       "source_location": "L184"
     },
     {
-      "community": 223,
+      "community": 224,
       "file_type": "code",
       "id": "timelineutils_enrichtimelineevents",
       "label": "enrichTimelineEvents()",
@@ -72304,7 +72523,7 @@
       "source_location": "L200"
     },
     {
-      "community": 223,
+      "community": 224,
       "file_type": "code",
       "id": "timelineutils_gettimerangelabel",
       "label": "getTimeRangeLabel()",
@@ -72313,7 +72532,7 @@
       "source_location": "L244"
     },
     {
-      "community": 223,
+      "community": 224,
       "file_type": "code",
       "id": "timelineutils_groupeventsbytimeframe",
       "label": "groupEventsByTimeframe()",
@@ -72322,7 +72541,7 @@
       "source_location": "L206"
     },
     {
-      "community": 224,
+      "community": 225,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_procurement_index_tsx",
       "label": "procurement.index.tsx",
@@ -72331,43 +72550,43 @@
       "source_location": "L1"
     },
     {
-      "community": 224,
+      "community": 225,
       "file_type": "code",
       "id": "procurement_index_getnextprocurementmodesearch",
       "label": "getNextProcurementModeSearch()",
       "norm_label": "getnextprocurementmodesearch()",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/procurement.index.tsx",
-      "source_location": "L13"
+      "source_location": "L16"
     },
     {
-      "community": 224,
+      "community": 225,
       "file_type": "code",
       "id": "procurement_index_getnextprocurementpagesearch",
       "label": "getNextProcurementPageSearch()",
       "norm_label": "getnextprocurementpagesearch()",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/procurement.index.tsx",
-      "source_location": "L31"
+      "source_location": "L34"
     },
     {
-      "community": 224,
+      "community": 225,
       "file_type": "code",
       "id": "procurement_index_getnextprocurementselectedskusearch",
       "label": "getNextProcurementSelectedSkuSearch()",
       "norm_label": "getnextprocurementselectedskusearch()",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/procurement.index.tsx",
-      "source_location": "L41"
+      "source_location": "L44"
     },
     {
-      "community": 224,
+      "community": 225,
       "file_type": "code",
       "id": "procurement_index_procurementroute",
       "label": "ProcurementRoute()",
       "norm_label": "procurementroute()",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/procurement.index.tsx",
-      "source_location": "L67"
+      "source_location": "L70"
     },
     {
-      "community": 225,
+      "community": 226,
       "file_type": "code",
       "id": "authed_authedcomponent",
       "label": "AuthedComponent()",
@@ -72376,7 +72595,7 @@
       "source_location": "L29"
     },
     {
-      "community": 225,
+      "community": 226,
       "file_type": "code",
       "id": "authed_layout",
       "label": "Layout()",
@@ -72385,7 +72604,7 @@
       "source_location": "L99"
     },
     {
-      "community": 225,
+      "community": 226,
       "file_type": "code",
       "id": "authed_topbar",
       "label": "TopBar()",
@@ -72394,7 +72613,7 @@
       "source_location": "L74"
     },
     {
-      "community": 225,
+      "community": 226,
       "file_type": "code",
       "id": "authed_usermenu",
       "label": "UserMenu()",
@@ -72403,7 +72622,7 @@
       "source_location": "L39"
     },
     {
-      "community": 225,
+      "community": 226,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_tsx",
       "label": "_authed.tsx",
@@ -72412,7 +72631,7 @@
       "source_location": "L1"
     },
     {
-      "community": 226,
+      "community": 227,
       "file_type": "code",
       "id": "layout_completependingauthsync",
       "label": "completePendingAuthSync()",
@@ -72421,7 +72640,7 @@
       "source_location": "L114"
     },
     {
-      "community": 226,
+      "community": 227,
       "file_type": "code",
       "id": "layout_handlependingauthsync",
       "label": "handlePendingAuthSync()",
@@ -72430,7 +72649,7 @@
       "source_location": "L81"
     },
     {
-      "community": 226,
+      "community": 227,
       "file_type": "code",
       "id": "layout_sleep",
       "label": "sleep()",
@@ -72439,7 +72658,7 @@
       "source_location": "L23"
     },
     {
-      "community": 226,
+      "community": 227,
       "file_type": "code",
       "id": "layout_usedocumentscrolllock",
       "label": "useDocumentScrollLock()",
@@ -72448,7 +72667,7 @@
       "source_location": "L27"
     },
     {
-      "community": 226,
+      "community": 227,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_login_layout_tsx",
       "label": "_layout.tsx",
@@ -72457,7 +72676,7 @@
       "source_location": "L1"
     },
     {
-      "community": 227,
+      "community": 228,
       "file_type": "code",
       "id": "analytics_getproductviewcount",
       "label": "getProductViewCount()",
@@ -72466,7 +72685,7 @@
       "source_location": "L93"
     },
     {
-      "community": 227,
+      "community": 228,
       "file_type": "code",
       "id": "analytics_logout",
       "label": "logout()",
@@ -72475,7 +72694,7 @@
       "source_location": "L75"
     },
     {
-      "community": 227,
+      "community": 228,
       "file_type": "code",
       "id": "analytics_postanalytics",
       "label": "postAnalytics()",
@@ -72484,7 +72703,7 @@
       "source_location": "L4"
     },
     {
-      "community": 227,
+      "community": 228,
       "file_type": "code",
       "id": "analytics_updateanalyticsowner",
       "label": "updateAnalyticsOwner()",
@@ -72493,7 +72712,7 @@
       "source_location": "L47"
     },
     {
-      "community": 227,
+      "community": 228,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_analytics_ts",
       "label": "analytics.ts",
@@ -72502,7 +72721,7 @@
       "source_location": "L1"
     },
     {
-      "community": 228,
+      "community": 229,
       "file_type": "code",
       "id": "category_getallcategories",
       "label": "getAllCategories()",
@@ -72511,7 +72730,7 @@
       "source_location": "L11"
     },
     {
-      "community": 228,
+      "community": 229,
       "file_type": "code",
       "id": "category_getallcategorieswithsubcategories",
       "label": "getAllCategoriesWithSubcategories()",
@@ -72520,7 +72739,7 @@
       "source_location": "L25"
     },
     {
-      "community": 228,
+      "community": 229,
       "file_type": "code",
       "id": "category_getbaseurl",
       "label": "getBaseUrl()",
@@ -72529,7 +72748,7 @@
       "source_location": "L9"
     },
     {
-      "community": 228,
+      "community": 229,
       "file_type": "code",
       "id": "category_getcategory",
       "label": "getCategory()",
@@ -72538,57 +72757,12 @@
       "source_location": "L39"
     },
     {
-      "community": 228,
+      "community": 229,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_category_ts",
       "label": "category.ts",
       "norm_label": "category.ts",
       "source_file": "packages/storefront-webapp/src/api/category.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 229,
-      "file_type": "code",
-      "id": "onlineorder_getbaseurl",
-      "label": "getBaseUrl()",
-      "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/onlineOrder.ts",
-      "source_location": "L4"
-    },
-    {
-      "community": 229,
-      "file_type": "code",
-      "id": "onlineorder_getorder",
-      "label": "getOrder()",
-      "norm_label": "getorder()",
-      "source_file": "packages/storefront-webapp/src/api/onlineOrder.ts",
-      "source_location": "L24"
-    },
-    {
-      "community": 229,
-      "file_type": "code",
-      "id": "onlineorder_getorders",
-      "label": "getOrders()",
-      "norm_label": "getorders()",
-      "source_file": "packages/storefront-webapp/src/api/onlineOrder.ts",
-      "source_location": "L6"
-    },
-    {
-      "community": 229,
-      "file_type": "code",
-      "id": "onlineorder_updateordersowner",
-      "label": "updateOrdersOwner()",
-      "norm_label": "updateordersowner()",
-      "source_file": "packages/storefront-webapp/src/api/onlineOrder.ts",
-      "source_location": "L42"
-    },
-    {
-      "community": 229,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_onlineorder_ts",
-      "label": "onlineOrder.ts",
-      "norm_label": "onlineorder.ts",
-      "source_file": "packages/storefront-webapp/src/api/onlineOrder.ts",
       "source_location": "L1"
     },
     {
@@ -72774,6 +72948,51 @@
     {
       "community": 230,
       "file_type": "code",
+      "id": "onlineorder_getbaseurl",
+      "label": "getBaseUrl()",
+      "norm_label": "getbaseurl()",
+      "source_file": "packages/storefront-webapp/src/api/onlineOrder.ts",
+      "source_location": "L4"
+    },
+    {
+      "community": 230,
+      "file_type": "code",
+      "id": "onlineorder_getorder",
+      "label": "getOrder()",
+      "norm_label": "getorder()",
+      "source_file": "packages/storefront-webapp/src/api/onlineOrder.ts",
+      "source_location": "L24"
+    },
+    {
+      "community": 230,
+      "file_type": "code",
+      "id": "onlineorder_getorders",
+      "label": "getOrders()",
+      "norm_label": "getorders()",
+      "source_file": "packages/storefront-webapp/src/api/onlineOrder.ts",
+      "source_location": "L6"
+    },
+    {
+      "community": 230,
+      "file_type": "code",
+      "id": "onlineorder_updateordersowner",
+      "label": "updateOrdersOwner()",
+      "norm_label": "updateordersowner()",
+      "source_file": "packages/storefront-webapp/src/api/onlineOrder.ts",
+      "source_location": "L42"
+    },
+    {
+      "community": 230,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_api_onlineorder_ts",
+      "label": "onlineOrder.ts",
+      "norm_label": "onlineorder.ts",
+      "source_file": "packages/storefront-webapp/src/api/onlineOrder.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 231,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_api_storefrontuser_ts",
       "label": "storeFrontUser.ts",
       "norm_label": "storefrontuser.ts",
@@ -72781,7 +73000,7 @@
       "source_location": "L1"
     },
     {
-      "community": 230,
+      "community": 231,
       "file_type": "code",
       "id": "storefrontuser_getactiveuser",
       "label": "getActiveUser()",
@@ -72790,7 +73009,7 @@
       "source_location": "L28"
     },
     {
-      "community": 230,
+      "community": 231,
       "file_type": "code",
       "id": "storefrontuser_getbaseurl",
       "label": "getBaseUrl()",
@@ -72799,7 +73018,7 @@
       "source_location": "L5"
     },
     {
-      "community": 230,
+      "community": 231,
       "file_type": "code",
       "id": "storefrontuser_getguest",
       "label": "getGuest()",
@@ -72808,7 +73027,7 @@
       "source_location": "L7"
     },
     {
-      "community": 230,
+      "community": 231,
       "file_type": "code",
       "id": "storefrontuser_updateuser",
       "label": "updateUser()",
@@ -72817,7 +73036,7 @@
       "source_location": "L46"
     },
     {
-      "community": 231,
+      "community": 232,
       "file_type": "code",
       "id": "homepage_enableprompts",
       "label": "enablePrompts()",
@@ -72826,7 +73045,7 @@
       "source_location": "L147"
     },
     {
-      "community": 231,
+      "community": 232,
       "file_type": "code",
       "id": "homepage_handleclickonleavereviewbutton",
       "label": "handleClickOnLeaveReviewButton()",
@@ -72835,7 +73054,7 @@
       "source_location": "L186"
     },
     {
-      "community": 231,
+      "community": 232,
       "file_type": "code",
       "id": "homepage_handlescroll",
       "label": "handleScroll()",
@@ -72844,7 +73063,7 @@
       "source_location": "L115"
     },
     {
-      "community": 231,
+      "community": 232,
       "file_type": "code",
       "id": "homepage_homepagereadyshell",
       "label": "HomePageReadyShell()",
@@ -72853,7 +73072,7 @@
       "source_location": "L31"
     },
     {
-      "community": 231,
+      "community": 232,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_homepage_tsx",
       "label": "HomePage.tsx",
@@ -72862,7 +73081,7 @@
       "source_location": "L1"
     },
     {
-      "community": 232,
+      "community": 233,
       "file_type": "code",
       "id": "inventorylevelbadge_lowstockbadge",
       "label": "LowStockBadge()",
@@ -72871,7 +73090,7 @@
       "source_location": "L14"
     },
     {
-      "community": 232,
+      "community": 233,
       "file_type": "code",
       "id": "inventorylevelbadge_sellingfastbadge",
       "label": "SellingFastBadge()",
@@ -72880,7 +73099,7 @@
       "source_location": "L22"
     },
     {
-      "community": 232,
+      "community": 233,
       "file_type": "code",
       "id": "inventorylevelbadge_sellingfastsignal",
       "label": "SellingFastSignal()",
@@ -72889,7 +73108,7 @@
       "source_location": "L30"
     },
     {
-      "community": 232,
+      "community": 233,
       "file_type": "code",
       "id": "inventorylevelbadge_soldoutbadge",
       "label": "SoldOutBadge()",
@@ -72898,7 +73117,7 @@
       "source_location": "L3"
     },
     {
-      "community": 232,
+      "community": 233,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_inventorylevelbadge_tsx",
       "label": "InventoryLevelBadge.tsx",
@@ -72907,7 +73126,7 @@
       "source_location": "L1"
     },
     {
-      "community": 233,
+      "community": 234,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_storefrontfailureobservability_ts",
       "label": "storefrontFailureObservability.ts",
@@ -72916,7 +73135,7 @@
       "source_location": "L1"
     },
     {
-      "community": 233,
+      "community": 234,
       "file_type": "code",
       "id": "storefrontfailureobservability_createstorefrontfailureevent",
       "label": "createStorefrontFailureEvent()",
@@ -72925,7 +73144,7 @@
       "source_location": "L136"
     },
     {
-      "community": 233,
+      "community": 234,
       "file_type": "code",
       "id": "storefrontfailureobservability_emitstorefrontfailure",
       "label": "emitStorefrontFailure()",
@@ -72934,7 +73153,7 @@
       "source_location": "L154"
     },
     {
-      "community": 233,
+      "community": 234,
       "file_type": "code",
       "id": "storefrontfailureobservability_inferstorefrontjourneyfromroute",
       "label": "inferStorefrontJourneyFromRoute()",
@@ -72943,7 +73162,7 @@
       "source_location": "L25"
     },
     {
-      "community": 233,
+      "community": 234,
       "file_type": "code",
       "id": "storefrontfailureobservability_normalizestorefronterror",
       "label": "normalizeStorefrontError()",
@@ -72952,7 +73171,7 @@
       "source_location": "L47"
     },
     {
-      "community": 234,
+      "community": 235,
       "file_type": "code",
       "id": "harness_behavior_test_createbrowser",
       "label": "createBrowser()",
@@ -72961,7 +73180,7 @@
       "source_location": "L52"
     },
     {
-      "community": 234,
+      "community": 235,
       "file_type": "code",
       "id": "harness_behavior_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -72970,7 +73189,7 @@
       "source_location": "L22"
     },
     {
-      "community": 234,
+      "community": 235,
       "file_type": "code",
       "id": "harness_behavior_test_createplaywrightmodule",
       "label": "createPlaywrightModule()",
@@ -72979,7 +73198,7 @@
       "source_location": "L44"
     },
     {
-      "community": 234,
+      "community": 235,
       "file_type": "code",
       "id": "harness_behavior_test_write",
       "label": "write()",
@@ -72988,7 +73207,7 @@
       "source_location": "L16"
     },
     {
-      "community": 234,
+      "community": 235,
       "file_type": "code",
       "id": "scripts_harness_behavior_test_ts",
       "label": "harness-behavior.test.ts",
@@ -72997,7 +73216,7 @@
       "source_location": "L1"
     },
     {
-      "community": 235,
+      "community": 236,
       "file_type": "code",
       "id": "harness_repo_validation_collectharnessrepovalidationselection",
       "label": "collectHarnessRepoValidationSelection()",
@@ -73006,7 +73225,7 @@
       "source_location": "L47"
     },
     {
-      "community": 235,
+      "community": 236,
       "file_type": "code",
       "id": "harness_repo_validation_matchesharnessrepovalidationpath",
       "label": "matchesHarnessRepoValidationPath()",
@@ -73015,7 +73234,7 @@
       "source_location": "L39"
     },
     {
-      "community": 235,
+      "community": 236,
       "file_type": "code",
       "id": "harness_repo_validation_normalizerepopath",
       "label": "normalizeRepoPath()",
@@ -73024,7 +73243,7 @@
       "source_location": "L29"
     },
     {
-      "community": 235,
+      "community": 236,
       "file_type": "code",
       "id": "harness_repo_validation_sortuniquepaths",
       "label": "sortUniquePaths()",
@@ -73033,7 +73252,7 @@
       "source_location": "L33"
     },
     {
-      "community": 235,
+      "community": 236,
       "file_type": "code",
       "id": "scripts_harness_repo_validation_ts",
       "label": "harness-repo-validation.ts",
@@ -73042,7 +73261,7 @@
       "source_location": "L1"
     },
     {
-      "community": 236,
+      "community": 237,
       "file_type": "code",
       "id": "pre_commit_generated_artifacts_test_log",
       "label": "log()",
@@ -73051,7 +73270,7 @@
       "source_location": "L73"
     },
     {
-      "community": 236,
+      "community": 237,
       "file_type": "code",
       "id": "pre_commit_generated_artifacts_test_spawn",
       "label": "spawn()",
@@ -73060,7 +73279,7 @@
       "source_location": "L65"
     },
     {
-      "community": 236,
+      "community": 237,
       "file_type": "code",
       "id": "pre_commit_generated_artifacts_test_withtemprepo",
       "label": "withTempRepo()",
@@ -73069,7 +73288,7 @@
       "source_location": "L14"
     },
     {
-      "community": 236,
+      "community": 237,
       "file_type": "code",
       "id": "pre_commit_generated_artifacts_test_writeconvexapifixture",
       "label": "writeConvexApiFixture()",
@@ -73078,7 +73297,7 @@
       "source_location": "L24"
     },
     {
-      "community": 236,
+      "community": 237,
       "file_type": "code",
       "id": "scripts_pre_commit_generated_artifacts_test_ts",
       "label": "pre-commit-generated-artifacts.test.ts",
@@ -73087,7 +73306,7 @@
       "source_location": "L1"
     },
     {
-      "community": 237,
+      "community": 238,
       "file_type": "code",
       "id": "scripts_worktree_manager_test_ts",
       "label": "worktree-manager.test.ts",
@@ -73096,7 +73315,7 @@
       "source_location": "L1"
     },
     {
-      "community": 237,
+      "community": 238,
       "file_type": "code",
       "id": "worktree_manager_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -73105,7 +73324,7 @@
       "source_location": "L17"
     },
     {
-      "community": 237,
+      "community": 238,
       "file_type": "code",
       "id": "worktree_manager_test_fixtureenv",
       "label": "fixtureEnv()",
@@ -73114,7 +73333,7 @@
       "source_location": "L72"
     },
     {
-      "community": 237,
+      "community": 238,
       "file_type": "code",
       "id": "worktree_manager_test_rungit",
       "label": "runGit()",
@@ -73123,7 +73342,7 @@
       "source_location": "L45"
     },
     {
-      "community": 237,
+      "community": 238,
       "file_type": "code",
       "id": "worktree_manager_test_runworktreemanager",
       "label": "runWorktreeManager()",
@@ -73132,7 +73351,7 @@
       "source_location": "L59"
     },
     {
-      "community": 238,
+      "community": 239,
       "file_type": "code",
       "id": "convexpaginationantipatterncheck_test_createtemproot",
       "label": "createTempRoot()",
@@ -73141,7 +73360,7 @@
       "source_location": "L12"
     },
     {
-      "community": 238,
+      "community": 239,
       "file_type": "code",
       "id": "convexpaginationantipatterncheck_test_runpaginationcheck",
       "label": "runPaginationCheck()",
@@ -73150,7 +73369,7 @@
       "source_location": "L26"
     },
     {
-      "community": 238,
+      "community": 239,
       "file_type": "code",
       "id": "convexpaginationantipatterncheck_test_writeconvexfile",
       "label": "writeConvexFile()",
@@ -73159,48 +73378,12 @@
       "source_location": "L20"
     },
     {
-      "community": 238,
+      "community": 239,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_convexpaginationantipatterncheck_test_ts",
       "label": "convexPaginationAntiPatternCheck.test.ts",
       "norm_label": "convexpaginationantipatterncheck.test.ts",
       "source_file": "packages/athena-webapp/convex/convexPaginationAntiPatternCheck.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 239,
-      "file_type": "code",
-      "id": "domain_maskreceiptphone",
-      "label": "maskReceiptPhone()",
-      "norm_label": "maskreceiptphone()",
-      "source_file": "packages/athena-webapp/convex/customerMessaging/domain.ts",
-      "source_location": "L67"
-    },
-    {
-      "community": 239,
-      "file_type": "code",
-      "id": "domain_normalizereceiptphone",
-      "label": "normalizeReceiptPhone()",
-      "norm_label": "normalizereceiptphone()",
-      "source_file": "packages/athena-webapp/convex/customerMessaging/domain.ts",
-      "source_location": "L52"
-    },
-    {
-      "community": 239,
-      "file_type": "code",
-      "id": "domain_statusisretryable",
-      "label": "statusIsRetryable()",
-      "norm_label": "statusisretryable()",
-      "source_file": "packages/athena-webapp/convex/customerMessaging/domain.ts",
-      "source_location": "L79"
-    },
-    {
-      "community": 239,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_customermessaging_domain_ts",
-      "label": "domain.ts",
-      "norm_label": "domain.ts",
-      "source_file": "packages/athena-webapp/convex/customerMessaging/domain.ts",
       "source_location": "L1"
     },
     {
@@ -73386,6 +73569,42 @@
     {
       "community": 240,
       "file_type": "code",
+      "id": "domain_maskreceiptphone",
+      "label": "maskReceiptPhone()",
+      "norm_label": "maskreceiptphone()",
+      "source_file": "packages/athena-webapp/convex/customerMessaging/domain.ts",
+      "source_location": "L67"
+    },
+    {
+      "community": 240,
+      "file_type": "code",
+      "id": "domain_normalizereceiptphone",
+      "label": "normalizeReceiptPhone()",
+      "norm_label": "normalizereceiptphone()",
+      "source_file": "packages/athena-webapp/convex/customerMessaging/domain.ts",
+      "source_location": "L52"
+    },
+    {
+      "community": 240,
+      "file_type": "code",
+      "id": "domain_statusisretryable",
+      "label": "statusIsRetryable()",
+      "norm_label": "statusisretryable()",
+      "source_file": "packages/athena-webapp/convex/customerMessaging/domain.ts",
+      "source_location": "L79"
+    },
+    {
+      "community": 240,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_customermessaging_domain_ts",
+      "label": "domain.ts",
+      "norm_label": "domain.ts",
+      "source_file": "packages/athena-webapp/convex/customerMessaging/domain.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 241,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_customermessaging_token_ts",
       "label": "token.ts",
       "norm_label": "token.ts",
@@ -73393,7 +73612,7 @@
       "source_location": "L1"
     },
     {
-      "community": 240,
+      "community": 241,
       "file_type": "code",
       "id": "token_createreceiptsharetoken",
       "label": "createReceiptShareToken()",
@@ -73402,7 +73621,7 @@
       "source_location": "L9"
     },
     {
-      "community": 240,
+      "community": 241,
       "file_type": "code",
       "id": "token_hashreceiptsharetoken",
       "label": "hashReceiptShareToken()",
@@ -73411,7 +73630,7 @@
       "source_location": "L15"
     },
     {
-      "community": 240,
+      "community": 241,
       "file_type": "code",
       "id": "token_tohex",
       "label": "toHex()",
@@ -73420,7 +73639,7 @@
       "source_location": "L3"
     },
     {
-      "community": 241,
+      "community": 242,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_customermessaging_webhooksecurity_ts",
       "label": "webhookSecurity.ts",
@@ -73429,7 +73648,7 @@
       "source_location": "L1"
     },
     {
-      "community": 241,
+      "community": 242,
       "file_type": "code",
       "id": "webhooksecurity_timingsafeequal",
       "label": "timingSafeEqual()",
@@ -73438,7 +73657,7 @@
       "source_location": "L9"
     },
     {
-      "community": 241,
+      "community": 242,
       "file_type": "code",
       "id": "webhooksecurity_tohex",
       "label": "toHex()",
@@ -73447,7 +73666,7 @@
       "source_location": "L3"
     },
     {
-      "community": 241,
+      "community": 242,
       "file_type": "code",
       "id": "webhooksecurity_verifymetawebhooksignature",
       "label": "verifyMetaWebhookSignature()",
@@ -73456,7 +73675,7 @@
       "source_location": "L22"
     },
     {
-      "community": 242,
+      "community": 243,
       "file_type": "code",
       "id": "checkout_hasallvisibilesessionitems",
       "label": "hasAllVisibileSessionItems()",
@@ -73465,7 +73684,7 @@
       "source_location": "L109"
     },
     {
-      "community": 242,
+      "community": 243,
       "file_type": "code",
       "id": "checkout_hasvalidcanonicalbagitem",
       "label": "hasValidCanonicalBagItem()",
@@ -73474,7 +73693,7 @@
       "source_location": "L84"
     },
     {
-      "community": 242,
+      "community": 243,
       "file_type": "code",
       "id": "checkout_hasvalidsessionitems",
       "label": "hasValidSessionItems()",
@@ -73483,7 +73702,7 @@
       "source_location": "L95"
     },
     {
-      "community": 242,
+      "community": 243,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_checkout_ts",
       "label": "checkout.ts",
@@ -73492,7 +73711,7 @@
       "source_location": "L1"
     },
     {
-      "community": 243,
+      "community": 244,
       "file_type": "code",
       "id": "expensesessions_test_buildsession",
       "label": "buildSession()",
@@ -73501,7 +73720,7 @@
       "source_location": "L235"
     },
     {
-      "community": 243,
+      "community": 244,
       "file_type": "code",
       "id": "expensesessions_test_createmutationctx",
       "label": "createMutationCtx()",
@@ -73510,7 +73729,7 @@
       "source_location": "L53"
     },
     {
-      "community": 243,
+      "community": 244,
       "file_type": "code",
       "id": "expensesessions_test_gethandler",
       "label": "getHandler()",
@@ -73519,7 +73738,7 @@
       "source_location": "L250"
     },
     {
-      "community": 243,
+      "community": 244,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_expensesessions_test_ts",
       "label": "expenseSessions.test.ts",
@@ -73528,7 +73747,7 @@
       "source_location": "L1"
     },
     {
-      "community": 244,
+      "community": 245,
       "file_type": "code",
       "id": "expensetransactions_createexpensetransactionfromsessionhandler",
       "label": "createExpenseTransactionFromSessionHandler()",
@@ -73537,7 +73756,7 @@
       "source_location": "L50"
     },
     {
-      "community": 244,
+      "community": 245,
       "file_type": "code",
       "id": "expensetransactions_expensetransactionerror",
       "label": "expenseTransactionError()",
@@ -73546,7 +73765,7 @@
       "source_location": "L23"
     },
     {
-      "community": 244,
+      "community": 245,
       "file_type": "code",
       "id": "expensetransactions_formatexpensestaffprofilename",
       "label": "formatExpenseStaffProfileName()",
@@ -73555,7 +73774,7 @@
       "source_location": "L37"
     },
     {
-      "community": 244,
+      "community": 245,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_expensetransactions_ts",
       "label": "expenseTransactions.ts",
@@ -73564,7 +73783,7 @@
       "source_location": "L1"
     },
     {
-      "community": 245,
+      "community": 246,
       "file_type": "code",
       "id": "expensesessionexpiration_calculateexpensesessionexpiration",
       "label": "calculateExpenseSessionExpiration()",
@@ -73573,7 +73792,7 @@
       "source_location": "L21"
     },
     {
-      "community": 245,
+      "community": 246,
       "file_type": "code",
       "id": "expensesessionexpiration_getexpensesessionexpiryduration",
       "label": "getExpenseSessionExpiryDuration()",
@@ -73582,7 +73801,7 @@
       "source_location": "L35"
     },
     {
-      "community": 245,
+      "community": 246,
       "file_type": "code",
       "id": "expensesessionexpiration_getexpensesessionexpirydurationminutes",
       "label": "getExpenseSessionExpiryDurationMinutes()",
@@ -73591,7 +73810,7 @@
       "source_location": "L45"
     },
     {
-      "community": 245,
+      "community": 246,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_helpers_expensesessionexpiration_ts",
       "label": "expenseSessionExpiration.ts",
@@ -73600,7 +73819,7 @@
       "source_location": "L1"
     },
     {
-      "community": 246,
+      "community": 247,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_helpers_sessionexpiration_ts",
       "label": "sessionExpiration.ts",
@@ -73609,7 +73828,7 @@
       "source_location": "L1"
     },
     {
-      "community": 246,
+      "community": 247,
       "file_type": "code",
       "id": "sessionexpiration_calculatesessionexpiration",
       "label": "calculateSessionExpiration()",
@@ -73618,7 +73837,7 @@
       "source_location": "L21"
     },
     {
-      "community": 246,
+      "community": 247,
       "file_type": "code",
       "id": "sessionexpiration_getsessionexpiryduration",
       "label": "getSessionExpiryDuration()",
@@ -73627,7 +73846,7 @@
       "source_location": "L35"
     },
     {
-      "community": 246,
+      "community": 247,
       "file_type": "code",
       "id": "sessionexpiration_getsessionexpirydurationminutes",
       "label": "getSessionExpiryDurationMinutes()",
@@ -73636,7 +73855,7 @@
       "source_location": "L45"
     },
     {
-      "community": 247,
+      "community": 248,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_possessions_trace_test_ts",
       "label": "posSessions.trace.test.ts",
@@ -73645,7 +73864,7 @@
       "source_location": "L1"
     },
     {
-      "community": 247,
+      "community": 248,
       "file_type": "code",
       "id": "possessions_trace_test_buildsession",
       "label": "buildSession()",
@@ -73654,7 +73873,7 @@
       "source_location": "L407"
     },
     {
-      "community": 247,
+      "community": 248,
       "file_type": "code",
       "id": "possessions_trace_test_createmutationctx",
       "label": "createMutationCtx()",
@@ -73663,7 +73882,7 @@
       "source_location": "L161"
     },
     {
-      "community": 247,
+      "community": 248,
       "file_type": "code",
       "id": "possessions_trace_test_gethandler",
       "label": "getHandler()",
@@ -73672,7 +73891,7 @@
       "source_location": "L424"
     },
     {
-      "community": 248,
+      "community": 249,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_products_sku_test_ts",
       "label": "products.sku.test.ts",
@@ -73681,7 +73900,7 @@
       "source_location": "L1"
     },
     {
-      "community": 248,
+      "community": 249,
       "file_type": "code",
       "id": "products_sku_test_createproductsqueryctx",
       "label": "createProductsQueryCtx()",
@@ -73690,7 +73909,7 @@
       "source_location": "L112"
     },
     {
-      "community": 248,
+      "community": 249,
       "file_type": "code",
       "id": "products_sku_test_createskumutationctx",
       "label": "createSkuMutationCtx()",
@@ -73699,49 +73918,13 @@
       "source_location": "L23"
     },
     {
-      "community": 248,
+      "community": 249,
       "file_type": "code",
       "id": "products_sku_test_gethandler",
       "label": "getHandler()",
       "norm_label": "gethandler()",
       "source_file": "packages/athena-webapp/convex/inventory/products.sku.test.ts",
       "source_location": "L19"
-    },
-    {
-      "community": 249,
-      "file_type": "code",
-      "id": "currency_todisplayamount",
-      "label": "toDisplayAmount()",
-      "norm_label": "todisplayamount()",
-      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
-      "source_location": "L5"
-    },
-    {
-      "community": 249,
-      "file_type": "code",
-      "id": "currency_topesewas",
-      "label": "toPesewas()",
-      "norm_label": "topesewas()",
-      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 249,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_lib_currency_ts",
-      "label": "currency.ts",
-      "norm_label": "currency.ts",
-      "source_file": "packages/athena-webapp/convex/lib/currency.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 249,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_currency_ts",
-      "label": "currency.ts",
-      "norm_label": "currency.ts",
-      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
-      "source_location": "L1"
     },
     {
       "community": 25,
@@ -73917,6 +74100,42 @@
     {
       "community": 250,
       "file_type": "code",
+      "id": "currency_todisplayamount",
+      "label": "toDisplayAmount()",
+      "norm_label": "todisplayamount()",
+      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 250,
+      "file_type": "code",
+      "id": "currency_topesewas",
+      "label": "toPesewas()",
+      "norm_label": "topesewas()",
+      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 250,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_lib_currency_ts",
+      "label": "currency.ts",
+      "norm_label": "currency.ts",
+      "source_file": "packages/athena-webapp/convex/lib/currency.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 250,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_currency_ts",
+      "label": "currency.ts",
+      "norm_label": "currency.ts",
+      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 251,
+      "file_type": "code",
       "id": "collections_getcachedtokenrecord",
       "label": "getCachedTokenRecord()",
       "norm_label": "getcachedtokenrecord()",
@@ -73924,7 +74143,7 @@
       "source_location": "L26"
     },
     {
-      "community": 250,
+      "community": 251,
       "file_type": "code",
       "id": "collections_resolveaccesstokenforstore",
       "label": "resolveAccessTokenForStore()",
@@ -73933,7 +74152,7 @@
       "source_location": "L79"
     },
     {
-      "community": 250,
+      "community": 251,
       "file_type": "code",
       "id": "collections_resolveconfigforstore",
       "label": "resolveConfigForStore()",
@@ -73942,7 +74161,7 @@
       "source_location": "L33"
     },
     {
-      "community": 250,
+      "community": 251,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_collections_ts",
       "label": "collections.ts",
@@ -73951,7 +74170,7 @@
       "source_location": "L1"
     },
     {
-      "community": 251,
+      "community": 252,
       "file_type": "code",
       "id": "normalize_maskmtnpartyid",
       "label": "maskMtnPartyId()",
@@ -73960,7 +74179,7 @@
       "source_location": "L10"
     },
     {
-      "community": 251,
+      "community": 252,
       "file_type": "code",
       "id": "normalize_normalizecollectionstransaction",
       "label": "normalizeCollectionsTransaction()",
@@ -73969,7 +74188,7 @@
       "source_location": "L18"
     },
     {
-      "community": 251,
+      "community": 252,
       "file_type": "code",
       "id": "normalize_parsecollectionsnotificationrequest",
       "label": "parseCollectionsNotificationRequest()",
@@ -73978,7 +74197,7 @@
       "source_location": "L52"
     },
     {
-      "community": 251,
+      "community": 252,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_normalize_ts",
       "label": "normalize.ts",
@@ -73987,7 +74206,7 @@
       "source_location": "L1"
     },
     {
-      "community": 252,
+      "community": 253,
       "file_type": "code",
       "id": "approvalproofs_consumeapprovalproofwithctx",
       "label": "consumeApprovalProofWithCtx()",
@@ -73996,7 +74215,7 @@
       "source_location": "L98"
     },
     {
-      "community": 252,
+      "community": 253,
       "file_type": "code",
       "id": "approvalproofs_createapprovalproofwithctx",
       "label": "createApprovalProofWithCtx()",
@@ -74005,7 +74224,7 @@
       "source_location": "L56"
     },
     {
-      "community": 252,
+      "community": 253,
       "file_type": "code",
       "id": "approvalproofs_invalidapprovalproofresult",
       "label": "invalidApprovalProofResult()",
@@ -74014,7 +74233,7 @@
       "source_location": "L49"
     },
     {
-      "community": 252,
+      "community": 253,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_approvalproofs_ts",
       "label": "approvalProofs.ts",
@@ -74023,7 +74242,7 @@
       "source_location": "L1"
     },
     {
-      "community": 253,
+      "community": 254,
       "file_type": "code",
       "id": "operationalevents_buildoperationalevent",
       "label": "buildOperationalEvent()",
@@ -74032,7 +74251,7 @@
       "source_location": "L28"
     },
     {
-      "community": 253,
+      "community": 254,
       "file_type": "code",
       "id": "operationalevents_matchesexistingevent",
       "label": "matchesExistingEvent()",
@@ -74041,7 +74260,7 @@
       "source_location": "L42"
     },
     {
-      "community": 253,
+      "community": 254,
       "file_type": "code",
       "id": "operationalevents_recordoperationaleventwithctx",
       "label": "recordOperationalEventWithCtx()",
@@ -74050,7 +74269,7 @@
       "source_location": "L73"
     },
     {
-      "community": 253,
+      "community": 254,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_operationalevents_ts",
       "label": "operationalEvents.ts",
@@ -74059,7 +74278,7 @@
       "source_location": "L1"
     },
     {
-      "community": 254,
+      "community": 255,
       "file_type": "code",
       "id": "operationalworkitems_buildoperationalworkitem",
       "label": "buildOperationalWorkItem()",
@@ -74068,7 +74287,7 @@
       "source_location": "L13"
     },
     {
-      "community": 254,
+      "community": 255,
       "file_type": "code",
       "id": "operationalworkitems_createoperationalworkitemwithctx",
       "label": "createOperationalWorkItemWithCtx()",
@@ -74077,7 +74296,7 @@
       "source_location": "L37"
     },
     {
-      "community": 254,
+      "community": 255,
       "file_type": "code",
       "id": "operationalworkitems_updateoperationalworkitemstatuswithctx",
       "label": "updateOperationalWorkItemStatusWithCtx()",
@@ -74086,7 +74305,7 @@
       "source_location": "L69"
     },
     {
-      "community": 254,
+      "community": 255,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_operationalworkitems_ts",
       "label": "operationalWorkItems.ts",
@@ -74095,7 +74314,7 @@
       "source_location": "L1"
     },
     {
-      "community": 255,
+      "community": 256,
       "file_type": "code",
       "id": "operationsqueryindexes_test_expectindex",
       "label": "expectIndex()",
@@ -74104,7 +74323,7 @@
       "source_location": "L18"
     },
     {
-      "community": 255,
+      "community": 256,
       "file_type": "code",
       "id": "operationsqueryindexes_test_getsource",
       "label": "getSource()",
@@ -74113,7 +74332,7 @@
       "source_location": "L25"
     },
     {
-      "community": 255,
+      "community": 256,
       "file_type": "code",
       "id": "operationsqueryindexes_test_gettableindexes",
       "label": "getTableIndexes()",
@@ -74122,7 +74341,7 @@
       "source_location": "L11"
     },
     {
-      "community": 255,
+      "community": 256,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_operationsqueryindexes_test_ts",
       "label": "operationsQueryIndexes.test.ts",
@@ -74131,7 +74350,7 @@
       "source_location": "L1"
     },
     {
-      "community": 256,
+      "community": 257,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_registersessiontracing_test_ts",
       "label": "registerSessionTracing.test.ts",
@@ -74140,7 +74359,7 @@
       "source_location": "L1"
     },
     {
-      "community": 256,
+      "community": 257,
       "file_type": "code",
       "id": "registersessiontracing_test_buildctx",
       "label": "buildCtx()",
@@ -74149,7 +74368,7 @@
       "source_location": "L33"
     },
     {
-      "community": 256,
+      "community": 257,
       "file_type": "code",
       "id": "registersessiontracing_test_buildsession",
       "label": "buildSession()",
@@ -74158,7 +74377,7 @@
       "source_location": "L19"
     },
     {
-      "community": 256,
+      "community": 257,
       "file_type": "code",
       "id": "registersessiontracing_test_formatstoredtraceamount",
       "label": "formatStoredTraceAmount()",
@@ -74167,7 +74386,7 @@
       "source_location": "L42"
     },
     {
-      "community": 257,
+      "community": 258,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_registersessions_trace_test_ts",
       "label": "registerSessions.trace.test.ts",
@@ -74176,7 +74395,7 @@
       "source_location": "L1"
     },
     {
-      "community": 257,
+      "community": 258,
       "file_type": "code",
       "id": "registersessions_trace_test_buildregistersession",
       "label": "buildRegisterSession()",
@@ -74185,7 +74404,7 @@
       "source_location": "L31"
     },
     {
-      "community": 257,
+      "community": 258,
       "file_type": "code",
       "id": "registersessions_trace_test_createmutationctx",
       "label": "createMutationCtx()",
@@ -74194,7 +74413,7 @@
       "source_location": "L48"
     },
     {
-      "community": 257,
+      "community": 258,
       "file_type": "code",
       "id": "registersessions_trace_test_gethandler",
       "label": "getHandler()",
@@ -74203,7 +74422,7 @@
       "source_location": "L131"
     },
     {
-      "community": 258,
+      "community": 259,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_serviceintake_ts",
       "label": "serviceIntake.ts",
@@ -74212,7 +74431,7 @@
       "source_location": "L1"
     },
     {
-      "community": 258,
+      "community": 259,
       "file_type": "code",
       "id": "serviceintake_resolveserviceintakecustomerprofile",
       "label": "resolveServiceIntakeCustomerProfile()",
@@ -74221,7 +74440,7 @@
       "source_location": "L37"
     },
     {
-      "community": 258,
+      "community": 259,
       "file_type": "code",
       "id": "serviceintake_splitfullname",
       "label": "splitFullName()",
@@ -74230,49 +74449,13 @@
       "source_location": "L24"
     },
     {
-      "community": 258,
+      "community": 259,
       "file_type": "code",
       "id": "serviceintake_trimoptional",
       "label": "trimOptional()",
       "norm_label": "trimoptional()",
       "source_file": "packages/athena-webapp/convex/operations/serviceIntake.ts",
       "source_location": "L19"
-    },
-    {
-      "community": 259,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_commands_register_ts",
-      "label": "register.ts",
-      "norm_label": "register.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/register.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 259,
-      "file_type": "code",
-      "id": "register_mapopendrawerusererror",
-      "label": "mapOpenDrawerUserError()",
-      "norm_label": "mapopendrawerusererror()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/register.ts",
-      "source_location": "L31"
-    },
-    {
-      "community": 259,
-      "file_type": "code",
-      "id": "register_normalizeregisternumber",
-      "label": "normalizeRegisterNumber()",
-      "norm_label": "normalizeregisternumber()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/register.ts",
-      "source_location": "L26"
-    },
-    {
-      "community": 259,
-      "file_type": "code",
-      "id": "register_opendrawer",
-      "label": "openDrawer()",
-      "norm_label": "opendrawer()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/register.ts",
-      "source_location": "L53"
     },
     {
       "community": 26,
@@ -74448,6 +74631,42 @@
     {
       "community": 260,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_commands_register_ts",
+      "label": "register.ts",
+      "norm_label": "register.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/register.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "register_mapopendrawerusererror",
+      "label": "mapOpenDrawerUserError()",
+      "norm_label": "mapopendrawerusererror()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/register.ts",
+      "source_location": "L31"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "register_normalizeregisternumber",
+      "label": "normalizeRegisterNumber()",
+      "norm_label": "normalizeregisternumber()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/register.ts",
+      "source_location": "L26"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "register_opendrawer",
+      "label": "openDrawer()",
+      "norm_label": "opendrawer()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/register.ts",
+      "source_location": "L53"
+    },
+    {
+      "community": 261,
+      "file_type": "code",
       "id": "opendrawer_test_createdbgetmock",
       "label": "createDbGetMock()",
       "norm_label": "createdbgetmock()",
@@ -74455,7 +74674,7 @@
       "source_location": "L36"
     },
     {
-      "community": 260,
+      "community": 261,
       "file_type": "code",
       "id": "opendrawer_test_createdbmock",
       "label": "createDbMock()",
@@ -74464,7 +74683,7 @@
       "source_location": "L96"
     },
     {
-      "community": 260,
+      "community": 261,
       "file_type": "code",
       "id": "opendrawer_test_createdbquerymock",
       "label": "createDbQueryMock()",
@@ -74473,7 +74692,7 @@
       "source_location": "L71"
     },
     {
-      "community": 260,
+      "community": 261,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_opendrawer_test_ts",
       "label": "openDrawer.test.ts",
@@ -74482,7 +74701,7 @@
       "source_location": "L1"
     },
     {
-      "community": 261,
+      "community": 262,
       "file_type": "code",
       "id": "getregisterstate_buildregisterstate",
       "label": "buildRegisterState()",
@@ -74491,7 +74710,7 @@
       "source_location": "L21"
     },
     {
-      "community": 261,
+      "community": 262,
       "file_type": "code",
       "id": "getregisterstate_getactivesessionconflictforregisterstate",
       "label": "getActiveSessionConflictForRegisterState()",
@@ -74500,7 +74719,7 @@
       "source_location": "L42"
     },
     {
-      "community": 261,
+      "community": 262,
       "file_type": "code",
       "id": "getregisterstate_getregisterstate",
       "label": "getRegisterState()",
@@ -74509,7 +74728,7 @@
       "source_location": "L80"
     },
     {
-      "community": 261,
+      "community": 262,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_queries_getregisterstate_ts",
       "label": "getRegisterState.ts",
@@ -74518,7 +74737,7 @@
       "source_location": "L1"
     },
     {
-      "community": 262,
+      "community": 263,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_queries_searchcatalog_ts",
       "label": "searchCatalog.ts",
@@ -74527,7 +74746,7 @@
       "source_location": "L1"
     },
     {
-      "community": 262,
+      "community": 263,
       "file_type": "code",
       "id": "searchcatalog_lookupbybarcode",
       "label": "lookupByBarcode()",
@@ -74536,7 +74755,7 @@
       "source_location": "L126"
     },
     {
-      "community": 262,
+      "community": 263,
       "file_type": "code",
       "id": "searchcatalog_mapskutocatalogresult",
       "label": "mapSkuToCatalogResult()",
@@ -74545,7 +74764,7 @@
       "source_location": "L34"
     },
     {
-      "community": 262,
+      "community": 263,
       "file_type": "code",
       "id": "searchcatalog_searchproducts",
       "label": "searchProducts()",
@@ -74554,7 +74773,7 @@
       "source_location": "L76"
     },
     {
-      "community": 263,
+      "community": 264,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_sessioncommandrepository_ts",
       "label": "sessionCommandRepository.ts",
@@ -74563,7 +74782,7 @@
       "source_location": "L1"
     },
     {
-      "community": 263,
+      "community": 264,
       "file_type": "code",
       "id": "sessioncommandrepository_collectsessionitemsfrompages",
       "label": "collectSessionItemsFromPages()",
@@ -74572,7 +74791,7 @@
       "source_location": "L159"
     },
     {
-      "community": 263,
+      "community": 264,
       "file_type": "code",
       "id": "sessioncommandrepository_createsessioncommandrepository",
       "label": "createSessionCommandRepository()",
@@ -74581,7 +74800,7 @@
       "source_location": "L56"
     },
     {
-      "community": 263,
+      "community": 264,
       "file_type": "code",
       "id": "sessioncommandrepository_scansessionitembyskuinpages",
       "label": "scanSessionItemBySkuInPages()",
@@ -74590,7 +74809,7 @@
       "source_location": "L177"
     },
     {
-      "community": 264,
+      "community": 265,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_transactions_test_ts",
       "label": "transactions.test.ts",
@@ -74599,7 +74818,7 @@
       "source_location": "L1"
     },
     {
-      "community": 264,
+      "community": 265,
       "file_type": "code",
       "id": "transactions_test_exportreturns",
       "label": "exportReturns()",
@@ -74608,7 +74827,7 @@
       "source_location": "L30"
     },
     {
-      "community": 264,
+      "community": 265,
       "file_type": "code",
       "id": "transactions_test_gethandler",
       "label": "getHandler()",
@@ -74617,7 +74836,7 @@
       "source_location": "L38"
     },
     {
-      "community": 264,
+      "community": 265,
       "file_type": "code",
       "id": "transactions_test_parsevalidator",
       "label": "parseValidator()",
@@ -74626,7 +74845,7 @@
       "source_location": "L34"
     },
     {
-      "community": 265,
+      "community": 266,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_replenishment_test_ts",
       "label": "replenishment.test.ts",
@@ -74635,7 +74854,7 @@
       "source_location": "L1"
     },
     {
-      "community": 265,
+      "community": 266,
       "file_type": "code",
       "id": "replenishment_test_createreplenishmentqueryctx",
       "label": "createReplenishmentQueryCtx()",
@@ -74644,7 +74863,7 @@
       "source_location": "L21"
     },
     {
-      "community": 265,
+      "community": 266,
       "file_type": "code",
       "id": "replenishment_test_getsource",
       "label": "getSource()",
@@ -74653,7 +74872,7 @@
       "source_location": "L7"
     },
     {
-      "community": 265,
+      "community": 266,
       "file_type": "code",
       "id": "replenishment_test_toasynciterable",
       "label": "toAsyncIterable()",
@@ -74662,7 +74881,7 @@
       "source_location": "L11"
     },
     {
-      "community": 266,
+      "community": 267,
       "file_type": "code",
       "id": "commercequeryindexes_test_expectindex",
       "label": "expectIndex()",
@@ -74671,7 +74890,7 @@
       "source_location": "L19"
     },
     {
-      "community": 266,
+      "community": 267,
       "file_type": "code",
       "id": "commercequeryindexes_test_getsource",
       "label": "getSource()",
@@ -74680,7 +74899,7 @@
       "source_location": "L26"
     },
     {
-      "community": 266,
+      "community": 267,
       "file_type": "code",
       "id": "commercequeryindexes_test_gettableindexes",
       "label": "getTableIndexes()",
@@ -74689,7 +74908,7 @@
       "source_location": "L12"
     },
     {
-      "community": 266,
+      "community": 267,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_commercequeryindexes_test_ts",
       "label": "commerceQueryIndexes.test.ts",
@@ -74698,7 +74917,7 @@
       "source_location": "L1"
     },
     {
-      "community": 267,
+      "community": 268,
       "file_type": "code",
       "id": "customerengagementevents_findexistingcustomerprofileid",
       "label": "findExistingCustomerProfileId()",
@@ -74707,7 +74926,7 @@
       "source_location": "L21"
     },
     {
-      "community": 267,
+      "community": 268,
       "file_type": "code",
       "id": "customerengagementevents_getstoreorganizationid",
       "label": "getStoreOrganizationId()",
@@ -74716,7 +74935,7 @@
       "source_location": "L63"
     },
     {
-      "community": 267,
+      "community": 268,
       "file_type": "code",
       "id": "customerengagementevents_recordstorefrontcustomermilestone",
       "label": "recordStoreFrontCustomerMilestone()",
@@ -74725,7 +74944,7 @@
       "source_location": "L71"
     },
     {
-      "community": 267,
+      "community": 268,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_helpers_customerengagementevents_ts",
       "label": "customerEngagementEvents.ts",
@@ -74734,7 +74953,7 @@
       "source_location": "L1"
     },
     {
-      "community": 268,
+      "community": 269,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_returnexchangeoperations_test_ts",
       "label": "returnExchangeOperations.test.ts",
@@ -74743,7 +74962,7 @@
       "source_location": "L1"
     },
     {
-      "community": 268,
+      "community": 269,
       "file_type": "code",
       "id": "returnexchangeoperations_test_createorderitem",
       "label": "createOrderItem()",
@@ -74752,7 +74971,7 @@
       "source_location": "L13"
     },
     {
-      "community": 268,
+      "community": 269,
       "file_type": "code",
       "id": "returnexchangeoperations_test_createreplacement",
       "label": "createReplacement()",
@@ -74761,49 +74980,13 @@
       "source_location": "L31"
     },
     {
-      "community": 268,
+      "community": 269,
       "file_type": "code",
       "id": "returnexchangeoperations_test_getsource",
       "label": "getSource()",
       "norm_label": "getsource()",
       "source_file": "packages/athena-webapp/convex/storeFront/returnExchangeOperations.test.ts",
       "source_location": "L9"
-    },
-    {
-      "community": 269,
-      "file_type": "code",
-      "id": "packages_athena_webapp_shared_staffdisplayname_ts",
-      "label": "staffDisplayName.ts",
-      "norm_label": "staffdisplayname.ts",
-      "source_file": "packages/athena-webapp/shared/staffDisplayName.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 269,
-      "file_type": "code",
-      "id": "staffdisplayname_formatstaffdisplayname",
-      "label": "formatStaffDisplayName()",
-      "norm_label": "formatstaffdisplayname()",
-      "source_file": "packages/athena-webapp/shared/staffDisplayName.ts",
-      "source_location": "L12"
-    },
-    {
-      "community": 269,
-      "file_type": "code",
-      "id": "staffdisplayname_formatstaffdisplaynameorfallback",
-      "label": "formatStaffDisplayNameOrFallback()",
-      "norm_label": "formatstaffdisplaynameorfallback()",
-      "source_file": "packages/athena-webapp/shared/staffDisplayName.ts",
-      "source_location": "L46"
-    },
-    {
-      "community": 269,
-      "file_type": "code",
-      "id": "staffdisplayname_normalizenamepart",
-      "label": "normalizeNamePart()",
-      "norm_label": "normalizenamepart()",
-      "source_file": "packages/athena-webapp/shared/staffDisplayName.ts",
-      "source_location": "L7"
     },
     {
       "community": 27,
@@ -74979,6 +75162,42 @@
     {
       "community": 270,
       "file_type": "code",
+      "id": "packages_athena_webapp_shared_staffdisplayname_ts",
+      "label": "staffDisplayName.ts",
+      "norm_label": "staffdisplayname.ts",
+      "source_file": "packages/athena-webapp/shared/staffDisplayName.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 270,
+      "file_type": "code",
+      "id": "staffdisplayname_formatstaffdisplayname",
+      "label": "formatStaffDisplayName()",
+      "norm_label": "formatstaffdisplayname()",
+      "source_file": "packages/athena-webapp/shared/staffDisplayName.ts",
+      "source_location": "L12"
+    },
+    {
+      "community": 270,
+      "file_type": "code",
+      "id": "staffdisplayname_formatstaffdisplaynameorfallback",
+      "label": "formatStaffDisplayNameOrFallback()",
+      "norm_label": "formatstaffdisplaynameorfallback()",
+      "source_file": "packages/athena-webapp/shared/staffDisplayName.ts",
+      "source_location": "L46"
+    },
+    {
+      "community": 270,
+      "file_type": "code",
+      "id": "staffdisplayname_normalizenamepart",
+      "label": "normalizeNamePart()",
+      "norm_label": "normalizenamepart()",
+      "source_file": "packages/athena-webapp/shared/staffDisplayName.ts",
+      "source_location": "L7"
+    },
+    {
+      "community": 271,
+      "file_type": "code",
       "id": "attributesmanager_attributesmanager",
       "label": "AttributesManager()",
       "norm_label": "attributesmanager()",
@@ -74986,7 +75205,7 @@
       "source_location": "L227"
     },
     {
-      "community": 270,
+      "community": 271,
       "file_type": "code",
       "id": "attributesmanager_colormanager",
       "label": "ColorManager()",
@@ -74995,7 +75214,7 @@
       "source_location": "L46"
     },
     {
-      "community": 270,
+      "community": 271,
       "file_type": "code",
       "id": "attributesmanager_sidebar",
       "label": "Sidebar()",
@@ -75004,7 +75223,7 @@
       "source_location": "L27"
     },
     {
-      "community": 270,
+      "community": 271,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_attributesmanager_tsx",
       "label": "AttributesManager.tsx",
@@ -75013,7 +75232,7 @@
       "source_location": "L1"
     },
     {
-      "community": 271,
+      "community": 272,
       "file_type": "code",
       "id": "attributestable_getproductattribute",
       "label": "getProductAttribute()",
@@ -75022,7 +75241,7 @@
       "source_location": "L55"
     },
     {
-      "community": 271,
+      "community": 272,
       "file_type": "code",
       "id": "attributestable_handlechange",
       "label": "handleChange()",
@@ -75031,7 +75250,7 @@
       "source_location": "L32"
     },
     {
-      "community": 271,
+      "community": 272,
       "file_type": "code",
       "id": "attributestable_onsubmit",
       "label": "onSubmit()",
@@ -75040,7 +75259,7 @@
       "source_location": "L211"
     },
     {
-      "community": 271,
+      "community": 272,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_attributestable_tsx",
       "label": "AttributesTable.tsx",
@@ -75049,7 +75268,7 @@
       "source_location": "L1"
     },
     {
-      "community": 272,
+      "community": 273,
       "file_type": "code",
       "id": "categorysubcategorymanager_categorymanager",
       "label": "CategoryManager()",
@@ -75058,7 +75277,7 @@
       "source_location": "L52"
     },
     {
-      "community": 272,
+      "community": 273,
       "file_type": "code",
       "id": "categorysubcategorymanager_sidebar",
       "label": "Sidebar()",
@@ -75067,7 +75286,7 @@
       "source_location": "L27"
     },
     {
-      "community": 272,
+      "community": 273,
       "file_type": "code",
       "id": "categorysubcategorymanager_subcategorymanager",
       "label": "SubcategoryManager()",
@@ -75076,7 +75295,7 @@
       "source_location": "L288"
     },
     {
-      "community": 272,
+      "community": 273,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_categorysubcategorymanager_tsx",
       "label": "CategorySubcategoryManager.tsx",
@@ -75085,7 +75304,7 @@
       "source_location": "L1"
     },
     {
-      "community": 273,
+      "community": 274,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_storefrontobservabilitypanel_tsx",
       "label": "StorefrontObservabilityPanel.tsx",
@@ -75094,7 +75313,7 @@
       "source_location": "L1"
     },
     {
-      "community": 273,
+      "community": 274,
       "file_type": "code",
       "id": "storefrontobservabilitypanel_formatlabel",
       "label": "formatLabel()",
@@ -75103,7 +75322,7 @@
       "source_location": "L15"
     },
     {
-      "community": 273,
+      "community": 274,
       "file_type": "code",
       "id": "storefrontobservabilitypanel_gettrafficsourcebadge",
       "label": "getTrafficSourceBadge()",
@@ -75112,7 +75331,7 @@
       "source_location": "L32"
     },
     {
-      "community": 273,
+      "community": 274,
       "file_type": "code",
       "id": "storefrontobservabilitypanel_summarycard",
       "label": "SummaryCard()",
@@ -75121,7 +75340,7 @@
       "source_location": "L19"
     },
     {
-      "community": 274,
+      "community": 275,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_utils_ts",
       "label": "utils.ts",
@@ -75130,7 +75349,7 @@
       "source_location": "L1"
     },
     {
-      "community": 274,
+      "community": 275,
       "file_type": "code",
       "id": "utils_countgroupedanalytics",
       "label": "countGroupedAnalytics()",
@@ -75139,7 +75358,7 @@
       "source_location": "L52"
     },
     {
-      "community": 274,
+      "community": 275,
       "file_type": "code",
       "id": "utils_groupanalytics",
       "label": "groupAnalytics()",
@@ -75148,7 +75367,7 @@
       "source_location": "L3"
     },
     {
-      "community": 274,
+      "community": 275,
       "file_type": "code",
       "id": "utils_groupproductviewsbyday",
       "label": "groupProductViewsByDay()",
@@ -75157,7 +75376,7 @@
       "source_location": "L90"
     },
     {
-      "community": 275,
+      "community": 276,
       "file_type": "code",
       "id": "maintenancemessageeditor_getcountdownstatus",
       "label": "getCountdownStatus()",
@@ -75166,7 +75385,7 @@
       "source_location": "L86"
     },
     {
-      "community": 275,
+      "community": 276,
       "file_type": "code",
       "id": "maintenancemessageeditor_handlecountdownchange",
       "label": "handleCountdownChange()",
@@ -75175,7 +75394,7 @@
       "source_location": "L76"
     },
     {
-      "community": 275,
+      "community": 276,
       "file_type": "code",
       "id": "maintenancemessageeditor_handlesave",
       "label": "handleSave()",
@@ -75184,7 +75403,7 @@
       "source_location": "L52"
     },
     {
-      "community": 275,
+      "community": 276,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_maintenancemessageeditor_tsx",
       "label": "MaintenanceMessageEditor.tsx",
@@ -75193,7 +75412,7 @@
       "source_location": "L1"
     },
     {
-      "community": 276,
+      "community": 277,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_shoplook_tsx",
       "label": "ShopLook.tsx",
@@ -75202,7 +75421,7 @@
       "source_location": "L1"
     },
     {
-      "community": 276,
+      "community": 277,
       "file_type": "code",
       "id": "shoplook_handlehighlighteditem",
       "label": "handleHighlightedItem()",
@@ -75211,7 +75430,7 @@
       "source_location": "L67"
     },
     {
-      "community": 276,
+      "community": 277,
       "file_type": "code",
       "id": "shoplook_handleimageupdate",
       "label": "handleImageUpdate()",
@@ -75220,7 +75439,7 @@
       "source_location": "L90"
     },
     {
-      "community": 276,
+      "community": 277,
       "file_type": "code",
       "id": "shoplook_ondragend",
       "label": "onDragEnd()",
@@ -75229,7 +75448,7 @@
       "source_location": "L73"
     },
     {
-      "community": 277,
+      "community": 278,
       "file_type": "code",
       "id": "commandapprovaldialog_getasyncresolution",
       "label": "getAsyncResolution()",
@@ -75238,7 +75457,7 @@
       "source_location": "L78"
     },
     {
-      "community": 277,
+      "community": 278,
       "file_type": "code",
       "id": "commandapprovaldialog_getinlinemanagerresolution",
       "label": "getInlineManagerResolution()",
@@ -75247,7 +75466,7 @@
       "source_location": "L67"
     },
     {
-      "community": 277,
+      "community": 278,
       "file_type": "code",
       "id": "commandapprovaldialog_tostaffauthenticationresult",
       "label": "toStaffAuthenticationResult()",
@@ -75256,7 +75475,7 @@
       "source_location": "L85"
     },
     {
-      "community": 277,
+      "community": 278,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_commandapprovaldialog_tsx",
       "label": "CommandApprovalDialog.tsx",
@@ -75265,7 +75484,7 @@
       "source_location": "L1"
     },
     {
-      "community": 278,
+      "community": 279,
       "file_type": "code",
       "id": "dailycloseview_test_disconnect",
       "label": "disconnect()",
@@ -75274,7 +75493,7 @@
       "source_location": "L278"
     },
     {
-      "community": 278,
+      "community": 279,
       "file_type": "code",
       "id": "dailycloseview_test_observe",
       "label": "observe()",
@@ -75283,7 +75502,7 @@
       "source_location": "L279"
     },
     {
-      "community": 278,
+      "community": 279,
       "file_type": "code",
       "id": "dailycloseview_test_unobserve",
       "label": "unobserve()",
@@ -75292,48 +75511,12 @@
       "source_location": "L280"
     },
     {
-      "community": 278,
+      "community": 279,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_dailycloseview_test_tsx",
       "label": "DailyCloseView.test.tsx",
       "norm_label": "dailycloseview.test.tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 279,
-      "file_type": "code",
-      "id": "dailyopeningview_test_disconnect",
-      "label": "disconnect()",
-      "norm_label": "disconnect()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.test.tsx",
-      "source_location": "L202"
-    },
-    {
-      "community": 279,
-      "file_type": "code",
-      "id": "dailyopeningview_test_observe",
-      "label": "observe()",
-      "norm_label": "observe()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.test.tsx",
-      "source_location": "L203"
-    },
-    {
-      "community": 279,
-      "file_type": "code",
-      "id": "dailyopeningview_test_unobserve",
-      "label": "unobserve()",
-      "norm_label": "unobserve()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.test.tsx",
-      "source_location": "L204"
-    },
-    {
-      "community": 279,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_operations_dailyopeningview_test_tsx",
-      "label": "DailyOpeningView.test.tsx",
-      "norm_label": "dailyopeningview.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.test.tsx",
       "source_location": "L1"
     },
     {
@@ -81292,7 +81475,7 @@
       "label": "addRecommendationToDraft()",
       "norm_label": "addrecommendationtodraft()",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L853"
+      "source_location": "L845"
     },
     {
       "community": 4,
@@ -81301,7 +81484,7 @@
       "label": "buildVendorOptions()",
       "norm_label": "buildvendoroptions()",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L512"
+      "source_location": "L499"
     },
     {
       "community": 4,
@@ -81310,7 +81493,7 @@
       "label": "canReceivePurchaseOrder()",
       "norm_label": "canreceivepurchaseorder()",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L492"
+      "source_location": "L479"
     },
     {
       "community": 4,
@@ -81319,7 +81502,7 @@
       "label": "cn()",
       "norm_label": "cn()",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L1252"
+      "source_location": "L1244"
     },
     {
       "community": 4,
@@ -81328,7 +81511,7 @@
       "label": "countRecommendationsForMode()",
       "norm_label": "countrecommendationsformode()",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L411"
+      "source_location": "L406"
     },
     {
       "community": 4,
@@ -81337,7 +81520,7 @@
       "label": "formatLineCount()",
       "norm_label": "formatlinecount()",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L265"
+      "source_location": "L264"
     },
     {
       "community": 4,
@@ -81346,7 +81529,7 @@
       "label": "formatOptionalDate()",
       "norm_label": "formatoptionaldate()",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L185"
+      "source_location": "L184"
     },
     {
       "community": 4,
@@ -81355,7 +81538,7 @@
       "label": "formatPurchaseOrderCount()",
       "norm_label": "formatpurchaseordercount()",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L269"
+      "source_location": "L268"
     },
     {
       "community": 4,
@@ -81364,7 +81547,7 @@
       "label": "formatStatus()",
       "norm_label": "formatstatus()",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L196"
+      "source_location": "L195"
     },
     {
       "community": 4,
@@ -81373,7 +81556,7 @@
       "label": "formatUnitCount()",
       "norm_label": "formatunitcount()",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L261"
+      "source_location": "L260"
     },
     {
       "community": 4,
@@ -81382,7 +81565,7 @@
       "label": "getContinuityStateCopy()",
       "norm_label": "getcontinuitystatecopy()",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L202"
+      "source_location": "L201"
     },
     {
       "community": 4,
@@ -81391,7 +81574,7 @@
       "label": "getModeEmptyStateCopy()",
       "norm_label": "getmodeemptystatecopy()",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L420"
+      "source_location": "L415"
     },
     {
       "community": 4,
@@ -81400,7 +81583,7 @@
       "label": "getNextLifecycleActions()",
       "norm_label": "getnextlifecycleactions()",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L475"
+      "source_location": "L462"
     },
     {
       "community": 4,
@@ -81409,7 +81592,7 @@
       "label": "getPurchaseOrderMode()",
       "norm_label": "getpurchaseordermode()",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L496"
+      "source_location": "L483"
     },
     {
       "community": 4,
@@ -81418,7 +81601,7 @@
       "label": "getRecommendationCountCopy()",
       "norm_label": "getrecommendationcountcopy()",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L455"
+      "source_location": "L444"
     },
     {
       "community": 4,
@@ -81427,7 +81610,7 @@
       "label": "getRecommendationForPurchaseOrder()",
       "norm_label": "getrecommendationforpurchaseorder()",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L789"
+      "source_location": "L778"
     },
     {
       "community": 4,
@@ -81436,7 +81619,7 @@
       "label": "getRecommendationStateNote()",
       "norm_label": "getrecommendationstatenote()",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L339"
+      "source_location": "L338"
     },
     {
       "community": 4,
@@ -81445,7 +81628,7 @@
       "label": "getRecommendationUrlSku()",
       "norm_label": "getrecommendationurlsku()",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L547"
+      "source_location": "L534"
     },
     {
       "community": 4,
@@ -81454,7 +81637,7 @@
       "label": "getUniquePurchaseOrderReferences()",
       "norm_label": "getuniquepurchaseorderreferences()",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L273"
+      "source_location": "L272"
     },
     {
       "community": 4,
@@ -81463,7 +81646,7 @@
       "label": "getUniqueVendorCount()",
       "norm_label": "getuniquevendorcount()",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L292"
+      "source_location": "L291"
     },
     {
       "community": 4,
@@ -81472,7 +81655,7 @@
       "label": "handleAdvancePurchaseOrderToOrdered()",
       "norm_label": "handleadvancepurchaseordertoordered()",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L1067"
+      "source_location": "L1059"
     },
     {
       "community": 4,
@@ -81481,7 +81664,7 @@
       "label": "handleCreateDraftPurchaseOrders()",
       "norm_label": "handlecreatedraftpurchaseorders()",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L948"
+      "source_location": "L940"
     },
     {
       "community": 4,
@@ -81490,7 +81673,7 @@
       "label": "handleModeChange()",
       "norm_label": "handlemodechange()",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L650"
+      "source_location": "L637"
     },
     {
       "community": 4,
@@ -81499,7 +81682,7 @@
       "label": "handlePurchaseOrderSummaryClick()",
       "norm_label": "handlepurchaseordersummaryclick()",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L799"
+      "source_location": "L788"
     },
     {
       "community": 4,
@@ -81508,7 +81691,7 @@
       "label": "handleQuickAddVendor()",
       "norm_label": "handlequickaddvendor()",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L896"
+      "source_location": "L888"
     },
     {
       "community": 4,
@@ -81517,7 +81700,7 @@
       "label": "handleRecommendationPageChange()",
       "norm_label": "handlerecommendationpagechange()",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L659"
+      "source_location": "L646"
     },
     {
       "community": 4,
@@ -81526,7 +81709,7 @@
       "label": "handleUpdatePurchaseOrderStatus()",
       "norm_label": "handleupdatepurchaseorderstatus()",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L1040"
+      "source_location": "L1032"
     },
     {
       "community": 4,
@@ -81535,7 +81718,7 @@
       "label": "hasInboundPurchaseOrderCover()",
       "norm_label": "hasinboundpurchaseordercover()",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L312"
+      "source_location": "L311"
     },
     {
       "community": 4,
@@ -81544,7 +81727,7 @@
       "label": "hasMixedPurchaseOrderCover()",
       "norm_label": "hasmixedpurchaseordercover()",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L324"
+      "source_location": "L323"
     },
     {
       "community": 4,
@@ -81553,7 +81736,7 @@
       "label": "hasPlannedPurchaseOrderCover()",
       "norm_label": "hasplannedpurchaseordercover()",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L300"
+      "source_location": "L299"
     },
     {
       "community": 4,
@@ -81562,7 +81745,7 @@
       "label": "if()",
       "norm_label": "if()",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L1279"
+      "source_location": "L1271"
     },
     {
       "community": 4,
@@ -81571,7 +81754,7 @@
       "label": "isRecommendationVisible()",
       "norm_label": "isrecommendationvisible()",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L369"
+      "source_location": "L368"
     },
     {
       "community": 4,
@@ -81580,7 +81763,7 @@
       "label": "matchesRecommendationSku()",
       "norm_label": "matchesrecommendationsku()",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L551"
+      "source_location": "L538"
     },
     {
       "community": 4,
@@ -81589,7 +81772,7 @@
       "label": "parseDraftLineQuantity()",
       "norm_label": "parsedraftlinequantity()",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L537"
+      "source_location": "L524"
     },
     {
       "community": 4,
@@ -81598,7 +81781,7 @@
       "label": "removeDraftLine()",
       "norm_label": "removedraftline()",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L890"
+      "source_location": "L882"
     },
     {
       "community": 4,
@@ -81607,7 +81790,7 @@
       "label": "sanitizeDraftQuantityInput()",
       "norm_label": "sanitizedraftquantityinput()",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L527"
+      "source_location": "L514"
     },
     {
       "community": 4,
@@ -81616,7 +81799,7 @@
       "label": "selectProductSku()",
       "norm_label": "selectproductsku()",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L643"
+      "source_location": "L630"
     },
     {
       "community": 4,
@@ -81625,7 +81808,7 @@
       "label": "setActiveRecommendationPage()",
       "norm_label": "setactiverecommendationpage()",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L636"
+      "source_location": "L623"
     },
     {
       "community": 4,
@@ -81634,7 +81817,7 @@
       "label": "updateDraftLine()",
       "norm_label": "updatedraftline()",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L879"
+      "source_location": "L871"
     },
     {
       "community": 40,
@@ -88830,289 +89013,289 @@
     {
       "community": 6,
       "file_type": "code",
-      "id": "harness_behavior_asregexp",
-      "label": "asRegExp()",
-      "norm_label": "asregexp()",
-      "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L300"
+      "id": "dailyopeningview_cn",
+      "label": "cn()",
+      "norm_label": "cn()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
+      "source_location": "L796"
     },
     {
       "community": 6,
       "file_type": "code",
-      "id": "harness_behavior_collectlatencydiagnostics",
-      "label": "collectLatencyDiagnostics()",
-      "norm_label": "collectlatencydiagnostics()",
-      "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L780"
+      "id": "dailyopeningview_formatcount",
+      "label": "formatCount()",
+      "norm_label": "formatcount()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
+      "source_location": "L445"
     },
     {
       "community": 6,
       "file_type": "code",
-      "id": "harness_behavior_collectruntimesignaldiagnostics",
-      "label": "collectRuntimeSignalDiagnostics()",
-      "norm_label": "collectruntimesignaldiagnostics()",
-      "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L747"
+      "id": "dailyopeningview_formatmetadatavalue",
+      "label": "formatMetadataValue()",
+      "norm_label": "formatmetadatavalue()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
+      "source_location": "L327"
     },
     {
       "community": 6,
       "file_type": "code",
-      "id": "harness_behavior_collectruntimesignalmatches",
-      "label": "collectRuntimeSignalMatches()",
-      "norm_label": "collectruntimesignalmatches()",
-      "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L690"
+      "id": "dailyopeningview_formatoperatingdate",
+      "label": "formatOperatingDate()",
+      "norm_label": "formatoperatingdate()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
+      "source_location": "L247"
     },
     {
       "community": 6,
       "file_type": "code",
-      "id": "harness_behavior_consumelines",
-      "label": "consumeLines()",
-      "norm_label": "consumelines()",
-      "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L333"
+      "id": "dailyopeningview_formattimestamp",
+      "label": "formatTimestamp()",
+      "norm_label": "formattimestamp()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
+      "source_location": "L263"
     },
     {
       "community": 6,
       "file_type": "code",
-      "id": "harness_behavior_escaperegexp",
-      "label": "escapeRegExp()",
-      "norm_label": "escaperegexp()",
-      "source_file": "scripts/harness-behavior.ts",
+      "id": "dailyopeningview_getacknowledgementkey",
+      "label": "getAcknowledgementKey()",
+      "norm_label": "getacknowledgementkey()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
+      "source_location": "L304"
+    },
+    {
+      "community": 6,
+      "file_type": "code",
+      "id": "dailyopeningview_getbucketconfigs",
+      "label": "getBucketConfigs()",
+      "norm_label": "getbucketconfigs()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
+      "source_location": "L475"
+    },
+    {
+      "community": 6,
+      "file_type": "code",
+      "id": "dailyopeningview_getbucketcountclassname",
+      "label": "getBucketCountClassName()",
+      "norm_label": "getbucketcountclassname()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
+      "source_location": "L433"
+    },
+    {
+      "community": 6,
+      "file_type": "code",
+      "id": "dailyopeningview_getdailyopeningapi",
+      "label": "getDailyOpeningApi()",
+      "norm_label": "getdailyopeningapi()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
+      "source_location": "L210"
+    },
+    {
+      "community": 6,
+      "file_type": "code",
+      "id": "dailyopeningview_getdefaultbucketvalue",
+      "label": "getDefaultBucketValue()",
+      "norm_label": "getdefaultbucketvalue()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
+      "source_location": "L456"
+    },
+    {
+      "community": 6,
+      "file_type": "code",
+      "id": "dailyopeningview_getitemcontextlabel",
+      "label": "getItemContextLabel()",
+      "norm_label": "getitemcontextlabel()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
+      "source_location": "L319"
+    },
+    {
+      "community": 6,
+      "file_type": "code",
+      "id": "dailyopeningview_getitemdescription",
+      "label": "getItemDescription()",
+      "norm_label": "getitemdescription()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
+      "source_location": "L315"
+    },
+    {
+      "community": 6,
+      "file_type": "code",
+      "id": "dailyopeningview_getitemid",
+      "label": "getItemId()",
+      "norm_label": "getitemid()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
+      "source_location": "L296"
+    },
+    {
+      "community": 6,
+      "file_type": "code",
+      "id": "dailyopeningview_getlocaloperatingdate",
+      "label": "getLocalOperatingDate()",
+      "norm_label": "getlocaloperatingdate()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
+      "source_location": "L220"
+    },
+    {
+      "community": 6,
+      "file_type": "code",
+      "id": "dailyopeningview_getlocaloperatingdaterange",
+      "label": "getLocalOperatingDateRange()",
+      "norm_label": "getlocaloperatingdaterange()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
+      "source_location": "L228"
+    },
+    {
+      "community": 6,
+      "file_type": "code",
+      "id": "dailyopeningview_getmetadataentries",
+      "label": "getMetadataEntries()",
+      "norm_label": "getmetadataentries()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
+      "source_location": "L360"
+    },
+    {
+      "community": 6,
+      "file_type": "code",
+      "id": "dailyopeningview_getmetadatalabel",
+      "label": "getMetadataLabel()",
+      "norm_label": "getmetadatalabel()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
+      "source_location": "L340"
+    },
+    {
+      "community": 6,
+      "file_type": "code",
+      "id": "dailyopeningview_getmetadatavalue",
+      "label": "getMetadataValue()",
+      "norm_label": "getmetadatavalue()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
+      "source_location": "L352"
+    },
+    {
+      "community": 6,
+      "file_type": "code",
+      "id": "dailyopeningview_getopeningstatus",
+      "label": "getOpeningStatus()",
+      "norm_label": "getopeningstatus()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
+      "source_location": "L282"
+    },
+    {
+      "community": 6,
+      "file_type": "code",
+      "id": "dailyopeningview_getrequiredacknowledgementkeys",
+      "label": "getRequiredAcknowledgementKeys()",
+      "norm_label": "getrequiredacknowledgementkeys()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
       "source_location": "L308"
     },
     {
       "community": 6,
       "file_type": "code",
-      "id": "harness_behavior_formatassertiondiagnostics",
-      "label": "formatAssertionDiagnostics()",
-      "norm_label": "formatassertiondiagnostics()",
-      "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L828"
+      "id": "dailyopeningview_getstatusicon",
+      "label": "getStatusIcon()",
+      "norm_label": "getstatusicon()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
+      "source_location": "L400"
     },
     {
       "community": 6,
       "file_type": "code",
-      "id": "harness_behavior_formaterror",
-      "label": "formatError()",
-      "norm_label": "formaterror()",
-      "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L312"
+      "id": "dailyopeningview_getstatuslabelclassname",
+      "label": "getStatusLabelClassName()",
+      "norm_label": "getstatuslabelclassname()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
+      "source_location": "L407"
     },
     {
       "community": 6,
       "file_type": "code",
-      "id": "harness_behavior_getlinesforsource",
-      "label": "getLinesForSource()",
-      "norm_label": "getlinesforsource()",
-      "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L320"
+      "id": "dailyopeningview_getstatusrailbadgeclassname",
+      "label": "getStatusRailBadgeClassName()",
+      "norm_label": "getstatusrailbadgeclassname()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
+      "source_location": "L425"
     },
     {
       "community": 6,
       "file_type": "code",
-      "id": "harness_behavior_harnessbehaviorphaseerror",
-      "label": "HarnessBehaviorPhaseError",
-      "norm_label": "harnessbehaviorphaseerror",
-      "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L227"
+      "id": "dailyopeningview_getstatusrailiconclassname",
+      "label": "getStatusRailIconClassName()",
+      "norm_label": "getstatusrailiconclassname()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
+      "source_location": "L416"
     },
     {
       "community": 6,
       "file_type": "code",
-      "id": "harness_behavior_harnessbehaviorphaseerror_constructor",
-      "label": ".constructor()",
-      "norm_label": ".constructor()",
-      "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L232"
+      "id": "dailyopeningview_handleauthenticateforapproval",
+      "label": "handleAuthenticateForApproval()",
+      "norm_label": "handleauthenticateforapproval()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
+      "source_location": "L1456"
     },
     {
       "community": 6,
       "file_type": "code",
-      "id": "harness_behavior_installplaywrightchromium",
-      "label": "installPlaywrightChromium()",
-      "norm_label": "installplaywrightchromium()",
-      "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L939"
+      "id": "dailyopeningview_handlebucketvaluechange",
+      "label": "handleBucketValueChange()",
+      "norm_label": "handlebucketvaluechange()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
+      "source_location": "L1259"
     },
     {
       "community": 6,
       "file_type": "code",
-      "id": "harness_behavior_ismissingplaywrightchromiumerror",
-      "label": "isMissingPlaywrightChromiumError()",
-      "norm_label": "ismissingplaywrightchromiumerror()",
-      "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L917"
+      "id": "dailyopeningview_handlestartday",
+      "label": "handleStartDay()",
+      "norm_label": "handlestartday()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
+      "source_location": "L1249"
     },
     {
       "community": 6,
       "file_type": "code",
-      "id": "harness_behavior_launchplaywrightchromium",
-      "label": "launchPlaywrightChromium()",
-      "norm_label": "launchplaywrightchromium()",
-      "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L943"
+      "id": "dailyopeningview_humanizemetadatalabel",
+      "label": "humanizeMetadataLabel()",
+      "norm_label": "humanizemetadatalabel()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
+      "source_location": "L275"
     },
     {
       "community": 6,
       "file_type": "code",
-      "id": "harness_behavior_logphase",
-      "label": "logPhase()",
-      "norm_label": "logphase()",
-      "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L286"
+      "id": "dailyopeningview_normalizebuckettab",
+      "label": "normalizeBucketTab()",
+      "norm_label": "normalizebuckettab()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
+      "source_location": "L468"
     },
     {
       "community": 6,
       "file_type": "code",
-      "id": "harness_behavior_missingplaywrightchromiumdiagnostic",
-      "label": "missingPlaywrightChromiumDiagnostic()",
-      "norm_label": "missingplaywrightchromiumdiagnostic()",
-      "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L930"
+      "id": "dailyopeningview_normalizecommandmessage",
+      "label": "normalizeCommandMessage()",
+      "norm_label": "normalizecommandmessage()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
+      "source_location": "L380"
     },
     {
       "community": 6,
       "file_type": "code",
-      "id": "harness_behavior_parseharnessbehaviorargs",
-      "label": "parseHarnessBehaviorArgs()",
-      "norm_label": "parseharnessbehaviorargs()",
-      "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L1341"
+      "id": "dailyopeningview_submitstartday",
+      "label": "submitStartDay()",
+      "norm_label": "submitstartday()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
+      "source_location": "L1216"
     },
     {
       "community": 6,
       "file_type": "code",
-      "id": "harness_behavior_printharnessbehaviorusage",
-      "label": "printHarnessBehaviorUsage()",
-      "norm_label": "printharnessbehaviorusage()",
-      "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L1413"
-    },
-    {
-      "community": 6,
-      "file_type": "code",
-      "id": "harness_behavior_resolveharnessbehaviorshell",
-      "label": "resolveHarnessBehaviorShell()",
-      "norm_label": "resolveharnessbehaviorshell()",
-      "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L631"
-    },
-    {
-      "community": 6,
-      "file_type": "code",
-      "id": "harness_behavior_runharnessbehaviorcli",
-      "label": "runHarnessBehaviorCli()",
-      "norm_label": "runharnessbehaviorcli()",
-      "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L1421"
-    },
-    {
-      "community": 6,
-      "file_type": "code",
-      "id": "harness_behavior_runharnessbehaviorscenario",
-      "label": "runHarnessBehaviorScenario()",
-      "norm_label": "runharnessbehaviorscenario()",
-      "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L1107"
-    },
-    {
-      "community": 6,
-      "file_type": "code",
-      "id": "harness_behavior_runhttpreadinesscheck",
-      "label": "runHttpReadinessCheck()",
-      "norm_label": "runhttpreadinesscheck()",
-      "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L658"
-    },
-    {
-      "community": 6,
-      "file_type": "code",
-      "id": "harness_behavior_runphasewithduration",
-      "label": "runPhaseWithDuration()",
-      "norm_label": "runphasewithduration()",
-      "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L1094"
-    },
-    {
-      "community": 6,
-      "file_type": "code",
-      "id": "harness_behavior_runplaywrightflow",
-      "label": "runPlaywrightFlow()",
-      "norm_label": "runplaywrightflow()",
-      "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L980"
-    },
-    {
-      "community": 6,
-      "file_type": "code",
-      "id": "harness_behavior_runshellcommand",
-      "label": "runShellCommand()",
-      "norm_label": "runshellcommand()",
-      "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L609"
-    },
-    {
-      "community": 6,
-      "file_type": "code",
-      "id": "harness_behavior_shouldautoinstallplaywrightchromium",
-      "label": "shouldAutoInstallPlaywrightChromium()",
-      "norm_label": "shouldautoinstallplaywrightchromium()",
-      "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L926"
-    },
-    {
-      "community": 6,
-      "file_type": "code",
-      "id": "harness_behavior_sleep",
-      "label": "sleep()",
-      "norm_label": "sleep()",
-      "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L294"
-    },
-    {
-      "community": 6,
-      "file_type": "code",
-      "id": "harness_behavior_spawncommand",
-      "label": "spawnCommand()",
-      "norm_label": "spawncommand()",
-      "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L555"
-    },
-    {
-      "community": 6,
-      "file_type": "code",
-      "id": "harness_behavior_startprocess",
-      "label": "startProcess()",
-      "norm_label": "startprocess()",
-      "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L421"
-    },
-    {
-      "community": 6,
-      "file_type": "code",
-      "id": "harness_behavior_stopprocess",
-      "label": "stopProcess()",
-      "norm_label": "stopprocess()",
-      "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L399"
-    },
-    {
-      "community": 6,
-      "file_type": "code",
-      "id": "harness_behavior_wrapphaseerror",
-      "label": "wrapPhaseError()",
-      "norm_label": "wrapphaseerror()",
-      "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L1083"
-    },
-    {
-      "community": 6,
-      "file_type": "code",
-      "id": "scripts_harness_behavior_ts",
-      "label": "harness-behavior.ts",
-      "norm_label": "harness-behavior.ts",
-      "source_file": "scripts/harness-behavior.ts",
+      "id": "packages_athena_webapp_src_components_operations_dailyopeningview_tsx",
+      "label": "DailyOpeningView.tsx",
+      "norm_label": "dailyopeningview.tsx",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
       "source_location": "L1"
     },
     {
@@ -91989,280 +92172,289 @@
     {
       "community": 7,
       "file_type": "code",
-      "id": "harness_generate_builddiscoveryindex",
-      "label": "buildDiscoveryIndex()",
-      "norm_label": "builddiscoveryindex()",
-      "source_file": "scripts/harness-generate.ts",
-      "source_location": "L386"
+      "id": "harness_behavior_asregexp",
+      "label": "asRegExp()",
+      "norm_label": "asregexp()",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L300"
     },
     {
       "community": 7,
       "file_type": "code",
-      "id": "harness_generate_buildgenerateddoc",
-      "label": "buildGeneratedDoc()",
-      "norm_label": "buildgenerateddoc()",
-      "source_file": "scripts/harness-generate.ts",
-      "source_location": "L376"
+      "id": "harness_behavior_collectlatencydiagnostics",
+      "label": "collectLatencyDiagnostics()",
+      "norm_label": "collectlatencydiagnostics()",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L780"
     },
     {
       "community": 7,
       "file_type": "code",
-      "id": "harness_generate_buildkeyfolderindex",
-      "label": "buildKeyFolderIndex()",
-      "norm_label": "buildkeyfolderindex()",
-      "source_file": "scripts/harness-generate.ts",
-      "source_location": "L478"
+      "id": "harness_behavior_collectruntimesignaldiagnostics",
+      "label": "collectRuntimeSignalDiagnostics()",
+      "norm_label": "collectruntimesignaldiagnostics()",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L747"
     },
     {
       "community": 7,
       "file_type": "code",
-      "id": "harness_generate_buildtestindex",
-      "label": "buildTestIndex()",
-      "norm_label": "buildtestindex()",
-      "source_file": "scripts/harness-generate.ts",
+      "id": "harness_behavior_collectruntimesignalmatches",
+      "label": "collectRuntimeSignalMatches()",
+      "norm_label": "collectruntimesignalmatches()",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L690"
+    },
+    {
+      "community": 7,
+      "file_type": "code",
+      "id": "harness_behavior_consumelines",
+      "label": "consumeLines()",
+      "norm_label": "consumelines()",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L333"
+    },
+    {
+      "community": 7,
+      "file_type": "code",
+      "id": "harness_behavior_escaperegexp",
+      "label": "escapeRegExp()",
+      "norm_label": "escaperegexp()",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L308"
+    },
+    {
+      "community": 7,
+      "file_type": "code",
+      "id": "harness_behavior_formatassertiondiagnostics",
+      "label": "formatAssertionDiagnostics()",
+      "norm_label": "formatassertiondiagnostics()",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L828"
+    },
+    {
+      "community": 7,
+      "file_type": "code",
+      "id": "harness_behavior_formaterror",
+      "label": "formatError()",
+      "norm_label": "formaterror()",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L312"
+    },
+    {
+      "community": 7,
+      "file_type": "code",
+      "id": "harness_behavior_getlinesforsource",
+      "label": "getLinesForSource()",
+      "norm_label": "getlinesforsource()",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L320"
+    },
+    {
+      "community": 7,
+      "file_type": "code",
+      "id": "harness_behavior_harnessbehaviorphaseerror",
+      "label": "HarnessBehaviorPhaseError",
+      "norm_label": "harnessbehaviorphaseerror",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L227"
+    },
+    {
+      "community": 7,
+      "file_type": "code",
+      "id": "harness_behavior_harnessbehaviorphaseerror_constructor",
+      "label": ".constructor()",
+      "norm_label": ".constructor()",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L232"
+    },
+    {
+      "community": 7,
+      "file_type": "code",
+      "id": "harness_behavior_installplaywrightchromium",
+      "label": "installPlaywrightChromium()",
+      "norm_label": "installplaywrightchromium()",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L939"
+    },
+    {
+      "community": 7,
+      "file_type": "code",
+      "id": "harness_behavior_ismissingplaywrightchromiumerror",
+      "label": "isMissingPlaywrightChromiumError()",
+      "norm_label": "ismissingplaywrightchromiumerror()",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L917"
+    },
+    {
+      "community": 7,
+      "file_type": "code",
+      "id": "harness_behavior_launchplaywrightchromium",
+      "label": "launchPlaywrightChromium()",
+      "norm_label": "launchplaywrightchromium()",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L943"
+    },
+    {
+      "community": 7,
+      "file_type": "code",
+      "id": "harness_behavior_logphase",
+      "label": "logPhase()",
+      "norm_label": "logphase()",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L286"
+    },
+    {
+      "community": 7,
+      "file_type": "code",
+      "id": "harness_behavior_missingplaywrightchromiumdiagnostic",
+      "label": "missingPlaywrightChromiumDiagnostic()",
+      "norm_label": "missingplaywrightchromiumdiagnostic()",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L930"
+    },
+    {
+      "community": 7,
+      "file_type": "code",
+      "id": "harness_behavior_parseharnessbehaviorargs",
+      "label": "parseHarnessBehaviorArgs()",
+      "norm_label": "parseharnessbehaviorargs()",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L1341"
+    },
+    {
+      "community": 7,
+      "file_type": "code",
+      "id": "harness_behavior_printharnessbehaviorusage",
+      "label": "printHarnessBehaviorUsage()",
+      "norm_label": "printharnessbehaviorusage()",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L1413"
+    },
+    {
+      "community": 7,
+      "file_type": "code",
+      "id": "harness_behavior_resolveharnessbehaviorshell",
+      "label": "resolveHarnessBehaviorShell()",
+      "norm_label": "resolveharnessbehaviorshell()",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L631"
+    },
+    {
+      "community": 7,
+      "file_type": "code",
+      "id": "harness_behavior_runharnessbehaviorcli",
+      "label": "runHarnessBehaviorCli()",
+      "norm_label": "runharnessbehaviorcli()",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L1421"
+    },
+    {
+      "community": 7,
+      "file_type": "code",
+      "id": "harness_behavior_runharnessbehaviorscenario",
+      "label": "runHarnessBehaviorScenario()",
+      "norm_label": "runharnessbehaviorscenario()",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L1107"
+    },
+    {
+      "community": 7,
+      "file_type": "code",
+      "id": "harness_behavior_runhttpreadinesscheck",
+      "label": "runHttpReadinessCheck()",
+      "norm_label": "runhttpreadinesscheck()",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L658"
+    },
+    {
+      "community": 7,
+      "file_type": "code",
+      "id": "harness_behavior_runphasewithduration",
+      "label": "runPhaseWithDuration()",
+      "norm_label": "runphasewithduration()",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L1094"
+    },
+    {
+      "community": 7,
+      "file_type": "code",
+      "id": "harness_behavior_runplaywrightflow",
+      "label": "runPlaywrightFlow()",
+      "norm_label": "runplaywrightflow()",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L980"
+    },
+    {
+      "community": 7,
+      "file_type": "code",
+      "id": "harness_behavior_runshellcommand",
+      "label": "runShellCommand()",
+      "norm_label": "runshellcommand()",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L609"
+    },
+    {
+      "community": 7,
+      "file_type": "code",
+      "id": "harness_behavior_shouldautoinstallplaywrightchromium",
+      "label": "shouldAutoInstallPlaywrightChromium()",
+      "norm_label": "shouldautoinstallplaywrightchromium()",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L926"
+    },
+    {
+      "community": 7,
+      "file_type": "code",
+      "id": "harness_behavior_sleep",
+      "label": "sleep()",
+      "norm_label": "sleep()",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L294"
+    },
+    {
+      "community": 7,
+      "file_type": "code",
+      "id": "harness_behavior_spawncommand",
+      "label": "spawnCommand()",
+      "norm_label": "spawncommand()",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L555"
+    },
+    {
+      "community": 7,
+      "file_type": "code",
+      "id": "harness_behavior_startprocess",
+      "label": "startProcess()",
+      "norm_label": "startprocess()",
+      "source_file": "scripts/harness-behavior.ts",
       "source_location": "L421"
     },
     {
       "community": 7,
       "file_type": "code",
-      "id": "harness_generate_buildvalidationguide",
-      "label": "buildValidationGuide()",
-      "norm_label": "buildvalidationguide()",
-      "source_file": "scripts/harness-generate.ts",
-      "source_location": "L511"
+      "id": "harness_behavior_stopprocess",
+      "label": "stopProcess()",
+      "norm_label": "stopprocess()",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L399"
     },
     {
       "community": 7,
       "file_type": "code",
-      "id": "harness_generate_buildvalidationmap",
-      "label": "buildValidationMap()",
-      "norm_label": "buildvalidationmap()",
-      "source_file": "scripts/harness-generate.ts",
-      "source_location": "L553"
+      "id": "harness_behavior_wrapphaseerror",
+      "label": "wrapPhaseError()",
+      "norm_label": "wrapphaseerror()",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L1083"
     },
     {
       "community": 7,
       "file_type": "code",
-      "id": "harness_generate_collectfolderfacts",
-      "label": "collectFolderFacts()",
-      "norm_label": "collectfolderfacts()",
-      "source_file": "scripts/harness-generate.ts",
-      "source_location": "L272"
-    },
-    {
-      "community": 7,
-      "file_type": "code",
-      "id": "harness_generate_collectroutegroups",
-      "label": "collectRouteGroups()",
-      "norm_label": "collectroutegroups()",
-      "source_file": "scripts/harness-generate.ts",
-      "source_location": "L126"
-    },
-    {
-      "community": 7,
-      "file_type": "code",
-      "id": "harness_generate_collectservicedocumentedentries",
-      "label": "collectServiceDocumentedEntries()",
-      "norm_label": "collectservicedocumentedentries()",
-      "source_file": "scripts/harness-generate.ts",
-      "source_location": "L152"
-    },
-    {
-      "community": 7,
-      "file_type": "code",
-      "id": "harness_generate_collectserviceentrygroups",
-      "label": "collectServiceEntryGroups()",
-      "norm_label": "collectserviceentrygroups()",
-      "source_file": "scripts/harness-generate.ts",
-      "source_location": "L177"
-    },
-    {
-      "community": 7,
-      "file_type": "code",
-      "id": "harness_generate_collecttestfiles",
-      "label": "collectTestFiles()",
-      "norm_label": "collecttestfiles()",
-      "source_file": "scripts/harness-generate.ts",
-      "source_location": "L196"
-    },
-    {
-      "community": 7,
-      "file_type": "code",
-      "id": "harness_generate_collecttestsurfaceroots",
-      "label": "collectTestSurfaceRoots()",
-      "norm_label": "collecttestsurfaceroots()",
-      "source_file": "scripts/harness-generate.ts",
-      "source_location": "L226"
-    },
-    {
-      "community": 7,
-      "file_type": "code",
-      "id": "harness_generate_fileexists",
-      "label": "fileExists()",
-      "norm_label": "fileexists()",
-      "source_file": "scripts/harness-generate.ts",
-      "source_location": "L32"
-    },
-    {
-      "community": 7,
-      "file_type": "code",
-      "id": "harness_generate_formatmarkdownlink",
-      "label": "formatMarkdownLink()",
-      "norm_label": "formatmarkdownlink()",
-      "source_file": "scripts/harness-generate.ts",
-      "source_location": "L85"
-    },
-    {
-      "community": 7,
-      "file_type": "code",
-      "id": "harness_generate_formatscriptcommand",
-      "label": "formatScriptCommand()",
-      "norm_label": "formatscriptcommand()",
-      "source_file": "scripts/harness-generate.ts",
-      "source_location": "L316"
-    },
-    {
-      "community": 7,
-      "file_type": "code",
-      "id": "harness_generate_formatvalidationcommandfordoc",
-      "label": "formatValidationCommandForDoc()",
-      "norm_label": "formatvalidationcommandfordoc()",
-      "source_file": "scripts/harness-generate.ts",
-      "source_location": "L338"
-    },
-    {
-      "community": 7,
-      "file_type": "code",
-      "id": "harness_generate_generateharnessdocs",
-      "label": "generateHarnessDocs()",
-      "norm_label": "generateharnessdocs()",
-      "source_file": "scripts/harness-generate.ts",
-      "source_location": "L560"
-    },
-    {
-      "community": 7,
-      "file_type": "code",
-      "id": "harness_generate_headingfromsegment",
-      "label": "headingFromSegment()",
-      "norm_label": "headingfromsegment()",
-      "source_file": "scripts/harness-generate.ts",
-      "source_location": "L89"
-    },
-    {
-      "community": 7,
-      "file_type": "code",
-      "id": "harness_generate_iswithinfolder",
-      "label": "isWithinFolder()",
-      "norm_label": "iswithinfolder()",
-      "source_file": "scripts/harness-generate.ts",
-      "source_location": "L105"
-    },
-    {
-      "community": 7,
-      "file_type": "code",
-      "id": "harness_generate_normalizerepopath",
-      "label": "normalizeRepoPath()",
-      "norm_label": "normalizerepopath()",
-      "source_file": "scripts/harness-generate.ts",
-      "source_location": "L24"
-    },
-    {
-      "community": 7,
-      "file_type": "code",
-      "id": "harness_generate_readpackageconfig",
-      "label": "readPackageConfig()",
-      "norm_label": "readpackageconfig()",
-      "source_file": "scripts/harness-generate.ts",
-      "source_location": "L63"
-    },
-    {
-      "community": 7,
-      "file_type": "code",
-      "id": "harness_generate_shouldskipgeneratedentry",
-      "label": "shouldSkipGeneratedEntry()",
-      "norm_label": "shouldskipgeneratedentry()",
-      "source_file": "scripts/harness-generate.ts",
-      "source_location": "L28"
-    },
-    {
-      "community": 7,
-      "file_type": "code",
-      "id": "harness_generate_slugifytitle",
-      "label": "slugifyTitle()",
-      "norm_label": "slugifytitle()",
-      "source_file": "scripts/harness-generate.ts",
-      "source_location": "L331"
-    },
-    {
-      "community": 7,
-      "file_type": "code",
-      "id": "harness_generate_summarizechildren",
-      "label": "summarizeChildren()",
-      "norm_label": "summarizechildren()",
-      "source_file": "scripts/harness-generate.ts",
-      "source_location": "L97"
-    },
-    {
-      "community": 7,
-      "file_type": "code",
-      "id": "harness_generate_todocpath",
-      "label": "toDocPath()",
-      "norm_label": "todocpath()",
-      "source_file": "scripts/harness-generate.ts",
-      "source_location": "L81"
-    },
-    {
-      "community": 7,
-      "file_type": "code",
-      "id": "harness_generate_togeneratedvalidationmap",
-      "label": "toGeneratedValidationMap()",
-      "norm_label": "togeneratedvalidationmap()",
-      "source_file": "scripts/harness-generate.ts",
-      "source_location": "L347"
-    },
-    {
-      "community": 7,
-      "file_type": "code",
-      "id": "harness_generate_topackagerelativegenerateddocpaths",
-      "label": "toPackageRelativeGeneratedDocPaths()",
-      "norm_label": "topackagerelativegenerateddocpaths()",
-      "source_file": "scripts/harness-generate.ts",
-      "source_location": "L116"
-    },
-    {
-      "community": 7,
-      "file_type": "code",
-      "id": "harness_generate_torepovalidationpath",
-      "label": "toRepoValidationPath()",
-      "norm_label": "torepovalidationpath()",
-      "source_file": "scripts/harness-generate.ts",
-      "source_location": "L326"
-    },
-    {
-      "community": 7,
-      "file_type": "code",
-      "id": "harness_generate_walkfiles",
-      "label": "walkFiles()",
-      "norm_label": "walkfiles()",
-      "source_file": "scripts/harness-generate.ts",
-      "source_location": "L41"
-    },
-    {
-      "community": 7,
-      "file_type": "code",
-      "id": "harness_generate_writegeneratedharnessdocs",
-      "label": "writeGeneratedHarnessDocs()",
-      "norm_label": "writegeneratedharnessdocs()",
-      "source_file": "scripts/harness-generate.ts",
-      "source_location": "L590"
-    },
-    {
-      "community": 7,
-      "file_type": "code",
-      "id": "scripts_harness_generate_ts",
-      "label": "harness-generate.ts",
-      "norm_label": "harness-generate.ts",
-      "source_file": "scripts/harness-generate.ts",
+      "id": "scripts_harness_behavior_ts",
+      "label": "harness-behavior.ts",
+      "norm_label": "harness-behavior.ts",
+      "source_file": "scripts/harness-behavior.ts",
       "source_location": "L1"
     },
     {
@@ -94986,254 +95178,281 @@
     {
       "community": 8,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_storeconfigv2_ts",
-      "label": "storeConfigV2.ts",
-      "norm_label": "storeconfigv2.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
-      "source_location": "L1"
+      "id": "harness_generate_builddiscoveryindex",
+      "label": "buildDiscoveryIndex()",
+      "norm_label": "builddiscoveryindex()",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L386"
     },
     {
       "community": 8,
       "file_type": "code",
-      "id": "storeconfigv2_asarray",
-      "label": "asArray()",
-      "norm_label": "asarray()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
-      "source_location": "L77"
+      "id": "harness_generate_buildgenerateddoc",
+      "label": "buildGeneratedDoc()",
+      "norm_label": "buildgenerateddoc()",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L376"
     },
     {
       "community": 8,
       "file_type": "code",
-      "id": "storeconfigv2_asboolean",
-      "label": "asBoolean()",
-      "norm_label": "asboolean()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
-      "source_location": "L69"
-    },
-    {
-      "community": 8,
-      "file_type": "code",
-      "id": "storeconfigv2_asmtnmomosetupstatus",
-      "label": "asMtnMomoSetupStatus()",
-      "norm_label": "asmtnmomosetupstatus()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
-      "source_location": "L165"
-    },
-    {
-      "community": 8,
-      "file_type": "code",
-      "id": "storeconfigv2_asnumber",
-      "label": "asNumber()",
-      "norm_label": "asnumber()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
-      "source_location": "L61"
-    },
-    {
-      "community": 8,
-      "file_type": "code",
-      "id": "storeconfigv2_asoptionalarray",
-      "label": "asOptionalArray()",
-      "norm_label": "asoptionalarray()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
-      "source_location": "L90"
-    },
-    {
-      "community": 8,
-      "file_type": "code",
-      "id": "storeconfigv2_asrecord",
-      "label": "asRecord()",
-      "norm_label": "asrecord()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
-      "source_location": "L57"
-    },
-    {
-      "community": 8,
-      "file_type": "code",
-      "id": "storeconfigv2_assignordelete",
-      "label": "assignOrDelete()",
-      "norm_label": "assignordelete()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
-      "source_location": "L507"
-    },
-    {
-      "community": 8,
-      "file_type": "code",
-      "id": "storeconfigv2_asstring",
-      "label": "asString()",
-      "norm_label": "asstring()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
-      "source_location": "L65"
-    },
-    {
-      "community": 8,
-      "file_type": "code",
-      "id": "storeconfigv2_cleanundefined",
-      "label": "cleanUndefined()",
-      "norm_label": "cleanundefined()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
-      "source_location": "L153"
-    },
-    {
-      "community": 8,
-      "file_type": "code",
-      "id": "storeconfigv2_deepmerge",
-      "label": "deepMerge()",
-      "norm_label": "deepmerge()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
+      "id": "harness_generate_buildkeyfolderindex",
+      "label": "buildKeyFolderIndex()",
+      "norm_label": "buildkeyfolderindex()",
+      "source_file": "scripts/harness-generate.ts",
       "source_location": "L478"
     },
     {
       "community": 8,
       "file_type": "code",
-      "id": "storeconfigv2_firstdefined",
-      "label": "firstDefined()",
-      "norm_label": "firstdefined()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
-      "source_location": "L101"
+      "id": "harness_generate_buildtestindex",
+      "label": "buildTestIndex()",
+      "norm_label": "buildtestindex()",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L421"
     },
     {
       "community": 8,
       "file_type": "code",
-      "id": "storeconfigv2_getunknownstoreconfigrootkeys",
-      "label": "getUnknownStoreConfigRootKeys()",
-      "norm_label": "getunknownstoreconfigrootkeys()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
-      "source_location": "L591"
+      "id": "harness_generate_buildvalidationguide",
+      "label": "buildValidationGuide()",
+      "norm_label": "buildvalidationguide()",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L511"
     },
     {
       "community": 8,
       "file_type": "code",
-      "id": "storeconfigv2_hasmtnmomoreceivingaccountdetails",
-      "label": "hasMtnMomoReceivingAccountDetails()",
-      "norm_label": "hasmtnmomoreceivingaccountdetails()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
-      "source_location": "L178"
+      "id": "harness_generate_buildvalidationmap",
+      "label": "buildValidationMap()",
+      "norm_label": "buildvalidationmap()",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L553"
     },
     {
       "community": 8,
       "file_type": "code",
-      "id": "storeconfigv2_islegacyrootkey",
-      "label": "isLegacyRootKey()",
-      "norm_label": "islegacyrootkey()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
-      "source_location": "L623"
+      "id": "harness_generate_collectfolderfacts",
+      "label": "collectFolderFacts()",
+      "norm_label": "collectfolderfacts()",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L272"
     },
     {
       "community": 8,
       "file_type": "code",
-      "id": "storeconfigv2_isplainobject",
-      "label": "isPlainObject()",
-      "norm_label": "isplainobject()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
-      "source_location": "L53"
+      "id": "harness_generate_collectroutegroups",
+      "label": "collectRouteGroups()",
+      "norm_label": "collectroutegroups()",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L126"
     },
     {
       "community": 8,
       "file_type": "code",
-      "id": "storeconfigv2_isstorecheckoutdisabled",
-      "label": "isStoreCheckoutDisabled()",
-      "norm_label": "isstorecheckoutdisabled()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
-      "source_location": "L597"
+      "id": "harness_generate_collectservicedocumentedentries",
+      "label": "collectServiceDocumentedEntries()",
+      "norm_label": "collectservicedocumentedentries()",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L152"
     },
     {
       "community": 8,
       "file_type": "code",
-      "id": "storeconfigv2_isv2rootkey",
-      "label": "isV2RootKey()",
-      "norm_label": "isv2rootkey()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
-      "source_location": "L627"
+      "id": "harness_generate_collectserviceentrygroups",
+      "label": "collectServiceEntryGroups()",
+      "norm_label": "collectserviceentrygroups()",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L177"
     },
     {
       "community": 8,
       "file_type": "code",
-      "id": "storeconfigv2_mapmtnmomoreceivingaccount",
-      "label": "mapMtnMomoReceivingAccount()",
-      "norm_label": "mapmtnmomoreceivingaccount()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
-      "source_location": "L191"
+      "id": "harness_generate_collecttestfiles",
+      "label": "collectTestFiles()",
+      "norm_label": "collecttestfiles()",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L196"
     },
     {
       "community": 8,
       "file_type": "code",
-      "id": "storeconfigv2_mappromotion",
-      "label": "mapPromotion()",
-      "norm_label": "mappromotion()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
-      "source_location": "L111"
+      "id": "harness_generate_collecttestsurfaceroots",
+      "label": "collectTestSurfaceRoots()",
+      "norm_label": "collecttestsurfaceroots()",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L226"
     },
     {
       "community": 8,
       "file_type": "code",
-      "id": "storeconfigv2_mapstreamreel",
-      "label": "mapStreamReel()",
-      "norm_label": "mapstreamreel()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
-      "source_location": "L115"
+      "id": "harness_generate_fileexists",
+      "label": "fileExists()",
+      "norm_label": "fileexists()",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L32"
     },
     {
       "community": 8,
       "file_type": "code",
-      "id": "storeconfigv2_mirrorlegacykeys",
-      "label": "mirrorLegacyKeys()",
-      "norm_label": "mirrorlegacykeys()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
-      "source_location": "L520"
+      "id": "harness_generate_formatmarkdownlink",
+      "label": "formatMarkdownLink()",
+      "norm_label": "formatmarkdownlink()",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L85"
     },
     {
       "community": 8,
       "file_type": "code",
-      "id": "storeconfigv2_normalizemtnmomoreceivingaccounts",
-      "label": "normalizeMtnMomoReceivingAccounts()",
-      "norm_label": "normalizemtnmomoreceivingaccounts()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
-      "source_location": "L214"
+      "id": "harness_generate_formatscriptcommand",
+      "label": "formatScriptCommand()",
+      "norm_label": "formatscriptcommand()",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L316"
     },
     {
       "community": 8,
       "file_type": "code",
-      "id": "storeconfigv2_normalizestoreconfig",
-      "label": "normalizeStoreConfig()",
-      "norm_label": "normalizestoreconfig()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
-      "source_location": "L474"
+      "id": "harness_generate_formatvalidationcommandfordoc",
+      "label": "formatValidationCommandForDoc()",
+      "norm_label": "formatvalidationcommandfordoc()",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L338"
     },
     {
       "community": 8,
       "file_type": "code",
-      "id": "storeconfigv2_normalizewaivedeliveryfees",
-      "label": "normalizeWaiveDeliveryFees()",
-      "norm_label": "normalizewaivedeliveryfees()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
-      "source_location": "L135"
+      "id": "harness_generate_generateharnessdocs",
+      "label": "generateHarnessDocs()",
+      "norm_label": "generateharnessdocs()",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L560"
     },
     {
       "community": 8,
       "file_type": "code",
-      "id": "storeconfigv2_patchv2config",
-      "label": "patchV2Config()",
-      "norm_label": "patchv2config()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
-      "source_location": "L498"
+      "id": "harness_generate_headingfromsegment",
+      "label": "headingFromSegment()",
+      "norm_label": "headingfromsegment()",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L89"
     },
     {
       "community": 8,
       "file_type": "code",
-      "id": "storeconfigv2_removelegacyrootkeysfromconfig",
-      "label": "removeLegacyRootKeysFromConfig()",
-      "norm_label": "removelegacyrootkeysfromconfig()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
-      "source_location": "L606"
+      "id": "harness_generate_iswithinfolder",
+      "label": "isWithinFolder()",
+      "norm_label": "iswithinfolder()",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L105"
     },
     {
       "community": 8,
       "file_type": "code",
-      "id": "storeconfigv2_tov2config",
-      "label": "toV2Config()",
-      "norm_label": "tov2config()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
-      "source_location": "L231"
+      "id": "harness_generate_normalizerepopath",
+      "label": "normalizeRepoPath()",
+      "norm_label": "normalizerepopath()",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L24"
+    },
+    {
+      "community": 8,
+      "file_type": "code",
+      "id": "harness_generate_readpackageconfig",
+      "label": "readPackageConfig()",
+      "norm_label": "readpackageconfig()",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L63"
+    },
+    {
+      "community": 8,
+      "file_type": "code",
+      "id": "harness_generate_shouldskipgeneratedentry",
+      "label": "shouldSkipGeneratedEntry()",
+      "norm_label": "shouldskipgeneratedentry()",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L28"
+    },
+    {
+      "community": 8,
+      "file_type": "code",
+      "id": "harness_generate_slugifytitle",
+      "label": "slugifyTitle()",
+      "norm_label": "slugifytitle()",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L331"
+    },
+    {
+      "community": 8,
+      "file_type": "code",
+      "id": "harness_generate_summarizechildren",
+      "label": "summarizeChildren()",
+      "norm_label": "summarizechildren()",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L97"
+    },
+    {
+      "community": 8,
+      "file_type": "code",
+      "id": "harness_generate_todocpath",
+      "label": "toDocPath()",
+      "norm_label": "todocpath()",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L81"
+    },
+    {
+      "community": 8,
+      "file_type": "code",
+      "id": "harness_generate_togeneratedvalidationmap",
+      "label": "toGeneratedValidationMap()",
+      "norm_label": "togeneratedvalidationmap()",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L347"
+    },
+    {
+      "community": 8,
+      "file_type": "code",
+      "id": "harness_generate_topackagerelativegenerateddocpaths",
+      "label": "toPackageRelativeGeneratedDocPaths()",
+      "norm_label": "topackagerelativegenerateddocpaths()",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L116"
+    },
+    {
+      "community": 8,
+      "file_type": "code",
+      "id": "harness_generate_torepovalidationpath",
+      "label": "toRepoValidationPath()",
+      "norm_label": "torepovalidationpath()",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L326"
+    },
+    {
+      "community": 8,
+      "file_type": "code",
+      "id": "harness_generate_walkfiles",
+      "label": "walkFiles()",
+      "norm_label": "walkfiles()",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L41"
+    },
+    {
+      "community": 8,
+      "file_type": "code",
+      "id": "harness_generate_writegeneratedharnessdocs",
+      "label": "writeGeneratedHarnessDocs()",
+      "norm_label": "writegeneratedharnessdocs()",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L590"
+    },
+    {
+      "community": 8,
+      "file_type": "code",
+      "id": "scripts_harness_generate_ts",
+      "label": "harness-generate.ts",
+      "norm_label": "harness-generate.ts",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L1"
     },
     {
       "community": 80,
@@ -97551,254 +97770,254 @@
     {
       "community": 9,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_cash_controls_registersessionview_tsx",
-      "label": "RegisterSessionView.tsx",
-      "norm_label": "registersessionview.tsx",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "id": "packages_athena_webapp_convex_inventory_storeconfigv2_ts",
+      "label": "storeConfigV2.ts",
+      "norm_label": "storeconfigv2.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L1"
     },
     {
       "community": 9,
       "file_type": "code",
-      "id": "registersessionview_applycloseoutcommandresult",
-      "label": "applyCloseoutCommandResult()",
-      "norm_label": "applycloseoutcommandresult()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L521"
+      "id": "storeconfigv2_asarray",
+      "label": "asArray()",
+      "norm_label": "asarray()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
+      "source_location": "L77"
     },
     {
       "community": 9,
       "file_type": "code",
-      "id": "registersessionview_applycommandresult",
-      "label": "applyCommandResult()",
-      "norm_label": "applycommandresult()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L511"
+      "id": "storeconfigv2_asboolean",
+      "label": "asBoolean()",
+      "norm_label": "asboolean()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
+      "source_location": "L69"
     },
     {
       "community": 9,
       "file_type": "code",
-      "id": "registersessionview_builddepositsubmissionkey",
-      "label": "buildDepositSubmissionKey()",
-      "norm_label": "builddepositsubmissionkey()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L276"
+      "id": "storeconfigv2_asmtnmomosetupstatus",
+      "label": "asMtnMomoSetupStatus()",
+      "norm_label": "asmtnmomosetupstatus()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
+      "source_location": "L165"
     },
     {
       "community": 9,
       "file_type": "code",
-      "id": "registersessionview_errormessage",
-      "label": "errorMessage()",
-      "norm_label": "errormessage()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L2141"
+      "id": "storeconfigv2_asnumber",
+      "label": "asNumber()",
+      "norm_label": "asnumber()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
+      "source_location": "L61"
     },
     {
       "community": 9,
       "file_type": "code",
-      "id": "registersessionview_formatcurrency",
-      "label": "formatCurrency()",
-      "norm_label": "formatcurrency()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L280"
+      "id": "storeconfigv2_asoptionalarray",
+      "label": "asOptionalArray()",
+      "norm_label": "asoptionalarray()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
+      "source_location": "L90"
     },
     {
       "community": 9,
       "file_type": "code",
-      "id": "registersessionview_formatpaymentmethod",
-      "label": "formatPaymentMethod()",
-      "norm_label": "formatpaymentmethod()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L329"
+      "id": "storeconfigv2_asrecord",
+      "label": "asRecord()",
+      "norm_label": "asrecord()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
+      "source_location": "L57"
     },
     {
       "community": 9,
       "file_type": "code",
-      "id": "registersessionview_formatregisterheadername",
-      "label": "formatRegisterHeaderName()",
-      "norm_label": "formatregisterheadername()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L342"
+      "id": "storeconfigv2_assignordelete",
+      "label": "assignOrDelete()",
+      "norm_label": "assignordelete()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
+      "source_location": "L507"
     },
     {
       "community": 9,
       "file_type": "code",
-      "id": "registersessionview_formatregistername",
-      "label": "formatRegisterName()",
-      "norm_label": "formatregistername()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L337"
+      "id": "storeconfigv2_asstring",
+      "label": "asString()",
+      "norm_label": "asstring()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
+      "source_location": "L65"
     },
     {
       "community": 9,
       "file_type": "code",
-      "id": "registersessionview_formatsessioncode",
-      "label": "formatSessionCode()",
-      "norm_label": "formatsessioncode()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L356"
+      "id": "storeconfigv2_cleanundefined",
+      "label": "cleanUndefined()",
+      "norm_label": "cleanundefined()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
+      "source_location": "L153"
     },
     {
       "community": 9,
       "file_type": "code",
-      "id": "registersessionview_formatstatuslabel",
-      "label": "formatStatusLabel()",
-      "norm_label": "formatstatuslabel()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L299"
+      "id": "storeconfigv2_deepmerge",
+      "label": "deepMerge()",
+      "norm_label": "deepmerge()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
+      "source_location": "L478"
     },
     {
       "community": 9,
       "file_type": "code",
-      "id": "registersessionview_formatstoredamountforinput",
-      "label": "formatStoredAmountForInput()",
-      "norm_label": "formatstoredamountforinput()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L288"
+      "id": "storeconfigv2_firstdefined",
+      "label": "firstDefined()",
+      "norm_label": "firstdefined()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
+      "source_location": "L101"
     },
     {
       "community": 9,
       "file_type": "code",
-      "id": "registersessionview_formattimestamp",
-      "label": "formatTimestamp()",
-      "norm_label": "formattimestamp()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L292"
+      "id": "storeconfigv2_getunknownstoreconfigrootkeys",
+      "label": "getUnknownStoreConfigRootKeys()",
+      "norm_label": "getunknownstoreconfigrootkeys()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
+      "source_location": "L591"
     },
     {
       "community": 9,
       "file_type": "code",
-      "id": "registersessionview_getnumericeventmetadata",
-      "label": "getNumericEventMetadata()",
-      "norm_label": "getnumericeventmetadata()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L314"
+      "id": "storeconfigv2_hasmtnmomoreceivingaccountdetails",
+      "label": "hasMtnMomoReceivingAccountDetails()",
+      "norm_label": "hasmtnmomoreceivingaccountdetails()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
+      "source_location": "L178"
     },
     {
       "community": 9,
       "file_type": "code",
-      "id": "registersessionview_getpaymentmethodicon",
-      "label": "getPaymentMethodIcon()",
-      "norm_label": "getpaymentmethodicon()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L368"
+      "id": "storeconfigv2_islegacyrootkey",
+      "label": "isLegacyRootKey()",
+      "norm_label": "islegacyrootkey()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
+      "source_location": "L623"
     },
     {
       "community": 9,
       "file_type": "code",
-      "id": "registersessionview_getvariancetone",
-      "label": "getVarianceTone()",
-      "norm_label": "getvariancetone()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L360"
+      "id": "storeconfigv2_isplainobject",
+      "label": "isPlainObject()",
+      "norm_label": "isplainobject()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
+      "source_location": "L53"
     },
     {
       "community": 9,
       "file_type": "code",
-      "id": "registersessionview_handleauthenticatedcloseoutstaff",
-      "label": "handleAuthenticatedCloseoutStaff()",
-      "norm_label": "handleauthenticatedcloseoutstaff()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L691"
+      "id": "storeconfigv2_isstorecheckoutdisabled",
+      "label": "isStoreCheckoutDisabled()",
+      "norm_label": "isstorecheckoutdisabled()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
+      "source_location": "L597"
     },
     {
       "community": 9,
       "file_type": "code",
-      "id": "registersessionview_handleopeningfloatapprovalapproved",
-      "label": "handleOpeningFloatApprovalApproved()",
-      "norm_label": "handleopeningfloatapprovalapproved()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L805"
+      "id": "storeconfigv2_isv2rootkey",
+      "label": "isV2RootKey()",
+      "norm_label": "isv2rootkey()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
+      "source_location": "L627"
     },
     {
       "community": 9,
       "file_type": "code",
-      "id": "registersessionview_handlerecorddeposit",
-      "label": "handleRecordDeposit()",
-      "norm_label": "handlerecorddeposit()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L538"
+      "id": "storeconfigv2_mapmtnmomoreceivingaccount",
+      "label": "mapMtnMomoReceivingAccount()",
+      "norm_label": "mapmtnmomoreceivingaccount()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
+      "source_location": "L191"
     },
     {
       "community": 9,
       "file_type": "code",
-      "id": "registersessionview_handlereviewcloseout",
-      "label": "handleReviewCloseout()",
-      "norm_label": "handlereviewcloseout()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L618"
+      "id": "storeconfigv2_mappromotion",
+      "label": "mapPromotion()",
+      "norm_label": "mappromotion()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
+      "source_location": "L111"
     },
     {
       "community": 9,
       "file_type": "code",
-      "id": "registersessionview_handlesubmitcloseout",
-      "label": "handleSubmitCloseout()",
-      "norm_label": "handlesubmitcloseout()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L581"
+      "id": "storeconfigv2_mapstreamreel",
+      "label": "mapStreamReel()",
+      "norm_label": "mapstreamreel()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
+      "source_location": "L115"
     },
     {
       "community": 9,
       "file_type": "code",
-      "id": "registersessionview_handlesubmitopeningfloatcorrection",
-      "label": "handleSubmitOpeningFloatCorrection()",
-      "norm_label": "handlesubmitopeningfloatcorrection()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L635"
+      "id": "storeconfigv2_mirrorlegacykeys",
+      "label": "mirrorLegacyKeys()",
+      "norm_label": "mirrorlegacykeys()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
+      "source_location": "L520"
     },
     {
       "community": 9,
       "file_type": "code",
-      "id": "registersessionview_iscloseoutrejectionevent",
-      "label": "isCloseoutRejectionEvent()",
-      "norm_label": "iscloseoutrejectionevent()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L303"
+      "id": "storeconfigv2_normalizemtnmomoreceivingaccounts",
+      "label": "normalizeMtnMomoReceivingAccounts()",
+      "norm_label": "normalizemtnmomoreceivingaccounts()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
+      "source_location": "L214"
     },
     {
       "community": 9,
       "file_type": "code",
-      "id": "registersessionview_ismanagerstaff",
-      "label": "isManagerStaff()",
-      "norm_label": "ismanagerstaff()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L272"
+      "id": "storeconfigv2_normalizestoreconfig",
+      "label": "normalizeStoreConfig()",
+      "norm_label": "normalizestoreconfig()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
+      "source_location": "L474"
     },
     {
       "community": 9,
       "file_type": "code",
-      "id": "registersessionview_isopeningfloatcorrectionevent",
-      "label": "isOpeningFloatCorrectionEvent()",
-      "norm_label": "isopeningfloatcorrectionevent()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L307"
+      "id": "storeconfigv2_normalizewaivedeliveryfees",
+      "label": "normalizeWaiveDeliveryFees()",
+      "norm_label": "normalizewaivedeliveryfees()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
+      "source_location": "L135"
     },
     {
       "community": 9,
       "file_type": "code",
-      "id": "registersessionview_isregistersessioncorrectionevent",
-      "label": "isRegisterSessionCorrectionEvent()",
-      "norm_label": "isregistersessioncorrectionevent()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L323"
+      "id": "storeconfigv2_patchv2config",
+      "label": "patchV2Config()",
+      "norm_label": "patchv2config()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
+      "source_location": "L498"
     },
     {
       "community": 9,
       "file_type": "code",
-      "id": "registersessionview_runopeningfloatcorrection",
-      "label": "runOpeningFloatCorrection()",
-      "norm_label": "runopeningfloatcorrection()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L759"
+      "id": "storeconfigv2_removelegacyrootkeysfromconfig",
+      "label": "removeLegacyRootKeysFromConfig()",
+      "norm_label": "removelegacyrootkeysfromconfig()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
+      "source_location": "L606"
     },
     {
       "community": 9,
       "file_type": "code",
-      "id": "registersessionview_trimoptional",
-      "label": "trimOptional()",
-      "norm_label": "trimoptional()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L267"
+      "id": "storeconfigv2_tov2config",
+      "label": "toV2Config()",
+      "norm_label": "tov2config()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
+      "source_location": "L231"
     },
     {
       "community": 90,
@@ -98631,73 +98850,73 @@
     {
       "community": 95,
       "file_type": "code",
-      "id": "index_senddiscountcodeemail",
-      "label": "sendDiscountCodeEmail()",
-      "norm_label": "senddiscountcodeemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L255"
+      "id": "config_buildmtncollectionscallbackurl",
+      "label": "buildMtnCollectionsCallbackUrl()",
+      "norm_label": "buildmtncollectionscallbackurl()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "source_location": "L135"
     },
     {
       "community": 95,
       "file_type": "code",
-      "id": "index_senddiscountreminderemail",
-      "label": "sendDiscountReminderEmail()",
-      "norm_label": "senddiscountreminderemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L334"
-    },
-    {
-      "community": 95,
-      "file_type": "code",
-      "id": "index_sendfeedbackrequestemail",
-      "label": "sendFeedbackRequestEmail()",
-      "norm_label": "sendfeedbackrequestemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L167"
-    },
-    {
-      "community": 95,
-      "file_type": "code",
-      "id": "index_sendneworderemail",
-      "label": "sendNewOrderEmail()",
-      "norm_label": "sendneworderemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L117"
-    },
-    {
-      "community": 95,
-      "file_type": "code",
-      "id": "index_sendorderemail",
-      "label": "sendOrderEmail()",
-      "norm_label": "sendorderemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "id": "config_buildmtncollectionslookupprefixes",
+      "label": "buildMtnCollectionsLookupPrefixes()",
+      "norm_label": "buildmtncollectionslookupprefixes()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
       "source_location": "L43"
     },
     {
       "community": 95,
       "file_type": "code",
-      "id": "index_sendverificationcode",
-      "label": "sendVerificationCode()",
-      "norm_label": "sendverificationcode()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L3"
+      "id": "config_istargetenvironment",
+      "label": "isTargetEnvironment()",
+      "norm_label": "istargetenvironment()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "source_location": "L67"
     },
     {
       "community": 95,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_mailersend_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/convex/mailersend/index.tsx",
-      "source_location": "L1"
+      "id": "config_readscopedvalue",
+      "label": "readScopedValue()",
+      "norm_label": "readscopedvalue()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "source_location": "L56"
     },
     {
       "community": 95,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_sendgrid_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "id": "config_resolveconfigforprefix",
+      "label": "resolveConfigForPrefix()",
+      "norm_label": "resolveconfigforprefix()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "source_location": "L73"
+    },
+    {
+      "community": 95,
+      "file_type": "code",
+      "id": "config_resolvemtncollectionsconfigfromenv",
+      "label": "resolveMtnCollectionsConfigFromEnv()",
+      "norm_label": "resolvemtncollectionsconfigfromenv()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "source_location": "L108"
+    },
+    {
+      "community": 95,
+      "file_type": "code",
+      "id": "config_toenvsegment",
+      "label": "toEnvSegment()",
+      "norm_label": "toenvsegment()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "source_location": "L29"
+    },
+    {
+      "community": 95,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_mtn_config_ts",
+      "label": "config.ts",
+      "norm_label": "config.ts",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
       "source_location": "L1"
     },
     {
@@ -98793,73 +99012,73 @@
     {
       "community": 96,
       "file_type": "code",
-      "id": "config_buildmtncollectionscallbackurl",
-      "label": "buildMtnCollectionsCallbackUrl()",
-      "norm_label": "buildmtncollectionscallbackurl()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
-      "source_location": "L135"
+      "id": "approvalauditevents_recordapprovalauditeventwithctx",
+      "label": "recordApprovalAuditEventWithCtx()",
+      "norm_label": "recordapprovalauditeventwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
+      "source_location": "L30"
     },
     {
       "community": 96,
       "file_type": "code",
-      "id": "config_buildmtncollectionslookupprefixes",
-      "label": "buildMtnCollectionsLookupPrefixes()",
-      "norm_label": "buildmtncollectionslookupprefixes()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
-      "source_location": "L43"
+      "id": "approvalauditevents_recordapprovaldecisionrecordedauditeventwithctx",
+      "label": "recordApprovalDecisionRecordedAuditEventWithCtx()",
+      "norm_label": "recordapprovaldecisionrecordedauditeventwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
+      "source_location": "L107"
     },
     {
       "community": 96,
       "file_type": "code",
-      "id": "config_istargetenvironment",
-      "label": "isTargetEnvironment()",
-      "norm_label": "istargetenvironment()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "id": "approvalauditevents_recordapprovalproofconsumedauditeventwithctx",
+      "label": "recordApprovalProofConsumedAuditEventWithCtx()",
+      "norm_label": "recordapprovalproofconsumedauditeventwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
+      "source_location": "L87"
+    },
+    {
+      "community": 96,
+      "file_type": "code",
+      "id": "approvalauditevents_recordapprovalrequiredauditeventwithctx",
+      "label": "recordApprovalRequiredAuditEventWithCtx()",
+      "norm_label": "recordapprovalrequiredauditeventwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
       "source_location": "L67"
     },
     {
       "community": 96,
       "file_type": "code",
-      "id": "config_readscopedvalue",
-      "label": "readScopedValue()",
-      "norm_label": "readscopedvalue()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
-      "source_location": "L56"
+      "id": "approvalauditevents_recordapprovedcommandappliedauditeventwithctx",
+      "label": "recordApprovedCommandAppliedAuditEventWithCtx()",
+      "norm_label": "recordapprovedcommandappliedauditeventwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
+      "source_location": "L117"
     },
     {
       "community": 96,
       "file_type": "code",
-      "id": "config_resolveconfigforprefix",
-      "label": "resolveConfigForPrefix()",
-      "norm_label": "resolveconfigforprefix()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
-      "source_location": "L73"
+      "id": "approvalauditevents_recordasyncapprovalrequestcreatedauditeventwithctx",
+      "label": "recordAsyncApprovalRequestCreatedAuditEventWithCtx()",
+      "norm_label": "recordasyncapprovalrequestcreatedauditeventwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
+      "source_location": "L97"
     },
     {
       "community": 96,
       "file_type": "code",
-      "id": "config_resolvemtncollectionsconfigfromenv",
-      "label": "resolveMtnCollectionsConfigFromEnv()",
-      "norm_label": "resolvemtncollectionsconfigfromenv()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
-      "source_location": "L108"
+      "id": "approvalauditevents_recordmanagerapprovalgrantedauditeventwithctx",
+      "label": "recordManagerApprovalGrantedAuditEventWithCtx()",
+      "norm_label": "recordmanagerapprovalgrantedauditeventwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
+      "source_location": "L77"
     },
     {
       "community": 96,
       "file_type": "code",
-      "id": "config_toenvsegment",
-      "label": "toEnvSegment()",
-      "norm_label": "toenvsegment()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
-      "source_location": "L29"
-    },
-    {
-      "community": 96,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_mtn_config_ts",
-      "label": "config.ts",
-      "norm_label": "config.ts",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "id": "packages_athena_webapp_convex_operations_approvalauditevents_ts",
+      "label": "approvalAuditEvents.ts",
+      "norm_label": "approvalauditevents.ts",
+      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
       "source_location": "L1"
     },
     {
@@ -98955,73 +99174,73 @@
     {
       "community": 97,
       "file_type": "code",
-      "id": "approvalauditevents_recordapprovalauditeventwithctx",
-      "label": "recordApprovalAuditEventWithCtx()",
-      "norm_label": "recordapprovalauditeventwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
-      "source_location": "L30"
+      "id": "approvalrequests_buildapprovaldecisionrequirement",
+      "label": "buildApprovalDecisionRequirement()",
+      "norm_label": "buildapprovaldecisionrequirement()",
+      "source_file": "packages/athena-webapp/convex/operations/approvalRequests.ts",
+      "source_location": "L54"
     },
     {
       "community": 97,
       "file_type": "code",
-      "id": "approvalauditevents_recordapprovaldecisionrecordedauditeventwithctx",
-      "label": "recordApprovalDecisionRecordedAuditEventWithCtx()",
-      "norm_label": "recordapprovaldecisionrecordedauditeventwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
-      "source_location": "L107"
+      "id": "approvalrequests_buildapprovaldecisionsubject",
+      "label": "buildApprovalDecisionSubject()",
+      "norm_label": "buildapprovaldecisionsubject()",
+      "source_file": "packages/athena-webapp/convex/operations/approvalRequests.ts",
+      "source_location": "L42"
     },
     {
       "community": 97,
       "file_type": "code",
-      "id": "approvalauditevents_recordapprovalproofconsumedauditeventwithctx",
-      "label": "recordApprovalProofConsumedAuditEventWithCtx()",
-      "norm_label": "recordapprovalproofconsumedauditeventwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
-      "source_location": "L87"
+      "id": "approvalrequests_consumeapprovaldecisionproofwithctx",
+      "label": "consumeApprovalDecisionProofWithCtx()",
+      "norm_label": "consumeapprovaldecisionproofwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/approvalRequests.ts",
+      "source_location": "L78"
     },
     {
       "community": 97,
       "file_type": "code",
-      "id": "approvalauditevents_recordapprovalrequiredauditeventwithctx",
-      "label": "recordApprovalRequiredAuditEventWithCtx()",
-      "norm_label": "recordapprovalrequiredauditeventwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
-      "source_location": "L67"
+      "id": "approvalrequests_decideapprovalrequestasauthenticateduserwithctx",
+      "label": "decideApprovalRequestAsAuthenticatedUserWithCtx()",
+      "norm_label": "decideapprovalrequestasauthenticateduserwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/approvalRequests.ts",
+      "source_location": "L167"
     },
     {
       "community": 97,
       "file_type": "code",
-      "id": "approvalauditevents_recordapprovedcommandappliedauditeventwithctx",
-      "label": "recordApprovedCommandAppliedAuditEventWithCtx()",
-      "norm_label": "recordapprovedcommandappliedauditeventwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
-      "source_location": "L117"
+      "id": "approvalrequests_decideapprovalrequestascommandwithctx",
+      "label": "decideApprovalRequestAsCommandWithCtx()",
+      "norm_label": "decideapprovalrequestascommandwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/approvalRequests.ts",
+      "source_location": "L283"
     },
     {
       "community": 97,
       "file_type": "code",
-      "id": "approvalauditevents_recordasyncapprovalrequestcreatedauditeventwithctx",
-      "label": "recordAsyncApprovalRequestCreatedAuditEventWithCtx()",
-      "norm_label": "recordasyncapprovalrequestcreatedauditeventwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
-      "source_location": "L97"
+      "id": "approvalrequests_decideapprovalrequestwithctx",
+      "label": "decideApprovalRequestWithCtx()",
+      "norm_label": "decideapprovalrequestwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/approvalRequests.ts",
+      "source_location": "L105"
     },
     {
       "community": 97,
       "file_type": "code",
-      "id": "approvalauditevents_recordmanagerapprovalgrantedauditeventwithctx",
-      "label": "recordManagerApprovalGrantedAuditEventWithCtx()",
-      "norm_label": "recordmanagerapprovalgrantedauditeventwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
-      "source_location": "L77"
+      "id": "approvalrequests_mapdecideapprovalrequesterror",
+      "label": "mapDecideApprovalRequestError()",
+      "norm_label": "mapdecideapprovalrequesterror()",
+      "source_file": "packages/athena-webapp/convex/operations/approvalRequests.ts",
+      "source_location": "L217"
     },
     {
       "community": 97,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_approvalauditevents_ts",
-      "label": "approvalAuditEvents.ts",
-      "norm_label": "approvalauditevents.ts",
-      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
+      "id": "packages_athena_webapp_convex_operations_approvalrequests_ts",
+      "label": "approvalRequests.ts",
+      "norm_label": "approvalrequests.ts",
+      "source_file": "packages/athena-webapp/convex/operations/approvalRequests.ts",
       "source_location": "L1"
     },
     {
@@ -99117,74 +99336,74 @@
     {
       "community": 98,
       "file_type": "code",
-      "id": "approvalrequests_buildapprovaldecisionrequirement",
-      "label": "buildApprovalDecisionRequirement()",
-      "norm_label": "buildapprovaldecisionrequirement()",
-      "source_file": "packages/athena-webapp/convex/operations/approvalRequests.ts",
-      "source_location": "L54"
-    },
-    {
-      "community": 98,
-      "file_type": "code",
-      "id": "approvalrequests_buildapprovaldecisionsubject",
-      "label": "buildApprovalDecisionSubject()",
-      "norm_label": "buildapprovaldecisionsubject()",
-      "source_file": "packages/athena-webapp/convex/operations/approvalRequests.ts",
-      "source_location": "L42"
-    },
-    {
-      "community": 98,
-      "file_type": "code",
-      "id": "approvalrequests_consumeapprovaldecisionproofwithctx",
-      "label": "consumeApprovalDecisionProofWithCtx()",
-      "norm_label": "consumeapprovaldecisionproofwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/approvalRequests.ts",
-      "source_location": "L78"
-    },
-    {
-      "community": 98,
-      "file_type": "code",
-      "id": "approvalrequests_decideapprovalrequestasauthenticateduserwithctx",
-      "label": "decideApprovalRequestAsAuthenticatedUserWithCtx()",
-      "norm_label": "decideapprovalrequestasauthenticateduserwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/approvalRequests.ts",
-      "source_location": "L167"
-    },
-    {
-      "community": 98,
-      "file_type": "code",
-      "id": "approvalrequests_decideapprovalrequestascommandwithctx",
-      "label": "decideApprovalRequestAsCommandWithCtx()",
-      "norm_label": "decideapprovalrequestascommandwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/approvalRequests.ts",
-      "source_location": "L283"
-    },
-    {
-      "community": 98,
-      "file_type": "code",
-      "id": "approvalrequests_decideapprovalrequestwithctx",
-      "label": "decideApprovalRequestWithCtx()",
-      "norm_label": "decideapprovalrequestwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/approvalRequests.ts",
-      "source_location": "L105"
-    },
-    {
-      "community": 98,
-      "file_type": "code",
-      "id": "approvalrequests_mapdecideapprovalrequesterror",
-      "label": "mapDecideApprovalRequestError()",
-      "norm_label": "mapdecideapprovalrequesterror()",
-      "source_file": "packages/athena-webapp/convex/operations/approvalRequests.ts",
-      "source_location": "L217"
-    },
-    {
-      "community": 98,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_approvalrequests_ts",
-      "label": "approvalRequests.ts",
-      "norm_label": "approvalrequests.ts",
-      "source_file": "packages/athena-webapp/convex/operations/approvalRequests.ts",
+      "id": "packages_athena_webapp_convex_operations_paymentallocations_ts",
+      "label": "paymentAllocations.ts",
+      "norm_label": "paymentallocations.ts",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 98,
+      "file_type": "code",
+      "id": "paymentallocations_buildpaymentallocation",
+      "label": "buildPaymentAllocation()",
+      "norm_label": "buildpaymentallocation()",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "source_location": "L27"
+    },
+    {
+      "community": 98,
+      "file_type": "code",
+      "id": "paymentallocations_correctsameamountsinglepaymentallocationwithctx",
+      "label": "correctSameAmountSinglePaymentAllocationWithCtx()",
+      "norm_label": "correctsameamountsinglepaymentallocationwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "source_location": "L153"
+    },
+    {
+      "community": 98,
+      "file_type": "code",
+      "id": "paymentallocations_findsameamountsinglepaymentallocation",
+      "label": "findSameAmountSinglePaymentAllocation()",
+      "norm_label": "findsameamountsinglepaymentallocation()",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "source_location": "L57"
+    },
+    {
+      "community": 98,
+      "file_type": "code",
+      "id": "paymentallocations_listpaymentallocationsfortargetwithctx",
+      "label": "listPaymentAllocationsForTargetWithCtx()",
+      "norm_label": "listpaymentallocationsfortargetwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "source_location": "L133"
+    },
+    {
+      "community": 98,
+      "file_type": "code",
+      "id": "paymentallocations_matchesexistingallocation",
+      "label": "matchesExistingAllocation()",
+      "norm_label": "matchesexistingallocation()",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "source_location": "L81"
+    },
+    {
+      "community": 98,
+      "file_type": "code",
+      "id": "paymentallocations_recordpaymentallocationwithctx",
+      "label": "recordPaymentAllocationWithCtx()",
+      "norm_label": "recordpaymentallocationwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "source_location": "L102"
+    },
+    {
+      "community": 98,
+      "file_type": "code",
+      "id": "paymentallocations_summarizepaymentallocations",
+      "label": "summarizePaymentAllocations()",
+      "norm_label": "summarizepaymentallocations()",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "source_location": "L41"
     },
     {
       "community": 980,
@@ -99279,74 +99498,74 @@
     {
       "community": 99,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_paymentallocations_ts",
-      "label": "paymentAllocations.ts",
-      "norm_label": "paymentallocations.ts",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "id": "packages_athena_webapp_convex_pos_application_commands_possessiontracing_ts",
+      "label": "posSessionTracing.ts",
+      "norm_label": "possessiontracing.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
       "source_location": "L1"
     },
     {
       "community": 99,
       "file_type": "code",
-      "id": "paymentallocations_buildpaymentallocation",
-      "label": "buildPaymentAllocation()",
-      "norm_label": "buildpaymentallocation()",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
-      "source_location": "L27"
+      "id": "possessiontracing_buildpossessiontraceevent",
+      "label": "buildPosSessionTraceEvent()",
+      "norm_label": "buildpossessiontraceevent()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L226"
     },
     {
       "community": 99,
       "file_type": "code",
-      "id": "paymentallocations_correctsameamountsinglepaymentallocationwithctx",
-      "label": "correctSameAmountSinglePaymentAllocationWithCtx()",
-      "norm_label": "correctsameamountsinglepaymentallocationwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
-      "source_location": "L153"
+      "id": "possessiontracing_buildpossessiontracerecord",
+      "label": "buildPosSessionTraceRecord()",
+      "norm_label": "buildpossessiontracerecord()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L142"
     },
     {
       "community": 99,
       "file_type": "code",
-      "id": "paymentallocations_findsameamountsinglepaymentallocation",
-      "label": "findSameAmountSinglePaymentAllocation()",
-      "norm_label": "findsameamountsinglepaymentallocation()",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
-      "source_location": "L57"
+      "id": "possessiontracing_buildtracesummary",
+      "label": "buildTraceSummary()",
+      "norm_label": "buildtracesummary()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L105"
     },
     {
       "community": 99,
       "file_type": "code",
-      "id": "paymentallocations_listpaymentallocationsfortargetwithctx",
-      "label": "listPaymentAllocationsForTargetWithCtx()",
-      "norm_label": "listpaymentallocationsfortargetwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
-      "source_location": "L133"
+      "id": "possessiontracing_createpossessiontracerecorder",
+      "label": "createPosSessionTraceRecorder()",
+      "norm_label": "createpossessiontracerecorder()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L559"
     },
     {
       "community": 99,
       "file_type": "code",
-      "id": "paymentallocations_matchesexistingallocation",
-      "label": "matchesExistingAllocation()",
-      "norm_label": "matchesexistingallocation()",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
-      "source_location": "L81"
+      "id": "possessiontracing_formatpaymentmethod",
+      "label": "formatPaymentMethod()",
+      "norm_label": "formatpaymentmethod()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L218"
     },
     {
       "community": 99,
       "file_type": "code",
-      "id": "paymentallocations_recordpaymentallocationwithctx",
-      "label": "recordPaymentAllocationWithCtx()",
-      "norm_label": "recordpaymentallocationwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
-      "source_location": "L102"
+      "id": "possessiontracing_recordpossessiontracebesteffort",
+      "label": "recordPosSessionTraceBestEffort()",
+      "norm_label": "recordpossessiontracebesteffort()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L532"
     },
     {
       "community": 99,
       "file_type": "code",
-      "id": "paymentallocations_summarizepaymentallocations",
-      "label": "summarizePaymentAllocations()",
-      "norm_label": "summarizepaymentallocations()",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
-      "source_location": "L41"
+      "id": "possessiontracing_safetracewrite",
+      "label": "safeTraceWrite()",
+      "norm_label": "safetracewrite()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L524"
     },
     {
       "community": 990,

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,8 +8,8 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 1636
-- Graph nodes: 4788
-- Graph edges: 4695
+- Graph nodes: 4795
+- Graph edges: 4708
 - Communities: 1564
 
 ## Graph Hotspots
@@ -20,7 +20,7 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 - `dailyClose.ts` (40 edges, Community 3) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../packages/athena-webapp/convex/operations/dailyClose.ts)
 - `ProcurementView.tsx` (39 edges, Community 4) - [`packages/athena-webapp/src/components/procurement/ProcurementView.tsx`](../../packages/athena-webapp/src/components/procurement/ProcurementView.tsx)
 - `harness-check.ts` (32 edges, Community 5) - [`scripts/harness-check.ts`](../../scripts/harness-check.ts)
-- `harness-behavior.ts` (30 edges, Community 6) - [`scripts/harness-behavior.ts`](../../scripts/harness-behavior.ts)
+- `DailyOpeningView.tsx` (31 edges, Community 6) - [`packages/athena-webapp/src/components/operations/DailyOpeningView.tsx`](../../packages/athena-webapp/src/components/operations/DailyOpeningView.tsx)
 
 ## Registered Packages
 - [Athena Webapp](packages/athena-webapp.md)

--- a/graphify-out/wiki/packages/athena-webapp.md
+++ b/graphify-out/wiki/packages/athena-webapp.md
@@ -20,8 +20,8 @@ Landing page for packages/athena-webapp. Use this page to orient around graph ho
 - `DailyCloseView.tsx` (49 edges, Community 0) - [`packages/athena-webapp/src/components/operations/DailyCloseView.tsx`](../../../packages/athena-webapp/src/components/operations/DailyCloseView.tsx)
 - `dailyClose.ts` (40 edges, Community 3) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../../packages/athena-webapp/convex/operations/dailyClose.ts)
 - `ProcurementView.tsx` (39 edges, Community 4) - [`packages/athena-webapp/src/components/procurement/ProcurementView.tsx`](../../../packages/athena-webapp/src/components/procurement/ProcurementView.tsx)
-- `DailyOpeningView.tsx` (27 edges, Community 10) - [`packages/athena-webapp/src/components/operations/DailyOpeningView.tsx`](../../../packages/athena-webapp/src/components/operations/DailyOpeningView.tsx)
-- `RegisterSessionView.tsx` (27 edges, Community 9) - [`packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx`](../../../packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx)
+- `DailyOpeningView.tsx` (31 edges, Community 6) - [`packages/athena-webapp/src/components/operations/DailyOpeningView.tsx`](../../../packages/athena-webapp/src/components/operations/DailyOpeningView.tsx)
+- `RegisterSessionView.tsx` (27 edges, Community 10) - [`packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx`](../../../packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx)
 
 ## Navigation
 - [wiki index](../index.md) - back to the wiki index

--- a/packages/athena-webapp/convex/operations/dailyOpening.test.ts
+++ b/packages/athena-webapp/convex/operations/dailyOpening.test.ts
@@ -233,6 +233,50 @@ describe("daily opening backend foundation", () => {
     ]);
   });
 
+  it("hydrates the started opening staff profile name", async () => {
+    const { db } = createDb({
+      dailyClose: [completedDailyClose()],
+      dailyOpening: [
+        {
+          _id: "daily-opening-1",
+          acknowledgedItemKeys: [],
+          actorStaffProfileId: "staff-1",
+          carryForwardWorkItemIds: [],
+          createdAt: Date.UTC(2026, 4, 8, 8),
+          operatingDate: "2026-05-08",
+          organizationId: "org-1",
+          priorDailyCloseId: "daily-close-1",
+          readiness: {
+            blockerCount: 0,
+            carryForwardCount: 0,
+            readyCount: 1,
+            reviewCount: 0,
+            status: "ready",
+          },
+          sourceSubjects: [],
+          startedAt: Date.UTC(2026, 4, 8, 8),
+          status: "started",
+          storeId: "store-1",
+          updatedAt: Date.UTC(2026, 4, 8, 8),
+        },
+      ],
+      staffProfile: [activeStaffProfile],
+      store: [store],
+    });
+
+    const snapshot = await buildDailyOpeningSnapshotWithCtx(
+      { db } as unknown as QueryCtx,
+      { operatingDate: "2026-05-08", storeId: "store-1" as Id<"store"> },
+    );
+
+    expect(snapshot.status).toBe("started");
+    expect(snapshot.startedOpening).toMatchObject({
+      _id: "daily-opening-1",
+      actorStaffProfileId: "staff-1",
+      startedByStaffName: "Store Manager",
+    });
+  });
+
   it("blocks calendar-invalid operating dates instead of normalizing them", async () => {
     const { db, inserts } = createDb({
       dailyClose: [completedDailyClose()],
@@ -422,8 +466,11 @@ describe("daily opening backend foundation", () => {
     expect(inserts).toEqual([]);
   });
 
-  it("blocks opening when there is no prior completed Daily Close", async () => {
+  it("requires acknowledgement when there is no prior completed Daily Close", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(Date.UTC(2026, 4, 8, 8));
+
     const { db, inserts } = createDb({
+      staffProfile: [activeStaffProfile],
       store: [store],
     });
 
@@ -436,18 +483,48 @@ describe("daily opening backend foundation", () => {
       { operatingDate: "2026-05-08", storeId: "store-1" as Id<"store"> },
     );
 
-    expect(snapshot.status).toBe("blocked");
-    expect(snapshot.blockers.map((item) => item.key)).toEqual([
+    expect(snapshot.status).toBe("needs_attention");
+    expect(snapshot.blockers).toEqual([]);
+    expect(snapshot.reviewItems.map((item) => item.key)).toEqual([
       "daily_close:prior:missing",
     ]);
     expect(result).toMatchObject({
       kind: "user_error",
       error: {
         code: "precondition_failed",
-        metadata: { blockerCount: 1 },
+        metadata: { unacknowledgedItemKeys: ["daily_close:prior:missing"] },
       },
     });
     expect(inserts).toEqual([]);
+
+    const acknowledgedResult = await startStoreDayWithCtx(
+      { db } as unknown as MutationCtx,
+      {
+        acknowledgedItemKeys: ["daily_close:prior:missing"],
+        actorStaffProfileId: "staff-1" as Id<"staffProfile">,
+        operatingDate: "2026-05-08",
+        storeId: "store-1" as Id<"store">,
+      },
+    );
+
+    expect(acknowledgedResult).toMatchObject({
+      kind: "ok",
+      data: {
+        action: "started",
+        dailyOpening: {
+          acknowledgedItemKeys: ["daily_close:prior:missing"],
+          readiness: {
+            blockerCount: 0,
+            reviewCount: 1,
+            status: "needs_attention",
+          },
+        },
+      },
+    });
+    expect(inserts.map((insert) => insert.table)).toEqual([
+      "dailyOpening",
+      "operationalEvent",
+    ]);
   });
 
   it("rechecks command-time readiness so stale ready snapshots cannot start a blocked day", async () => {

--- a/packages/athena-webapp/convex/operations/dailyOpening.ts
+++ b/packages/athena-webapp/convex/operations/dailyOpening.ts
@@ -65,7 +65,9 @@ type DailyOpeningSnapshot = {
   carryForwardItems: DailyOpeningItem[];
   readyItems: DailyOpeningItem[];
   readiness: DailyOpeningReadiness;
-  startedOpening: Doc<"dailyOpening"> | null;
+  startedOpening:
+    | (Doc<"dailyOpening"> & { startedByStaffName?: string | null })
+    | null;
   startAt: number;
   sourceSubjects: DailyOpeningItem["subject"][];
   summary: Omit<DailyOpeningReadiness, "status">;
@@ -185,6 +187,32 @@ async function getStartedDailyOpeningForDate(
     .first();
 }
 
+function getStaffDisplayName(staffProfile: Doc<"staffProfile"> | null) {
+  if (!staffProfile) return null;
+
+  const name =
+    staffProfile.fullName ||
+    [staffProfile.firstName, staffProfile.lastName].filter(Boolean).join(" ");
+
+  return name || null;
+}
+
+async function hydrateStartedOpening(
+  ctx: Pick<QueryCtx, "db">,
+  opening: Doc<"dailyOpening"> | null,
+) {
+  if (!opening) return null;
+
+  const staffProfile = opening.actorStaffProfileId
+    ? await ctx.db.get("staffProfile", opening.actorStaffProfileId)
+    : null;
+
+  return {
+    ...opening,
+    startedByStaffName: getStaffDisplayName(staffProfile),
+  };
+}
+
 async function listPendingOpeningBlockerApprovals(
   ctx: Pick<QueryCtx, "db">,
   storeId: Id<"store">,
@@ -232,17 +260,17 @@ function pendingApprovalItem(
   };
 }
 
-function missingPriorCloseItem(args: {
+function missingPriorCloseReviewItem(args: {
   operatingDate: string;
   storeId: Id<"store">;
 }): DailyOpeningItem {
   return {
     key: "daily_close:prior:missing",
-    severity: "blocker",
+    severity: "review",
     category: "prior_close",
-    title: "Prior Daily Close is missing",
+    title: "Prior Daily Close not found",
     message:
-      "Opening needs the prior completed Daily Close before the store day can be acknowledged.",
+      "No completed Daily Close was found for the prior store day. Acknowledge this before starting the store day.",
     subject: {
       type: DAILY_CLOSE_SUBJECT_TYPE,
       id: `${args.storeId}:${args.operatingDate}:prior`,
@@ -484,6 +512,7 @@ export async function buildDailyOpeningSnapshotWithCtx(
 ): Promise<DailyOpeningSnapshot> {
   const store = await getStore(ctx, args.storeId);
   const existingOpening = await getDailyOpeningForDate(ctx, args);
+  const startedOpening = await hydrateStartedOpening(ctx, existingOpening);
   const operatingDateRange = resolveOperatingDateRange(args);
 
   if (!isValidOperatingDate(args.operatingDate)) {
@@ -508,7 +537,7 @@ export async function buildDailyOpeningSnapshotWithCtx(
         carryForwardCount: 0,
         readyCount: 0,
       },
-      startedOpening: existingOpening,
+      startedOpening,
       startAt: operatingDateRange.startAt,
       sourceSubjects: [blocker.subject],
       summary: {
@@ -543,7 +572,7 @@ export async function buildDailyOpeningSnapshotWithCtx(
       reviewItems.push(notesItem);
     }
   } else {
-    blockers.push(missingPriorCloseItem(args));
+    reviewItems.push(missingPriorCloseReviewItem(args));
   }
 
   blockers.push(...pendingApprovals.map(pendingApprovalItem));
@@ -574,7 +603,7 @@ export async function buildDailyOpeningSnapshotWithCtx(
     carryForwardItems,
     readyItems,
     readiness,
-    startedOpening: existingOpening,
+    startedOpening,
     startAt: operatingDateRange.startAt,
     sourceSubjects: uniqueSourceSubjects(allItems),
     summary: {

--- a/packages/athena-webapp/src/components/operations/DailyOpeningView.test.tsx
+++ b/packages/athena-webapp/src/components/operations/DailyOpeningView.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { AnchorHTMLAttributes, ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -18,6 +18,7 @@ const mockedHooks = vi.hoisted(() => ({
 }));
 
 const mockedApi = vi.hoisted(() => ({
+  authenticateStaffCredentialForApproval: "authenticateStaffCredentialForApproval",
   getDailyOpeningSnapshot: "getDailyOpeningSnapshot",
   startStoreDay: "startStoreDay",
 }));
@@ -72,10 +73,82 @@ vi.mock("@/hooks/useProtectedAdminPageState", () => ({
   useProtectedAdminPageState: mockedHooks.useProtectedAdminPageState,
 }));
 
+vi.mock("./CommandApprovalDialog", () => ({
+  CommandApprovalDialog: ({
+    approval,
+    onApproved,
+    onAuthenticateForApproval,
+    onDismiss,
+    open,
+  }: {
+    approval: {
+      action: { key: string };
+      reason: string;
+      requiredRole: "manager";
+      subject: { id: string; label?: string; type: string };
+    };
+    onApproved: (result: {
+      approvalProofId: Id<"approvalProof">;
+      approvedByStaffProfileId: Id<"staffProfile">;
+      expiresAt: number;
+    }) => void;
+    onAuthenticateForApproval: (args: {
+      actionKey: string;
+      pinHash: string;
+      reason: string;
+      requiredRole: "manager";
+      storeId: Id<"store">;
+      subject: { id: string; label?: string; type: string };
+      username: string;
+    }) => Promise<{
+      data?: {
+        approvalProofId: Id<"approvalProof">;
+        approvedByStaffProfileId: Id<"staffProfile">;
+        expiresAt: number;
+      };
+      kind: string;
+    }>;
+    onDismiss: () => void;
+    open: boolean;
+  }) =>
+    open ? (
+      <div aria-label="Manager sign-in required" role="dialog">
+        <p>Manager sign-in required</p>
+        <button
+          onClick={async () => {
+            const result = await onAuthenticateForApproval({
+              actionKey: approval.action.key,
+              pinHash: "pin-hash",
+              reason: approval.reason,
+              requiredRole: approval.requiredRole,
+              storeId: "store-1" as Id<"store">,
+              subject: approval.subject,
+              username: "manager",
+            });
+
+            if (result.kind === "ok" && result.data) {
+              onApproved(result.data);
+            }
+          }}
+          type="button"
+        >
+          Confirm manager
+        </button>
+        <button onClick={onDismiss} type="button">
+          Cancel
+        </button>
+      </div>
+    ) : null,
+}));
+
 vi.mock("~/convex/_generated/api", () => ({
   api: {
     operations: {
       dailyOpening: mockedApi,
+      staffCredentials: {
+        authenticateStaffCredentialForApproval:
+          mockedApi.authenticateStaffCredentialForApproval,
+      },
     },
   },
 }));
@@ -246,6 +319,40 @@ describe("DailyOpeningViewContent", () => {
     expect(screen.getByRole("button", { name: /start day/i })).toBeDisabled();
   });
 
+  it("explains the store day when prior Daily Close is missing", () => {
+    renderContent({
+      ...readySnapshot,
+      blockers: [],
+      priorClose: null,
+      readyItems: [],
+      reviewItems: [
+        {
+          category: "prior_close",
+          id: "missing-prior-close",
+          key: "daily_close:prior:missing",
+          metadata: {
+            operatingDate: "2026-05-08",
+          },
+          statusLabel: "Needs review",
+          title: "Prior Daily Close not found",
+        },
+      ],
+      status: "needs_attention",
+      summary: {
+        blockerCount: 0,
+        carryForwardCount: 0,
+        readyCount: 0,
+        reviewCount: 1,
+      },
+    });
+
+    const storeDayLabel = screen.getByText("Store day being opened");
+    expect(storeDayLabel).toBeInTheDocument();
+    expect(within(storeDayLabel.closest("div")!).getByText("May 8, 2026"))
+      .toBeInTheDocument();
+    expect(screen.queryByText("Operating Date")).not.toBeInTheDocument();
+  });
+
   it("requires review and carry-forward acknowledgements before starting", async () => {
     const user = userEvent.setup();
     const onStartDay = vi.fn(async () => ok({ openingId: "opening-1" }));
@@ -305,6 +412,56 @@ describe("DailyOpeningViewContent", () => {
     ).toBeInTheDocument();
   });
 
+  it("presents manager approval before starting the store day", async () => {
+    const user = userEvent.setup();
+    const onAuthenticateForApproval = vi.fn(async () =>
+      ok({
+        approvalProofId: "proof-1" as Id<"approvalProof">,
+        approvedByStaffProfileId: "staff-manager" as Id<"staffProfile">,
+        expiresAt: 1_800_000_000_000,
+      }),
+    );
+    const onStartDay = vi.fn(async () => ok({ openingId: "opening-1" }));
+
+    renderContent(readySnapshot, {
+      onAuthenticateForApproval,
+      onStartDay,
+    });
+
+    await user.click(screen.getByRole("button", { name: /start day/i }));
+
+    expect(
+      screen.getByRole("dialog", { name: /manager sign-in required/i }),
+    ).toBeInTheDocument();
+    expect(onStartDay).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole("button", { name: /confirm manager/i }));
+
+    await waitFor(() => {
+      expect(onAuthenticateForApproval).toHaveBeenCalledWith({
+        actionKey: "operations.daily_opening.start_day",
+        pinHash: "pin-hash",
+        reason: "Manager approval is required to start the store day.",
+        requiredRole: "manager",
+        storeId: "store-1",
+        subject: {
+          id: "store-1:2026-05-08",
+          label: "Opening May 8, 2026",
+          type: "daily_opening",
+        },
+        username: "manager",
+      });
+      expect(onStartDay).toHaveBeenCalledWith({
+        acknowledgedItemKeys: [],
+        actorStaffProfileId: "staff-manager",
+        endAt: readySnapshot.endAt,
+        notes: "",
+        operatingDate: "2026-05-08",
+        startAt: readySnapshot.startAt,
+      });
+    });
+  });
+
   it("shows already-started state without offering a duplicate start", () => {
     renderContent({
       ...readySnapshot,
@@ -317,7 +474,15 @@ describe("DailyOpeningViewContent", () => {
     });
 
     expect(screen.getByText("Store day started")).toBeInTheDocument();
-    expect(screen.getByText(/Kofi Mensah/)).toBeInTheDocument();
+    expect(
+      screen.getAllByText(
+        "Opening handoff is complete. The store day is ready to run.",
+      ).length,
+    ).toBeGreaterThan(0);
+    expect(screen.getByText("Opening handoff complete")).toBeInTheDocument();
+    expect(screen.getByText("Started by")).toBeInTheDocument();
+    expect(screen.getByText("Kofi Mensah")).toBeInTheDocument();
+    expect(screen.getByText("Started at")).toBeInTheDocument();
     expect(screen.getByText("Morning handoff reviewed.")).toBeInTheDocument();
     expect(
       screen.queryByRole("button", { name: /start day/i }),

--- a/packages/athena-webapp/src/components/operations/DailyOpeningView.tsx
+++ b/packages/athena-webapp/src/components/operations/DailyOpeningView.tsx
@@ -26,6 +26,7 @@ import {
 import { getOrigin } from "@/lib/navigationUtils";
 import { api } from "~/convex/_generated/api";
 import type { Id } from "~/convex/_generated/dataModel";
+import type { ApprovalRequirement } from "~/shared/approvalPolicy";
 import type { CommandResult } from "~/shared/commandResult";
 import View from "../View";
 import { FadeIn } from "../common/FadeIn";
@@ -37,10 +38,16 @@ import {
   PageWorkspaceRail,
 } from "../common/PageLevelHeader";
 import { EmptyState } from "../states/empty/empty-state";
+import {
+  CommandApprovalDialog,
+  type CommandApprovalDialogProps,
+} from "./CommandApprovalDialog";
 import { NoPermissionView } from "../states/no-permission/NoPermissionView";
 import { ProtectedAdminSignInView } from "../states/signed-out/ProtectedAdminSignInView";
 import { Badge } from "../ui/badge";
 import { Button } from "../ui/button";
+import { Checkbox } from "../ui/checkbox";
+import { Label } from "../ui/label";
 import { LoadingButton } from "../ui/loading-button";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "../ui/tabs";
 
@@ -57,11 +64,7 @@ const useExpectedDailyOpeningMutation = useMutation as unknown as (
   mutation: unknown,
 ) => (args: Record<string, unknown>) => Promise<unknown>;
 
-type DailyOpeningStatus =
-  | "blocked"
-  | "needs_attention"
-  | "ready"
-  | "started";
+type DailyOpeningStatus = "blocked" | "needs_attention" | "ready" | "started";
 
 export type DailyOpeningItemLink = {
   href?: string;
@@ -131,6 +134,7 @@ export type DailyOpeningSnapshot = {
 
 type StartDayArgs = {
   acknowledgedItemKeys: string[];
+  actorStaffProfileId?: Id<"staffProfile">;
   endAt: number;
   notes: string;
   operatingDate: string;
@@ -146,9 +150,8 @@ type DailyOpeningViewContentProps = {
   isLoadingAccess: boolean;
   isLoadingSnapshot: boolean;
   isStarting: boolean;
-  onStartDay: (
-    args: StartDayArgs,
-  ) => Promise<NormalizedCommandResult<unknown>>;
+  onStartDay: (args: StartDayArgs) => Promise<NormalizedCommandResult<unknown>>;
+  onAuthenticateForApproval?: CommandApprovalDialogProps["onAuthenticateForApproval"];
   orgUrlSlug: string;
   snapshot?: DailyOpeningSnapshot;
   storeId?: Id<"store">;
@@ -199,7 +202,7 @@ const statusCopy: Record<
   },
   started: {
     badge: "Started",
-    description: "The store day has a saved opening record.",
+    description: "Opening handoff is complete. The store day is ready to run.",
     title: "Store day started",
   },
 };
@@ -281,7 +284,10 @@ function getOpeningStatus(snapshot: DailyOpeningSnapshot): DailyOpeningStatus {
   if (snapshot.status) return snapshot.status;
   if (snapshot.readiness?.status) return snapshot.readiness.status;
   if (snapshot.blockers.length > 0) return "blocked";
-  if (snapshot.reviewItems.length > 0 || snapshot.carryForwardItems.length > 0) {
+  if (
+    snapshot.reviewItems.length > 0 ||
+    snapshot.carryForwardItems.length > 0
+  ) {
     return "needs_attention";
   }
   return "ready";
@@ -331,6 +337,26 @@ function formatMetadataValue(value: ReactNode, currency: string) {
   return value;
 }
 
+function getMetadataLabel(item: DailyOpeningItem, label: string) {
+  if (label === "operatingDate") {
+    if (item.key === "daily_close:prior:missing") {
+      return "Store day being opened";
+    }
+
+    return "Store day";
+  }
+
+  return humanizeMetadataLabel(label);
+}
+
+function getMetadataValue(label: string, value: ReactNode, currency: string) {
+  if (label === "operatingDate" && typeof value === "string") {
+    return formatOperatingDate(value);
+  }
+
+  return formatMetadataValue(value, currency);
+}
+
 function getMetadataEntries(item: DailyOpeningItem, currency: string) {
   if (!item.metadata) return [];
 
@@ -342,10 +368,12 @@ function getMetadataEntries(item: DailyOpeningItem, currency: string) {
   }
 
   return Object.entries(item.metadata)
-    .filter(([, value]) => value !== null && value !== undefined && value !== "")
+    .filter(
+      ([, value]) => value !== null && value !== undefined && value !== "",
+    )
     .map(([label, value]) => ({
-      label: humanizeMetadataLabel(label),
-      value: formatMetadataValue(value as ReactNode, currency),
+      label: getMetadataLabel(item, label),
+      value: getMetadataValue(label, value as ReactNode, currency),
     }));
 }
 
@@ -466,7 +494,8 @@ function getBucketConfigs(snapshot: DailyOpeningSnapshot): BucketConfig[] {
     },
     {
       ariaLabel: "Carry-forward items",
-      description: "These open work items remain unresolved after acknowledgement.",
+      description:
+        "These open work items remain unresolved after acknowledgement.",
       emptyText: "No carry-forward items are currently reported.",
       items: snapshot.carryForwardItems,
       status: "carry-forward",
@@ -475,7 +504,8 @@ function getBucketConfigs(snapshot: DailyOpeningSnapshot): BucketConfig[] {
     },
     {
       ariaLabel: "Ready opening items",
-      description: "Completed handoff checks that support starting the store day.",
+      description:
+        "Completed handoff checks that support starting the store day.",
       emptyText: "Ready items will appear after the handoff is checked.",
       items: snapshot.readyItems,
       status: "ready",
@@ -796,13 +826,7 @@ function BucketTabs({
   );
 }
 
-function SummaryMetric({
-  label,
-  value,
-}: {
-  label: string;
-  value: string;
-}) {
+function SummaryMetric({ label, value }: { label: string; value: string }) {
   return (
     <div className="rounded-lg border border-border bg-surface-raised p-layout-md shadow-surface">
       <p className="text-[11px] font-medium uppercase tracking-[0.18em] text-muted-foreground">
@@ -868,13 +892,8 @@ function OpeningRail({
     {
       label: "Carry forward",
       tone: "workflow",
-      value: formatCount(
-        snapshot.carryForwardItems.length,
-        "item",
-        "None",
-      ),
-      valueTone:
-        snapshot.carryForwardItems.length > 0 ? "workflow" : "plain",
+      value: formatCount(snapshot.carryForwardItems.length, "item", "None"),
+      valueTone: snapshot.carryForwardItems.length > 0 ? "workflow" : "plain",
     },
   ];
 
@@ -948,8 +967,7 @@ function OpeningRail({
                   className={cn(
                     "shrink-0 text-right font-medium text-foreground",
                     item.valueTone === "danger" && "text-danger",
-                    item.valueTone === "warning" &&
-                      "text-warning-foreground",
+                    item.valueTone === "warning" && "text-warning-foreground",
                     item.valueTone === "workflow" && "text-action-workflow",
                   )}
                 >
@@ -970,29 +988,35 @@ function OpeningRail({
             <div className="mt-layout-sm space-y-layout-xs">
               {acknowledgementItems.map((item) => {
                 const acknowledgementKey = getAcknowledgementKey(item);
+                const checkboxId = `daily-opening-acknowledgement-${acknowledgementKey.replace(/[^a-zA-Z0-9_-]/g, "-")}`;
 
                 return (
-                  <label
-                    className="flex items-start gap-layout-xs text-sm text-foreground"
+                  <div
+                    className="flex items-start gap-layout-xs rounded-md border border-warning/30 bg-surface-raised/70 p-layout-xs"
                     key={acknowledgementKey}
                   >
-                    <input
+                    <Checkbox
                       aria-label={`Acknowledge ${item.title}`}
                       checked={acknowledgedKeys.includes(acknowledgementKey)}
-                      className="mt-1 h-4 w-4 rounded border-border text-signal focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-                      onChange={(event) => {
+                      className="mt-0.5"
+                      id={checkboxId}
+                      onCheckedChange={(checked) => {
                         onAcknowledgedKeysChange(
-                          event.target.checked
+                          checked === true
                             ? [...acknowledgedKeys, acknowledgementKey]
                             : acknowledgedKeys.filter(
                                 (key) => key !== acknowledgementKey,
                               ),
                         );
                       }}
-                      type="checkbox"
                     />
-                    <span>{item.title}</span>
-                  </label>
+                    <Label
+                      className="cursor-pointer text-sm font-medium leading-5"
+                      htmlFor={checkboxId}
+                    >
+                      {item.title}
+                    </Label>
+                  </div>
                 );
               })}
             </div>
@@ -1000,16 +1024,25 @@ function OpeningRail({
         ) : null}
 
         {isStarted && snapshot.startedOpening ? (
-          <div className="mt-layout-md rounded-lg border border-success/30 bg-success/10 p-layout-sm">
+          <div className="mt-layout-lg rounded-lg border border-success/30 bg-success/10 p-layout-sm">
             <p className="text-sm font-medium text-success">
-              Opening record saved
+              Opening handoff complete
             </p>
-            <p className="mt-1 text-sm leading-6 text-muted-foreground">
-              {snapshot.startedOpening.startedByStaffName
-                ? `Started by ${snapshot.startedOpening.startedByStaffName}.`
-                : "Started staff unavailable."}{" "}
-              {formatTimestamp(snapshot.startedOpening.startedAt)}
-            </p>
+            <dl className="mt-layout-sm space-y-layout-xs text-sm">
+              <div className="flex items-start justify-between gap-layout-md">
+                <dt className="text-muted-foreground">Started by</dt>
+                <dd className="text-right font-medium text-foreground">
+                  {snapshot.startedOpening.startedByStaffName ??
+                    "Staff unavailable"}
+                </dd>
+              </div>
+              <div className="flex items-start justify-between gap-layout-md">
+                <dt className="text-muted-foreground">Started at</dt>
+                <dd className="text-right font-medium text-foreground">
+                  {formatTimestamp(snapshot.startedOpening.startedAt)}
+                </dd>
+              </div>
+            </dl>
             {snapshot.startedOpening.notes ? (
               <p className="mt-layout-sm text-sm leading-6 text-foreground">
                 {snapshot.startedOpening.notes}
@@ -1084,6 +1117,7 @@ export function DailyOpeningViewContent({
   isLoadingAccess,
   isLoadingSnapshot,
   isStarting,
+  onAuthenticateForApproval,
   onStartDay,
   orgUrlSlug,
   snapshot,
@@ -1092,6 +1126,7 @@ export function DailyOpeningViewContent({
 }: DailyOpeningViewContentProps) {
   const [acknowledgedKeys, setAcknowledgedKeys] = useState<string[]>([]);
   const [notes, setNotes] = useState("");
+  const [isManagerApprovalOpen, setIsManagerApprovalOpen] = useState(false);
   const [commandMessage, setCommandMessage] = useState<{
     kind: "error" | "success";
     message: string;
@@ -1109,6 +1144,29 @@ export function DailyOpeningViewContent({
     ],
     [snapshot],
   );
+  const openingApproval = useMemo<ApprovalRequirement | null>(() => {
+    if (!snapshot || !storeId) return null;
+
+    return {
+      action: {
+        key: "operations.daily_opening.start_day",
+        label: "Start store day",
+      },
+      copy: {
+        title: "Manager approval required",
+        message: "Manager approval is required to start the store day.",
+        primaryActionLabel: "Start Day",
+      },
+      reason: "Manager approval is required to start the store day.",
+      requiredRole: "manager",
+      resolutionModes: [{ kind: "inline_manager_proof" }],
+      subject: {
+        id: `${storeId}:${snapshot.operatingDate}`,
+        label: `Opening ${formatOperatingDate(snapshot.operatingDate)}`,
+        type: "daily_opening",
+      },
+    };
+  }, [snapshot, storeId]);
 
   if (isLoadingAccess) {
     return (
@@ -1155,8 +1213,7 @@ export function DailyOpeningViewContent({
   const acknowledgedRequiredCount = requiredAcknowledgementKeys.filter((key) =>
     acknowledgedKeys.includes(key),
   ).length;
-
-  const handleStartDay = async () => {
+  const submitStartDay = async (actorStaffProfileId?: Id<"staffProfile">) => {
     if (!snapshot || isBlocked || isStarted) return;
 
     const acknowledgementComplete =
@@ -1168,6 +1225,7 @@ export function DailyOpeningViewContent({
 
     const result = await onStartDay({
       acknowledgedItemKeys: requiredAcknowledgementKeys,
+      ...(actorStaffProfileId ? { actorStaffProfileId } : {}),
       endAt: snapshot.endAt,
       notes,
       operatingDate: snapshot.operatingDate,
@@ -1186,6 +1244,16 @@ export function DailyOpeningViewContent({
       kind: "error",
       message: normalizeCommandMessage(result),
     });
+  };
+
+  const handleStartDay = () => {
+    if (onAuthenticateForApproval && openingApproval) {
+      setCommandMessage(null);
+      setIsManagerApprovalOpen(true);
+      return;
+    }
+
+    void submitStartDay();
   };
 
   const handleBucketValueChange = (value: BucketStatus) => {
@@ -1248,7 +1316,8 @@ export function DailyOpeningViewContent({
                   <SummaryMetric
                     label="Blockers"
                     value={formatCount(
-                      snapshot.summary?.blockerCount ?? snapshot.blockers.length,
+                      snapshot.summary?.blockerCount ??
+                        snapshot.blockers.length,
                       "blocker",
                       "No hard blockers",
                     )}
@@ -1299,7 +1368,7 @@ export function DailyOpeningViewContent({
                   notes={notes}
                   onAcknowledgedKeysChange={setAcknowledgedKeys}
                   onNotesChange={setNotes}
-                  onStartDay={() => void handleStartDay()}
+                  onStartDay={handleStartDay}
                   requiredAcknowledgementCount={
                     requiredAcknowledgementKeys.length
                   }
@@ -1307,6 +1376,19 @@ export function DailyOpeningViewContent({
                   status={status}
                 />
               </PageWorkspaceGrid>
+              {onAuthenticateForApproval && openingApproval ? (
+                <CommandApprovalDialog
+                  approval={openingApproval}
+                  onApproved={(result) => {
+                    setIsManagerApprovalOpen(false);
+                    void submitStartDay(result.approvedByStaffProfileId);
+                  }}
+                  onAuthenticateForApproval={onAuthenticateForApproval}
+                  onDismiss={() => setIsManagerApprovalOpen(false)}
+                  open={isManagerApprovalOpen}
+                  storeId={storeId}
+                />
+              ) : null}
             </PageWorkspace>
           )}
         </PageWorkspace>
@@ -1367,6 +1449,48 @@ function DailyOpeningConnectedView({
       : "skip",
   ) as DailyOpeningSnapshot | undefined;
   const startStoreDayMutation = useExpectedDailyOpeningMutation(startStoreDay);
+  const authenticateStaffCredentialForApproval = useMutation(
+    api.operations.staffCredentials.authenticateStaffCredentialForApproval,
+  );
+
+  async function handleAuthenticateForApproval(args: {
+    actionKey: string;
+    pinHash: string;
+    reason?: string;
+    requiredRole: ApprovalRequirement["requiredRole"];
+    requestedByStaffProfileId?: Id<"staffProfile">;
+    storeId: Id<"store">;
+    subject: ApprovalRequirement["subject"];
+    username: string;
+  }) {
+    if (!activeStore?._id) {
+      return {
+        kind: "user_error",
+        error: {
+          code: "authentication_failed",
+          message: "Select a store before confirming manager credentials.",
+        },
+      } as NormalizedCommandResult<{
+        approvalProofId: Id<"approvalProof">;
+        approvedByStaffProfileId: Id<"staffProfile">;
+        expiresAt: number;
+        requestedByStaffProfileId?: Id<"staffProfile">;
+      }>;
+    }
+
+    return runCommand(() =>
+      authenticateStaffCredentialForApproval({
+        actionKey: args.actionKey,
+        pinHash: args.pinHash,
+        reason: args.reason,
+        requiredRole: args.requiredRole,
+        requestedByStaffProfileId: args.requestedByStaffProfileId,
+        storeId: args.storeId,
+        subject: args.subject,
+        username: args.username,
+      }),
+    );
+  }
 
   const handleStartDay = async (args: StartDayArgs) => {
     if (!activeStore?._id) {
@@ -1386,6 +1510,7 @@ function DailyOpeningConnectedView({
         () =>
           startStoreDayMutation({
             acknowledgedItemKeys: args.acknowledgedItemKeys,
+            actorStaffProfileId: args.actorStaffProfileId,
             endAt: args.endAt,
             notes: args.notes || undefined,
             operatingDate: args.operatingDate,
@@ -1406,6 +1531,7 @@ function DailyOpeningConnectedView({
       isLoadingAccess={isLoadingAccess}
       isLoadingSnapshot={snapshot === undefined}
       isStarting={isStarting}
+      onAuthenticateForApproval={handleAuthenticateForApproval}
       onStartDay={handleStartDay}
       orgUrlSlug={params?.orgUrlSlug ?? ""}
       snapshot={snapshot}

--- a/packages/athena-webapp/src/components/procurement/ProcurementView.test.tsx
+++ b/packages/athena-webapp/src/components/procurement/ProcurementView.test.tsx
@@ -632,7 +632,7 @@ describe("ProcurementViewContent", () => {
     expect(screen.getByText("Camera")).toBeInTheDocument();
   });
 
-  it("communicates handled rows with inbound cover as handled pressure", async () => {
+  it("communicates handled rows with inbound cover inside the inbound queue", async () => {
     const { default: userEvent } = await import("@testing-library/user-event");
     const user = userEvent.setup();
 
@@ -646,8 +646,9 @@ describe("ProcurementViewContent", () => {
     await user.click(screen.getByRole("tab", { name: /inbound/i }));
 
     expect(screen.getByText("Logitech Mouse")).toBeInTheDocument();
-
-    await user.click(screen.getByRole("tab", { name: /handled/i }));
+    expect(
+      screen.queryByRole("tab", { name: /handled/i }),
+    ).not.toBeInTheDocument();
 
     const resolvedRow = screen.getByText("Logitech Mouse").closest("article")!;
     expect(within(resolvedRow).getByText("Handled")).toBeInTheDocument();
@@ -670,7 +671,7 @@ describe("ProcurementViewContent", () => {
     render(
       <ProcurementViewContent
         {...baseProps}
-        mode="resolved"
+        mode="all"
         recommendations={resolvedRecommendations}
       />,
     );

--- a/packages/athena-webapp/src/components/procurement/ProcurementView.tsx
+++ b/packages/athena-webapp/src/components/procurement/ProcurementView.tsx
@@ -155,7 +155,6 @@ const MODE_OPTIONS = [
   { label: "Planned", value: "planned" as const },
   { label: "Inbound", value: "inbound" as const },
   { label: "Exceptions", value: "exceptions" as const },
-  { label: "Handled", value: "resolved" as const },
   { label: "All", value: "all" as const },
 ] as const;
 
@@ -392,10 +391,6 @@ function isRecommendationVisible(
     );
   }
 
-  if (mode === "resolved") {
-    return recommendation.status === "resolved";
-  }
-
   return (
     recommendation.needsAction ||
     recommendation.status === "exposed" ||
@@ -437,12 +432,6 @@ function getModeEmptyStateCopy(mode: ProcurementMode) {
           "No draft, submitted, or approved purchase orders are currently planned against pressure",
         title: "No planned procurement work",
       };
-    case "resolved":
-      return {
-        description:
-          "No rows have enough stock or purchase order cover right now",
-        title: "No handled rows",
-      };
     default:
       return {
         description:
@@ -467,8 +456,6 @@ function getRecommendationCountCopy(mode: ProcurementMode, count: number) {
       return `${countCopy} need${count === 1 ? "s" : ""} action`;
     case "planned":
       return `${countCopy} planned stock item${count === 1 ? "" : "s"}`;
-    case "resolved":
-      return `${countCopy} handled stock item${count === 1 ? "" : "s"}`;
   }
 }
 
@@ -493,7 +480,7 @@ function canReceivePurchaseOrder(status: PurchaseOrderStatus) {
   return status === "ordered" || status === "partially_received";
 }
 
-function getPurchaseOrderMode(status: PurchaseOrderStatus): ProcurementMode {
+function getPurchaseOrderMode(status: PurchaseOrderStatus) {
   switch (status) {
     case "draft":
     case "submitted":
@@ -503,7 +490,7 @@ function getPurchaseOrderMode(status: PurchaseOrderStatus): ProcurementMode {
     case "partially_received":
       return "inbound";
     case "received":
-      return "resolved";
+      return null;
     case "cancelled":
       return "exceptions";
   }
@@ -735,15 +722,17 @@ export function ProcurementViewContent({
     inbound: countRecommendationsForMode(recommendations, "inbound"),
     needs_action: countRecommendationsForMode(recommendations, "needs_action"),
     planned: countRecommendationsForMode(recommendations, "planned"),
-    resolved: countRecommendationsForMode(recommendations, "resolved"),
   };
+  const resolvedRecommendationCount = recommendations.filter(
+    (recommendation) => recommendation.status === "resolved",
+  ).length;
   const summary = {
     activePurchaseOrders: activePurchaseOrders.length,
     exceptions: recommendationCounts.exceptions,
     inbound: recommendationCounts.inbound,
     needsAction: recommendationCounts.needs_action,
     planned: recommendationCounts.planned,
-    resolved: recommendationCounts.resolved,
+    resolved: resolvedRecommendationCount,
   };
   const shouldPrioritizeReorderDraft = draftLines.length > 0;
   const plannedPurchaseOrderActionCount = visibleRecommendations.reduce(
@@ -806,6 +795,9 @@ export function ProcurementViewContent({
     if (recommendation) {
       selectProductSku(recommendation);
       setScrollTargetProductSkuId(recommendation._id);
+    }
+    if (!nextMode) {
+      return;
     }
     handleModeChange(nextMode);
     if (recommendation) {

--- a/packages/athena-webapp/src/routes/__root.tsx
+++ b/packages/athena-webapp/src/routes/__root.tsx
@@ -1,7 +1,6 @@
 import {
   Outlet,
   ScrollRestoration,
-  createRootRoute,
   createRootRouteWithContext,
 } from "@tanstack/react-router";
 
@@ -12,6 +11,11 @@ import { NotFoundView } from "@/components/states/not-found/NotFoundView";
 import { z } from "zod";
 import { useNavigationKeyboardShortcuts } from "@/hooks/use-navigation-keyboard-shortcuts";
 
+const procurementModeSchema = z.preprocess(
+  (value) => (value === "resolved" ? undefined : value),
+  z.enum(["needs_action", "planned", "inbound", "exceptions", "all"]).optional(),
+);
+
 const rootPageSchema = z.object({
   o: z.string().optional(),
   variant: z.string().optional(),
@@ -20,9 +24,7 @@ const rootPageSchema = z.object({
   registerSessionId: z.string().optional(),
   mode: z.enum(["cycle_count", "manual"]).optional(),
   page: z.coerce.number().int().positive().optional(),
-  procurementMode: z
-    .enum(["needs_action", "planned", "inbound", "exceptions", "resolved", "all"])
-    .optional(),
+  procurementMode: procurementModeSchema,
   scope: z.string().optional(),
   sku: z.string().optional(),
 });

--- a/packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/procurement.index.test.ts
+++ b/packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/procurement.index.test.ts
@@ -4,6 +4,7 @@ import {
   getNextProcurementModeSearch,
   getNextProcurementPageSearch,
   getNextProcurementSelectedSkuSearch,
+  procurementSearchSchema,
 } from "./procurement.index";
 
 describe("procurement route search state", () => {
@@ -38,6 +39,15 @@ describe("procurement route search state", () => {
         "needs_action",
       ),
     ).toEqual({ page: 1, sku: "6N2Y-XEH-P6B" });
+  });
+
+  it("normalizes the removed handled mode to the default queue", () => {
+    expect(
+      procurementSearchSchema.parse({
+        page: "2",
+        procurementMode: "resolved",
+      }),
+    ).toEqual({ page: 2, procurementMode: undefined });
   });
 
   it("encodes the visible recommendation page in the URL search state", () => {

--- a/packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/procurement.index.tsx
+++ b/packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/procurement.index.tsx
@@ -2,10 +2,13 @@ import { createFileRoute } from "@tanstack/react-router";
 import { z } from "zod";
 import { ProcurementView } from "~/src/components/procurement/ProcurementView";
 
-const procurementSearchSchema = z.object({
-  procurementMode: z
-    .enum(["needs_action", "planned", "inbound", "exceptions", "resolved", "all"])
-    .optional(),
+const procurementModeSchema = z.preprocess(
+  (value) => (value === "resolved" ? undefined : value),
+  z.enum(["needs_action", "planned", "inbound", "exceptions", "all"]).optional(),
+);
+
+export const procurementSearchSchema = z.object({
+  procurementMode: procurementModeSchema,
   page: z.coerce.number().int().positive().optional(),
   sku: z.string().optional(),
 });


### PR DESCRIPTION
## Summary
- Treat missing prior daily close as an opening review item instead of a hard blocker, with checklist acknowledgement before start.
- Use manager approval for starting the day and persist the approved staff profile on the opening record.
- Tighten opening status copy/IA and remove the visible handled procurement queue while preserving broader queue visibility.
- Refresh graphify artifacts and update the daily opening readiness solution note.

## Validation
- bun run pr:athena
- pre-push hook reused the recorded pr:athena proof

Visual validation left to the browser review loop per request.