### PR TITLE
Include expenses in Daily Close ready items

### DIFF
--- a/docs/solutions/logic-errors/athena-daily-close-store-day-boundary-2026-05-07.md
+++ b/docs/solutions/logic-errors/athena-daily-close-store-day-boundary-2026-05-07.md
@@ -11,6 +11,7 @@ symptoms:
   - "Register, POS session, and store-day close data can drift without a server-owned snapshot"
   - "Late-night local transactions can be omitted when the server interprets an operating date as a UTC day"
   - "An empty operating day can look accidentally ready instead of intentionally closable"
+  - "Expense totals can appear in Daily Close metrics without the underlying expense transactions appearing in the ready list"
 root_cause: store_day_lifecycle_missing_authoritative_close_record
 resolution_type: domain_model_plus_command_boundary
 severity: medium
@@ -46,6 +47,8 @@ Keep the scopes explicit:
 - Daily Close is store-day scoped.
 - Cash Controls is drawer/session scoped.
 - A POS session is the sale/cart lifecycle.
+- An expense transaction is a completed store-day outflow that must be visible
+  alongside completed sales.
 - `registerSession` is the drawer/shift ledger behind cash-control closeout.
 
 The close command should accept reviewed item keys and carry-forward work item
@@ -73,6 +76,14 @@ operating day. The client should pass the local `startAt`/`endAt` bounds it is
 using for the operating date, and the server should validate those bounds before
 using them for transaction, register-session, expense, and variance reads.
 
+Every source table that contributes to close totals should also contribute
+operator-visible close evidence unless the source is intentionally hidden by
+policy. Completed expense transactions are not enough as an aggregate expense
+total; they should create `readyItems` with the expense report number, staff
+owner, register when available, amount, completion time, notes, and a link back
+to the expense report. Query them through a store/status/completed-at index so
+the snapshot cannot miss valid expenses after a broad store-level limit.
+
 For POS completion, recompute totals from normalized line items and compare the
 submitted payment against that canonical total. The persisted transaction
 summary, payment allocation, and cash metrics should derive from the final
@@ -96,4 +107,6 @@ server-side item totals, not from stale client cart state.
   than the UI displayed.
 - Test local-day boundary cases with a completed transaction after UTC midnight
   but before the local operating day ends.
+- Test expense transactions with the same local-day boundary, store filtering,
+  and completed-status filtering used for POS transactions.
 - Add query-index coverage whenever a new close-readiness source table is added.

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -3551,7 +3551,7 @@
       "relation": "calls",
       "source": "dailyclose_buildpaymenttotals",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1271",
+      "source_location": "L1305",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -3563,7 +3563,7 @@
       "relation": "calls",
       "source": "dailyclose_buildreadiness",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1273",
+      "source_location": "L1307",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -3779,7 +3779,7 @@
       "relation": "calls",
       "source": "dailyclose_uniquesourcesubjects",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1317",
+      "source_location": "L1351",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -3791,7 +3791,7 @@
       "relation": "calls",
       "source": "dailyclose_builddailycloseapprovalsubject",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1531",
+      "source_location": "L1565",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -3803,7 +3803,7 @@
       "relation": "calls",
       "source": "dailyclose_builddailyclosecompletionapprovalrequirement",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1518",
+      "source_location": "L1552",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -3815,7 +3815,7 @@
       "relation": "calls",
       "source": "dailyclose_builddailyclosesnapshotwithctx",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1454",
+      "source_location": "L1488",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -3827,7 +3827,7 @@
       "relation": "calls",
       "source": "dailyclose_createcarryforwardworkitems",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1541",
+      "source_location": "L1575",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -3839,7 +3839,7 @@
       "relation": "calls",
       "source": "dailyclose_getstore",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1429",
+      "source_location": "L1463",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -3851,7 +3851,7 @@
       "relation": "calls",
       "source": "dailyclose_markotherdailyclosesnotcurrent",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1600",
+      "source_location": "L1634",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -3863,7 +3863,7 @@
       "relation": "calls",
       "source": "dailyclose_resolveoperatingdaterange",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1445",
+      "source_location": "L1479",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -3875,7 +3875,7 @@
       "relation": "calls",
       "source": "dailyclose_trimoptional",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1582",
+      "source_location": "L1616",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -3887,7 +3887,7 @@
       "relation": "calls",
       "source": "dailyclose_validatecarryforwardworkitemids",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1504",
+      "source_location": "L1538",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -3899,7 +3899,7 @@
       "relation": "calls",
       "source": "dailyclose_trimoptional",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1363",
+      "source_location": "L1397",
       "target": "dailyclose_createcarryforwardworkitems",
       "weight": 1
     },
@@ -3911,7 +3911,7 @@
       "relation": "calls",
       "source": "dailyclose_getpriorcompleteddailyclose",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1667",
+      "source_location": "L1701",
       "target": "dailyclose_getdailycloseopeningcontextwithctx",
       "weight": 1
     },
@@ -3959,7 +3959,7 @@
       "relation": "calls",
       "source": "dailycloseview_formatmetadatavalue",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L782",
+      "source_location": "L791",
       "target": "dailycloseview_formatmetadatadisplayvalue",
       "weight": 1
     },
@@ -3971,7 +3971,7 @@
       "relation": "calls",
       "source": "dailycloseview_getmetadatastringvalue",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L784",
+      "source_location": "L793",
       "target": "dailycloseview_formatmetadatadisplayvalue",
       "weight": 1
     },
@@ -3983,7 +3983,7 @@
       "relation": "calls",
       "source": "dailycloseview_getnumericmetadatavalue",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L808",
+      "source_location": "L817",
       "target": "dailycloseview_formatmetadatadisplayvalue",
       "weight": 1
     },
@@ -3995,7 +3995,7 @@
       "relation": "calls",
       "source": "dailycloseview_getvariancetone",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L813",
+      "source_location": "L822",
       "target": "dailycloseview_formatmetadatadisplayvalue",
       "weight": 1
     },
@@ -4007,7 +4007,7 @@
       "relation": "calls",
       "source": "dailycloseview_normalizemetadatalabel",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L787",
+      "source_location": "L796",
       "target": "dailycloseview_formatmetadatadisplayvalue",
       "weight": 1
     },
@@ -4019,7 +4019,7 @@
       "relation": "calls",
       "source": "dailycloseview_formatmoney",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L730",
+      "source_location": "L739",
       "target": "dailycloseview_formatmetadatavalue",
       "weight": 1
     },
@@ -4031,7 +4031,7 @@
       "relation": "calls",
       "source": "dailycloseview_formattimestampmetadata",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L726",
+      "source_location": "L735",
       "target": "dailycloseview_formatmetadatavalue",
       "weight": 1
     },
@@ -4043,7 +4043,7 @@
       "relation": "calls",
       "source": "dailycloseview_humanizemetadatalabel",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L754",
+      "source_location": "L763",
       "target": "dailycloseview_formatmetadatavalue",
       "weight": 1
     },
@@ -4055,7 +4055,7 @@
       "relation": "calls",
       "source": "dailycloseview_ismoneymetadatalabel",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L729",
+      "source_location": "L738",
       "target": "dailycloseview_formatmetadatavalue",
       "weight": 1
     },
@@ -4067,7 +4067,7 @@
       "relation": "calls",
       "source": "dailycloseview_istimestampmetadatalabel",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L725",
+      "source_location": "L734",
       "target": "dailycloseview_formatmetadatavalue",
       "weight": 1
     },
@@ -4079,7 +4079,7 @@
       "relation": "calls",
       "source": "dailycloseview_normalizemetadatalabel",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L718",
+      "source_location": "L727",
       "target": "dailycloseview_formatmetadatavalue",
       "weight": 1
     },
@@ -4091,7 +4091,7 @@
       "relation": "calls",
       "source": "dailycloseview_iszeroactivitydailyclose",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1121",
+      "source_location": "L1130",
       "target": "dailycloseview_getbucketconfigs",
       "weight": 1
     },
@@ -4127,7 +4127,7 @@
       "relation": "calls",
       "source": "dailycloseview_humanizemetadatalabel",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L694",
+      "source_location": "L703",
       "target": "dailycloseview_getdisplaymetadatalabel",
       "weight": 1
     },
@@ -4139,7 +4139,7 @@
       "relation": "calls",
       "source": "dailycloseview_normalizemetadatalabel",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L687",
+      "source_location": "L696",
       "target": "dailycloseview_getdisplaymetadatalabel",
       "weight": 1
     },
@@ -4175,7 +4175,7 @@
       "relation": "calls",
       "source": "dailycloseview_normalizemetadatalabel",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L832",
+      "source_location": "L841",
       "target": "dailycloseview_getmetadataentries",
       "weight": 1
     },
@@ -4187,7 +4187,7 @@
       "relation": "calls",
       "source": "dailycloseview_normalizemetadatalabel",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L708",
+      "source_location": "L717",
       "target": "dailycloseview_getmetadatavalue",
       "weight": 1
     },
@@ -4199,7 +4199,7 @@
       "relation": "calls",
       "source": "dailycloseview_iszeroactivitydailyclose",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1091",
+      "source_location": "L1100",
       "target": "dailycloseview_getstatusdisplaycopy",
       "weight": 1
     },
@@ -4247,7 +4247,7 @@
       "relation": "calls",
       "source": "dailycloseview_getsummaryamount",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1030",
+      "source_location": "L1039",
       "target": "dailycloseview_getsummaryregistervariancecount",
       "weight": 1
     },
@@ -4259,7 +4259,7 @@
       "relation": "calls",
       "source": "dailycloseview_normalizemetadatalabel",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L632",
+      "source_location": "L641",
       "target": "dailycloseview_ismoneymetadatalabel",
       "weight": 1
     },
@@ -4271,7 +4271,7 @@
       "relation": "calls",
       "source": "dailycloseview_normalizemetadatalabel",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L636",
+      "source_location": "L645",
       "target": "dailycloseview_istimestampmetadatalabel",
       "weight": 1
     },
@@ -4283,7 +4283,7 @@
       "relation": "calls",
       "source": "dailycloseview_getexpensestaffcount",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1068",
+      "source_location": "L1077",
       "target": "dailycloseview_iszeroactivitydailyclose",
       "weight": 1
     },
@@ -4295,7 +4295,7 @@
       "relation": "calls",
       "source": "dailycloseview_getsummaryamount",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1070",
+      "source_location": "L1079",
       "target": "dailycloseview_iszeroactivitydailyclose",
       "weight": 1
     },
@@ -4307,7 +4307,7 @@
       "relation": "calls",
       "source": "dailycloseview_getsummarycount",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1056",
+      "source_location": "L1065",
       "target": "dailycloseview_iszeroactivitydailyclose",
       "weight": 1
     },
@@ -4319,7 +4319,7 @@
       "relation": "calls",
       "source": "dailycloseview_getsummaryregistervariancecount",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1069",
+      "source_location": "L1078",
       "target": "dailycloseview_iszeroactivitydailyclose",
       "weight": 1
     },
@@ -4331,7 +4331,7 @@
       "relation": "calls",
       "source": "dailycloseview_getnumericmetadatavalue",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L668",
+      "source_location": "L677",
       "target": "dailycloseview_shouldshowmetadataentry",
       "weight": 1
     },
@@ -4343,7 +4343,7 @@
       "relation": "calls",
       "source": "dailycloseview_normalizemetadatalabel",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L661",
+      "source_location": "L670",
       "target": "dailycloseview_shouldshowmetadataentry",
       "weight": 1
     },
@@ -14723,7 +14723,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1425",
+      "source_location": "L1459",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -14735,7 +14735,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1349",
+      "source_location": "L1383",
       "target": "dailyclose_createcarryforwardworkitems",
       "weight": 1
     },
@@ -14783,7 +14783,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1660",
+      "source_location": "L1694",
       "target": "dailyclose_getdailycloseopeningcontextwithctx",
       "weight": 1
     },
@@ -14939,7 +14939,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1402",
+      "source_location": "L1436",
       "target": "dailyclose_markotherdailyclosesnotcurrent",
       "weight": 1
     },
@@ -15059,7 +15059,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1321",
+      "source_location": "L1355",
       "target": "dailyclose_validatecarryforwardworkitemids",
       "weight": 1
     },
@@ -26123,7 +26123,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_test_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.test.tsx",
-      "source_location": "L278",
+      "source_location": "L302",
       "target": "dailycloseview_test_disconnect",
       "weight": 1
     },
@@ -26135,7 +26135,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_test_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.test.tsx",
-      "source_location": "L279",
+      "source_location": "L303",
       "target": "dailycloseview_test_observe",
       "weight": 1
     },
@@ -26147,7 +26147,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_test_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.test.tsx",
-      "source_location": "L280",
+      "source_location": "L304",
       "target": "dailycloseview_test_unobserve",
       "weight": 1
     },
@@ -26159,7 +26159,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1621",
+      "source_location": "L1630",
       "target": "dailycloseview_cn",
       "weight": 1
     },
@@ -26219,7 +26219,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L767",
+      "source_location": "L776",
       "target": "dailycloseview_formatmetadatadisplayvalue",
       "weight": 1
     },
@@ -26231,7 +26231,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L715",
+      "source_location": "L724",
       "target": "dailycloseview_formatmetadatavalue",
       "weight": 1
     },
@@ -26291,7 +26291,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L675",
+      "source_location": "L684",
       "target": "dailycloseview_formattimestampmetadata",
       "weight": 1
     },
@@ -26315,7 +26315,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1120",
+      "source_location": "L1129",
       "target": "dailycloseview_getbucketconfigs",
       "weight": 1
     },
@@ -26387,7 +26387,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1103",
+      "source_location": "L1112",
       "target": "dailycloseview_getdefaultbucketvalue",
       "weight": 1
     },
@@ -26399,7 +26399,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L685",
+      "source_location": "L694",
       "target": "dailycloseview_getdisplaymetadatalabel",
       "weight": 1
     },
@@ -26411,7 +26411,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1038",
+      "source_location": "L1047",
       "target": "dailycloseview_getexpensestaffcount",
       "weight": 1
     },
@@ -26483,7 +26483,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L824",
+      "source_location": "L833",
       "target": "dailycloseview_getmetadataentries",
       "weight": 1
     },
@@ -26495,7 +26495,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L697",
+      "source_location": "L706",
       "target": "dailycloseview_getmetadatastringvalue",
       "weight": 1
     },
@@ -26507,7 +26507,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L707",
+      "source_location": "L716",
       "target": "dailycloseview_getmetadatavalue",
       "weight": 1
     },
@@ -26519,7 +26519,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L647",
+      "source_location": "L656",
       "target": "dailycloseview_getnumericmetadatavalue",
       "weight": 1
     },
@@ -26543,7 +26543,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1087",
+      "source_location": "L1096",
       "target": "dailycloseview_getstatusdisplaycopy",
       "weight": 1
     },
@@ -26603,7 +26603,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L993",
+      "source_location": "L1002",
       "target": "dailycloseview_getsummaryamount",
       "weight": 1
     },
@@ -26615,7 +26615,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1008",
+      "source_location": "L1017",
       "target": "dailycloseview_getsummarycount",
       "weight": 1
     },
@@ -26627,7 +26627,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1023",
+      "source_location": "L1032",
       "target": "dailycloseview_getsummaryregistervariancecount",
       "weight": 1
     },
@@ -26639,7 +26639,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L639",
+      "source_location": "L648",
       "target": "dailycloseview_getvariancetone",
       "weight": 1
     },
@@ -26663,7 +26663,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L631",
+      "source_location": "L640",
       "target": "dailycloseview_ismoneymetadatalabel",
       "weight": 1
     },
@@ -26675,7 +26675,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L635",
+      "source_location": "L644",
       "target": "dailycloseview_istimestampmetadatalabel",
       "weight": 1
     },
@@ -26687,7 +26687,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1050",
+      "source_location": "L1059",
       "target": "dailycloseview_iszeroactivitydailyclose",
       "weight": 1
     },
@@ -26699,7 +26699,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1113",
+      "source_location": "L1122",
       "target": "dailycloseview_normalizebuckettab",
       "weight": 1
     },
@@ -26723,7 +26723,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L627",
+      "source_location": "L636",
       "target": "dailycloseview_normalizemetadatalabel",
       "weight": 1
     },
@@ -26735,7 +26735,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L660",
+      "source_location": "L669",
       "target": "dailycloseview_shouldshowmetadataentry",
       "weight": 1
     },
@@ -56509,7 +56509,7 @@
       "label": "cn()",
       "norm_label": "cn()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1477"
+      "source_location": "L1486"
     },
     {
       "community": 0,
@@ -56554,7 +56554,7 @@
       "label": "formatMetadataDisplayValue()",
       "norm_label": "formatmetadatadisplayvalue()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L767"
+      "source_location": "L776"
     },
     {
       "community": 0,
@@ -56563,7 +56563,7 @@
       "label": "formatMetadataValue()",
       "norm_label": "formatmetadatavalue()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L715"
+      "source_location": "L724"
     },
     {
       "community": 0,
@@ -56608,7 +56608,7 @@
       "label": "formatTimestampMetadata()",
       "norm_label": "formattimestampmetadata()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L675"
+      "source_location": "L684"
     },
     {
       "community": 0,
@@ -56626,7 +56626,7 @@
       "label": "getBucketConfigs()",
       "norm_label": "getbucketconfigs()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1120"
+      "source_location": "L1129"
     },
     {
       "community": 0,
@@ -56680,7 +56680,7 @@
       "label": "getDefaultBucketValue()",
       "norm_label": "getdefaultbucketvalue()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1103"
+      "source_location": "L1112"
     },
     {
       "community": 0,
@@ -56689,7 +56689,7 @@
       "label": "getDisplayMetadataLabel()",
       "norm_label": "getdisplaymetadatalabel()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L685"
+      "source_location": "L694"
     },
     {
       "community": 0,
@@ -56698,7 +56698,7 @@
       "label": "getExpenseStaffCount()",
       "norm_label": "getexpensestaffcount()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1038"
+      "source_location": "L1047"
     },
     {
       "community": 0,
@@ -56752,7 +56752,7 @@
       "label": "getMetadataEntries()",
       "norm_label": "getmetadataentries()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L824"
+      "source_location": "L833"
     },
     {
       "community": 0,
@@ -56761,7 +56761,7 @@
       "label": "getMetadataStringValue()",
       "norm_label": "getmetadatastringvalue()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L697"
+      "source_location": "L706"
     },
     {
       "community": 0,
@@ -56770,7 +56770,7 @@
       "label": "getMetadataValue()",
       "norm_label": "getmetadatavalue()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L707"
+      "source_location": "L716"
     },
     {
       "community": 0,
@@ -56779,7 +56779,7 @@
       "label": "getNumericMetadataValue()",
       "norm_label": "getnumericmetadatavalue()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L647"
+      "source_location": "L656"
     },
     {
       "community": 0,
@@ -56797,7 +56797,7 @@
       "label": "getStatusDisplayCopy()",
       "norm_label": "getstatusdisplaycopy()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1087"
+      "source_location": "L1096"
     },
     {
       "community": 0,
@@ -56842,7 +56842,7 @@
       "label": "getSummaryAmount()",
       "norm_label": "getsummaryamount()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L993"
+      "source_location": "L1002"
     },
     {
       "community": 0,
@@ -56851,7 +56851,7 @@
       "label": "getSummaryCount()",
       "norm_label": "getsummarycount()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1008"
+      "source_location": "L1017"
     },
     {
       "community": 0,
@@ -56860,7 +56860,7 @@
       "label": "getSummaryRegisterVarianceCount()",
       "norm_label": "getsummaryregistervariancecount()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1023"
+      "source_location": "L1032"
     },
     {
       "community": 0,
@@ -56869,7 +56869,7 @@
       "label": "getVarianceTone()",
       "norm_label": "getvariancetone()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L639"
+      "source_location": "L648"
     },
     {
       "community": 0,
@@ -56887,7 +56887,7 @@
       "label": "isMoneyMetadataLabel()",
       "norm_label": "ismoneymetadatalabel()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L631"
+      "source_location": "L640"
     },
     {
       "community": 0,
@@ -56896,7 +56896,7 @@
       "label": "isTimestampMetadataLabel()",
       "norm_label": "istimestampmetadatalabel()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L635"
+      "source_location": "L644"
     },
     {
       "community": 0,
@@ -56905,7 +56905,7 @@
       "label": "isZeroActivityDailyClose()",
       "norm_label": "iszeroactivitydailyclose()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1050"
+      "source_location": "L1059"
     },
     {
       "community": 0,
@@ -56914,7 +56914,7 @@
       "label": "normalizeBucketTab()",
       "norm_label": "normalizebuckettab()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1113"
+      "source_location": "L1122"
     },
     {
       "community": 0,
@@ -56932,7 +56932,7 @@
       "label": "normalizeMetadataLabel()",
       "norm_label": "normalizemetadatalabel()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L627"
+      "source_location": "L636"
     },
     {
       "community": 0,
@@ -56941,7 +56941,7 @@
       "label": "shouldShowMetadataEntry()",
       "norm_label": "shouldshowmetadataentry()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L660"
+      "source_location": "L669"
     },
     {
       "community": 0,
@@ -75490,7 +75490,7 @@
       "label": "disconnect()",
       "norm_label": "disconnect()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.test.tsx",
-      "source_location": "L278"
+      "source_location": "L302"
     },
     {
       "community": 279,
@@ -75499,7 +75499,7 @@
       "label": "observe()",
       "norm_label": "observe()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.test.tsx",
-      "source_location": "L279"
+      "source_location": "L303"
     },
     {
       "community": 279,
@@ -75508,7 +75508,7 @@
       "label": "unobserve()",
       "norm_label": "unobserve()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.test.tsx",
-      "source_location": "L280"
+      "source_location": "L304"
     },
     {
       "community": 279,
@@ -76687,7 +76687,7 @@
       "label": "completeDailyCloseWithCtx()",
       "norm_label": "completedailyclosewithctx()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1425"
+      "source_location": "L1459"
     },
     {
       "community": 3,
@@ -76696,7 +76696,7 @@
       "label": "createCarryForwardWorkItems()",
       "norm_label": "createcarryforwardworkitems()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1349"
+      "source_location": "L1383"
     },
     {
       "community": 3,
@@ -76732,7 +76732,7 @@
       "label": "getDailyCloseOpeningContextWithCtx()",
       "norm_label": "getdailycloseopeningcontextwithctx()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1660"
+      "source_location": "L1694"
     },
     {
       "community": 3,
@@ -76849,7 +76849,7 @@
       "label": "markOtherDailyClosesNotCurrent()",
       "norm_label": "markotherdailyclosesnotcurrent()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1402"
+      "source_location": "L1436"
     },
     {
       "community": 3,
@@ -76939,7 +76939,7 @@
       "label": "validateCarryForwardWorkItemIds()",
       "norm_label": "validatecarryforwardworkitemids()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1321"
+      "source_location": "L1355"
     },
     {
       "community": 3,

--- a/packages/athena-webapp/convex/operations/dailyClose.test.ts
+++ b/packages/athena-webapp/convex/operations/dailyClose.test.ts
@@ -272,6 +272,8 @@ describe("daily close backend foundation", () => {
         {
           _id: "expense-1",
           completedAt: Date.UTC(2026, 4, 7, 17),
+          notes: "Restocked petty cash supplies.",
+          registerNumber: "A3",
           sessionId: "expense-session-1",
           staffProfileId: "staff-1",
           status: "completed",
@@ -554,6 +556,12 @@ describe("daily close backend foundation", () => {
     expect(snapshot.readyItems.map((item) => item.key)).toContain(
       "pos_transaction:txn-1:completed",
     );
+    expect(snapshot.readyItems.map((item) => item.key)).toEqual(
+      expect.arrayContaining([
+        "expense_transaction:expense-1:completed",
+        "expense_transaction:expense-2:completed",
+      ]),
+    );
     expect(
       snapshot.readyItems.find(
         (item) => item.key === "pos_transaction:txn-1:completed",
@@ -595,6 +603,32 @@ describe("daily close backend foundation", () => {
       params: { transactionId: "txn-1" },
       to: "/$orgUrlSlug/store/$storeUrlSlug/pos/transactions/$transactionId",
     });
+    expect(
+      snapshot.readyItems.find(
+        (item) => item.key === "expense_transaction:expense-1:completed",
+      ),
+    ).toMatchObject({
+      category: "expense",
+      link: {
+        label: "View expense",
+        params: { reportId: "expense-1" },
+        to: "/$orgUrlSlug/store/$storeUrlSlug/pos/expense-reports/$reportId",
+      },
+      metadata: {
+        completedAt: Date.UTC(2026, 4, 7, 17),
+        notes: "Restocked petty cash supplies.",
+        owner: "Kofi Mensah",
+        register: "Register A3",
+        report: "EXP-1",
+        total: 4500,
+      },
+      subject: {
+        id: "expense-1",
+        label: "EXP-1",
+        type: "expense_transaction",
+      },
+      title: "Completed expense",
+    });
     expect(snapshot.summary).toMatchObject({
       carriedOverCashTotal: 10000,
       carriedOverRegisterCount: 1,
@@ -616,6 +650,18 @@ describe("daily close backend foundation", () => {
     });
     expect(snapshot.readyItems.map((item) => item.key)).not.toContain(
       "pos_transaction:txn-prior-day:completed",
+    );
+    expect(snapshot.readyItems.map((item) => item.key)).not.toContain(
+      "expense_transaction:expense-prior-day:completed",
+    );
+    expect(snapshot.sourceSubjects).toEqual(
+      expect.arrayContaining([
+        {
+          id: "expense-1",
+          label: "EXP-1",
+          type: "expense_transaction",
+        },
+      ]),
     );
   });
 
@@ -712,6 +758,89 @@ describe("daily close backend foundation", () => {
       currentDayCashTransactionCount: 1,
       salesTotal: 25000,
       transactionCount: 1,
+    });
+  });
+
+  it("uses the supplied operating-day range for completed expense transactions", async () => {
+    const { db } = createDb({
+      expenseTransaction: [
+        {
+          _id: "expense-after-utc-midnight",
+          completedAt: Date.UTC(2026, 4, 8, 1, 3),
+          sessionId: "expense-session-1",
+          staffProfileId: "staff-1",
+          status: "completed",
+          storeId: "store-1",
+          totalValue: 25000,
+          transactionNumber: "EXP-LOCAL",
+        },
+        {
+          _id: "expense-void",
+          completedAt: Date.UTC(2026, 4, 8, 1, 4),
+          sessionId: "expense-session-void",
+          staffProfileId: "staff-1",
+          status: "void",
+          storeId: "store-1",
+          totalValue: 10000,
+          transactionNumber: "EXP-VOID",
+        },
+        {
+          _id: "expense-other-store",
+          completedAt: Date.UTC(2026, 4, 8, 1, 5),
+          sessionId: "expense-session-other-store",
+          staffProfileId: "staff-1",
+          status: "completed",
+          storeId: "store-2",
+          totalValue: 9000,
+          transactionNumber: "EXP-OTHER",
+        },
+      ],
+      staffProfile: [
+        {
+          _id: "staff-1",
+          firstName: "Kofi",
+          fullName: "Kofi Mensah",
+          lastName: "Mensah",
+          organizationId: "org-1",
+          status: "active",
+          storeId: "store-1",
+        },
+      ],
+      store: [store],
+    });
+
+    const utcSnapshot = await buildDailyCloseSnapshotWithCtx(
+      { db } as unknown as QueryCtx,
+      {
+        operatingDate: "2026-05-07",
+        storeId: "store-1" as Id<"store">,
+      },
+    );
+    const localSnapshot = await buildDailyCloseSnapshotWithCtx(
+      { db } as unknown as QueryCtx,
+      {
+        endAt: Date.UTC(2026, 4, 8, 4),
+        operatingDate: "2026-05-07",
+        startAt: Date.UTC(2026, 4, 7, 4),
+        storeId: "store-1" as Id<"store">,
+      },
+    );
+
+    expect(utcSnapshot.readyItems.map((item) => item.key)).not.toContain(
+      "expense_transaction:expense-after-utc-midnight:completed",
+    );
+    expect(localSnapshot.readyItems.map((item) => item.key)).toContain(
+      "expense_transaction:expense-after-utc-midnight:completed",
+    );
+    expect(localSnapshot.readyItems.map((item) => item.key)).not.toContain(
+      "expense_transaction:expense-void:completed",
+    );
+    expect(localSnapshot.readyItems.map((item) => item.key)).not.toContain(
+      "expense_transaction:expense-other-store:completed",
+    );
+    expect(localSnapshot.summary).toMatchObject({
+      expenseStaffCount: 1,
+      expenseTotal: 25000,
     });
   });
 

--- a/packages/athena-webapp/convex/operations/dailyClose.ts
+++ b/packages/athena-webapp/convex/operations/dailyClose.ts
@@ -554,16 +554,16 @@ async function listExpensesForDay(
     storeId: Id<"store">;
   },
 ) {
-  const expenses = await ctx.db
+  return ctx.db
     .query("expenseTransaction")
-    .withIndex("by_storeId", (q) => q.eq("storeId", args.storeId))
+    .withIndex("by_storeId_status_completedAt", (q) =>
+      q
+        .eq("storeId", args.storeId)
+        .eq("status", "completed")
+        .gte("completedAt", args.startAt)
+        .lt("completedAt", args.endAt),
+    )
     .take(DAILY_CLOSE_QUERY_LIMIT);
-
-  return expenses.filter(
-    (expense) =>
-      expense.status === "completed" &&
-      isInRange(expense.completedAt, args.startAt, args.endAt),
-  );
 }
 
 async function listDepositsForDay(
@@ -811,6 +811,7 @@ export async function buildDailyCloseSnapshotWithCtx(
     ...openPosSessions.map((session) => session.staffProfileId),
     ...completedTransactions.map((transaction) => transaction.staffProfileId),
     ...voidedTransactions.map((transaction) => transaction.staffProfileId),
+    ...expenseTransactions.map((transaction) => transaction.staffProfileId),
     ...pendingApprovals.map((approval) => approval.requestedByStaffProfileId),
   ]);
   const blockers: DailyCloseItem[] = [];
@@ -1159,6 +1160,39 @@ export async function buildDailyCloseSnapshotWithCtx(
         ...(typeof transaction.changeGiven === "number"
           ? { changeGiven: transaction.changeGiven }
           : {}),
+      },
+    });
+  });
+
+  expenseTransactions.forEach((transaction) => {
+    const staffName = staffNamesById.get(transaction.staffProfileId);
+    const registerLabel = trimOptional(transaction.registerNumber)
+      ? `Register ${transaction.registerNumber}`
+      : undefined;
+
+    readyItems.push({
+      key: `expense_transaction:${transaction._id}:completed`,
+      severity: "ready",
+      category: "expense",
+      title: "Completed expense",
+      message: "Completed expense is included in Daily Close.",
+      subject: {
+        type: "expense_transaction",
+        id: transaction._id,
+        label: transaction.transactionNumber,
+      },
+      link: {
+        label: "View expense",
+        params: { reportId: transaction._id },
+        to: "/$orgUrlSlug/store/$storeUrlSlug/pos/expense-reports/$reportId",
+      },
+      metadata: {
+        report: transaction.transactionNumber,
+        ...(staffName ? { owner: staffName } : {}),
+        ...(registerLabel ? { register: registerLabel } : {}),
+        ...(transaction.notes ? { notes: transaction.notes } : {}),
+        total: transaction.totalValue,
+        completedAt: transaction.completedAt,
       },
     });
   });

--- a/packages/athena-webapp/convex/schema.ts
+++ b/packages/athena-webapp/convex/schema.ts
@@ -356,7 +356,12 @@ const schema = defineSchema({
     .index("by_storeId", ["storeId"])
     .index("by_status", ["status"])
     .index("by_staffProfileId", ["staffProfileId"])
-    .index("by_sessionId", ["sessionId"]),
+    .index("by_sessionId", ["sessionId"])
+    .index("by_storeId_status_completedAt", [
+      "storeId",
+      "status",
+      "completedAt",
+    ]),
   expenseTransactionItem: defineTable(expenseTransactionItemSchema).index(
     "by_transactionId",
     ["transactionId"]

--- a/packages/athena-webapp/src/components/operations/DailyCloseView.test.tsx
+++ b/packages/athena-webapp/src/components/operations/DailyCloseView.test.tsx
@@ -152,6 +152,30 @@ const readySnapshot: DailyCloseSnapshot = {
       },
       title: "Completed sale",
     },
+    {
+      category: "expense",
+      description: "Completed expense is included in Daily Close.",
+      id: "ready-3",
+      link: {
+        label: "View expense",
+        params: { reportId: "expense-1" },
+        to: "/$orgUrlSlug/store/$storeUrlSlug/pos/expense-reports/$reportId",
+      },
+      metadata: {
+        completedAt: Date.UTC(2026, 4, 7, 16),
+        notes: "Bought packing supplies.",
+        owner: "Akosua Mensah",
+        register: "Register A1",
+        report: "EXP-1",
+        total: 12500,
+      },
+      subject: {
+        id: "expense-1",
+        label: "EXP-1",
+        type: "expense_transaction",
+      },
+      title: "Completed expense",
+    },
   ],
   reviewItems: [
     {
@@ -385,14 +409,54 @@ describe("DailyCloseViewContent", () => {
       "href",
       "/wigclub/store/osu/pos/transactions/txn-1?o=%252F",
     );
+    const saleItem = screen.getByText("Completed sale").closest("article");
+    expect(saleItem).not.toBeNull();
     expect(
-      screen.getByText("Front counter terminal / Register A1"),
+      within(saleItem as HTMLElement).getByText(
+        "Front counter terminal / Register A1",
+      ),
     ).toBeInTheDocument();
-    expect(screen.getByText("Kofi Mensah")).toBeInTheDocument();
-    expect(screen.getByText("Cash, Mobile Money")).toBeInTheDocument();
-    expect(screen.getByText("Completed At")).toBeInTheDocument();
-    expect(screen.getByText("GH₵495")).toBeInTheDocument();
-    expect(screen.getByText("GH₵500")).toBeInTheDocument();
+    expect(
+      within(saleItem as HTMLElement).getByText("Kofi Mensah"),
+    ).toBeInTheDocument();
+    expect(
+      within(saleItem as HTMLElement).getByText("Cash, Mobile Money"),
+    ).toBeInTheDocument();
+    expect(
+      within(saleItem as HTMLElement).getByText("Completed At"),
+    ).toBeInTheDocument();
+    expect(
+      within(saleItem as HTMLElement).getByText("GH₵495"),
+    ).toBeInTheDocument();
+    expect(
+      within(saleItem as HTMLElement).getByText("GH₵500"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Completed expense")).toBeInTheDocument();
+    const expenseItem = screen.getByText("Completed expense").closest("article");
+    expect(expenseItem).not.toBeNull();
+    expect(
+      within(expenseItem as HTMLElement).getByText("EXP-1"),
+    ).toBeInTheDocument();
+    expect(
+      within(expenseItem as HTMLElement).getByText("Akosua Mensah"),
+    ).toBeInTheDocument();
+    expect(
+      within(expenseItem as HTMLElement).getByText("Register A1"),
+    ).toBeInTheDocument();
+    expect(
+      within(expenseItem as HTMLElement).getByText("Bought packing supplies."),
+    ).toBeInTheDocument();
+    expect(
+      within(expenseItem as HTMLElement).getByText("GH₵125"),
+    ).toBeInTheDocument();
+    expect(
+      within(expenseItem as HTMLElement).getByRole("link", {
+        name: /view expense/i,
+      }),
+    ).toHaveAttribute(
+      "href",
+      "/wigclub/store/osu/pos/expense-reports/expense-1?o=%252F",
+    );
     expect(
       screen.getByRole("button", { name: /complete daily close/i }),
     ).toBeEnabled();

--- a/packages/athena-webapp/src/components/operations/DailyCloseView.tsx
+++ b/packages/athena-webapp/src/components/operations/DailyCloseView.tsx
@@ -514,6 +514,7 @@ const timestampMetadataLabels = new Set([
 const metadataLabelOrder = [
   "approval",
   "transaction",
+  "report",
   "session",
   "terminal",
   "register",
@@ -610,6 +611,14 @@ const metadataLabelsByCategory: Record<string, string[]> = {
     "totalPaid",
     "changeGiven",
     "completedAt",
+  ],
+  expense: [
+    "report",
+    "register",
+    "owner",
+    "total",
+    "completedAt",
+    "notes",
   ],
   voidedsale: [
     "transaction",


### PR DESCRIPTION
## Summary
- Add completed expense transactions to Daily Close ready items with staff, register, amount, completion time, notes, and expense-report links.
- Query Daily Close expense transactions through a store/status/completed-at index so large stores do not lose valid expenses behind a broad store limit.
- Teach the Daily Close item metadata ordering to present expense reports cleanly and cover the behavior in backend/frontend tests.
- Update the Daily Close store-day boundary solution note and refresh graphify artifacts.

## Validation
- bun run --filter '@athena/webapp' test -- convex/operations/dailyClose.test.ts src/components/operations/DailyCloseView.test.tsx
- bun run pr:athena