### PR TITLE
feat: add optimistic expense cart updates

### DIFF
--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 4795 nodes · 4708 edges · 1564 communities detected
+- 4802 nodes · 4715 edges · 1564 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -1983,39 +1983,39 @@ Nodes (6): findAthenaUserByEmailWithCtx(), getAuthenticatedAthenaUserWithCtx(), 
 
 ### Community 95 - "Community 95"
 Cohesion: 0.43
-Nodes (6): buildMtnCollectionsLookupPrefixes(), isTargetEnvironment(), readScopedValue(), resolveConfigForPrefix(), resolveMtnCollectionsConfigFromEnv(), toEnvSegment()
+Nodes (6): sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
 
 ### Community 96 - "Community 96"
+Cohesion: 0.43
+Nodes (6): buildMtnCollectionsLookupPrefixes(), isTargetEnvironment(), readScopedValue(), resolveConfigForPrefix(), resolveMtnCollectionsConfigFromEnv(), toEnvSegment()
+
+### Community 97 - "Community 97"
 Cohesion: 0.46
 Nodes (7): recordApprovalAuditEventWithCtx(), recordApprovalDecisionRecordedAuditEventWithCtx(), recordApprovalProofConsumedAuditEventWithCtx(), recordApprovalRequiredAuditEventWithCtx(), recordApprovedCommandAppliedAuditEventWithCtx(), recordAsyncApprovalRequestCreatedAuditEventWithCtx(), recordManagerApprovalGrantedAuditEventWithCtx()
 
-### Community 97 - "Community 97"
+### Community 98 - "Community 98"
 Cohesion: 0.5
 Nodes (7): buildApprovalDecisionRequirement(), buildApprovalDecisionSubject(), consumeApprovalDecisionProofWithCtx(), decideApprovalRequestAsAuthenticatedUserWithCtx(), decideApprovalRequestAsCommandWithCtx(), decideApprovalRequestWithCtx(), mapDecideApprovalRequestError()
 
-### Community 98 - "Community 98"
+### Community 99 - "Community 99"
 Cohesion: 0.36
 Nodes (5): buildPaymentAllocation(), correctSameAmountSinglePaymentAllocationWithCtx(), findSameAmountSinglePaymentAllocation(), listPaymentAllocationsForTargetWithCtx(), recordPaymentAllocationWithCtx()
 
-### Community 99 - "Community 99"
+### Community 100 - "Community 100"
 Cohesion: 0.43
 Nodes (6): buildPosSessionTraceEvent(), buildPosSessionTraceRecord(), buildTraceSummary(), formatPaymentMethod(), recordPosSessionTraceBestEffort(), safeTraceWrite()
 
-### Community 100 - "Community 100"
+### Community 101 - "Community 101"
 Cohesion: 0.5
 Nodes (7): findExistingSku(), findOrCreateQuickAddCategory(), findOrCreateQuickAddSubcategory(), generateSKU(), isBarcodeLike(), mapSkuToCatalogResult(), quickAddCatalogItem()
-
-### Community 101 - "Community 101"
-Cohesion: 0.25
-Nodes (0):
 
 ### Community 102 - "Community 102"
 Cohesion: 0.25
 Nodes (0):
 
 ### Community 103 - "Community 103"
-Cohesion: 0.43
-Nodes (6): sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
+Cohesion: 0.25
+Nodes (0):
 
 ### Community 104 - "Community 104"
 Cohesion: 0.25
@@ -2042,220 +2042,220 @@ Cohesion: 0.29
 Nodes (2): mapProductByIdResult(), useConvexProductIdLookup()
 
 ### Community 110 - "Community 110"
-Cohesion: 0.46
-Nodes (7): addItemToBag(), clearBag(), getActiveBag(), getBaseUrl(), removeItemFromBag(), updateBagItem(), updateBagOwner()
-
-### Community 111 - "Community 111"
-Cohesion: 0.43
-Nodes (6): buildQueryString(), getAllProducts(), getBaseUrl(), getBestSellers(), getFeatured(), getProduct()
-
-### Community 112 - "Community 112"
 Cohesion: 0.25
 Nodes (0):
 
+### Community 111 - "Community 111"
+Cohesion: 0.46
+Nodes (7): addItemToBag(), clearBag(), getActiveBag(), getBaseUrl(), removeItemFromBag(), updateBagItem(), updateBagOwner()
+
+### Community 112 - "Community 112"
+Cohesion: 0.43
+Nodes (6): buildQueryString(), getAllProducts(), getBaseUrl(), getBestSellers(), getFeatured(), getProduct()
+
 ### Community 113 - "Community 113"
+Cohesion: 0.25
+Nodes (0):
+
+### Community 114 - "Community 114"
 Cohesion: 0.43
 Nodes (7): createStorefrontObservabilityContext(), createStorefrontObservabilityPayload(), getOrCreateStorefrontObservabilitySessionId(), isBrowserAutomationContext(), isSyntheticMonitorOrigin(), resolveStorefrontAnalyticsOrigin(), trackStorefrontEvent()
 
-### Community 114 - "Community 114"
+### Community 115 - "Community 115"
 Cohesion: 0.39
 Nodes (5): createPackage(), installFixtureToolchain(), linkWorkspacePackage(), writeFixtureManifests(), writeJson()
 
-### Community 115 - "Community 115"
+### Community 116 - "Community 116"
 Cohesion: 0.52
 Nodes (5): getWhatsAppReceiptConfig(), getWhatsAppWebhookAppSecret(), getWhatsAppWebhookVerifyToken(), optionalEnv(), requiredEnv()
 
-### Community 116 - "Community 116"
+### Community 117 - "Community 117"
 Cohesion: 0.33
 Nodes (2): expenseSessionError(), mapExpenseSessionValidationError()
 
-### Community 117 - "Community 117"
+### Community 118 - "Community 118"
 Cohesion: 0.57
 Nodes (6): buildHeaders(), createCollectionsAccessToken(), encodeBasicAuth(), getRequestToPayStatus(), requestToPay(), toError()
 
-### Community 118 - "Community 118"
+### Community 119 - "Community 119"
 Cohesion: 0.52
 Nodes (6): buildCustomerProfileDraft(), buildFullName(), findMatchingCustomerProfile(), normalizeLookupValue(), normalizePhoneNumber(), splitFullName()
 
-### Community 119 - "Community 119"
+### Community 120 - "Community 120"
 Cohesion: 0.48
 Nodes (5): buildExpenseSessionTraceEvent(), buildExpenseSessionTraceRecord(), buildTraceSummary(), recordExpenseSessionTraceBestEffort(), safeTraceWrite()
 
-### Community 120 - "Community 120"
+### Community 121 - "Community 121"
 Cohesion: 0.43
 Nodes (4): assertRegisterNumberIsAvailable(), mapRegisterTerminalError(), normalizeRegisterNumber(), registerTerminal()
 
-### Community 121 - "Community 121"
+### Community 122 - "Community 122"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 122 - "Community 122"
+### Community 123 - "Community 123"
 Cohesion: 0.48
 Nodes (5): getActiveSessionForRegisterState(), listHeldSessionsForRegisterState(), querySessionsByStatus(), selectRegisterStateLookupStrategy(), summarizeRegisterStateSessions()
 
-### Community 123 - "Community 123"
+### Community 124 - "Community 124"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 124 - "Community 124"
+### Community 125 - "Community 125"
 Cohesion: 0.33
 Nodes (2): getCustomerOperationalTimelineEvents(), resolveCustomerProfileIdForTimeline()
 
-### Community 125 - "Community 125"
+### Community 126 - "Community 126"
 Cohesion: 0.38
 Nodes (3): clearBagItems(), createOrderFromCheckoutSession(), generateOrderNumber()
 
-### Community 126 - "Community 126"
+### Community 127 - "Community 127"
 Cohesion: 0.57
 Nodes (5): getDeliveryAddress(), getLocationDetails(), getPickupLocation(), handleOrderStatusUpdate(), processOrderUpdateEmail()
 
-### Community 127 - "Community 127"
+### Community 128 - "Community 128"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 128 - "Community 128"
+### Community 129 - "Community 129"
 Cohesion: 0.33
 Nodes (2): appendTransition(), applyOnlineOrderUpdate()
 
-### Community 129 - "Community 129"
+### Community 130 - "Community 130"
 Cohesion: 0.38
 Nodes (3): createWorkflowTraceWithCtx(), getWorkflowTraceByIdWithCtx(), getWorkflowTraceByLookupWithCtx()
 
-### Community 130 - "Community 130"
+### Community 131 - "Community 131"
 Cohesion: 0.38
 Nodes (4): calculateCycleCountQuantityDelta(), hasHighStockAdjustmentVariance(), requiresStockAdjustmentApproval(), resolveStockAdjustmentQuantityDelta()
 
-### Community 131 - "Community 131"
+### Community 132 - "Community 132"
 Cohesion: 0.33
 Nodes (2): handleKeypadPress(), setAmountFromTouch()
 
-### Community 132 - "Community 132"
+### Community 133 - "Community 133"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 133 - "Community 133"
+### Community 134 - "Community 134"
 Cohesion: 0.48
 Nodes (4): applyCommandResult(), async(), handleSubmit(), parseDateTimeLocal()
 
-### Community 134 - "Community 134"
+### Community 135 - "Community 135"
 Cohesion: 0.52
 Nodes (6): deriveRegisterPhase(), hasActiveRegisterSession(), hasResumableRegisterSession(), isRegisterReadyToStart(), requiresCashier(), requiresTerminal()
-
-### Community 135 - "Community 135"
-Cohesion: 0.29
-Nodes (0):
 
 ### Community 136 - "Community 136"
 Cohesion: 0.29
 Nodes (0):
 
 ### Community 137 - "Community 137"
-Cohesion: 0.33
-Nodes (2): getProductName(), sortProduct()
-
-### Community 138 - "Community 138"
 Cohesion: 0.29
 Nodes (0):
 
+### Community 138 - "Community 138"
+Cohesion: 0.33
+Nodes (2): getProductName(), sortProduct()
+
 ### Community 139 - "Community 139"
+Cohesion: 0.29
+Nodes (0):
+
+### Community 140 - "Community 140"
 Cohesion: 0.52
 Nodes (6): addItemToSavedBag(), getActiveSavedBag(), getBaseUrl(), removeItemFromSavedBag(), updateSavedBagItem(), updateSavedBagOwner()
 
-### Community 140 - "Community 140"
+### Community 141 - "Community 141"
 Cohesion: 0.43
 Nodes (4): createFixtureRepo(), gitEnv(), runGit(), write()
 
-### Community 141 - "Community 141"
+### Community 142 - "Community 142"
 Cohesion: 0.52
 Nodes (5): emitSignal(), handleCheckoutSessionFetch(), handleCheckoutSessionUpdate(), jsonResponse(), withCorsHeaders()
 
-### Community 142 - "Community 142"
+### Community 143 - "Community 143"
 Cohesion: 0.33
 Nodes (2): overwriteFreshGraphifyArtifacts(), write()
 
-### Community 143 - "Community 143"
+### Community 144 - "Community 144"
 Cohesion: 0.38
 Nodes (4): createFixtureRepo(), initializeGitHistory(), runGit(), write()
 
-### Community 144 - "Community 144"
+### Community 145 - "Community 145"
 Cohesion: 0.33
 Nodes (1): ValkeyClient
 
-### Community 145 - "Community 145"
+### Community 146 - "Community 146"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 146 - "Community 146"
+### Community 147 - "Community 147"
 Cohesion: 0.53
 Nodes (4): listRegisterCatalog(), mapSkuToRegisterCatalogRow(), readCategoryName(), readColorName()
 
-### Community 147 - "Community 147"
+### Community 148 - "Community 148"
 Cohesion: 0.73
 Nodes (5): buildOrderStatusMessage(), buildPickupDetails(), sendPaymentVerificationEmails(), sendPODOrderEmails(), shouldSendToAdmins()
 
-### Community 148 - "Community 148"
+### Community 149 - "Community 149"
 Cohesion: 0.6
 Nodes (5): createVendorCommandWithCtx(), createVendorWithCtx(), mapCreateVendorError(), normalizeVendorLookupKey(), trimOptional()
 
-### Community 149 - "Community 149"
+### Community 150 - "Community 150"
 Cohesion: 0.6
 Nodes (5): find_block_end(), list_convex_files(), main(), scan_file(), strip_code()
 
-### Community 150 - "Community 150"
+### Community 151 - "Community 151"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 151 - "Community 151"
+### Community 152 - "Community 152"
 Cohesion: 0.53
 Nodes (4): includesRegisterSessionStatus(), isCashControlVisibleRegisterSessionStatus(), isPosUsableRegisterSessionStatus(), isRegisterSessionConflictBlockingStatus()
 
-### Community 152 - "Community 152"
+### Community 153 - "Community 153"
 Cohesion: 0.33
 Nodes (1): DataTableToolbar()
-
-### Community 153 - "Community 153"
-Cohesion: 0.4
-Nodes (2): handlePinChange(), normalizeOtpCode()
 
 ### Community 154 - "Community 154"
 Cohesion: 0.53
 Nodes (2): SelectedProductsProvider(), useSelectedProducts()
 
 ### Community 155 - "Community 155"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.4
+Nodes (2): handlePinChange(), normalizeOtpCode()
 
 ### Community 156 - "Community 156"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 157 - "Community 157"
-Cohesion: 0.4
-Nodes (2): buildApprovalRetryArgs(), getAsyncApprovalRequestId()
-
-### Community 158 - "Community 158"
 Cohesion: 0.33
 Nodes (0):
+
+### Community 158 - "Community 158"
+Cohesion: 0.4
+Nodes (2): buildApprovalRetryArgs(), getAsyncApprovalRequestId()
 
 ### Community 159 - "Community 159"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 160 - "Community 160"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 161 - "Community 161"
 Cohesion: 0.47
 Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
 
-### Community 161 - "Community 161"
+### Community 162 - "Community 162"
 Cohesion: 0.33
 Nodes (0):
-
-### Community 162 - "Community 162"
-Cohesion: 0.4
-Nodes (2): useBulkOperations(), validateOperationValue()
 
 ### Community 163 - "Community 163"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.4
+Nodes (2): useBulkOperations(), validateOperationValue()
 
 ### Community 164 - "Community 164"
 Cohesion: 0.33
@@ -2270,12 +2270,12 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 167 - "Community 167"
-Cohesion: 0.53
-Nodes (4): calculatePosChange(), calculatePosRemainingDue(), calculatePosTotalPaid(), roundPosAmount()
-
-### Community 168 - "Community 168"
 Cohesion: 0.33
 Nodes (0):
+
+### Community 168 - "Community 168"
+Cohesion: 0.53
+Nodes (4): calculatePosChange(), calculatePosRemainingDue(), calculatePosTotalPaid(), roundPosAmount()
 
 ### Community 169 - "Community 169"
 Cohesion: 0.33
@@ -2286,64 +2286,64 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 171 - "Community 171"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 172 - "Community 172"
 Cohesion: 0.4
 Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 173 - "Community 173"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 174 - "Community 174"
-Cohesion: 0.47
-Nodes (4): fetchPosTransaction(), getBaseUrl(), getPosTransactionByReceiptToken(), PosTransactionReceiptError
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 175 - "Community 175"
 Cohesion: 0.47
-Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
+Nodes (4): fetchPosTransaction(), getBaseUrl(), getPosTransactionByReceiptToken(), PosTransactionReceiptError
 
 ### Community 176 - "Community 176"
+Cohesion: 0.47
+Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
+
+### Community 177 - "Community 177"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 177 - "Community 177"
+### Community 178 - "Community 178"
 Cohesion: 0.4
 Nodes (2): handleConfirm(), handlePrimaryAction()
 
-### Community 178 - "Community 178"
+### Community 179 - "Community 179"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 179 - "Community 179"
+### Community 180 - "Community 180"
 Cohesion: 0.53
 Nodes (5): getRemainingForFreeDelivery(), hasWaiverConfigured(), isAnyFeeWaived(), isFeeWaived(), meetsThreshold()
 
-### Community 180 - "Community 180"
+### Community 181 - "Community 181"
 Cohesion: 0.47
 Nodes (3): onSubmit(), reportAuthFailure(), resendVerificationCode()
 
-### Community 181 - "Community 181"
+### Community 182 - "Community 182"
 Cohesion: 0.53
 Nodes (4): coverageSummary(), write(), writePackageSummaries(), writeRealBaselineSummaries()
 
-### Community 182 - "Community 182"
+### Community 183 - "Community 183"
 Cohesion: 0.67
 Nodes (5): collectRepoCodeFiles(), collectStaleGraphifyArtifacts(), copyGraphifyCheckInputs(), fileExists(), runGraphifyCheck()
 
-### Community 183 - "Community 183"
+### Community 184 - "Community 184"
 Cohesion: 0.4
 Nodes (2): createFixtureRoot(), write()
 
-### Community 184 - "Community 184"
+### Community 185 - "Community 185"
 Cohesion: 0.6
 Nodes (4): buildInStorePaymentAllocations(), normalizeInStorePayments(), resolveRegisterSessionForInStoreCollectionWithCtx(), selectRegisterSessionForAttribution()
-
-### Community 185 - "Community 185"
-Cohesion: 0.4
-Nodes (0):
 
 ### Community 186 - "Community 186"
 Cohesion: 0.4
@@ -2354,48 +2354,48 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 188 - "Community 188"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 189 - "Community 189"
 Cohesion: 0.7
 Nodes (4): compactRecord(), ensureCustomerProfileFromSourcesWithCtx(), findExistingProfile(), loadCustomerSources()
 
-### Community 189 - "Community 189"
+### Community 190 - "Community 190"
 Cohesion: 0.5
 Nodes (2): buildInventoryMovement(), recordInventoryMovementWithCtx()
-
-### Community 190 - "Community 190"
-Cohesion: 0.4
-Nodes (0):
 
 ### Community 191 - "Community 191"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 192 - "Community 192"
-Cohesion: 0.7
-Nodes (4): buildDecision(), classifyCorrectionIntent(), isSupportedCorrectionIntent(), isUnsupportedHighRiskCorrectionIntent()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 193 - "Community 193"
 Cohesion: 0.7
-Nodes (4): getPaystackHeaders(), initializeTransaction(), initiateRefund(), verifyTransaction()
+Nodes (4): buildDecision(), classifyCorrectionIntent(), isSupportedCorrectionIntent(), isUnsupportedHighRiskCorrectionIntent()
 
 ### Community 194 - "Community 194"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.7
+Nodes (4): getPaystackHeaders(), initializeTransaction(), initiateRefund(), verifyTransaction()
 
 ### Community 195 - "Community 195"
-Cohesion: 0.6
-Nodes (3): buildOnlineOrderReturnExchangePlan(), getApprovalReason(), getKind()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 196 - "Community 196"
 Cohesion: 0.6
-Nodes (3): createOffer(), isDuplicate(), updateStoreFrontActorEmail()
+Nodes (3): buildOnlineOrderReturnExchangePlan(), getApprovalReason(), getKind()
 
 ### Community 197 - "Community 197"
-Cohesion: 0.5
-Nodes (2): getNonEmptyString(), normalizeStorefrontObservabilityEvent()
+Cohesion: 0.6
+Nodes (3): createOffer(), isDuplicate(), updateStoreFrontActorEmail()
 
 ### Community 198 - "Community 198"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.5
+Nodes (2): getNonEmptyString(), normalizeStorefrontObservabilityEvent()
 
 ### Community 199 - "Community 199"
 Cohesion: 0.4
@@ -2403,11 +2403,11 @@ Nodes (0):
 
 ### Community 200 - "Community 200"
 Cohesion: 0.4
-Nodes (1): Header()
+Nodes (0):
 
 ### Community 201 - "Community 201"
 Cohesion: 0.4
-Nodes (0):
+Nodes (1): Header()
 
 ### Community 202 - "Community 202"
 Cohesion: 0.4
@@ -2422,12 +2422,12 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 205 - "Community 205"
-Cohesion: 0.5
-Nodes (2): handleFileSelect(), validateFile()
-
-### Community 206 - "Community 206"
 Cohesion: 0.4
 Nodes (0):
+
+### Community 206 - "Community 206"
+Cohesion: 0.5
+Nodes (2): handleFileSelect(), validateFile()
 
 ### Community 207 - "Community 207"
 Cohesion: 0.4
@@ -2442,20 +2442,20 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 210 - "Community 210"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 211 - "Community 211"
 Cohesion: 0.5
 Nodes (2): getBalanceDueLabel(), getBalanceDuePanel()
 
-### Community 211 - "Community 211"
+### Community 212 - "Community 212"
 Cohesion: 0.6
 Nodes (3): getSummaryAmount(), getSummaryLabel(), getSummaryPanel()
 
-### Community 212 - "Community 212"
+### Community 213 - "Community 213"
 Cohesion: 0.6
 Nodes (3): handleClearSearch(), handleQuickAddSubmit(), resetQuickAddForm()
-
-### Community 213 - "Community 213"
-Cohesion: 0.4
-Nodes (0):
 
 ### Community 214 - "Community 214"
 Cohesion: 0.4
@@ -2470,32 +2470,32 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 217 - "Community 217"
-Cohesion: 0.7
-Nodes (4): getRuntimeOrigin(), isLocalHost(), resolveStoreFrontUrl(), trimTrailingSlash()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 218 - "Community 218"
 Cohesion: 0.7
-Nodes (4): bufferToHex(), collectBrowserInfo(), generateBrowserFingerprint(), hashFingerprintSource()
+Nodes (4): getRuntimeOrigin(), isLocalHost(), resolveStoreFrontUrl(), trimTrailingSlash()
 
 ### Community 219 - "Community 219"
-Cohesion: 0.4
-Nodes (1): MockImage
+Cohesion: 0.7
+Nodes (4): bufferToHex(), collectBrowserInfo(), generateBrowserFingerprint(), hashFingerprintSource()
 
 ### Community 220 - "Community 220"
 Cohesion: 0.4
-Nodes (0):
+Nodes (1): MockImage
 
 ### Community 221 - "Community 221"
-Cohesion: 0.6
-Nodes (3): calculatePosCartTotals(), calculatePosItemTotal(), roundPosAmount()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 222 - "Community 222"
 Cohesion: 0.6
-Nodes (4): mapRegisterStateDto(), mapTerminalDto(), useConvexRegisterState(), useConvexTerminalByFingerprint()
+Nodes (3): calculatePosCartTotals(), calculatePosItemTotal(), roundPosAmount()
 
 ### Community 223 - "Community 223"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.6
+Nodes (4): mapRegisterStateDto(), mapTerminalDto(), useConvexRegisterState(), useConvexTerminalByFingerprint()
 
 ### Community 224 - "Community 224"
 Cohesion: 0.4
@@ -2510,84 +2510,84 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 227 - "Community 227"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 228 - "Community 228"
 Cohesion: 0.5
 Nodes (2): completePendingAuthSync(), sleep()
 
-### Community 228 - "Community 228"
+### Community 229 - "Community 229"
 Cohesion: 0.4
 Nodes (0):
-
-### Community 229 - "Community 229"
-Cohesion: 0.7
-Nodes (4): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory()
 
 ### Community 230 - "Community 230"
 Cohesion: 0.7
-Nodes (4): getBaseUrl(), getOrder(), getOrders(), updateOrdersOwner()
+Nodes (4): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory()
 
 ### Community 231 - "Community 231"
 Cohesion: 0.7
-Nodes (4): getActiveUser(), getBaseUrl(), getGuest(), updateUser()
+Nodes (4): getBaseUrl(), getOrder(), getOrders(), updateOrdersOwner()
 
 ### Community 232 - "Community 232"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.7
+Nodes (4): getActiveUser(), getBaseUrl(), getGuest(), updateUser()
 
 ### Community 233 - "Community 233"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 234 - "Community 234"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 235 - "Community 235"
 Cohesion: 0.7
 Nodes (4): createStorefrontFailureEvent(), emitStorefrontFailure(), inferStorefrontJourneyFromRoute(), normalizeStorefrontError()
 
-### Community 235 - "Community 235"
+### Community 236 - "Community 236"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 236 - "Community 236"
+### Community 237 - "Community 237"
 Cohesion: 0.6
 Nodes (4): collectHarnessRepoValidationSelection(), matchesHarnessRepoValidationPath(), normalizeRepoPath(), sortUniquePaths()
 
-### Community 237 - "Community 237"
+### Community 238 - "Community 238"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 238 - "Community 238"
+### Community 239 - "Community 239"
 Cohesion: 0.7
 Nodes (4): createFixtureRepo(), fixtureEnv(), runGit(), runWorktreeManager()
 
-### Community 239 - "Community 239"
+### Community 240 - "Community 240"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 240 - "Community 240"
+### Community 241 - "Community 241"
 Cohesion: 0.67
 Nodes (2): maskReceiptPhone(), normalizeReceiptPhone()
 
-### Community 241 - "Community 241"
+### Community 242 - "Community 242"
 Cohesion: 0.83
 Nodes (3): createReceiptShareToken(), hashReceiptShareToken(), toHex()
 
-### Community 242 - "Community 242"
+### Community 243 - "Community 243"
 Cohesion: 0.83
 Nodes (3): timingSafeEqual(), toHex(), verifyMetaWebhookSignature()
-
-### Community 243 - "Community 243"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 244 - "Community 244"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 245 - "Community 245"
-Cohesion: 0.67
-Nodes (2): createExpenseTransactionFromSessionHandler(), expenseTransactionError()
-
-### Community 246 - "Community 246"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 246 - "Community 246"
+Cohesion: 0.67
+Nodes (2): createExpenseTransactionFromSessionHandler(), expenseTransactionError()
 
 ### Community 247 - "Community 247"
 Cohesion: 0.5
@@ -2598,68 +2598,68 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 249 - "Community 249"
-Cohesion: 0.67
-Nodes (2): createProductsQueryCtx(), createSkuMutationCtx()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 250 - "Community 250"
 Cohesion: 0.67
-Nodes (2): toDisplayAmount(), toPesewas()
+Nodes (2): createProductsQueryCtx(), createSkuMutationCtx()
 
 ### Community 251 - "Community 251"
+Cohesion: 0.67
+Nodes (2): toDisplayAmount(), toPesewas()
+
+### Community 252 - "Community 252"
 Cohesion: 0.83
 Nodes (3): getCachedTokenRecord(), resolveAccessTokenForStore(), resolveConfigForStore()
 
-### Community 252 - "Community 252"
+### Community 253 - "Community 253"
 Cohesion: 0.67
 Nodes (2): maskMtnPartyId(), normalizeCollectionsTransaction()
 
-### Community 253 - "Community 253"
+### Community 254 - "Community 254"
 Cohesion: 0.67
 Nodes (2): consumeApprovalProofWithCtx(), invalidApprovalProofResult()
 
-### Community 254 - "Community 254"
+### Community 255 - "Community 255"
 Cohesion: 0.67
 Nodes (2): buildOperationalEvent(), recordOperationalEventWithCtx()
 
-### Community 255 - "Community 255"
+### Community 256 - "Community 256"
 Cohesion: 0.67
 Nodes (2): buildOperationalWorkItem(), createOperationalWorkItemWithCtx()
 
-### Community 256 - "Community 256"
+### Community 257 - "Community 257"
 Cohesion: 0.67
 Nodes (2): expectIndex(), getTableIndexes()
-
-### Community 257 - "Community 257"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 258 - "Community 258"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 259 - "Community 259"
-Cohesion: 0.83
-Nodes (3): resolveServiceIntakeCustomerProfile(), splitFullName(), trimOptional()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 260 - "Community 260"
 Cohesion: 0.83
-Nodes (3): mapOpenDrawerUserError(), normalizeRegisterNumber(), openDrawer()
+Nodes (3): resolveServiceIntakeCustomerProfile(), splitFullName(), trimOptional()
 
 ### Community 261 - "Community 261"
 Cohesion: 0.83
-Nodes (3): createDbGetMock(), createDbMock(), createDbQueryMock()
+Nodes (3): mapOpenDrawerUserError(), normalizeRegisterNumber(), openDrawer()
 
 ### Community 262 - "Community 262"
 Cohesion: 0.83
-Nodes (3): buildRegisterState(), getActiveSessionConflictForRegisterState(), getRegisterState()
+Nodes (3): createDbGetMock(), createDbMock(), createDbQueryMock()
 
 ### Community 263 - "Community 263"
-Cohesion: 0.67
-Nodes (2): lookupByBarcode(), mapSkuToCatalogResult()
+Cohesion: 0.83
+Nodes (3): buildRegisterState(), getActiveSessionConflictForRegisterState(), getRegisterState()
 
 ### Community 264 - "Community 264"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): lookupByBarcode(), mapSkuToCatalogResult()
 
 ### Community 265 - "Community 265"
 Cohesion: 0.5
@@ -2670,24 +2670,24 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 267 - "Community 267"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 268 - "Community 268"
 Cohesion: 0.67
 Nodes (2): expectIndex(), getTableIndexes()
 
-### Community 268 - "Community 268"
+### Community 269 - "Community 269"
 Cohesion: 0.83
 Nodes (3): findExistingCustomerProfileId(), getStoreOrganizationId(), recordStoreFrontCustomerMilestone()
 
-### Community 269 - "Community 269"
+### Community 270 - "Community 270"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 270 - "Community 270"
-Cohesion: 0.83
-Nodes (3): formatStaffDisplayName(), formatStaffDisplayNameOrFallback(), normalizeNamePart()
 
 ### Community 271 - "Community 271"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): formatStaffDisplayName(), formatStaffDisplayNameOrFallback(), normalizeNamePart()
 
 ### Community 272 - "Community 272"
 Cohesion: 0.5
@@ -2702,12 +2702,12 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 275 - "Community 275"
-Cohesion: 0.67
-Nodes (2): countGroupedAnalytics(), groupAnalytics()
-
-### Community 276 - "Community 276"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 276 - "Community 276"
+Cohesion: 0.67
+Nodes (2): countGroupedAnalytics(), groupAnalytics()
 
 ### Community 277 - "Community 277"
 Cohesion: 0.5
@@ -2726,12 +2726,12 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 281 - "Community 281"
-Cohesion: 0.67
-Nodes (2): handleSubmit(), resetReplacementFields()
-
-### Community 282 - "Community 282"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 282 - "Community 282"
+Cohesion: 0.67
+Nodes (2): handleSubmit(), resetReplacementFields()
 
 ### Community 283 - "Community 283"
 Cohesion: 0.5
@@ -2758,24 +2758,24 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 289 - "Community 289"
-Cohesion: 0.67
-Nodes (2): applyCommandResult(), handleCreateCase()
-
-### Community 290 - "Community 290"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 290 - "Community 290"
+Cohesion: 0.67
+Nodes (2): applyCommandResult(), handleCreateCase()
 
 ### Community 291 - "Community 291"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 292 - "Community 292"
-Cohesion: 0.67
-Nodes (2): getRiskStyles(), RiskIndicators()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 293 - "Community 293"
 Cohesion: 0.67
-Nodes (2): useGetArchivedProducts(), useGetProducts()
+Nodes (2): getRiskStyles(), RiskIndicators()
 
 ### Community 294 - "Community 294"
 Cohesion: 0.5
@@ -2783,51 +2783,51 @@ Nodes (0):
 
 ### Community 295 - "Community 295"
 Cohesion: 0.67
-Nodes (2): extractTraceId(), runCommand()
+Nodes (2): useGetArchivedProducts(), useGetProducts()
 
 ### Community 296 - "Community 296"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 297 - "Community 297"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): extractTraceId(), runCommand()
 
 ### Community 298 - "Community 298"
-Cohesion: 0.67
-Nodes (2): mapActiveSessionDto(), normalizeCartItems()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 299 - "Community 299"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 300 - "Community 300"
-Cohesion: 0.83
-Nodes (3): isBrowserFingerprintResult(), readStoredTerminalFingerprint(), readStoredTerminalFingerprintHash()
+Cohesion: 0.67
+Nodes (2): mapActiveSessionDto(), normalizeCartItems()
 
 ### Community 301 - "Community 301"
-Cohesion: 0.67
-Nodes (2): getCashierDisplayName(), useExpenseRegisterViewModel()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 302 - "Community 302"
 Cohesion: 0.83
-Nodes (3): getBaseUrl(), getUserRedeemedOffers(), submitOffer()
+Nodes (3): isBrowserFingerprintResult(), readStoredTerminalFingerprint(), readStoredTerminalFingerprintHash()
 
 ### Community 303 - "Community 303"
-Cohesion: 0.83
-Nodes (3): getAllStores(), getBaseUrl(), getStore()
+Cohesion: 0.67
+Nodes (2): getCashierDisplayName(), useExpenseRegisterViewModel()
 
 ### Community 304 - "Community 304"
 Cohesion: 0.83
-Nodes (3): getAllSubcategories(), getBaseUrl(), getSubategory()
+Nodes (3): getBaseUrl(), getUserRedeemedOffers(), submitOffer()
 
 ### Community 305 - "Community 305"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): getAllStores(), getBaseUrl(), getStore()
 
 ### Community 306 - "Community 306"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): getAllSubcategories(), getBaseUrl(), getSubategory()
 
 ### Community 307 - "Community 307"
 Cohesion: 0.5
@@ -2850,76 +2850,76 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 312 - "Community 312"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 313 - "Community 313"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 314 - "Community 314"
 Cohesion: 0.67
 Nodes (2): useOptionalStoreContext(), useStoreContext()
 
-### Community 313 - "Community 313"
+### Community 315 - "Community 315"
 Cohesion: 0.67
 Nodes (2): clearFilters(), onMobileFiltersCloseClick()
 
-### Community 314 - "Community 314"
+### Community 316 - "Community 316"
 Cohesion: 0.83
 Nodes (3): cancelOrder(), getErrorMessage(), placeOrder()
 
-### Community 315 - "Community 315"
+### Community 317 - "Community 317"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 316 - "Community 316"
+### Community 318 - "Community 318"
 Cohesion: 0.83
 Nodes (3): bootstrapCheckout(), createBootstrapToken(), createMarker()
 
-### Community 317 - "Community 317"
+### Community 319 - "Community 319"
 Cohesion: 0.83
 Nodes (3): createFixtureRoot(), write(), writeGraphifyWikiArtifacts()
 
-### Community 318 - "Community 318"
+### Community 320 - "Community 320"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 319 - "Community 319"
+### Community 321 - "Community 321"
 Cohesion: 0.67
 Nodes (2): buildHarnessDocPaths(), buildHarnessDocPathsForArchetype()
 
-### Community 320 - "Community 320"
+### Community 322 - "Community 322"
 Cohesion: 0.67
 Nodes (2): shutdown(), stopValkeyRuntimeServer()
 
-### Community 321 - "Community 321"
+### Community 323 - "Community 323"
 Cohesion: 0.83
 Nodes (3): createFixtureRepo(), createInferentialArtifact(), write()
 
-### Community 322 - "Community 322"
+### Community 324 - "Community 324"
 Cohesion: 0.67
 Nodes (2): collectHarnessTestTargets(), runHarnessTest()
 
-### Community 323 - "Community 323"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 324 - "Community 324"
-Cohesion: 0.5
-Nodes (0):
-
 ### Community 325 - "Community 325"
-Cohesion: 0.67
+Cohesion: 0.5
 Nodes (0):
 
 ### Community 326 - "Community 326"
-Cohesion: 0.67
+Cohesion: 0.5
 Nodes (0):
 
 ### Community 327 - "Community 327"
-Cohesion: 1.0
-Nodes (2): providerErrorCategory(), sendWhatsAppReceiptTemplate()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 328 - "Community 328"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 329 - "Community 329"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): providerErrorCategory(), sendWhatsAppReceiptTemplate()
 
 ### Community 330 - "Community 330"
 Cohesion: 0.67
@@ -2971,7 +2971,7 @@ Nodes (0):
 
 ### Community 342 - "Community 342"
 Cohesion: 0.67
-Nodes (1): PosServerError
+Nodes (0):
 
 ### Community 343 - "Community 343"
 Cohesion: 0.67
@@ -2979,7 +2979,7 @@ Nodes (0):
 
 ### Community 344 - "Community 344"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): PosServerError
 
 ### Community 345 - "Community 345"
 Cohesion: 0.67
@@ -2990,8 +2990,8 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 347 - "Community 347"
-Cohesion: 1.0
-Nodes (2): getActiveRegisterSessionForRegisterState(), mapRegisterSessionToCashDrawerSummary()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 348 - "Community 348"
 Cohesion: 0.67
@@ -2999,15 +2999,15 @@ Nodes (0):
 
 ### Community 349 - "Community 349"
 Cohesion: 1.0
-Nodes (2): expectIndex(), getTableIndexes()
+Nodes (2): getActiveRegisterSessionForRegisterState(), mapRegisterSessionToCashDrawerSummary()
 
 ### Community 350 - "Community 350"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 351 - "Community 351"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): expectIndex(), getTableIndexes()
 
 ### Community 352 - "Community 352"
 Cohesion: 0.67
@@ -3018,40 +3018,40 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 354 - "Community 354"
-Cohesion: 1.0
-Nodes (2): listBagItems(), loadBagWithItems()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 355 - "Community 355"
-Cohesion: 1.0
-Nodes (2): buildRegisterSessionTraceSeed(), formatRegisterSessionLabel()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 356 - "Community 356"
 Cohesion: 1.0
-Nodes (2): getWorkflowTraceViewByIdWithCtx(), getWorkflowTraceViewByLookupWithCtx()
+Nodes (2): listBagItems(), loadBagWithItems()
 
 ### Community 357 - "Community 357"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): buildRegisterSessionTraceSeed(), formatRegisterSessionLabel()
 
 ### Community 358 - "Community 358"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getWorkflowTraceViewByIdWithCtx(), getWorkflowTraceViewByLookupWithCtx()
 
 ### Community 359 - "Community 359"
-Cohesion: 1.0
-Nodes (2): createWorkflowTraceId(), normalizeWorkflowTraceLookupValue()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 360 - "Community 360"
 Cohesion: 0.67
-Nodes (1): View()
+Nodes (0):
 
 ### Community 361 - "Community 361"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): createWorkflowTraceId(), normalizeWorkflowTraceLookupValue()
 
 ### Community 362 - "Community 362"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): View()
 
 ### Community 363 - "Community 363"
 Cohesion: 0.67
@@ -3062,16 +3062,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 365 - "Community 365"
-Cohesion: 1.0
-Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 366 - "Community 366"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 367 - "Community 367"
-Cohesion: 0.67
-Nodes (1): FadeIn()
+Cohesion: 1.0
+Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
 
 ### Community 368 - "Community 368"
 Cohesion: 0.67
@@ -3079,31 +3079,31 @@ Nodes (0):
 
 ### Community 369 - "Community 369"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): FadeIn()
 
 ### Community 370 - "Community 370"
 Cohesion: 0.67
-Nodes (1): VideoPlayer()
+Nodes (0):
 
 ### Community 371 - "Community 371"
-Cohesion: 1.0
-Nodes (2): handleRefundOrder(), toast()
-
-### Community 372 - "Community 372"
 Cohesion: 0.67
 Nodes (0):
 
+### Community 372 - "Community 372"
+Cohesion: 0.67
+Nodes (1): VideoPlayer()
+
 ### Community 373 - "Community 373"
 Cohesion: 1.0
-Nodes (2): CashierAuthDialog(), getStaffDisplayName()
+Nodes (2): handleRefundOrder(), toast()
 
 ### Community 374 - "Community 374"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 375 - "Community 375"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): CashierAuthDialog(), getStaffDisplayName()
 
 ### Community 376 - "Community 376"
 Cohesion: 0.67
@@ -3154,88 +3154,88 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 388 - "Community 388"
-Cohesion: 1.0
-Nodes (2): handleKeyDown(), handleSubmit()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 389 - "Community 389"
 Cohesion: 0.67
-Nodes (1): SingleLineError()
+Nodes (0):
 
 ### Community 390 - "Community 390"
-Cohesion: 0.67
-Nodes (1): ErrorPage()
+Cohesion: 1.0
+Nodes (2): handleKeyDown(), handleSubmit()
 
 ### Community 391 - "Community 391"
 Cohesion: 0.67
-Nodes (1): AppSkeleton()
+Nodes (1): SingleLineError()
 
 ### Community 392 - "Community 392"
 Cohesion: 0.67
-Nodes (1): DashboardSkeleton()
+Nodes (1): ErrorPage()
 
 ### Community 393 - "Community 393"
 Cohesion: 0.67
-Nodes (1): TableSkeleton()
+Nodes (1): AppSkeleton()
 
 ### Community 394 - "Community 394"
 Cohesion: 0.67
-Nodes (1): TransactionsSkeleton()
+Nodes (1): DashboardSkeleton()
 
 ### Community 395 - "Community 395"
 Cohesion: 0.67
-Nodes (1): NotFound()
+Nodes (1): TableSkeleton()
 
 ### Community 396 - "Community 396"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): TransactionsSkeleton()
 
 ### Community 397 - "Community 397"
-Cohesion: 1.0
-Nodes (2): getWorkflowTraceRouteTarget(), WorkflowTraceRouteLink()
+Cohesion: 0.67
+Nodes (1): NotFound()
 
 ### Community 398 - "Community 398"
 Cohesion: 0.67
-Nodes (1): AppContextMenu()
+Nodes (0):
 
 ### Community 399 - "Community 399"
-Cohesion: 0.67
-Nodes (1): Badge()
+Cohesion: 1.0
+Nodes (2): getWorkflowTraceRouteTarget(), WorkflowTraceRouteLink()
 
 ### Community 400 - "Community 400"
 Cohesion: 0.67
-Nodes (1): LoadingButton()
+Nodes (1): AppContextMenu()
 
 ### Community 401 - "Community 401"
 Cohesion: 0.67
-Nodes (1): onChange()
+Nodes (1): Badge()
 
 ### Community 402 - "Community 402"
 Cohesion: 0.67
-Nodes (1): AlertModal()
+Nodes (1): LoadingButton()
 
 ### Community 403 - "Community 403"
 Cohesion: 0.67
-Nodes (1): OverlayModal()
+Nodes (1): onChange()
 
 ### Community 404 - "Community 404"
 Cohesion: 0.67
-Nodes (1): Skeleton()
+Nodes (1): AlertModal()
 
 ### Community 405 - "Community 405"
 Cohesion: 0.67
-Nodes (1): Toaster()
+Nodes (1): OverlayModal()
 
 ### Community 406 - "Community 406"
 Cohesion: 0.67
-Nodes (1): Spinner()
+Nodes (1): Skeleton()
 
 ### Community 407 - "Community 407"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): Toaster()
 
 ### Community 408 - "Community 408"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): Spinner()
 
 ### Community 409 - "Community 409"
 Cohesion: 0.67
@@ -3259,7 +3259,7 @@ Nodes (0):
 
 ### Community 414 - "Community 414"
 Cohesion: 0.67
-Nodes (1): useAuth()
+Nodes (0):
 
 ### Community 415 - "Community 415"
 Cohesion: 0.67
@@ -3267,27 +3267,27 @@ Nodes (0):
 
 ### Community 416 - "Community 416"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): useAuth()
 
 ### Community 417 - "Community 417"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 418 - "Community 418"
-Cohesion: 1.0
-Nodes (2): getApprovalGuidance(), presentCommandToast()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 419 - "Community 419"
 Cohesion: 0.67
-Nodes (1): isInMaintenanceMode()
+Nodes (0):
 
 ### Community 420 - "Community 420"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getApprovalGuidance(), presentCommandToast()
 
 ### Community 421 - "Community 421"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): isInMaintenanceMode()
 
 ### Community 422 - "Community 422"
 Cohesion: 0.67
@@ -3303,67 +3303,67 @@ Nodes (0):
 
 ### Community 425 - "Community 425"
 Cohesion: 0.67
-Nodes (1): App()
+Nodes (0):
 
 ### Community 426 - "Community 426"
-Cohesion: 1.0
-Nodes (2): collectSourceFiles(), findIllegalConvexImports()
+Cohesion: 0.67
+Nodes (1): App()
 
 ### Community 427 - "Community 427"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): collectSourceFiles(), findIllegalConvexImports()
 
 ### Community 428 - "Community 428"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 429 - "Community 429"
-Cohesion: 1.0
-Nodes (2): getAthenaDesignTokenStyle(), withAthenaTheme()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 430 - "Community 430"
 Cohesion: 1.0
-Nodes (2): mockGetSku(), validateInventoryForTransaction()
+Nodes (2): getAthenaDesignTokenStyle(), withAthenaTheme()
 
 ### Community 431 - "Community 431"
-Cohesion: 0.67
-Nodes (1): hashPassword()
+Cohesion: 1.0
+Nodes (2): mockGetSku(), validateInventoryForTransaction()
 
 ### Community 432 - "Community 432"
 Cohesion: 0.67
-Nodes (1): createVersionChecker()
+Nodes (1): hashPassword()
 
 ### Community 433 - "Community 433"
 Cohesion: 0.67
-Nodes (1): manualChunks()
+Nodes (1): createVersionChecker()
 
 ### Community 434 - "Community 434"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): manualChunks()
 
 ### Community 435 - "Community 435"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 436 - "Community 436"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 437 - "Community 437"
 Cohesion: 1.0
 Nodes (2): getAllColors(), getBaseUrl()
 
-### Community 437 - "Community 437"
+### Community 438 - "Community 438"
 Cohesion: 0.67
 Nodes (0):
-
-### Community 438 - "Community 438"
-Cohesion: 1.0
-Nodes (2): getBaseUrl(), getLastViewedProduct()
 
 ### Community 439 - "Community 439"
 Cohesion: 1.0
-Nodes (2): getBaseUrl(), getUserOffersEligibility()
+Nodes (2): getBaseUrl(), getLastViewedProduct()
 
 ### Community 440 - "Community 440"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getBaseUrl(), getUserOffersEligibility()
 
 ### Community 441 - "Community 441"
 Cohesion: 0.67
@@ -3374,12 +3374,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 443 - "Community 443"
-Cohesion: 1.0
-Nodes (2): handleKeyDown(), handleRedeemPromoCode()
-
-### Community 444 - "Community 444"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 444 - "Community 444"
+Cohesion: 1.0
+Nodes (2): handleKeyDown(), handleRedeemPromoCode()
 
 ### Community 445 - "Community 445"
 Cohesion: 0.67
@@ -3390,12 +3390,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 447 - "Community 447"
-Cohesion: 1.0
-Nodes (2): getPromoAlertCopy(), PromoAlert()
-
-### Community 448 - "Community 448"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 448 - "Community 448"
+Cohesion: 1.0
+Nodes (2): getPromoAlertCopy(), PromoAlert()
 
 ### Community 449 - "Community 449"
 Cohesion: 0.67
@@ -3466,8 +3466,8 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 466 - "Community 466"
-Cohesion: 1.0
-Nodes (2): createFixtureRepo(), write()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 467 - "Community 467"
 Cohesion: 1.0
@@ -3486,20 +3486,20 @@ Cohesion: 1.0
 Nodes (2): createFixtureRepo(), write()
 
 ### Community 471 - "Community 471"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): createFixtureRepo(), write()
 
 ### Community 472 - "Community 472"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 473 - "Community 473"
-Cohesion: 1.0
-Nodes (2): collectRootScriptTestFiles(), runRootScriptsCoverage()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 474 - "Community 474"
 Cohesion: 1.0
-Nodes (0):
+Nodes (2): collectRootScriptTestFiles(), runRootScriptsCoverage()
 
 ### Community 475 - "Community 475"
 Cohesion: 1.0
@@ -7860,437 +7860,435 @@ Nodes (0):
 ## Knowledge Gaps
 - **1 isolated node(s):** `HelpRequested`
   These have ≤1 connection - possible missing edges or undocumented components.
-- **Thin community `Community 474`** (2 nodes): `getSource()`, `deposits.test.ts`
+- **Thin community `Community 475`** (2 nodes): `getSource()`, `deposits.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 475`** (2 nodes): `paymentAllocationAttribution.test.ts`, `readProjectFile()`
+- **Thin community `Community 476`** (2 nodes): `paymentAllocationAttribution.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 476`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
+- **Thin community `Community 477`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 477`** (2 nodes): `createCommandShimBin()`, `convexAuditScript.test.ts`
+- **Thin community `Community 478`** (2 nodes): `createCommandShimBin()`, `convexAuditScript.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 478`** (2 nodes): `policy.ts`, `assertSupportedCustomerMessagePolicy()`
+- **Thin community `Community 479`** (2 nodes): `policy.ts`, `assertSupportedCustomerMessagePolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 479`** (2 nodes): `repository.test.ts`, `queryResult()`
+- **Thin community `Community 480`** (2 nodes): `repository.test.ts`, `queryResult()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 480`** (2 nodes): `webhookSecurity.test.ts`, `sign()`
+- **Thin community `Community 481`** (2 nodes): `webhookSecurity.test.ts`, `sign()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 481`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
+- **Thin community `Community 482`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 482`** (2 nodes): `subcategories.ts`, `removeStorefrontHiddenSubcategoryList()`
+- **Thin community `Community 483`** (2 nodes): `subcategories.ts`, `removeStorefrontHiddenSubcategoryList()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 483`** (2 nodes): `storefrontCors.test.ts`, `readRouteFile()`
+- **Thin community `Community 484`** (2 nodes): `storefrontCors.test.ts`, `readRouteFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 484`** (2 nodes): `whatsapp.ts`, `mapWebhookStatus()`
+- **Thin community `Community 485`** (2 nodes): `whatsapp.ts`, `mapWebhookStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 485`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
+- **Thin community `Community 486`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 486`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
+- **Thin community `Community 487`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 487`** (2 nodes): `mapAthenaAuthSyncError()`, `auth.ts`
+- **Thin community `Community 488`** (2 nodes): `mapAthenaAuthSyncError()`, `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 488`** (2 nodes): `getHandler()`, `bestSeller.test.ts`
+- **Thin community `Community 489`** (2 nodes): `getHandler()`, `bestSeller.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 489`** (2 nodes): `userErrorFromExpenseItemCommandFailure()`, `expenseSessionItems.ts`
+- **Thin community `Community 490`** (2 nodes): `userErrorFromExpenseItemCommandFailure()`, `expenseSessionItems.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 490`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
+- **Thin community `Community 491`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 491`** (2 nodes): `posSessionItems.ts`, `userErrorFromSessionItemFailure()`
+- **Thin community `Community 492`** (2 nodes): `posSessionItems.ts`, `userErrorFromSessionItemFailure()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 492`** (2 nodes): `productUtil.ts`, `buildAllProductsCacheKey()`
+- **Thin community `Community 493`** (2 nodes): `productUtil.ts`, `buildAllProductsCacheKey()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 493`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
+- **Thin community `Community 494`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 494`** (2 nodes): `commandResultValidator()`, `commandResultValidators.ts`
+- **Thin community `Community 495`** (2 nodes): `commandResultValidator()`, `commandResultValidators.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 495`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
+- **Thin community `Community 496`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 496`** (2 nodes): `callAnthropic()`, `anthropic.ts`
+- **Thin community `Community 497`** (2 nodes): `callAnthropic()`, `anthropic.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 497`** (2 nodes): `callOpenAi()`, `openai.ts`
+- **Thin community `Community 498`** (2 nodes): `callOpenAi()`, `openai.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 498`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
+- **Thin community `Community 499`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 499`** (2 nodes): `consumeCommandApprovalProofWithCtx()`, `approvalActions.ts`
+- **Thin community `Community 500`** (2 nodes): `consumeCommandApprovalProofWithCtx()`, `approvalActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 500`** (2 nodes): `createOperationalEventCtx()`, `approvalAuditEvents.test.ts`
+- **Thin community `Community 501`** (2 nodes): `createOperationalEventCtx()`, `approvalAuditEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 501`** (2 nodes): `createApprovalProofMutationCtx()`, `approvalProofs.test.ts`
+- **Thin community `Community 502`** (2 nodes): `createApprovalProofMutationCtx()`, `approvalProofs.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 502`** (2 nodes): `buildApprovalRequest()`, `approvalRequestHelpers.ts`
+- **Thin community `Community 503`** (2 nodes): `buildApprovalRequest()`, `approvalRequestHelpers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 503`** (2 nodes): `createApprovalRequestMutationCtx()`, `approvalRequests.test.ts`
+- **Thin community `Community 504`** (2 nodes): `createApprovalRequestMutationCtx()`, `approvalRequests.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 504`** (2 nodes): `buildOperationalEventMessage()`, `eventBuilders.ts`
+- **Thin community `Community 505`** (2 nodes): `buildOperationalEventMessage()`, `eventBuilders.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 505`** (2 nodes): `formatValidTime()`, `EmailOTP.ts`
+- **Thin community `Community 506`** (2 nodes): `formatValidTime()`, `EmailOTP.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 506`** (2 nodes): `quickAddCatalogItem.test.ts`, `createQuickAddCtx()`
+- **Thin community `Community 507`** (2 nodes): `quickAddCatalogItem.test.ts`, `createQuickAddCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 507`** (2 nodes): `expectNoCompletionSideEffects()`, `completeTransaction.test.ts`
+- **Thin community `Community 508`** (2 nodes): `expectNoCompletionSideEffects()`, `completeTransaction.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 508`** (2 nodes): `createMutationCtx()`, `correctTransactionPaymentMethod.test.ts`
+- **Thin community `Community 509`** (2 nodes): `createMutationCtx()`, `correctTransactionPaymentMethod.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 509`** (2 nodes): `buildCorrectionOperationalEvent()`, `correctionEvents.ts`
+- **Thin community `Community 510`** (2 nodes): `buildCorrectionOperationalEvent()`, `correctionEvents.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 510`** (2 nodes): `mockCorrectionHistoryDb()`, `getTransactions.test.ts`
+- **Thin community `Community 511`** (2 nodes): `mockCorrectionHistoryDb()`, `getTransactions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 511`** (2 nodes): `createRegisterCatalogCtx()`, `listRegisterCatalog.test.ts`
+- **Thin community `Community 512`** (2 nodes): `createRegisterCatalogCtx()`, `listRegisterCatalog.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 512`** (2 nodes): `getCashierForRegisterState()`, `cashierRepository.ts`
+- **Thin community `Community 513`** (2 nodes): `getCashierForRegisterState()`, `cashierRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 513`** (2 nodes): `createExpenseSessionCommandRepository()`, `expenseSessionCommandRepository.ts`
+- **Thin community `Community 514`** (2 nodes): `createExpenseSessionCommandRepository()`, `expenseSessionCommandRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 514`** (2 nodes): `sessionCommandRepository.test.ts`, `readProjectFile()`
+- **Thin community `Community 515`** (2 nodes): `sessionCommandRepository.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 515`** (2 nodes): `sessionRepository.test.ts`, `buildSession()`
+- **Thin community `Community 516`** (2 nodes): `sessionRepository.test.ts`, `buildSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 516`** (2 nodes): `transactions.ts`, `mapCorrectionError()`
+- **Thin community `Community 517`** (2 nodes): `transactions.ts`, `mapCorrectionError()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 517`** (2 nodes): `buildServiceCatalogItem()`, `catalog.ts`
+- **Thin community `Community 518`** (2 nodes): `buildServiceCatalogItem()`, `catalog.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 518`** (2 nodes): `getSource()`, `moduleWiring.test.ts`
+- **Thin community `Community 519`** (2 nodes): `getSource()`, `moduleWiring.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 519`** (2 nodes): `createStockOpsAccessQueryCtx()`, `access.test.ts`
+- **Thin community `Community 520`** (2 nodes): `createStockOpsAccessQueryCtx()`, `access.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 520`** (2 nodes): `requireStoreFullAdminAccess()`, `access.ts`
+- **Thin community `Community 521`** (2 nodes): `requireStoreFullAdminAccess()`, `access.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 521`** (2 nodes): `createCycleCountDraftCtx()`, `cycleCountDrafts.test.ts`
+- **Thin community `Community 522`** (2 nodes): `createCycleCountDraftCtx()`, `cycleCountDrafts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 522`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
+- **Thin community `Community 523`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 523`** (2 nodes): `createQueryCtx()`, `customerBehaviorTimeline.test.ts`
+- **Thin community `Community 524`** (2 nodes): `createQueryCtx()`, `customerBehaviorTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 524`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
+- **Thin community `Community 525`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 525`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
+- **Thin community `Community 526`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 526`** (2 nodes): `createMutationCtx()`, `customerEngagementEvents.test.ts`
+- **Thin community `Community 527`** (2 nodes): `createMutationCtx()`, `customerEngagementEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 527`** (2 nodes): `updateOnlineOrderItem()`, `onlineOrderItem.ts`
+- **Thin community `Community 528`** (2 nodes): `updateOnlineOrderItem()`, `onlineOrderItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 528`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
+- **Thin community `Community 529`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 529`** (2 nodes): `rewards.ts`, `formatPointsLabel()`
+- **Thin community `Community 530`** (2 nodes): `rewards.ts`, `formatPointsLabel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 530`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
+- **Thin community `Community 531`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 531`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
+- **Thin community `Community 532`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 532`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
+- **Thin community `Community 533`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 533`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
+- **Thin community `Community 534`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 534`** (2 nodes): `user.ts`, `getStoreFrontActorById()`
+- **Thin community `Community 535`** (2 nodes): `user.ts`, `getStoreFrontActorById()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 535`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
+- **Thin community `Community 536`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 536`** (2 nodes): `buildExpenseSessionTraceSeed()`, `expenseSession.ts`
+- **Thin community `Community 537`** (2 nodes): `buildExpenseSessionTraceSeed()`, `expenseSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 537`** (2 nodes): `posSession.ts`, `buildPosSessionTraceSeed()`
+- **Thin community `Community 538`** (2 nodes): `posSession.ts`, `buildPosSessionTraceSeed()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 538`** (2 nodes): `presentation.ts`, `buildWorkflowTraceViewModel()`
+- **Thin community `Community 539`** (2 nodes): `presentation.ts`, `buildWorkflowTraceViewModel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 539`** (2 nodes): `schemaIndexes.test.ts`, `getTableIndexes()`
+- **Thin community `Community 540`** (2 nodes): `schemaIndexes.test.ts`, `getTableIndexes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 540`** (2 nodes): `serviceIntake.ts`, `validateServiceIntakeInput()`
+- **Thin community `Community 541`** (2 nodes): `serviceIntake.ts`, `validateServiceIntakeInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 541`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
+- **Thin community `Community 542`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 542`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
+- **Thin community `Community 543`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 543`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
+- **Thin community `Community 544`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 544`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
+- **Thin community `Community 545`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 545`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
+- **Thin community `Community 546`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 546`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
+- **Thin community `Community 547`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 547`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
+- **Thin community `Community 548`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 548`** (2 nodes): `StoreView.tsx`, `Navigation()`
+- **Thin community `Community 549`** (2 nodes): `StoreView.tsx`, `Navigation()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 549`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
+- **Thin community `Community 550`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 550`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
+- **Thin community `Community 551`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 551`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
+- **Thin community `Community 552`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 552`** (2 nodes): `ProductAttributes.tsx`, `isAllowedAttribute()`
+- **Thin community `Community 553`** (2 nodes): `ProductAttributes.tsx`, `isAllowedAttribute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 553`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
+- **Thin community `Community 554`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 554`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
+- **Thin community `Community 555`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 555`** (2 nodes): `ProductImages.tsx`, `Header()`
+- **Thin community `Community 556`** (2 nodes): `ProductImages.tsx`, `Header()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 556`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
+- **Thin community `Community 557`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 557`** (2 nodes): `setIsUpdatingSku()`, `CopyImagesView.tsx`
+- **Thin community `Community 558`** (2 nodes): `setIsUpdatingSku()`, `CopyImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 558`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
+- **Thin community `Community 559`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 559`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
+- **Thin community `Community 560`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 560`** (2 nodes): `AnalyticsCombinedUsers()`, `AnalyticsCombinedUsers.tsx`
+- **Thin community `Community 561`** (2 nodes): `AnalyticsCombinedUsers()`, `AnalyticsCombinedUsers.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 561`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
+- **Thin community `Community 562`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 562`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
+- **Thin community `Community 563`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 563`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
+- **Thin community `Community 564`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 564`** (2 nodes): `formatMetric()`, `AnalyticsView.tsx`
+- **Thin community `Community 565`** (2 nodes): `formatMetric()`, `AnalyticsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 565`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
+- **Thin community `Community 566`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 566`** (2 nodes): `StoreInsights.tsx`, `getTrendIcon()`
+- **Thin community `Community 567`** (2 nodes): `StoreInsights.tsx`, `getTrendIcon()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 567`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
+- **Thin community `Community 568`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 568`** (2 nodes): `readSource()`, `analyticsWorkspaceEfficiency.test.ts`
+- **Thin community `Community 569`** (2 nodes): `readSource()`, `analyticsWorkspaceEfficiency.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 569`** (2 nodes): `LogItems()`, `LogItems.tsx`
+- **Thin community `Community 570`** (2 nodes): `LogItems()`, `LogItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 570`** (2 nodes): `Header()`, `LogView.tsx`
+- **Thin community `Community 571`** (2 nodes): `Header()`, `LogView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 571`** (2 nodes): `Navigation()`, `LogsView.tsx`
+- **Thin community `Community 572`** (2 nodes): `Navigation()`, `LogsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 572`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
+- **Thin community `Community 573`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 573`** (2 nodes): `SidebarMenuCollapsible()`, `app-sidebar.tsx`
+- **Thin community `Community 574`** (2 nodes): `SidebarMenuCollapsible()`, `app-sidebar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 574`** (2 nodes): `Auth()`, `Auth.tsx`
+- **Thin community `Community 575`** (2 nodes): `Auth()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 575`** (2 nodes): `resolveSignIn()`, `InputOTP.test.tsx`
+- **Thin community `Community 576`** (2 nodes): `resolveSignIn()`, `InputOTP.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 576`** (2 nodes): `Login()`, `index.tsx`
+- **Thin community `Community 577`** (2 nodes): `Login()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 577`** (2 nodes): `DataTableColumnHeader()`, `data-table-column-header.tsx`
+- **Thin community `Community 578`** (2 nodes): `DataTableColumnHeader()`, `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 578`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
+- **Thin community `Community 579`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 579`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
+- **Thin community `Community 580`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 580`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
+- **Thin community `Community 581`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 581`** (2 nodes): `formatReviewReason()`, `formatReviewReason.ts`
+- **Thin community `Community 582`** (2 nodes): `formatReviewReason()`, `formatReviewReason.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 582`** (2 nodes): `registerSessionColumns.tsx`, `RegisterSessionLink()`
+- **Thin community `Community 583`** (2 nodes): `registerSessionColumns.tsx`, `RegisterSessionLink()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 583`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
+- **Thin community `Community 584`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 584`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
+- **Thin community `Community 585`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 585`** (2 nodes): `ExpenseCompletion()`, `ExpenseCompletion.tsx`
+- **Thin community `Community 586`** (2 nodes): `ExpenseCompletion()`, `ExpenseCompletion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 586`** (2 nodes): `ExpenseView()`, `ExpenseView.tsx`
+- **Thin community `Community 587`** (2 nodes): `ExpenseView()`, `ExpenseView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 587`** (2 nodes): `handleAddBestSeller()`, `BestSellersDialog.tsx`
+- **Thin community `Community 588`** (2 nodes): `handleAddBestSeller()`, `BestSellersDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 588`** (2 nodes): `handleAddFeaturedItem()`, `FeaturedSectionDialog.tsx`
+- **Thin community `Community 589`** (2 nodes): `handleAddFeaturedItem()`, `FeaturedSectionDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 589`** (2 nodes): `Navigation()`, `Home.tsx`
+- **Thin community `Community 590`** (2 nodes): `Navigation()`, `Home.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 590`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
+- **Thin community `Community 591`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 591`** (2 nodes): `ShopLookDialog.tsx`, `handleAddFeaturedItem()`
+- **Thin community `Community 592`** (2 nodes): `ShopLookDialog.tsx`, `handleAddFeaturedItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 592`** (2 nodes): `ShopLookImageUploader.tsx`, `ShopLookImageUploader()`
+- **Thin community `Community 593`** (2 nodes): `ShopLookImageUploader.tsx`, `ShopLookImageUploader()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 593`** (2 nodes): `JoinTeam()`, `index.tsx`
+- **Thin community `Community 594`** (2 nodes): `JoinTeam()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 594`** (2 nodes): `StockAdjustmentWorkspace.test.tsx`, `renderStockAdjustmentWorkspace()`
+- **Thin community `Community 595`** (2 nodes): `StockAdjustmentWorkspace.test.tsx`, `renderStockAdjustmentWorkspace()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 595`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
+- **Thin community `Community 596`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 596`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
+- **Thin community `Community 597`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 597`** (2 nodes): `handleTimeRangeChange()`, `OrderMetricsPanel.tsx`
+- **Thin community `Community 598`** (2 nodes): `handleTimeRangeChange()`, `OrderMetricsPanel.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 598`** (2 nodes): `getTimeFilter()`, `OrdersView.tsx`
+- **Thin community `Community 599`** (2 nodes): `getTimeFilter()`, `OrdersView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 599`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
+- **Thin community `Community 600`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 600`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
+- **Thin community `Community 601`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 601`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
+- **Thin community `Community 602`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 602`** (2 nodes): `if()`, `orderColumns.tsx`
+- **Thin community `Community 603`** (2 nodes): `if()`, `orderColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 603`** (2 nodes): `OrganizationSwitcher()`, `organization-switcher.tsx`
+- **Thin community `Community 604`** (2 nodes): `OrganizationSwitcher()`, `organization-switcher.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 604`** (2 nodes): `cn()`, `CartItems.tsx`
+- **Thin community `Community 605`** (2 nodes): `cn()`, `CartItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 605`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
+- **Thin community `Community 606`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 606`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
+- **Thin community `Community 607`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 607`** (2 nodes): `PinInput.tsx`, `PinInput()`
+- **Thin community `Community 608`** (2 nodes): `PinInput.tsx`, `PinInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 608`** (2 nodes): `PointOfSaleView.tsx`, `Navigation()`
+- **Thin community `Community 609`** (2 nodes): `PointOfSaleView.tsx`, `Navigation()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 609`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
+- **Thin community `Community 610`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 610`** (2 nodes): `ProductCard.tsx`, `ProductCard()`
+- **Thin community `Community 611`** (2 nodes): `ProductCard.tsx`, `ProductCard()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 611`** (2 nodes): `SearchResultsSection.test.tsx`, `buildProduct()`
+- **Thin community `Community 612`** (2 nodes): `SearchResultsSection.test.tsx`, `buildProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 612`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
+- **Thin community `Community 613`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 613`** (2 nodes): `ExpenseCompletionPanel()`, `ExpenseCompletionPanel.tsx`
+- **Thin community `Community 614`** (2 nodes): `ExpenseCompletionPanel()`, `ExpenseCompletionPanel.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 614`** (2 nodes): `RegisterCustomerAttribution.test.tsx`, `makeCustomer()`
+- **Thin community `Community 615`** (2 nodes): `RegisterCustomerAttribution.test.tsx`, `makeCustomer()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 615`** (2 nodes): `RegisterCustomerPanel.tsx`, `RegisterCustomerPanel()`
+- **Thin community `Community 616`** (2 nodes): `RegisterCustomerPanel.tsx`, `RegisterCustomerPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 616`** (2 nodes): `RegisterDrawerGate.test.tsx`, `renderGate()`
+- **Thin community `Community 617`** (2 nodes): `RegisterDrawerGate.test.tsx`, `renderGate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 617`** (2 nodes): `RegisterSessionPanel.tsx`, `RegisterSessionPanel()`
+- **Thin community `Community 618`** (2 nodes): `RegisterSessionPanel.tsx`, `RegisterSessionPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 618`** (2 nodes): `transactionColumns.test.tsx`, `renderTransactionCell()`
+- **Thin community `Community 619`** (2 nodes): `transactionColumns.test.tsx`, `renderTransactionCell()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 619`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
+- **Thin community `Community 620`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 620`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
+- **Thin community `Community 621`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 621`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
+- **Thin community `Community 622`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 622`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
+- **Thin community `Community 623`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 623`** (2 nodes): `ProductStatus.tsx`, `ProductStatus()`
+- **Thin community `Community 624`** (2 nodes): `ProductStatus.tsx`, `ProductStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 624`** (2 nodes): `SKUSelector.tsx`, `SKUSelector()`
+- **Thin community `Community 625`** (2 nodes): `SKUSelector.tsx`, `SKUSelector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 625`** (2 nodes): `product-actions.tsx`, `useArchiveProduct()`
+- **Thin community `Community 626`** (2 nodes): `product-actions.tsx`, `useArchiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 626`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
+- **Thin community `Community 627`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 627`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
+- **Thin community `Community 628`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 628`** (2 nodes): `Products.tsx`, `Products()`
+- **Thin community `Community 629`** (2 nodes): `Products.tsx`, `Products()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 629`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
+- **Thin community `Community 630`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 630`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
+- **Thin community `Community 631`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 631`** (2 nodes): `PromoCodePreview.tsx`, `Discount()`
+- **Thin community `Community 632`** (2 nodes): `PromoCodePreview.tsx`, `Discount()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 632`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
+- **Thin community `Community 633`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 633`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
+- **Thin community `Community 634`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 634`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
+- **Thin community `Community 635`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 635`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
+- **Thin community `Community 636`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 636`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
+- **Thin community `Community 637`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 637`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
+- **Thin community `Community 638`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 638`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
+- **Thin community `Community 639`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 639`** (2 nodes): `ServiceCasesView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 640`** (2 nodes): `ServiceCasesView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 640`** (2 nodes): `ServiceCatalogView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 641`** (2 nodes): `ServiceCatalogView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 641`** (2 nodes): `ServiceIntakeForm.tsx`, `ServiceIntakeForm()`
+- **Thin community `Community 642`** (2 nodes): `ServiceIntakeForm.tsx`, `ServiceIntakeForm()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 642`** (2 nodes): `ServiceIntakeView.auth.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 643`** (2 nodes): `ServiceIntakeView.auth.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 643`** (2 nodes): `ServiceIntakeView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 644`** (2 nodes): `ServiceIntakeView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 644`** (2 nodes): `onClick()`, `empty-state.tsx`
+- **Thin community `Community 645`** (2 nodes): `onClick()`, `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 645`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
+- **Thin community `Community 646`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 646`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
+- **Thin community `Community 647`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 647`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
+- **Thin community `Community 648`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 648`** (2 nodes): `ProtectedAdminSignInView.tsx`, `ProtectedAdminSignInView()`
+- **Thin community `Community 649`** (2 nodes): `ProtectedAdminSignInView.tsx`, `ProtectedAdminSignInView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 649`** (2 nodes): `ContactView()`, `ContactView.tsx`
+- **Thin community `Community 650`** (2 nodes): `ContactView()`, `ContactView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 650`** (2 nodes): `Header()`, `Header.tsx`
+- **Thin community `Community 651`** (2 nodes): `Header()`, `Header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 651`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
+- **Thin community `Community 652`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 652`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
+- **Thin community `Community 653`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 653`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
+- **Thin community `Community 654`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 654`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
+- **Thin community `Community 655`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 655`** (2 nodes): `Calendar()`, `calendar.tsx`
+- **Thin community `Community 656`** (2 nodes): `Calendar()`, `calendar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 656`** (2 nodes): `useChart()`, `chart.tsx`
+- **Thin community `Community 657`** (2 nodes): `useChart()`, `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 657`** (2 nodes): `handleCopy()`, `copy-button.tsx`
+- **Thin community `Community 658`** (2 nodes): `handleCopy()`, `copy-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 658`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
+- **Thin community `Community 659`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 659`** (2 nodes): `Label()`, `label.tsx`
+- **Thin community `Community 660`** (2 nodes): `Label()`, `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 660`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
+- **Thin community `Community 661`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 661`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
+- **Thin community `Community 662`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 662`** (2 nodes): `store-modal.tsx`, `onSubmit()`
+- **Thin community `Community 663`** (2 nodes): `store-modal.tsx`, `onSubmit()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 663`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
+- **Thin community `Community 664`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 664`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
+- **Thin community `Community 665`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 665`** (2 nodes): `select-native.tsx`, `cn()`
+- **Thin community `Community 666`** (2 nodes): `select-native.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 666`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
+- **Thin community `Community 667`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 667`** (2 nodes): `webp-image.tsx`, `WebpImage()`
+- **Thin community `Community 668`** (2 nodes): `webp-image.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 668`** (2 nodes): `BagItems()`, `BagItems.tsx`
+- **Thin community `Community 669`** (2 nodes): `BagItems()`, `BagItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 669`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
+- **Thin community `Community 670`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 670`** (2 nodes): `Bags()`, `Bags.tsx`
+- **Thin community `Community 671`** (2 nodes): `Bags()`, `Bags.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 671`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
+- **Thin community `Community 672`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 672`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
+- **Thin community `Community 673`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 673`** (2 nodes): `UserBag.tsx`, `UserBag()`
+- **Thin community `Community 674`** (2 nodes): `UserBag.tsx`, `UserBag()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 674`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
+- **Thin community `Community 675`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 675`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
+- **Thin community `Community 676`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 676`** (2 nodes): `UserView.tsx`, `UserActions()`
+- **Thin community `Community 677`** (2 nodes): `UserView.tsx`, `UserActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 677`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
+- **Thin community `Community 678`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 678`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
+- **Thin community `Community 679`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 679`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
+- **Thin community `Community 680`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 680`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
+- **Thin community `Community 681`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 681`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
+- **Thin community `Community 682`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 682`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
+- **Thin community `Community 683`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 683`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
+- **Thin community `Community 684`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 684`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
+- **Thin community `Community 685`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 685`** (2 nodes): `useConvexAuthIdentity.ts`, `useConvexAuthIdentity()`
+- **Thin community `Community 686`** (2 nodes): `useConvexAuthIdentity.ts`, `useConvexAuthIdentity()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 686`** (2 nodes): `useCopyText.ts`, `useCopyText()`
+- **Thin community `Community 687`** (2 nodes): `useCopyText.ts`, `useCopyText()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 687`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
+- **Thin community `Community 688`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 688`** (2 nodes): `useDebounce.ts`, `useDebounce()`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 689`** (2 nodes): `useExpenseOperations.ts`, `useExpenseOperations()`
+- **Thin community `Community 689`** (2 nodes): `useDebounce.ts`, `useDebounce()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 690`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -33641,13 +33641,37 @@
     },
     {
       "_src": "packages_athena_webapp_src_hooks_useexpenseoperations_ts",
+      "_tgt": "useexpenseoperations_clonecartitems",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_hooks_useexpenseoperations_ts",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseOperations.ts",
+      "source_location": "L19",
+      "target": "useexpenseoperations_clonecartitems",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_hooks_useexpenseoperations_ts",
+      "_tgt": "useexpenseoperations_mapproducttoexpensecartitem",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_hooks_useexpenseoperations_ts",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseOperations.ts",
+      "source_location": "L23",
+      "target": "useexpenseoperations_mapproducttoexpensecartitem",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_hooks_useexpenseoperations_ts",
       "_tgt": "useexpenseoperations_useexpenseoperations",
       "confidence": "EXTRACTED",
       "confidence_score": 1,
       "relation": "contains",
       "source": "packages_athena_webapp_src_hooks_useexpenseoperations_ts",
       "source_file": "packages/athena-webapp/src/hooks/useExpenseOperations.ts",
-      "source_location": "L24",
+      "source_location": "L50",
       "target": "useexpenseoperations_useexpenseoperations",
       "weight": 1
     },
@@ -35345,13 +35369,49 @@
     },
     {
       "_src": "packages_athena_webapp_src_lib_pos_presentation_expense_useexpenseregisterviewmodel_test_ts",
+      "_tgt": "useexpenseregisterviewmodel_test_buildactiveexpensesession",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_lib_pos_presentation_expense_useexpenseregisterviewmodel_test_ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/expense/useExpenseRegisterViewModel.test.ts",
+      "source_location": "L171",
+      "target": "useexpenseregisterviewmodel_test_buildactiveexpensesession",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_lib_pos_presentation_expense_useexpenseregisterviewmodel_test_ts",
+      "_tgt": "useexpenseregisterviewmodel_test_buildexpensecartitem",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_lib_pos_presentation_expense_useexpenseregisterviewmodel_test_ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/expense/useExpenseRegisterViewModel.test.ts",
+      "source_location": "L186",
+      "target": "useexpenseregisterviewmodel_test_buildexpensecartitem",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_lib_pos_presentation_expense_useexpenseregisterviewmodel_test_ts",
+      "_tgt": "useexpenseregisterviewmodel_test_buildproduct",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_lib_pos_presentation_expense_useexpenseregisterviewmodel_test_ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/expense/useExpenseRegisterViewModel.test.ts",
+      "source_location": "L209",
+      "target": "useexpenseregisterviewmodel_test_buildproduct",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_lib_pos_presentation_expense_useexpenseregisterviewmodel_test_ts",
       "_tgt": "useexpenseregisterviewmodel_test_buildregistercatalogavailabilityrow",
       "confidence": "EXTRACTED",
       "confidence_score": 1,
       "relation": "contains",
       "source": "packages_athena_webapp_src_lib_pos_presentation_expense_useexpenseregisterviewmodel_test_ts",
       "source_file": "packages/athena-webapp/src/lib/pos/presentation/expense/useExpenseRegisterViewModel.test.ts",
-      "source_location": "L149",
+      "source_location": "L159",
       "target": "useexpenseregisterviewmodel_test_buildregistercatalogavailabilityrow",
       "weight": 1
     },
@@ -35363,8 +35423,32 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_lib_pos_presentation_expense_useexpenseregisterviewmodel_test_ts",
       "source_file": "packages/athena-webapp/src/lib/pos/presentation/expense/useExpenseRegisterViewModel.test.ts",
-      "source_location": "L126",
+      "source_location": "L136",
       "target": "useexpenseregisterviewmodel_test_buildregistercatalogrow",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_lib_pos_presentation_expense_useexpenseregisterviewmodel_test_ts",
+      "_tgt": "useexpenseregisterviewmodel_test_deferred",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_lib_pos_presentation_expense_useexpenseregisterviewmodel_test_ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/expense/useExpenseRegisterViewModel.test.ts",
+      "source_location": "L227",
+      "target": "useexpenseregisterviewmodel_test_deferred",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_lib_pos_presentation_expense_useexpenseregisterviewmodel_test_ts",
+      "_tgt": "useexpenseregisterviewmodel_test_seedactiveexpensecart",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_lib_pos_presentation_expense_useexpenseregisterviewmodel_test_ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/expense/useExpenseRegisterViewModel.test.ts",
+      "source_location": "L238",
+      "target": "useexpenseregisterviewmodel_test_seedactiveexpensecart",
       "weight": 1
     },
     {
@@ -56123,7 +56207,7 @@
       "relation": "calls",
       "source": "useexpenseregisterviewmodel_getcashierdisplayname",
       "source_file": "packages/athena-webapp/src/lib/pos/presentation/expense/useExpenseRegisterViewModel.ts",
-      "source_location": "L602",
+      "source_location": "L629",
       "target": "useexpenseregisterviewmodel_useexpenseregisterviewmodel",
       "weight": 1
     },
@@ -57630,74 +57714,74 @@
     {
       "community": 100,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_commands_quickaddcatalogitem_ts",
-      "label": "quickAddCatalogItem.ts",
-      "norm_label": "quickaddcatalogitem.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
+      "id": "packages_athena_webapp_convex_pos_application_commands_possessiontracing_ts",
+      "label": "posSessionTracing.ts",
+      "norm_label": "possessiontracing.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
       "source_location": "L1"
     },
     {
       "community": 100,
       "file_type": "code",
-      "id": "quickaddcatalogitem_findexistingsku",
-      "label": "findExistingSku()",
-      "norm_label": "findexistingsku()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
-      "source_location": "L125"
+      "id": "possessiontracing_buildpossessiontraceevent",
+      "label": "buildPosSessionTraceEvent()",
+      "norm_label": "buildpossessiontraceevent()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L226"
     },
     {
       "community": 100,
       "file_type": "code",
-      "id": "quickaddcatalogitem_findorcreatequickaddcategory",
-      "label": "findOrCreateQuickAddCategory()",
-      "norm_label": "findorcreatequickaddcategory()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
-      "source_location": "L29"
+      "id": "possessiontracing_buildpossessiontracerecord",
+      "label": "buildPosSessionTraceRecord()",
+      "norm_label": "buildpossessiontracerecord()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L142"
     },
     {
       "community": 100,
       "file_type": "code",
-      "id": "quickaddcatalogitem_findorcreatequickaddsubcategory",
-      "label": "findOrCreateQuickAddSubcategory()",
-      "norm_label": "findorcreatequickaddsubcategory()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
-      "source_location": "L56"
+      "id": "possessiontracing_buildtracesummary",
+      "label": "buildTraceSummary()",
+      "norm_label": "buildtracesummary()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L105"
     },
     {
       "community": 100,
       "file_type": "code",
-      "id": "quickaddcatalogitem_generatesku",
-      "label": "generateSKU()",
-      "norm_label": "generatesku()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
-      "source_location": "L153"
+      "id": "possessiontracing_createpossessiontracerecorder",
+      "label": "createPosSessionTraceRecorder()",
+      "norm_label": "createpossessiontracerecorder()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L559"
     },
     {
       "community": 100,
       "file_type": "code",
-      "id": "quickaddcatalogitem_isbarcodelike",
-      "label": "isBarcodeLike()",
-      "norm_label": "isbarcodelike()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
-      "source_location": "L149"
+      "id": "possessiontracing_formatpaymentmethod",
+      "label": "formatPaymentMethod()",
+      "norm_label": "formatpaymentmethod()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L218"
     },
     {
       "community": 100,
       "file_type": "code",
-      "id": "quickaddcatalogitem_mapskutocatalogresult",
-      "label": "mapSkuToCatalogResult()",
-      "norm_label": "mapskutocatalogresult()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
-      "source_location": "L88"
+      "id": "possessiontracing_recordpossessiontracebesteffort",
+      "label": "recordPosSessionTraceBestEffort()",
+      "norm_label": "recordpossessiontracebesteffort()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L532"
     },
     {
       "community": 100,
       "file_type": "code",
-      "id": "quickaddcatalogitem_quickaddcatalogitem",
-      "label": "quickAddCatalogItem()",
-      "norm_label": "quickaddcatalogitem()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
-      "source_location": "L174"
+      "id": "possessiontracing_safetracewrite",
+      "label": "safeTraceWrite()",
+      "norm_label": "safetracewrite()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L524"
     },
     {
       "community": 1000,
@@ -57792,74 +57876,74 @@
     {
       "community": 101,
       "file_type": "code",
-      "id": "expensesessioncommands_test_builditem",
-      "label": "buildItem()",
-      "norm_label": "builditem()",
-      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
-      "source_location": "L645"
-    },
-    {
-      "community": 101,
-      "file_type": "code",
-      "id": "expensesessioncommands_test_buildregistersession",
-      "label": "buildRegisterSession()",
-      "norm_label": "buildregistersession()",
-      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
-      "source_location": "L639"
-    },
-    {
-      "community": 101,
-      "file_type": "code",
-      "id": "expensesessioncommands_test_buildsession",
-      "label": "buildSession()",
-      "norm_label": "buildsession()",
-      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
-      "source_location": "L635"
-    },
-    {
-      "community": 101,
-      "file_type": "code",
-      "id": "expensesessioncommands_test_createcommandservice",
-      "label": "createCommandService()",
-      "norm_label": "createcommandservice()",
-      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
-      "source_location": "L655"
-    },
-    {
-      "community": 101,
-      "file_type": "code",
-      "id": "expensesessioncommands_test_createdependencies",
-      "label": "createDependencies()",
-      "norm_label": "createdependencies()",
-      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
-      "source_location": "L424"
-    },
-    {
-      "community": 101,
-      "file_type": "code",
-      "id": "expensesessioncommands_test_createfakerepository",
-      "label": "createFakeRepository()",
-      "norm_label": "createfakerepository()",
-      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
-      "source_location": "L492"
-    },
-    {
-      "community": 101,
-      "file_type": "code",
-      "id": "expensesessioncommands_test_loadcommandservice",
-      "label": "loadCommandService()",
-      "norm_label": "loadcommandservice()",
-      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
-      "source_location": "L404"
-    },
-    {
-      "community": 101,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_expensesessioncommands_test_ts",
-      "label": "expenseSessionCommands.test.ts",
-      "norm_label": "expensesessioncommands.test.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
+      "id": "packages_athena_webapp_convex_pos_application_commands_quickaddcatalogitem_ts",
+      "label": "quickAddCatalogItem.ts",
+      "norm_label": "quickaddcatalogitem.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 101,
+      "file_type": "code",
+      "id": "quickaddcatalogitem_findexistingsku",
+      "label": "findExistingSku()",
+      "norm_label": "findexistingsku()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
+      "source_location": "L125"
+    },
+    {
+      "community": 101,
+      "file_type": "code",
+      "id": "quickaddcatalogitem_findorcreatequickaddcategory",
+      "label": "findOrCreateQuickAddCategory()",
+      "norm_label": "findorcreatequickaddcategory()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
+      "source_location": "L29"
+    },
+    {
+      "community": 101,
+      "file_type": "code",
+      "id": "quickaddcatalogitem_findorcreatequickaddsubcategory",
+      "label": "findOrCreateQuickAddSubcategory()",
+      "norm_label": "findorcreatequickaddsubcategory()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
+      "source_location": "L56"
+    },
+    {
+      "community": 101,
+      "file_type": "code",
+      "id": "quickaddcatalogitem_generatesku",
+      "label": "generateSKU()",
+      "norm_label": "generatesku()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
+      "source_location": "L153"
+    },
+    {
+      "community": 101,
+      "file_type": "code",
+      "id": "quickaddcatalogitem_isbarcodelike",
+      "label": "isBarcodeLike()",
+      "norm_label": "isbarcodelike()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
+      "source_location": "L149"
+    },
+    {
+      "community": 101,
+      "file_type": "code",
+      "id": "quickaddcatalogitem_mapskutocatalogresult",
+      "label": "mapSkuToCatalogResult()",
+      "norm_label": "mapskutocatalogresult()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
+      "source_location": "L88"
+    },
+    {
+      "community": 101,
+      "file_type": "code",
+      "id": "quickaddcatalogitem_quickaddcatalogitem",
+      "label": "quickAddCatalogItem()",
+      "norm_label": "quickaddcatalogitem()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
+      "source_location": "L174"
     },
     {
       "community": 1010,
@@ -57954,74 +58038,74 @@
     {
       "community": 102,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_sessioncommands_test_ts",
-      "label": "sessionCommands.test.ts",
-      "norm_label": "sessioncommands.test.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 102,
-      "file_type": "code",
-      "id": "sessioncommands_test_builditem",
+      "id": "expensesessioncommands_test_builditem",
       "label": "buildItem()",
       "norm_label": "builditem()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L2406"
+      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
+      "source_location": "L645"
     },
     {
       "community": 102,
       "file_type": "code",
-      "id": "sessioncommands_test_buildregistersession",
+      "id": "expensesessioncommands_test_buildregistersession",
       "label": "buildRegisterSession()",
       "norm_label": "buildregistersession()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L2400"
+      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
+      "source_location": "L639"
     },
     {
       "community": 102,
       "file_type": "code",
-      "id": "sessioncommands_test_buildsession",
+      "id": "expensesessioncommands_test_buildsession",
       "label": "buildSession()",
       "norm_label": "buildsession()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L2396"
+      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
+      "source_location": "L635"
     },
     {
       "community": 102,
       "file_type": "code",
-      "id": "sessioncommands_test_createcommandservice",
+      "id": "expensesessioncommands_test_createcommandservice",
       "label": "createCommandService()",
       "norm_label": "createcommandservice()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L2416"
+      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
+      "source_location": "L655"
     },
     {
       "community": 102,
       "file_type": "code",
-      "id": "sessioncommands_test_createdependencies",
+      "id": "expensesessioncommands_test_createdependencies",
       "label": "createDependencies()",
       "norm_label": "createdependencies()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L2155"
+      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
+      "source_location": "L424"
     },
     {
       "community": 102,
       "file_type": "code",
-      "id": "sessioncommands_test_createfakerepository",
+      "id": "expensesessioncommands_test_createfakerepository",
       "label": "createFakeRepository()",
       "norm_label": "createfakerepository()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L2252"
+      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
+      "source_location": "L492"
     },
     {
       "community": 102,
       "file_type": "code",
-      "id": "sessioncommands_test_loadcommandservice",
+      "id": "expensesessioncommands_test_loadcommandservice",
       "label": "loadCommandService()",
       "norm_label": "loadcommandservice()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L2137"
+      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
+      "source_location": "L404"
+    },
+    {
+      "community": 102,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_expensesessioncommands_test_ts",
+      "label": "expenseSessionCommands.test.ts",
+      "norm_label": "expensesessioncommands.test.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
+      "source_location": "L1"
     },
     {
       "community": 1020,
@@ -58116,74 +58200,74 @@
     {
       "community": 103,
       "file_type": "code",
-      "id": "index_senddiscountcodeemail",
-      "label": "sendDiscountCodeEmail()",
-      "norm_label": "senddiscountcodeemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L255"
-    },
-    {
-      "community": 103,
-      "file_type": "code",
-      "id": "index_senddiscountreminderemail",
-      "label": "sendDiscountReminderEmail()",
-      "norm_label": "senddiscountreminderemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L334"
-    },
-    {
-      "community": 103,
-      "file_type": "code",
-      "id": "index_sendfeedbackrequestemail",
-      "label": "sendFeedbackRequestEmail()",
-      "norm_label": "sendfeedbackrequestemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L167"
-    },
-    {
-      "community": 103,
-      "file_type": "code",
-      "id": "index_sendneworderemail",
-      "label": "sendNewOrderEmail()",
-      "norm_label": "sendneworderemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L117"
-    },
-    {
-      "community": 103,
-      "file_type": "code",
-      "id": "index_sendorderemail",
-      "label": "sendOrderEmail()",
-      "norm_label": "sendorderemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L43"
-    },
-    {
-      "community": 103,
-      "file_type": "code",
-      "id": "index_sendverificationcode",
-      "label": "sendVerificationCode()",
-      "norm_label": "sendverificationcode()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L3"
-    },
-    {
-      "community": 103,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_mailersend_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/convex/mailersend/index.tsx",
+      "id": "packages_athena_webapp_convex_pos_application_sessioncommands_test_ts",
+      "label": "sessionCommands.test.ts",
+      "norm_label": "sessioncommands.test.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
       "source_location": "L1"
     },
     {
       "community": 103,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_sendgrid_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L1"
+      "id": "sessioncommands_test_builditem",
+      "label": "buildItem()",
+      "norm_label": "builditem()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L2406"
+    },
+    {
+      "community": 103,
+      "file_type": "code",
+      "id": "sessioncommands_test_buildregistersession",
+      "label": "buildRegisterSession()",
+      "norm_label": "buildregistersession()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L2400"
+    },
+    {
+      "community": 103,
+      "file_type": "code",
+      "id": "sessioncommands_test_buildsession",
+      "label": "buildSession()",
+      "norm_label": "buildsession()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L2396"
+    },
+    {
+      "community": 103,
+      "file_type": "code",
+      "id": "sessioncommands_test_createcommandservice",
+      "label": "createCommandService()",
+      "norm_label": "createcommandservice()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L2416"
+    },
+    {
+      "community": 103,
+      "file_type": "code",
+      "id": "sessioncommands_test_createdependencies",
+      "label": "createDependencies()",
+      "norm_label": "createdependencies()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L2155"
+    },
+    {
+      "community": 103,
+      "file_type": "code",
+      "id": "sessioncommands_test_createfakerepository",
+      "label": "createFakeRepository()",
+      "norm_label": "createfakerepository()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L2252"
+    },
+    {
+      "community": 103,
+      "file_type": "code",
+      "id": "sessioncommands_test_loadcommandservice",
+      "label": "loadCommandService()",
+      "norm_label": "loadcommandservice()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L2137"
     },
     {
       "community": 1030,
@@ -59502,74 +59586,74 @@
     {
       "community": 110,
       "file_type": "code",
-      "id": "bag_additemtobag",
-      "label": "addItemToBag()",
-      "norm_label": "additemtobag()",
-      "source_file": "packages/storefront-webapp/src/api/bag.ts",
-      "source_location": "L27"
-    },
-    {
-      "community": 110,
-      "file_type": "code",
-      "id": "bag_clearbag",
-      "label": "clearBag()",
-      "norm_label": "clearbag()",
-      "source_file": "packages/storefront-webapp/src/api/bag.ts",
-      "source_location": "L106"
-    },
-    {
-      "community": 110,
-      "file_type": "code",
-      "id": "bag_getactivebag",
-      "label": "getActiveBag()",
-      "norm_label": "getactivebag()",
-      "source_file": "packages/storefront-webapp/src/api/bag.ts",
-      "source_location": "L12"
-    },
-    {
-      "community": 110,
-      "file_type": "code",
-      "id": "bag_getbaseurl",
-      "label": "getBaseUrl()",
-      "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/bag.ts",
-      "source_location": "L10"
-    },
-    {
-      "community": 110,
-      "file_type": "code",
-      "id": "bag_removeitemfrombag",
-      "label": "removeItemFromBag()",
-      "norm_label": "removeitemfrombag()",
-      "source_file": "packages/storefront-webapp/src/api/bag.ts",
-      "source_location": "L90"
-    },
-    {
-      "community": 110,
-      "file_type": "code",
-      "id": "bag_updatebagitem",
-      "label": "updateBagItem()",
-      "norm_label": "updatebagitem()",
-      "source_file": "packages/storefront-webapp/src/api/bag.ts",
-      "source_location": "L63"
-    },
-    {
-      "community": 110,
-      "file_type": "code",
-      "id": "bag_updatebagowner",
-      "label": "updateBagOwner()",
-      "norm_label": "updatebagowner()",
-      "source_file": "packages/storefront-webapp/src/api/bag.ts",
-      "source_location": "L118"
-    },
-    {
-      "community": 110,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_bag_ts",
-      "label": "bag.ts",
-      "norm_label": "bag.ts",
-      "source_file": "packages/storefront-webapp/src/api/bag.ts",
+      "id": "packages_athena_webapp_src_lib_pos_presentation_expense_useexpenseregisterviewmodel_test_ts",
+      "label": "useExpenseRegisterViewModel.test.ts",
+      "norm_label": "useexpenseregisterviewmodel.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/expense/useExpenseRegisterViewModel.test.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 110,
+      "file_type": "code",
+      "id": "useexpenseregisterviewmodel_test_buildactiveexpensesession",
+      "label": "buildActiveExpenseSession()",
+      "norm_label": "buildactiveexpensesession()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/expense/useExpenseRegisterViewModel.test.ts",
+      "source_location": "L171"
+    },
+    {
+      "community": 110,
+      "file_type": "code",
+      "id": "useexpenseregisterviewmodel_test_buildexpensecartitem",
+      "label": "buildExpenseCartItem()",
+      "norm_label": "buildexpensecartitem()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/expense/useExpenseRegisterViewModel.test.ts",
+      "source_location": "L186"
+    },
+    {
+      "community": 110,
+      "file_type": "code",
+      "id": "useexpenseregisterviewmodel_test_buildproduct",
+      "label": "buildProduct()",
+      "norm_label": "buildproduct()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/expense/useExpenseRegisterViewModel.test.ts",
+      "source_location": "L209"
+    },
+    {
+      "community": 110,
+      "file_type": "code",
+      "id": "useexpenseregisterviewmodel_test_buildregistercatalogavailabilityrow",
+      "label": "buildRegisterCatalogAvailabilityRow()",
+      "norm_label": "buildregistercatalogavailabilityrow()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/expense/useExpenseRegisterViewModel.test.ts",
+      "source_location": "L159"
+    },
+    {
+      "community": 110,
+      "file_type": "code",
+      "id": "useexpenseregisterviewmodel_test_buildregistercatalogrow",
+      "label": "buildRegisterCatalogRow()",
+      "norm_label": "buildregistercatalogrow()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/expense/useExpenseRegisterViewModel.test.ts",
+      "source_location": "L136"
+    },
+    {
+      "community": 110,
+      "file_type": "code",
+      "id": "useexpenseregisterviewmodel_test_deferred",
+      "label": "deferred()",
+      "norm_label": "deferred()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/expense/useExpenseRegisterViewModel.test.ts",
+      "source_location": "L227"
+    },
+    {
+      "community": 110,
+      "file_type": "code",
+      "id": "useexpenseregisterviewmodel_test_seedactiveexpensecart",
+      "label": "seedActiveExpenseCart()",
+      "norm_label": "seedactiveexpensecart()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/expense/useExpenseRegisterViewModel.test.ts",
+      "source_location": "L238"
     },
     {
       "community": 1100,
@@ -59664,74 +59748,74 @@
     {
       "community": 111,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_product_ts",
-      "label": "product.ts",
-      "norm_label": "product.ts",
-      "source_file": "packages/storefront-webapp/src/api/product.ts",
-      "source_location": "L1"
+      "id": "bag_additemtobag",
+      "label": "addItemToBag()",
+      "norm_label": "additemtobag()",
+      "source_file": "packages/storefront-webapp/src/api/bag.ts",
+      "source_location": "L27"
     },
     {
       "community": 111,
       "file_type": "code",
-      "id": "product_buildquerystring",
-      "label": "buildQueryString()",
-      "norm_label": "buildquerystring()",
-      "source_file": "packages/storefront-webapp/src/api/product.ts",
-      "source_location": "L5"
+      "id": "bag_clearbag",
+      "label": "clearBag()",
+      "norm_label": "clearbag()",
+      "source_file": "packages/storefront-webapp/src/api/bag.ts",
+      "source_location": "L106"
     },
     {
       "community": 111,
       "file_type": "code",
-      "id": "product_getallproducts",
-      "label": "getAllProducts()",
-      "norm_label": "getallproducts()",
-      "source_file": "packages/storefront-webapp/src/api/product.ts",
-      "source_location": "L20"
+      "id": "bag_getactivebag",
+      "label": "getActiveBag()",
+      "norm_label": "getactivebag()",
+      "source_file": "packages/storefront-webapp/src/api/bag.ts",
+      "source_location": "L12"
     },
     {
       "community": 111,
       "file_type": "code",
-      "id": "product_getbaseurl",
+      "id": "bag_getbaseurl",
       "label": "getBaseUrl()",
       "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/product.ts",
-      "source_location": "L18"
+      "source_file": "packages/storefront-webapp/src/api/bag.ts",
+      "source_location": "L10"
     },
     {
       "community": 111,
       "file_type": "code",
-      "id": "product_getbestsellers",
-      "label": "getBestSellers()",
-      "norm_label": "getbestsellers()",
-      "source_file": "packages/storefront-webapp/src/api/product.ts",
-      "source_location": "L59"
+      "id": "bag_removeitemfrombag",
+      "label": "removeItemFromBag()",
+      "norm_label": "removeitemfrombag()",
+      "source_file": "packages/storefront-webapp/src/api/bag.ts",
+      "source_location": "L90"
     },
     {
       "community": 111,
       "file_type": "code",
-      "id": "product_getfeatured",
-      "label": "getFeatured()",
-      "norm_label": "getfeatured()",
-      "source_file": "packages/storefront-webapp/src/api/product.ts",
-      "source_location": "L73"
+      "id": "bag_updatebagitem",
+      "label": "updateBagItem()",
+      "norm_label": "updatebagitem()",
+      "source_file": "packages/storefront-webapp/src/api/bag.ts",
+      "source_location": "L63"
     },
     {
       "community": 111,
       "file_type": "code",
-      "id": "product_getinventorybyskuids",
-      "label": "getInventoryBySkuIds()",
-      "norm_label": "getinventorybyskuids()",
-      "source_file": "packages/storefront-webapp/src/api/product.ts",
-      "source_location": "L93"
+      "id": "bag_updatebagowner",
+      "label": "updateBagOwner()",
+      "norm_label": "updatebagowner()",
+      "source_file": "packages/storefront-webapp/src/api/bag.ts",
+      "source_location": "L118"
     },
     {
       "community": 111,
       "file_type": "code",
-      "id": "product_getproduct",
-      "label": "getProduct()",
-      "norm_label": "getproduct()",
-      "source_file": "packages/storefront-webapp/src/api/product.ts",
-      "source_location": "L40"
+      "id": "packages_storefront_webapp_src_api_bag_ts",
+      "label": "bag.ts",
+      "norm_label": "bag.ts",
+      "source_file": "packages/storefront-webapp/src/api/bag.ts",
+      "source_location": "L1"
     },
     {
       "community": 1110,
@@ -59826,74 +59910,74 @@
     {
       "community": 112,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_shopping_bag_shoppingbag_tsx",
-      "label": "ShoppingBag.tsx",
-      "norm_label": "shoppingbag.tsx",
-      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
+      "id": "packages_storefront_webapp_src_api_product_ts",
+      "label": "product.ts",
+      "norm_label": "product.ts",
+      "source_file": "packages/storefront-webapp/src/api/product.ts",
       "source_location": "L1"
     },
     {
       "community": 112,
       "file_type": "code",
-      "id": "shoppingbag_handleclickondiscountcode",
-      "label": "handleClickOnDiscountCode()",
-      "norm_label": "handleclickondiscountcode()",
-      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
-      "source_location": "L553"
+      "id": "product_buildquerystring",
+      "label": "buildQueryString()",
+      "norm_label": "buildquerystring()",
+      "source_file": "packages/storefront-webapp/src/api/product.ts",
+      "source_location": "L5"
     },
     {
       "community": 112,
       "file_type": "code",
-      "id": "shoppingbag_handledeleteitem",
-      "label": "handleDeleteItem()",
-      "norm_label": "handledeleteitem()",
-      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
-      "source_location": "L594"
+      "id": "product_getallproducts",
+      "label": "getAllProducts()",
+      "norm_label": "getallproducts()",
+      "source_file": "packages/storefront-webapp/src/api/product.ts",
+      "source_location": "L20"
     },
     {
       "community": 112,
       "file_type": "code",
-      "id": "shoppingbag_handlemovetosaved",
-      "label": "handleMoveToSaved()",
-      "norm_label": "handlemovetosaved()",
-      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
-      "source_location": "L580"
+      "id": "product_getbaseurl",
+      "label": "getBaseUrl()",
+      "norm_label": "getbaseurl()",
+      "source_file": "packages/storefront-webapp/src/api/product.ts",
+      "source_location": "L18"
     },
     {
       "community": 112,
       "file_type": "code",
-      "id": "shoppingbag_handleoncheckoutclick",
-      "label": "handleOnCheckoutClick()",
-      "norm_label": "handleoncheckoutclick()",
-      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
-      "source_location": "L504"
+      "id": "product_getbestsellers",
+      "label": "getBestSellers()",
+      "norm_label": "getbestsellers()",
+      "source_file": "packages/storefront-webapp/src/api/product.ts",
+      "source_location": "L59"
     },
     {
       "community": 112,
       "file_type": "code",
-      "id": "shoppingbag_isskuunavailable",
-      "label": "isSkuUnavailable()",
-      "norm_label": "isskuunavailable()",
-      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
-      "source_location": "L565"
+      "id": "product_getfeatured",
+      "label": "getFeatured()",
+      "norm_label": "getfeatured()",
+      "source_file": "packages/storefront-webapp/src/api/product.ts",
+      "source_location": "L73"
     },
     {
       "community": 112,
       "file_type": "code",
-      "id": "shoppingbag_pendingitem",
-      "label": "PendingItem()",
-      "norm_label": "pendingitem()",
-      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
-      "source_location": "L62"
+      "id": "product_getinventorybyskuids",
+      "label": "getInventoryBySkuIds()",
+      "norm_label": "getinventorybyskuids()",
+      "source_file": "packages/storefront-webapp/src/api/product.ts",
+      "source_location": "L93"
     },
     {
       "community": 112,
       "file_type": "code",
-      "id": "shoppingbag_shoppingbagcheckoutbutton",
-      "label": "ShoppingBagCheckoutButton()",
-      "norm_label": "shoppingbagcheckoutbutton()",
-      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
-      "source_location": "L110"
+      "id": "product_getproduct",
+      "label": "getProduct()",
+      "norm_label": "getproduct()",
+      "source_file": "packages/storefront-webapp/src/api/product.ts",
+      "source_location": "L40"
     },
     {
       "community": 1120,
@@ -59988,74 +60072,74 @@
     {
       "community": 113,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_storefrontobservability_ts",
-      "label": "storefrontObservability.ts",
-      "norm_label": "storefrontobservability.ts",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
+      "id": "packages_storefront_webapp_src_components_shopping_bag_shoppingbag_tsx",
+      "label": "ShoppingBag.tsx",
+      "norm_label": "shoppingbag.tsx",
+      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
       "source_location": "L1"
     },
     {
       "community": 113,
       "file_type": "code",
-      "id": "storefrontobservability_createstorefrontobservabilitycontext",
-      "label": "createStorefrontObservabilityContext()",
-      "norm_label": "createstorefrontobservabilitycontext()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
-      "source_location": "L172"
+      "id": "shoppingbag_handleclickondiscountcode",
+      "label": "handleClickOnDiscountCode()",
+      "norm_label": "handleclickondiscountcode()",
+      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
+      "source_location": "L553"
     },
     {
       "community": 113,
       "file_type": "code",
-      "id": "storefrontobservability_createstorefrontobservabilitypayload",
-      "label": "createStorefrontObservabilityPayload()",
-      "norm_label": "createstorefrontobservabilitypayload()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
-      "source_location": "L200"
+      "id": "shoppingbag_handledeleteitem",
+      "label": "handleDeleteItem()",
+      "norm_label": "handledeleteitem()",
+      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
+      "source_location": "L594"
     },
     {
       "community": 113,
       "file_type": "code",
-      "id": "storefrontobservability_getorcreatestorefrontobservabilitysessionid",
-      "label": "getOrCreateStorefrontObservabilitySessionId()",
-      "norm_label": "getorcreatestorefrontobservabilitysessionid()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
-      "source_location": "L147"
+      "id": "shoppingbag_handlemovetosaved",
+      "label": "handleMoveToSaved()",
+      "norm_label": "handlemovetosaved()",
+      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
+      "source_location": "L580"
     },
     {
       "community": 113,
       "file_type": "code",
-      "id": "storefrontobservability_isbrowserautomationcontext",
-      "label": "isBrowserAutomationContext()",
-      "norm_label": "isbrowserautomationcontext()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
-      "source_location": "L115"
+      "id": "shoppingbag_handleoncheckoutclick",
+      "label": "handleOnCheckoutClick()",
+      "norm_label": "handleoncheckoutclick()",
+      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
+      "source_location": "L504"
     },
     {
       "community": 113,
       "file_type": "code",
-      "id": "storefrontobservability_issyntheticmonitororigin",
-      "label": "isSyntheticMonitorOrigin()",
-      "norm_label": "issyntheticmonitororigin()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
-      "source_location": "L111"
+      "id": "shoppingbag_isskuunavailable",
+      "label": "isSkuUnavailable()",
+      "norm_label": "isskuunavailable()",
+      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
+      "source_location": "L565"
     },
     {
       "community": 113,
       "file_type": "code",
-      "id": "storefrontobservability_resolvestorefrontanalyticsorigin",
-      "label": "resolveStorefrontAnalyticsOrigin()",
-      "norm_label": "resolvestorefrontanalyticsorigin()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
-      "source_location": "L125"
+      "id": "shoppingbag_pendingitem",
+      "label": "PendingItem()",
+      "norm_label": "pendingitem()",
+      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
+      "source_location": "L62"
     },
     {
       "community": 113,
       "file_type": "code",
-      "id": "storefrontobservability_trackstorefrontevent",
-      "label": "trackStorefrontEvent()",
-      "norm_label": "trackstorefrontevent()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
-      "source_location": "L236"
+      "id": "shoppingbag_shoppingbagcheckoutbutton",
+      "label": "ShoppingBagCheckoutButton()",
+      "norm_label": "shoppingbagcheckoutbutton()",
+      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
+      "source_location": "L110"
     },
     {
       "community": 1130,
@@ -60150,74 +60234,74 @@
     {
       "community": 114,
       "file_type": "code",
-      "id": "coverage_toolchain_parity_test_createfixtureroot",
-      "label": "createFixtureRoot()",
-      "norm_label": "createfixtureroot()",
-      "source_file": "scripts/coverage-toolchain-parity.test.ts",
-      "source_location": "L14"
-    },
-    {
-      "community": 114,
-      "file_type": "code",
-      "id": "coverage_toolchain_parity_test_createpackage",
-      "label": "createPackage()",
-      "norm_label": "createpackage()",
-      "source_file": "scripts/coverage-toolchain-parity.test.ts",
-      "source_location": "L26"
-    },
-    {
-      "community": 114,
-      "file_type": "code",
-      "id": "coverage_toolchain_parity_test_installfixturetoolchain",
-      "label": "installFixtureToolchain()",
-      "norm_label": "installfixturetoolchain()",
-      "source_file": "scripts/coverage-toolchain-parity.test.ts",
-      "source_location": "L64"
-    },
-    {
-      "community": 114,
-      "file_type": "code",
-      "id": "coverage_toolchain_parity_test_linkworkspacepackage",
-      "label": "linkWorkspacePackage()",
-      "norm_label": "linkworkspacepackage()",
-      "source_file": "scripts/coverage-toolchain-parity.test.ts",
-      "source_location": "L33"
-    },
-    {
-      "community": 114,
-      "file_type": "code",
-      "id": "coverage_toolchain_parity_test_writefixtureinstaller",
-      "label": "writeFixtureInstaller()",
-      "norm_label": "writefixtureinstaller()",
-      "source_file": "scripts/coverage-toolchain-parity.test.ts",
-      "source_location": "L75"
-    },
-    {
-      "community": 114,
-      "file_type": "code",
-      "id": "coverage_toolchain_parity_test_writefixturemanifests",
-      "label": "writeFixtureManifests()",
-      "norm_label": "writefixturemanifests()",
-      "source_file": "scripts/coverage-toolchain-parity.test.ts",
-      "source_location": "L43"
-    },
-    {
-      "community": 114,
-      "file_type": "code",
-      "id": "coverage_toolchain_parity_test_writejson",
-      "label": "writeJson()",
-      "norm_label": "writejson()",
-      "source_file": "scripts/coverage-toolchain-parity.test.ts",
-      "source_location": "L20"
-    },
-    {
-      "community": 114,
-      "file_type": "code",
-      "id": "scripts_coverage_toolchain_parity_test_ts",
-      "label": "coverage-toolchain-parity.test.ts",
-      "norm_label": "coverage-toolchain-parity.test.ts",
-      "source_file": "scripts/coverage-toolchain-parity.test.ts",
+      "id": "packages_storefront_webapp_src_lib_storefrontobservability_ts",
+      "label": "storefrontObservability.ts",
+      "norm_label": "storefrontobservability.ts",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 114,
+      "file_type": "code",
+      "id": "storefrontobservability_createstorefrontobservabilitycontext",
+      "label": "createStorefrontObservabilityContext()",
+      "norm_label": "createstorefrontobservabilitycontext()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
+      "source_location": "L172"
+    },
+    {
+      "community": 114,
+      "file_type": "code",
+      "id": "storefrontobservability_createstorefrontobservabilitypayload",
+      "label": "createStorefrontObservabilityPayload()",
+      "norm_label": "createstorefrontobservabilitypayload()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
+      "source_location": "L200"
+    },
+    {
+      "community": 114,
+      "file_type": "code",
+      "id": "storefrontobservability_getorcreatestorefrontobservabilitysessionid",
+      "label": "getOrCreateStorefrontObservabilitySessionId()",
+      "norm_label": "getorcreatestorefrontobservabilitysessionid()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
+      "source_location": "L147"
+    },
+    {
+      "community": 114,
+      "file_type": "code",
+      "id": "storefrontobservability_isbrowserautomationcontext",
+      "label": "isBrowserAutomationContext()",
+      "norm_label": "isbrowserautomationcontext()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
+      "source_location": "L115"
+    },
+    {
+      "community": 114,
+      "file_type": "code",
+      "id": "storefrontobservability_issyntheticmonitororigin",
+      "label": "isSyntheticMonitorOrigin()",
+      "norm_label": "issyntheticmonitororigin()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
+      "source_location": "L111"
+    },
+    {
+      "community": 114,
+      "file_type": "code",
+      "id": "storefrontobservability_resolvestorefrontanalyticsorigin",
+      "label": "resolveStorefrontAnalyticsOrigin()",
+      "norm_label": "resolvestorefrontanalyticsorigin()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
+      "source_location": "L125"
+    },
+    {
+      "community": 114,
+      "file_type": "code",
+      "id": "storefrontobservability_trackstorefrontevent",
+      "label": "trackStorefrontEvent()",
+      "norm_label": "trackstorefrontevent()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
+      "source_location": "L236"
     },
     {
       "community": 1140,
@@ -60312,65 +60396,74 @@
     {
       "community": 115,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_customermessaging_whatsappconfig_ts",
-      "label": "whatsappConfig.ts",
-      "norm_label": "whatsappconfig.ts",
-      "source_file": "packages/athena-webapp/convex/customerMessaging/whatsappConfig.ts",
-      "source_location": "L1"
+      "id": "coverage_toolchain_parity_test_createfixtureroot",
+      "label": "createFixtureRoot()",
+      "norm_label": "createfixtureroot()",
+      "source_file": "scripts/coverage-toolchain-parity.test.ts",
+      "source_location": "L14"
     },
     {
       "community": 115,
       "file_type": "code",
-      "id": "whatsappconfig_buildreceiptshareurl",
-      "label": "buildReceiptShareUrl()",
-      "norm_label": "buildreceiptshareurl()",
-      "source_file": "packages/athena-webapp/convex/customerMessaging/whatsappConfig.ts",
+      "id": "coverage_toolchain_parity_test_createpackage",
+      "label": "createPackage()",
+      "norm_label": "createpackage()",
+      "source_file": "scripts/coverage-toolchain-parity.test.ts",
+      "source_location": "L26"
+    },
+    {
+      "community": 115,
+      "file_type": "code",
+      "id": "coverage_toolchain_parity_test_installfixturetoolchain",
+      "label": "installFixtureToolchain()",
+      "norm_label": "installfixturetoolchain()",
+      "source_file": "scripts/coverage-toolchain-parity.test.ts",
+      "source_location": "L64"
+    },
+    {
+      "community": 115,
+      "file_type": "code",
+      "id": "coverage_toolchain_parity_test_linkworkspacepackage",
+      "label": "linkWorkspacePackage()",
+      "norm_label": "linkworkspacepackage()",
+      "source_file": "scripts/coverage-toolchain-parity.test.ts",
+      "source_location": "L33"
+    },
+    {
+      "community": 115,
+      "file_type": "code",
+      "id": "coverage_toolchain_parity_test_writefixtureinstaller",
+      "label": "writeFixtureInstaller()",
+      "norm_label": "writefixtureinstaller()",
+      "source_file": "scripts/coverage-toolchain-parity.test.ts",
+      "source_location": "L75"
+    },
+    {
+      "community": 115,
+      "file_type": "code",
+      "id": "coverage_toolchain_parity_test_writefixturemanifests",
+      "label": "writeFixtureManifests()",
+      "norm_label": "writefixturemanifests()",
+      "source_file": "scripts/coverage-toolchain-parity.test.ts",
       "source_location": "L43"
     },
     {
       "community": 115,
       "file_type": "code",
-      "id": "whatsappconfig_getwhatsappreceiptconfig",
-      "label": "getWhatsAppReceiptConfig()",
-      "norm_label": "getwhatsappreceiptconfig()",
-      "source_file": "packages/athena-webapp/convex/customerMessaging/whatsappConfig.ts",
-      "source_location": "L23"
+      "id": "coverage_toolchain_parity_test_writejson",
+      "label": "writeJson()",
+      "norm_label": "writejson()",
+      "source_file": "scripts/coverage-toolchain-parity.test.ts",
+      "source_location": "L20"
     },
     {
       "community": 115,
       "file_type": "code",
-      "id": "whatsappconfig_getwhatsappwebhookappsecret",
-      "label": "getWhatsAppWebhookAppSecret()",
-      "norm_label": "getwhatsappwebhookappsecret()",
-      "source_file": "packages/athena-webapp/convex/customerMessaging/whatsappConfig.ts",
-      "source_location": "L39"
-    },
-    {
-      "community": 115,
-      "file_type": "code",
-      "id": "whatsappconfig_getwhatsappwebhookverifytoken",
-      "label": "getWhatsAppWebhookVerifyToken()",
-      "norm_label": "getwhatsappwebhookverifytoken()",
-      "source_file": "packages/athena-webapp/convex/customerMessaging/whatsappConfig.ts",
-      "source_location": "L35"
-    },
-    {
-      "community": 115,
-      "file_type": "code",
-      "id": "whatsappconfig_optionalenv",
-      "label": "optionalEnv()",
-      "norm_label": "optionalenv()",
-      "source_file": "packages/athena-webapp/convex/customerMessaging/whatsappConfig.ts",
-      "source_location": "L11"
-    },
-    {
-      "community": 115,
-      "file_type": "code",
-      "id": "whatsappconfig_requiredenv",
-      "label": "requiredEnv()",
-      "norm_label": "requiredenv()",
-      "source_file": "packages/athena-webapp/convex/customerMessaging/whatsappConfig.ts",
-      "source_location": "L15"
+      "id": "scripts_coverage_toolchain_parity_test_ts",
+      "label": "coverage-toolchain-parity.test.ts",
+      "norm_label": "coverage-toolchain-parity.test.ts",
+      "source_file": "scripts/coverage-toolchain-parity.test.ts",
+      "source_location": "L1"
     },
     {
       "community": 1150,
@@ -60465,65 +60558,65 @@
     {
       "community": 116,
       "file_type": "code",
-      "id": "expensesessions_expensesessionerror",
-      "label": "expenseSessionError()",
-      "norm_label": "expensesessionerror()",
-      "source_file": "packages/athena-webapp/convex/inventory/expenseSessions.ts",
-      "source_location": "L47"
-    },
-    {
-      "community": 116,
-      "file_type": "code",
-      "id": "expensesessions_listexpensesessionsbystatusbefore",
-      "label": "listExpenseSessionsByStatusBefore()",
-      "norm_label": "listexpensesessionsbystatusbefore()",
-      "source_file": "packages/athena-webapp/convex/inventory/expenseSessions.ts",
-      "source_location": "L163"
-    },
-    {
-      "community": 116,
-      "file_type": "code",
-      "id": "expensesessions_loadexpensesessionitems",
-      "label": "loadExpenseSessionItems()",
-      "norm_label": "loadexpensesessionitems()",
-      "source_file": "packages/athena-webapp/convex/inventory/expenseSessions.ts",
-      "source_location": "L114"
-    },
-    {
-      "community": 116,
-      "file_type": "code",
-      "id": "expensesessions_mapexpensesessionvalidationerror",
-      "label": "mapExpenseSessionValidationError()",
-      "norm_label": "mapexpensesessionvalidationerror()",
-      "source_file": "packages/athena-webapp/convex/inventory/expenseSessions.ts",
-      "source_location": "L95"
-    },
-    {
-      "community": 116,
-      "file_type": "code",
-      "id": "expensesessions_recordexpensesessionlifecycletrace",
-      "label": "recordExpenseSessionLifecycleTrace()",
-      "norm_label": "recordexpensesessionlifecycletrace()",
-      "source_file": "packages/athena-webapp/convex/inventory/expenseSessions.ts",
-      "source_location": "L139"
-    },
-    {
-      "community": 116,
-      "file_type": "code",
-      "id": "expensesessions_usererrorfromexpensesessioncommandfailure",
-      "label": "userErrorFromExpenseSessionCommandFailure()",
-      "norm_label": "usererrorfromexpensesessioncommandfailure()",
-      "source_file": "packages/athena-webapp/convex/inventory/expenseSessions.ts",
-      "source_location": "L61"
-    },
-    {
-      "community": 116,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_expensesessions_ts",
-      "label": "expenseSessions.ts",
-      "norm_label": "expensesessions.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/expenseSessions.ts",
+      "id": "packages_athena_webapp_convex_customermessaging_whatsappconfig_ts",
+      "label": "whatsappConfig.ts",
+      "norm_label": "whatsappconfig.ts",
+      "source_file": "packages/athena-webapp/convex/customerMessaging/whatsappConfig.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 116,
+      "file_type": "code",
+      "id": "whatsappconfig_buildreceiptshareurl",
+      "label": "buildReceiptShareUrl()",
+      "norm_label": "buildreceiptshareurl()",
+      "source_file": "packages/athena-webapp/convex/customerMessaging/whatsappConfig.ts",
+      "source_location": "L43"
+    },
+    {
+      "community": 116,
+      "file_type": "code",
+      "id": "whatsappconfig_getwhatsappreceiptconfig",
+      "label": "getWhatsAppReceiptConfig()",
+      "norm_label": "getwhatsappreceiptconfig()",
+      "source_file": "packages/athena-webapp/convex/customerMessaging/whatsappConfig.ts",
+      "source_location": "L23"
+    },
+    {
+      "community": 116,
+      "file_type": "code",
+      "id": "whatsappconfig_getwhatsappwebhookappsecret",
+      "label": "getWhatsAppWebhookAppSecret()",
+      "norm_label": "getwhatsappwebhookappsecret()",
+      "source_file": "packages/athena-webapp/convex/customerMessaging/whatsappConfig.ts",
+      "source_location": "L39"
+    },
+    {
+      "community": 116,
+      "file_type": "code",
+      "id": "whatsappconfig_getwhatsappwebhookverifytoken",
+      "label": "getWhatsAppWebhookVerifyToken()",
+      "norm_label": "getwhatsappwebhookverifytoken()",
+      "source_file": "packages/athena-webapp/convex/customerMessaging/whatsappConfig.ts",
+      "source_location": "L35"
+    },
+    {
+      "community": 116,
+      "file_type": "code",
+      "id": "whatsappconfig_optionalenv",
+      "label": "optionalEnv()",
+      "norm_label": "optionalenv()",
+      "source_file": "packages/athena-webapp/convex/customerMessaging/whatsappConfig.ts",
+      "source_location": "L11"
+    },
+    {
+      "community": 116,
+      "file_type": "code",
+      "id": "whatsappconfig_requiredenv",
+      "label": "requiredEnv()",
+      "norm_label": "requiredenv()",
+      "source_file": "packages/athena-webapp/convex/customerMessaging/whatsappConfig.ts",
+      "source_location": "L15"
     },
     {
       "community": 1160,
@@ -60618,64 +60711,64 @@
     {
       "community": 117,
       "file_type": "code",
-      "id": "client_buildheaders",
-      "label": "buildHeaders()",
-      "norm_label": "buildheaders()",
-      "source_file": "packages/athena-webapp/convex/mtn/client.ts",
-      "source_location": "L20"
+      "id": "expensesessions_expensesessionerror",
+      "label": "expenseSessionError()",
+      "norm_label": "expensesessionerror()",
+      "source_file": "packages/athena-webapp/convex/inventory/expenseSessions.ts",
+      "source_location": "L47"
     },
     {
       "community": 117,
       "file_type": "code",
-      "id": "client_createcollectionsaccesstoken",
-      "label": "createCollectionsAccessToken()",
-      "norm_label": "createcollectionsaccesstoken()",
-      "source_file": "packages/athena-webapp/convex/mtn/client.ts",
-      "source_location": "L30"
+      "id": "expensesessions_listexpensesessionsbystatusbefore",
+      "label": "listExpenseSessionsByStatusBefore()",
+      "norm_label": "listexpensesessionsbystatusbefore()",
+      "source_file": "packages/athena-webapp/convex/inventory/expenseSessions.ts",
+      "source_location": "L163"
     },
     {
       "community": 117,
       "file_type": "code",
-      "id": "client_encodebasicauth",
-      "label": "encodeBasicAuth()",
-      "norm_label": "encodebasicauth()",
-      "source_file": "packages/athena-webapp/convex/mtn/client.ts",
-      "source_location": "L9"
+      "id": "expensesessions_loadexpensesessionitems",
+      "label": "loadExpenseSessionItems()",
+      "norm_label": "loadexpensesessionitems()",
+      "source_file": "packages/athena-webapp/convex/inventory/expenseSessions.ts",
+      "source_location": "L114"
     },
     {
       "community": 117,
       "file_type": "code",
-      "id": "client_getrequesttopaystatus",
-      "label": "getRequestToPayStatus()",
-      "norm_label": "getrequesttopaystatus()",
-      "source_file": "packages/athena-webapp/convex/mtn/client.ts",
-      "source_location": "L115"
+      "id": "expensesessions_mapexpensesessionvalidationerror",
+      "label": "mapExpenseSessionValidationError()",
+      "norm_label": "mapexpensesessionvalidationerror()",
+      "source_file": "packages/athena-webapp/convex/inventory/expenseSessions.ts",
+      "source_location": "L95"
     },
     {
       "community": 117,
       "file_type": "code",
-      "id": "client_requesttopay",
-      "label": "requestToPay()",
-      "norm_label": "requesttopay()",
-      "source_file": "packages/athena-webapp/convex/mtn/client.ts",
-      "source_location": "L65"
+      "id": "expensesessions_recordexpensesessionlifecycletrace",
+      "label": "recordExpenseSessionLifecycleTrace()",
+      "norm_label": "recordexpensesessionlifecycletrace()",
+      "source_file": "packages/athena-webapp/convex/inventory/expenseSessions.ts",
+      "source_location": "L139"
     },
     {
       "community": 117,
       "file_type": "code",
-      "id": "client_toerror",
-      "label": "toError()",
-      "norm_label": "toerror()",
-      "source_file": "packages/athena-webapp/convex/mtn/client.ts",
-      "source_location": "L13"
+      "id": "expensesessions_usererrorfromexpensesessioncommandfailure",
+      "label": "userErrorFromExpenseSessionCommandFailure()",
+      "norm_label": "usererrorfromexpensesessioncommandfailure()",
+      "source_file": "packages/athena-webapp/convex/inventory/expenseSessions.ts",
+      "source_location": "L61"
     },
     {
       "community": 117,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_mtn_client_ts",
-      "label": "client.ts",
-      "norm_label": "client.ts",
-      "source_file": "packages/athena-webapp/convex/mtn/client.ts",
+      "id": "packages_athena_webapp_convex_inventory_expensesessions_ts",
+      "label": "expenseSessions.ts",
+      "norm_label": "expensesessions.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/expenseSessions.ts",
       "source_location": "L1"
     },
     {
@@ -60771,64 +60864,64 @@
     {
       "community": 118,
       "file_type": "code",
-      "id": "linking_buildcustomerprofiledraft",
-      "label": "buildCustomerProfileDraft()",
-      "norm_label": "buildcustomerprofiledraft()",
-      "source_file": "packages/athena-webapp/convex/operations/helpers/linking.ts",
-      "source_location": "L110"
+      "id": "client_buildheaders",
+      "label": "buildHeaders()",
+      "norm_label": "buildheaders()",
+      "source_file": "packages/athena-webapp/convex/mtn/client.ts",
+      "source_location": "L20"
     },
     {
       "community": 118,
       "file_type": "code",
-      "id": "linking_buildfullname",
-      "label": "buildFullName()",
-      "norm_label": "buildfullname()",
-      "source_file": "packages/athena-webapp/convex/operations/helpers/linking.ts",
-      "source_location": "L85"
+      "id": "client_createcollectionsaccesstoken",
+      "label": "createCollectionsAccessToken()",
+      "norm_label": "createcollectionsaccesstoken()",
+      "source_file": "packages/athena-webapp/convex/mtn/client.ts",
+      "source_location": "L30"
     },
     {
       "community": 118,
       "file_type": "code",
-      "id": "linking_findmatchingcustomerprofile",
-      "label": "findMatchingCustomerProfile()",
-      "norm_label": "findmatchingcustomerprofile()",
-      "source_file": "packages/athena-webapp/convex/operations/helpers/linking.ts",
-      "source_location": "L172"
+      "id": "client_encodebasicauth",
+      "label": "encodeBasicAuth()",
+      "norm_label": "encodebasicauth()",
+      "source_file": "packages/athena-webapp/convex/mtn/client.ts",
+      "source_location": "L9"
     },
     {
       "community": 118,
       "file_type": "code",
-      "id": "linking_normalizelookupvalue",
-      "label": "normalizeLookupValue()",
-      "norm_label": "normalizelookupvalue()",
-      "source_file": "packages/athena-webapp/convex/operations/helpers/linking.ts",
-      "source_location": "L58"
+      "id": "client_getrequesttopaystatus",
+      "label": "getRequestToPayStatus()",
+      "norm_label": "getrequesttopaystatus()",
+      "source_file": "packages/athena-webapp/convex/mtn/client.ts",
+      "source_location": "L115"
     },
     {
       "community": 118,
       "file_type": "code",
-      "id": "linking_normalizephonenumber",
-      "label": "normalizePhoneNumber()",
-      "norm_label": "normalizephonenumber()",
-      "source_file": "packages/athena-webapp/convex/operations/helpers/linking.ts",
-      "source_location": "L62"
+      "id": "client_requesttopay",
+      "label": "requestToPay()",
+      "norm_label": "requesttopay()",
+      "source_file": "packages/athena-webapp/convex/mtn/client.ts",
+      "source_location": "L65"
     },
     {
       "community": 118,
       "file_type": "code",
-      "id": "linking_splitfullname",
-      "label": "splitFullName()",
-      "norm_label": "splitfullname()",
-      "source_file": "packages/athena-webapp/convex/operations/helpers/linking.ts",
-      "source_location": "L66"
+      "id": "client_toerror",
+      "label": "toError()",
+      "norm_label": "toerror()",
+      "source_file": "packages/athena-webapp/convex/mtn/client.ts",
+      "source_location": "L13"
     },
     {
       "community": 118,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_helpers_linking_ts",
-      "label": "linking.ts",
-      "norm_label": "linking.ts",
-      "source_file": "packages/athena-webapp/convex/operations/helpers/linking.ts",
+      "id": "packages_athena_webapp_convex_mtn_client_ts",
+      "label": "client.ts",
+      "norm_label": "client.ts",
+      "source_file": "packages/athena-webapp/convex/mtn/client.ts",
       "source_location": "L1"
     },
     {
@@ -60924,64 +61017,64 @@
     {
       "community": 119,
       "file_type": "code",
-      "id": "expensesessiontracing_buildexpensesessiontraceevent",
-      "label": "buildExpenseSessionTraceEvent()",
-      "norm_label": "buildexpensesessiontraceevent()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionTracing.ts",
-      "source_location": "L150"
+      "id": "linking_buildcustomerprofiledraft",
+      "label": "buildCustomerProfileDraft()",
+      "norm_label": "buildcustomerprofiledraft()",
+      "source_file": "packages/athena-webapp/convex/operations/helpers/linking.ts",
+      "source_location": "L110"
     },
     {
       "community": 119,
       "file_type": "code",
-      "id": "expensesessiontracing_buildexpensesessiontracerecord",
-      "label": "buildExpenseSessionTraceRecord()",
-      "norm_label": "buildexpensesessiontracerecord()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionTracing.ts",
-      "source_location": "L101"
+      "id": "linking_buildfullname",
+      "label": "buildFullName()",
+      "norm_label": "buildfullname()",
+      "source_file": "packages/athena-webapp/convex/operations/helpers/linking.ts",
+      "source_location": "L85"
     },
     {
       "community": 119,
       "file_type": "code",
-      "id": "expensesessiontracing_buildtracesummary",
-      "label": "buildTraceSummary()",
-      "norm_label": "buildtracesummary()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionTracing.ts",
-      "source_location": "L71"
+      "id": "linking_findmatchingcustomerprofile",
+      "label": "findMatchingCustomerProfile()",
+      "norm_label": "findmatchingcustomerprofile()",
+      "source_file": "packages/athena-webapp/convex/operations/helpers/linking.ts",
+      "source_location": "L172"
     },
     {
       "community": 119,
       "file_type": "code",
-      "id": "expensesessiontracing_createexpensesessiontracerecorder",
-      "label": "createExpenseSessionTraceRecorder()",
-      "norm_label": "createexpensesessiontracerecorder()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionTracing.ts",
-      "source_location": "L293"
+      "id": "linking_normalizelookupvalue",
+      "label": "normalizeLookupValue()",
+      "norm_label": "normalizelookupvalue()",
+      "source_file": "packages/athena-webapp/convex/operations/helpers/linking.ts",
+      "source_location": "L58"
     },
     {
       "community": 119,
       "file_type": "code",
-      "id": "expensesessiontracing_recordexpensesessiontracebesteffort",
-      "label": "recordExpenseSessionTraceBestEffort()",
-      "norm_label": "recordexpensesessiontracebesteffort()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionTracing.ts",
-      "source_location": "L266"
+      "id": "linking_normalizephonenumber",
+      "label": "normalizePhoneNumber()",
+      "norm_label": "normalizephonenumber()",
+      "source_file": "packages/athena-webapp/convex/operations/helpers/linking.ts",
+      "source_location": "L62"
     },
     {
       "community": 119,
       "file_type": "code",
-      "id": "expensesessiontracing_safetracewrite",
-      "label": "safeTraceWrite()",
-      "norm_label": "safetracewrite()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionTracing.ts",
-      "source_location": "L258"
+      "id": "linking_splitfullname",
+      "label": "splitFullName()",
+      "norm_label": "splitfullname()",
+      "source_file": "packages/athena-webapp/convex/operations/helpers/linking.ts",
+      "source_location": "L66"
     },
     {
       "community": 119,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_commands_expensesessiontracing_ts",
-      "label": "expenseSessionTracing.ts",
-      "norm_label": "expensesessiontracing.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionTracing.ts",
+      "id": "packages_athena_webapp_convex_operations_helpers_linking_ts",
+      "label": "linking.ts",
+      "norm_label": "linking.ts",
+      "source_file": "packages/athena-webapp/convex/operations/helpers/linking.ts",
       "source_location": "L1"
     },
     {
@@ -61302,65 +61395,65 @@
     {
       "community": 120,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_commands_terminals_ts",
-      "label": "terminals.ts",
-      "norm_label": "terminals.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/terminals.ts",
-      "source_location": "L1"
+      "id": "expensesessiontracing_buildexpensesessiontraceevent",
+      "label": "buildExpenseSessionTraceEvent()",
+      "norm_label": "buildexpensesessiontraceevent()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionTracing.ts",
+      "source_location": "L150"
     },
     {
       "community": 120,
       "file_type": "code",
-      "id": "terminals_assertregisternumberisavailable",
-      "label": "assertRegisterNumberIsAvailable()",
-      "norm_label": "assertregisternumberisavailable()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/terminals.ts",
-      "source_location": "L47"
+      "id": "expensesessiontracing_buildexpensesessiontracerecord",
+      "label": "buildExpenseSessionTraceRecord()",
+      "norm_label": "buildexpensesessiontracerecord()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionTracing.ts",
+      "source_location": "L101"
     },
     {
       "community": 120,
       "file_type": "code",
-      "id": "terminals_deleteterminal",
-      "label": "deleteTerminal()",
-      "norm_label": "deleteterminal()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/terminals.ts",
-      "source_location": "L169"
-    },
-    {
-      "community": 120,
-      "file_type": "code",
-      "id": "terminals_mapregisterterminalerror",
-      "label": "mapRegisterTerminalError()",
-      "norm_label": "mapregisterterminalerror()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/terminals.ts",
-      "source_location": "L30"
-    },
-    {
-      "community": 120,
-      "file_type": "code",
-      "id": "terminals_normalizeregisternumber",
-      "label": "normalizeRegisterNumber()",
-      "norm_label": "normalizeregisternumber()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/terminals.ts",
-      "source_location": "L25"
-    },
-    {
-      "community": 120,
-      "file_type": "code",
-      "id": "terminals_registerterminal",
-      "label": "registerTerminal()",
-      "norm_label": "registerterminal()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/terminals.ts",
+      "id": "expensesessiontracing_buildtracesummary",
+      "label": "buildTraceSummary()",
+      "norm_label": "buildtracesummary()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionTracing.ts",
       "source_location": "L71"
     },
     {
       "community": 120,
       "file_type": "code",
-      "id": "terminals_updateterminal",
-      "label": "updateTerminal()",
-      "norm_label": "updateterminal()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/terminals.ts",
-      "source_location": "L134"
+      "id": "expensesessiontracing_createexpensesessiontracerecorder",
+      "label": "createExpenseSessionTraceRecorder()",
+      "norm_label": "createexpensesessiontracerecorder()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionTracing.ts",
+      "source_location": "L293"
+    },
+    {
+      "community": 120,
+      "file_type": "code",
+      "id": "expensesessiontracing_recordexpensesessiontracebesteffort",
+      "label": "recordExpenseSessionTraceBestEffort()",
+      "norm_label": "recordexpensesessiontracebesteffort()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionTracing.ts",
+      "source_location": "L266"
+    },
+    {
+      "community": 120,
+      "file_type": "code",
+      "id": "expensesessiontracing_safetracewrite",
+      "label": "safeTraceWrite()",
+      "norm_label": "safetracewrite()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionTracing.ts",
+      "source_location": "L258"
+    },
+    {
+      "community": 120,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_commands_expensesessiontracing_ts",
+      "label": "expenseSessionTracing.ts",
+      "norm_label": "expensesessiontracing.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionTracing.ts",
+      "source_location": "L1"
     },
     {
       "community": 1200,
@@ -61455,65 +61548,65 @@
     {
       "community": 121,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_queries_searchcustomers_ts",
-      "label": "searchCustomers.ts",
-      "norm_label": "searchcustomers.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCustomers.ts",
+      "id": "packages_athena_webapp_convex_pos_application_commands_terminals_ts",
+      "label": "terminals.ts",
+      "norm_label": "terminals.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/terminals.ts",
       "source_location": "L1"
     },
     {
       "community": 121,
       "file_type": "code",
-      "id": "searchcustomers_findbystorefrontuser",
-      "label": "findByStoreFrontUser()",
-      "norm_label": "findbystorefrontuser()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCustomers.ts",
-      "source_location": "L95"
+      "id": "terminals_assertregisternumberisavailable",
+      "label": "assertRegisterNumberIsAvailable()",
+      "norm_label": "assertregisternumberisavailable()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/terminals.ts",
+      "source_location": "L47"
     },
     {
       "community": 121,
       "file_type": "code",
-      "id": "searchcustomers_findpotentialmatches",
-      "label": "findPotentialMatches()",
-      "norm_label": "findpotentialmatches()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCustomers.ts",
-      "source_location": "L122"
+      "id": "terminals_deleteterminal",
+      "label": "deleteTerminal()",
+      "norm_label": "deleteterminal()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/terminals.ts",
+      "source_location": "L169"
     },
     {
       "community": 121,
       "file_type": "code",
-      "id": "searchcustomers_getcustomerbyid",
-      "label": "getCustomerById()",
-      "norm_label": "getcustomerbyid()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCustomers.ts",
-      "source_location": "L66"
+      "id": "terminals_mapregisterterminalerror",
+      "label": "mapRegisterTerminalError()",
+      "norm_label": "mapregisterterminalerror()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/terminals.ts",
+      "source_location": "L30"
     },
     {
       "community": 121,
       "file_type": "code",
-      "id": "searchcustomers_getcustomerprofileidforposcustomer",
-      "label": "getCustomerProfileIdForPosCustomer()",
-      "norm_label": "getcustomerprofileidforposcustomer()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCustomers.ts",
-      "source_location": "L15"
+      "id": "terminals_normalizeregisternumber",
+      "label": "normalizeRegisterNumber()",
+      "norm_label": "normalizeregisternumber()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/terminals.ts",
+      "source_location": "L25"
     },
     {
       "community": 121,
       "file_type": "code",
-      "id": "searchcustomers_getcustomertransactions",
-      "label": "getCustomerTransactions()",
-      "norm_label": "getcustomertransactions()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCustomers.ts",
-      "source_location": "L75"
+      "id": "terminals_registerterminal",
+      "label": "registerTerminal()",
+      "norm_label": "registerterminal()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/terminals.ts",
+      "source_location": "L71"
     },
     {
       "community": 121,
       "file_type": "code",
-      "id": "searchcustomers_searchcustomers",
-      "label": "searchCustomers()",
-      "norm_label": "searchcustomers()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCustomers.ts",
-      "source_location": "L27"
+      "id": "terminals_updateterminal",
+      "label": "updateTerminal()",
+      "norm_label": "updateterminal()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/terminals.ts",
+      "source_location": "L134"
     },
     {
       "community": 1210,
@@ -61608,65 +61701,65 @@
     {
       "community": 122,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_sessionrepository_ts",
-      "label": "sessionRepository.ts",
-      "norm_label": "sessionrepository.ts",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionRepository.ts",
+      "id": "packages_athena_webapp_convex_pos_application_queries_searchcustomers_ts",
+      "label": "searchCustomers.ts",
+      "norm_label": "searchcustomers.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCustomers.ts",
       "source_location": "L1"
     },
     {
       "community": 122,
       "file_type": "code",
-      "id": "sessionrepository_getactivesessionforregisterstate",
-      "label": "getActiveSessionForRegisterState()",
-      "norm_label": "getactivesessionforregisterstate()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionRepository.ts",
-      "source_location": "L18"
+      "id": "searchcustomers_findbystorefrontuser",
+      "label": "findByStoreFrontUser()",
+      "norm_label": "findbystorefrontuser()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCustomers.ts",
+      "source_location": "L95"
     },
     {
       "community": 122,
       "file_type": "code",
-      "id": "sessionrepository_listheldsessionsforregisterstate",
-      "label": "listHeldSessionsForRegisterState()",
-      "norm_label": "listheldsessionsforregisterstate()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionRepository.ts",
-      "source_location": "L26"
+      "id": "searchcustomers_findpotentialmatches",
+      "label": "findPotentialMatches()",
+      "norm_label": "findpotentialmatches()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCustomers.ts",
+      "source_location": "L122"
     },
     {
       "community": 122,
       "file_type": "code",
-      "id": "sessionrepository_matchesregisteridentity",
-      "label": "matchesRegisterIdentity()",
-      "norm_label": "matchesregisteridentity()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionRepository.ts",
-      "source_location": "L119"
+      "id": "searchcustomers_getcustomerbyid",
+      "label": "getCustomerById()",
+      "norm_label": "getcustomerbyid()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCustomers.ts",
+      "source_location": "L66"
     },
     {
       "community": 122,
       "file_type": "code",
-      "id": "sessionrepository_querysessionsbystatus",
-      "label": "querySessionsByStatus()",
-      "norm_label": "querysessionsbystatus()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionRepository.ts",
-      "source_location": "L33"
+      "id": "searchcustomers_getcustomerprofileidforposcustomer",
+      "label": "getCustomerProfileIdForPosCustomer()",
+      "norm_label": "getcustomerprofileidforposcustomer()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCustomers.ts",
+      "source_location": "L15"
     },
     {
       "community": 122,
       "file_type": "code",
-      "id": "sessionrepository_selectregisterstatelookupstrategy",
-      "label": "selectRegisterStateLookupStrategy()",
-      "norm_label": "selectregisterstatelookupstrategy()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionRepository.ts",
-      "source_location": "L83"
+      "id": "searchcustomers_getcustomertransactions",
+      "label": "getCustomerTransactions()",
+      "norm_label": "getcustomertransactions()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCustomers.ts",
+      "source_location": "L75"
     },
     {
       "community": 122,
       "file_type": "code",
-      "id": "sessionrepository_summarizeregisterstatesessions",
-      "label": "summarizeRegisterStateSessions()",
-      "norm_label": "summarizeregisterstatesessions()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionRepository.ts",
-      "source_location": "L97"
+      "id": "searchcustomers_searchcustomers",
+      "label": "searchCustomers()",
+      "norm_label": "searchcustomers()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCustomers.ts",
+      "source_location": "L27"
     },
     {
       "community": 1220,
@@ -61761,65 +61854,65 @@
     {
       "community": 123,
       "file_type": "code",
-      "id": "analytics_extractpromocodeid",
-      "label": "extractPromoCodeId()",
-      "norm_label": "extractpromocodeid()",
-      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
-      "source_location": "L48"
-    },
-    {
-      "community": 123,
-      "file_type": "code",
-      "id": "analytics_getanalyticsbystoreandactionquery",
-      "label": "getAnalyticsByStoreAndActionQuery()",
-      "norm_label": "getanalyticsbystoreandactionquery()",
-      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
-      "source_location": "L153"
-    },
-    {
-      "community": 123,
-      "file_type": "code",
-      "id": "analytics_getanalyticsbystorequery",
-      "label": "getAnalyticsByStoreQuery()",
-      "norm_label": "getanalyticsbystorequery()",
-      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
-      "source_location": "L58"
-    },
-    {
-      "community": 123,
-      "file_type": "code",
-      "id": "analytics_getcompletedordersquery",
-      "label": "getCompletedOrdersQuery()",
-      "norm_label": "getcompletedordersquery()",
-      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
-      "source_location": "L106"
-    },
-    {
-      "community": 123,
-      "file_type": "code",
-      "id": "analytics_getskumapforproducts",
-      "label": "getSkuMapForProducts()",
-      "norm_label": "getskumapforproducts()",
-      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
-      "source_location": "L211"
-    },
-    {
-      "community": 123,
-      "file_type": "code",
-      "id": "analytics_getstorefrontactor",
-      "label": "getStoreFrontActor()",
-      "norm_label": "getstorefrontactor()",
-      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
-      "source_location": "L29"
-    },
-    {
-      "community": 123,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_analytics_ts",
-      "label": "analytics.ts",
-      "norm_label": "analytics.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
+      "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_sessionrepository_ts",
+      "label": "sessionRepository.ts",
+      "norm_label": "sessionrepository.ts",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionRepository.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 123,
+      "file_type": "code",
+      "id": "sessionrepository_getactivesessionforregisterstate",
+      "label": "getActiveSessionForRegisterState()",
+      "norm_label": "getactivesessionforregisterstate()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionRepository.ts",
+      "source_location": "L18"
+    },
+    {
+      "community": 123,
+      "file_type": "code",
+      "id": "sessionrepository_listheldsessionsforregisterstate",
+      "label": "listHeldSessionsForRegisterState()",
+      "norm_label": "listheldsessionsforregisterstate()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionRepository.ts",
+      "source_location": "L26"
+    },
+    {
+      "community": 123,
+      "file_type": "code",
+      "id": "sessionrepository_matchesregisteridentity",
+      "label": "matchesRegisterIdentity()",
+      "norm_label": "matchesregisteridentity()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionRepository.ts",
+      "source_location": "L119"
+    },
+    {
+      "community": 123,
+      "file_type": "code",
+      "id": "sessionrepository_querysessionsbystatus",
+      "label": "querySessionsByStatus()",
+      "norm_label": "querysessionsbystatus()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionRepository.ts",
+      "source_location": "L33"
+    },
+    {
+      "community": 123,
+      "file_type": "code",
+      "id": "sessionrepository_selectregisterstatelookupstrategy",
+      "label": "selectRegisterStateLookupStrategy()",
+      "norm_label": "selectregisterstatelookupstrategy()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionRepository.ts",
+      "source_location": "L83"
+    },
+    {
+      "community": 123,
+      "file_type": "code",
+      "id": "sessionrepository_summarizeregisterstatesessions",
+      "label": "summarizeRegisterStateSessions()",
+      "norm_label": "summarizeregisterstatesessions()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionRepository.ts",
+      "source_location": "L97"
     },
     {
       "community": 1230,
@@ -61914,64 +62007,64 @@
     {
       "community": 124,
       "file_type": "code",
-      "id": "customerbehaviortimeline_getcustomeranalyticsquery",
-      "label": "getCustomerAnalyticsQuery()",
-      "norm_label": "getcustomeranalyticsquery()",
-      "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
-      "source_location": "L27"
+      "id": "analytics_extractpromocodeid",
+      "label": "extractPromoCodeId()",
+      "norm_label": "extractpromocodeid()",
+      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
+      "source_location": "L48"
     },
     {
       "community": 124,
       "file_type": "code",
-      "id": "customerbehaviortimeline_getcustomeroperationaltimelineevents",
-      "label": "getCustomerOperationalTimelineEvents()",
-      "norm_label": "getcustomeroperationaltimelineevents()",
-      "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
+      "id": "analytics_getanalyticsbystoreandactionquery",
+      "label": "getAnalyticsByStoreAndActionQuery()",
+      "norm_label": "getanalyticsbystoreandactionquery()",
+      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
       "source_location": "L153"
     },
     {
       "community": 124,
       "file_type": "code",
-      "id": "customerbehaviortimeline_getproductinfomaps",
-      "label": "getProductInfoMaps()",
-      "norm_label": "getproductinfomaps()",
-      "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
-      "source_location": "L71"
+      "id": "analytics_getanalyticsbystorequery",
+      "label": "getAnalyticsByStoreQuery()",
+      "norm_label": "getanalyticsbystorequery()",
+      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
+      "source_location": "L58"
     },
     {
       "community": 124,
       "file_type": "code",
-      "id": "customerbehaviortimeline_gettimefilterforrange",
-      "label": "getTimeFilterForRange()",
-      "norm_label": "gettimefilterforrange()",
-      "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
-      "source_location": "L12"
+      "id": "analytics_getcompletedordersquery",
+      "label": "getCompletedOrdersQuery()",
+      "norm_label": "getcompletedordersquery()",
+      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
+      "source_location": "L106"
     },
     {
       "community": 124,
       "file_type": "code",
-      "id": "customerbehaviortimeline_gettimelineuserdata",
-      "label": "getTimelineUserData()",
-      "norm_label": "gettimelineuserdata()",
-      "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
-      "source_location": "L47"
+      "id": "analytics_getskumapforproducts",
+      "label": "getSkuMapForProducts()",
+      "norm_label": "getskumapforproducts()",
+      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
+      "source_location": "L211"
     },
     {
       "community": 124,
       "file_type": "code",
-      "id": "customerbehaviortimeline_resolvecustomerprofileidfortimeline",
-      "label": "resolveCustomerProfileIdForTimeline()",
-      "norm_label": "resolvecustomerprofileidfortimeline()",
-      "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
-      "source_location": "L115"
+      "id": "analytics_getstorefrontactor",
+      "label": "getStoreFrontActor()",
+      "norm_label": "getstorefrontactor()",
+      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
+      "source_location": "L29"
     },
     {
       "community": 124,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_customerbehaviortimeline_ts",
-      "label": "customerBehaviorTimeline.ts",
-      "norm_label": "customerbehaviortimeline.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
+      "id": "packages_athena_webapp_convex_storefront_analytics_ts",
+      "label": "analytics.ts",
+      "norm_label": "analytics.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
       "source_location": "L1"
     },
     {
@@ -62067,64 +62160,64 @@
     {
       "community": 125,
       "file_type": "code",
-      "id": "onlineorder_clearbagitems",
-      "label": "clearBagItems()",
-      "norm_label": "clearbagitems()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
-      "source_location": "L45"
+      "id": "customerbehaviortimeline_getcustomeranalyticsquery",
+      "label": "getCustomerAnalyticsQuery()",
+      "norm_label": "getcustomeranalyticsquery()",
+      "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
+      "source_location": "L27"
     },
     {
       "community": 125,
       "file_type": "code",
-      "id": "onlineorder_createorderfromcheckoutsession",
-      "label": "createOrderFromCheckoutSession()",
-      "norm_label": "createorderfromcheckoutsession()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
-      "source_location": "L104"
+      "id": "customerbehaviortimeline_getcustomeroperationaltimelineevents",
+      "label": "getCustomerOperationalTimelineEvents()",
+      "norm_label": "getcustomeroperationaltimelineevents()",
+      "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
+      "source_location": "L153"
     },
     {
       "community": 125,
       "file_type": "code",
-      "id": "onlineorder_findorderbyexternalreference",
-      "label": "findOrderByExternalReference()",
-      "norm_label": "findorderbyexternalreference()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
-      "source_location": "L21"
+      "id": "customerbehaviortimeline_getproductinfomaps",
+      "label": "getProductInfoMaps()",
+      "norm_label": "getproductinfomaps()",
+      "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
+      "source_location": "L71"
     },
     {
       "community": 125,
       "file_type": "code",
-      "id": "onlineorder_findorderbyexternaltransactionid",
-      "label": "findOrderByExternalTransactionId()",
-      "norm_label": "findorderbyexternaltransactionid()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
-      "source_location": "L33"
+      "id": "customerbehaviortimeline_gettimefilterforrange",
+      "label": "getTimeFilterForRange()",
+      "norm_label": "gettimefilterforrange()",
+      "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
+      "source_location": "L12"
     },
     {
       "community": 125,
       "file_type": "code",
-      "id": "onlineorder_generateordernumber",
-      "label": "generateOrderNumber()",
-      "norm_label": "generateordernumber()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
-      "source_location": "L14"
+      "id": "customerbehaviortimeline_gettimelineuserdata",
+      "label": "getTimelineUserData()",
+      "norm_label": "gettimelineuserdata()",
+      "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
+      "source_location": "L47"
     },
     {
       "community": 125,
       "file_type": "code",
-      "id": "onlineorder_returnorderitemstostock",
-      "label": "returnOrderItemsToStock()",
-      "norm_label": "returnorderitemstostock()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
-      "source_location": "L57"
+      "id": "customerbehaviortimeline_resolvecustomerprofileidfortimeline",
+      "label": "resolveCustomerProfileIdForTimeline()",
+      "norm_label": "resolvecustomerprofileidfortimeline()",
+      "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
+      "source_location": "L115"
     },
     {
       "community": 125,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_helpers_onlineorder_ts",
-      "label": "onlineOrder.ts",
-      "norm_label": "onlineorder.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
+      "id": "packages_athena_webapp_convex_storefront_customerbehaviortimeline_ts",
+      "label": "customerBehaviorTimeline.ts",
+      "norm_label": "customerbehaviortimeline.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
       "source_location": "L1"
     },
     {
@@ -62220,64 +62313,64 @@
     {
       "community": 126,
       "file_type": "code",
-      "id": "orderupdateemails_formatorderitems",
-      "label": "formatOrderItems()",
-      "norm_label": "formatorderitems()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
-      "source_location": "L64"
+      "id": "onlineorder_clearbagitems",
+      "label": "clearBagItems()",
+      "norm_label": "clearbagitems()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
+      "source_location": "L45"
     },
     {
       "community": 126,
       "file_type": "code",
-      "id": "orderupdateemails_getdeliveryaddress",
-      "label": "getDeliveryAddress()",
-      "norm_label": "getdeliveryaddress()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
-      "source_location": "L55"
+      "id": "onlineorder_createorderfromcheckoutsession",
+      "label": "createOrderFromCheckoutSession()",
+      "norm_label": "createorderfromcheckoutsession()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
+      "source_location": "L104"
     },
     {
       "community": 126,
       "file_type": "code",
-      "id": "orderupdateemails_getlocationdetails",
-      "label": "getLocationDetails()",
-      "norm_label": "getlocationdetails()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
-      "source_location": "L58"
+      "id": "onlineorder_findorderbyexternalreference",
+      "label": "findOrderByExternalReference()",
+      "norm_label": "findorderbyexternalreference()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
+      "source_location": "L21"
     },
     {
       "community": 126,
       "file_type": "code",
-      "id": "orderupdateemails_getpickuplocation",
-      "label": "getPickupLocation()",
-      "norm_label": "getpickuplocation()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
-      "source_location": "L52"
+      "id": "onlineorder_findorderbyexternaltransactionid",
+      "label": "findOrderByExternalTransactionId()",
+      "norm_label": "findorderbyexternaltransactionid()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
+      "source_location": "L33"
     },
     {
       "community": 126,
       "file_type": "code",
-      "id": "orderupdateemails_handleorderstatusupdate",
-      "label": "handleOrderStatusUpdate()",
-      "norm_label": "handleorderstatusupdate()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
-      "source_location": "L118"
+      "id": "onlineorder_generateordernumber",
+      "label": "generateOrderNumber()",
+      "norm_label": "generateordernumber()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
+      "source_location": "L14"
     },
     {
       "community": 126,
       "file_type": "code",
-      "id": "orderupdateemails_processorderupdateemail",
-      "label": "processOrderUpdateEmail()",
-      "norm_label": "processorderupdateemail()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
-      "source_location": "L293"
+      "id": "onlineorder_returnorderitemstostock",
+      "label": "returnOrderItemsToStock()",
+      "norm_label": "returnorderitemstostock()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
+      "source_location": "L57"
     },
     {
       "community": 126,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_helpers_orderupdateemails_ts",
-      "label": "orderUpdateEmails.ts",
-      "norm_label": "orderupdateemails.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
+      "id": "packages_athena_webapp_convex_storefront_helpers_onlineorder_ts",
+      "label": "onlineOrder.ts",
+      "norm_label": "onlineorder.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
       "source_location": "L1"
     },
     {
@@ -62373,65 +62466,65 @@
     {
       "community": 127,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_helpers_paymenthelpers_ts",
-      "label": "paymentHelpers.ts",
-      "norm_label": "paymenthelpers.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
+      "id": "orderupdateemails_formatorderitems",
+      "label": "formatOrderItems()",
+      "norm_label": "formatorderitems()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
+      "source_location": "L64"
+    },
+    {
+      "community": 127,
+      "file_type": "code",
+      "id": "orderupdateemails_getdeliveryaddress",
+      "label": "getDeliveryAddress()",
+      "norm_label": "getdeliveryaddress()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
+      "source_location": "L55"
+    },
+    {
+      "community": 127,
+      "file_type": "code",
+      "id": "orderupdateemails_getlocationdetails",
+      "label": "getLocationDetails()",
+      "norm_label": "getlocationdetails()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
+      "source_location": "L58"
+    },
+    {
+      "community": 127,
+      "file_type": "code",
+      "id": "orderupdateemails_getpickuplocation",
+      "label": "getPickupLocation()",
+      "norm_label": "getpickuplocation()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
+      "source_location": "L52"
+    },
+    {
+      "community": 127,
+      "file_type": "code",
+      "id": "orderupdateemails_handleorderstatusupdate",
+      "label": "handleOrderStatusUpdate()",
+      "norm_label": "handleorderstatusupdate()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
+      "source_location": "L118"
+    },
+    {
+      "community": 127,
+      "file_type": "code",
+      "id": "orderupdateemails_processorderupdateemail",
+      "label": "processOrderUpdateEmail()",
+      "norm_label": "processorderupdateemail()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
+      "source_location": "L293"
+    },
+    {
+      "community": 127,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_helpers_orderupdateemails_ts",
+      "label": "orderUpdateEmails.ts",
+      "norm_label": "orderupdateemails.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 127,
-      "file_type": "code",
-      "id": "paymenthelpers_calculateorderamount",
-      "label": "calculateOrderAmount()",
-      "norm_label": "calculateorderamount()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
-      "source_location": "L35"
-    },
-    {
-      "community": 127,
-      "file_type": "code",
-      "id": "paymenthelpers_calculaterewardpoints",
-      "label": "calculateRewardPoints()",
-      "norm_label": "calculaterewardpoints()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
-      "source_location": "L53"
-    },
-    {
-      "community": 127,
-      "file_type": "code",
-      "id": "paymenthelpers_extractorderitems",
-      "label": "extractOrderItems()",
-      "norm_label": "extractorderitems()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
-      "source_location": "L18"
-    },
-    {
-      "community": 127,
-      "file_type": "code",
-      "id": "paymenthelpers_generatepodreference",
-      "label": "generatePODReference()",
-      "norm_label": "generatepodreference()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
-      "source_location": "L9"
-    },
-    {
-      "community": 127,
-      "file_type": "code",
-      "id": "paymenthelpers_getorderdiscountvalue",
-      "label": "getOrderDiscountValue()",
-      "norm_label": "getorderdiscountvalue()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
-      "source_location": "L75"
-    },
-    {
-      "community": 127,
-      "file_type": "code",
-      "id": "paymenthelpers_validatepaymentamount",
-      "label": "validatePaymentAmount()",
-      "norm_label": "validatepaymentamount()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
-      "source_location": "L61"
     },
     {
       "community": 1270,
@@ -62526,65 +62619,65 @@
     {
       "community": 128,
       "file_type": "code",
-      "id": "onlineorder_appendtransition",
-      "label": "appendTransition()",
-      "norm_label": "appendtransition()",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
-      "source_location": "L61"
-    },
-    {
-      "community": 128,
-      "file_type": "code",
-      "id": "onlineorder_applyonlineorderupdate",
-      "label": "applyOnlineOrderUpdate()",
-      "norm_label": "applyonlineorderupdate()",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
-      "source_location": "L85"
-    },
-    {
-      "community": 128,
-      "file_type": "code",
-      "id": "onlineorder_buildreturnexchangereplacementsourceid",
-      "label": "buildReturnExchangeReplacementSourceId()",
-      "norm_label": "buildreturnexchangereplacementsourceid()",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
-      "source_location": "L206"
-    },
-    {
-      "community": 128,
-      "file_type": "code",
-      "id": "onlineorder_buildreturnexchangereturnsourceid",
-      "label": "buildReturnExchangeReturnSourceId()",
-      "norm_label": "buildreturnexchangereturnsourceid()",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
-      "source_location": "L214"
-    },
-    {
-      "community": 128,
-      "file_type": "code",
-      "id": "onlineorder_listorderitems",
-      "label": "listOrderItems()",
-      "norm_label": "listorderitems()",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
-      "source_location": "L51"
-    },
-    {
-      "community": 128,
-      "file_type": "code",
-      "id": "onlineorder_mapupdateordererror",
-      "label": "mapUpdateOrderError()",
-      "norm_label": "mapupdateordererror()",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
-      "source_location": "L221"
-    },
-    {
-      "community": 128,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_onlineorder_ts",
-      "label": "onlineOrder.ts",
-      "norm_label": "onlineorder.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
+      "id": "packages_athena_webapp_convex_storefront_helpers_paymenthelpers_ts",
+      "label": "paymentHelpers.ts",
+      "norm_label": "paymenthelpers.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 128,
+      "file_type": "code",
+      "id": "paymenthelpers_calculateorderamount",
+      "label": "calculateOrderAmount()",
+      "norm_label": "calculateorderamount()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
+      "source_location": "L35"
+    },
+    {
+      "community": 128,
+      "file_type": "code",
+      "id": "paymenthelpers_calculaterewardpoints",
+      "label": "calculateRewardPoints()",
+      "norm_label": "calculaterewardpoints()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
+      "source_location": "L53"
+    },
+    {
+      "community": 128,
+      "file_type": "code",
+      "id": "paymenthelpers_extractorderitems",
+      "label": "extractOrderItems()",
+      "norm_label": "extractorderitems()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
+      "source_location": "L18"
+    },
+    {
+      "community": 128,
+      "file_type": "code",
+      "id": "paymenthelpers_generatepodreference",
+      "label": "generatePODReference()",
+      "norm_label": "generatepodreference()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
+      "source_location": "L9"
+    },
+    {
+      "community": 128,
+      "file_type": "code",
+      "id": "paymenthelpers_getorderdiscountvalue",
+      "label": "getOrderDiscountValue()",
+      "norm_label": "getorderdiscountvalue()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
+      "source_location": "L75"
+    },
+    {
+      "community": 128,
+      "file_type": "code",
+      "id": "paymenthelpers_validatepaymentamount",
+      "label": "validatePaymentAmount()",
+      "norm_label": "validatepaymentamount()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
+      "source_location": "L61"
     },
     {
       "community": 1280,
@@ -62679,64 +62772,64 @@
     {
       "community": 129,
       "file_type": "code",
-      "id": "core_appendworkflowtraceeventwithctx",
-      "label": "appendWorkflowTraceEventWithCtx()",
-      "norm_label": "appendworkflowtraceeventwithctx()",
-      "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
-      "source_location": "L134"
+      "id": "onlineorder_appendtransition",
+      "label": "appendTransition()",
+      "norm_label": "appendtransition()",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
+      "source_location": "L61"
     },
     {
       "community": 129,
       "file_type": "code",
-      "id": "core_createworkflowtracewithctx",
-      "label": "createWorkflowTraceWithCtx()",
-      "norm_label": "createworkflowtracewithctx()",
-      "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
-      "source_location": "L81"
+      "id": "onlineorder_applyonlineorderupdate",
+      "label": "applyOnlineOrderUpdate()",
+      "norm_label": "applyonlineorderupdate()",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
+      "source_location": "L85"
     },
     {
       "community": 129,
       "file_type": "code",
-      "id": "core_getworkflowtracebyidwithctx",
-      "label": "getWorkflowTraceByIdWithCtx()",
-      "norm_label": "getworkflowtracebyidwithctx()",
-      "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
-      "source_location": "L17"
+      "id": "onlineorder_buildreturnexchangereplacementsourceid",
+      "label": "buildReturnExchangeReplacementSourceId()",
+      "norm_label": "buildreturnexchangereplacementsourceid()",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
+      "source_location": "L206"
     },
     {
       "community": 129,
       "file_type": "code",
-      "id": "core_getworkflowtracebylookupwithctx",
-      "label": "getWorkflowTraceByLookupWithCtx()",
-      "norm_label": "getworkflowtracebylookupwithctx()",
-      "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
-      "source_location": "L32"
+      "id": "onlineorder_buildreturnexchangereturnsourceid",
+      "label": "buildReturnExchangeReturnSourceId()",
+      "norm_label": "buildreturnexchangereturnsourceid()",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
+      "source_location": "L214"
     },
     {
       "community": 129,
       "file_type": "code",
-      "id": "core_listworkflowtraceeventswithctx",
-      "label": "listWorkflowTraceEventsWithCtx()",
-      "norm_label": "listworkflowtraceeventswithctx()",
-      "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
-      "source_location": "L65"
+      "id": "onlineorder_listorderitems",
+      "label": "listOrderItems()",
+      "norm_label": "listorderitems()",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
+      "source_location": "L51"
     },
     {
       "community": 129,
       "file_type": "code",
-      "id": "core_registerworkflowtracelookupwithctx",
-      "label": "registerWorkflowTraceLookupWithCtx()",
-      "norm_label": "registerworkflowtracelookupwithctx()",
-      "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
-      "source_location": "L104"
+      "id": "onlineorder_mapupdateordererror",
+      "label": "mapUpdateOrderError()",
+      "norm_label": "mapupdateordererror()",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
+      "source_location": "L221"
     },
     {
       "community": 129,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_workflowtraces_core_ts",
-      "label": "core.ts",
-      "norm_label": "core.ts",
-      "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
+      "id": "packages_athena_webapp_convex_storefront_onlineorder_ts",
+      "label": "onlineOrder.ts",
+      "norm_label": "onlineorder.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
       "source_location": "L1"
     },
     {
@@ -63057,65 +63150,65 @@
     {
       "community": 130,
       "file_type": "code",
-      "id": "packages_athena_webapp_shared_stockadjustment_ts",
-      "label": "stockAdjustment.ts",
-      "norm_label": "stockadjustment.ts",
-      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
+      "id": "core_appendworkflowtraceeventwithctx",
+      "label": "appendWorkflowTraceEventWithCtx()",
+      "norm_label": "appendworkflowtraceeventwithctx()",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
+      "source_location": "L134"
+    },
+    {
+      "community": 130,
+      "file_type": "code",
+      "id": "core_createworkflowtracewithctx",
+      "label": "createWorkflowTraceWithCtx()",
+      "norm_label": "createworkflowtracewithctx()",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
+      "source_location": "L81"
+    },
+    {
+      "community": 130,
+      "file_type": "code",
+      "id": "core_getworkflowtracebyidwithctx",
+      "label": "getWorkflowTraceByIdWithCtx()",
+      "norm_label": "getworkflowtracebyidwithctx()",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
+      "source_location": "L17"
+    },
+    {
+      "community": 130,
+      "file_type": "code",
+      "id": "core_getworkflowtracebylookupwithctx",
+      "label": "getWorkflowTraceByLookupWithCtx()",
+      "norm_label": "getworkflowtracebylookupwithctx()",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
+      "source_location": "L32"
+    },
+    {
+      "community": 130,
+      "file_type": "code",
+      "id": "core_listworkflowtraceeventswithctx",
+      "label": "listWorkflowTraceEventsWithCtx()",
+      "norm_label": "listworkflowtraceeventswithctx()",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
+      "source_location": "L65"
+    },
+    {
+      "community": 130,
+      "file_type": "code",
+      "id": "core_registerworkflowtracelookupwithctx",
+      "label": "registerWorkflowTraceLookupWithCtx()",
+      "norm_label": "registerworkflowtracelookupwithctx()",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
+      "source_location": "L104"
+    },
+    {
+      "community": 130,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_workflowtraces_core_ts",
+      "label": "core.ts",
+      "norm_label": "core.ts",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 130,
-      "file_type": "code",
-      "id": "stockadjustment_assertstockadjustmentreasoncode",
-      "label": "assertStockAdjustmentReasonCode()",
-      "norm_label": "assertstockadjustmentreasoncode()",
-      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
-      "source_location": "L25"
-    },
-    {
-      "community": 130,
-      "file_type": "code",
-      "id": "stockadjustment_calculatecyclecountquantitydelta",
-      "label": "calculateCycleCountQuantityDelta()",
-      "norm_label": "calculatecyclecountquantitydelta()",
-      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
-      "source_location": "L14"
-    },
-    {
-      "community": 130,
-      "file_type": "code",
-      "id": "stockadjustment_hashighstockadjustmentvariance",
-      "label": "hasHighStockAdjustmentVariance()",
-      "norm_label": "hashighstockadjustmentvariance()",
-      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
-      "source_location": "L96"
-    },
-    {
-      "community": 130,
-      "file_type": "code",
-      "id": "stockadjustment_requiresstockadjustmentapproval",
-      "label": "requiresStockAdjustmentApproval()",
-      "norm_label": "requiresstockadjustmentapproval()",
-      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
-      "source_location": "L102"
-    },
-    {
-      "community": 130,
-      "file_type": "code",
-      "id": "stockadjustment_resolvestockadjustmentquantitydelta",
-      "label": "resolveStockAdjustmentQuantityDelta()",
-      "norm_label": "resolvestockadjustmentquantitydelta()",
-      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
-      "source_location": "L45"
-    },
-    {
-      "community": 130,
-      "file_type": "code",
-      "id": "stockadjustment_summarizestockadjustmentlineitems",
-      "label": "summarizeStockAdjustmentLineItems()",
-      "norm_label": "summarizestockadjustmentlineitems()",
-      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
-      "source_location": "L76"
     },
     {
       "community": 1300,
@@ -63210,65 +63303,65 @@
     {
       "community": 131,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_paymentview_tsx",
-      "label": "PaymentView.tsx",
-      "norm_label": "paymentview.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
+      "id": "packages_athena_webapp_shared_stockadjustment_ts",
+      "label": "stockAdjustment.ts",
+      "norm_label": "stockadjustment.ts",
+      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
       "source_location": "L1"
     },
     {
       "community": 131,
       "file_type": "code",
-      "id": "paymentview_cn",
-      "label": "cn()",
-      "norm_label": "cn()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
-      "source_location": "L404"
+      "id": "stockadjustment_assertstockadjustmentreasoncode",
+      "label": "assertStockAdjustmentReasonCode()",
+      "norm_label": "assertstockadjustmentreasoncode()",
+      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
+      "source_location": "L25"
     },
     {
       "community": 131,
       "file_type": "code",
-      "id": "paymentview_handleaddpayment",
-      "label": "handleAddPayment()",
-      "norm_label": "handleaddpayment()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
-      "source_location": "L181"
+      "id": "stockadjustment_calculatecyclecountquantitydelta",
+      "label": "calculateCycleCountQuantityDelta()",
+      "norm_label": "calculatecyclecountquantitydelta()",
+      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
+      "source_location": "L14"
     },
     {
       "community": 131,
       "file_type": "code",
-      "id": "paymentview_handleamountblur",
-      "label": "handleAmountBlur()",
-      "norm_label": "handleamountblur()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
-      "source_location": "L253"
+      "id": "stockadjustment_hashighstockadjustmentvariance",
+      "label": "hasHighStockAdjustmentVariance()",
+      "norm_label": "hashighstockadjustmentvariance()",
+      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
+      "source_location": "L96"
     },
     {
       "community": 131,
       "file_type": "code",
-      "id": "paymentview_handleamountchange",
-      "label": "handleAmountChange()",
-      "norm_label": "handleamountchange()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
-      "source_location": "L231"
+      "id": "stockadjustment_requiresstockadjustmentapproval",
+      "label": "requiresStockAdjustmentApproval()",
+      "norm_label": "requiresstockadjustmentapproval()",
+      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
+      "source_location": "L102"
     },
     {
       "community": 131,
       "file_type": "code",
-      "id": "paymentview_handlekeypadpress",
-      "label": "handleKeypadPress()",
-      "norm_label": "handlekeypadpress()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
-      "source_location": "L275"
+      "id": "stockadjustment_resolvestockadjustmentquantitydelta",
+      "label": "resolveStockAdjustmentQuantityDelta()",
+      "norm_label": "resolvestockadjustmentquantitydelta()",
+      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
+      "source_location": "L45"
     },
     {
       "community": 131,
       "file_type": "code",
-      "id": "paymentview_setamountfromtouch",
-      "label": "setAmountFromTouch()",
-      "norm_label": "setamountfromtouch()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
-      "source_location": "L259"
+      "id": "stockadjustment_summarizestockadjustmentlineitems",
+      "label": "summarizeStockAdjustmentLineItems()",
+      "norm_label": "summarizestockadjustmentlineitems()",
+      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
+      "source_location": "L76"
     },
     {
       "community": 1310,
@@ -63363,65 +63456,65 @@
     {
       "community": 132,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_register_posregisterview_tsx",
-      "label": "POSRegisterView.tsx",
-      "norm_label": "posregisterview.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
+      "id": "packages_athena_webapp_src_components_pos_paymentview_tsx",
+      "label": "PaymentView.tsx",
+      "norm_label": "paymentview.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
       "source_location": "L1"
     },
     {
       "community": 132,
       "file_type": "code",
-      "id": "posregisterview_cartcountsummary",
-      "label": "CartCountSummary()",
-      "norm_label": "cartcountsummary()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
-      "source_location": "L152"
+      "id": "paymentview_cn",
+      "label": "cn()",
+      "norm_label": "cn()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
+      "source_location": "L404"
     },
     {
       "community": 132,
       "file_type": "code",
-      "id": "posregisterview_cashierauthworkspace",
-      "label": "CashierAuthWorkspace()",
-      "norm_label": "cashierauthworkspace()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
-      "source_location": "L114"
+      "id": "paymentview_handleaddpayment",
+      "label": "handleAddPayment()",
+      "norm_label": "handleaddpayment()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
+      "source_location": "L181"
     },
     {
       "community": 132,
       "file_type": "code",
-      "id": "posregisterview_handlecmdk",
-      "label": "handleCmdK()",
-      "norm_label": "handlecmdk()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
-      "source_location": "L431"
+      "id": "paymentview_handleamountblur",
+      "label": "handleAmountBlur()",
+      "norm_label": "handleamountblur()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
+      "source_location": "L253"
     },
     {
       "community": 132,
       "file_type": "code",
-      "id": "posregisterview_productlookupemptystate",
-      "label": "ProductLookupEmptyState()",
-      "norm_label": "productlookupemptystate()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
-      "source_location": "L73"
+      "id": "paymentview_handleamountchange",
+      "label": "handleAmountChange()",
+      "norm_label": "handleamountchange()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
+      "source_location": "L231"
     },
     {
       "community": 132,
       "file_type": "code",
-      "id": "posregisterview_registersetupresolvingworkspace",
-      "label": "RegisterSetupResolvingWorkspace()",
-      "norm_label": "registersetupresolvingworkspace()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
-      "source_location": "L146"
+      "id": "paymentview_handlekeypadpress",
+      "label": "handleKeypadPress()",
+      "norm_label": "handlekeypadpress()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
+      "source_location": "L275"
     },
     {
       "community": 132,
       "file_type": "code",
-      "id": "posregisterview_usecollapsesidebarforposflow",
-      "label": "useCollapseSidebarForPosFlow()",
-      "norm_label": "usecollapsesidebarforposflow()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
-      "source_location": "L41"
+      "id": "paymentview_setamountfromtouch",
+      "label": "setAmountFromTouch()",
+      "norm_label": "setamountfromtouch()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
+      "source_location": "L259"
     },
     {
       "community": 1320,
@@ -63516,65 +63609,65 @@
     {
       "community": 133,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_services_serviceappointmentsview_tsx",
-      "label": "ServiceAppointmentsView.tsx",
-      "norm_label": "serviceappointmentsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
+      "id": "packages_athena_webapp_src_components_pos_register_posregisterview_tsx",
+      "label": "POSRegisterView.tsx",
+      "norm_label": "posregisterview.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
       "source_location": "L1"
     },
     {
       "community": 133,
       "file_type": "code",
-      "id": "serviceappointmentsview_applycommandresult",
-      "label": "applyCommandResult()",
-      "norm_label": "applycommandresult()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
-      "source_location": "L129"
+      "id": "posregisterview_cartcountsummary",
+      "label": "CartCountSummary()",
+      "norm_label": "cartcountsummary()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
+      "source_location": "L152"
     },
     {
       "community": 133,
       "file_type": "code",
-      "id": "serviceappointmentsview_async",
-      "label": "async()",
-      "norm_label": "async()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
-      "source_location": "L393"
+      "id": "posregisterview_cashierauthworkspace",
+      "label": "CashierAuthWorkspace()",
+      "norm_label": "cashierauthworkspace()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
+      "source_location": "L114"
     },
     {
       "community": 133,
       "file_type": "code",
-      "id": "serviceappointmentsview_formatdatetimelocal",
-      "label": "formatDateTimeLocal()",
-      "norm_label": "formatdatetimelocal()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
-      "source_location": "L102"
+      "id": "posregisterview_handlecmdk",
+      "label": "handleCmdK()",
+      "norm_label": "handlecmdk()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
+      "source_location": "L431"
     },
     {
       "community": 133,
       "file_type": "code",
-      "id": "serviceappointmentsview_handlesubmit",
-      "label": "handleSubmit()",
-      "norm_label": "handlesubmit()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
-      "source_location": "L153"
+      "id": "posregisterview_productlookupemptystate",
+      "label": "ProductLookupEmptyState()",
+      "norm_label": "productlookupemptystate()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
+      "source_location": "L73"
     },
     {
       "community": 133,
       "file_type": "code",
-      "id": "serviceappointmentsview_parsedatetimelocal",
-      "label": "parseDateTimeLocal()",
-      "norm_label": "parsedatetimelocal()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
-      "source_location": "L97"
+      "id": "posregisterview_registersetupresolvingworkspace",
+      "label": "RegisterSetupResolvingWorkspace()",
+      "norm_label": "registersetupresolvingworkspace()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
+      "source_location": "L146"
     },
     {
       "community": 133,
       "file_type": "code",
-      "id": "serviceappointmentsview_withsavestate",
-      "label": "withSaveState()",
-      "norm_label": "withsavestate()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
-      "source_location": "L521"
+      "id": "posregisterview_usecollapsesidebarforposflow",
+      "label": "useCollapseSidebarForPosFlow()",
+      "norm_label": "usecollapsesidebarforposflow()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
+      "source_location": "L41"
     },
     {
       "community": 1330,
@@ -63669,65 +63762,65 @@
     {
       "community": 134,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_domain_session_ts",
-      "label": "session.ts",
-      "norm_label": "session.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
+      "id": "packages_athena_webapp_src_components_services_serviceappointmentsview_tsx",
+      "label": "ServiceAppointmentsView.tsx",
+      "norm_label": "serviceappointmentsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
       "source_location": "L1"
     },
     {
       "community": 134,
       "file_type": "code",
-      "id": "session_deriveregisterphase",
-      "label": "deriveRegisterPhase()",
-      "norm_label": "deriveregisterphase()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
-      "source_location": "L3"
+      "id": "serviceappointmentsview_applycommandresult",
+      "label": "applyCommandResult()",
+      "norm_label": "applycommandresult()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
+      "source_location": "L129"
     },
     {
       "community": 134,
       "file_type": "code",
-      "id": "session_hasactiveregistersession",
-      "label": "hasActiveRegisterSession()",
-      "norm_label": "hasactiveregistersession()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
-      "source_location": "L33"
+      "id": "serviceappointmentsview_async",
+      "label": "async()",
+      "norm_label": "async()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
+      "source_location": "L393"
     },
     {
       "community": 134,
       "file_type": "code",
-      "id": "session_hasresumableregistersession",
-      "label": "hasResumableRegisterSession()",
-      "norm_label": "hasresumableregistersession()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
-      "source_location": "L39"
+      "id": "serviceappointmentsview_formatdatetimelocal",
+      "label": "formatDateTimeLocal()",
+      "norm_label": "formatdatetimelocal()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
+      "source_location": "L102"
     },
     {
       "community": 134,
       "file_type": "code",
-      "id": "session_isregisterreadytostart",
-      "label": "isRegisterReadyToStart()",
-      "norm_label": "isregisterreadytostart()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
-      "source_location": "L45"
+      "id": "serviceappointmentsview_handlesubmit",
+      "label": "handleSubmit()",
+      "norm_label": "handlesubmit()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
+      "source_location": "L153"
     },
     {
       "community": 134,
       "file_type": "code",
-      "id": "session_requirescashier",
-      "label": "requiresCashier()",
-      "norm_label": "requirescashier()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
-      "source_location": "L29"
+      "id": "serviceappointmentsview_parsedatetimelocal",
+      "label": "parseDateTimeLocal()",
+      "norm_label": "parsedatetimelocal()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
+      "source_location": "L97"
     },
     {
       "community": 134,
       "file_type": "code",
-      "id": "session_requiresterminal",
-      "label": "requiresTerminal()",
-      "norm_label": "requiresterminal()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
-      "source_location": "L25"
+      "id": "serviceappointmentsview_withsavestate",
+      "label": "withSaveState()",
+      "norm_label": "withsavestate()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
+      "source_location": "L521"
     },
     {
       "community": 1340,
@@ -63822,65 +63915,65 @@
     {
       "community": 135,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_presentation_register_useregisterviewmodel_test_ts",
-      "label": "useRegisterViewModel.test.ts",
-      "norm_label": "useregisterviewmodel.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts",
+      "id": "packages_athena_webapp_src_lib_pos_domain_session_ts",
+      "label": "session.ts",
+      "norm_label": "session.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
       "source_location": "L1"
     },
     {
       "community": 135,
       "file_type": "code",
-      "id": "useregisterviewmodel_test_buildregistercatalogavailabilityrow",
-      "label": "buildRegisterCatalogAvailabilityRow()",
-      "norm_label": "buildregistercatalogavailabilityrow()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts",
-      "source_location": "L254"
+      "id": "session_deriveregisterphase",
+      "label": "deriveRegisterPhase()",
+      "norm_label": "deriveregisterphase()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
+      "source_location": "L3"
     },
     {
       "community": 135,
       "file_type": "code",
-      "id": "useregisterviewmodel_test_buildregistercatalogrow",
-      "label": "buildRegisterCatalogRow()",
-      "norm_label": "buildregistercatalogrow()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts",
-      "source_location": "L231"
+      "id": "session_hasactiveregistersession",
+      "label": "hasActiveRegisterSession()",
+      "norm_label": "hasactiveregistersession()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
+      "source_location": "L33"
     },
     {
       "community": 135,
       "file_type": "code",
-      "id": "useregisterviewmodel_test_deferred",
-      "label": "deferred()",
-      "norm_label": "deferred()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts",
-      "source_location": "L222"
+      "id": "session_hasresumableregistersession",
+      "label": "hasResumableRegisterSession()",
+      "norm_label": "hasresumableregistersession()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
+      "source_location": "L39"
     },
     {
       "community": 135,
       "file_type": "code",
-      "id": "useregisterviewmodel_test_resolveadditem",
-      "label": "resolveAddItem()",
-      "norm_label": "resolveadditem()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts",
-      "source_location": "L2232"
+      "id": "session_isregisterreadytostart",
+      "label": "isRegisterReadyToStart()",
+      "norm_label": "isregisterreadytostart()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
+      "source_location": "L45"
     },
     {
       "community": 135,
       "file_type": "code",
-      "id": "useregisterviewmodel_test_resolveclearcart",
-      "label": "resolveClearCart()",
-      "norm_label": "resolveclearcart()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts",
-      "source_location": "L2680"
+      "id": "session_requirescashier",
+      "label": "requiresCashier()",
+      "norm_label": "requirescashier()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
+      "source_location": "L29"
     },
     {
       "community": 135,
       "file_type": "code",
-      "id": "useregisterviewmodel_test_resolveremoveitem",
-      "label": "resolveRemoveItem()",
-      "norm_label": "resolveremoveitem()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts",
-      "source_location": "L2553"
+      "id": "session_requiresterminal",
+      "label": "requiresTerminal()",
+      "norm_label": "requiresterminal()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
+      "source_location": "L25"
     },
     {
       "community": 1350,
@@ -63975,65 +64068,65 @@
     {
       "community": 136,
       "file_type": "code",
-      "id": "calculationservice_calculatecarttotals",
-      "label": "calculateCartTotals()",
-      "norm_label": "calculatecarttotals()",
-      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
-      "source_location": "L28"
-    },
-    {
-      "community": 136,
-      "file_type": "code",
-      "id": "calculationservice_calculatechange",
-      "label": "calculateChange()",
-      "norm_label": "calculatechange()",
-      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
-      "source_location": "L42"
-    },
-    {
-      "community": 136,
-      "file_type": "code",
-      "id": "calculationservice_calculateitemtotal",
-      "label": "calculateItemTotal()",
-      "norm_label": "calculateitemtotal()",
-      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
-      "source_location": "L35"
-    },
-    {
-      "community": 136,
-      "file_type": "code",
-      "id": "calculationservice_formatcurrency",
-      "label": "formatCurrency()",
-      "norm_label": "formatcurrency()",
-      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
-      "source_location": "L49"
-    },
-    {
-      "community": 136,
-      "file_type": "code",
-      "id": "calculationservice_geteffectiveprice",
-      "label": "getEffectivePrice()",
-      "norm_label": "geteffectiveprice()",
-      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
-      "source_location": "L70"
-    },
-    {
-      "community": 136,
-      "file_type": "code",
-      "id": "calculationservice_ispaymentsufficient",
-      "label": "isPaymentSufficient()",
-      "norm_label": "ispaymentsufficient()",
-      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
-      "source_location": "L59"
-    },
-    {
-      "community": 136,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_services_calculationservice_ts",
-      "label": "calculationService.ts",
-      "norm_label": "calculationservice.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
+      "id": "packages_athena_webapp_src_lib_pos_presentation_register_useregisterviewmodel_test_ts",
+      "label": "useRegisterViewModel.test.ts",
+      "norm_label": "useregisterviewmodel.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 136,
+      "file_type": "code",
+      "id": "useregisterviewmodel_test_buildregistercatalogavailabilityrow",
+      "label": "buildRegisterCatalogAvailabilityRow()",
+      "norm_label": "buildregistercatalogavailabilityrow()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts",
+      "source_location": "L254"
+    },
+    {
+      "community": 136,
+      "file_type": "code",
+      "id": "useregisterviewmodel_test_buildregistercatalogrow",
+      "label": "buildRegisterCatalogRow()",
+      "norm_label": "buildregistercatalogrow()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts",
+      "source_location": "L231"
+    },
+    {
+      "community": 136,
+      "file_type": "code",
+      "id": "useregisterviewmodel_test_deferred",
+      "label": "deferred()",
+      "norm_label": "deferred()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts",
+      "source_location": "L222"
+    },
+    {
+      "community": 136,
+      "file_type": "code",
+      "id": "useregisterviewmodel_test_resolveadditem",
+      "label": "resolveAddItem()",
+      "norm_label": "resolveadditem()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts",
+      "source_location": "L2232"
+    },
+    {
+      "community": 136,
+      "file_type": "code",
+      "id": "useregisterviewmodel_test_resolveclearcart",
+      "label": "resolveClearCart()",
+      "norm_label": "resolveclearcart()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts",
+      "source_location": "L2680"
+    },
+    {
+      "community": 136,
+      "file_type": "code",
+      "id": "useregisterviewmodel_test_resolveremoveitem",
+      "label": "resolveRemoveItem()",
+      "norm_label": "resolveremoveitem()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts",
+      "source_location": "L2553"
     },
     {
       "community": 1360,
@@ -64128,65 +64221,65 @@
     {
       "community": 137,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_productutils_ts",
-      "label": "productUtils.ts",
-      "norm_label": "productutils.ts",
-      "source_file": "packages/athena-webapp/src/lib/productUtils.ts",
+      "id": "calculationservice_calculatecarttotals",
+      "label": "calculateCartTotals()",
+      "norm_label": "calculatecarttotals()",
+      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
+      "source_location": "L28"
+    },
+    {
+      "community": 137,
+      "file_type": "code",
+      "id": "calculationservice_calculatechange",
+      "label": "calculateChange()",
+      "norm_label": "calculatechange()",
+      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
+      "source_location": "L42"
+    },
+    {
+      "community": 137,
+      "file_type": "code",
+      "id": "calculationservice_calculateitemtotal",
+      "label": "calculateItemTotal()",
+      "norm_label": "calculateitemtotal()",
+      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
+      "source_location": "L35"
+    },
+    {
+      "community": 137,
+      "file_type": "code",
+      "id": "calculationservice_formatcurrency",
+      "label": "formatCurrency()",
+      "norm_label": "formatcurrency()",
+      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
+      "source_location": "L49"
+    },
+    {
+      "community": 137,
+      "file_type": "code",
+      "id": "calculationservice_geteffectiveprice",
+      "label": "getEffectivePrice()",
+      "norm_label": "geteffectiveprice()",
+      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
+      "source_location": "L70"
+    },
+    {
+      "community": 137,
+      "file_type": "code",
+      "id": "calculationservice_ispaymentsufficient",
+      "label": "isPaymentSufficient()",
+      "norm_label": "ispaymentsufficient()",
+      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
+      "source_location": "L59"
+    },
+    {
+      "community": 137,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_services_calculationservice_ts",
+      "label": "calculationService.ts",
+      "norm_label": "calculationservice.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 137,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_productutils_ts",
-      "label": "productUtils.ts",
-      "norm_label": "productutils.ts",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 137,
-      "file_type": "code",
-      "id": "productutils_getproductname",
-      "label": "getProductName()",
-      "norm_label": "getproductname()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L18"
-    },
-    {
-      "community": 137,
-      "file_type": "code",
-      "id": "productutils_haslowstock",
-      "label": "hasLowStock()",
-      "norm_label": "haslowstock()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L52"
-    },
-    {
-      "community": 137,
-      "file_type": "code",
-      "id": "productutils_issoldout",
-      "label": "isSoldOut()",
-      "norm_label": "issoldout()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L45"
-    },
-    {
-      "community": 137,
-      "file_type": "code",
-      "id": "productutils_sortproduct",
-      "label": "sortProduct()",
-      "norm_label": "sortproduct()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L66"
-    },
-    {
-      "community": 137,
-      "file_type": "code",
-      "id": "productutils_sortskusbylength",
-      "label": "sortSkusByLength()",
-      "norm_label": "sortskusbylength()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L62"
     },
     {
       "community": 1370,
@@ -64281,65 +64374,65 @@
     {
       "community": 138,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_templates_reference_fixtures_tsx",
-      "label": "reference-fixtures.tsx",
-      "norm_label": "reference-fixtures.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "id": "packages_athena_webapp_src_lib_productutils_ts",
+      "label": "productUtils.ts",
+      "norm_label": "productutils.ts",
+      "source_file": "packages/athena-webapp/src/lib/productUtils.ts",
       "source_location": "L1"
     },
     {
       "community": 138,
       "file_type": "code",
-      "id": "reference_fixtures_compacttable",
-      "label": "CompactTable()",
-      "norm_label": "compacttable()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L263"
+      "id": "packages_storefront_webapp_src_lib_productutils_ts",
+      "label": "productUtils.ts",
+      "norm_label": "productutils.ts",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L1"
     },
     {
       "community": 138,
       "file_type": "code",
-      "id": "reference_fixtures_framecard",
-      "label": "FrameCard()",
-      "norm_label": "framecard()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L163"
+      "id": "productutils_getproductname",
+      "label": "getProductName()",
+      "norm_label": "getproductname()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L18"
     },
     {
       "community": 138,
       "file_type": "code",
-      "id": "reference_fixtures_lanecard",
-      "label": "LaneCard()",
-      "norm_label": "lanecard()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L213"
+      "id": "productutils_haslowstock",
+      "label": "hasLowStock()",
+      "norm_label": "haslowstock()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L52"
     },
     {
       "community": 138,
       "file_type": "code",
-      "id": "reference_fixtures_metrictile",
-      "label": "MetricTile()",
-      "norm_label": "metrictile()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L194"
+      "id": "productutils_issoldout",
+      "label": "isSoldOut()",
+      "norm_label": "issoldout()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L45"
     },
     {
       "community": 138,
       "file_type": "code",
-      "id": "reference_fixtures_minitrendchart",
-      "label": "MiniTrendChart()",
-      "norm_label": "minitrendchart()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L240"
+      "id": "productutils_sortproduct",
+      "label": "sortProduct()",
+      "norm_label": "sortproduct()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L66"
     },
     {
       "community": 138,
       "file_type": "code",
-      "id": "reference_fixtures_referencepageshell",
-      "label": "ReferencePageShell()",
-      "norm_label": "referencepageshell()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L145"
+      "id": "productutils_sortskusbylength",
+      "label": "sortSkusByLength()",
+      "norm_label": "sortskusbylength()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L62"
     },
     {
       "community": 1380,
@@ -64434,65 +64527,65 @@
     {
       "community": 139,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_savedbag_ts",
-      "label": "savedBag.ts",
-      "norm_label": "savedbag.ts",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "id": "packages_athena_webapp_src_stories_templates_reference_fixtures_tsx",
+      "label": "reference-fixtures.tsx",
+      "norm_label": "reference-fixtures.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
       "source_location": "L1"
     },
     {
       "community": 139,
       "file_type": "code",
-      "id": "savedbag_additemtosavedbag",
-      "label": "addItemToSavedBag()",
-      "norm_label": "additemtosavedbag()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L25"
+      "id": "reference_fixtures_compacttable",
+      "label": "CompactTable()",
+      "norm_label": "compacttable()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L263"
     },
     {
       "community": 139,
       "file_type": "code",
-      "id": "savedbag_getactivesavedbag",
-      "label": "getActiveSavedBag()",
-      "norm_label": "getactivesavedbag()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L10"
+      "id": "reference_fixtures_framecard",
+      "label": "FrameCard()",
+      "norm_label": "framecard()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L163"
     },
     {
       "community": 139,
       "file_type": "code",
-      "id": "savedbag_getbaseurl",
-      "label": "getBaseUrl()",
-      "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L8"
+      "id": "reference_fixtures_lanecard",
+      "label": "LaneCard()",
+      "norm_label": "lanecard()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L213"
     },
     {
       "community": 139,
       "file_type": "code",
-      "id": "savedbag_removeitemfromsavedbag",
-      "label": "removeItemFromSavedBag()",
-      "norm_label": "removeitemfromsavedbag()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L91"
+      "id": "reference_fixtures_metrictile",
+      "label": "MetricTile()",
+      "norm_label": "metrictile()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L194"
     },
     {
       "community": 139,
       "file_type": "code",
-      "id": "savedbag_updatesavedbagitem",
-      "label": "updateSavedBagItem()",
-      "norm_label": "updatesavedbagitem()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L61"
+      "id": "reference_fixtures_minitrendchart",
+      "label": "MiniTrendChart()",
+      "norm_label": "minitrendchart()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L240"
     },
     {
       "community": 139,
       "file_type": "code",
-      "id": "savedbag_updatesavedbagowner",
-      "label": "updateSavedBagOwner()",
-      "norm_label": "updatesavedbagowner()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L109"
+      "id": "reference_fixtures_referencepageshell",
+      "label": "ReferencePageShell()",
+      "norm_label": "referencepageshell()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L145"
     },
     {
       "community": 1390,
@@ -64812,65 +64905,65 @@
     {
       "community": 140,
       "file_type": "code",
-      "id": "compound_solution_check_test_createfixturerepo",
-      "label": "createFixtureRepo()",
-      "norm_label": "createfixturerepo()",
-      "source_file": "scripts/compound-solution-check.test.ts",
-      "source_location": "L15"
-    },
-    {
-      "community": 140,
-      "file_type": "code",
-      "id": "compound_solution_check_test_gitenv",
-      "label": "gitEnv()",
-      "norm_label": "gitenv()",
-      "source_file": "scripts/compound-solution-check.test.ts",
-      "source_location": "L50"
-    },
-    {
-      "community": 140,
-      "file_type": "code",
-      "id": "compound_solution_check_test_linechanges",
-      "label": "lineChanges()",
-      "norm_label": "linechanges()",
-      "source_file": "scripts/compound-solution-check.test.ts",
-      "source_location": "L66"
-    },
-    {
-      "community": 140,
-      "file_type": "code",
-      "id": "compound_solution_check_test_rungit",
-      "label": "runGit()",
-      "norm_label": "rungit()",
-      "source_file": "scripts/compound-solution-check.test.ts",
-      "source_location": "L35"
-    },
-    {
-      "community": 140,
-      "file_type": "code",
-      "id": "compound_solution_check_test_solutionnote",
-      "label": "solutionNote()",
-      "norm_label": "solutionnote()",
-      "source_file": "scripts/compound-solution-check.test.ts",
-      "source_location": "L75"
-    },
-    {
-      "community": 140,
-      "file_type": "code",
-      "id": "compound_solution_check_test_write",
-      "label": "write()",
-      "norm_label": "write()",
-      "source_file": "scripts/compound-solution-check.test.ts",
-      "source_location": "L29"
-    },
-    {
-      "community": 140,
-      "file_type": "code",
-      "id": "scripts_compound_solution_check_test_ts",
-      "label": "compound-solution-check.test.ts",
-      "norm_label": "compound-solution-check.test.ts",
-      "source_file": "scripts/compound-solution-check.test.ts",
+      "id": "packages_storefront_webapp_src_api_savedbag_ts",
+      "label": "savedBag.ts",
+      "norm_label": "savedbag.ts",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 140,
+      "file_type": "code",
+      "id": "savedbag_additemtosavedbag",
+      "label": "addItemToSavedBag()",
+      "norm_label": "additemtosavedbag()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L25"
+    },
+    {
+      "community": 140,
+      "file_type": "code",
+      "id": "savedbag_getactivesavedbag",
+      "label": "getActiveSavedBag()",
+      "norm_label": "getactivesavedbag()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L10"
+    },
+    {
+      "community": 140,
+      "file_type": "code",
+      "id": "savedbag_getbaseurl",
+      "label": "getBaseUrl()",
+      "norm_label": "getbaseurl()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L8"
+    },
+    {
+      "community": 140,
+      "file_type": "code",
+      "id": "savedbag_removeitemfromsavedbag",
+      "label": "removeItemFromSavedBag()",
+      "norm_label": "removeitemfromsavedbag()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L91"
+    },
+    {
+      "community": 140,
+      "file_type": "code",
+      "id": "savedbag_updatesavedbagitem",
+      "label": "updateSavedBagItem()",
+      "norm_label": "updatesavedbagitem()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L61"
+    },
+    {
+      "community": 140,
+      "file_type": "code",
+      "id": "savedbag_updatesavedbagowner",
+      "label": "updateSavedBagOwner()",
+      "norm_label": "updatesavedbagowner()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L109"
     },
     {
       "community": 1400,
@@ -64965,65 +65058,65 @@
     {
       "community": 141,
       "file_type": "code",
-      "id": "scripts_harness_behavior_fixtures_storefront_runtime_api_ts",
-      "label": "storefront-runtime-api.ts",
-      "norm_label": "storefront-runtime-api.ts",
-      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
+      "id": "compound_solution_check_test_createfixturerepo",
+      "label": "createFixtureRepo()",
+      "norm_label": "createfixturerepo()",
+      "source_file": "scripts/compound-solution-check.test.ts",
+      "source_location": "L15"
+    },
+    {
+      "community": 141,
+      "file_type": "code",
+      "id": "compound_solution_check_test_gitenv",
+      "label": "gitEnv()",
+      "norm_label": "gitenv()",
+      "source_file": "scripts/compound-solution-check.test.ts",
+      "source_location": "L50"
+    },
+    {
+      "community": 141,
+      "file_type": "code",
+      "id": "compound_solution_check_test_linechanges",
+      "label": "lineChanges()",
+      "norm_label": "linechanges()",
+      "source_file": "scripts/compound-solution-check.test.ts",
+      "source_location": "L66"
+    },
+    {
+      "community": 141,
+      "file_type": "code",
+      "id": "compound_solution_check_test_rungit",
+      "label": "runGit()",
+      "norm_label": "rungit()",
+      "source_file": "scripts/compound-solution-check.test.ts",
+      "source_location": "L35"
+    },
+    {
+      "community": 141,
+      "file_type": "code",
+      "id": "compound_solution_check_test_solutionnote",
+      "label": "solutionNote()",
+      "norm_label": "solutionnote()",
+      "source_file": "scripts/compound-solution-check.test.ts",
+      "source_location": "L75"
+    },
+    {
+      "community": 141,
+      "file_type": "code",
+      "id": "compound_solution_check_test_write",
+      "label": "write()",
+      "norm_label": "write()",
+      "source_file": "scripts/compound-solution-check.test.ts",
+      "source_location": "L29"
+    },
+    {
+      "community": 141,
+      "file_type": "code",
+      "id": "scripts_compound_solution_check_test_ts",
+      "label": "compound-solution-check.test.ts",
+      "norm_label": "compound-solution-check.test.ts",
+      "source_file": "scripts/compound-solution-check.test.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 141,
-      "file_type": "code",
-      "id": "storefront_runtime_api_emitsignal",
-      "label": "emitSignal()",
-      "norm_label": "emitsignal()",
-      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
-      "source_location": "L210"
-    },
-    {
-      "community": 141,
-      "file_type": "code",
-      "id": "storefront_runtime_api_handlecheckoutsessionfetch",
-      "label": "handleCheckoutSessionFetch()",
-      "norm_label": "handlecheckoutsessionfetch()",
-      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
-      "source_location": "L214"
-    },
-    {
-      "community": 141,
-      "file_type": "code",
-      "id": "storefront_runtime_api_handlecheckoutsessionupdate",
-      "label": "handleCheckoutSessionUpdate()",
-      "norm_label": "handlecheckoutsessionupdate()",
-      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
-      "source_location": "L236"
-    },
-    {
-      "community": 141,
-      "file_type": "code",
-      "id": "storefront_runtime_api_jsonresponse",
-      "label": "jsonResponse()",
-      "norm_label": "jsonresponse()",
-      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
-      "source_location": "L201"
-    },
-    {
-      "community": 141,
-      "file_type": "code",
-      "id": "storefront_runtime_api_shutdown",
-      "label": "shutdown()",
-      "norm_label": "shutdown()",
-      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
-      "source_location": "L421"
-    },
-    {
-      "community": 141,
-      "file_type": "code",
-      "id": "storefront_runtime_api_withcorsheaders",
-      "label": "withCorsHeaders()",
-      "norm_label": "withcorsheaders()",
-      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
-      "source_location": "L186"
     },
     {
       "community": 1410,
@@ -65118,65 +65211,65 @@
     {
       "community": 142,
       "file_type": "code",
-      "id": "harness_janitor_test_createfixtureroot",
-      "label": "createFixtureRoot()",
-      "norm_label": "createfixtureroot()",
-      "source_file": "scripts/harness-janitor.test.ts",
-      "source_location": "L29"
-    },
-    {
-      "community": 142,
-      "file_type": "code",
-      "id": "harness_janitor_test_overwritefreshgenerateddocs",
-      "label": "overwriteFreshGeneratedDocs()",
-      "norm_label": "overwritefreshgenerateddocs()",
-      "source_file": "scripts/harness-janitor.test.ts",
-      "source_location": "L46"
-    },
-    {
-      "community": 142,
-      "file_type": "code",
-      "id": "harness_janitor_test_overwritefreshgraphifyartifacts",
-      "label": "overwriteFreshGraphifyArtifacts()",
-      "norm_label": "overwritefreshgraphifyartifacts()",
-      "source_file": "scripts/harness-janitor.test.ts",
-      "source_location": "L54"
-    },
-    {
-      "community": 142,
-      "file_type": "code",
-      "id": "harness_janitor_test_seedartifacts",
-      "label": "seedArtifacts()",
-      "norm_label": "seedartifacts()",
-      "source_file": "scripts/harness-janitor.test.ts",
-      "source_location": "L35"
-    },
-    {
-      "community": 142,
-      "file_type": "code",
-      "id": "harness_janitor_test_sortpaths",
-      "label": "sortPaths()",
-      "norm_label": "sortpaths()",
-      "source_file": "scripts/harness-janitor.test.ts",
-      "source_location": "L61"
-    },
-    {
-      "community": 142,
-      "file_type": "code",
-      "id": "harness_janitor_test_write",
-      "label": "write()",
-      "norm_label": "write()",
-      "source_file": "scripts/harness-janitor.test.ts",
-      "source_location": "L23"
-    },
-    {
-      "community": 142,
-      "file_type": "code",
-      "id": "scripts_harness_janitor_test_ts",
-      "label": "harness-janitor.test.ts",
-      "norm_label": "harness-janitor.test.ts",
-      "source_file": "scripts/harness-janitor.test.ts",
+      "id": "scripts_harness_behavior_fixtures_storefront_runtime_api_ts",
+      "label": "storefront-runtime-api.ts",
+      "norm_label": "storefront-runtime-api.ts",
+      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 142,
+      "file_type": "code",
+      "id": "storefront_runtime_api_emitsignal",
+      "label": "emitSignal()",
+      "norm_label": "emitsignal()",
+      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
+      "source_location": "L210"
+    },
+    {
+      "community": 142,
+      "file_type": "code",
+      "id": "storefront_runtime_api_handlecheckoutsessionfetch",
+      "label": "handleCheckoutSessionFetch()",
+      "norm_label": "handlecheckoutsessionfetch()",
+      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
+      "source_location": "L214"
+    },
+    {
+      "community": 142,
+      "file_type": "code",
+      "id": "storefront_runtime_api_handlecheckoutsessionupdate",
+      "label": "handleCheckoutSessionUpdate()",
+      "norm_label": "handlecheckoutsessionupdate()",
+      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
+      "source_location": "L236"
+    },
+    {
+      "community": 142,
+      "file_type": "code",
+      "id": "storefront_runtime_api_jsonresponse",
+      "label": "jsonResponse()",
+      "norm_label": "jsonresponse()",
+      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
+      "source_location": "L201"
+    },
+    {
+      "community": 142,
+      "file_type": "code",
+      "id": "storefront_runtime_api_shutdown",
+      "label": "shutdown()",
+      "norm_label": "shutdown()",
+      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
+      "source_location": "L421"
+    },
+    {
+      "community": 142,
+      "file_type": "code",
+      "id": "storefront_runtime_api_withcorsheaders",
+      "label": "withCorsHeaders()",
+      "norm_label": "withcorsheaders()",
+      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
+      "source_location": "L186"
     },
     {
       "community": 1420,
@@ -65271,64 +65364,64 @@
     {
       "community": 143,
       "file_type": "code",
-      "id": "harness_review_test_createfixturerepo",
-      "label": "createFixtureRepo()",
-      "norm_label": "createfixturerepo()",
-      "source_file": "scripts/harness-review.test.ts",
+      "id": "harness_janitor_test_createfixtureroot",
+      "label": "createFixtureRoot()",
+      "norm_label": "createfixtureroot()",
+      "source_file": "scripts/harness-janitor.test.ts",
+      "source_location": "L29"
+    },
+    {
+      "community": 143,
+      "file_type": "code",
+      "id": "harness_janitor_test_overwritefreshgenerateddocs",
+      "label": "overwriteFreshGeneratedDocs()",
+      "norm_label": "overwritefreshgenerateddocs()",
+      "source_file": "scripts/harness-janitor.test.ts",
+      "source_location": "L46"
+    },
+    {
+      "community": 143,
+      "file_type": "code",
+      "id": "harness_janitor_test_overwritefreshgraphifyartifacts",
+      "label": "overwriteFreshGraphifyArtifacts()",
+      "norm_label": "overwritefreshgraphifyartifacts()",
+      "source_file": "scripts/harness-janitor.test.ts",
+      "source_location": "L54"
+    },
+    {
+      "community": 143,
+      "file_type": "code",
+      "id": "harness_janitor_test_seedartifacts",
+      "label": "seedArtifacts()",
+      "norm_label": "seedartifacts()",
+      "source_file": "scripts/harness-janitor.test.ts",
+      "source_location": "L35"
+    },
+    {
+      "community": 143,
+      "file_type": "code",
+      "id": "harness_janitor_test_sortpaths",
+      "label": "sortPaths()",
+      "norm_label": "sortpaths()",
+      "source_file": "scripts/harness-janitor.test.ts",
+      "source_location": "L61"
+    },
+    {
+      "community": 143,
+      "file_type": "code",
+      "id": "harness_janitor_test_write",
+      "label": "write()",
+      "norm_label": "write()",
+      "source_file": "scripts/harness-janitor.test.ts",
       "source_location": "L23"
     },
     {
       "community": 143,
       "file_type": "code",
-      "id": "harness_review_test_error",
-      "label": "error()",
-      "norm_label": "error()",
-      "source_file": "scripts/harness-review.test.ts",
-      "source_location": "L291"
-    },
-    {
-      "community": 143,
-      "file_type": "code",
-      "id": "harness_review_test_initializegithistory",
-      "label": "initializeGitHistory()",
-      "norm_label": "initializegithistory()",
-      "source_file": "scripts/harness-review.test.ts",
-      "source_location": "L260"
-    },
-    {
-      "community": 143,
-      "file_type": "code",
-      "id": "harness_review_test_log",
-      "label": "log()",
-      "norm_label": "log()",
-      "source_file": "scripts/harness-review.test.ts",
-      "source_location": "L290"
-    },
-    {
-      "community": 143,
-      "file_type": "code",
-      "id": "harness_review_test_rungit",
-      "label": "runGit()",
-      "norm_label": "rungit()",
-      "source_file": "scripts/harness-review.test.ts",
-      "source_location": "L246"
-    },
-    {
-      "community": 143,
-      "file_type": "code",
-      "id": "harness_review_test_write",
-      "label": "write()",
-      "norm_label": "write()",
-      "source_file": "scripts/harness-review.test.ts",
-      "source_location": "L17"
-    },
-    {
-      "community": 143,
-      "file_type": "code",
-      "id": "scripts_harness_review_test_ts",
-      "label": "harness-review.test.ts",
-      "norm_label": "harness-review.test.ts",
-      "source_file": "scripts/harness-review.test.ts",
+      "id": "scripts_harness_janitor_test_ts",
+      "label": "harness-janitor.test.ts",
+      "norm_label": "harness-janitor.test.ts",
+      "source_file": "scripts/harness-janitor.test.ts",
       "source_location": "L1"
     },
     {
@@ -65424,55 +65517,64 @@
     {
       "community": 144,
       "file_type": "code",
-      "id": "index_valkeyclient",
-      "label": "ValkeyClient",
-      "norm_label": "valkeyclient",
-      "source_file": "packages/athena-webapp/convex/cache/index.ts",
-      "source_location": "L4"
+      "id": "harness_review_test_createfixturerepo",
+      "label": "createFixtureRepo()",
+      "norm_label": "createfixturerepo()",
+      "source_file": "scripts/harness-review.test.ts",
+      "source_location": "L23"
     },
     {
       "community": 144,
       "file_type": "code",
-      "id": "index_valkeyclient_constructor",
-      "label": ".constructor()",
-      "norm_label": ".constructor()",
-      "source_file": "packages/athena-webapp/convex/cache/index.ts",
-      "source_location": "L11"
+      "id": "harness_review_test_error",
+      "label": "error()",
+      "norm_label": "error()",
+      "source_file": "scripts/harness-review.test.ts",
+      "source_location": "L291"
     },
     {
       "community": 144,
       "file_type": "code",
-      "id": "index_valkeyclient_get",
-      "label": ".get()",
-      "norm_label": ".get()",
-      "source_file": "packages/athena-webapp/convex/cache/index.ts",
-      "source_location": "L20"
+      "id": "harness_review_test_initializegithistory",
+      "label": "initializeGitHistory()",
+      "norm_label": "initializegithistory()",
+      "source_file": "scripts/harness-review.test.ts",
+      "source_location": "L260"
     },
     {
       "community": 144,
       "file_type": "code",
-      "id": "index_valkeyclient_invalidate",
-      "label": ".invalidate()",
-      "norm_label": ".invalidate()",
-      "source_file": "packages/athena-webapp/convex/cache/index.ts",
-      "source_location": "L75"
+      "id": "harness_review_test_log",
+      "label": "log()",
+      "norm_label": "log()",
+      "source_file": "scripts/harness-review.test.ts",
+      "source_location": "L290"
     },
     {
       "community": 144,
       "file_type": "code",
-      "id": "index_valkeyclient_set",
-      "label": ".set()",
-      "norm_label": ".set()",
-      "source_file": "packages/athena-webapp/convex/cache/index.ts",
-      "source_location": "L48"
+      "id": "harness_review_test_rungit",
+      "label": "runGit()",
+      "norm_label": "rungit()",
+      "source_file": "scripts/harness-review.test.ts",
+      "source_location": "L246"
     },
     {
       "community": 144,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_cache_index_ts",
-      "label": "index.ts",
-      "norm_label": "index.ts",
-      "source_file": "packages/athena-webapp/convex/cache/index.ts",
+      "id": "harness_review_test_write",
+      "label": "write()",
+      "norm_label": "write()",
+      "source_file": "scripts/harness-review.test.ts",
+      "source_location": "L17"
+    },
+    {
+      "community": 144,
+      "file_type": "code",
+      "id": "scripts_harness_review_test_ts",
+      "label": "harness-review.test.ts",
+      "norm_label": "harness-review.test.ts",
+      "source_file": "scripts/harness-review.test.ts",
       "source_location": "L1"
     },
     {
@@ -65568,56 +65670,56 @@
     {
       "community": 145,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_security_ts",
-      "label": "security.ts",
-      "norm_label": "security.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/security.ts",
+      "id": "index_valkeyclient",
+      "label": "ValkeyClient",
+      "norm_label": "valkeyclient",
+      "source_file": "packages/athena-webapp/convex/cache/index.ts",
+      "source_location": "L4"
+    },
+    {
+      "community": 145,
+      "file_type": "code",
+      "id": "index_valkeyclient_constructor",
+      "label": ".constructor()",
+      "norm_label": ".constructor()",
+      "source_file": "packages/athena-webapp/convex/cache/index.ts",
+      "source_location": "L11"
+    },
+    {
+      "community": 145,
+      "file_type": "code",
+      "id": "index_valkeyclient_get",
+      "label": ".get()",
+      "norm_label": ".get()",
+      "source_file": "packages/athena-webapp/convex/cache/index.ts",
+      "source_location": "L20"
+    },
+    {
+      "community": 145,
+      "file_type": "code",
+      "id": "index_valkeyclient_invalidate",
+      "label": ".invalidate()",
+      "norm_label": ".invalidate()",
+      "source_file": "packages/athena-webapp/convex/cache/index.ts",
+      "source_location": "L75"
+    },
+    {
+      "community": 145,
+      "file_type": "code",
+      "id": "index_valkeyclient_set",
+      "label": ".set()",
+      "norm_label": ".set()",
+      "source_file": "packages/athena-webapp/convex/cache/index.ts",
+      "source_location": "L48"
+    },
+    {
+      "community": 145,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_cache_index_ts",
+      "label": "index.ts",
+      "norm_label": "index.ts",
+      "source_file": "packages/athena-webapp/convex/cache/index.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 145,
-      "file_type": "code",
-      "id": "security_buildcanonicalcheckoutproducts",
-      "label": "buildCanonicalCheckoutProducts()",
-      "norm_label": "buildcanonicalcheckoutproducts()",
-      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/security.ts",
-      "source_location": "L42"
-    },
-    {
-      "community": 145,
-      "file_type": "code",
-      "id": "security_hasvalidpositivequantity",
-      "label": "hasValidPositiveQuantity()",
-      "norm_label": "hasvalidpositivequantity()",
-      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/security.ts",
-      "source_location": "L27"
-    },
-    {
-      "community": 145,
-      "file_type": "code",
-      "id": "security_isamounttampered",
-      "label": "isAmountTampered()",
-      "norm_label": "isamounttampered()",
-      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/security.ts",
-      "source_location": "L65"
-    },
-    {
-      "community": 145,
-      "file_type": "code",
-      "id": "security_isauthorizedresourceowner",
-      "label": "isAuthorizedResourceOwner()",
-      "norm_label": "isauthorizedresourceowner()",
-      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/security.ts",
-      "source_location": "L31"
-    },
-    {
-      "community": 145,
-      "file_type": "code",
-      "id": "security_isduplicatechargesuccess",
-      "label": "isDuplicateChargeSuccess()",
-      "norm_label": "isduplicatechargesuccess()",
-      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/security.ts",
-      "source_location": "L76"
     },
     {
       "community": 1450,
@@ -65712,56 +65814,56 @@
     {
       "community": 146,
       "file_type": "code",
-      "id": "listregistercatalog_listregistercatalog",
-      "label": "listRegisterCatalog()",
-      "norm_label": "listregistercatalog()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/listRegisterCatalog.ts",
-      "source_location": "L95"
-    },
-    {
-      "community": 146,
-      "file_type": "code",
-      "id": "listregistercatalog_listregistercatalogavailability",
-      "label": "listRegisterCatalogAvailability()",
-      "norm_label": "listregistercatalogavailability()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/listRegisterCatalog.ts",
-      "source_location": "L137"
-    },
-    {
-      "community": 146,
-      "file_type": "code",
-      "id": "listregistercatalog_mapskutoregistercatalogrow",
-      "label": "mapSkuToRegisterCatalogRow()",
-      "norm_label": "mapskutoregistercatalogrow()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/listRegisterCatalog.ts",
-      "source_location": "L70"
-    },
-    {
-      "community": 146,
-      "file_type": "code",
-      "id": "listregistercatalog_readcategoryname",
-      "label": "readCategoryName()",
-      "norm_label": "readcategoryname()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/listRegisterCatalog.ts",
-      "source_location": "L32"
-    },
-    {
-      "community": 146,
-      "file_type": "code",
-      "id": "listregistercatalog_readcolorname",
-      "label": "readColorName()",
-      "norm_label": "readcolorname()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/listRegisterCatalog.ts",
-      "source_location": "L49"
-    },
-    {
-      "community": 146,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_queries_listregistercatalog_ts",
-      "label": "listRegisterCatalog.ts",
-      "norm_label": "listregistercatalog.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/listRegisterCatalog.ts",
+      "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_security_ts",
+      "label": "security.ts",
+      "norm_label": "security.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/security.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 146,
+      "file_type": "code",
+      "id": "security_buildcanonicalcheckoutproducts",
+      "label": "buildCanonicalCheckoutProducts()",
+      "norm_label": "buildcanonicalcheckoutproducts()",
+      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/security.ts",
+      "source_location": "L42"
+    },
+    {
+      "community": 146,
+      "file_type": "code",
+      "id": "security_hasvalidpositivequantity",
+      "label": "hasValidPositiveQuantity()",
+      "norm_label": "hasvalidpositivequantity()",
+      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/security.ts",
+      "source_location": "L27"
+    },
+    {
+      "community": 146,
+      "file_type": "code",
+      "id": "security_isamounttampered",
+      "label": "isAmountTampered()",
+      "norm_label": "isamounttampered()",
+      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/security.ts",
+      "source_location": "L65"
+    },
+    {
+      "community": 146,
+      "file_type": "code",
+      "id": "security_isauthorizedresourceowner",
+      "label": "isAuthorizedResourceOwner()",
+      "norm_label": "isauthorizedresourceowner()",
+      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/security.ts",
+      "source_location": "L31"
+    },
+    {
+      "community": 146,
+      "file_type": "code",
+      "id": "security_isduplicatechargesuccess",
+      "label": "isDuplicateChargeSuccess()",
+      "norm_label": "isduplicatechargesuccess()",
+      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/security.ts",
+      "source_location": "L76"
     },
     {
       "community": 1460,
@@ -65856,55 +65958,55 @@
     {
       "community": 147,
       "file_type": "code",
-      "id": "orderemailservice_buildorderstatusmessage",
-      "label": "buildOrderStatusMessage()",
-      "norm_label": "buildorderstatusmessage()",
-      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
+      "id": "listregistercatalog_listregistercatalog",
+      "label": "listRegisterCatalog()",
+      "norm_label": "listregistercatalog()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/listRegisterCatalog.ts",
+      "source_location": "L95"
+    },
+    {
+      "community": 147,
+      "file_type": "code",
+      "id": "listregistercatalog_listregistercatalogavailability",
+      "label": "listRegisterCatalogAvailability()",
+      "norm_label": "listregistercatalogavailability()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/listRegisterCatalog.ts",
+      "source_location": "L137"
+    },
+    {
+      "community": 147,
+      "file_type": "code",
+      "id": "listregistercatalog_mapskutoregistercatalogrow",
+      "label": "mapSkuToRegisterCatalogRow()",
+      "norm_label": "mapskutoregistercatalogrow()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/listRegisterCatalog.ts",
+      "source_location": "L70"
+    },
+    {
+      "community": 147,
+      "file_type": "code",
+      "id": "listregistercatalog_readcategoryname",
+      "label": "readCategoryName()",
+      "norm_label": "readcategoryname()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/listRegisterCatalog.ts",
+      "source_location": "L32"
+    },
+    {
+      "community": 147,
+      "file_type": "code",
+      "id": "listregistercatalog_readcolorname",
+      "label": "readColorName()",
+      "norm_label": "readcolorname()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/listRegisterCatalog.ts",
       "source_location": "L49"
     },
     {
       "community": 147,
       "file_type": "code",
-      "id": "orderemailservice_buildpickupdetails",
-      "label": "buildPickupDetails()",
-      "norm_label": "buildpickupdetails()",
-      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
-      "source_location": "L77"
-    },
-    {
-      "community": 147,
-      "file_type": "code",
-      "id": "orderemailservice_sendpaymentverificationemails",
-      "label": "sendPaymentVerificationEmails()",
-      "norm_label": "sendpaymentverificationemails()",
-      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
-      "source_location": "L217"
-    },
-    {
-      "community": 147,
-      "file_type": "code",
-      "id": "orderemailservice_sendpodorderemails",
-      "label": "sendPODOrderEmails()",
-      "norm_label": "sendpodorderemails()",
-      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
-      "source_location": "L96"
-    },
-    {
-      "community": 147,
-      "file_type": "code",
-      "id": "orderemailservice_shouldsendtoadmins",
-      "label": "shouldSendToAdmins()",
-      "norm_label": "shouldsendtoadmins()",
-      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
-      "source_location": "L42"
-    },
-    {
-      "community": 147,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_services_orderemailservice_ts",
-      "label": "orderEmailService.ts",
-      "norm_label": "orderemailservice.ts",
-      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
+      "id": "packages_athena_webapp_convex_pos_application_queries_listregistercatalog_ts",
+      "label": "listRegisterCatalog.ts",
+      "norm_label": "listregistercatalog.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/listRegisterCatalog.ts",
       "source_location": "L1"
     },
     {
@@ -66000,56 +66102,56 @@
     {
       "community": 148,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_stockops_vendors_ts",
-      "label": "vendors.ts",
-      "norm_label": "vendors.ts",
-      "source_file": "packages/athena-webapp/convex/stockOps/vendors.ts",
+      "id": "orderemailservice_buildorderstatusmessage",
+      "label": "buildOrderStatusMessage()",
+      "norm_label": "buildorderstatusmessage()",
+      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
+      "source_location": "L49"
+    },
+    {
+      "community": 148,
+      "file_type": "code",
+      "id": "orderemailservice_buildpickupdetails",
+      "label": "buildPickupDetails()",
+      "norm_label": "buildpickupdetails()",
+      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
+      "source_location": "L77"
+    },
+    {
+      "community": 148,
+      "file_type": "code",
+      "id": "orderemailservice_sendpaymentverificationemails",
+      "label": "sendPaymentVerificationEmails()",
+      "norm_label": "sendpaymentverificationemails()",
+      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
+      "source_location": "L217"
+    },
+    {
+      "community": 148,
+      "file_type": "code",
+      "id": "orderemailservice_sendpodorderemails",
+      "label": "sendPODOrderEmails()",
+      "norm_label": "sendpodorderemails()",
+      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
+      "source_location": "L96"
+    },
+    {
+      "community": 148,
+      "file_type": "code",
+      "id": "orderemailservice_shouldsendtoadmins",
+      "label": "shouldSendToAdmins()",
+      "norm_label": "shouldsendtoadmins()",
+      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
+      "source_location": "L42"
+    },
+    {
+      "community": 148,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_services_orderemailservice_ts",
+      "label": "orderEmailService.ts",
+      "norm_label": "orderemailservice.ts",
+      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 148,
-      "file_type": "code",
-      "id": "vendors_createvendorcommandwithctx",
-      "label": "createVendorCommandWithCtx()",
-      "norm_label": "createvendorcommandwithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/vendors.ts",
-      "source_location": "L118"
-    },
-    {
-      "community": 148,
-      "file_type": "code",
-      "id": "vendors_createvendorwithctx",
-      "label": "createVendorWithCtx()",
-      "norm_label": "createvendorwithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/vendors.ts",
-      "source_location": "L74"
-    },
-    {
-      "community": 148,
-      "file_type": "code",
-      "id": "vendors_mapcreatevendorerror",
-      "label": "mapCreateVendorError()",
-      "norm_label": "mapcreatevendorerror()",
-      "source_file": "packages/athena-webapp/convex/stockOps/vendors.ts",
-      "source_location": "L45"
-    },
-    {
-      "community": 148,
-      "file_type": "code",
-      "id": "vendors_normalizevendorlookupkey",
-      "label": "normalizeVendorLookupKey()",
-      "norm_label": "normalizevendorlookupkey()",
-      "source_file": "packages/athena-webapp/convex/stockOps/vendors.ts",
-      "source_location": "L37"
-    },
-    {
-      "community": 148,
-      "file_type": "code",
-      "id": "vendors_trimoptional",
-      "label": "trimOptional()",
-      "norm_label": "trimoptional()",
-      "source_file": "packages/athena-webapp/convex/stockOps/vendors.ts",
-      "source_location": "L32"
     },
     {
       "community": 1480,
@@ -66144,56 +66246,56 @@
     {
       "community": 149,
       "file_type": "code",
-      "id": "convexpaginationantipatterncheck_find_block_end",
-      "label": "find_block_end()",
-      "norm_label": "find_block_end()",
-      "source_file": "packages/athena-webapp/scripts/convexPaginationAntiPatternCheck.py",
-      "source_location": "L123"
-    },
-    {
-      "community": 149,
-      "file_type": "code",
-      "id": "convexpaginationantipatterncheck_list_convex_files",
-      "label": "list_convex_files()",
-      "norm_label": "list_convex_files()",
-      "source_file": "packages/athena-webapp/scripts/convexPaginationAntiPatternCheck.py",
-      "source_location": "L187"
-    },
-    {
-      "community": 149,
-      "file_type": "code",
-      "id": "convexpaginationantipatterncheck_main",
-      "label": "main()",
-      "norm_label": "main()",
-      "source_file": "packages/athena-webapp/scripts/convexPaginationAntiPatternCheck.py",
-      "source_location": "L207"
-    },
-    {
-      "community": 149,
-      "file_type": "code",
-      "id": "convexpaginationantipatterncheck_scan_file",
-      "label": "scan_file()",
-      "norm_label": "scan_file()",
-      "source_file": "packages/athena-webapp/scripts/convexPaginationAntiPatternCheck.py",
-      "source_location": "L137"
-    },
-    {
-      "community": 149,
-      "file_type": "code",
-      "id": "convexpaginationantipatterncheck_strip_code",
-      "label": "strip_code()",
-      "norm_label": "strip_code()",
-      "source_file": "packages/athena-webapp/scripts/convexPaginationAntiPatternCheck.py",
-      "source_location": "L9"
-    },
-    {
-      "community": 149,
-      "file_type": "code",
-      "id": "packages_athena_webapp_scripts_convexpaginationantipatterncheck_py",
-      "label": "convexPaginationAntiPatternCheck.py",
-      "norm_label": "convexpaginationantipatterncheck.py",
-      "source_file": "packages/athena-webapp/scripts/convexPaginationAntiPatternCheck.py",
+      "id": "packages_athena_webapp_convex_stockops_vendors_ts",
+      "label": "vendors.ts",
+      "norm_label": "vendors.ts",
+      "source_file": "packages/athena-webapp/convex/stockOps/vendors.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 149,
+      "file_type": "code",
+      "id": "vendors_createvendorcommandwithctx",
+      "label": "createVendorCommandWithCtx()",
+      "norm_label": "createvendorcommandwithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/vendors.ts",
+      "source_location": "L118"
+    },
+    {
+      "community": 149,
+      "file_type": "code",
+      "id": "vendors_createvendorwithctx",
+      "label": "createVendorWithCtx()",
+      "norm_label": "createvendorwithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/vendors.ts",
+      "source_location": "L74"
+    },
+    {
+      "community": 149,
+      "file_type": "code",
+      "id": "vendors_mapcreatevendorerror",
+      "label": "mapCreateVendorError()",
+      "norm_label": "mapcreatevendorerror()",
+      "source_file": "packages/athena-webapp/convex/stockOps/vendors.ts",
+      "source_location": "L45"
+    },
+    {
+      "community": 149,
+      "file_type": "code",
+      "id": "vendors_normalizevendorlookupkey",
+      "label": "normalizeVendorLookupKey()",
+      "norm_label": "normalizevendorlookupkey()",
+      "source_file": "packages/athena-webapp/convex/stockOps/vendors.ts",
+      "source_location": "L37"
+    },
+    {
+      "community": 149,
+      "file_type": "code",
+      "id": "vendors_trimoptional",
+      "label": "trimOptional()",
+      "norm_label": "trimoptional()",
+      "source_file": "packages/athena-webapp/convex/stockOps/vendors.ts",
+      "source_location": "L32"
     },
     {
       "community": 1490,
@@ -66504,55 +66606,55 @@
     {
       "community": 150,
       "file_type": "code",
-      "id": "commandresult_approvalrequired",
-      "label": "approvalRequired()",
-      "norm_label": "approvalrequired()",
-      "source_file": "packages/athena-webapp/shared/commandResult.ts",
-      "source_location": "L62"
+      "id": "convexpaginationantipatterncheck_find_block_end",
+      "label": "find_block_end()",
+      "norm_label": "find_block_end()",
+      "source_file": "packages/athena-webapp/scripts/convexPaginationAntiPatternCheck.py",
+      "source_location": "L123"
     },
     {
       "community": 150,
       "file_type": "code",
-      "id": "commandresult_isapprovalrequiredresult",
-      "label": "isApprovalRequiredResult()",
-      "norm_label": "isapprovalrequiredresult()",
-      "source_file": "packages/athena-webapp/shared/commandResult.ts",
-      "source_location": "L77"
+      "id": "convexpaginationantipatterncheck_list_convex_files",
+      "label": "list_convex_files()",
+      "norm_label": "list_convex_files()",
+      "source_file": "packages/athena-webapp/scripts/convexPaginationAntiPatternCheck.py",
+      "source_location": "L187"
     },
     {
       "community": 150,
       "file_type": "code",
-      "id": "commandresult_isusererrorresult",
-      "label": "isUserErrorResult()",
-      "norm_label": "isusererrorresult()",
-      "source_file": "packages/athena-webapp/shared/commandResult.ts",
-      "source_location": "L71"
+      "id": "convexpaginationantipatterncheck_main",
+      "label": "main()",
+      "norm_label": "main()",
+      "source_file": "packages/athena-webapp/scripts/convexPaginationAntiPatternCheck.py",
+      "source_location": "L207"
     },
     {
       "community": 150,
       "file_type": "code",
-      "id": "commandresult_ok",
-      "label": "ok()",
-      "norm_label": "ok()",
-      "source_file": "packages/athena-webapp/shared/commandResult.ts",
-      "source_location": "L48"
+      "id": "convexpaginationantipatterncheck_scan_file",
+      "label": "scan_file()",
+      "norm_label": "scan_file()",
+      "source_file": "packages/athena-webapp/scripts/convexPaginationAntiPatternCheck.py",
+      "source_location": "L137"
     },
     {
       "community": 150,
       "file_type": "code",
-      "id": "commandresult_usererror",
-      "label": "userError()",
-      "norm_label": "usererror()",
-      "source_file": "packages/athena-webapp/shared/commandResult.ts",
-      "source_location": "L55"
+      "id": "convexpaginationantipatterncheck_strip_code",
+      "label": "strip_code()",
+      "norm_label": "strip_code()",
+      "source_file": "packages/athena-webapp/scripts/convexPaginationAntiPatternCheck.py",
+      "source_location": "L9"
     },
     {
       "community": 150,
       "file_type": "code",
-      "id": "packages_athena_webapp_shared_commandresult_ts",
-      "label": "commandResult.ts",
-      "norm_label": "commandresult.ts",
-      "source_file": "packages/athena-webapp/shared/commandResult.ts",
+      "id": "packages_athena_webapp_scripts_convexpaginationantipatterncheck_py",
+      "label": "convexPaginationAntiPatternCheck.py",
+      "norm_label": "convexpaginationantipatterncheck.py",
+      "source_file": "packages/athena-webapp/scripts/convexPaginationAntiPatternCheck.py",
       "source_location": "L1"
     },
     {
@@ -66648,56 +66750,56 @@
     {
       "community": 151,
       "file_type": "code",
-      "id": "packages_athena_webapp_shared_registersessionstatus_ts",
-      "label": "registerSessionStatus.ts",
-      "norm_label": "registersessionstatus.ts",
-      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
+      "id": "commandresult_approvalrequired",
+      "label": "approvalRequired()",
+      "norm_label": "approvalrequired()",
+      "source_file": "packages/athena-webapp/shared/commandResult.ts",
+      "source_location": "L62"
+    },
+    {
+      "community": 151,
+      "file_type": "code",
+      "id": "commandresult_isapprovalrequiredresult",
+      "label": "isApprovalRequiredResult()",
+      "norm_label": "isapprovalrequiredresult()",
+      "source_file": "packages/athena-webapp/shared/commandResult.ts",
+      "source_location": "L77"
+    },
+    {
+      "community": 151,
+      "file_type": "code",
+      "id": "commandresult_isusererrorresult",
+      "label": "isUserErrorResult()",
+      "norm_label": "isusererrorresult()",
+      "source_file": "packages/athena-webapp/shared/commandResult.ts",
+      "source_location": "L71"
+    },
+    {
+      "community": 151,
+      "file_type": "code",
+      "id": "commandresult_ok",
+      "label": "ok()",
+      "norm_label": "ok()",
+      "source_file": "packages/athena-webapp/shared/commandResult.ts",
+      "source_location": "L48"
+    },
+    {
+      "community": 151,
+      "file_type": "code",
+      "id": "commandresult_usererror",
+      "label": "userError()",
+      "norm_label": "usererror()",
+      "source_file": "packages/athena-webapp/shared/commandResult.ts",
+      "source_location": "L55"
+    },
+    {
+      "community": 151,
+      "file_type": "code",
+      "id": "packages_athena_webapp_shared_commandresult_ts",
+      "label": "commandResult.ts",
+      "norm_label": "commandresult.ts",
+      "source_file": "packages/athena-webapp/shared/commandResult.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 151,
-      "file_type": "code",
-      "id": "registersessionstatus_includesregistersessionstatus",
-      "label": "includesRegisterSessionStatus()",
-      "norm_label": "includesregistersessionstatus()",
-      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
-      "source_location": "L33"
-    },
-    {
-      "community": 151,
-      "file_type": "code",
-      "id": "registersessionstatus_iscashcontrolvisibleregistersessionstatus",
-      "label": "isCashControlVisibleRegisterSessionStatus()",
-      "norm_label": "iscashcontrolvisibleregistersessionstatus()",
-      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
-      "source_location": "L57"
-    },
-    {
-      "community": 151,
-      "file_type": "code",
-      "id": "registersessionstatus_isposusableregistersessionstatus",
-      "label": "isPosUsableRegisterSessionStatus()",
-      "norm_label": "isposusableregistersessionstatus()",
-      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
-      "source_location": "L43"
-    },
-    {
-      "community": 151,
-      "file_type": "code",
-      "id": "registersessionstatus_isregistersessionconflictblockingstatus",
-      "label": "isRegisterSessionConflictBlockingStatus()",
-      "norm_label": "isregistersessionconflictblockingstatus()",
-      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
-      "source_location": "L50"
-    },
-    {
-      "community": 151,
-      "file_type": "code",
-      "id": "registersessionstatus_isregistersessionstatus",
-      "label": "isRegisterSessionStatus()",
-      "norm_label": "isregistersessionstatus()",
-      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
-      "source_location": "L24"
     },
     {
       "community": 1510,
@@ -66792,56 +66894,56 @@
     {
       "community": 152,
       "file_type": "code",
-      "id": "data_table_toolbar_datatabletoolbar",
-      "label": "DataTableToolbar()",
-      "norm_label": "datatabletoolbar()",
-      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar.tsx",
-      "source_location": "L23"
-    },
-    {
-      "community": 152,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_toolbar_tsx",
-      "label": "data-table-toolbar.tsx",
-      "norm_label": "data-table-toolbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table-toolbar.tsx",
+      "id": "packages_athena_webapp_shared_registersessionstatus_ts",
+      "label": "registerSessionStatus.ts",
+      "norm_label": "registersessionstatus.ts",
+      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
       "source_location": "L1"
     },
     {
       "community": 152,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_table_data_table_toolbar_tsx",
-      "label": "data-table-toolbar.tsx",
-      "norm_label": "data-table-toolbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/table/data-table-toolbar.tsx",
-      "source_location": "L1"
+      "id": "registersessionstatus_includesregistersessionstatus",
+      "label": "includesRegisterSessionStatus()",
+      "norm_label": "includesregistersessionstatus()",
+      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
+      "source_location": "L33"
     },
     {
       "community": 152,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_base_table_data_table_toolbar_tsx",
-      "label": "data-table-toolbar.tsx",
-      "norm_label": "data-table-toolbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/base/table/data-table-toolbar.tsx",
-      "source_location": "L1"
+      "id": "registersessionstatus_iscashcontrolvisibleregistersessionstatus",
+      "label": "isCashControlVisibleRegisterSessionStatus()",
+      "norm_label": "iscashcontrolvisibleregistersessionstatus()",
+      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
+      "source_location": "L57"
     },
     {
       "community": 152,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_toolbar_tsx",
-      "label": "data-table-toolbar.tsx",
-      "norm_label": "data-table-toolbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/table/data-table-toolbar.tsx",
-      "source_location": "L1"
+      "id": "registersessionstatus_isposusableregistersessionstatus",
+      "label": "isPosUsableRegisterSessionStatus()",
+      "norm_label": "isposusableregistersessionstatus()",
+      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
+      "source_location": "L43"
     },
     {
       "community": 152,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_table_data_table_toolbar_tsx",
-      "label": "data-table-toolbar.tsx",
-      "norm_label": "data-table-toolbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar.tsx",
-      "source_location": "L1"
+      "id": "registersessionstatus_isregistersessionconflictblockingstatus",
+      "label": "isRegisterSessionConflictBlockingStatus()",
+      "norm_label": "isregistersessionconflictblockingstatus()",
+      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
+      "source_location": "L50"
+    },
+    {
+      "community": 152,
+      "file_type": "code",
+      "id": "registersessionstatus_isregistersessionstatus",
+      "label": "isRegisterSessionStatus()",
+      "norm_label": "isregistersessionstatus()",
+      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
+      "source_location": "L24"
     },
     {
       "community": 1520,
@@ -66936,55 +67038,55 @@
     {
       "community": 153,
       "file_type": "code",
-      "id": "inputotp_formatrequestdelay",
-      "label": "formatRequestDelay()",
-      "norm_label": "formatrequestdelay()",
-      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
-      "source_location": "L46"
+      "id": "data_table_toolbar_datatabletoolbar",
+      "label": "DataTableToolbar()",
+      "norm_label": "datatabletoolbar()",
+      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar.tsx",
+      "source_location": "L23"
     },
     {
       "community": 153,
       "file_type": "code",
-      "id": "inputotp_handlepinchange",
-      "label": "handlePinChange()",
-      "norm_label": "handlepinchange()",
-      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
-      "source_location": "L95"
+      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_toolbar_tsx",
+      "label": "data-table-toolbar.tsx",
+      "norm_label": "data-table-toolbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table-toolbar.tsx",
+      "source_location": "L1"
     },
     {
       "community": 153,
       "file_type": "code",
-      "id": "inputotp_handlerequestnewcode",
-      "label": "handleRequestNewCode()",
-      "norm_label": "handlerequestnewcode()",
-      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
-      "source_location": "L143"
+      "id": "packages_athena_webapp_src_components_analytics_table_data_table_toolbar_tsx",
+      "label": "data-table-toolbar.tsx",
+      "norm_label": "data-table-toolbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/table/data-table-toolbar.tsx",
+      "source_location": "L1"
     },
     {
       "community": 153,
       "file_type": "code",
-      "id": "inputotp_normalizeotpcode",
-      "label": "normalizeOtpCode()",
-      "norm_label": "normalizeotpcode()",
-      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
-      "source_location": "L30"
+      "id": "packages_athena_webapp_src_components_base_table_data_table_toolbar_tsx",
+      "label": "data-table-toolbar.tsx",
+      "norm_label": "data-table-toolbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/base/table/data-table-toolbar.tsx",
+      "source_location": "L1"
     },
     {
       "community": 153,
       "file_type": "code",
-      "id": "inputotp_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
-      "source_location": "L105"
+      "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_toolbar_tsx",
+      "label": "data-table-toolbar.tsx",
+      "norm_label": "data-table-toolbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/table/data-table-toolbar.tsx",
+      "source_location": "L1"
     },
     {
       "community": 153,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_auth_login_inputotp_tsx",
-      "label": "InputOTP.tsx",
-      "norm_label": "inputotp.tsx",
-      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
+      "id": "packages_athena_webapp_src_components_user_bags_table_data_table_toolbar_tsx",
+      "label": "data-table-toolbar.tsx",
+      "norm_label": "data-table-toolbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar.tsx",
       "source_location": "L1"
     },
     {
@@ -67224,56 +67326,56 @@
     {
       "community": 155,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_common_pagelevelheader_tsx",
-      "label": "PageLevelHeader.tsx",
-      "norm_label": "pagelevelheader.tsx",
-      "source_file": "packages/athena-webapp/src/components/common/PageLevelHeader.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 155,
-      "file_type": "code",
-      "id": "pagelevelheader_pagelevelheader",
-      "label": "PageLevelHeader()",
-      "norm_label": "pagelevelheader()",
-      "source_file": "packages/athena-webapp/src/components/common/PageLevelHeader.tsx",
-      "source_location": "L12"
-    },
-    {
-      "community": 155,
-      "file_type": "code",
-      "id": "pagelevelheader_pageworkspace",
-      "label": "PageWorkspace()",
-      "norm_label": "pageworkspace()",
-      "source_file": "packages/athena-webapp/src/components/common/PageLevelHeader.tsx",
+      "id": "inputotp_formatrequestdelay",
+      "label": "formatRequestDelay()",
+      "norm_label": "formatrequestdelay()",
+      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
       "source_location": "L46"
     },
     {
       "community": 155,
       "file_type": "code",
-      "id": "pagelevelheader_pageworkspacegrid",
-      "label": "PageWorkspaceGrid()",
-      "norm_label": "pageworkspacegrid()",
-      "source_file": "packages/athena-webapp/src/components/common/PageLevelHeader.tsx",
-      "source_location": "L63"
+      "id": "inputotp_handlepinchange",
+      "label": "handlePinChange()",
+      "norm_label": "handlepinchange()",
+      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
+      "source_location": "L95"
     },
     {
       "community": 155,
       "file_type": "code",
-      "id": "pagelevelheader_pageworkspacemain",
-      "label": "PageWorkspaceMain()",
-      "norm_label": "pageworkspacemain()",
-      "source_file": "packages/athena-webapp/src/components/common/PageLevelHeader.tsx",
-      "source_location": "L85"
+      "id": "inputotp_handlerequestnewcode",
+      "label": "handleRequestNewCode()",
+      "norm_label": "handlerequestnewcode()",
+      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
+      "source_location": "L143"
     },
     {
       "community": 155,
       "file_type": "code",
-      "id": "pagelevelheader_pageworkspacerail",
-      "label": "PageWorkspaceRail()",
-      "norm_label": "pageworkspacerail()",
-      "source_file": "packages/athena-webapp/src/components/common/PageLevelHeader.tsx",
-      "source_location": "L97"
+      "id": "inputotp_normalizeotpcode",
+      "label": "normalizeOtpCode()",
+      "norm_label": "normalizeotpcode()",
+      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
+      "source_location": "L30"
+    },
+    {
+      "community": 155,
+      "file_type": "code",
+      "id": "inputotp_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
+      "source_location": "L105"
+    },
+    {
+      "community": 155,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_auth_login_inputotp_tsx",
+      "label": "InputOTP.tsx",
+      "norm_label": "inputotp.tsx",
+      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
+      "source_location": "L1"
     },
     {
       "community": 1550,
@@ -67368,56 +67470,56 @@
     {
       "community": 156,
       "file_type": "code",
-      "id": "bannermessageeditor_getcountdownstatus",
-      "label": "getCountdownStatus()",
-      "norm_label": "getcountdownstatus()",
-      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
-      "source_location": "L123"
+      "id": "packages_athena_webapp_src_components_common_pagelevelheader_tsx",
+      "label": "PageLevelHeader.tsx",
+      "norm_label": "pagelevelheader.tsx",
+      "source_file": "packages/athena-webapp/src/components/common/PageLevelHeader.tsx",
+      "source_location": "L1"
     },
     {
       "community": 156,
       "file_type": "code",
-      "id": "bannermessageeditor_handleactivetoggle",
-      "label": "handleActiveToggle()",
-      "norm_label": "handleactivetoggle()",
-      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
-      "source_location": "L91"
+      "id": "pagelevelheader_pagelevelheader",
+      "label": "PageLevelHeader()",
+      "norm_label": "pagelevelheader()",
+      "source_file": "packages/athena-webapp/src/components/common/PageLevelHeader.tsx",
+      "source_location": "L12"
     },
     {
       "community": 156,
       "file_type": "code",
-      "id": "bannermessageeditor_handleclear",
-      "label": "handleClear()",
-      "norm_label": "handleclear()",
-      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
-      "source_location": "L66"
-    },
-    {
-      "community": 156,
-      "file_type": "code",
-      "id": "bannermessageeditor_handlecountdownchange",
-      "label": "handleCountdownChange()",
-      "norm_label": "handlecountdownchange()",
-      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
-      "source_location": "L113"
-    },
-    {
-      "community": 156,
-      "file_type": "code",
-      "id": "bannermessageeditor_handlesave",
-      "label": "handleSave()",
-      "norm_label": "handlesave()",
-      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
+      "id": "pagelevelheader_pageworkspace",
+      "label": "PageWorkspace()",
+      "norm_label": "pageworkspace()",
+      "source_file": "packages/athena-webapp/src/components/common/PageLevelHeader.tsx",
       "source_location": "L46"
     },
     {
       "community": 156,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_homepage_bannermessageeditor_tsx",
-      "label": "BannerMessageEditor.tsx",
-      "norm_label": "bannermessageeditor.tsx",
-      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
-      "source_location": "L1"
+      "id": "pagelevelheader_pageworkspacegrid",
+      "label": "PageWorkspaceGrid()",
+      "norm_label": "pageworkspacegrid()",
+      "source_file": "packages/athena-webapp/src/components/common/PageLevelHeader.tsx",
+      "source_location": "L63"
+    },
+    {
+      "community": 156,
+      "file_type": "code",
+      "id": "pagelevelheader_pageworkspacemain",
+      "label": "PageWorkspaceMain()",
+      "norm_label": "pageworkspacemain()",
+      "source_file": "packages/athena-webapp/src/components/common/PageLevelHeader.tsx",
+      "source_location": "L85"
+    },
+    {
+      "community": 156,
+      "file_type": "code",
+      "id": "pagelevelheader_pageworkspacerail",
+      "label": "PageWorkspaceRail()",
+      "norm_label": "pageworkspacerail()",
+      "source_file": "packages/athena-webapp/src/components/common/PageLevelHeader.tsx",
+      "source_location": "L97"
     },
     {
       "community": 1560,
@@ -67458,6 +67560,60 @@
     {
       "community": 157,
       "file_type": "code",
+      "id": "bannermessageeditor_getcountdownstatus",
+      "label": "getCountdownStatus()",
+      "norm_label": "getcountdownstatus()",
+      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
+      "source_location": "L123"
+    },
+    {
+      "community": 157,
+      "file_type": "code",
+      "id": "bannermessageeditor_handleactivetoggle",
+      "label": "handleActiveToggle()",
+      "norm_label": "handleactivetoggle()",
+      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
+      "source_location": "L91"
+    },
+    {
+      "community": 157,
+      "file_type": "code",
+      "id": "bannermessageeditor_handleclear",
+      "label": "handleClear()",
+      "norm_label": "handleclear()",
+      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
+      "source_location": "L66"
+    },
+    {
+      "community": 157,
+      "file_type": "code",
+      "id": "bannermessageeditor_handlecountdownchange",
+      "label": "handleCountdownChange()",
+      "norm_label": "handlecountdownchange()",
+      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
+      "source_location": "L113"
+    },
+    {
+      "community": 157,
+      "file_type": "code",
+      "id": "bannermessageeditor_handlesave",
+      "label": "handleSave()",
+      "norm_label": "handlesave()",
+      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
+      "source_location": "L46"
+    },
+    {
+      "community": 157,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_homepage_bannermessageeditor_tsx",
+      "label": "BannerMessageEditor.tsx",
+      "norm_label": "bannermessageeditor.tsx",
+      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 158,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_useapprovedcommand_tsx",
       "label": "useApprovedCommand.tsx",
       "norm_label": "useapprovedcommand.tsx",
@@ -67465,7 +67621,7 @@
       "source_location": "L1"
     },
     {
-      "community": 157,
+      "community": 158,
       "file_type": "code",
       "id": "useapprovedcommand_buildapprovalretryargs",
       "label": "buildApprovalRetryArgs()",
@@ -67474,7 +67630,7 @@
       "source_location": "L86"
     },
     {
-      "community": 157,
+      "community": 158,
       "file_type": "code",
       "id": "useapprovedcommand_getasyncapprovalrequestid",
       "label": "getAsyncApprovalRequestId()",
@@ -67483,7 +67639,7 @@
       "source_location": "L74"
     },
     {
-      "community": 157,
+      "community": 158,
       "file_type": "code",
       "id": "useapprovedcommand_hasasyncapprovalrequest",
       "label": "hasAsyncApprovalRequest()",
@@ -67492,7 +67648,7 @@
       "source_location": "L68"
     },
     {
-      "community": 157,
+      "community": 158,
       "file_type": "code",
       "id": "useapprovedcommand_hasinlinemanagerproof",
       "label": "hasInlineManagerProof()",
@@ -67501,7 +67657,7 @@
       "source_location": "L62"
     },
     {
-      "community": 157,
+      "community": 158,
       "file_type": "code",
       "id": "useapprovedcommand_useapprovedcommand",
       "label": "useApprovedCommand()",
@@ -67510,7 +67666,7 @@
       "source_location": "L98"
     },
     {
-      "community": 158,
+      "community": 159,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_procurement_receivingview_tsx",
       "label": "ReceivingView.tsx",
@@ -67519,7 +67675,7 @@
       "source_location": "L1"
     },
     {
-      "community": 158,
+      "community": 159,
       "file_type": "code",
       "id": "receivingview_builddefaultreceivedquantities",
       "label": "buildDefaultReceivedQuantities()",
@@ -67528,7 +67684,7 @@
       "source_location": "L50"
     },
     {
-      "community": 158,
+      "community": 159,
       "file_type": "code",
       "id": "receivingview_buildreceivedquantitiesaftersubmission",
       "label": "buildReceivedQuantitiesAfterSubmission()",
@@ -67537,7 +67693,7 @@
       "source_location": "L59"
     },
     {
-      "community": 158,
+      "community": 159,
       "file_type": "code",
       "id": "receivingview_buildsubmissionkey",
       "label": "buildSubmissionKey()",
@@ -67546,7 +67702,7 @@
       "source_location": "L32"
     },
     {
-      "community": 158,
+      "community": 159,
       "file_type": "code",
       "id": "receivingview_parselineitemdescription",
       "label": "parseLineItemDescription()",
@@ -67555,67 +67711,13 @@
       "source_location": "L36"
     },
     {
-      "community": 158,
+      "community": 159,
       "file_type": "code",
       "id": "receivingview_receivingview",
       "label": "ReceivingView()",
       "norm_label": "receivingview()",
       "source_file": "packages/athena-webapp/src/components/procurement/ReceivingView.tsx",
       "source_location": "L85"
-    },
-    {
-      "community": 159,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_reviews_reviewsview_tsx",
-      "label": "ReviewsView.tsx",
-      "norm_label": "reviewsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 159,
-      "file_type": "code",
-      "id": "reviewsview_handleapprove",
-      "label": "handleApprove()",
-      "norm_label": "handleapprove()",
-      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
-      "source_location": "L44"
-    },
-    {
-      "community": 159,
-      "file_type": "code",
-      "id": "reviewsview_handlepublish",
-      "label": "handlePublish()",
-      "norm_label": "handlepublish()",
-      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
-      "source_location": "L80"
-    },
-    {
-      "community": 159,
-      "file_type": "code",
-      "id": "reviewsview_handlereject",
-      "label": "handleReject()",
-      "norm_label": "handlereject()",
-      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
-      "source_location": "L62"
-    },
-    {
-      "community": 159,
-      "file_type": "code",
-      "id": "reviewsview_handleunpublish",
-      "label": "handleUnpublish()",
-      "norm_label": "handleunpublish()",
-      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
-      "source_location": "L98"
-    },
-    {
-      "community": 159,
-      "file_type": "code",
-      "id": "reviewsview_header",
-      "label": "Header()",
-      "norm_label": "header()",
-      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
-      "source_location": "L15"
     },
     {
       "community": 16,
@@ -67836,6 +67938,60 @@
     {
       "community": 160,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_reviews_reviewsview_tsx",
+      "label": "ReviewsView.tsx",
+      "norm_label": "reviewsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 160,
+      "file_type": "code",
+      "id": "reviewsview_handleapprove",
+      "label": "handleApprove()",
+      "norm_label": "handleapprove()",
+      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
+      "source_location": "L44"
+    },
+    {
+      "community": 160,
+      "file_type": "code",
+      "id": "reviewsview_handlepublish",
+      "label": "handlePublish()",
+      "norm_label": "handlepublish()",
+      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
+      "source_location": "L80"
+    },
+    {
+      "community": 160,
+      "file_type": "code",
+      "id": "reviewsview_handlereject",
+      "label": "handleReject()",
+      "norm_label": "handlereject()",
+      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
+      "source_location": "L62"
+    },
+    {
+      "community": 160,
+      "file_type": "code",
+      "id": "reviewsview_handleunpublish",
+      "label": "handleUnpublish()",
+      "norm_label": "handleunpublish()",
+      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
+      "source_location": "L98"
+    },
+    {
+      "community": 160,
+      "file_type": "code",
+      "id": "reviewsview_header",
+      "label": "Header()",
+      "norm_label": "header()",
+      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
+      "source_location": "L15"
+    },
+    {
+      "community": 161,
+      "file_type": "code",
       "id": "image_uploader_ondragend",
       "label": "onDragEnd()",
       "norm_label": "ondragend()",
@@ -67843,7 +67999,7 @@
       "source_location": "L100"
     },
     {
-      "community": 160,
+      "community": 161,
       "file_type": "code",
       "id": "image_uploader_ondrop",
       "label": "onDrop()",
@@ -67852,7 +68008,7 @@
       "source_location": "L20"
     },
     {
-      "community": 160,
+      "community": 161,
       "file_type": "code",
       "id": "image_uploader_removeimage",
       "label": "removeImage()",
@@ -67861,7 +68017,7 @@
       "source_location": "L31"
     },
     {
-      "community": 160,
+      "community": 161,
       "file_type": "code",
       "id": "image_uploader_unmarkfordeletion",
       "label": "unmarkForDeletion()",
@@ -67870,7 +68026,7 @@
       "source_location": "L46"
     },
     {
-      "community": 160,
+      "community": 161,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_image_uploader_tsx",
       "label": "image-uploader.tsx",
@@ -67879,7 +68035,7 @@
       "source_location": "L1"
     },
     {
-      "community": 160,
+      "community": 161,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_image_uploader_tsx",
       "label": "image-uploader.tsx",
@@ -67888,7 +68044,7 @@
       "source_location": "L1"
     },
     {
-      "community": 161,
+      "community": 162,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_sidebar_tsx",
       "label": "sidebar.tsx",
@@ -67897,7 +68053,7 @@
       "source_location": "L1"
     },
     {
-      "community": 161,
+      "community": 162,
       "file_type": "code",
       "id": "sidebar_cn",
       "label": "cn()",
@@ -67906,7 +68062,7 @@
       "source_location": "L147"
     },
     {
-      "community": 161,
+      "community": 162,
       "file_type": "code",
       "id": "sidebar_handlekeydown",
       "label": "handleKeyDown()",
@@ -67915,7 +68071,7 @@
       "source_location": "L105"
     },
     {
-      "community": 161,
+      "community": 162,
       "file_type": "code",
       "id": "sidebar_handleonhover",
       "label": "handleOnHover()",
@@ -67924,7 +68080,7 @@
       "source_location": "L224"
     },
     {
-      "community": 161,
+      "community": 162,
       "file_type": "code",
       "id": "sidebar_handleonmouseleave",
       "label": "handleOnMouseLeave()",
@@ -67933,7 +68089,7 @@
       "source_location": "L228"
     },
     {
-      "community": 161,
+      "community": 162,
       "file_type": "code",
       "id": "sidebar_usesidebar",
       "label": "useSidebar()",
@@ -67942,7 +68098,7 @@
       "source_location": "L45"
     },
     {
-      "community": 162,
+      "community": 163,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usebulkoperations_ts",
       "label": "useBulkOperations.ts",
@@ -67951,7 +68107,7 @@
       "source_location": "L1"
     },
     {
-      "community": 162,
+      "community": 163,
       "file_type": "code",
       "id": "usebulkoperations_applyoperation",
       "label": "applyOperation()",
@@ -67960,7 +68116,7 @@
       "source_location": "L56"
     },
     {
-      "community": 162,
+      "community": 163,
       "file_type": "code",
       "id": "usebulkoperations_calculatepricewithfee",
       "label": "calculatePriceWithFee()",
@@ -67969,7 +68125,7 @@
       "source_location": "L87"
     },
     {
-      "community": 162,
+      "community": 163,
       "file_type": "code",
       "id": "usebulkoperations_computepreview",
       "label": "computePreview()",
@@ -67978,7 +68134,7 @@
       "source_location": "L101"
     },
     {
-      "community": 162,
+      "community": 163,
       "file_type": "code",
       "id": "usebulkoperations_usebulkoperations",
       "label": "useBulkOperations()",
@@ -67987,7 +68143,7 @@
       "source_location": "L158"
     },
     {
-      "community": 162,
+      "community": 163,
       "file_type": "code",
       "id": "usebulkoperations_validateoperationvalue",
       "label": "validateOperationValue()",
@@ -67996,7 +68152,7 @@
       "source_location": "L139"
     },
     {
-      "community": 163,
+      "community": 164,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useexpensesessions_ts",
       "label": "useExpenseSessions.ts",
@@ -68005,7 +68161,7 @@
       "source_location": "L1"
     },
     {
-      "community": 163,
+      "community": 164,
       "file_type": "code",
       "id": "useexpensesessions_useexpenseactivesession",
       "label": "useExpenseActiveSession()",
@@ -68014,7 +68170,7 @@
       "source_location": "L42"
     },
     {
-      "community": 163,
+      "community": 164,
       "file_type": "code",
       "id": "useexpensesessions_useexpensesession",
       "label": "useExpenseSession()",
@@ -68023,7 +68179,7 @@
       "source_location": "L32"
     },
     {
-      "community": 163,
+      "community": 164,
       "file_type": "code",
       "id": "useexpensesessions_useexpensesessioncreate",
       "label": "useExpenseSessionCreate()",
@@ -68032,7 +68188,7 @@
       "source_location": "L62"
     },
     {
-      "community": 163,
+      "community": 164,
       "file_type": "code",
       "id": "useexpensesessions_useexpensesessionupdate",
       "label": "useExpenseSessionUpdate()",
@@ -68041,7 +68197,7 @@
       "source_location": "L101"
     },
     {
-      "community": 163,
+      "community": 164,
       "file_type": "code",
       "id": "useexpensesessions_useexpensestoresessions",
       "label": "useExpenseStoreSessions()",
@@ -68050,7 +68206,7 @@
       "source_location": "L10"
     },
     {
-      "community": 164,
+      "community": 165,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useposproducts_ts",
       "label": "usePOSProducts.ts",
@@ -68059,7 +68215,7 @@
       "source_location": "L1"
     },
     {
-      "community": 164,
+      "community": 165,
       "file_type": "code",
       "id": "useposproducts_useposbarcodesearch",
       "label": "usePOSBarcodeSearch()",
@@ -68068,7 +68224,7 @@
       "source_location": "L17"
     },
     {
-      "community": 164,
+      "community": 165,
       "file_type": "code",
       "id": "useposproducts_useposproductidsearch",
       "label": "usePOSProductIdSearch()",
@@ -68077,7 +68233,7 @@
       "source_location": "L24"
     },
     {
-      "community": 164,
+      "community": 165,
       "file_type": "code",
       "id": "useposproducts_useposproductsearch",
       "label": "usePOSProductSearch()",
@@ -68086,7 +68242,7 @@
       "source_location": "L10"
     },
     {
-      "community": 164,
+      "community": 165,
       "file_type": "code",
       "id": "useposproducts_useposquickaddproductsku",
       "label": "usePOSQuickAddProductSku()",
@@ -68095,7 +68251,7 @@
       "source_location": "L33"
     },
     {
-      "community": 164,
+      "community": 165,
       "file_type": "code",
       "id": "useposproducts_usepostransactioncomplete",
       "label": "usePOSTransactionComplete()",
@@ -68104,7 +68260,7 @@
       "source_location": "L31"
     },
     {
-      "community": 165,
+      "community": 166,
       "file_type": "code",
       "id": "behaviorutils_calculateengagementmetrics",
       "label": "calculateEngagementMetrics()",
@@ -68113,7 +68269,7 @@
       "source_location": "L173"
     },
     {
-      "community": 165,
+      "community": 166,
       "file_type": "code",
       "id": "behaviorutils_calculateriskindicators",
       "label": "calculateRiskIndicators()",
@@ -68122,7 +68278,7 @@
       "source_location": "L71"
     },
     {
-      "community": 165,
+      "community": 166,
       "file_type": "code",
       "id": "behaviorutils_getactivitypriority",
       "label": "getActivityPriority()",
@@ -68131,7 +68287,7 @@
       "source_location": "L251"
     },
     {
-      "community": 165,
+      "community": 166,
       "file_type": "code",
       "id": "behaviorutils_getcustomerjourneystage",
       "label": "getCustomerJourneyStage()",
@@ -68140,7 +68296,7 @@
       "source_location": "L36"
     },
     {
-      "community": 165,
+      "community": 166,
       "file_type": "code",
       "id": "behaviorutils_getjourneystageinfo",
       "label": "getJourneyStageInfo()",
@@ -68149,7 +68305,7 @@
       "source_location": "L277"
     },
     {
-      "community": 165,
+      "community": 166,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_behaviorutils_ts",
       "label": "behaviorUtils.ts",
@@ -68158,7 +68314,7 @@
       "source_location": "L1"
     },
     {
-      "community": 166,
+      "community": 167,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_results_ts",
       "label": "results.ts",
@@ -68167,7 +68323,7 @@
       "source_location": "L1"
     },
     {
-      "community": 166,
+      "community": 167,
       "file_type": "code",
       "id": "results_isposusecasesuccess",
       "label": "isPosUseCaseSuccess()",
@@ -68176,7 +68332,7 @@
       "source_location": "L122"
     },
     {
-      "community": 166,
+      "community": 167,
       "file_type": "code",
       "id": "results_mapcommandoutcome",
       "label": "mapCommandOutcome()",
@@ -68185,7 +68341,7 @@
       "source_location": "L68"
     },
     {
-      "community": 166,
+      "community": 167,
       "file_type": "code",
       "id": "results_mapcommandresult",
       "label": "mapCommandResult()",
@@ -68194,7 +68350,7 @@
       "source_location": "L85"
     },
     {
-      "community": 166,
+      "community": 167,
       "file_type": "code",
       "id": "results_maplegacymutationresult",
       "label": "mapLegacyMutationResult()",
@@ -68203,7 +68359,7 @@
       "source_location": "L51"
     },
     {
-      "community": 166,
+      "community": 167,
       "file_type": "code",
       "id": "results_mapthrownerror",
       "label": "mapThrownError()",
@@ -68212,7 +68368,7 @@
       "source_location": "L102"
     },
     {
-      "community": 167,
+      "community": 168,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_domain_payments_ts",
       "label": "payments.ts",
@@ -68221,7 +68377,7 @@
       "source_location": "L1"
     },
     {
-      "community": 167,
+      "community": 168,
       "file_type": "code",
       "id": "payments_calculateposchange",
       "label": "calculatePosChange()",
@@ -68230,7 +68386,7 @@
       "source_location": "L3"
     },
     {
-      "community": 167,
+      "community": 168,
       "file_type": "code",
       "id": "payments_calculateposremainingdue",
       "label": "calculatePosRemainingDue()",
@@ -68239,7 +68395,7 @@
       "source_location": "L20"
     },
     {
-      "community": 167,
+      "community": 168,
       "file_type": "code",
       "id": "payments_calculatepostotalpaid",
       "label": "calculatePosTotalPaid()",
@@ -68248,7 +68404,7 @@
       "source_location": "L14"
     },
     {
-      "community": 167,
+      "community": 168,
       "file_type": "code",
       "id": "payments_ispospaymentsufficient",
       "label": "isPosPaymentSufficient()",
@@ -68257,7 +68413,7 @@
       "source_location": "L7"
     },
     {
-      "community": 167,
+      "community": 168,
       "file_type": "code",
       "id": "payments_roundposamount",
       "label": "roundPosAmount()",
@@ -68266,7 +68422,7 @@
       "source_location": "L27"
     },
     {
-      "community": 168,
+      "community": 169,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_presentation_register_selectors_ts",
       "label": "selectors.ts",
@@ -68275,7 +68431,7 @@
       "source_location": "L1"
     },
     {
-      "community": 168,
+      "community": 169,
       "file_type": "code",
       "id": "selectors_buildregisterheaderstate",
       "label": "buildRegisterHeaderState()",
@@ -68284,7 +68440,7 @@
       "source_location": "L28"
     },
     {
-      "community": 168,
+      "community": 169,
       "file_type": "code",
       "id": "selectors_buildregisterinfostate",
       "label": "buildRegisterInfoState()",
@@ -68293,7 +68449,7 @@
       "source_location": "L37"
     },
     {
-      "community": 168,
+      "community": 169,
       "file_type": "code",
       "id": "selectors_getcashierdisplayname",
       "label": "getCashierDisplayName()",
@@ -68302,7 +68458,7 @@
       "source_location": "L12"
     },
     {
-      "community": 168,
+      "community": 169,
       "file_type": "code",
       "id": "selectors_getregistercustomerinfo",
       "label": "getRegisterCustomerInfo()",
@@ -68311,67 +68467,13 @@
       "source_location": "L6"
     },
     {
-      "community": 168,
+      "community": 169,
       "file_type": "code",
       "id": "selectors_isregistersessionactive",
       "label": "isRegisterSessionActive()",
       "norm_label": "isregistersessionactive()",
       "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts",
       "source_location": "L49"
-    },
-    {
-      "community": 169,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_toastservice_ts",
-      "label": "toastService.ts",
-      "norm_label": "toastservice.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 169,
-      "file_type": "code",
-      "id": "toastservice_handleposoperation",
-      "label": "handlePOSOperation()",
-      "norm_label": "handleposoperation()",
-      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
-      "source_location": "L171"
-    },
-    {
-      "community": 169,
-      "file_type": "code",
-      "id": "toastservice_showinventoryerror",
-      "label": "showInventoryError()",
-      "norm_label": "showinventoryerror()",
-      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
-      "source_location": "L302"
-    },
-    {
-      "community": 169,
-      "file_type": "code",
-      "id": "toastservice_shownoactivesessionerror",
-      "label": "showNoActiveSessionError()",
-      "norm_label": "shownoactivesessionerror()",
-      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
-      "source_location": "L319"
-    },
-    {
-      "community": 169,
-      "file_type": "code",
-      "id": "toastservice_showsessionexpirederror",
-      "label": "showSessionExpiredError()",
-      "norm_label": "showsessionexpirederror()",
-      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
-      "source_location": "L312"
-    },
-    {
-      "community": 169,
-      "file_type": "code",
-      "id": "toastservice_showvalidationerror",
-      "label": "showValidationError()",
-      "norm_label": "showvalidationerror()",
-      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
-      "source_location": "L293"
     },
     {
       "community": 17,
@@ -68574,6 +68676,60 @@
     {
       "community": 170,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_toastservice_ts",
+      "label": "toastService.ts",
+      "norm_label": "toastservice.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 170,
+      "file_type": "code",
+      "id": "toastservice_handleposoperation",
+      "label": "handlePOSOperation()",
+      "norm_label": "handleposoperation()",
+      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
+      "source_location": "L171"
+    },
+    {
+      "community": 170,
+      "file_type": "code",
+      "id": "toastservice_showinventoryerror",
+      "label": "showInventoryError()",
+      "norm_label": "showinventoryerror()",
+      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
+      "source_location": "L302"
+    },
+    {
+      "community": 170,
+      "file_type": "code",
+      "id": "toastservice_shownoactivesessionerror",
+      "label": "showNoActiveSessionError()",
+      "norm_label": "shownoactivesessionerror()",
+      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
+      "source_location": "L319"
+    },
+    {
+      "community": 170,
+      "file_type": "code",
+      "id": "toastservice_showsessionexpirederror",
+      "label": "showSessionExpiredError()",
+      "norm_label": "showsessionexpirederror()",
+      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
+      "source_location": "L312"
+    },
+    {
+      "community": 170,
+      "file_type": "code",
+      "id": "toastservice_showvalidationerror",
+      "label": "showValidationError()",
+      "norm_label": "showvalidationerror()",
+      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
+      "source_location": "L293"
+    },
+    {
+      "community": 171,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_traces_traceid_tsx",
       "label": "$traceId.tsx",
       "norm_label": "$traceid.tsx",
@@ -68581,7 +68737,7 @@
       "source_location": "L1"
     },
     {
-      "community": 170,
+      "community": 171,
       "file_type": "code",
       "id": "traceid_hasorgnotfoundpayload",
       "label": "hasOrgNotFoundPayload()",
@@ -68590,7 +68746,7 @@
       "source_location": "L12"
     },
     {
-      "community": 170,
+      "community": 171,
       "file_type": "code",
       "id": "traceid_workflowtraceloadingstate",
       "label": "WorkflowTraceLoadingState()",
@@ -68599,7 +68755,7 @@
       "source_location": "L21"
     },
     {
-      "community": 170,
+      "community": 171,
       "file_type": "code",
       "id": "traceid_workflowtraceroute",
       "label": "WorkflowTraceRoute()",
@@ -68608,7 +68764,7 @@
       "source_location": "L101"
     },
     {
-      "community": 170,
+      "community": 171,
       "file_type": "code",
       "id": "traceid_workflowtraceroutecontent",
       "label": "WorkflowTraceRouteContent()",
@@ -68617,7 +68773,7 @@
       "source_location": "L35"
     },
     {
-      "community": 170,
+      "community": 171,
       "file_type": "code",
       "id": "traceid_workflowtracerouteshell",
       "label": "WorkflowTraceRouteShell()",
@@ -68626,7 +68782,7 @@
       "source_location": "L66"
     },
     {
-      "community": 171,
+      "community": 172,
       "file_type": "code",
       "id": "organizationsettingsview_handledeletestore",
       "label": "handleDeleteStore()",
@@ -68635,7 +68791,7 @@
       "source_location": "L155"
     },
     {
-      "community": 171,
+      "community": 172,
       "file_type": "code",
       "id": "organizationsettingsview_navigation",
       "label": "Navigation()",
@@ -68644,7 +68800,7 @@
       "source_location": "L197"
     },
     {
-      "community": 171,
+      "community": 172,
       "file_type": "code",
       "id": "organizationsettingsview_onsubmit",
       "label": "onSubmit()",
@@ -68653,7 +68809,7 @@
       "source_location": "L104"
     },
     {
-      "community": 171,
+      "community": 172,
       "file_type": "code",
       "id": "organizationsettingsview_organizationsettings",
       "label": "OrganizationSettings()",
@@ -68662,7 +68818,7 @@
       "source_location": "L25"
     },
     {
-      "community": 171,
+      "community": 172,
       "file_type": "code",
       "id": "organizationsettingsview_savestorechanges",
       "label": "saveStoreChanges()",
@@ -68671,7 +68827,7 @@
       "source_location": "L72"
     },
     {
-      "community": 171,
+      "community": 172,
       "file_type": "code",
       "id": "packages_athena_webapp_src_settings_organization_components_organizationsettingsview_tsx",
       "label": "OrganizationSettingsView.tsx",
@@ -68680,7 +68836,7 @@
       "source_location": "L1"
     },
     {
-      "community": 172,
+      "community": 173,
       "file_type": "code",
       "id": "packages_athena_webapp_src_settings_store_storesettingsview_tsx",
       "label": "StoreSettingsView.tsx",
@@ -68689,7 +68845,7 @@
       "source_location": "L1"
     },
     {
-      "community": 172,
+      "community": 173,
       "file_type": "code",
       "id": "storesettingsview_handledeleteallproductsinstore",
       "label": "handleDeleteAllProductsInStore()",
@@ -68698,7 +68854,7 @@
       "source_location": "L231"
     },
     {
-      "community": 172,
+      "community": 173,
       "file_type": "code",
       "id": "storesettingsview_handledeletestore",
       "label": "handleDeleteStore()",
@@ -68707,7 +68863,7 @@
       "source_location": "L167"
     },
     {
-      "community": 172,
+      "community": 173,
       "file_type": "code",
       "id": "storesettingsview_onsubmit",
       "label": "onSubmit()",
@@ -68716,7 +68872,7 @@
       "source_location": "L116"
     },
     {
-      "community": 172,
+      "community": 173,
       "file_type": "code",
       "id": "storesettingsview_savestorechanges",
       "label": "saveStoreChanges()",
@@ -68725,7 +68881,7 @@
       "source_location": "L83"
     },
     {
-      "community": 172,
+      "community": 173,
       "file_type": "code",
       "id": "storesettingsview_storesettings",
       "label": "StoreSettings()",
@@ -68734,7 +68890,7 @@
       "source_location": "L29"
     },
     {
-      "community": 173,
+      "community": 174,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_storybook_shell_tsx",
       "label": "storybook-shell.tsx",
@@ -68743,7 +68899,7 @@
       "source_location": "L1"
     },
     {
-      "community": 173,
+      "community": 174,
       "file_type": "code",
       "id": "storybook_shell_storybookcallout",
       "label": "StorybookCallout()",
@@ -68752,7 +68908,7 @@
       "source_location": "L76"
     },
     {
-      "community": 173,
+      "community": 174,
       "file_type": "code",
       "id": "storybook_shell_storybooklist",
       "label": "StorybookList()",
@@ -68761,7 +68917,7 @@
       "source_location": "L55"
     },
     {
-      "community": 173,
+      "community": 174,
       "file_type": "code",
       "id": "storybook_shell_storybookpillrow",
       "label": "StorybookPillRow()",
@@ -68770,7 +68926,7 @@
       "source_location": "L88"
     },
     {
-      "community": 173,
+      "community": 174,
       "file_type": "code",
       "id": "storybook_shell_storybooksection",
       "label": "StorybookSection()",
@@ -68779,7 +68935,7 @@
       "source_location": "L34"
     },
     {
-      "community": 173,
+      "community": 174,
       "file_type": "code",
       "id": "storybook_shell_storybookshell",
       "label": "StorybookShell()",
@@ -68788,7 +68944,7 @@
       "source_location": "L13"
     },
     {
-      "community": 174,
+      "community": 175,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_postransaction_ts",
       "label": "posTransaction.ts",
@@ -68797,7 +68953,7 @@
       "source_location": "L1"
     },
     {
-      "community": 174,
+      "community": 175,
       "file_type": "code",
       "id": "postransaction_fetchpostransaction",
       "label": "fetchPosTransaction()",
@@ -68806,7 +68962,7 @@
       "source_location": "L69"
     },
     {
-      "community": 174,
+      "community": 175,
       "file_type": "code",
       "id": "postransaction_getbaseurl",
       "label": "getBaseUrl()",
@@ -68815,7 +68971,7 @@
       "source_location": "L57"
     },
     {
-      "community": 174,
+      "community": 175,
       "file_type": "code",
       "id": "postransaction_getpostransactionbyreceipttoken",
       "label": "getPosTransactionByReceiptToken()",
@@ -68824,7 +68980,7 @@
       "source_location": "L90"
     },
     {
-      "community": 174,
+      "community": 175,
       "file_type": "code",
       "id": "postransaction_postransactionreceipterror",
       "label": "PosTransactionReceiptError",
@@ -68833,7 +68989,7 @@
       "source_location": "L59"
     },
     {
-      "community": 174,
+      "community": 175,
       "file_type": "code",
       "id": "postransaction_postransactionreceipterror_constructor",
       "label": ".constructor()",
@@ -68842,7 +68998,7 @@
       "source_location": "L62"
     },
     {
-      "community": 175,
+      "community": 176,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_promocodes_ts",
       "label": "promoCodes.ts",
@@ -68851,7 +69007,7 @@
       "source_location": "L1"
     },
     {
-      "community": 175,
+      "community": 176,
       "file_type": "code",
       "id": "promocodes_getbaseurl",
       "label": "getBaseUrl()",
@@ -68860,7 +69016,7 @@
       "source_location": "L4"
     },
     {
-      "community": 175,
+      "community": 176,
       "file_type": "code",
       "id": "promocodes_getpromocodeitems",
       "label": "getPromoCodeItems()",
@@ -68869,7 +69025,7 @@
       "source_location": "L49"
     },
     {
-      "community": 175,
+      "community": 176,
       "file_type": "code",
       "id": "promocodes_getpromocodes",
       "label": "getPromoCodes()",
@@ -68878,7 +69034,7 @@
       "source_location": "L34"
     },
     {
-      "community": 175,
+      "community": 176,
       "file_type": "code",
       "id": "promocodes_getredeemedpromocodes",
       "label": "getRedeemedPromoCodes()",
@@ -68887,7 +69043,7 @@
       "source_location": "L74"
     },
     {
-      "community": 175,
+      "community": 176,
       "file_type": "code",
       "id": "promocodes_redeempromocode",
       "label": "redeemPromoCode()",
@@ -68896,7 +69052,7 @@
       "source_location": "L6"
     },
     {
-      "community": 176,
+      "community": 177,
       "file_type": "code",
       "id": "billingdetails_clearform",
       "label": "clearForm()",
@@ -68905,7 +69061,7 @@
       "source_location": "L173"
     },
     {
-      "community": 176,
+      "community": 177,
       "file_type": "code",
       "id": "billingdetails_enteredbillingaddressdetails",
       "label": "EnteredBillingAddressDetails()",
@@ -68914,7 +69070,7 @@
       "source_location": "L102"
     },
     {
-      "community": 176,
+      "community": 177,
       "file_type": "code",
       "id": "billingdetails_handleusebillingaddressonfile",
       "label": "handleUseBillingAddressOnFile()",
@@ -68923,7 +69079,7 @@
       "source_location": "L201"
     },
     {
-      "community": 176,
+      "community": 177,
       "file_type": "code",
       "id": "billingdetails_onsubmit",
       "label": "onSubmit()",
@@ -68932,7 +69088,7 @@
       "source_location": "L150"
     },
     {
-      "community": 176,
+      "community": 177,
       "file_type": "code",
       "id": "billingdetails_togglesameasdelivery",
       "label": "toggleSameAsDelivery()",
@@ -68941,7 +69097,7 @@
       "source_location": "L155"
     },
     {
-      "community": 176,
+      "community": 177,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_billingdetails_tsx",
       "label": "BillingDetails.tsx",
@@ -68950,7 +69106,7 @@
       "source_location": "L1"
     },
     {
-      "community": 177,
+      "community": 178,
       "file_type": "code",
       "id": "mobileproductactions_collapseonpageclick",
       "label": "collapseOnPageClick()",
@@ -68959,7 +69115,7 @@
       "source_location": "L76"
     },
     {
-      "community": 177,
+      "community": 178,
       "file_type": "code",
       "id": "mobileproductactions_handleconfirm",
       "label": "handleConfirm()",
@@ -68968,7 +69124,7 @@
       "source_location": "L120"
     },
     {
-      "community": 177,
+      "community": 178,
       "file_type": "code",
       "id": "mobileproductactions_handleprimaryaction",
       "label": "handlePrimaryAction()",
@@ -68977,7 +69133,7 @@
       "source_location": "L129"
     },
     {
-      "community": 177,
+      "community": 178,
       "file_type": "code",
       "id": "mobileproductactions_handlesecondaryaction",
       "label": "handleSecondaryAction()",
@@ -68986,7 +69142,7 @@
       "source_location": "L133"
     },
     {
-      "community": 177,
+      "community": 178,
       "file_type": "code",
       "id": "mobileproductactions_updateposition",
       "label": "updatePosition()",
@@ -68995,7 +69151,7 @@
       "source_location": "L44"
     },
     {
-      "community": 177,
+      "community": 178,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_mobileproductactions_tsx",
       "label": "MobileProductActions.tsx",
@@ -69004,7 +69160,7 @@
       "source_location": "L1"
     },
     {
-      "community": 178,
+      "community": 179,
       "file_type": "code",
       "id": "checkoutexpired_checkoutexpired",
       "label": "CheckoutExpired()",
@@ -69013,7 +69169,7 @@
       "source_location": "L9"
     },
     {
-      "community": 178,
+      "community": 179,
       "file_type": "code",
       "id": "checkoutexpired_checkoutsessiongeneric",
       "label": "CheckoutSessionGeneric()",
@@ -69022,7 +69178,7 @@
       "source_location": "L73"
     },
     {
-      "community": 178,
+      "community": 179,
       "file_type": "code",
       "id": "checkoutexpired_checkoutsessionnotfound",
       "label": "CheckoutSessionNotFound()",
@@ -69031,7 +69187,7 @@
       "source_location": "L54"
     },
     {
-      "community": 178,
+      "community": 179,
       "file_type": "code",
       "id": "checkoutexpired_handlesendemail",
       "label": "handleSendEmail()",
@@ -69040,7 +69196,7 @@
       "source_location": "L98"
     },
     {
-      "community": 178,
+      "community": 179,
       "file_type": "code",
       "id": "checkoutexpired_nocheckoutsession",
       "label": "NoCheckoutSession()",
@@ -69049,66 +69205,12 @@
       "source_location": "L33"
     },
     {
-      "community": 178,
+      "community": 179,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_checkout_expired_checkoutexpired_tsx",
       "label": "CheckoutExpired.tsx",
       "norm_label": "checkoutexpired.tsx",
       "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 179,
-      "file_type": "code",
-      "id": "feeutils_getremainingforfreedelivery",
-      "label": "getRemainingForFreeDelivery()",
-      "norm_label": "getremainingforfreedelivery()",
-      "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
-      "source_location": "L138"
-    },
-    {
-      "community": 179,
-      "file_type": "code",
-      "id": "feeutils_haswaiverconfigured",
-      "label": "hasWaiverConfigured()",
-      "norm_label": "haswaiverconfigured()",
-      "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
-      "source_location": "L100"
-    },
-    {
-      "community": 179,
-      "file_type": "code",
-      "id": "feeutils_isanyfeewaived",
-      "label": "isAnyFeeWaived()",
-      "norm_label": "isanyfeewaived()",
-      "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
-      "source_location": "L74"
-    },
-    {
-      "community": 179,
-      "file_type": "code",
-      "id": "feeutils_isfeewaived",
-      "label": "isFeeWaived()",
-      "norm_label": "isfeewaived()",
-      "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
-      "source_location": "L34"
-    },
-    {
-      "community": 179,
-      "file_type": "code",
-      "id": "feeutils_meetsthreshold",
-      "label": "meetsThreshold()",
-      "norm_label": "meetsthreshold()",
-      "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
-      "source_location": "L17"
-    },
-    {
-      "community": 179,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_feeutils_ts",
-      "label": "feeUtils.ts",
-      "norm_label": "feeutils.ts",
-      "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
       "source_location": "L1"
     },
     {
@@ -69312,6 +69414,60 @@
     {
       "community": 180,
       "file_type": "code",
+      "id": "feeutils_getremainingforfreedelivery",
+      "label": "getRemainingForFreeDelivery()",
+      "norm_label": "getremainingforfreedelivery()",
+      "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
+      "source_location": "L138"
+    },
+    {
+      "community": 180,
+      "file_type": "code",
+      "id": "feeutils_haswaiverconfigured",
+      "label": "hasWaiverConfigured()",
+      "norm_label": "haswaiverconfigured()",
+      "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
+      "source_location": "L100"
+    },
+    {
+      "community": 180,
+      "file_type": "code",
+      "id": "feeutils_isanyfeewaived",
+      "label": "isAnyFeeWaived()",
+      "norm_label": "isanyfeewaived()",
+      "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
+      "source_location": "L74"
+    },
+    {
+      "community": 180,
+      "file_type": "code",
+      "id": "feeutils_isfeewaived",
+      "label": "isFeeWaived()",
+      "norm_label": "isfeewaived()",
+      "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
+      "source_location": "L34"
+    },
+    {
+      "community": 180,
+      "file_type": "code",
+      "id": "feeutils_meetsthreshold",
+      "label": "meetsThreshold()",
+      "norm_label": "meetsthreshold()",
+      "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
+      "source_location": "L17"
+    },
+    {
+      "community": 180,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_feeutils_ts",
+      "label": "feeUtils.ts",
+      "norm_label": "feeutils.ts",
+      "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 181,
+      "file_type": "code",
       "id": "auth_verify_formattime",
       "label": "formatTime()",
       "norm_label": "formattime()",
@@ -69319,7 +69475,7 @@
       "source_location": "L149"
     },
     {
-      "community": 180,
+      "community": 181,
       "file_type": "code",
       "id": "auth_verify_handlecodechange",
       "label": "handleCodeChange()",
@@ -69328,7 +69484,7 @@
       "source_location": "L156"
     },
     {
-      "community": 180,
+      "community": 181,
       "file_type": "code",
       "id": "auth_verify_onsubmit",
       "label": "onSubmit()",
@@ -69337,7 +69493,7 @@
       "source_location": "L201"
     },
     {
-      "community": 180,
+      "community": 181,
       "file_type": "code",
       "id": "auth_verify_reportauthfailure",
       "label": "reportAuthFailure()",
@@ -69346,7 +69502,7 @@
       "source_location": "L93"
     },
     {
-      "community": 180,
+      "community": 181,
       "file_type": "code",
       "id": "auth_verify_resendverificationcode",
       "label": "resendVerificationCode()",
@@ -69355,7 +69511,7 @@
       "source_location": "L282"
     },
     {
-      "community": 180,
+      "community": 181,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_auth_verify_tsx",
       "label": "auth.verify.tsx",
@@ -69364,7 +69520,7 @@
       "source_location": "L1"
     },
     {
-      "community": 181,
+      "community": 182,
       "file_type": "code",
       "id": "coverage_summary_test_coveragesummary",
       "label": "coverageSummary()",
@@ -69373,7 +69529,7 @@
       "source_location": "L27"
     },
     {
-      "community": 181,
+      "community": 182,
       "file_type": "code",
       "id": "coverage_summary_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -69382,7 +69538,7 @@
       "source_location": "L15"
     },
     {
-      "community": 181,
+      "community": 182,
       "file_type": "code",
       "id": "coverage_summary_test_write",
       "label": "write()",
@@ -69391,7 +69547,7 @@
       "source_location": "L21"
     },
     {
-      "community": 181,
+      "community": 182,
       "file_type": "code",
       "id": "coverage_summary_test_writepackagesummaries",
       "label": "writePackageSummaries()",
@@ -69400,7 +69556,7 @@
       "source_location": "L38"
     },
     {
-      "community": 181,
+      "community": 182,
       "file_type": "code",
       "id": "coverage_summary_test_writerealbaselinesummaries",
       "label": "writeRealBaselineSummaries()",
@@ -69409,7 +69565,7 @@
       "source_location": "L54"
     },
     {
-      "community": 181,
+      "community": 182,
       "file_type": "code",
       "id": "scripts_coverage_summary_test_ts",
       "label": "coverage-summary.test.ts",
@@ -69418,7 +69574,7 @@
       "source_location": "L1"
     },
     {
-      "community": 182,
+      "community": 183,
       "file_type": "code",
       "id": "graphify_check_collectrepocodefiles",
       "label": "collectRepoCodeFiles()",
@@ -69427,7 +69583,7 @@
       "source_location": "L72"
     },
     {
-      "community": 182,
+      "community": 183,
       "file_type": "code",
       "id": "graphify_check_collectstalegraphifyartifacts",
       "label": "collectStaleGraphifyArtifacts()",
@@ -69436,7 +69592,7 @@
       "source_location": "L124"
     },
     {
-      "community": 182,
+      "community": 183,
       "file_type": "code",
       "id": "graphify_check_copygraphifycheckinputs",
       "label": "copyGraphifyCheckInputs()",
@@ -69445,7 +69601,7 @@
       "source_location": "L106"
     },
     {
-      "community": 182,
+      "community": 183,
       "file_type": "code",
       "id": "graphify_check_fileexists",
       "label": "fileExists()",
@@ -69454,7 +69610,7 @@
       "source_location": "L63"
     },
     {
-      "community": 182,
+      "community": 183,
       "file_type": "code",
       "id": "graphify_check_rungraphifycheck",
       "label": "runGraphifyCheck()",
@@ -69463,7 +69619,7 @@
       "source_location": "L151"
     },
     {
-      "community": 182,
+      "community": 183,
       "file_type": "code",
       "id": "scripts_graphify_check_ts",
       "label": "graphify-check.ts",
@@ -69472,7 +69628,7 @@
       "source_location": "L1"
     },
     {
-      "community": 183,
+      "community": 184,
       "file_type": "code",
       "id": "pre_push_validation_proof_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -69481,7 +69637,7 @@
       "source_location": "L19"
     },
     {
-      "community": 183,
+      "community": 184,
       "file_type": "code",
       "id": "pre_push_validation_proof_test_createspawn",
       "label": "createSpawn()",
@@ -69490,7 +69646,7 @@
       "source_location": "L50"
     },
     {
-      "community": 183,
+      "community": 184,
       "file_type": "code",
       "id": "pre_push_validation_proof_test_log",
       "label": "log()",
@@ -69499,7 +69655,7 @@
       "source_location": "L187"
     },
     {
-      "community": 183,
+      "community": 184,
       "file_type": "code",
       "id": "pre_push_validation_proof_test_warn",
       "label": "warn()",
@@ -69508,7 +69664,7 @@
       "source_location": "L187"
     },
     {
-      "community": 183,
+      "community": 184,
       "file_type": "code",
       "id": "pre_push_validation_proof_test_write",
       "label": "write()",
@@ -69517,7 +69673,7 @@
       "source_location": "L13"
     },
     {
-      "community": 183,
+      "community": 184,
       "file_type": "code",
       "id": "scripts_pre_push_validation_proof_test_ts",
       "label": "pre-push-validation-proof.test.ts",
@@ -69526,7 +69682,7 @@
       "source_location": "L1"
     },
     {
-      "community": 184,
+      "community": 185,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cashcontrols_paymentallocationattribution_ts",
       "label": "paymentAllocationAttribution.ts",
@@ -69535,7 +69691,7 @@
       "source_location": "L1"
     },
     {
-      "community": 184,
+      "community": 185,
       "file_type": "code",
       "id": "paymentallocationattribution_buildinstorepaymentallocations",
       "label": "buildInStorePaymentAllocations()",
@@ -69544,7 +69700,7 @@
       "source_location": "L46"
     },
     {
-      "community": 184,
+      "community": 185,
       "file_type": "code",
       "id": "paymentallocationattribution_normalizeinstorepayments",
       "label": "normalizeInStorePayments()",
@@ -69553,7 +69709,7 @@
       "source_location": "L22"
     },
     {
-      "community": 184,
+      "community": 185,
       "file_type": "code",
       "id": "paymentallocationattribution_resolveregistersessionforinstorecollectionwithctx",
       "label": "resolveRegisterSessionForInStoreCollectionWithCtx()",
@@ -69562,7 +69718,7 @@
       "source_location": "L118"
     },
     {
-      "community": 184,
+      "community": 185,
       "file_type": "code",
       "id": "paymentallocationattribution_selectregistersessionforattribution",
       "label": "selectRegisterSessionForAttribution()",
@@ -69571,7 +69727,7 @@
       "source_location": "L81"
     },
     {
-      "community": 185,
+      "community": 186,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cashcontrols_registersessiontracelifecycle_test_ts",
       "label": "registerSessionTraceLifecycle.test.ts",
@@ -69580,7 +69736,7 @@
       "source_location": "L1"
     },
     {
-      "community": 185,
+      "community": 186,
       "file_type": "code",
       "id": "registersessiontracelifecycle_test_buildapprovalproof",
       "label": "buildApprovalProof()",
@@ -69589,7 +69745,7 @@
       "source_location": "L292"
     },
     {
-      "community": 185,
+      "community": 186,
       "file_type": "code",
       "id": "registersessiontracelifecycle_test_buildregistersession",
       "label": "buildRegisterSession()",
@@ -69598,7 +69754,7 @@
       "source_location": "L94"
     },
     {
-      "community": 185,
+      "community": 186,
       "file_type": "code",
       "id": "registersessiontracelifecycle_test_createmutationctx",
       "label": "createMutationCtx()",
@@ -69607,7 +69763,7 @@
       "source_location": "L110"
     },
     {
-      "community": 185,
+      "community": 186,
       "file_type": "code",
       "id": "registersessiontracelifecycle_test_gethandler",
       "label": "getHandler()",
@@ -69616,7 +69772,7 @@
       "source_location": "L311"
     },
     {
-      "community": 186,
+      "community": 187,
       "file_type": "code",
       "id": "expensesessionvalidation_validateexpenseitembelongstosession",
       "label": "validateExpenseItemBelongsToSession()",
@@ -69625,7 +69781,7 @@
       "source_location": "L135"
     },
     {
-      "community": 186,
+      "community": 187,
       "file_type": "code",
       "id": "expensesessionvalidation_validateexpensesessionactive",
       "label": "validateExpenseSessionActive()",
@@ -69634,7 +69790,7 @@
       "source_location": "L39"
     },
     {
-      "community": 186,
+      "community": 187,
       "file_type": "code",
       "id": "expensesessionvalidation_validateexpensesessionexists",
       "label": "validateExpenseSessionExists()",
@@ -69643,7 +69799,7 @@
       "source_location": "L19"
     },
     {
-      "community": 186,
+      "community": 187,
       "file_type": "code",
       "id": "expensesessionvalidation_validateexpensesessionmodifiable",
       "label": "validateExpenseSessionModifiable()",
@@ -69652,7 +69808,7 @@
       "source_location": "L92"
     },
     {
-      "community": 186,
+      "community": 187,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_helpers_expensesessionvalidation_ts",
       "label": "expenseSessionValidation.ts",
@@ -69661,7 +69817,7 @@
       "source_location": "L1"
     },
     {
-      "community": 187,
+      "community": 188,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_products_ts",
       "label": "products.ts",
@@ -69670,7 +69826,7 @@
       "source_location": "L1"
     },
     {
-      "community": 187,
+      "community": 188,
       "file_type": "code",
       "id": "products_calculatetotalavailablecount",
       "label": "calculateTotalAvailableCount()",
@@ -69679,7 +69835,7 @@
       "source_location": "L71"
     },
     {
-      "community": 187,
+      "community": 188,
       "file_type": "code",
       "id": "products_calculatetotalinventorycount",
       "label": "calculateTotalInventoryCount()",
@@ -69688,7 +69844,7 @@
       "source_location": "L66"
     },
     {
-      "community": 187,
+      "community": 188,
       "file_type": "code",
       "id": "products_generatebarcode",
       "label": "generateBarcode()",
@@ -69697,7 +69853,7 @@
       "source_location": "L43"
     },
     {
-      "community": 187,
+      "community": 188,
       "file_type": "code",
       "id": "products_generatesku",
       "label": "generateSKU()",
@@ -69706,7 +69862,7 @@
       "source_location": "L19"
     },
     {
-      "community": 188,
+      "community": 189,
       "file_type": "code",
       "id": "customerprofiles_compactrecord",
       "label": "compactRecord()",
@@ -69715,7 +69871,7 @@
       "source_location": "L24"
     },
     {
-      "community": 188,
+      "community": 189,
       "file_type": "code",
       "id": "customerprofiles_ensurecustomerprofilefromsourceswithctx",
       "label": "ensureCustomerProfileFromSourcesWithCtx()",
@@ -69724,7 +69880,7 @@
       "source_location": "L207"
     },
     {
-      "community": 188,
+      "community": 189,
       "file_type": "code",
       "id": "customerprofiles_findexistingprofile",
       "label": "findExistingProfile()",
@@ -69733,7 +69889,7 @@
       "source_location": "L45"
     },
     {
-      "community": 188,
+      "community": 189,
       "file_type": "code",
       "id": "customerprofiles_loadcustomersources",
       "label": "loadCustomerSources()",
@@ -69742,57 +69898,12 @@
       "source_location": "L30"
     },
     {
-      "community": 188,
+      "community": 189,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_customerprofiles_ts",
       "label": "customerProfiles.ts",
       "norm_label": "customerprofiles.ts",
       "source_file": "packages/athena-webapp/convex/operations/customerProfiles.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 189,
-      "file_type": "code",
-      "id": "inventorymovements_buildinventorymovement",
-      "label": "buildInventoryMovement()",
-      "norm_label": "buildinventorymovement()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L25"
-    },
-    {
-      "community": 189,
-      "file_type": "code",
-      "id": "inventorymovements_matchesexistingmovement",
-      "label": "matchesExistingMovement()",
-      "norm_label": "matchesexistingmovement()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L51"
-    },
-    {
-      "community": 189,
-      "file_type": "code",
-      "id": "inventorymovements_recordinventorymovementwithctx",
-      "label": "recordInventoryMovementWithCtx()",
-      "norm_label": "recordinventorymovementwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L70"
-    },
-    {
-      "community": 189,
-      "file_type": "code",
-      "id": "inventorymovements_summarizeinventorymovements",
-      "label": "summarizeInventoryMovements()",
-      "norm_label": "summarizeinventorymovements()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L36"
-    },
-    {
-      "community": 189,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_inventorymovements_ts",
-      "label": "inventoryMovements.ts",
-      "norm_label": "inventorymovements.ts",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
       "source_location": "L1"
     },
     {
@@ -69996,6 +70107,51 @@
     {
       "community": 190,
       "file_type": "code",
+      "id": "inventorymovements_buildinventorymovement",
+      "label": "buildInventoryMovement()",
+      "norm_label": "buildinventorymovement()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L25"
+    },
+    {
+      "community": 190,
+      "file_type": "code",
+      "id": "inventorymovements_matchesexistingmovement",
+      "label": "matchesExistingMovement()",
+      "norm_label": "matchesexistingmovement()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L51"
+    },
+    {
+      "community": 190,
+      "file_type": "code",
+      "id": "inventorymovements_recordinventorymovementwithctx",
+      "label": "recordInventoryMovementWithCtx()",
+      "norm_label": "recordinventorymovementwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L70"
+    },
+    {
+      "community": 190,
+      "file_type": "code",
+      "id": "inventorymovements_summarizeinventorymovements",
+      "label": "summarizeInventoryMovements()",
+      "norm_label": "summarizeinventorymovements()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L36"
+    },
+    {
+      "community": 190,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_inventorymovements_ts",
+      "label": "inventoryMovements.ts",
+      "norm_label": "inventorymovements.ts",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 191,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_serviceintake_test_ts",
       "label": "serviceIntake.test.ts",
       "norm_label": "serviceintake.test.ts",
@@ -70003,7 +70159,7 @@
       "source_location": "L1"
     },
     {
-      "community": 190,
+      "community": 191,
       "file_type": "code",
       "id": "serviceintake_test_buildcreateserviceintakeargs",
       "label": "buildCreateServiceIntakeArgs()",
@@ -70012,7 +70168,7 @@
       "source_location": "L16"
     },
     {
-      "community": 190,
+      "community": 191,
       "file_type": "code",
       "id": "serviceintake_test_createmutationctx",
       "label": "createMutationCtx()",
@@ -70021,7 +70177,7 @@
       "source_location": "L29"
     },
     {
-      "community": 190,
+      "community": 191,
       "file_type": "code",
       "id": "serviceintake_test_gethandler",
       "label": "getHandler()",
@@ -70030,7 +70186,7 @@
       "source_location": "L12"
     },
     {
-      "community": 190,
+      "community": 191,
       "file_type": "code",
       "id": "serviceintake_test_getsource",
       "label": "getSource()",
@@ -70039,7 +70195,7 @@
       "source_location": "L8"
     },
     {
-      "community": 191,
+      "community": 192,
       "file_type": "code",
       "id": "assigncustomer_test_customerprofile",
       "label": "customerProfile()",
@@ -70048,7 +70204,7 @@
       "source_location": "L255"
     },
     {
-      "community": 191,
+      "community": 192,
       "file_type": "code",
       "id": "assigncustomer_test_guest",
       "label": "guest()",
@@ -70057,7 +70213,7 @@
       "source_location": "L282"
     },
     {
-      "community": 191,
+      "community": 192,
       "file_type": "code",
       "id": "assigncustomer_test_poscustomer",
       "label": "posCustomer()",
@@ -70066,7 +70222,7 @@
       "source_location": "L239"
     },
     {
-      "community": 191,
+      "community": 192,
       "file_type": "code",
       "id": "assigncustomer_test_storefrontuser",
       "label": "storeFrontUser()",
@@ -70075,7 +70231,7 @@
       "source_location": "L269"
     },
     {
-      "community": 191,
+      "community": 192,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_commands_assigncustomer_test_ts",
       "label": "assignCustomer.test.ts",
@@ -70084,7 +70240,7 @@
       "source_location": "L1"
     },
     {
-      "community": 192,
+      "community": 193,
       "file_type": "code",
       "id": "correctionpolicy_builddecision",
       "label": "buildDecision()",
@@ -70093,7 +70249,7 @@
       "source_location": "L100"
     },
     {
-      "community": 192,
+      "community": 193,
       "file_type": "code",
       "id": "correctionpolicy_classifycorrectionintent",
       "label": "classifyCorrectionIntent()",
@@ -70102,7 +70258,7 @@
       "source_location": "L110"
     },
     {
-      "community": 192,
+      "community": 193,
       "file_type": "code",
       "id": "correctionpolicy_issupportedcorrectionintent",
       "label": "isSupportedCorrectionIntent()",
@@ -70111,7 +70267,7 @@
       "source_location": "L84"
     },
     {
-      "community": 192,
+      "community": 193,
       "file_type": "code",
       "id": "correctionpolicy_isunsupportedhighriskcorrectionintent",
       "label": "isUnsupportedHighRiskCorrectionIntent()",
@@ -70120,7 +70276,7 @@
       "source_location": "L92"
     },
     {
-      "community": 192,
+      "community": 193,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_corrections_correctionpolicy_ts",
       "label": "correctionPolicy.ts",
@@ -70129,7 +70285,7 @@
       "source_location": "L1"
     },
     {
-      "community": 193,
+      "community": 194,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_services_paystackservice_ts",
       "label": "paystackService.ts",
@@ -70138,7 +70294,7 @@
       "source_location": "L1"
     },
     {
-      "community": 193,
+      "community": 194,
       "file_type": "code",
       "id": "paystackservice_getpaystackheaders",
       "label": "getPaystackHeaders()",
@@ -70147,7 +70303,7 @@
       "source_location": "L11"
     },
     {
-      "community": 193,
+      "community": 194,
       "file_type": "code",
       "id": "paystackservice_initializetransaction",
       "label": "initializeTransaction()",
@@ -70156,7 +70312,7 @@
       "source_location": "L21"
     },
     {
-      "community": 193,
+      "community": 194,
       "file_type": "code",
       "id": "paystackservice_initiaterefund",
       "label": "initiateRefund()",
@@ -70165,7 +70321,7 @@
       "source_location": "L87"
     },
     {
-      "community": 193,
+      "community": 194,
       "file_type": "code",
       "id": "paystackservice_verifytransaction",
       "label": "verifyTransaction()",
@@ -70174,7 +70330,7 @@
       "source_location": "L65"
     },
     {
-      "community": 194,
+      "community": 195,
       "file_type": "code",
       "id": "adjustments_test_createapprovaldecisionmutationctx",
       "label": "createApprovalDecisionMutationCtx()",
@@ -70183,7 +70339,7 @@
       "source_location": "L173"
     },
     {
-      "community": 194,
+      "community": 195,
       "file_type": "code",
       "id": "adjustments_test_createinventorysnapshotqueryctx",
       "label": "createInventorySnapshotQueryCtx()",
@@ -70192,7 +70348,7 @@
       "source_location": "L33"
     },
     {
-      "community": 194,
+      "community": 195,
       "file_type": "code",
       "id": "adjustments_test_createsubmissionmutationctx",
       "label": "createSubmissionMutationCtx()",
@@ -70201,7 +70357,7 @@
       "source_location": "L318"
     },
     {
-      "community": 194,
+      "community": 195,
       "file_type": "code",
       "id": "adjustments_test_getsource",
       "label": "getSource()",
@@ -70210,7 +70366,7 @@
       "source_location": "L29"
     },
     {
-      "community": 194,
+      "community": 195,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_adjustments_test_ts",
       "label": "adjustments.test.ts",
@@ -70219,7 +70375,7 @@
       "source_location": "L1"
     },
     {
-      "community": 195,
+      "community": 196,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_helpers_returnexchangeoperations_ts",
       "label": "returnExchangeOperations.ts",
@@ -70228,7 +70384,7 @@
       "source_location": "L1"
     },
     {
-      "community": 195,
+      "community": 196,
       "file_type": "code",
       "id": "returnexchangeoperations_buildonlineorderreturnexchangeplan",
       "label": "buildOnlineOrderReturnExchangePlan()",
@@ -70237,7 +70393,7 @@
       "source_location": "L115"
     },
     {
-      "community": 195,
+      "community": 196,
       "file_type": "code",
       "id": "returnexchangeoperations_getapprovalreason",
       "label": "getApprovalReason()",
@@ -70246,7 +70402,7 @@
       "source_location": "L90"
     },
     {
-      "community": 195,
+      "community": 196,
       "file_type": "code",
       "id": "returnexchangeoperations_getkind",
       "label": "getKind()",
@@ -70255,7 +70411,7 @@
       "source_location": "L74"
     },
     {
-      "community": 195,
+      "community": 196,
       "file_type": "code",
       "id": "returnexchangeoperations_getlinerefundamount",
       "label": "getLineRefundAmount()",
@@ -70264,7 +70420,7 @@
       "source_location": "L70"
     },
     {
-      "community": 196,
+      "community": 197,
       "file_type": "code",
       "id": "offers_createoffer",
       "label": "createOffer()",
@@ -70273,7 +70429,7 @@
       "source_location": "L89"
     },
     {
-      "community": 196,
+      "community": 197,
       "file_type": "code",
       "id": "offers_getupsellproducts",
       "label": "getUpsellProducts()",
@@ -70282,7 +70438,7 @@
       "source_location": "L765"
     },
     {
-      "community": 196,
+      "community": 197,
       "file_type": "code",
       "id": "offers_isduplicate",
       "label": "isDuplicate()",
@@ -70291,7 +70447,7 @@
       "source_location": "L37"
     },
     {
-      "community": 196,
+      "community": 197,
       "file_type": "code",
       "id": "offers_updatestorefrontactoremail",
       "label": "updateStoreFrontActorEmail()",
@@ -70300,7 +70456,7 @@
       "source_location": "L60"
     },
     {
-      "community": 196,
+      "community": 197,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_offers_ts",
       "label": "offers.ts",
@@ -70309,7 +70465,7 @@
       "source_location": "L1"
     },
     {
-      "community": 197,
+      "community": 198,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_storefrontobservabilityreport_ts",
       "label": "storefrontObservabilityReport.ts",
@@ -70318,7 +70474,7 @@
       "source_location": "L1"
     },
     {
-      "community": 197,
+      "community": 198,
       "file_type": "code",
       "id": "storefrontobservabilityreport_buildstorefrontobservabilityreport",
       "label": "buildStorefrontObservabilityReport()",
@@ -70327,7 +70483,7 @@
       "source_location": "L124"
     },
     {
-      "community": 197,
+      "community": 198,
       "file_type": "code",
       "id": "storefrontobservabilityreport_getnonemptystring",
       "label": "getNonEmptyString()",
@@ -70336,7 +70492,7 @@
       "source_location": "L67"
     },
     {
-      "community": 197,
+      "community": 198,
       "file_type": "code",
       "id": "storefrontobservabilityreport_gettrafficsource",
       "label": "getTrafficSource()",
@@ -70345,7 +70501,7 @@
       "source_location": "L106"
     },
     {
-      "community": 197,
+      "community": 198,
       "file_type": "code",
       "id": "storefrontobservabilityreport_normalizestorefrontobservabilityevent",
       "label": "normalizeStorefrontObservabilityEvent()",
@@ -70354,7 +70510,7 @@
       "source_location": "L73"
     },
     {
-      "community": 198,
+      "community": 199,
       "file_type": "code",
       "id": "navbar_appheader",
       "label": "AppHeader()",
@@ -70363,7 +70519,7 @@
       "source_location": "L61"
     },
     {
-      "community": 198,
+      "community": 199,
       "file_type": "code",
       "id": "navbar_header",
       "label": "Header()",
@@ -70372,7 +70528,7 @@
       "source_location": "L75"
     },
     {
-      "community": 198,
+      "community": 199,
       "file_type": "code",
       "id": "navbar_navbar",
       "label": "Navbar()",
@@ -70381,7 +70537,7 @@
       "source_location": "L116"
     },
     {
-      "community": 198,
+      "community": 199,
       "file_type": "code",
       "id": "navbar_settingsheader",
       "label": "SettingsHeader()",
@@ -70390,58 +70546,13 @@
       "source_location": "L20"
     },
     {
-      "community": 198,
+      "community": 199,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_navbar_tsx",
       "label": "Navbar.tsx",
       "norm_label": "navbar.tsx",
       "source_file": "packages/athena-webapp/src/components/Navbar.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 199,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_productcategorization_tsx",
-      "label": "ProductCategorization.tsx",
-      "norm_label": "productcategorization.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductCategorization.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 199,
-      "file_type": "code",
-      "id": "productcategorization_getproductname",
-      "label": "getProductName()",
-      "norm_label": "getproductname()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductCategorization.tsx",
-      "source_location": "L287"
-    },
-    {
-      "community": 199,
-      "file_type": "code",
-      "id": "productcategorization_handleclose",
-      "label": "handleClose()",
-      "norm_label": "handleclose()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductCategorization.tsx",
-      "source_location": "L203"
-    },
-    {
-      "community": 199,
-      "file_type": "code",
-      "id": "productcategorization_handleproductvisibility",
-      "label": "handleProductVisibility()",
-      "norm_label": "handleproductvisibility()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductCategorization.tsx",
-      "source_location": "L243"
-    },
-    {
-      "community": 199,
-      "file_type": "code",
-      "id": "productcategorization_setinitialselectedoption",
-      "label": "setInitialSelectedOption()",
-      "norm_label": "setinitialselectedoption()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductCategorization.tsx",
-      "source_location": "L230"
     },
     {
       "community": 2,
@@ -71049,6 +71160,51 @@
     {
       "community": 200,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_productcategorization_tsx",
+      "label": "ProductCategorization.tsx",
+      "norm_label": "productcategorization.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductCategorization.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 200,
+      "file_type": "code",
+      "id": "productcategorization_getproductname",
+      "label": "getProductName()",
+      "norm_label": "getproductname()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductCategorization.tsx",
+      "source_location": "L287"
+    },
+    {
+      "community": 200,
+      "file_type": "code",
+      "id": "productcategorization_handleclose",
+      "label": "handleClose()",
+      "norm_label": "handleclose()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductCategorization.tsx",
+      "source_location": "L203"
+    },
+    {
+      "community": 200,
+      "file_type": "code",
+      "id": "productcategorization_handleproductvisibility",
+      "label": "handleProductVisibility()",
+      "norm_label": "handleproductvisibility()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductCategorization.tsx",
+      "source_location": "L243"
+    },
+    {
+      "community": 200,
+      "file_type": "code",
+      "id": "productcategorization_setinitialselectedoption",
+      "label": "setInitialSelectedOption()",
+      "norm_label": "setinitialselectedoption()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductCategorization.tsx",
+      "source_location": "L230"
+    },
+    {
+      "community": 201,
+      "file_type": "code",
       "id": "index_feesview",
       "label": "FeesView()",
       "norm_label": "feesview()",
@@ -71056,7 +71212,7 @@
       "source_location": "L30"
     },
     {
-      "community": 200,
+      "community": 201,
       "file_type": "code",
       "id": "index_header",
       "label": "Header()",
@@ -71065,7 +71221,7 @@
       "source_location": "L43"
     },
     {
-      "community": 200,
+      "community": 201,
       "file_type": "code",
       "id": "index_onsubmit",
       "label": "onSubmit()",
@@ -71074,7 +71230,7 @@
       "source_location": "L106"
     },
     {
-      "community": 200,
+      "community": 201,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_index_tsx",
       "label": "index.tsx",
@@ -71083,7 +71239,7 @@
       "source_location": "L1"
     },
     {
-      "community": 200,
+      "community": 201,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_index_tsx",
       "label": "index.tsx",
@@ -71092,7 +71248,7 @@
       "source_location": "L1"
     },
     {
-      "community": 201,
+      "community": 202,
       "file_type": "code",
       "id": "cashcontrolsdashboard_cn",
       "label": "cn()",
@@ -71101,7 +71257,7 @@
       "source_location": "L363"
     },
     {
-      "community": 201,
+      "community": 202,
       "file_type": "code",
       "id": "cashcontrolsdashboard_if",
       "label": "if()",
@@ -71110,7 +71266,7 @@
       "source_location": "L423"
     },
     {
-      "community": 201,
+      "community": 202,
       "file_type": "code",
       "id": "cashcontrolsdashboard_metriccardskeleton",
       "label": "MetricCardSkeleton()",
@@ -71119,7 +71275,7 @@
       "source_location": "L87"
     },
     {
-      "community": 201,
+      "community": 202,
       "file_type": "code",
       "id": "cashcontrolsdashboard_switch",
       "label": "switch()",
@@ -71128,7 +71284,7 @@
       "source_location": "L256"
     },
     {
-      "community": 201,
+      "community": 202,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_cashcontrolsdashboard_tsx",
       "label": "CashControlsDashboard.tsx",
@@ -71137,7 +71293,7 @@
       "source_location": "L1"
     },
     {
-      "community": 202,
+      "community": 203,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_common_pageheader_tsx",
       "label": "PageHeader.tsx",
@@ -71146,7 +71302,7 @@
       "source_location": "L1"
     },
     {
-      "community": 202,
+      "community": 203,
       "file_type": "code",
       "id": "pageheader_navigatebackbutton",
       "label": "NavigateBackButton()",
@@ -71155,7 +71311,7 @@
       "source_location": "L30"
     },
     {
-      "community": 202,
+      "community": 203,
       "file_type": "code",
       "id": "pageheader_pageheader",
       "label": "PageHeader()",
@@ -71164,7 +71320,7 @@
       "source_location": "L8"
     },
     {
-      "community": 202,
+      "community": 203,
       "file_type": "code",
       "id": "pageheader_simplepageheader",
       "label": "SimplePageHeader()",
@@ -71173,7 +71329,7 @@
       "source_location": "L50"
     },
     {
-      "community": 202,
+      "community": 203,
       "file_type": "code",
       "id": "pageheader_viewheader",
       "label": "ViewHeader()",
@@ -71182,7 +71338,7 @@
       "source_location": "L67"
     },
     {
-      "community": 203,
+      "community": 204,
       "file_type": "code",
       "id": "dashboard_getperiodrange",
       "label": "getPeriodRange()",
@@ -71191,7 +71347,7 @@
       "source_location": "L20"
     },
     {
-      "community": 203,
+      "community": 204,
       "file_type": "code",
       "id": "dashboard_loadingsection",
       "label": "LoadingSection()",
@@ -71200,7 +71356,7 @@
       "source_location": "L50"
     },
     {
-      "community": 203,
+      "community": 204,
       "file_type": "code",
       "id": "dashboard_renderproductssection",
       "label": "renderProductsSection()",
@@ -71209,7 +71365,7 @@
       "source_location": "L342"
     },
     {
-      "community": 203,
+      "community": 204,
       "file_type": "code",
       "id": "dashboard_rendersalessection",
       "label": "renderSalesSection()",
@@ -71218,7 +71374,7 @@
       "source_location": "L322"
     },
     {
-      "community": 203,
+      "community": 204,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_dashboard_dashboard_tsx",
       "label": "Dashboard.tsx",
@@ -71227,7 +71383,7 @@
       "source_location": "L1"
     },
     {
-      "community": 204,
+      "community": 205,
       "file_type": "code",
       "id": "herosectiontabs_handledisplaytypechange",
       "label": "handleDisplayTypeChange()",
@@ -71236,7 +71392,7 @@
       "source_location": "L61"
     },
     {
-      "community": 204,
+      "community": 205,
       "file_type": "code",
       "id": "herosectiontabs_handleimageupdate",
       "label": "handleImageUpdate()",
@@ -71245,7 +71401,7 @@
       "source_location": "L57"
     },
     {
-      "community": 204,
+      "community": 205,
       "file_type": "code",
       "id": "herosectiontabs_handleoverlaytoggle",
       "label": "handleOverlayToggle()",
@@ -71254,7 +71410,7 @@
       "source_location": "L98"
     },
     {
-      "community": 204,
+      "community": 205,
       "file_type": "code",
       "id": "herosectiontabs_handletexttoggle",
       "label": "handleTextToggle()",
@@ -71263,7 +71419,7 @@
       "source_location": "L134"
     },
     {
-      "community": 204,
+      "community": 205,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_herosectiontabs_tsx",
       "label": "HeroSectionTabs.tsx",
@@ -71272,7 +71428,7 @@
       "source_location": "L1"
     },
     {
-      "community": 205,
+      "community": 206,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_reeluploader_tsx",
       "label": "ReelUploader.tsx",
@@ -71281,7 +71437,7 @@
       "source_location": "L1"
     },
     {
-      "community": 205,
+      "community": 206,
       "file_type": "code",
       "id": "reeluploader_formatfilesize",
       "label": "formatFileSize()",
@@ -71290,7 +71446,7 @@
       "source_location": "L38"
     },
     {
-      "community": 205,
+      "community": 206,
       "file_type": "code",
       "id": "reeluploader_handlefileselect",
       "label": "handleFileSelect()",
@@ -71299,7 +71455,7 @@
       "source_location": "L64"
     },
     {
-      "community": 205,
+      "community": 206,
       "file_type": "code",
       "id": "reeluploader_handleupload",
       "label": "handleUpload()",
@@ -71308,7 +71464,7 @@
       "source_location": "L135"
     },
     {
-      "community": 205,
+      "community": 206,
       "file_type": "code",
       "id": "reeluploader_validatefile",
       "label": "validateFile()",
@@ -71317,7 +71473,7 @@
       "source_location": "L43"
     },
     {
-      "community": 206,
+      "community": 207,
       "file_type": "code",
       "id": "dailyopeningview_test_async",
       "label": "async()",
@@ -71326,7 +71482,7 @@
       "source_location": "L118"
     },
     {
-      "community": 206,
+      "community": 207,
       "file_type": "code",
       "id": "dailyopeningview_test_disconnect",
       "label": "disconnect()",
@@ -71335,7 +71491,7 @@
       "source_location": "L275"
     },
     {
-      "community": 206,
+      "community": 207,
       "file_type": "code",
       "id": "dailyopeningview_test_observe",
       "label": "observe()",
@@ -71344,7 +71500,7 @@
       "source_location": "L276"
     },
     {
-      "community": 206,
+      "community": 207,
       "file_type": "code",
       "id": "dailyopeningview_test_unobserve",
       "label": "unobserve()",
@@ -71353,7 +71509,7 @@
       "source_location": "L277"
     },
     {
-      "community": 206,
+      "community": 207,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_dailyopeningview_test_tsx",
       "label": "DailyOpeningView.test.tsx",
@@ -71362,7 +71518,7 @@
       "source_location": "L1"
     },
     {
-      "community": 207,
+      "community": 208,
       "file_type": "code",
       "id": "activityview_iscreatedaction",
       "label": "isCreatedAction()",
@@ -71371,7 +71527,7 @@
       "source_location": "L58"
     },
     {
-      "community": 207,
+      "community": 208,
       "file_type": "code",
       "id": "activityview_isfeedbackrequestaction",
       "label": "isFeedbackRequestAction()",
@@ -71380,7 +71536,7 @@
       "source_location": "L63"
     },
     {
-      "community": 207,
+      "community": 208,
       "file_type": "code",
       "id": "activityview_isrefundaction",
       "label": "isRefundAction()",
@@ -71389,7 +71545,7 @@
       "source_location": "L50"
     },
     {
-      "community": 207,
+      "community": 208,
       "file_type": "code",
       "id": "activityview_istransitionaction",
       "label": "isTransitionAction()",
@@ -71398,7 +71554,7 @@
       "source_location": "L53"
     },
     {
-      "community": 207,
+      "community": 208,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_activityview_tsx",
       "label": "ActivityView.tsx",
@@ -71407,7 +71563,7 @@
       "source_location": "L1"
     },
     {
-      "community": 208,
+      "community": 209,
       "file_type": "code",
       "id": "orderdetailsview_fetchtransactions",
       "label": "fetchTransactions()",
@@ -71416,7 +71572,7 @@
       "source_location": "L140"
     },
     {
-      "community": 208,
+      "community": 209,
       "file_type": "code",
       "id": "orderdetailsview_handlemarkasverified",
       "label": "handleMarkAsVerified()",
@@ -71425,7 +71581,7 @@
       "source_location": "L177"
     },
     {
-      "community": 208,
+      "community": 209,
       "file_type": "code",
       "id": "orderdetailsview_handlemarkpaymentcollected",
       "label": "handleMarkPaymentCollected()",
@@ -71434,7 +71590,7 @@
       "source_location": "L195"
     },
     {
-      "community": 208,
+      "community": 209,
       "file_type": "code",
       "id": "orderdetailsview_verifiedbadge",
       "label": "VerifiedBadge()",
@@ -71443,57 +71599,12 @@
       "source_location": "L45"
     },
     {
-      "community": 208,
+      "community": 209,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orderdetailsview_tsx",
       "label": "OrderDetailsView.tsx",
       "norm_label": "orderdetailsview.tsx",
       "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 209,
-      "file_type": "code",
-      "id": "orderitemsview_handlerequestfeedback",
-      "label": "handleRequestFeedback()",
-      "norm_label": "handlerequestfeedback()",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
-      "source_location": "L92"
-    },
-    {
-      "community": 209,
-      "file_type": "code",
-      "id": "orderitemsview_handlerestockall",
-      "label": "handleRestockAll()",
-      "norm_label": "handlerestockall()",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
-      "source_location": "L307"
-    },
-    {
-      "community": 209,
-      "file_type": "code",
-      "id": "orderitemsview_handlereturnitemtostock",
-      "label": "handleReturnItemToStock()",
-      "norm_label": "handlereturnitemtostock()",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
-      "source_location": "L70"
-    },
-    {
-      "community": 209,
-      "file_type": "code",
-      "id": "orderitemsview_handleupdateorderitem",
-      "label": "handleUpdateOrderItem()",
-      "norm_label": "handleupdateorderitem()",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
-      "source_location": "L50"
-    },
-    {
-      "community": 209,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_orderitemsview_tsx",
-      "label": "OrderItemsView.tsx",
-      "norm_label": "orderitemsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
       "source_location": "L1"
     },
     {
@@ -71688,6 +71799,51 @@
     {
       "community": 210,
       "file_type": "code",
+      "id": "orderitemsview_handlerequestfeedback",
+      "label": "handleRequestFeedback()",
+      "norm_label": "handlerequestfeedback()",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
+      "source_location": "L92"
+    },
+    {
+      "community": 210,
+      "file_type": "code",
+      "id": "orderitemsview_handlerestockall",
+      "label": "handleRestockAll()",
+      "norm_label": "handlerestockall()",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
+      "source_location": "L307"
+    },
+    {
+      "community": 210,
+      "file_type": "code",
+      "id": "orderitemsview_handlereturnitemtostock",
+      "label": "handleReturnItemToStock()",
+      "norm_label": "handlereturnitemtostock()",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
+      "source_location": "L70"
+    },
+    {
+      "community": 210,
+      "file_type": "code",
+      "id": "orderitemsview_handleupdateorderitem",
+      "label": "handleUpdateOrderItem()",
+      "norm_label": "handleupdateorderitem()",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
+      "source_location": "L50"
+    },
+    {
+      "community": 210,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_orderitemsview_tsx",
+      "label": "OrderItemsView.tsx",
+      "norm_label": "orderitemsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 211,
+      "file_type": "code",
       "id": "ordersummary_test_getbalancedueamount",
       "label": "getBalanceDueAmount()",
       "norm_label": "getbalancedueamount()",
@@ -71695,7 +71851,7 @@
       "source_location": "L40"
     },
     {
-      "community": 210,
+      "community": 211,
       "file_type": "code",
       "id": "ordersummary_test_getbalanceduelabel",
       "label": "getBalanceDueLabel()",
@@ -71704,7 +71860,7 @@
       "source_location": "L57"
     },
     {
-      "community": 210,
+      "community": 211,
       "file_type": "code",
       "id": "ordersummary_test_getbalanceduepanel",
       "label": "getBalanceDuePanel()",
@@ -71713,7 +71869,7 @@
       "source_location": "L66"
     },
     {
-      "community": 210,
+      "community": 211,
       "file_type": "code",
       "id": "ordersummary_test_stripwhitespace",
       "label": "stripWhitespace()",
@@ -71722,7 +71878,7 @@
       "source_location": "L36"
     },
     {
-      "community": 210,
+      "community": 211,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_ordersummary_test_tsx",
       "label": "OrderSummary.test.tsx",
@@ -71731,7 +71887,7 @@
       "source_location": "L1"
     },
     {
-      "community": 211,
+      "community": 212,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_paymentsaddedlist_test_tsx",
       "label": "PaymentsAddedList.test.tsx",
@@ -71740,7 +71896,7 @@
       "source_location": "L1"
     },
     {
-      "community": 211,
+      "community": 212,
       "file_type": "code",
       "id": "paymentsaddedlist_test_getsummaryamount",
       "label": "getSummaryAmount()",
@@ -71749,7 +71905,7 @@
       "source_location": "L27"
     },
     {
-      "community": 211,
+      "community": 212,
       "file_type": "code",
       "id": "paymentsaddedlist_test_getsummarylabel",
       "label": "getSummaryLabel()",
@@ -71758,7 +71914,7 @@
       "source_location": "L18"
     },
     {
-      "community": 211,
+      "community": 212,
       "file_type": "code",
       "id": "paymentsaddedlist_test_getsummarypanel",
       "label": "getSummaryPanel()",
@@ -71767,7 +71923,7 @@
       "source_location": "L40"
     },
     {
-      "community": 211,
+      "community": 212,
       "file_type": "code",
       "id": "paymentsaddedlist_test_stripwhitespace",
       "label": "stripWhitespace()",
@@ -71776,7 +71932,7 @@
       "source_location": "L14"
     },
     {
-      "community": 212,
+      "community": 213,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_productentry_tsx",
       "label": "ProductEntry.tsx",
@@ -71785,7 +71941,7 @@
       "source_location": "L1"
     },
     {
-      "community": 212,
+      "community": 213,
       "file_type": "code",
       "id": "productentry_handleclearsearch",
       "label": "handleClearSearch()",
@@ -71794,7 +71950,7 @@
       "source_location": "L234"
     },
     {
-      "community": 212,
+      "community": 213,
       "file_type": "code",
       "id": "productentry_handleopenquickadd",
       "label": "handleOpenQuickAdd()",
@@ -71803,7 +71959,7 @@
       "source_location": "L239"
     },
     {
-      "community": 212,
+      "community": 213,
       "file_type": "code",
       "id": "productentry_handlequickaddsubmit",
       "label": "handleQuickAddSubmit()",
@@ -71812,7 +71968,7 @@
       "source_location": "L272"
     },
     {
-      "community": 212,
+      "community": 213,
       "file_type": "code",
       "id": "productentry_resetquickaddform",
       "label": "resetQuickAddForm()",
@@ -71821,7 +71977,7 @@
       "source_location": "L263"
     },
     {
-      "community": 213,
+      "community": 214,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_registerdrawergate_tsx",
       "label": "RegisterDrawerGate.tsx",
@@ -71830,7 +71986,7 @@
       "source_location": "L1"
     },
     {
-      "community": 213,
+      "community": 214,
       "file_type": "code",
       "id": "registerdrawergate_handlecloseoutsubmit",
       "label": "handleCloseoutSubmit()",
@@ -71839,7 +71995,7 @@
       "source_location": "L80"
     },
     {
-      "community": 213,
+      "community": 214,
       "file_type": "code",
       "id": "registerdrawergate_handleopeningfloatcorrectionsubmit",
       "label": "handleOpeningFloatCorrectionSubmit()",
@@ -71848,7 +72004,7 @@
       "source_location": "L84"
     },
     {
-      "community": 213,
+      "community": 214,
       "file_type": "code",
       "id": "registerdrawergate_handlesubmit",
       "label": "handleSubmit()",
@@ -71857,7 +72013,7 @@
       "source_location": "L73"
     },
     {
-      "community": 213,
+      "community": 214,
       "file_type": "code",
       "id": "registerdrawergate_if",
       "label": "if()",
@@ -71866,7 +72022,7 @@
       "source_location": "L61"
     },
     {
-      "community": 214,
+      "community": 215,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodeview_tsx",
       "label": "PromoCodeView.tsx",
@@ -71875,7 +72031,7 @@
       "source_location": "L1"
     },
     {
-      "community": 214,
+      "community": 215,
       "file_type": "code",
       "id": "promocodeview_handleaddpromocode",
       "label": "handleAddPromoCode()",
@@ -71884,7 +72040,7 @@
       "source_location": "L157"
     },
     {
-      "community": 214,
+      "community": 215,
       "file_type": "code",
       "id": "promocodeview_handleupdatepromocode",
       "label": "handleUpdatePromoCode()",
@@ -71893,7 +72049,7 @@
       "source_location": "L230"
     },
     {
-      "community": 214,
+      "community": 215,
       "file_type": "code",
       "id": "promocodeview_updatehomepagediscountcode",
       "label": "updateHomepageDiscountCode()",
@@ -71902,7 +72058,7 @@
       "source_location": "L322"
     },
     {
-      "community": 214,
+      "community": 215,
       "file_type": "code",
       "id": "promocodeview_updateleaveareviewdiscountcode",
       "label": "updateLeaveAReviewDiscountCode()",
@@ -71911,7 +72067,7 @@
       "source_location": "L377"
     },
     {
-      "community": 215,
+      "community": 216,
       "file_type": "code",
       "id": "date_time_picker_handleclear",
       "label": "handleClear()",
@@ -71920,7 +72076,7 @@
       "source_location": "L99"
     },
     {
-      "community": 215,
+      "community": 216,
       "file_type": "code",
       "id": "date_time_picker_handledateselect",
       "label": "handleDateSelect()",
@@ -71929,7 +72085,7 @@
       "source_location": "L53"
     },
     {
-      "community": 215,
+      "community": 216,
       "file_type": "code",
       "id": "date_time_picker_handletimeblur",
       "label": "handleTimeBlur()",
@@ -71938,7 +72094,7 @@
       "source_location": "L75"
     },
     {
-      "community": 215,
+      "community": 216,
       "file_type": "code",
       "id": "date_time_picker_handletimechange",
       "label": "handleTimeChange()",
@@ -71947,7 +72103,7 @@
       "source_location": "L63"
     },
     {
-      "community": 215,
+      "community": 216,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_date_time_picker_tsx",
       "label": "date-time-picker.tsx",
@@ -71956,7 +72112,7 @@
       "source_location": "L1"
     },
     {
-      "community": 216,
+      "community": 217,
       "file_type": "code",
       "id": "custom_modal_example_basicmodalexample",
       "label": "BasicModalExample()",
@@ -71965,7 +72121,7 @@
       "source_location": "L7"
     },
     {
-      "community": 216,
+      "community": 217,
       "file_type": "code",
       "id": "custom_modal_example_customclosebuttonexample",
       "label": "CustomCloseButtonExample()",
@@ -71974,7 +72130,7 @@
       "source_location": "L69"
     },
     {
-      "community": 216,
+      "community": 217,
       "file_type": "code",
       "id": "custom_modal_example_custompositionmodalexample",
       "label": "CustomPositionModalExample()",
@@ -71983,7 +72139,7 @@
       "source_location": "L44"
     },
     {
-      "community": 216,
+      "community": 217,
       "file_type": "code",
       "id": "custom_modal_example_fullscreenmodalexample",
       "label": "FullScreenModalExample()",
@@ -71992,7 +72148,7 @@
       "source_location": "L103"
     },
     {
-      "community": 216,
+      "community": 217,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_custom_modal_example_tsx",
       "label": "custom-modal-example.tsx",
@@ -72001,7 +72157,7 @@
       "source_location": "L1"
     },
     {
-      "community": 217,
+      "community": 218,
       "file_type": "code",
       "id": "config_getruntimeorigin",
       "label": "getRuntimeOrigin()",
@@ -72010,7 +72166,7 @@
       "source_location": "L12"
     },
     {
-      "community": 217,
+      "community": 218,
       "file_type": "code",
       "id": "config_islocalhost",
       "label": "isLocalHost()",
@@ -72019,7 +72175,7 @@
       "source_location": "L20"
     },
     {
-      "community": 217,
+      "community": 218,
       "file_type": "code",
       "id": "config_resolvestorefronturl",
       "label": "resolveStoreFrontUrl()",
@@ -72028,7 +72184,7 @@
       "source_location": "L24"
     },
     {
-      "community": 217,
+      "community": 218,
       "file_type": "code",
       "id": "config_trimtrailingslash",
       "label": "trimTrailingSlash()",
@@ -72037,7 +72193,7 @@
       "source_location": "L8"
     },
     {
-      "community": 217,
+      "community": 218,
       "file_type": "code",
       "id": "packages_athena_webapp_src_config_ts",
       "label": "config.ts",
@@ -72046,7 +72202,7 @@
       "source_location": "L1"
     },
     {
-      "community": 218,
+      "community": 219,
       "file_type": "code",
       "id": "browserfingerprint_buffertohex",
       "label": "bufferToHex()",
@@ -72055,7 +72211,7 @@
       "source_location": "L18"
     },
     {
-      "community": 218,
+      "community": 219,
       "file_type": "code",
       "id": "browserfingerprint_collectbrowserinfo",
       "label": "collectBrowserInfo()",
@@ -72064,7 +72220,7 @@
       "source_location": "L23"
     },
     {
-      "community": 218,
+      "community": 219,
       "file_type": "code",
       "id": "browserfingerprint_generatebrowserfingerprint",
       "label": "generateBrowserFingerprint()",
@@ -72073,7 +72229,7 @@
       "source_location": "L65"
     },
     {
-      "community": 218,
+      "community": 219,
       "file_type": "code",
       "id": "browserfingerprint_hashfingerprintsource",
       "label": "hashFingerprintSource()",
@@ -72082,57 +72238,12 @@
       "source_location": "L45"
     },
     {
-      "community": 218,
+      "community": 219,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_browserfingerprint_ts",
       "label": "browserFingerprint.ts",
       "norm_label": "browserfingerprint.ts",
       "source_file": "packages/athena-webapp/src/lib/browserFingerprint.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 219,
-      "file_type": "code",
-      "id": "imageutils_test_arraybuffer",
-      "label": "arrayBuffer()",
-      "norm_label": "arraybuffer()",
-      "source_file": "packages/athena-webapp/src/lib/imageUtils.test.ts",
-      "source_location": "L78"
-    },
-    {
-      "community": 219,
-      "file_type": "code",
-      "id": "imageutils_test_constructor",
-      "label": "constructor()",
-      "norm_label": "constructor()",
-      "source_file": "packages/athena-webapp/src/lib/imageUtils.test.ts",
-      "source_location": "L74"
-    },
-    {
-      "community": 219,
-      "file_type": "code",
-      "id": "imageutils_test_mockimage",
-      "label": "MockImage",
-      "norm_label": "mockimage",
-      "source_file": "packages/athena-webapp/src/lib/imageUtils.test.ts",
-      "source_location": "L103"
-    },
-    {
-      "community": 219,
-      "file_type": "code",
-      "id": "imageutils_test_mockimage_src",
-      "label": ".src()",
-      "norm_label": ".src()",
-      "source_file": "packages/athena-webapp/src/lib/imageUtils.test.ts",
-      "source_location": "L109"
-    },
-    {
-      "community": 219,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_imageutils_test_ts",
-      "label": "imageUtils.test.ts",
-      "norm_label": "imageutils.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/imageUtils.test.ts",
       "source_location": "L1"
     },
     {
@@ -72318,6 +72429,51 @@
     {
       "community": 220,
       "file_type": "code",
+      "id": "imageutils_test_arraybuffer",
+      "label": "arrayBuffer()",
+      "norm_label": "arraybuffer()",
+      "source_file": "packages/athena-webapp/src/lib/imageUtils.test.ts",
+      "source_location": "L78"
+    },
+    {
+      "community": 220,
+      "file_type": "code",
+      "id": "imageutils_test_constructor",
+      "label": "constructor()",
+      "norm_label": "constructor()",
+      "source_file": "packages/athena-webapp/src/lib/imageUtils.test.ts",
+      "source_location": "L74"
+    },
+    {
+      "community": 220,
+      "file_type": "code",
+      "id": "imageutils_test_mockimage",
+      "label": "MockImage",
+      "norm_label": "mockimage",
+      "source_file": "packages/athena-webapp/src/lib/imageUtils.test.ts",
+      "source_location": "L103"
+    },
+    {
+      "community": 220,
+      "file_type": "code",
+      "id": "imageutils_test_mockimage_src",
+      "label": ".src()",
+      "norm_label": ".src()",
+      "source_file": "packages/athena-webapp/src/lib/imageUtils.test.ts",
+      "source_location": "L109"
+    },
+    {
+      "community": 220,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_imageutils_test_ts",
+      "label": "imageUtils.test.ts",
+      "norm_label": "imageutils.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/imageUtils.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 221,
+      "file_type": "code",
       "id": "imageutils_convertimagestojpg",
       "label": "convertImagesToJpg()",
       "norm_label": "convertimagestojpg()",
@@ -72325,7 +72481,7 @@
       "source_location": "L75"
     },
     {
-      "community": 220,
+      "community": 221,
       "file_type": "code",
       "id": "imageutils_convertimagestowebp",
       "label": "convertImagesToWebp()",
@@ -72334,7 +72490,7 @@
       "source_location": "L26"
     },
     {
-      "community": 220,
+      "community": 221,
       "file_type": "code",
       "id": "imageutils_converttojpg",
       "label": "convertToJpg()",
@@ -72343,7 +72499,7 @@
       "source_location": "L38"
     },
     {
-      "community": 220,
+      "community": 221,
       "file_type": "code",
       "id": "imageutils_getuploadimagesdata",
       "label": "getUploadImagesData()",
@@ -72352,7 +72508,7 @@
       "source_location": "L4"
     },
     {
-      "community": 220,
+      "community": 221,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_imageutils_ts",
       "label": "imageUtils.ts",
@@ -72361,7 +72517,7 @@
       "source_location": "L1"
     },
     {
-      "community": 221,
+      "community": 222,
       "file_type": "code",
       "id": "cart_calculateposcarttotals",
       "label": "calculatePosCartTotals()",
@@ -72370,7 +72526,7 @@
       "source_location": "L3"
     },
     {
-      "community": 221,
+      "community": 222,
       "file_type": "code",
       "id": "cart_calculatepositemtotal",
       "label": "calculatePosItemTotal()",
@@ -72379,7 +72535,7 @@
       "source_location": "L29"
     },
     {
-      "community": 221,
+      "community": 222,
       "file_type": "code",
       "id": "cart_getposeffectiveprice",
       "label": "getPosEffectivePrice()",
@@ -72388,7 +72544,7 @@
       "source_location": "L33"
     },
     {
-      "community": 221,
+      "community": 222,
       "file_type": "code",
       "id": "cart_roundposamount",
       "label": "roundPosAmount()",
@@ -72397,7 +72553,7 @@
       "source_location": "L40"
     },
     {
-      "community": 221,
+      "community": 222,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_domain_cart_ts",
       "label": "cart.ts",
@@ -72406,7 +72562,7 @@
       "source_location": "L1"
     },
     {
-      "community": 222,
+      "community": 223,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_registergateway_ts",
       "label": "registerGateway.ts",
@@ -72415,7 +72571,7 @@
       "source_location": "L1"
     },
     {
-      "community": 222,
+      "community": 223,
       "file_type": "code",
       "id": "registergateway_mapregisterstatedto",
       "label": "mapRegisterStateDto()",
@@ -72424,7 +72580,7 @@
       "source_location": "L12"
     },
     {
-      "community": 222,
+      "community": 223,
       "file_type": "code",
       "id": "registergateway_mapterminaldto",
       "label": "mapTerminalDto()",
@@ -72433,7 +72589,7 @@
       "source_location": "L30"
     },
     {
-      "community": 222,
+      "community": 223,
       "file_type": "code",
       "id": "registergateway_useconvexregisterstate",
       "label": "useConvexRegisterState()",
@@ -72442,7 +72598,7 @@
       "source_location": "L36"
     },
     {
-      "community": 222,
+      "community": 223,
       "file_type": "code",
       "id": "registergateway_useconvexterminalbyfingerprint",
       "label": "useConvexTerminalByFingerprint()",
@@ -72451,7 +72607,7 @@
       "source_location": "L58"
     },
     {
-      "community": 223,
+      "community": 224,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_transactionutils_ts",
       "label": "transactionUtils.ts",
@@ -72460,7 +72616,7 @@
       "source_location": "L1"
     },
     {
-      "community": 223,
+      "community": 224,
       "file_type": "code",
       "id": "transactionutils_calculatechange",
       "label": "calculateChange()",
@@ -72469,7 +72625,7 @@
       "source_location": "L42"
     },
     {
-      "community": 223,
+      "community": 224,
       "file_type": "code",
       "id": "transactionutils_formatcurrency",
       "label": "formatCurrency()",
@@ -72478,7 +72634,7 @@
       "source_location": "L29"
     },
     {
-      "community": 223,
+      "community": 224,
       "file_type": "code",
       "id": "transactionutils_formattimestamp",
       "label": "formatTimestamp()",
@@ -72487,7 +72643,7 @@
       "source_location": "L49"
     },
     {
-      "community": 223,
+      "community": 224,
       "file_type": "code",
       "id": "transactionutils_generatetransactionnumber",
       "label": "generateTransactionNumber()",
@@ -72496,7 +72652,7 @@
       "source_location": "L14"
     },
     {
-      "community": 224,
+      "community": 225,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_timelineutils_ts",
       "label": "timelineUtils.ts",
@@ -72505,7 +72661,7 @@
       "source_location": "L1"
     },
     {
-      "community": 224,
+      "community": 225,
       "file_type": "code",
       "id": "timelineutils_enrichtimelineevent",
       "label": "enrichTimelineEvent()",
@@ -72514,7 +72670,7 @@
       "source_location": "L184"
     },
     {
-      "community": 224,
+      "community": 225,
       "file_type": "code",
       "id": "timelineutils_enrichtimelineevents",
       "label": "enrichTimelineEvents()",
@@ -72523,7 +72679,7 @@
       "source_location": "L200"
     },
     {
-      "community": 224,
+      "community": 225,
       "file_type": "code",
       "id": "timelineutils_gettimerangelabel",
       "label": "getTimeRangeLabel()",
@@ -72532,7 +72688,7 @@
       "source_location": "L244"
     },
     {
-      "community": 224,
+      "community": 225,
       "file_type": "code",
       "id": "timelineutils_groupeventsbytimeframe",
       "label": "groupEventsByTimeframe()",
@@ -72541,7 +72697,7 @@
       "source_location": "L206"
     },
     {
-      "community": 225,
+      "community": 226,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_procurement_index_tsx",
       "label": "procurement.index.tsx",
@@ -72550,7 +72706,7 @@
       "source_location": "L1"
     },
     {
-      "community": 225,
+      "community": 226,
       "file_type": "code",
       "id": "procurement_index_getnextprocurementmodesearch",
       "label": "getNextProcurementModeSearch()",
@@ -72559,7 +72715,7 @@
       "source_location": "L16"
     },
     {
-      "community": 225,
+      "community": 226,
       "file_type": "code",
       "id": "procurement_index_getnextprocurementpagesearch",
       "label": "getNextProcurementPageSearch()",
@@ -72568,7 +72724,7 @@
       "source_location": "L34"
     },
     {
-      "community": 225,
+      "community": 226,
       "file_type": "code",
       "id": "procurement_index_getnextprocurementselectedskusearch",
       "label": "getNextProcurementSelectedSkuSearch()",
@@ -72577,7 +72733,7 @@
       "source_location": "L44"
     },
     {
-      "community": 225,
+      "community": 226,
       "file_type": "code",
       "id": "procurement_index_procurementroute",
       "label": "ProcurementRoute()",
@@ -72586,7 +72742,7 @@
       "source_location": "L70"
     },
     {
-      "community": 226,
+      "community": 227,
       "file_type": "code",
       "id": "authed_authedcomponent",
       "label": "AuthedComponent()",
@@ -72595,7 +72751,7 @@
       "source_location": "L29"
     },
     {
-      "community": 226,
+      "community": 227,
       "file_type": "code",
       "id": "authed_layout",
       "label": "Layout()",
@@ -72604,7 +72760,7 @@
       "source_location": "L99"
     },
     {
-      "community": 226,
+      "community": 227,
       "file_type": "code",
       "id": "authed_topbar",
       "label": "TopBar()",
@@ -72613,7 +72769,7 @@
       "source_location": "L74"
     },
     {
-      "community": 226,
+      "community": 227,
       "file_type": "code",
       "id": "authed_usermenu",
       "label": "UserMenu()",
@@ -72622,7 +72778,7 @@
       "source_location": "L39"
     },
     {
-      "community": 226,
+      "community": 227,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_tsx",
       "label": "_authed.tsx",
@@ -72631,7 +72787,7 @@
       "source_location": "L1"
     },
     {
-      "community": 227,
+      "community": 228,
       "file_type": "code",
       "id": "layout_completependingauthsync",
       "label": "completePendingAuthSync()",
@@ -72640,7 +72796,7 @@
       "source_location": "L114"
     },
     {
-      "community": 227,
+      "community": 228,
       "file_type": "code",
       "id": "layout_handlependingauthsync",
       "label": "handlePendingAuthSync()",
@@ -72649,7 +72805,7 @@
       "source_location": "L81"
     },
     {
-      "community": 227,
+      "community": 228,
       "file_type": "code",
       "id": "layout_sleep",
       "label": "sleep()",
@@ -72658,7 +72814,7 @@
       "source_location": "L23"
     },
     {
-      "community": 227,
+      "community": 228,
       "file_type": "code",
       "id": "layout_usedocumentscrolllock",
       "label": "useDocumentScrollLock()",
@@ -72667,7 +72823,7 @@
       "source_location": "L27"
     },
     {
-      "community": 227,
+      "community": 228,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_login_layout_tsx",
       "label": "_layout.tsx",
@@ -72676,7 +72832,7 @@
       "source_location": "L1"
     },
     {
-      "community": 228,
+      "community": 229,
       "file_type": "code",
       "id": "analytics_getproductviewcount",
       "label": "getProductViewCount()",
@@ -72685,7 +72841,7 @@
       "source_location": "L93"
     },
     {
-      "community": 228,
+      "community": 229,
       "file_type": "code",
       "id": "analytics_logout",
       "label": "logout()",
@@ -72694,7 +72850,7 @@
       "source_location": "L75"
     },
     {
-      "community": 228,
+      "community": 229,
       "file_type": "code",
       "id": "analytics_postanalytics",
       "label": "postAnalytics()",
@@ -72703,7 +72859,7 @@
       "source_location": "L4"
     },
     {
-      "community": 228,
+      "community": 229,
       "file_type": "code",
       "id": "analytics_updateanalyticsowner",
       "label": "updateAnalyticsOwner()",
@@ -72712,57 +72868,12 @@
       "source_location": "L47"
     },
     {
-      "community": 228,
+      "community": 229,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_analytics_ts",
       "label": "analytics.ts",
       "norm_label": "analytics.ts",
       "source_file": "packages/storefront-webapp/src/api/analytics.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 229,
-      "file_type": "code",
-      "id": "category_getallcategories",
-      "label": "getAllCategories()",
-      "norm_label": "getallcategories()",
-      "source_file": "packages/storefront-webapp/src/api/category.ts",
-      "source_location": "L11"
-    },
-    {
-      "community": 229,
-      "file_type": "code",
-      "id": "category_getallcategorieswithsubcategories",
-      "label": "getAllCategoriesWithSubcategories()",
-      "norm_label": "getallcategorieswithsubcategories()",
-      "source_file": "packages/storefront-webapp/src/api/category.ts",
-      "source_location": "L25"
-    },
-    {
-      "community": 229,
-      "file_type": "code",
-      "id": "category_getbaseurl",
-      "label": "getBaseUrl()",
-      "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/category.ts",
-      "source_location": "L9"
-    },
-    {
-      "community": 229,
-      "file_type": "code",
-      "id": "category_getcategory",
-      "label": "getCategory()",
-      "norm_label": "getcategory()",
-      "source_file": "packages/storefront-webapp/src/api/category.ts",
-      "source_location": "L39"
-    },
-    {
-      "community": 229,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_category_ts",
-      "label": "category.ts",
-      "norm_label": "category.ts",
-      "source_file": "packages/storefront-webapp/src/api/category.ts",
       "source_location": "L1"
     },
     {
@@ -72948,6 +73059,51 @@
     {
       "community": 230,
       "file_type": "code",
+      "id": "category_getallcategories",
+      "label": "getAllCategories()",
+      "norm_label": "getallcategories()",
+      "source_file": "packages/storefront-webapp/src/api/category.ts",
+      "source_location": "L11"
+    },
+    {
+      "community": 230,
+      "file_type": "code",
+      "id": "category_getallcategorieswithsubcategories",
+      "label": "getAllCategoriesWithSubcategories()",
+      "norm_label": "getallcategorieswithsubcategories()",
+      "source_file": "packages/storefront-webapp/src/api/category.ts",
+      "source_location": "L25"
+    },
+    {
+      "community": 230,
+      "file_type": "code",
+      "id": "category_getbaseurl",
+      "label": "getBaseUrl()",
+      "norm_label": "getbaseurl()",
+      "source_file": "packages/storefront-webapp/src/api/category.ts",
+      "source_location": "L9"
+    },
+    {
+      "community": 230,
+      "file_type": "code",
+      "id": "category_getcategory",
+      "label": "getCategory()",
+      "norm_label": "getcategory()",
+      "source_file": "packages/storefront-webapp/src/api/category.ts",
+      "source_location": "L39"
+    },
+    {
+      "community": 230,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_api_category_ts",
+      "label": "category.ts",
+      "norm_label": "category.ts",
+      "source_file": "packages/storefront-webapp/src/api/category.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 231,
+      "file_type": "code",
       "id": "onlineorder_getbaseurl",
       "label": "getBaseUrl()",
       "norm_label": "getbaseurl()",
@@ -72955,7 +73111,7 @@
       "source_location": "L4"
     },
     {
-      "community": 230,
+      "community": 231,
       "file_type": "code",
       "id": "onlineorder_getorder",
       "label": "getOrder()",
@@ -72964,7 +73120,7 @@
       "source_location": "L24"
     },
     {
-      "community": 230,
+      "community": 231,
       "file_type": "code",
       "id": "onlineorder_getorders",
       "label": "getOrders()",
@@ -72973,7 +73129,7 @@
       "source_location": "L6"
     },
     {
-      "community": 230,
+      "community": 231,
       "file_type": "code",
       "id": "onlineorder_updateordersowner",
       "label": "updateOrdersOwner()",
@@ -72982,7 +73138,7 @@
       "source_location": "L42"
     },
     {
-      "community": 230,
+      "community": 231,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_onlineorder_ts",
       "label": "onlineOrder.ts",
@@ -72991,7 +73147,7 @@
       "source_location": "L1"
     },
     {
-      "community": 231,
+      "community": 232,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_storefrontuser_ts",
       "label": "storeFrontUser.ts",
@@ -73000,7 +73156,7 @@
       "source_location": "L1"
     },
     {
-      "community": 231,
+      "community": 232,
       "file_type": "code",
       "id": "storefrontuser_getactiveuser",
       "label": "getActiveUser()",
@@ -73009,7 +73165,7 @@
       "source_location": "L28"
     },
     {
-      "community": 231,
+      "community": 232,
       "file_type": "code",
       "id": "storefrontuser_getbaseurl",
       "label": "getBaseUrl()",
@@ -73018,7 +73174,7 @@
       "source_location": "L5"
     },
     {
-      "community": 231,
+      "community": 232,
       "file_type": "code",
       "id": "storefrontuser_getguest",
       "label": "getGuest()",
@@ -73027,7 +73183,7 @@
       "source_location": "L7"
     },
     {
-      "community": 231,
+      "community": 232,
       "file_type": "code",
       "id": "storefrontuser_updateuser",
       "label": "updateUser()",
@@ -73036,7 +73192,7 @@
       "source_location": "L46"
     },
     {
-      "community": 232,
+      "community": 233,
       "file_type": "code",
       "id": "homepage_enableprompts",
       "label": "enablePrompts()",
@@ -73045,7 +73201,7 @@
       "source_location": "L147"
     },
     {
-      "community": 232,
+      "community": 233,
       "file_type": "code",
       "id": "homepage_handleclickonleavereviewbutton",
       "label": "handleClickOnLeaveReviewButton()",
@@ -73054,7 +73210,7 @@
       "source_location": "L186"
     },
     {
-      "community": 232,
+      "community": 233,
       "file_type": "code",
       "id": "homepage_handlescroll",
       "label": "handleScroll()",
@@ -73063,7 +73219,7 @@
       "source_location": "L115"
     },
     {
-      "community": 232,
+      "community": 233,
       "file_type": "code",
       "id": "homepage_homepagereadyshell",
       "label": "HomePageReadyShell()",
@@ -73072,7 +73228,7 @@
       "source_location": "L31"
     },
     {
-      "community": 232,
+      "community": 233,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_homepage_tsx",
       "label": "HomePage.tsx",
@@ -73081,7 +73237,7 @@
       "source_location": "L1"
     },
     {
-      "community": 233,
+      "community": 234,
       "file_type": "code",
       "id": "inventorylevelbadge_lowstockbadge",
       "label": "LowStockBadge()",
@@ -73090,7 +73246,7 @@
       "source_location": "L14"
     },
     {
-      "community": 233,
+      "community": 234,
       "file_type": "code",
       "id": "inventorylevelbadge_sellingfastbadge",
       "label": "SellingFastBadge()",
@@ -73099,7 +73255,7 @@
       "source_location": "L22"
     },
     {
-      "community": 233,
+      "community": 234,
       "file_type": "code",
       "id": "inventorylevelbadge_sellingfastsignal",
       "label": "SellingFastSignal()",
@@ -73108,7 +73264,7 @@
       "source_location": "L30"
     },
     {
-      "community": 233,
+      "community": 234,
       "file_type": "code",
       "id": "inventorylevelbadge_soldoutbadge",
       "label": "SoldOutBadge()",
@@ -73117,7 +73273,7 @@
       "source_location": "L3"
     },
     {
-      "community": 233,
+      "community": 234,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_inventorylevelbadge_tsx",
       "label": "InventoryLevelBadge.tsx",
@@ -73126,7 +73282,7 @@
       "source_location": "L1"
     },
     {
-      "community": 234,
+      "community": 235,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_storefrontfailureobservability_ts",
       "label": "storefrontFailureObservability.ts",
@@ -73135,7 +73291,7 @@
       "source_location": "L1"
     },
     {
-      "community": 234,
+      "community": 235,
       "file_type": "code",
       "id": "storefrontfailureobservability_createstorefrontfailureevent",
       "label": "createStorefrontFailureEvent()",
@@ -73144,7 +73300,7 @@
       "source_location": "L136"
     },
     {
-      "community": 234,
+      "community": 235,
       "file_type": "code",
       "id": "storefrontfailureobservability_emitstorefrontfailure",
       "label": "emitStorefrontFailure()",
@@ -73153,7 +73309,7 @@
       "source_location": "L154"
     },
     {
-      "community": 234,
+      "community": 235,
       "file_type": "code",
       "id": "storefrontfailureobservability_inferstorefrontjourneyfromroute",
       "label": "inferStorefrontJourneyFromRoute()",
@@ -73162,7 +73318,7 @@
       "source_location": "L25"
     },
     {
-      "community": 234,
+      "community": 235,
       "file_type": "code",
       "id": "storefrontfailureobservability_normalizestorefronterror",
       "label": "normalizeStorefrontError()",
@@ -73171,7 +73327,7 @@
       "source_location": "L47"
     },
     {
-      "community": 235,
+      "community": 236,
       "file_type": "code",
       "id": "harness_behavior_test_createbrowser",
       "label": "createBrowser()",
@@ -73180,7 +73336,7 @@
       "source_location": "L52"
     },
     {
-      "community": 235,
+      "community": 236,
       "file_type": "code",
       "id": "harness_behavior_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -73189,7 +73345,7 @@
       "source_location": "L22"
     },
     {
-      "community": 235,
+      "community": 236,
       "file_type": "code",
       "id": "harness_behavior_test_createplaywrightmodule",
       "label": "createPlaywrightModule()",
@@ -73198,7 +73354,7 @@
       "source_location": "L44"
     },
     {
-      "community": 235,
+      "community": 236,
       "file_type": "code",
       "id": "harness_behavior_test_write",
       "label": "write()",
@@ -73207,7 +73363,7 @@
       "source_location": "L16"
     },
     {
-      "community": 235,
+      "community": 236,
       "file_type": "code",
       "id": "scripts_harness_behavior_test_ts",
       "label": "harness-behavior.test.ts",
@@ -73216,7 +73372,7 @@
       "source_location": "L1"
     },
     {
-      "community": 236,
+      "community": 237,
       "file_type": "code",
       "id": "harness_repo_validation_collectharnessrepovalidationselection",
       "label": "collectHarnessRepoValidationSelection()",
@@ -73225,7 +73381,7 @@
       "source_location": "L47"
     },
     {
-      "community": 236,
+      "community": 237,
       "file_type": "code",
       "id": "harness_repo_validation_matchesharnessrepovalidationpath",
       "label": "matchesHarnessRepoValidationPath()",
@@ -73234,7 +73390,7 @@
       "source_location": "L39"
     },
     {
-      "community": 236,
+      "community": 237,
       "file_type": "code",
       "id": "harness_repo_validation_normalizerepopath",
       "label": "normalizeRepoPath()",
@@ -73243,7 +73399,7 @@
       "source_location": "L29"
     },
     {
-      "community": 236,
+      "community": 237,
       "file_type": "code",
       "id": "harness_repo_validation_sortuniquepaths",
       "label": "sortUniquePaths()",
@@ -73252,7 +73408,7 @@
       "source_location": "L33"
     },
     {
-      "community": 236,
+      "community": 237,
       "file_type": "code",
       "id": "scripts_harness_repo_validation_ts",
       "label": "harness-repo-validation.ts",
@@ -73261,7 +73417,7 @@
       "source_location": "L1"
     },
     {
-      "community": 237,
+      "community": 238,
       "file_type": "code",
       "id": "pre_commit_generated_artifacts_test_log",
       "label": "log()",
@@ -73270,7 +73426,7 @@
       "source_location": "L73"
     },
     {
-      "community": 237,
+      "community": 238,
       "file_type": "code",
       "id": "pre_commit_generated_artifacts_test_spawn",
       "label": "spawn()",
@@ -73279,7 +73435,7 @@
       "source_location": "L65"
     },
     {
-      "community": 237,
+      "community": 238,
       "file_type": "code",
       "id": "pre_commit_generated_artifacts_test_withtemprepo",
       "label": "withTempRepo()",
@@ -73288,7 +73444,7 @@
       "source_location": "L14"
     },
     {
-      "community": 237,
+      "community": 238,
       "file_type": "code",
       "id": "pre_commit_generated_artifacts_test_writeconvexapifixture",
       "label": "writeConvexApiFixture()",
@@ -73297,7 +73453,7 @@
       "source_location": "L24"
     },
     {
-      "community": 237,
+      "community": 238,
       "file_type": "code",
       "id": "scripts_pre_commit_generated_artifacts_test_ts",
       "label": "pre-commit-generated-artifacts.test.ts",
@@ -73306,7 +73462,7 @@
       "source_location": "L1"
     },
     {
-      "community": 238,
+      "community": 239,
       "file_type": "code",
       "id": "scripts_worktree_manager_test_ts",
       "label": "worktree-manager.test.ts",
@@ -73315,7 +73471,7 @@
       "source_location": "L1"
     },
     {
-      "community": 238,
+      "community": 239,
       "file_type": "code",
       "id": "worktree_manager_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -73324,7 +73480,7 @@
       "source_location": "L17"
     },
     {
-      "community": 238,
+      "community": 239,
       "file_type": "code",
       "id": "worktree_manager_test_fixtureenv",
       "label": "fixtureEnv()",
@@ -73333,7 +73489,7 @@
       "source_location": "L72"
     },
     {
-      "community": 238,
+      "community": 239,
       "file_type": "code",
       "id": "worktree_manager_test_rungit",
       "label": "runGit()",
@@ -73342,49 +73498,13 @@
       "source_location": "L45"
     },
     {
-      "community": 238,
+      "community": 239,
       "file_type": "code",
       "id": "worktree_manager_test_runworktreemanager",
       "label": "runWorktreeManager()",
       "norm_label": "runworktreemanager()",
       "source_file": "scripts/worktree-manager.test.ts",
       "source_location": "L59"
-    },
-    {
-      "community": 239,
-      "file_type": "code",
-      "id": "convexpaginationantipatterncheck_test_createtemproot",
-      "label": "createTempRoot()",
-      "norm_label": "createtemproot()",
-      "source_file": "packages/athena-webapp/convex/convexPaginationAntiPatternCheck.test.ts",
-      "source_location": "L12"
-    },
-    {
-      "community": 239,
-      "file_type": "code",
-      "id": "convexpaginationantipatterncheck_test_runpaginationcheck",
-      "label": "runPaginationCheck()",
-      "norm_label": "runpaginationcheck()",
-      "source_file": "packages/athena-webapp/convex/convexPaginationAntiPatternCheck.test.ts",
-      "source_location": "L26"
-    },
-    {
-      "community": 239,
-      "file_type": "code",
-      "id": "convexpaginationantipatterncheck_test_writeconvexfile",
-      "label": "writeConvexFile()",
-      "norm_label": "writeconvexfile()",
-      "source_file": "packages/athena-webapp/convex/convexPaginationAntiPatternCheck.test.ts",
-      "source_location": "L20"
-    },
-    {
-      "community": 239,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_convexpaginationantipatterncheck_test_ts",
-      "label": "convexPaginationAntiPatternCheck.test.ts",
-      "norm_label": "convexpaginationantipatterncheck.test.ts",
-      "source_file": "packages/athena-webapp/convex/convexPaginationAntiPatternCheck.test.ts",
-      "source_location": "L1"
     },
     {
       "community": 24,
@@ -73569,6 +73689,42 @@
     {
       "community": 240,
       "file_type": "code",
+      "id": "convexpaginationantipatterncheck_test_createtemproot",
+      "label": "createTempRoot()",
+      "norm_label": "createtemproot()",
+      "source_file": "packages/athena-webapp/convex/convexPaginationAntiPatternCheck.test.ts",
+      "source_location": "L12"
+    },
+    {
+      "community": 240,
+      "file_type": "code",
+      "id": "convexpaginationantipatterncheck_test_runpaginationcheck",
+      "label": "runPaginationCheck()",
+      "norm_label": "runpaginationcheck()",
+      "source_file": "packages/athena-webapp/convex/convexPaginationAntiPatternCheck.test.ts",
+      "source_location": "L26"
+    },
+    {
+      "community": 240,
+      "file_type": "code",
+      "id": "convexpaginationantipatterncheck_test_writeconvexfile",
+      "label": "writeConvexFile()",
+      "norm_label": "writeconvexfile()",
+      "source_file": "packages/athena-webapp/convex/convexPaginationAntiPatternCheck.test.ts",
+      "source_location": "L20"
+    },
+    {
+      "community": 240,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_convexpaginationantipatterncheck_test_ts",
+      "label": "convexPaginationAntiPatternCheck.test.ts",
+      "norm_label": "convexpaginationantipatterncheck.test.ts",
+      "source_file": "packages/athena-webapp/convex/convexPaginationAntiPatternCheck.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 241,
+      "file_type": "code",
       "id": "domain_maskreceiptphone",
       "label": "maskReceiptPhone()",
       "norm_label": "maskreceiptphone()",
@@ -73576,7 +73732,7 @@
       "source_location": "L67"
     },
     {
-      "community": 240,
+      "community": 241,
       "file_type": "code",
       "id": "domain_normalizereceiptphone",
       "label": "normalizeReceiptPhone()",
@@ -73585,7 +73741,7 @@
       "source_location": "L52"
     },
     {
-      "community": 240,
+      "community": 241,
       "file_type": "code",
       "id": "domain_statusisretryable",
       "label": "statusIsRetryable()",
@@ -73594,7 +73750,7 @@
       "source_location": "L79"
     },
     {
-      "community": 240,
+      "community": 241,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_customermessaging_domain_ts",
       "label": "domain.ts",
@@ -73603,7 +73759,7 @@
       "source_location": "L1"
     },
     {
-      "community": 241,
+      "community": 242,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_customermessaging_token_ts",
       "label": "token.ts",
@@ -73612,7 +73768,7 @@
       "source_location": "L1"
     },
     {
-      "community": 241,
+      "community": 242,
       "file_type": "code",
       "id": "token_createreceiptsharetoken",
       "label": "createReceiptShareToken()",
@@ -73621,7 +73777,7 @@
       "source_location": "L9"
     },
     {
-      "community": 241,
+      "community": 242,
       "file_type": "code",
       "id": "token_hashreceiptsharetoken",
       "label": "hashReceiptShareToken()",
@@ -73630,7 +73786,7 @@
       "source_location": "L15"
     },
     {
-      "community": 241,
+      "community": 242,
       "file_type": "code",
       "id": "token_tohex",
       "label": "toHex()",
@@ -73639,7 +73795,7 @@
       "source_location": "L3"
     },
     {
-      "community": 242,
+      "community": 243,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_customermessaging_webhooksecurity_ts",
       "label": "webhookSecurity.ts",
@@ -73648,7 +73804,7 @@
       "source_location": "L1"
     },
     {
-      "community": 242,
+      "community": 243,
       "file_type": "code",
       "id": "webhooksecurity_timingsafeequal",
       "label": "timingSafeEqual()",
@@ -73657,7 +73813,7 @@
       "source_location": "L9"
     },
     {
-      "community": 242,
+      "community": 243,
       "file_type": "code",
       "id": "webhooksecurity_tohex",
       "label": "toHex()",
@@ -73666,7 +73822,7 @@
       "source_location": "L3"
     },
     {
-      "community": 242,
+      "community": 243,
       "file_type": "code",
       "id": "webhooksecurity_verifymetawebhooksignature",
       "label": "verifyMetaWebhookSignature()",
@@ -73675,7 +73831,7 @@
       "source_location": "L22"
     },
     {
-      "community": 243,
+      "community": 244,
       "file_type": "code",
       "id": "checkout_hasallvisibilesessionitems",
       "label": "hasAllVisibileSessionItems()",
@@ -73684,7 +73840,7 @@
       "source_location": "L109"
     },
     {
-      "community": 243,
+      "community": 244,
       "file_type": "code",
       "id": "checkout_hasvalidcanonicalbagitem",
       "label": "hasValidCanonicalBagItem()",
@@ -73693,7 +73849,7 @@
       "source_location": "L84"
     },
     {
-      "community": 243,
+      "community": 244,
       "file_type": "code",
       "id": "checkout_hasvalidsessionitems",
       "label": "hasValidSessionItems()",
@@ -73702,7 +73858,7 @@
       "source_location": "L95"
     },
     {
-      "community": 243,
+      "community": 244,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_checkout_ts",
       "label": "checkout.ts",
@@ -73711,7 +73867,7 @@
       "source_location": "L1"
     },
     {
-      "community": 244,
+      "community": 245,
       "file_type": "code",
       "id": "expensesessions_test_buildsession",
       "label": "buildSession()",
@@ -73720,7 +73876,7 @@
       "source_location": "L235"
     },
     {
-      "community": 244,
+      "community": 245,
       "file_type": "code",
       "id": "expensesessions_test_createmutationctx",
       "label": "createMutationCtx()",
@@ -73729,7 +73885,7 @@
       "source_location": "L53"
     },
     {
-      "community": 244,
+      "community": 245,
       "file_type": "code",
       "id": "expensesessions_test_gethandler",
       "label": "getHandler()",
@@ -73738,7 +73894,7 @@
       "source_location": "L250"
     },
     {
-      "community": 244,
+      "community": 245,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_expensesessions_test_ts",
       "label": "expenseSessions.test.ts",
@@ -73747,7 +73903,7 @@
       "source_location": "L1"
     },
     {
-      "community": 245,
+      "community": 246,
       "file_type": "code",
       "id": "expensetransactions_createexpensetransactionfromsessionhandler",
       "label": "createExpenseTransactionFromSessionHandler()",
@@ -73756,7 +73912,7 @@
       "source_location": "L50"
     },
     {
-      "community": 245,
+      "community": 246,
       "file_type": "code",
       "id": "expensetransactions_expensetransactionerror",
       "label": "expenseTransactionError()",
@@ -73765,7 +73921,7 @@
       "source_location": "L23"
     },
     {
-      "community": 245,
+      "community": 246,
       "file_type": "code",
       "id": "expensetransactions_formatexpensestaffprofilename",
       "label": "formatExpenseStaffProfileName()",
@@ -73774,7 +73930,7 @@
       "source_location": "L37"
     },
     {
-      "community": 245,
+      "community": 246,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_expensetransactions_ts",
       "label": "expenseTransactions.ts",
@@ -73783,7 +73939,7 @@
       "source_location": "L1"
     },
     {
-      "community": 246,
+      "community": 247,
       "file_type": "code",
       "id": "expensesessionexpiration_calculateexpensesessionexpiration",
       "label": "calculateExpenseSessionExpiration()",
@@ -73792,7 +73948,7 @@
       "source_location": "L21"
     },
     {
-      "community": 246,
+      "community": 247,
       "file_type": "code",
       "id": "expensesessionexpiration_getexpensesessionexpiryduration",
       "label": "getExpenseSessionExpiryDuration()",
@@ -73801,7 +73957,7 @@
       "source_location": "L35"
     },
     {
-      "community": 246,
+      "community": 247,
       "file_type": "code",
       "id": "expensesessionexpiration_getexpensesessionexpirydurationminutes",
       "label": "getExpenseSessionExpiryDurationMinutes()",
@@ -73810,7 +73966,7 @@
       "source_location": "L45"
     },
     {
-      "community": 246,
+      "community": 247,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_helpers_expensesessionexpiration_ts",
       "label": "expenseSessionExpiration.ts",
@@ -73819,7 +73975,7 @@
       "source_location": "L1"
     },
     {
-      "community": 247,
+      "community": 248,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_helpers_sessionexpiration_ts",
       "label": "sessionExpiration.ts",
@@ -73828,7 +73984,7 @@
       "source_location": "L1"
     },
     {
-      "community": 247,
+      "community": 248,
       "file_type": "code",
       "id": "sessionexpiration_calculatesessionexpiration",
       "label": "calculateSessionExpiration()",
@@ -73837,7 +73993,7 @@
       "source_location": "L21"
     },
     {
-      "community": 247,
+      "community": 248,
       "file_type": "code",
       "id": "sessionexpiration_getsessionexpiryduration",
       "label": "getSessionExpiryDuration()",
@@ -73846,7 +74002,7 @@
       "source_location": "L35"
     },
     {
-      "community": 247,
+      "community": 248,
       "file_type": "code",
       "id": "sessionexpiration_getsessionexpirydurationminutes",
       "label": "getSessionExpiryDurationMinutes()",
@@ -73855,7 +74011,7 @@
       "source_location": "L45"
     },
     {
-      "community": 248,
+      "community": 249,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_possessions_trace_test_ts",
       "label": "posSessions.trace.test.ts",
@@ -73864,7 +74020,7 @@
       "source_location": "L1"
     },
     {
-      "community": 248,
+      "community": 249,
       "file_type": "code",
       "id": "possessions_trace_test_buildsession",
       "label": "buildSession()",
@@ -73873,7 +74029,7 @@
       "source_location": "L407"
     },
     {
-      "community": 248,
+      "community": 249,
       "file_type": "code",
       "id": "possessions_trace_test_createmutationctx",
       "label": "createMutationCtx()",
@@ -73882,49 +74038,13 @@
       "source_location": "L161"
     },
     {
-      "community": 248,
+      "community": 249,
       "file_type": "code",
       "id": "possessions_trace_test_gethandler",
       "label": "getHandler()",
       "norm_label": "gethandler()",
       "source_file": "packages/athena-webapp/convex/inventory/posSessions.trace.test.ts",
       "source_location": "L424"
-    },
-    {
-      "community": 249,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_products_sku_test_ts",
-      "label": "products.sku.test.ts",
-      "norm_label": "products.sku.test.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/products.sku.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 249,
-      "file_type": "code",
-      "id": "products_sku_test_createproductsqueryctx",
-      "label": "createProductsQueryCtx()",
-      "norm_label": "createproductsqueryctx()",
-      "source_file": "packages/athena-webapp/convex/inventory/products.sku.test.ts",
-      "source_location": "L112"
-    },
-    {
-      "community": 249,
-      "file_type": "code",
-      "id": "products_sku_test_createskumutationctx",
-      "label": "createSkuMutationCtx()",
-      "norm_label": "createskumutationctx()",
-      "source_file": "packages/athena-webapp/convex/inventory/products.sku.test.ts",
-      "source_location": "L23"
-    },
-    {
-      "community": 249,
-      "file_type": "code",
-      "id": "products_sku_test_gethandler",
-      "label": "getHandler()",
-      "norm_label": "gethandler()",
-      "source_file": "packages/athena-webapp/convex/inventory/products.sku.test.ts",
-      "source_location": "L19"
     },
     {
       "community": 25,
@@ -74100,6 +74220,42 @@
     {
       "community": 250,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_products_sku_test_ts",
+      "label": "products.sku.test.ts",
+      "norm_label": "products.sku.test.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/products.sku.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 250,
+      "file_type": "code",
+      "id": "products_sku_test_createproductsqueryctx",
+      "label": "createProductsQueryCtx()",
+      "norm_label": "createproductsqueryctx()",
+      "source_file": "packages/athena-webapp/convex/inventory/products.sku.test.ts",
+      "source_location": "L112"
+    },
+    {
+      "community": 250,
+      "file_type": "code",
+      "id": "products_sku_test_createskumutationctx",
+      "label": "createSkuMutationCtx()",
+      "norm_label": "createskumutationctx()",
+      "source_file": "packages/athena-webapp/convex/inventory/products.sku.test.ts",
+      "source_location": "L23"
+    },
+    {
+      "community": 250,
+      "file_type": "code",
+      "id": "products_sku_test_gethandler",
+      "label": "getHandler()",
+      "norm_label": "gethandler()",
+      "source_file": "packages/athena-webapp/convex/inventory/products.sku.test.ts",
+      "source_location": "L19"
+    },
+    {
+      "community": 251,
+      "file_type": "code",
       "id": "currency_todisplayamount",
       "label": "toDisplayAmount()",
       "norm_label": "todisplayamount()",
@@ -74107,7 +74263,7 @@
       "source_location": "L5"
     },
     {
-      "community": 250,
+      "community": 251,
       "file_type": "code",
       "id": "currency_topesewas",
       "label": "toPesewas()",
@@ -74116,7 +74272,7 @@
       "source_location": "L1"
     },
     {
-      "community": 250,
+      "community": 251,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_lib_currency_ts",
       "label": "currency.ts",
@@ -74125,7 +74281,7 @@
       "source_location": "L1"
     },
     {
-      "community": 250,
+      "community": 251,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_currency_ts",
       "label": "currency.ts",
@@ -74134,7 +74290,7 @@
       "source_location": "L1"
     },
     {
-      "community": 251,
+      "community": 252,
       "file_type": "code",
       "id": "collections_getcachedtokenrecord",
       "label": "getCachedTokenRecord()",
@@ -74143,7 +74299,7 @@
       "source_location": "L26"
     },
     {
-      "community": 251,
+      "community": 252,
       "file_type": "code",
       "id": "collections_resolveaccesstokenforstore",
       "label": "resolveAccessTokenForStore()",
@@ -74152,7 +74308,7 @@
       "source_location": "L79"
     },
     {
-      "community": 251,
+      "community": 252,
       "file_type": "code",
       "id": "collections_resolveconfigforstore",
       "label": "resolveConfigForStore()",
@@ -74161,7 +74317,7 @@
       "source_location": "L33"
     },
     {
-      "community": 251,
+      "community": 252,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_collections_ts",
       "label": "collections.ts",
@@ -74170,7 +74326,7 @@
       "source_location": "L1"
     },
     {
-      "community": 252,
+      "community": 253,
       "file_type": "code",
       "id": "normalize_maskmtnpartyid",
       "label": "maskMtnPartyId()",
@@ -74179,7 +74335,7 @@
       "source_location": "L10"
     },
     {
-      "community": 252,
+      "community": 253,
       "file_type": "code",
       "id": "normalize_normalizecollectionstransaction",
       "label": "normalizeCollectionsTransaction()",
@@ -74188,7 +74344,7 @@
       "source_location": "L18"
     },
     {
-      "community": 252,
+      "community": 253,
       "file_type": "code",
       "id": "normalize_parsecollectionsnotificationrequest",
       "label": "parseCollectionsNotificationRequest()",
@@ -74197,7 +74353,7 @@
       "source_location": "L52"
     },
     {
-      "community": 252,
+      "community": 253,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_normalize_ts",
       "label": "normalize.ts",
@@ -74206,7 +74362,7 @@
       "source_location": "L1"
     },
     {
-      "community": 253,
+      "community": 254,
       "file_type": "code",
       "id": "approvalproofs_consumeapprovalproofwithctx",
       "label": "consumeApprovalProofWithCtx()",
@@ -74215,7 +74371,7 @@
       "source_location": "L98"
     },
     {
-      "community": 253,
+      "community": 254,
       "file_type": "code",
       "id": "approvalproofs_createapprovalproofwithctx",
       "label": "createApprovalProofWithCtx()",
@@ -74224,7 +74380,7 @@
       "source_location": "L56"
     },
     {
-      "community": 253,
+      "community": 254,
       "file_type": "code",
       "id": "approvalproofs_invalidapprovalproofresult",
       "label": "invalidApprovalProofResult()",
@@ -74233,7 +74389,7 @@
       "source_location": "L49"
     },
     {
-      "community": 253,
+      "community": 254,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_approvalproofs_ts",
       "label": "approvalProofs.ts",
@@ -74242,7 +74398,7 @@
       "source_location": "L1"
     },
     {
-      "community": 254,
+      "community": 255,
       "file_type": "code",
       "id": "operationalevents_buildoperationalevent",
       "label": "buildOperationalEvent()",
@@ -74251,7 +74407,7 @@
       "source_location": "L28"
     },
     {
-      "community": 254,
+      "community": 255,
       "file_type": "code",
       "id": "operationalevents_matchesexistingevent",
       "label": "matchesExistingEvent()",
@@ -74260,7 +74416,7 @@
       "source_location": "L42"
     },
     {
-      "community": 254,
+      "community": 255,
       "file_type": "code",
       "id": "operationalevents_recordoperationaleventwithctx",
       "label": "recordOperationalEventWithCtx()",
@@ -74269,7 +74425,7 @@
       "source_location": "L73"
     },
     {
-      "community": 254,
+      "community": 255,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_operationalevents_ts",
       "label": "operationalEvents.ts",
@@ -74278,7 +74434,7 @@
       "source_location": "L1"
     },
     {
-      "community": 255,
+      "community": 256,
       "file_type": "code",
       "id": "operationalworkitems_buildoperationalworkitem",
       "label": "buildOperationalWorkItem()",
@@ -74287,7 +74443,7 @@
       "source_location": "L13"
     },
     {
-      "community": 255,
+      "community": 256,
       "file_type": "code",
       "id": "operationalworkitems_createoperationalworkitemwithctx",
       "label": "createOperationalWorkItemWithCtx()",
@@ -74296,7 +74452,7 @@
       "source_location": "L37"
     },
     {
-      "community": 255,
+      "community": 256,
       "file_type": "code",
       "id": "operationalworkitems_updateoperationalworkitemstatuswithctx",
       "label": "updateOperationalWorkItemStatusWithCtx()",
@@ -74305,7 +74461,7 @@
       "source_location": "L69"
     },
     {
-      "community": 255,
+      "community": 256,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_operationalworkitems_ts",
       "label": "operationalWorkItems.ts",
@@ -74314,7 +74470,7 @@
       "source_location": "L1"
     },
     {
-      "community": 256,
+      "community": 257,
       "file_type": "code",
       "id": "operationsqueryindexes_test_expectindex",
       "label": "expectIndex()",
@@ -74323,7 +74479,7 @@
       "source_location": "L18"
     },
     {
-      "community": 256,
+      "community": 257,
       "file_type": "code",
       "id": "operationsqueryindexes_test_getsource",
       "label": "getSource()",
@@ -74332,7 +74488,7 @@
       "source_location": "L25"
     },
     {
-      "community": 256,
+      "community": 257,
       "file_type": "code",
       "id": "operationsqueryindexes_test_gettableindexes",
       "label": "getTableIndexes()",
@@ -74341,7 +74497,7 @@
       "source_location": "L11"
     },
     {
-      "community": 256,
+      "community": 257,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_operationsqueryindexes_test_ts",
       "label": "operationsQueryIndexes.test.ts",
@@ -74350,7 +74506,7 @@
       "source_location": "L1"
     },
     {
-      "community": 257,
+      "community": 258,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_registersessiontracing_test_ts",
       "label": "registerSessionTracing.test.ts",
@@ -74359,7 +74515,7 @@
       "source_location": "L1"
     },
     {
-      "community": 257,
+      "community": 258,
       "file_type": "code",
       "id": "registersessiontracing_test_buildctx",
       "label": "buildCtx()",
@@ -74368,7 +74524,7 @@
       "source_location": "L33"
     },
     {
-      "community": 257,
+      "community": 258,
       "file_type": "code",
       "id": "registersessiontracing_test_buildsession",
       "label": "buildSession()",
@@ -74377,7 +74533,7 @@
       "source_location": "L19"
     },
     {
-      "community": 257,
+      "community": 258,
       "file_type": "code",
       "id": "registersessiontracing_test_formatstoredtraceamount",
       "label": "formatStoredTraceAmount()",
@@ -74386,7 +74542,7 @@
       "source_location": "L42"
     },
     {
-      "community": 258,
+      "community": 259,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_registersessions_trace_test_ts",
       "label": "registerSessions.trace.test.ts",
@@ -74395,7 +74551,7 @@
       "source_location": "L1"
     },
     {
-      "community": 258,
+      "community": 259,
       "file_type": "code",
       "id": "registersessions_trace_test_buildregistersession",
       "label": "buildRegisterSession()",
@@ -74404,7 +74560,7 @@
       "source_location": "L31"
     },
     {
-      "community": 258,
+      "community": 259,
       "file_type": "code",
       "id": "registersessions_trace_test_createmutationctx",
       "label": "createMutationCtx()",
@@ -74413,49 +74569,13 @@
       "source_location": "L48"
     },
     {
-      "community": 258,
+      "community": 259,
       "file_type": "code",
       "id": "registersessions_trace_test_gethandler",
       "label": "getHandler()",
       "norm_label": "gethandler()",
       "source_file": "packages/athena-webapp/convex/operations/registerSessions.trace.test.ts",
       "source_location": "L131"
-    },
-    {
-      "community": 259,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_serviceintake_ts",
-      "label": "serviceIntake.ts",
-      "norm_label": "serviceintake.ts",
-      "source_file": "packages/athena-webapp/convex/operations/serviceIntake.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 259,
-      "file_type": "code",
-      "id": "serviceintake_resolveserviceintakecustomerprofile",
-      "label": "resolveServiceIntakeCustomerProfile()",
-      "norm_label": "resolveserviceintakecustomerprofile()",
-      "source_file": "packages/athena-webapp/convex/operations/serviceIntake.ts",
-      "source_location": "L37"
-    },
-    {
-      "community": 259,
-      "file_type": "code",
-      "id": "serviceintake_splitfullname",
-      "label": "splitFullName()",
-      "norm_label": "splitfullname()",
-      "source_file": "packages/athena-webapp/convex/operations/serviceIntake.ts",
-      "source_location": "L24"
-    },
-    {
-      "community": 259,
-      "file_type": "code",
-      "id": "serviceintake_trimoptional",
-      "label": "trimOptional()",
-      "norm_label": "trimoptional()",
-      "source_file": "packages/athena-webapp/convex/operations/serviceIntake.ts",
-      "source_location": "L19"
     },
     {
       "community": 26,
@@ -74631,6 +74751,42 @@
     {
       "community": 260,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_serviceintake_ts",
+      "label": "serviceIntake.ts",
+      "norm_label": "serviceintake.ts",
+      "source_file": "packages/athena-webapp/convex/operations/serviceIntake.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "serviceintake_resolveserviceintakecustomerprofile",
+      "label": "resolveServiceIntakeCustomerProfile()",
+      "norm_label": "resolveserviceintakecustomerprofile()",
+      "source_file": "packages/athena-webapp/convex/operations/serviceIntake.ts",
+      "source_location": "L37"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "serviceintake_splitfullname",
+      "label": "splitFullName()",
+      "norm_label": "splitfullname()",
+      "source_file": "packages/athena-webapp/convex/operations/serviceIntake.ts",
+      "source_location": "L24"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "serviceintake_trimoptional",
+      "label": "trimOptional()",
+      "norm_label": "trimoptional()",
+      "source_file": "packages/athena-webapp/convex/operations/serviceIntake.ts",
+      "source_location": "L19"
+    },
+    {
+      "community": 261,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_commands_register_ts",
       "label": "register.ts",
       "norm_label": "register.ts",
@@ -74638,7 +74794,7 @@
       "source_location": "L1"
     },
     {
-      "community": 260,
+      "community": 261,
       "file_type": "code",
       "id": "register_mapopendrawerusererror",
       "label": "mapOpenDrawerUserError()",
@@ -74647,7 +74803,7 @@
       "source_location": "L31"
     },
     {
-      "community": 260,
+      "community": 261,
       "file_type": "code",
       "id": "register_normalizeregisternumber",
       "label": "normalizeRegisterNumber()",
@@ -74656,7 +74812,7 @@
       "source_location": "L26"
     },
     {
-      "community": 260,
+      "community": 261,
       "file_type": "code",
       "id": "register_opendrawer",
       "label": "openDrawer()",
@@ -74665,7 +74821,7 @@
       "source_location": "L53"
     },
     {
-      "community": 261,
+      "community": 262,
       "file_type": "code",
       "id": "opendrawer_test_createdbgetmock",
       "label": "createDbGetMock()",
@@ -74674,7 +74830,7 @@
       "source_location": "L36"
     },
     {
-      "community": 261,
+      "community": 262,
       "file_type": "code",
       "id": "opendrawer_test_createdbmock",
       "label": "createDbMock()",
@@ -74683,7 +74839,7 @@
       "source_location": "L96"
     },
     {
-      "community": 261,
+      "community": 262,
       "file_type": "code",
       "id": "opendrawer_test_createdbquerymock",
       "label": "createDbQueryMock()",
@@ -74692,7 +74848,7 @@
       "source_location": "L71"
     },
     {
-      "community": 261,
+      "community": 262,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_opendrawer_test_ts",
       "label": "openDrawer.test.ts",
@@ -74701,7 +74857,7 @@
       "source_location": "L1"
     },
     {
-      "community": 262,
+      "community": 263,
       "file_type": "code",
       "id": "getregisterstate_buildregisterstate",
       "label": "buildRegisterState()",
@@ -74710,7 +74866,7 @@
       "source_location": "L21"
     },
     {
-      "community": 262,
+      "community": 263,
       "file_type": "code",
       "id": "getregisterstate_getactivesessionconflictforregisterstate",
       "label": "getActiveSessionConflictForRegisterState()",
@@ -74719,7 +74875,7 @@
       "source_location": "L42"
     },
     {
-      "community": 262,
+      "community": 263,
       "file_type": "code",
       "id": "getregisterstate_getregisterstate",
       "label": "getRegisterState()",
@@ -74728,7 +74884,7 @@
       "source_location": "L80"
     },
     {
-      "community": 262,
+      "community": 263,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_queries_getregisterstate_ts",
       "label": "getRegisterState.ts",
@@ -74737,7 +74893,7 @@
       "source_location": "L1"
     },
     {
-      "community": 263,
+      "community": 264,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_queries_searchcatalog_ts",
       "label": "searchCatalog.ts",
@@ -74746,7 +74902,7 @@
       "source_location": "L1"
     },
     {
-      "community": 263,
+      "community": 264,
       "file_type": "code",
       "id": "searchcatalog_lookupbybarcode",
       "label": "lookupByBarcode()",
@@ -74755,7 +74911,7 @@
       "source_location": "L126"
     },
     {
-      "community": 263,
+      "community": 264,
       "file_type": "code",
       "id": "searchcatalog_mapskutocatalogresult",
       "label": "mapSkuToCatalogResult()",
@@ -74764,7 +74920,7 @@
       "source_location": "L34"
     },
     {
-      "community": 263,
+      "community": 264,
       "file_type": "code",
       "id": "searchcatalog_searchproducts",
       "label": "searchProducts()",
@@ -74773,7 +74929,7 @@
       "source_location": "L76"
     },
     {
-      "community": 264,
+      "community": 265,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_sessioncommandrepository_ts",
       "label": "sessionCommandRepository.ts",
@@ -74782,7 +74938,7 @@
       "source_location": "L1"
     },
     {
-      "community": 264,
+      "community": 265,
       "file_type": "code",
       "id": "sessioncommandrepository_collectsessionitemsfrompages",
       "label": "collectSessionItemsFromPages()",
@@ -74791,7 +74947,7 @@
       "source_location": "L159"
     },
     {
-      "community": 264,
+      "community": 265,
       "file_type": "code",
       "id": "sessioncommandrepository_createsessioncommandrepository",
       "label": "createSessionCommandRepository()",
@@ -74800,7 +74956,7 @@
       "source_location": "L56"
     },
     {
-      "community": 264,
+      "community": 265,
       "file_type": "code",
       "id": "sessioncommandrepository_scansessionitembyskuinpages",
       "label": "scanSessionItemBySkuInPages()",
@@ -74809,7 +74965,7 @@
       "source_location": "L177"
     },
     {
-      "community": 265,
+      "community": 266,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_transactions_test_ts",
       "label": "transactions.test.ts",
@@ -74818,7 +74974,7 @@
       "source_location": "L1"
     },
     {
-      "community": 265,
+      "community": 266,
       "file_type": "code",
       "id": "transactions_test_exportreturns",
       "label": "exportReturns()",
@@ -74827,7 +74983,7 @@
       "source_location": "L30"
     },
     {
-      "community": 265,
+      "community": 266,
       "file_type": "code",
       "id": "transactions_test_gethandler",
       "label": "getHandler()",
@@ -74836,7 +74992,7 @@
       "source_location": "L38"
     },
     {
-      "community": 265,
+      "community": 266,
       "file_type": "code",
       "id": "transactions_test_parsevalidator",
       "label": "parseValidator()",
@@ -74845,7 +75001,7 @@
       "source_location": "L34"
     },
     {
-      "community": 266,
+      "community": 267,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_replenishment_test_ts",
       "label": "replenishment.test.ts",
@@ -74854,7 +75010,7 @@
       "source_location": "L1"
     },
     {
-      "community": 266,
+      "community": 267,
       "file_type": "code",
       "id": "replenishment_test_createreplenishmentqueryctx",
       "label": "createReplenishmentQueryCtx()",
@@ -74863,7 +75019,7 @@
       "source_location": "L21"
     },
     {
-      "community": 266,
+      "community": 267,
       "file_type": "code",
       "id": "replenishment_test_getsource",
       "label": "getSource()",
@@ -74872,7 +75028,7 @@
       "source_location": "L7"
     },
     {
-      "community": 266,
+      "community": 267,
       "file_type": "code",
       "id": "replenishment_test_toasynciterable",
       "label": "toAsyncIterable()",
@@ -74881,7 +75037,7 @@
       "source_location": "L11"
     },
     {
-      "community": 267,
+      "community": 268,
       "file_type": "code",
       "id": "commercequeryindexes_test_expectindex",
       "label": "expectIndex()",
@@ -74890,7 +75046,7 @@
       "source_location": "L19"
     },
     {
-      "community": 267,
+      "community": 268,
       "file_type": "code",
       "id": "commercequeryindexes_test_getsource",
       "label": "getSource()",
@@ -74899,7 +75055,7 @@
       "source_location": "L26"
     },
     {
-      "community": 267,
+      "community": 268,
       "file_type": "code",
       "id": "commercequeryindexes_test_gettableindexes",
       "label": "getTableIndexes()",
@@ -74908,7 +75064,7 @@
       "source_location": "L12"
     },
     {
-      "community": 267,
+      "community": 268,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_commercequeryindexes_test_ts",
       "label": "commerceQueryIndexes.test.ts",
@@ -74917,7 +75073,7 @@
       "source_location": "L1"
     },
     {
-      "community": 268,
+      "community": 269,
       "file_type": "code",
       "id": "customerengagementevents_findexistingcustomerprofileid",
       "label": "findExistingCustomerProfileId()",
@@ -74926,7 +75082,7 @@
       "source_location": "L21"
     },
     {
-      "community": 268,
+      "community": 269,
       "file_type": "code",
       "id": "customerengagementevents_getstoreorganizationid",
       "label": "getStoreOrganizationId()",
@@ -74935,7 +75091,7 @@
       "source_location": "L63"
     },
     {
-      "community": 268,
+      "community": 269,
       "file_type": "code",
       "id": "customerengagementevents_recordstorefrontcustomermilestone",
       "label": "recordStoreFrontCustomerMilestone()",
@@ -74944,49 +75100,13 @@
       "source_location": "L71"
     },
     {
-      "community": 268,
+      "community": 269,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_helpers_customerengagementevents_ts",
       "label": "customerEngagementEvents.ts",
       "norm_label": "customerengagementevents.ts",
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/customerEngagementEvents.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 269,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_returnexchangeoperations_test_ts",
-      "label": "returnExchangeOperations.test.ts",
-      "norm_label": "returnexchangeoperations.test.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/returnExchangeOperations.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 269,
-      "file_type": "code",
-      "id": "returnexchangeoperations_test_createorderitem",
-      "label": "createOrderItem()",
-      "norm_label": "createorderitem()",
-      "source_file": "packages/athena-webapp/convex/storeFront/returnExchangeOperations.test.ts",
-      "source_location": "L13"
-    },
-    {
-      "community": 269,
-      "file_type": "code",
-      "id": "returnexchangeoperations_test_createreplacement",
-      "label": "createReplacement()",
-      "norm_label": "createreplacement()",
-      "source_file": "packages/athena-webapp/convex/storeFront/returnExchangeOperations.test.ts",
-      "source_location": "L31"
-    },
-    {
-      "community": 269,
-      "file_type": "code",
-      "id": "returnexchangeoperations_test_getsource",
-      "label": "getSource()",
-      "norm_label": "getsource()",
-      "source_file": "packages/athena-webapp/convex/storeFront/returnExchangeOperations.test.ts",
-      "source_location": "L9"
     },
     {
       "community": 27,
@@ -75162,6 +75282,42 @@
     {
       "community": 270,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_returnexchangeoperations_test_ts",
+      "label": "returnExchangeOperations.test.ts",
+      "norm_label": "returnexchangeoperations.test.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/returnExchangeOperations.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 270,
+      "file_type": "code",
+      "id": "returnexchangeoperations_test_createorderitem",
+      "label": "createOrderItem()",
+      "norm_label": "createorderitem()",
+      "source_file": "packages/athena-webapp/convex/storeFront/returnExchangeOperations.test.ts",
+      "source_location": "L13"
+    },
+    {
+      "community": 270,
+      "file_type": "code",
+      "id": "returnexchangeoperations_test_createreplacement",
+      "label": "createReplacement()",
+      "norm_label": "createreplacement()",
+      "source_file": "packages/athena-webapp/convex/storeFront/returnExchangeOperations.test.ts",
+      "source_location": "L31"
+    },
+    {
+      "community": 270,
+      "file_type": "code",
+      "id": "returnexchangeoperations_test_getsource",
+      "label": "getSource()",
+      "norm_label": "getsource()",
+      "source_file": "packages/athena-webapp/convex/storeFront/returnExchangeOperations.test.ts",
+      "source_location": "L9"
+    },
+    {
+      "community": 271,
+      "file_type": "code",
       "id": "packages_athena_webapp_shared_staffdisplayname_ts",
       "label": "staffDisplayName.ts",
       "norm_label": "staffdisplayname.ts",
@@ -75169,7 +75325,7 @@
       "source_location": "L1"
     },
     {
-      "community": 270,
+      "community": 271,
       "file_type": "code",
       "id": "staffdisplayname_formatstaffdisplayname",
       "label": "formatStaffDisplayName()",
@@ -75178,7 +75334,7 @@
       "source_location": "L12"
     },
     {
-      "community": 270,
+      "community": 271,
       "file_type": "code",
       "id": "staffdisplayname_formatstaffdisplaynameorfallback",
       "label": "formatStaffDisplayNameOrFallback()",
@@ -75187,7 +75343,7 @@
       "source_location": "L46"
     },
     {
-      "community": 270,
+      "community": 271,
       "file_type": "code",
       "id": "staffdisplayname_normalizenamepart",
       "label": "normalizeNamePart()",
@@ -75196,7 +75352,7 @@
       "source_location": "L7"
     },
     {
-      "community": 271,
+      "community": 272,
       "file_type": "code",
       "id": "attributesmanager_attributesmanager",
       "label": "AttributesManager()",
@@ -75205,7 +75361,7 @@
       "source_location": "L227"
     },
     {
-      "community": 271,
+      "community": 272,
       "file_type": "code",
       "id": "attributesmanager_colormanager",
       "label": "ColorManager()",
@@ -75214,7 +75370,7 @@
       "source_location": "L46"
     },
     {
-      "community": 271,
+      "community": 272,
       "file_type": "code",
       "id": "attributesmanager_sidebar",
       "label": "Sidebar()",
@@ -75223,7 +75379,7 @@
       "source_location": "L27"
     },
     {
-      "community": 271,
+      "community": 272,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_attributesmanager_tsx",
       "label": "AttributesManager.tsx",
@@ -75232,7 +75388,7 @@
       "source_location": "L1"
     },
     {
-      "community": 272,
+      "community": 273,
       "file_type": "code",
       "id": "attributestable_getproductattribute",
       "label": "getProductAttribute()",
@@ -75241,7 +75397,7 @@
       "source_location": "L55"
     },
     {
-      "community": 272,
+      "community": 273,
       "file_type": "code",
       "id": "attributestable_handlechange",
       "label": "handleChange()",
@@ -75250,7 +75406,7 @@
       "source_location": "L32"
     },
     {
-      "community": 272,
+      "community": 273,
       "file_type": "code",
       "id": "attributestable_onsubmit",
       "label": "onSubmit()",
@@ -75259,7 +75415,7 @@
       "source_location": "L211"
     },
     {
-      "community": 272,
+      "community": 273,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_attributestable_tsx",
       "label": "AttributesTable.tsx",
@@ -75268,7 +75424,7 @@
       "source_location": "L1"
     },
     {
-      "community": 273,
+      "community": 274,
       "file_type": "code",
       "id": "categorysubcategorymanager_categorymanager",
       "label": "CategoryManager()",
@@ -75277,7 +75433,7 @@
       "source_location": "L52"
     },
     {
-      "community": 273,
+      "community": 274,
       "file_type": "code",
       "id": "categorysubcategorymanager_sidebar",
       "label": "Sidebar()",
@@ -75286,7 +75442,7 @@
       "source_location": "L27"
     },
     {
-      "community": 273,
+      "community": 274,
       "file_type": "code",
       "id": "categorysubcategorymanager_subcategorymanager",
       "label": "SubcategoryManager()",
@@ -75295,7 +75451,7 @@
       "source_location": "L288"
     },
     {
-      "community": 273,
+      "community": 274,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_categorysubcategorymanager_tsx",
       "label": "CategorySubcategoryManager.tsx",
@@ -75304,7 +75460,7 @@
       "source_location": "L1"
     },
     {
-      "community": 274,
+      "community": 275,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_storefrontobservabilitypanel_tsx",
       "label": "StorefrontObservabilityPanel.tsx",
@@ -75313,7 +75469,7 @@
       "source_location": "L1"
     },
     {
-      "community": 274,
+      "community": 275,
       "file_type": "code",
       "id": "storefrontobservabilitypanel_formatlabel",
       "label": "formatLabel()",
@@ -75322,7 +75478,7 @@
       "source_location": "L15"
     },
     {
-      "community": 274,
+      "community": 275,
       "file_type": "code",
       "id": "storefrontobservabilitypanel_gettrafficsourcebadge",
       "label": "getTrafficSourceBadge()",
@@ -75331,7 +75487,7 @@
       "source_location": "L32"
     },
     {
-      "community": 274,
+      "community": 275,
       "file_type": "code",
       "id": "storefrontobservabilitypanel_summarycard",
       "label": "SummaryCard()",
@@ -75340,7 +75496,7 @@
       "source_location": "L19"
     },
     {
-      "community": 275,
+      "community": 276,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_utils_ts",
       "label": "utils.ts",
@@ -75349,7 +75505,7 @@
       "source_location": "L1"
     },
     {
-      "community": 275,
+      "community": 276,
       "file_type": "code",
       "id": "utils_countgroupedanalytics",
       "label": "countGroupedAnalytics()",
@@ -75358,7 +75514,7 @@
       "source_location": "L52"
     },
     {
-      "community": 275,
+      "community": 276,
       "file_type": "code",
       "id": "utils_groupanalytics",
       "label": "groupAnalytics()",
@@ -75367,7 +75523,7 @@
       "source_location": "L3"
     },
     {
-      "community": 275,
+      "community": 276,
       "file_type": "code",
       "id": "utils_groupproductviewsbyday",
       "label": "groupProductViewsByDay()",
@@ -75376,7 +75532,7 @@
       "source_location": "L90"
     },
     {
-      "community": 276,
+      "community": 277,
       "file_type": "code",
       "id": "maintenancemessageeditor_getcountdownstatus",
       "label": "getCountdownStatus()",
@@ -75385,7 +75541,7 @@
       "source_location": "L86"
     },
     {
-      "community": 276,
+      "community": 277,
       "file_type": "code",
       "id": "maintenancemessageeditor_handlecountdownchange",
       "label": "handleCountdownChange()",
@@ -75394,7 +75550,7 @@
       "source_location": "L76"
     },
     {
-      "community": 276,
+      "community": 277,
       "file_type": "code",
       "id": "maintenancemessageeditor_handlesave",
       "label": "handleSave()",
@@ -75403,7 +75559,7 @@
       "source_location": "L52"
     },
     {
-      "community": 276,
+      "community": 277,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_maintenancemessageeditor_tsx",
       "label": "MaintenanceMessageEditor.tsx",
@@ -75412,7 +75568,7 @@
       "source_location": "L1"
     },
     {
-      "community": 277,
+      "community": 278,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_shoplook_tsx",
       "label": "ShopLook.tsx",
@@ -75421,7 +75577,7 @@
       "source_location": "L1"
     },
     {
-      "community": 277,
+      "community": 278,
       "file_type": "code",
       "id": "shoplook_handlehighlighteditem",
       "label": "handleHighlightedItem()",
@@ -75430,7 +75586,7 @@
       "source_location": "L67"
     },
     {
-      "community": 277,
+      "community": 278,
       "file_type": "code",
       "id": "shoplook_handleimageupdate",
       "label": "handleImageUpdate()",
@@ -75439,7 +75595,7 @@
       "source_location": "L90"
     },
     {
-      "community": 277,
+      "community": 278,
       "file_type": "code",
       "id": "shoplook_ondragend",
       "label": "onDragEnd()",
@@ -75448,7 +75604,7 @@
       "source_location": "L73"
     },
     {
-      "community": 278,
+      "community": 279,
       "file_type": "code",
       "id": "commandapprovaldialog_getasyncresolution",
       "label": "getAsyncResolution()",
@@ -75457,7 +75613,7 @@
       "source_location": "L78"
     },
     {
-      "community": 278,
+      "community": 279,
       "file_type": "code",
       "id": "commandapprovaldialog_getinlinemanagerresolution",
       "label": "getInlineManagerResolution()",
@@ -75466,7 +75622,7 @@
       "source_location": "L67"
     },
     {
-      "community": 278,
+      "community": 279,
       "file_type": "code",
       "id": "commandapprovaldialog_tostaffauthenticationresult",
       "label": "toStaffAuthenticationResult()",
@@ -75475,48 +75631,12 @@
       "source_location": "L85"
     },
     {
-      "community": 278,
+      "community": 279,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_commandapprovaldialog_tsx",
       "label": "CommandApprovalDialog.tsx",
       "norm_label": "commandapprovaldialog.tsx",
       "source_file": "packages/athena-webapp/src/components/operations/CommandApprovalDialog.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 279,
-      "file_type": "code",
-      "id": "dailycloseview_test_disconnect",
-      "label": "disconnect()",
-      "norm_label": "disconnect()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.test.tsx",
-      "source_location": "L302"
-    },
-    {
-      "community": 279,
-      "file_type": "code",
-      "id": "dailycloseview_test_observe",
-      "label": "observe()",
-      "norm_label": "observe()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.test.tsx",
-      "source_location": "L303"
-    },
-    {
-      "community": 279,
-      "file_type": "code",
-      "id": "dailycloseview_test_unobserve",
-      "label": "unobserve()",
-      "norm_label": "unobserve()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.test.tsx",
-      "source_location": "L304"
-    },
-    {
-      "community": 279,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_operations_dailycloseview_test_tsx",
-      "label": "DailyCloseView.test.tsx",
-      "norm_label": "dailycloseview.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.test.tsx",
       "source_location": "L1"
     },
     {
@@ -75693,6 +75813,42 @@
     {
       "community": 280,
       "file_type": "code",
+      "id": "dailycloseview_test_disconnect",
+      "label": "disconnect()",
+      "norm_label": "disconnect()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.test.tsx",
+      "source_location": "L302"
+    },
+    {
+      "community": 280,
+      "file_type": "code",
+      "id": "dailycloseview_test_observe",
+      "label": "observe()",
+      "norm_label": "observe()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.test.tsx",
+      "source_location": "L303"
+    },
+    {
+      "community": 280,
+      "file_type": "code",
+      "id": "dailycloseview_test_unobserve",
+      "label": "unobserve()",
+      "norm_label": "unobserve()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.test.tsx",
+      "source_location": "L304"
+    },
+    {
+      "community": 280,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_operations_dailycloseview_test_tsx",
+      "label": "DailyCloseView.test.tsx",
+      "norm_label": "dailycloseview.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 281,
+      "file_type": "code",
       "id": "operationsqueueview_test_disconnect",
       "label": "disconnect()",
       "norm_label": "disconnect()",
@@ -75700,7 +75856,7 @@
       "source_location": "L220"
     },
     {
-      "community": 280,
+      "community": 281,
       "file_type": "code",
       "id": "operationsqueueview_test_observe",
       "label": "observe()",
@@ -75709,7 +75865,7 @@
       "source_location": "L221"
     },
     {
-      "community": 280,
+      "community": 281,
       "file_type": "code",
       "id": "operationsqueueview_test_unobserve",
       "label": "unobserve()",
@@ -75718,7 +75874,7 @@
       "source_location": "L222"
     },
     {
-      "community": 280,
+      "community": 281,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_operationsqueueview_test_tsx",
       "label": "OperationsQueueView.test.tsx",
@@ -75727,7 +75883,7 @@
       "source_location": "L1"
     },
     {
-      "community": 281,
+      "community": 282,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_returnexchangeview_tsx",
       "label": "ReturnExchangeView.tsx",
@@ -75736,7 +75892,7 @@
       "source_location": "L1"
     },
     {
-      "community": 281,
+      "community": 282,
       "file_type": "code",
       "id": "returnexchangeview_handlesubmit",
       "label": "handleSubmit()",
@@ -75745,7 +75901,7 @@
       "source_location": "L105"
     },
     {
-      "community": 281,
+      "community": 282,
       "file_type": "code",
       "id": "returnexchangeview_resetreplacementfields",
       "label": "resetReplacementFields()",
@@ -75754,7 +75910,7 @@
       "source_location": "L97"
     },
     {
-      "community": 281,
+      "community": 282,
       "file_type": "code",
       "id": "returnexchangeview_toggleitem",
       "label": "toggleItem()",
@@ -75763,7 +75919,7 @@
       "source_location": "L83"
     },
     {
-      "community": 282,
+      "community": 283,
       "file_type": "code",
       "id": "newtransactionview_handlequickstart",
       "label": "handleQuickStart()",
@@ -75772,7 +75928,7 @@
       "source_location": "L91"
     },
     {
-      "community": 282,
+      "community": 283,
       "file_type": "code",
       "id": "newtransactionview_handlestarttransaction",
       "label": "handleStartTransaction()",
@@ -75781,7 +75937,7 @@
       "source_location": "L68"
     },
     {
-      "community": 282,
+      "community": 283,
       "file_type": "code",
       "id": "newtransactionview_navigation",
       "label": "Navigation()",
@@ -75790,7 +75946,7 @@
       "source_location": "L22"
     },
     {
-      "community": 282,
+      "community": 283,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_newtransactionview_tsx",
       "label": "NewTransactionView.tsx",
@@ -75799,7 +75955,7 @@
       "source_location": "L1"
     },
     {
-      "community": 283,
+      "community": 284,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_transactions_transactionview_test_tsx",
       "label": "TransactionView.test.tsx",
@@ -75808,7 +75964,7 @@
       "source_location": "L1"
     },
     {
-      "community": 283,
+      "community": 284,
       "file_type": "code",
       "id": "transactionview_test_async",
       "label": "async()",
@@ -75817,7 +75973,7 @@
       "source_location": "L164"
     },
     {
-      "community": 283,
+      "community": 284,
       "file_type": "code",
       "id": "transactionview_test_mocktransactionmutations",
       "label": "mockTransactionMutations()",
@@ -75826,7 +75982,7 @@
       "source_location": "L388"
     },
     {
-      "community": 283,
+      "community": 284,
       "file_type": "code",
       "id": "transactionview_test_paymentapprovalrequirement",
       "label": "paymentApprovalRequirement()",
@@ -75835,7 +75991,7 @@
       "source_location": "L347"
     },
     {
-      "community": 284,
+      "community": 285,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_transactions_transactionsview_tsx",
       "label": "TransactionsView.tsx",
@@ -75844,7 +76000,7 @@
       "source_location": "L1"
     },
     {
-      "community": 284,
+      "community": 285,
       "file_type": "code",
       "id": "transactionsview_formatpaymentmethod",
       "label": "formatPaymentMethod()",
@@ -75853,7 +76009,7 @@
       "source_location": "L22"
     },
     {
-      "community": 284,
+      "community": 285,
       "file_type": "code",
       "id": "transactionsview_formatregisterfilterlabel",
       "label": "formatRegisterFilterLabel()",
@@ -75862,7 +76018,7 @@
       "source_location": "L27"
     },
     {
-      "community": 284,
+      "community": 285,
       "file_type": "code",
       "id": "transactionsview_istoday",
       "label": "isToday()",
@@ -75871,7 +76027,7 @@
       "source_location": "L40"
     },
     {
-      "community": 285,
+      "community": 286,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_procurement_procurementview_test_tsx",
       "label": "ProcurementView.test.tsx",
@@ -75880,7 +76036,7 @@
       "source_location": "L1"
     },
     {
-      "community": 285,
+      "community": 286,
       "file_type": "code",
       "id": "procurementview_test_choosedraftvendor",
       "label": "chooseDraftVendor()",
@@ -75889,7 +76045,7 @@
       "source_location": "L324"
     },
     {
-      "community": 285,
+      "community": 286,
       "file_type": "code",
       "id": "procurementview_test_installmutationmocks",
       "label": "installMutationMocks()",
@@ -75898,7 +76054,7 @@
       "source_location": "L290"
     },
     {
-      "community": 285,
+      "community": 286,
       "file_type": "code",
       "id": "procurementview_test_makerecommendation",
       "label": "makeRecommendation()",
@@ -75907,7 +76063,7 @@
       "source_location": "L279"
     },
     {
-      "community": 286,
+      "community": 287,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_productstock_tsx",
       "label": "ProductStock.tsx",
@@ -75916,7 +76072,7 @@
       "source_location": "L1"
     },
     {
-      "community": 286,
+      "community": 287,
       "file_type": "code",
       "id": "productstock_lowstockstatus",
       "label": "LowStockStatus()",
@@ -75925,7 +76081,7 @@
       "source_location": "L63"
     },
     {
-      "community": 286,
+      "community": 287,
       "file_type": "code",
       "id": "productstock_outofstockstatus",
       "label": "OutOfStockStatus()",
@@ -75934,7 +76090,7 @@
       "source_location": "L54"
     },
     {
-      "community": 286,
+      "community": 287,
       "file_type": "code",
       "id": "productstock_productstockstatus",
       "label": "ProductStockStatus()",
@@ -75943,7 +76099,7 @@
       "source_location": "L11"
     },
     {
-      "community": 287,
+      "community": 288,
       "file_type": "code",
       "id": "complimentaryproductsview_body",
       "label": "Body()",
@@ -75952,7 +76108,7 @@
       "source_location": "L16"
     },
     {
-      "community": 287,
+      "community": 288,
       "file_type": "code",
       "id": "complimentaryproductsview_complimentaryproductsview",
       "label": "ComplimentaryProductsView()",
@@ -75961,7 +76117,7 @@
       "source_location": "L35"
     },
     {
-      "community": 287,
+      "community": 288,
       "file_type": "code",
       "id": "complimentaryproductsview_navigation",
       "label": "Navigation()",
@@ -75970,7 +76126,7 @@
       "source_location": "L6"
     },
     {
-      "community": 287,
+      "community": 288,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_complimentary_complimentaryproductsview_tsx",
       "label": "ComplimentaryProductsView.tsx",
@@ -75979,7 +76135,7 @@
       "source_location": "L1"
     },
     {
-      "community": 288,
+      "community": 289,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodemoney_ts",
       "label": "promoCodeMoney.ts",
@@ -75988,7 +76144,7 @@
       "source_location": "L1"
     },
     {
-      "community": 288,
+      "community": 289,
       "file_type": "code",
       "id": "promocodemoney_parsepromodiscountinput",
       "label": "parsePromoDiscountInput()",
@@ -75997,7 +76153,7 @@
       "source_location": "L5"
     },
     {
-      "community": 288,
+      "community": 289,
       "file_type": "code",
       "id": "promocodemoney_promodiscountdisplaytext",
       "label": "promoDiscountDisplayText()",
@@ -76006,49 +76162,13 @@
       "source_location": "L30"
     },
     {
-      "community": 288,
+      "community": 289,
       "file_type": "code",
       "id": "promocodemoney_promodiscountinputvalue",
       "label": "promoDiscountInputValue()",
       "norm_label": "promodiscountinputvalue()",
       "source_file": "packages/athena-webapp/src/components/promo-codes/promoCodeMoney.ts",
       "source_location": "L21"
-    },
-    {
-      "community": 289,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_services_servicecasesview_tsx",
-      "label": "ServiceCasesView.tsx",
-      "norm_label": "servicecasesview.tsx",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceCasesView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 289,
-      "file_type": "code",
-      "id": "servicecasesview_applycommandresult",
-      "label": "applyCommandResult()",
-      "norm_label": "applycommandresult()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceCasesView.tsx",
-      "source_location": "L178"
-    },
-    {
-      "community": 289,
-      "file_type": "code",
-      "id": "servicecasesview_handlecreatecase",
-      "label": "handleCreateCase()",
-      "norm_label": "handlecreatecase()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceCasesView.tsx",
-      "source_location": "L205"
-    },
-    {
-      "community": 289,
-      "file_type": "code",
-      "id": "servicecasesview_withsavestate",
-      "label": "withSaveState()",
-      "norm_label": "withsavestate()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceCasesView.tsx",
-      "source_location": "L806"
     },
     {
       "community": 29,
@@ -76224,6 +76344,42 @@
     {
       "community": 290,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_services_servicecasesview_tsx",
+      "label": "ServiceCasesView.tsx",
+      "norm_label": "servicecasesview.tsx",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceCasesView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 290,
+      "file_type": "code",
+      "id": "servicecasesview_applycommandresult",
+      "label": "applyCommandResult()",
+      "norm_label": "applycommandresult()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceCasesView.tsx",
+      "source_location": "L178"
+    },
+    {
+      "community": 290,
+      "file_type": "code",
+      "id": "servicecasesview_handlecreatecase",
+      "label": "handleCreateCase()",
+      "norm_label": "handlecreatecase()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceCasesView.tsx",
+      "source_location": "L205"
+    },
+    {
+      "community": 290,
+      "file_type": "code",
+      "id": "servicecasesview_withsavestate",
+      "label": "withSaveState()",
+      "norm_label": "withsavestate()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceCasesView.tsx",
+      "source_location": "L806"
+    },
+    {
+      "community": 291,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_traces_workflowtraceview_tsx",
       "label": "WorkflowTraceView.tsx",
       "norm_label": "workflowtraceview.tsx",
@@ -76231,7 +76387,7 @@
       "source_location": "L1"
     },
     {
-      "community": 290,
+      "community": 291,
       "file_type": "code",
       "id": "workflowtraceview_formattracelabel",
       "label": "formatTraceLabel()",
@@ -76240,7 +76396,7 @@
       "source_location": "L41"
     },
     {
-      "community": 290,
+      "community": 291,
       "file_type": "code",
       "id": "workflowtraceview_getstatustone",
       "label": "getStatusTone()",
@@ -76249,7 +76405,7 @@
       "source_location": "L45"
     },
     {
-      "community": 290,
+      "community": 291,
       "file_type": "code",
       "id": "workflowtraceview_workflowtraceheader",
       "label": "WorkflowTraceHeader()",
@@ -76258,7 +76414,7 @@
       "source_location": "L65"
     },
     {
-      "community": 291,
+      "community": 292,
       "file_type": "code",
       "id": "engagementmetrics_formatlastactivity",
       "label": "formatLastActivity()",
@@ -76267,7 +76423,7 @@
       "source_location": "L75"
     },
     {
-      "community": 291,
+      "community": 292,
       "file_type": "code",
       "id": "engagementmetrics_getdeviceicon",
       "label": "getDeviceIcon()",
@@ -76276,7 +76432,7 @@
       "source_location": "L82"
     },
     {
-      "community": 291,
+      "community": 292,
       "file_type": "code",
       "id": "engagementmetrics_getdevicelabel",
       "label": "getDeviceLabel()",
@@ -76285,7 +76441,7 @@
       "source_location": "L93"
     },
     {
-      "community": 291,
+      "community": 292,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_engagementmetrics_tsx",
       "label": "EngagementMetrics.tsx",
@@ -76294,7 +76450,7 @@
       "source_location": "L1"
     },
     {
-      "community": 292,
+      "community": 293,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_riskindicators_tsx",
       "label": "RiskIndicators.tsx",
@@ -76303,7 +76459,7 @@
       "source_location": "L1"
     },
     {
-      "community": 292,
+      "community": 293,
       "file_type": "code",
       "id": "riskindicators_getriskicon",
       "label": "getRiskIcon()",
@@ -76312,7 +76468,7 @@
       "source_location": "L15"
     },
     {
-      "community": 292,
+      "community": 293,
       "file_type": "code",
       "id": "riskindicators_getriskstyles",
       "label": "getRiskStyles()",
@@ -76321,7 +76477,7 @@
       "source_location": "L28"
     },
     {
-      "community": 292,
+      "community": 293,
       "file_type": "code",
       "id": "riskindicators_riskindicators",
       "label": "RiskIndicators()",
@@ -76330,7 +76486,43 @@
       "source_location": "L54"
     },
     {
-      "community": 293,
+      "community": 294,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_useexpenseoperations_ts",
+      "label": "useExpenseOperations.ts",
+      "norm_label": "useexpenseoperations.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseOperations.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 294,
+      "file_type": "code",
+      "id": "useexpenseoperations_clonecartitems",
+      "label": "cloneCartItems()",
+      "norm_label": "clonecartitems()",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseOperations.ts",
+      "source_location": "L19"
+    },
+    {
+      "community": 294,
+      "file_type": "code",
+      "id": "useexpenseoperations_mapproducttoexpensecartitem",
+      "label": "mapProductToExpenseCartItem()",
+      "norm_label": "mapproducttoexpensecartitem()",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseOperations.ts",
+      "source_location": "L23"
+    },
+    {
+      "community": 294,
+      "file_type": "code",
+      "id": "useexpenseoperations_useexpenseoperations",
+      "label": "useExpenseOperations()",
+      "norm_label": "useexpenseoperations()",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseOperations.ts",
+      "source_location": "L50"
+    },
+    {
+      "community": 295,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetproducts_ts",
       "label": "useGetProducts.ts",
@@ -76339,7 +76531,7 @@
       "source_location": "L1"
     },
     {
-      "community": 293,
+      "community": 295,
       "file_type": "code",
       "id": "usegetproducts_usegetarchivedproducts",
       "label": "useGetArchivedProducts()",
@@ -76348,7 +76540,7 @@
       "source_location": "L36"
     },
     {
-      "community": 293,
+      "community": 295,
       "file_type": "code",
       "id": "usegetproducts_usegetproducts",
       "label": "useGetProducts()",
@@ -76357,7 +76549,7 @@
       "source_location": "L7"
     },
     {
-      "community": 293,
+      "community": 295,
       "file_type": "code",
       "id": "usegetproducts_usegetunresolvedproducts",
       "label": "useGetUnresolvedProducts()",
@@ -76366,7 +76558,7 @@
       "source_location": "L40"
     },
     {
-      "community": 294,
+      "community": 296,
       "file_type": "code",
       "id": "customerobservabilitytimeline_formatobservabilitylabel",
       "label": "formatObservabilityLabel()",
@@ -76375,7 +76567,7 @@
       "source_location": "L66"
     },
     {
-      "community": 294,
+      "community": 296,
       "file_type": "code",
       "id": "customerobservabilitytimeline_getdeviceicon",
       "label": "getDeviceIcon()",
@@ -76384,7 +76576,7 @@
       "source_location": "L121"
     },
     {
-      "community": 294,
+      "community": 296,
       "file_type": "code",
       "id": "customerobservabilitytimeline_getobservabilitystatusstyles",
       "label": "getObservabilityStatusStyles()",
@@ -76393,7 +76585,7 @@
       "source_location": "L74"
     },
     {
-      "community": 294,
+      "community": 296,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_customerobservabilitytimeline_ts",
       "label": "customerObservabilityTimeline.ts",
@@ -76402,7 +76594,7 @@
       "source_location": "L1"
     },
     {
-      "community": 295,
+      "community": 297,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_runcommand_ts",
       "label": "runCommand.ts",
@@ -76411,7 +76603,7 @@
       "source_location": "L1"
     },
     {
-      "community": 295,
+      "community": 297,
       "file_type": "code",
       "id": "runcommand_extracttraceid",
       "label": "extractTraceId()",
@@ -76420,7 +76612,7 @@
       "source_location": "L34"
     },
     {
-      "community": 295,
+      "community": 297,
       "file_type": "code",
       "id": "runcommand_isapprovalrequiredresult",
       "label": "isApprovalRequiredResult()",
@@ -76429,7 +76621,7 @@
       "source_location": "L28"
     },
     {
-      "community": 295,
+      "community": 297,
       "file_type": "code",
       "id": "runcommand_runcommand",
       "label": "runCommand()",
@@ -76438,7 +76630,7 @@
       "source_location": "L48"
     },
     {
-      "community": 296,
+      "community": 298,
       "file_type": "code",
       "id": "barcodeutils_extractbarcodefrominput",
       "label": "extractBarcodeFromInput()",
@@ -76447,7 +76639,7 @@
       "source_location": "L51"
     },
     {
-      "community": 296,
+      "community": 298,
       "file_type": "code",
       "id": "barcodeutils_isurlorbarcode",
       "label": "isUrlOrBarcode()",
@@ -76456,7 +76648,7 @@
       "source_location": "L92"
     },
     {
-      "community": 296,
+      "community": 298,
       "file_type": "code",
       "id": "barcodeutils_isvalidconvexid",
       "label": "isValidConvexId()",
@@ -76465,7 +76657,7 @@
       "source_location": "L16"
     },
     {
-      "community": 296,
+      "community": 298,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_barcodeutils_ts",
       "label": "barcodeUtils.ts",
@@ -76474,7 +76666,7 @@
       "source_location": "L1"
     },
     {
-      "community": 297,
+      "community": 299,
       "file_type": "code",
       "id": "customergateway_useconvexposcustomercreate",
       "label": "useConvexPosCustomerCreate()",
@@ -76483,7 +76675,7 @@
       "source_location": "L22"
     },
     {
-      "community": 297,
+      "community": 299,
       "file_type": "code",
       "id": "customergateway_useconvexposcustomersearch",
       "label": "useConvexPosCustomerSearch()",
@@ -76492,7 +76684,7 @@
       "source_location": "L10"
     },
     {
-      "community": 297,
+      "community": 299,
       "file_type": "code",
       "id": "customergateway_useconvexposcustomerupdate",
       "label": "useConvexPosCustomerUpdate()",
@@ -76501,85 +76693,13 @@
       "source_location": "L57"
     },
     {
-      "community": 297,
+      "community": 299,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_customergateway_ts",
       "label": "customerGateway.ts",
       "norm_label": "customergateway.ts",
       "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/customerGateway.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 298,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_sessiongateway_mapper_ts",
-      "label": "sessionGateway.mapper.ts",
-      "norm_label": "sessiongateway.mapper.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/sessionGateway.mapper.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 298,
-      "file_type": "code",
-      "id": "sessiongateway_mapper_mapactivesessiondto",
-      "label": "mapActiveSessionDto()",
-      "norm_label": "mapactivesessiondto()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/sessionGateway.mapper.ts",
-      "source_location": "L83"
-    },
-    {
-      "community": 298,
-      "file_type": "code",
-      "id": "sessiongateway_mapper_mapheldsessionsdto",
-      "label": "mapHeldSessionsDto()",
-      "norm_label": "mapheldsessionsdto()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/sessionGateway.mapper.ts",
-      "source_location": "L100"
-    },
-    {
-      "community": 298,
-      "file_type": "code",
-      "id": "sessiongateway_mapper_normalizecartitems",
-      "label": "normalizeCartItems()",
-      "norm_label": "normalizecartitems()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/sessionGateway.mapper.ts",
-      "source_location": "L79"
-    },
-    {
-      "community": 299,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_sessiongateway_ts",
-      "label": "sessionGateway.ts",
-      "norm_label": "sessiongateway.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/sessionGateway.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 299,
-      "file_type": "code",
-      "id": "sessiongateway_useconvexactivesession",
-      "label": "useConvexActiveSession()",
-      "norm_label": "useconvexactivesession()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/sessionGateway.ts",
-      "source_location": "L38"
-    },
-    {
-      "community": 299,
-      "file_type": "code",
-      "id": "sessiongateway_useconvexheldsessions",
-      "label": "useConvexHeldSessions()",
-      "norm_label": "useconvexheldsessions()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/sessionGateway.ts",
-      "source_location": "L65"
-    },
-    {
-      "community": 299,
-      "file_type": "code",
-      "id": "sessiongateway_useconvexsessionactions",
-      "label": "useConvexSessionActions()",
-      "norm_label": "useconvexsessionactions()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/sessionGateway.ts",
-      "source_location": "L91"
     },
     {
       "community": 3,
@@ -77115,6 +77235,78 @@
     {
       "community": 300,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_sessiongateway_mapper_ts",
+      "label": "sessionGateway.mapper.ts",
+      "norm_label": "sessiongateway.mapper.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/sessionGateway.mapper.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 300,
+      "file_type": "code",
+      "id": "sessiongateway_mapper_mapactivesessiondto",
+      "label": "mapActiveSessionDto()",
+      "norm_label": "mapactivesessiondto()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/sessionGateway.mapper.ts",
+      "source_location": "L83"
+    },
+    {
+      "community": 300,
+      "file_type": "code",
+      "id": "sessiongateway_mapper_mapheldsessionsdto",
+      "label": "mapHeldSessionsDto()",
+      "norm_label": "mapheldsessionsdto()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/sessionGateway.mapper.ts",
+      "source_location": "L100"
+    },
+    {
+      "community": 300,
+      "file_type": "code",
+      "id": "sessiongateway_mapper_normalizecartitems",
+      "label": "normalizeCartItems()",
+      "norm_label": "normalizecartitems()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/sessionGateway.mapper.ts",
+      "source_location": "L79"
+    },
+    {
+      "community": 301,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_sessiongateway_ts",
+      "label": "sessionGateway.ts",
+      "norm_label": "sessiongateway.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/sessionGateway.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 301,
+      "file_type": "code",
+      "id": "sessiongateway_useconvexactivesession",
+      "label": "useConvexActiveSession()",
+      "norm_label": "useconvexactivesession()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/sessionGateway.ts",
+      "source_location": "L38"
+    },
+    {
+      "community": 301,
+      "file_type": "code",
+      "id": "sessiongateway_useconvexheldsessions",
+      "label": "useConvexHeldSessions()",
+      "norm_label": "useconvexheldsessions()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/sessionGateway.ts",
+      "source_location": "L65"
+    },
+    {
+      "community": 301,
+      "file_type": "code",
+      "id": "sessiongateway_useconvexsessionactions",
+      "label": "useConvexSessionActions()",
+      "norm_label": "useconvexsessionactions()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/sessionGateway.ts",
+      "source_location": "L91"
+    },
+    {
+      "community": 302,
+      "file_type": "code",
       "id": "fingerprint_isbrowserfingerprintresult",
       "label": "isBrowserFingerprintResult()",
       "norm_label": "isbrowserfingerprintresult()",
@@ -77122,7 +77314,7 @@
       "source_location": "L4"
     },
     {
-      "community": 300,
+      "community": 302,
       "file_type": "code",
       "id": "fingerprint_readstoredterminalfingerprint",
       "label": "readStoredTerminalFingerprint()",
@@ -77131,7 +77323,7 @@
       "source_location": "L20"
     },
     {
-      "community": 300,
+      "community": 302,
       "file_type": "code",
       "id": "fingerprint_readstoredterminalfingerprinthash",
       "label": "readStoredTerminalFingerprintHash()",
@@ -77140,7 +77332,7 @@
       "source_location": "L42"
     },
     {
-      "community": 300,
+      "community": 302,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_terminal_fingerprint_ts",
       "label": "fingerprint.ts",
@@ -77149,7 +77341,7 @@
       "source_location": "L1"
     },
     {
-      "community": 301,
+      "community": 303,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_presentation_expense_useexpenseregisterviewmodel_ts",
       "label": "useExpenseRegisterViewModel.ts",
@@ -77158,7 +77350,7 @@
       "source_location": "L1"
     },
     {
-      "community": 301,
+      "community": 303,
       "file_type": "code",
       "id": "useexpenseregisterviewmodel_getcashierdisplayname",
       "label": "getCashierDisplayName()",
@@ -77167,7 +77359,7 @@
       "source_location": "L37"
     },
     {
-      "community": 301,
+      "community": 303,
       "file_type": "code",
       "id": "useexpenseregisterviewmodel_getexpensesessionloadkey",
       "label": "getExpenseSessionLoadKey()",
@@ -77176,7 +77368,7 @@
       "source_location": "L49"
     },
     {
-      "community": 301,
+      "community": 303,
       "file_type": "code",
       "id": "useexpenseregisterviewmodel_useexpenseregisterviewmodel",
       "label": "useExpenseRegisterViewModel()",
@@ -77185,7 +77377,7 @@
       "source_location": "L68"
     },
     {
-      "community": 302,
+      "community": 304,
       "file_type": "code",
       "id": "offers_getbaseurl",
       "label": "getBaseUrl()",
@@ -77194,7 +77386,7 @@
       "source_location": "L13"
     },
     {
-      "community": 302,
+      "community": 304,
       "file_type": "code",
       "id": "offers_getuserredeemedoffers",
       "label": "getUserRedeemedOffers()",
@@ -77203,7 +77395,7 @@
       "source_location": "L46"
     },
     {
-      "community": 302,
+      "community": 304,
       "file_type": "code",
       "id": "offers_submitoffer",
       "label": "submitOffer()",
@@ -77212,7 +77404,7 @@
       "source_location": "L21"
     },
     {
-      "community": 302,
+      "community": 304,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_offers_ts",
       "label": "offers.ts",
@@ -77221,7 +77413,7 @@
       "source_location": "L1"
     },
     {
-      "community": 303,
+      "community": 305,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_stores_ts",
       "label": "stores.ts",
@@ -77230,7 +77422,7 @@
       "source_location": "L1"
     },
     {
-      "community": 303,
+      "community": 305,
       "file_type": "code",
       "id": "stores_getallstores",
       "label": "getAllStores()",
@@ -77239,7 +77431,7 @@
       "source_location": "L8"
     },
     {
-      "community": 303,
+      "community": 305,
       "file_type": "code",
       "id": "stores_getbaseurl",
       "label": "getBaseUrl()",
@@ -77248,7 +77440,7 @@
       "source_location": "L5"
     },
     {
-      "community": 303,
+      "community": 305,
       "file_type": "code",
       "id": "stores_getstore",
       "label": "getStore()",
@@ -77257,7 +77449,7 @@
       "source_location": "L20"
     },
     {
-      "community": 304,
+      "community": 306,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_subcategory_ts",
       "label": "subcategory.ts",
@@ -77266,7 +77458,7 @@
       "source_location": "L1"
     },
     {
-      "community": 304,
+      "community": 306,
       "file_type": "code",
       "id": "subcategory_getallsubcategories",
       "label": "getAllSubcategories()",
@@ -77275,7 +77467,7 @@
       "source_location": "L11"
     },
     {
-      "community": 304,
+      "community": 306,
       "file_type": "code",
       "id": "subcategory_getbaseurl",
       "label": "getBaseUrl()",
@@ -77284,7 +77476,7 @@
       "source_location": "L9"
     },
     {
-      "community": 304,
+      "community": 306,
       "file_type": "code",
       "id": "subcategory_getsubategory",
       "label": "getSubategory()",
@@ -77293,7 +77485,7 @@
       "source_location": "L25"
     },
     {
-      "community": 305,
+      "community": 307,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_productactionbar_tsx",
       "label": "ProductActionBar.tsx",
@@ -77302,7 +77494,7 @@
       "source_location": "L1"
     },
     {
-      "community": 305,
+      "community": 307,
       "file_type": "code",
       "id": "productactionbar_checkscroll",
       "label": "checkScroll()",
@@ -77311,7 +77503,7 @@
       "source_location": "L50"
     },
     {
-      "community": 305,
+      "community": 307,
       "file_type": "code",
       "id": "productactionbar_handleaction",
       "label": "handleAction()",
@@ -77320,7 +77512,7 @@
       "source_location": "L92"
     },
     {
-      "community": 305,
+      "community": 307,
       "file_type": "code",
       "id": "productactionbar_handledismiss",
       "label": "handleDismiss()",
@@ -77329,7 +77521,7 @@
       "source_location": "L74"
     },
     {
-      "community": 306,
+      "community": 308,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_productreminderbar_tsx",
       "label": "ProductReminderBar.tsx",
@@ -77338,7 +77530,7 @@
       "source_location": "L1"
     },
     {
-      "community": 306,
+      "community": 308,
       "file_type": "code",
       "id": "productreminderbar_checkscroll",
       "label": "checkScroll()",
@@ -77347,7 +77539,7 @@
       "source_location": "L62"
     },
     {
-      "community": 306,
+      "community": 308,
       "file_type": "code",
       "id": "productreminderbar_handleaddtobag",
       "label": "handleAddToBag()",
@@ -77356,7 +77548,7 @@
       "source_location": "L109"
     },
     {
-      "community": 306,
+      "community": 308,
       "file_type": "code",
       "id": "productreminderbar_handledismiss",
       "label": "handleDismiss()",
@@ -77365,7 +77557,7 @@
       "source_location": "L177"
     },
     {
-      "community": 307,
+      "community": 309,
       "file_type": "code",
       "id": "billingdetailssection_clearform",
       "label": "clearForm()",
@@ -77374,7 +77566,7 @@
       "source_location": "L18"
     },
     {
-      "community": 307,
+      "community": 309,
       "file_type": "code",
       "id": "billingdetailssection_handleusebillingaddressonfile",
       "label": "handleUseBillingAddressOnFile()",
@@ -77383,7 +77575,7 @@
       "source_location": "L52"
     },
     {
-      "community": 307,
+      "community": 309,
       "file_type": "code",
       "id": "billingdetailssection_togglesameasdelivery",
       "label": "toggleSameAsDelivery()",
@@ -77392,85 +77584,13 @@
       "source_location": "L68"
     },
     {
-      "community": 307,
+      "community": 309,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_billingdetailssection_tsx",
       "label": "BillingDetailsSection.tsx",
       "norm_label": "billingdetailssection.tsx",
       "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetailsSection.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 308,
-      "file_type": "code",
-      "id": "hooks_usegetshopsearchparams",
-      "label": "useGetShopSearchParams()",
-      "norm_label": "usegetshopsearchparams()",
-      "source_file": "packages/storefront-webapp/src/components/navigation/hooks.ts",
-      "source_location": "L68"
-    },
-    {
-      "community": 308,
-      "file_type": "code",
-      "id": "hooks_usegetstorecategories",
-      "label": "useGetStoreCategories()",
-      "norm_label": "usegetstorecategories()",
-      "source_file": "packages/storefront-webapp/src/components/navigation/hooks.ts",
-      "source_location": "L26"
-    },
-    {
-      "community": 308,
-      "file_type": "code",
-      "id": "hooks_usegetstoresubcategories",
-      "label": "useGetStoreSubcategories()",
-      "norm_label": "usegetstoresubcategories()",
-      "source_file": "packages/storefront-webapp/src/components/navigation/hooks.ts",
-      "source_location": "L7"
-    },
-    {
-      "community": 308,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_navigation_hooks_ts",
-      "label": "hooks.ts",
-      "norm_label": "hooks.ts",
-      "source_file": "packages/storefront-webapp/src/components/navigation/hooks.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 309,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_page_productattribute_tsx",
-      "label": "ProductAttribute.tsx",
-      "norm_label": "productattribute.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-page/ProductAttribute.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 309,
-      "file_type": "code",
-      "id": "productattribute_findsize",
-      "label": "findSize()",
-      "norm_label": "findsize()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/ProductAttribute.tsx",
-      "source_location": "L81"
-    },
-    {
-      "community": 309,
-      "file_type": "code",
-      "id": "productattribute_handleclick",
-      "label": "handleClick()",
-      "norm_label": "handleclick()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/ProductAttribute.tsx",
-      "source_location": "L85"
-    },
-    {
-      "community": 309,
-      "file_type": "code",
-      "id": "productattribute_optionclassname",
-      "label": "optionClassName()",
-      "norm_label": "optionclassname()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/ProductAttribute.tsx",
-      "source_location": "L27"
     },
     {
       "community": 31,
@@ -77637,6 +77757,78 @@
     {
       "community": 310,
       "file_type": "code",
+      "id": "hooks_usegetshopsearchparams",
+      "label": "useGetShopSearchParams()",
+      "norm_label": "usegetshopsearchparams()",
+      "source_file": "packages/storefront-webapp/src/components/navigation/hooks.ts",
+      "source_location": "L68"
+    },
+    {
+      "community": 310,
+      "file_type": "code",
+      "id": "hooks_usegetstorecategories",
+      "label": "useGetStoreCategories()",
+      "norm_label": "usegetstorecategories()",
+      "source_file": "packages/storefront-webapp/src/components/navigation/hooks.ts",
+      "source_location": "L26"
+    },
+    {
+      "community": 310,
+      "file_type": "code",
+      "id": "hooks_usegetstoresubcategories",
+      "label": "useGetStoreSubcategories()",
+      "norm_label": "usegetstoresubcategories()",
+      "source_file": "packages/storefront-webapp/src/components/navigation/hooks.ts",
+      "source_location": "L7"
+    },
+    {
+      "community": 310,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_navigation_hooks_ts",
+      "label": "hooks.ts",
+      "norm_label": "hooks.ts",
+      "source_file": "packages/storefront-webapp/src/components/navigation/hooks.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 311,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_page_productattribute_tsx",
+      "label": "ProductAttribute.tsx",
+      "norm_label": "productattribute.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-page/ProductAttribute.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 311,
+      "file_type": "code",
+      "id": "productattribute_findsize",
+      "label": "findSize()",
+      "norm_label": "findsize()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/ProductAttribute.tsx",
+      "source_location": "L81"
+    },
+    {
+      "community": 311,
+      "file_type": "code",
+      "id": "productattribute_handleclick",
+      "label": "handleClick()",
+      "norm_label": "handleclick()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/ProductAttribute.tsx",
+      "source_location": "L85"
+    },
+    {
+      "community": 311,
+      "file_type": "code",
+      "id": "productattribute_optionclassname",
+      "label": "optionClassName()",
+      "norm_label": "optionclassname()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/ProductAttribute.tsx",
+      "source_location": "L27"
+    },
+    {
+      "community": 312,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productdetails_tsx",
       "label": "ProductDetails.tsx",
       "norm_label": "productdetails.tsx",
@@ -77644,7 +77836,7 @@
       "source_location": "L1"
     },
     {
-      "community": 310,
+      "community": 312,
       "file_type": "code",
       "id": "productdetails_bagproduct",
       "label": "BagProduct()",
@@ -77653,7 +77845,7 @@
       "source_location": "L43"
     },
     {
-      "community": 310,
+      "community": 312,
       "file_type": "code",
       "id": "productdetails_pickupdetails",
       "label": "PickupDetails()",
@@ -77662,7 +77854,7 @@
       "source_location": "L13"
     },
     {
-      "community": 310,
+      "community": 312,
       "file_type": "code",
       "id": "productdetails_shippingpolicy",
       "label": "ShippingPolicy()",
@@ -77671,7 +77863,7 @@
       "source_location": "L88"
     },
     {
-      "community": 311,
+      "community": 313,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_upsellmodal_tsx",
       "label": "UpsellModal.tsx",
@@ -77680,7 +77872,7 @@
       "source_location": "L1"
     },
     {
-      "community": 311,
+      "community": 313,
       "file_type": "code",
       "id": "upsellmodal_handleclose",
       "label": "handleClose()",
@@ -77689,7 +77881,7 @@
       "source_location": "L111"
     },
     {
-      "community": 311,
+      "community": 313,
       "file_type": "code",
       "id": "upsellmodal_handlescroll",
       "label": "handleScroll()",
@@ -77698,7 +77890,7 @@
       "source_location": "L66"
     },
     {
-      "community": 311,
+      "community": 313,
       "file_type": "code",
       "id": "upsellmodal_handlesuccess",
       "label": "handleSuccess()",
@@ -77707,7 +77899,7 @@
       "source_location": "L127"
     },
     {
-      "community": 312,
+      "community": 314,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_contexts_storecontext_tsx",
       "label": "StoreContext.tsx",
@@ -77716,7 +77908,7 @@
       "source_location": "L1"
     },
     {
-      "community": 312,
+      "community": 314,
       "file_type": "code",
       "id": "storecontext_storeprovider",
       "label": "StoreProvider()",
@@ -77725,7 +77917,7 @@
       "source_location": "L25"
     },
     {
-      "community": 312,
+      "community": 314,
       "file_type": "code",
       "id": "storecontext_useoptionalstorecontext",
       "label": "useOptionalStoreContext()",
@@ -77734,7 +77926,7 @@
       "source_location": "L90"
     },
     {
-      "community": 312,
+      "community": 314,
       "file_type": "code",
       "id": "storecontext_usestorecontext",
       "label": "useStoreContext()",
@@ -77743,7 +77935,7 @@
       "source_location": "L82"
     },
     {
-      "community": 313,
+      "community": 315,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_shoplayout_tsx",
       "label": "_shopLayout.tsx",
@@ -77752,7 +77944,7 @@
       "source_location": "L1"
     },
     {
-      "community": 313,
+      "community": 315,
       "file_type": "code",
       "id": "shoplayout_clearfilters",
       "label": "clearFilters()",
@@ -77761,7 +77953,7 @@
       "source_location": "L115"
     },
     {
-      "community": 313,
+      "community": 315,
       "file_type": "code",
       "id": "shoplayout_onclickonmobilefilters",
       "label": "onClickOnMobileFilters()",
@@ -77770,7 +77962,7 @@
       "source_location": "L105"
     },
     {
-      "community": 313,
+      "community": 315,
       "file_type": "code",
       "id": "shoplayout_onmobilefilterscloseclick",
       "label": "onMobileFiltersCloseClick()",
@@ -77779,7 +77971,7 @@
       "source_location": "L110"
     },
     {
-      "community": 314,
+      "community": 316,
       "file_type": "code",
       "id": "index_cancelorder",
       "label": "cancelOrder()",
@@ -77788,7 +77980,7 @@
       "source_location": "L121"
     },
     {
-      "community": 314,
+      "community": 316,
       "file_type": "code",
       "id": "index_geterrormessage",
       "label": "getErrorMessage()",
@@ -77797,7 +77989,7 @@
       "source_location": "L26"
     },
     {
-      "community": 314,
+      "community": 316,
       "file_type": "code",
       "id": "index_placeorder",
       "label": "placeOrder()",
@@ -77806,7 +77998,7 @@
       "source_location": "L71"
     },
     {
-      "community": 314,
+      "community": 316,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_index_tsx",
       "label": "index.tsx",
@@ -77815,7 +78007,7 @@
       "source_location": "L1"
     },
     {
-      "community": 315,
+      "community": 317,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_receipt_posreceiptpage_tsx",
       "label": "-PosReceiptPage.tsx",
@@ -77824,7 +78016,7 @@
       "source_location": "L1"
     },
     {
-      "community": 315,
+      "community": 317,
       "file_type": "code",
       "id": "posreceiptpage_money",
       "label": "money()",
@@ -77833,7 +78025,7 @@
       "source_location": "L51"
     },
     {
-      "community": 315,
+      "community": 317,
       "file_type": "code",
       "id": "posreceiptpage_paymentlabel",
       "label": "paymentLabel()",
@@ -77842,7 +78034,7 @@
       "source_location": "L13"
     },
     {
-      "community": 315,
+      "community": 317,
       "file_type": "code",
       "id": "posreceiptpage_shouldretryreceiptlookup",
       "label": "shouldRetryReceiptLookup()",
@@ -77851,7 +78043,7 @@
       "source_location": "L21"
     },
     {
-      "community": 316,
+      "community": 318,
       "file_type": "code",
       "id": "bootstrap_bootstrapcheckout",
       "label": "bootstrapCheckout()",
@@ -77860,7 +78052,7 @@
       "source_location": "L46"
     },
     {
-      "community": 316,
+      "community": 318,
       "file_type": "code",
       "id": "bootstrap_createbootstraptoken",
       "label": "createBootstrapToken()",
@@ -77869,7 +78061,7 @@
       "source_location": "L24"
     },
     {
-      "community": 316,
+      "community": 318,
       "file_type": "code",
       "id": "bootstrap_createmarker",
       "label": "createMarker()",
@@ -77878,7 +78070,7 @@
       "source_location": "L20"
     },
     {
-      "community": 316,
+      "community": 318,
       "file_type": "code",
       "id": "packages_storefront_webapp_tests_e2e_helpers_bootstrap_ts",
       "label": "bootstrap.ts",
@@ -77887,7 +78079,7 @@
       "source_location": "L1"
     },
     {
-      "community": 317,
+      "community": 319,
       "file_type": "code",
       "id": "graphify_check_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -77896,7 +78088,7 @@
       "source_location": "L17"
     },
     {
-      "community": 317,
+      "community": 319,
       "file_type": "code",
       "id": "graphify_check_test_write",
       "label": "write()",
@@ -77905,7 +78097,7 @@
       "source_location": "L11"
     },
     {
-      "community": 317,
+      "community": 319,
       "file_type": "code",
       "id": "graphify_check_test_writegraphifywikiartifacts",
       "label": "writeGraphifyWikiArtifacts()",
@@ -77914,84 +78106,12 @@
       "source_location": "L24"
     },
     {
-      "community": 317,
+      "community": 319,
       "file_type": "code",
       "id": "scripts_graphify_check_test_ts",
       "label": "graphify-check.test.ts",
       "norm_label": "graphify-check.test.ts",
       "source_file": "scripts/graphify-check.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 318,
-      "file_type": "code",
-      "id": "graphify_rebuild_test_createfixtureroot",
-      "label": "createFixtureRoot()",
-      "norm_label": "createfixtureroot()",
-      "source_file": "scripts/graphify-rebuild.test.ts",
-      "source_location": "L20"
-    },
-    {
-      "community": 318,
-      "file_type": "code",
-      "id": "graphify_rebuild_test_spawn",
-      "label": "spawn()",
-      "norm_label": "spawn()",
-      "source_file": "scripts/graphify-rebuild.test.ts",
-      "source_location": "L65"
-    },
-    {
-      "community": 318,
-      "file_type": "code",
-      "id": "graphify_rebuild_test_write",
-      "label": "write()",
-      "norm_label": "write()",
-      "source_file": "scripts/graphify-rebuild.test.ts",
-      "source_location": "L14"
-    },
-    {
-      "community": 318,
-      "file_type": "code",
-      "id": "scripts_graphify_rebuild_test_ts",
-      "label": "graphify-rebuild.test.ts",
-      "norm_label": "graphify-rebuild.test.ts",
-      "source_file": "scripts/graphify-rebuild.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 319,
-      "file_type": "code",
-      "id": "harness_app_registry_buildharnessdocpaths",
-      "label": "buildHarnessDocPaths()",
-      "norm_label": "buildharnessdocpaths()",
-      "source_file": "scripts/harness-app-registry.ts",
-      "source_location": "L126"
-    },
-    {
-      "community": 319,
-      "file_type": "code",
-      "id": "harness_app_registry_buildharnessdocpathsforarchetype",
-      "label": "buildHarnessDocPathsForArchetype()",
-      "norm_label": "buildharnessdocpathsforarchetype()",
-      "source_file": "scripts/harness-app-registry.ts",
-      "source_location": "L130"
-    },
-    {
-      "community": 319,
-      "file_type": "code",
-      "id": "harness_app_registry_getharnesspackageregistration",
-      "label": "getHarnessPackageRegistration()",
-      "norm_label": "getharnesspackageregistration()",
-      "source_file": "scripts/harness-app-registry.ts",
-      "source_location": "L919"
-    },
-    {
-      "community": 319,
-      "file_type": "code",
-      "id": "scripts_harness_app_registry_ts",
-      "label": "harness-app-registry.ts",
-      "norm_label": "harness-app-registry.ts",
-      "source_file": "scripts/harness-app-registry.ts",
       "source_location": "L1"
     },
     {
@@ -78159,6 +78279,78 @@
     {
       "community": 320,
       "file_type": "code",
+      "id": "graphify_rebuild_test_createfixtureroot",
+      "label": "createFixtureRoot()",
+      "norm_label": "createfixtureroot()",
+      "source_file": "scripts/graphify-rebuild.test.ts",
+      "source_location": "L20"
+    },
+    {
+      "community": 320,
+      "file_type": "code",
+      "id": "graphify_rebuild_test_spawn",
+      "label": "spawn()",
+      "norm_label": "spawn()",
+      "source_file": "scripts/graphify-rebuild.test.ts",
+      "source_location": "L65"
+    },
+    {
+      "community": 320,
+      "file_type": "code",
+      "id": "graphify_rebuild_test_write",
+      "label": "write()",
+      "norm_label": "write()",
+      "source_file": "scripts/graphify-rebuild.test.ts",
+      "source_location": "L14"
+    },
+    {
+      "community": 320,
+      "file_type": "code",
+      "id": "scripts_graphify_rebuild_test_ts",
+      "label": "graphify-rebuild.test.ts",
+      "norm_label": "graphify-rebuild.test.ts",
+      "source_file": "scripts/graphify-rebuild.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 321,
+      "file_type": "code",
+      "id": "harness_app_registry_buildharnessdocpaths",
+      "label": "buildHarnessDocPaths()",
+      "norm_label": "buildharnessdocpaths()",
+      "source_file": "scripts/harness-app-registry.ts",
+      "source_location": "L126"
+    },
+    {
+      "community": 321,
+      "file_type": "code",
+      "id": "harness_app_registry_buildharnessdocpathsforarchetype",
+      "label": "buildHarnessDocPathsForArchetype()",
+      "norm_label": "buildharnessdocpathsforarchetype()",
+      "source_file": "scripts/harness-app-registry.ts",
+      "source_location": "L130"
+    },
+    {
+      "community": 321,
+      "file_type": "code",
+      "id": "harness_app_registry_getharnesspackageregistration",
+      "label": "getHarnessPackageRegistration()",
+      "norm_label": "getharnesspackageregistration()",
+      "source_file": "scripts/harness-app-registry.ts",
+      "source_location": "L919"
+    },
+    {
+      "community": 321,
+      "file_type": "code",
+      "id": "scripts_harness_app_registry_ts",
+      "label": "harness-app-registry.ts",
+      "norm_label": "harness-app-registry.ts",
+      "source_file": "scripts/harness-app-registry.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 322,
+      "file_type": "code",
       "id": "scripts_harness_behavior_fixtures_valkey_runtime_app_ts",
       "label": "valkey-runtime-app.ts",
       "norm_label": "valkey-runtime-app.ts",
@@ -78166,7 +78358,7 @@
       "source_location": "L1"
     },
     {
-      "community": 320,
+      "community": 322,
       "file_type": "code",
       "id": "valkey_runtime_app_createvalkeyruntimeserver",
       "label": "createValkeyRuntimeServer()",
@@ -78175,7 +78367,7 @@
       "source_location": "L8"
     },
     {
-      "community": 320,
+      "community": 322,
       "file_type": "code",
       "id": "valkey_runtime_app_shutdown",
       "label": "shutdown()",
@@ -78184,7 +78376,7 @@
       "source_location": "L79"
     },
     {
-      "community": 320,
+      "community": 322,
       "file_type": "code",
       "id": "valkey_runtime_app_stopvalkeyruntimeserver",
       "label": "stopValkeyRuntimeServer()",
@@ -78193,7 +78385,7 @@
       "source_location": "L61"
     },
     {
-      "community": 321,
+      "community": 323,
       "file_type": "code",
       "id": "harness_scorecard_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -78202,7 +78394,7 @@
       "source_location": "L49"
     },
     {
-      "community": 321,
+      "community": 323,
       "file_type": "code",
       "id": "harness_scorecard_test_createinferentialartifact",
       "label": "createInferentialArtifact()",
@@ -78211,7 +78403,7 @@
       "source_location": "L17"
     },
     {
-      "community": 321,
+      "community": 323,
       "file_type": "code",
       "id": "harness_scorecard_test_write",
       "label": "write()",
@@ -78220,7 +78412,7 @@
       "source_location": "L11"
     },
     {
-      "community": 321,
+      "community": 323,
       "file_type": "code",
       "id": "scripts_harness_scorecard_test_ts",
       "label": "harness-scorecard.test.ts",
@@ -78229,7 +78421,7 @@
       "source_location": "L1"
     },
     {
-      "community": 322,
+      "community": 324,
       "file_type": "code",
       "id": "harness_test_collectharnesstesttargets",
       "label": "collectHarnessTestTargets()",
@@ -78238,7 +78430,7 @@
       "source_location": "L26"
     },
     {
-      "community": 322,
+      "community": 324,
       "file_type": "code",
       "id": "harness_test_parseharnesstestcliargs",
       "label": "parseHarnessTestCliArgs()",
@@ -78247,7 +78439,7 @@
       "source_location": "L72"
     },
     {
-      "community": 322,
+      "community": 324,
       "file_type": "code",
       "id": "harness_test_runharnesstest",
       "label": "runHarnessTest()",
@@ -78256,7 +78448,7 @@
       "source_location": "L36"
     },
     {
-      "community": 322,
+      "community": 324,
       "file_type": "code",
       "id": "scripts_harness_test_ts",
       "label": "harness-test.ts",
@@ -78265,7 +78457,7 @@
       "source_location": "L1"
     },
     {
-      "community": 323,
+      "community": 325,
       "file_type": "code",
       "id": "pre_push_review_test_error",
       "label": "error()",
@@ -78274,7 +78466,7 @@
       "source_location": "L96"
     },
     {
-      "community": 323,
+      "community": 325,
       "file_type": "code",
       "id": "pre_push_review_test_log",
       "label": "log()",
@@ -78283,7 +78475,7 @@
       "source_location": "L94"
     },
     {
-      "community": 323,
+      "community": 325,
       "file_type": "code",
       "id": "pre_push_review_test_warn",
       "label": "warn()",
@@ -78292,7 +78484,7 @@
       "source_location": "L95"
     },
     {
-      "community": 323,
+      "community": 325,
       "file_type": "code",
       "id": "scripts_pre_push_review_test_ts",
       "label": "pre-push-review.test.ts",
@@ -78301,7 +78493,7 @@
       "source_location": "L1"
     },
     {
-      "community": 324,
+      "community": 326,
       "file_type": "code",
       "id": "preview_worktree_test_makedir",
       "label": "makeDir()",
@@ -78310,7 +78502,7 @@
       "source_location": "L17"
     },
     {
-      "community": 324,
+      "community": 326,
       "file_type": "code",
       "id": "preview_worktree_test_previewoptions",
       "label": "previewOptions()",
@@ -78319,7 +78511,7 @@
       "source_location": "L23"
     },
     {
-      "community": 324,
+      "community": 326,
       "file_type": "code",
       "id": "preview_worktree_test_real",
       "label": "real()",
@@ -78328,7 +78520,7 @@
       "source_location": "L40"
     },
     {
-      "community": 324,
+      "community": 326,
       "file_type": "code",
       "id": "scripts_preview_worktree_test_ts",
       "label": "preview-worktree.test.ts",
@@ -78337,7 +78529,7 @@
       "source_location": "L1"
     },
     {
-      "community": 325,
+      "community": 327,
       "file_type": "code",
       "id": "closeouts_test_gethandler",
       "label": "getHandler()",
@@ -78346,7 +78538,7 @@
       "source_location": "L15"
     },
     {
-      "community": 325,
+      "community": 327,
       "file_type": "code",
       "id": "closeouts_test_getsource",
       "label": "getSource()",
@@ -78355,7 +78547,7 @@
       "source_location": "L11"
     },
     {
-      "community": 325,
+      "community": 327,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cashcontrols_closeouts_test_ts",
       "label": "closeouts.test.ts",
@@ -78364,7 +78556,7 @@
       "source_location": "L1"
     },
     {
-      "community": 326,
+      "community": 328,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_customermessaging_public_ts",
       "label": "public.ts",
@@ -78373,7 +78565,7 @@
       "source_location": "L1"
     },
     {
-      "community": 326,
+      "community": 328,
       "file_type": "code",
       "id": "public_resolverecipient",
       "label": "resolveRecipient()",
@@ -78382,7 +78574,7 @@
       "source_location": "L57"
     },
     {
-      "community": 326,
+      "community": 328,
       "file_type": "code",
       "id": "public_topublicreceipttransaction",
       "label": "toPublicReceiptTransaction()",
@@ -78391,7 +78583,7 @@
       "source_location": "L29"
     },
     {
-      "community": 327,
+      "community": 329,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_customermessaging_whatsappclient_ts",
       "label": "whatsappClient.ts",
@@ -78400,7 +78592,7 @@
       "source_location": "L1"
     },
     {
-      "community": 327,
+      "community": 329,
       "file_type": "code",
       "id": "whatsappclient_providererrorcategory",
       "label": "providerErrorCategory()",
@@ -78409,67 +78601,13 @@
       "source_location": "L20"
     },
     {
-      "community": 327,
+      "community": 329,
       "file_type": "code",
       "id": "whatsappclient_sendwhatsappreceipttemplate",
       "label": "sendWhatsAppReceiptTemplate()",
       "norm_label": "sendwhatsappreceipttemplate()",
       "source_file": "packages/athena-webapp/convex/customerMessaging/whatsappClient.ts",
       "source_location": "L27"
-    },
-    {
-      "community": 328,
-      "file_type": "code",
-      "id": "discountcode_chunkproducts",
-      "label": "chunkProducts()",
-      "norm_label": "chunkproducts()",
-      "source_file": "packages/athena-webapp/convex/emails/DiscountCode.tsx",
-      "source_location": "L98"
-    },
-    {
-      "community": 328,
-      "file_type": "code",
-      "id": "discountcode_productcard",
-      "label": "ProductCard()",
-      "norm_label": "productcard()",
-      "source_file": "packages/athena-webapp/convex/emails/DiscountCode.tsx",
-      "source_location": "L33"
-    },
-    {
-      "community": 328,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_emails_discountcode_tsx",
-      "label": "DiscountCode.tsx",
-      "norm_label": "discountcode.tsx",
-      "source_file": "packages/athena-webapp/convex/emails/DiscountCode.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 329,
-      "file_type": "code",
-      "id": "discountreminder_chunkproducts",
-      "label": "chunkProducts()",
-      "norm_label": "chunkproducts()",
-      "source_file": "packages/athena-webapp/convex/emails/DiscountReminder.tsx",
-      "source_location": "L85"
-    },
-    {
-      "community": 329,
-      "file_type": "code",
-      "id": "discountreminder_productcard",
-      "label": "ProductCard()",
-      "norm_label": "productcard()",
-      "source_file": "packages/athena-webapp/convex/emails/DiscountReminder.tsx",
-      "source_location": "L31"
-    },
-    {
-      "community": 329,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_emails_discountreminder_tsx",
-      "label": "DiscountReminder.tsx",
-      "norm_label": "discountreminder.tsx",
-      "source_file": "packages/athena-webapp/convex/emails/DiscountReminder.tsx",
-      "source_location": "L1"
     },
     {
       "community": 33,
@@ -78636,6 +78774,60 @@
     {
       "community": 330,
       "file_type": "code",
+      "id": "discountcode_chunkproducts",
+      "label": "chunkProducts()",
+      "norm_label": "chunkproducts()",
+      "source_file": "packages/athena-webapp/convex/emails/DiscountCode.tsx",
+      "source_location": "L98"
+    },
+    {
+      "community": 330,
+      "file_type": "code",
+      "id": "discountcode_productcard",
+      "label": "ProductCard()",
+      "norm_label": "productcard()",
+      "source_file": "packages/athena-webapp/convex/emails/DiscountCode.tsx",
+      "source_location": "L33"
+    },
+    {
+      "community": 330,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_emails_discountcode_tsx",
+      "label": "DiscountCode.tsx",
+      "norm_label": "discountcode.tsx",
+      "source_file": "packages/athena-webapp/convex/emails/DiscountCode.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 331,
+      "file_type": "code",
+      "id": "discountreminder_chunkproducts",
+      "label": "chunkProducts()",
+      "norm_label": "chunkproducts()",
+      "source_file": "packages/athena-webapp/convex/emails/DiscountReminder.tsx",
+      "source_location": "L85"
+    },
+    {
+      "community": 331,
+      "file_type": "code",
+      "id": "discountreminder_productcard",
+      "label": "ProductCard()",
+      "norm_label": "productcard()",
+      "source_file": "packages/athena-webapp/convex/emails/DiscountReminder.tsx",
+      "source_location": "L31"
+    },
+    {
+      "community": 331,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_emails_discountreminder_tsx",
+      "label": "DiscountReminder.tsx",
+      "norm_label": "discountreminder.tsx",
+      "source_file": "packages/athena-webapp/convex/emails/DiscountReminder.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 332,
+      "file_type": "code",
       "id": "categories_removestorefronthiddencategories",
       "label": "removeStorefrontHiddenCategories()",
       "norm_label": "removestorefronthiddencategories()",
@@ -78643,7 +78835,7 @@
       "source_location": "L12"
     },
     {
-      "community": 330,
+      "community": 332,
       "file_type": "code",
       "id": "categories_removestorefronthiddensubcategories",
       "label": "removeStorefrontHiddenSubcategories()",
@@ -78652,7 +78844,7 @@
       "source_location": "L21"
     },
     {
-      "community": 330,
+      "community": 332,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_core_routes_categories_ts",
       "label": "categories.ts",
@@ -78661,7 +78853,7 @@
       "source_location": "L1"
     },
     {
-      "community": 331,
+      "community": 333,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_utils_ts",
       "label": "utils.ts",
@@ -78670,7 +78862,7 @@
       "source_location": "L1"
     },
     {
-      "community": 331,
+      "community": 333,
       "file_type": "code",
       "id": "utils_getstoredatafromrequest",
       "label": "getStoreDataFromRequest()",
@@ -78679,7 +78871,7 @@
       "source_location": "L5"
     },
     {
-      "community": 331,
+      "community": 333,
       "file_type": "code",
       "id": "utils_getstorefrontuserfromrequest",
       "label": "getStorefrontUserFromRequest()",
@@ -78688,7 +78880,7 @@
       "source_location": "L12"
     },
     {
-      "community": 332,
+      "community": 334,
       "file_type": "code",
       "id": "inventoryholds_test_buildhold",
       "label": "buildHold()",
@@ -78697,7 +78889,7 @@
       "source_location": "L566"
     },
     {
-      "community": 332,
+      "community": 334,
       "file_type": "code",
       "id": "inventoryholds_test_createdb",
       "label": "createDb()",
@@ -78706,7 +78898,7 @@
       "source_location": "L40"
     },
     {
-      "community": 332,
+      "community": 334,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_helpers_inventoryholds_test_ts",
       "label": "inventoryHolds.test.ts",
@@ -78715,7 +78907,7 @@
       "source_location": "L1"
     },
     {
-      "community": 333,
+      "community": 335,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_sessionqueryindexes_test_ts",
       "label": "sessionQueryIndexes.test.ts",
@@ -78724,7 +78916,7 @@
       "source_location": "L1"
     },
     {
-      "community": 333,
+      "community": 335,
       "file_type": "code",
       "id": "sessionqueryindexes_test_readprojectfile",
       "label": "readProjectFile()",
@@ -78733,7 +78925,7 @@
       "source_location": "L6"
     },
     {
-      "community": 333,
+      "community": 335,
       "file_type": "code",
       "id": "sessionqueryindexes_test_readsourceslice",
       "label": "readSourceSlice()",
@@ -78742,7 +78934,7 @@
       "source_location": "L9"
     },
     {
-      "community": 334,
+      "community": 336,
       "file_type": "code",
       "id": "analyticsutils_calculateactivitytrend",
       "label": "calculateActivityTrend()",
@@ -78751,7 +78943,7 @@
       "source_location": "L43"
     },
     {
-      "community": 334,
+      "community": 336,
       "file_type": "code",
       "id": "analyticsutils_calculatedevicedistribution",
       "label": "calculateDeviceDistribution()",
@@ -78760,7 +78952,7 @@
       "source_location": "L11"
     },
     {
-      "community": 334,
+      "community": 336,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_utils_analyticsutils_ts",
       "label": "analyticsUtils.ts",
@@ -78769,7 +78961,7 @@
       "source_location": "L1"
     },
     {
-      "community": 335,
+      "community": 337,
       "file_type": "code",
       "id": "dailyclose_test_createdb",
       "label": "createDb()",
@@ -78778,7 +78970,7 @@
       "source_location": "L27"
     },
     {
-      "community": 335,
+      "community": 337,
       "file_type": "code",
       "id": "dailyclose_test_dailycloseapprovalproof",
       "label": "dailyCloseApprovalProof()",
@@ -78787,7 +78979,7 @@
       "source_location": "L208"
     },
     {
-      "community": 335,
+      "community": 337,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_dailyclose_test_ts",
       "label": "dailyClose.test.ts",
@@ -78796,7 +78988,7 @@
       "source_location": "L1"
     },
     {
-      "community": 336,
+      "community": 338,
       "file_type": "code",
       "id": "dailyopening_test_completeddailyclose",
       "label": "completedDailyClose()",
@@ -78805,7 +78997,7 @@
       "source_location": "L168"
     },
     {
-      "community": 336,
+      "community": 338,
       "file_type": "code",
       "id": "dailyopening_test_createdb",
       "label": "createDb()",
@@ -78814,7 +79006,7 @@
       "source_location": "L21"
     },
     {
-      "community": 336,
+      "community": 338,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_dailyopening_test_ts",
       "label": "dailyOpening.test.ts",
@@ -78823,7 +79015,7 @@
       "source_location": "L1"
     },
     {
-      "community": 337,
+      "community": 339,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_staffcredentials_test_ts",
       "label": "staffCredentials.test.ts",
@@ -78832,7 +79024,7 @@
       "source_location": "L1"
     },
     {
-      "community": 337,
+      "community": 339,
       "file_type": "code",
       "id": "staffcredentials_test_createstaffcredentialsmutationctx",
       "label": "createStaffCredentialsMutationCtx()",
@@ -78841,67 +79033,13 @@
       "source_location": "L26"
     },
     {
-      "community": 337,
+      "community": 339,
       "file_type": "code",
       "id": "staffcredentials_test_gethandler",
       "label": "getHandler()",
       "norm_label": "gethandler()",
       "source_file": "packages/athena-webapp/convex/operations/staffCredentials.test.ts",
       "source_location": "L118"
-    },
-    {
-      "community": 338,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_staffprofiles_test_ts",
-      "label": "staffProfiles.test.ts",
-      "norm_label": "staffprofiles.test.ts",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 338,
-      "file_type": "code",
-      "id": "staffprofiles_test_createstaffprofilesmutationctx",
-      "label": "createStaffProfilesMutationCtx()",
-      "norm_label": "createstaffprofilesmutationctx()",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.test.ts",
-      "source_location": "L16"
-    },
-    {
-      "community": 338,
-      "file_type": "code",
-      "id": "staffprofiles_test_gethandler",
-      "label": "getHandler()",
-      "norm_label": "gethandler()",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.test.ts",
-      "source_location": "L92"
-    },
-    {
-      "community": 339,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_staffroles_ts",
-      "label": "staffRoles.ts",
-      "norm_label": "staffroles.ts",
-      "source_file": "packages/athena-webapp/convex/operations/staffRoles.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 339,
-      "file_type": "code",
-      "id": "staffroles_derivedefaultoperationalroles",
-      "label": "deriveDefaultOperationalRoles()",
-      "norm_label": "derivedefaultoperationalroles()",
-      "source_file": "packages/athena-webapp/convex/operations/staffRoles.ts",
-      "source_location": "L21"
-    },
-    {
-      "community": 339,
-      "file_type": "code",
-      "id": "staffroles_uniqueoperationalroles",
-      "label": "uniqueOperationalRoles()",
-      "norm_label": "uniqueoperationalroles()",
-      "source_file": "packages/athena-webapp/convex/operations/staffRoles.ts",
-      "source_location": "L31"
     },
     {
       "community": 34,
@@ -79068,6 +79206,60 @@
     {
       "community": 340,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_staffprofiles_test_ts",
+      "label": "staffProfiles.test.ts",
+      "norm_label": "staffprofiles.test.ts",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 340,
+      "file_type": "code",
+      "id": "staffprofiles_test_createstaffprofilesmutationctx",
+      "label": "createStaffProfilesMutationCtx()",
+      "norm_label": "createstaffprofilesmutationctx()",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.test.ts",
+      "source_location": "L16"
+    },
+    {
+      "community": 340,
+      "file_type": "code",
+      "id": "staffprofiles_test_gethandler",
+      "label": "getHandler()",
+      "norm_label": "gethandler()",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.test.ts",
+      "source_location": "L92"
+    },
+    {
+      "community": 341,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_staffroles_ts",
+      "label": "staffRoles.ts",
+      "norm_label": "staffroles.ts",
+      "source_file": "packages/athena-webapp/convex/operations/staffRoles.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 341,
+      "file_type": "code",
+      "id": "staffroles_derivedefaultoperationalroles",
+      "label": "deriveDefaultOperationalRoles()",
+      "norm_label": "derivedefaultoperationalroles()",
+      "source_file": "packages/athena-webapp/convex/operations/staffRoles.ts",
+      "source_location": "L21"
+    },
+    {
+      "community": 341,
+      "file_type": "code",
+      "id": "staffroles_uniqueoperationalroles",
+      "label": "uniqueOperationalRoles()",
+      "norm_label": "uniqueoperationalroles()",
+      "source_file": "packages/athena-webapp/convex/operations/staffRoles.ts",
+      "source_location": "L31"
+    },
+    {
+      "community": 342,
+      "file_type": "code",
       "id": "index_listtransactions",
       "label": "listTransactions()",
       "norm_label": "listtransactions()",
@@ -79075,7 +79267,7 @@
       "source_location": "L7"
     },
     {
-      "community": 340,
+      "community": 342,
       "file_type": "code",
       "id": "index_verifytransaction",
       "label": "verifyTransaction()",
@@ -79084,7 +79276,7 @@
       "source_location": "L109"
     },
     {
-      "community": 340,
+      "community": 342,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_paystack_index_ts",
       "label": "index.ts",
@@ -79093,7 +79285,7 @@
       "source_location": "L1"
     },
     {
-      "community": 341,
+      "community": 343,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_queries_terminals_ts",
       "label": "terminals.ts",
@@ -79102,7 +79294,7 @@
       "source_location": "L1"
     },
     {
-      "community": 341,
+      "community": 343,
       "file_type": "code",
       "id": "terminals_getterminalbyfingerprint",
       "label": "getTerminalByFingerprint()",
@@ -79111,7 +79303,7 @@
       "source_location": "L18"
     },
     {
-      "community": 341,
+      "community": 343,
       "file_type": "code",
       "id": "terminals_listterminals",
       "label": "listTerminals()",
@@ -79120,7 +79312,7 @@
       "source_location": "L9"
     },
     {
-      "community": 342,
+      "community": 344,
       "file_type": "code",
       "id": "errors_posservererror",
       "label": "PosServerError",
@@ -79129,7 +79321,7 @@
       "source_location": "L8"
     },
     {
-      "community": 342,
+      "community": 344,
       "file_type": "code",
       "id": "errors_posservererror_constructor",
       "label": ".constructor()",
@@ -79138,7 +79330,7 @@
       "source_location": "L9"
     },
     {
-      "community": 342,
+      "community": 344,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_domain_errors_ts",
       "label": "errors.ts",
@@ -79147,7 +79339,7 @@
       "source_location": "L1"
     },
     {
-      "community": 343,
+      "community": 345,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_domain_sessionrules_ts",
       "label": "sessionRules.ts",
@@ -79156,7 +79348,7 @@
       "source_location": "L1"
     },
     {
-      "community": 343,
+      "community": 345,
       "file_type": "code",
       "id": "sessionrules_deriveregisterphase",
       "label": "deriveRegisterPhase()",
@@ -79165,7 +79357,7 @@
       "source_location": "L7"
     },
     {
-      "community": 343,
+      "community": 345,
       "file_type": "code",
       "id": "sessionrules_selectresumablesession",
       "label": "selectResumableSession()",
@@ -79174,7 +79366,7 @@
       "source_location": "L29"
     },
     {
-      "community": 344,
+      "community": 346,
       "file_type": "code",
       "id": "inventoryholdgateway_test_createctx",
       "label": "createCtx()",
@@ -79183,7 +79375,7 @@
       "source_location": "L16"
     },
     {
-      "community": 344,
+      "community": 346,
       "file_type": "code",
       "id": "inventoryholdgateway_test_createlegacypatchctx",
       "label": "createLegacyPatchCtx()",
@@ -79192,7 +79384,7 @@
       "source_location": "L22"
     },
     {
-      "community": 344,
+      "community": 346,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_integrations_inventoryholdgateway_test_ts",
       "label": "inventoryHoldGateway.test.ts",
@@ -79201,7 +79393,7 @@
       "source_location": "L1"
     },
     {
-      "community": 345,
+      "community": 347,
       "file_type": "code",
       "id": "inventoryholdgateway_assertobjectshapedholdargs",
       "label": "assertObjectShapedHoldArgs()",
@@ -79210,7 +79402,7 @@
       "source_location": "L43"
     },
     {
-      "community": 345,
+      "community": 347,
       "file_type": "code",
       "id": "inventoryholdgateway_createinventoryholdgateway",
       "label": "createInventoryHoldGateway()",
@@ -79219,7 +79411,7 @@
       "source_location": "L24"
     },
     {
-      "community": 345,
+      "community": 347,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_integrations_inventoryholdgateway_ts",
       "label": "inventoryHoldGateway.ts",
@@ -79228,7 +79420,7 @@
       "source_location": "L1"
     },
     {
-      "community": 346,
+      "community": 348,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_integrations_paymentallocationservice_ts",
       "label": "paymentAllocationService.ts",
@@ -79237,7 +79429,7 @@
       "source_location": "L1"
     },
     {
-      "community": 346,
+      "community": 348,
       "file_type": "code",
       "id": "paymentallocationservice_recordretailsalepaymentallocations",
       "label": "recordRetailSalePaymentAllocations()",
@@ -79246,7 +79438,7 @@
       "source_location": "L13"
     },
     {
-      "community": 346,
+      "community": 348,
       "file_type": "code",
       "id": "paymentallocationservice_recordretailvoidpaymentallocations",
       "label": "recordRetailVoidPaymentAllocations()",
@@ -79255,7 +79447,7 @@
       "source_location": "L45"
     },
     {
-      "community": 347,
+      "community": 349,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_registersessionrepository_ts",
       "label": "registerSessionRepository.ts",
@@ -79264,7 +79456,7 @@
       "source_location": "L1"
     },
     {
-      "community": 347,
+      "community": 349,
       "file_type": "code",
       "id": "registersessionrepository_getactiveregistersessionforregisterstate",
       "label": "getActiveRegisterSessionForRegisterState()",
@@ -79273,67 +79465,13 @@
       "source_location": "L36"
     },
     {
-      "community": 347,
+      "community": 349,
       "file_type": "code",
       "id": "registersessionrepository_mapregistersessiontocashdrawersummary",
       "label": "mapRegisterSessionToCashDrawerSummary()",
       "norm_label": "mapregistersessiontocashdrawersummary()",
       "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/registerSessionRepository.ts",
       "source_location": "L13"
-    },
-    {
-      "community": 348,
-      "file_type": "code",
-      "id": "appointments_buildserviceappointment",
-      "label": "buildServiceAppointment()",
-      "norm_label": "buildserviceappointment()",
-      "source_file": "packages/athena-webapp/convex/serviceOps/appointments.ts",
-      "source_location": "L17"
-    },
-    {
-      "community": 348,
-      "file_type": "code",
-      "id": "appointments_findoverlappingappointment",
-      "label": "findOverlappingAppointment()",
-      "norm_label": "findoverlappingappointment()",
-      "source_file": "packages/athena-webapp/convex/serviceOps/appointments.ts",
-      "source_location": "L61"
-    },
-    {
-      "community": 348,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_serviceops_appointments_ts",
-      "label": "appointments.ts",
-      "norm_label": "appointments.ts",
-      "source_file": "packages/athena-webapp/convex/serviceOps/appointments.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 349,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_serviceops_servicecases_test_ts",
-      "label": "serviceCases.test.ts",
-      "norm_label": "servicecases.test.ts",
-      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 349,
-      "file_type": "code",
-      "id": "servicecases_test_expectindex",
-      "label": "expectIndex()",
-      "norm_label": "expectindex()",
-      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.test.ts",
-      "source_location": "L23"
-    },
-    {
-      "community": 349,
-      "file_type": "code",
-      "id": "servicecases_test_gettableindexes",
-      "label": "getTableIndexes()",
-      "norm_label": "gettableindexes()",
-      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.test.ts",
-      "source_location": "L16"
     },
     {
       "community": 35,
@@ -79500,6 +79638,60 @@
     {
       "community": 350,
       "file_type": "code",
+      "id": "appointments_buildserviceappointment",
+      "label": "buildServiceAppointment()",
+      "norm_label": "buildserviceappointment()",
+      "source_file": "packages/athena-webapp/convex/serviceOps/appointments.ts",
+      "source_location": "L17"
+    },
+    {
+      "community": 350,
+      "file_type": "code",
+      "id": "appointments_findoverlappingappointment",
+      "label": "findOverlappingAppointment()",
+      "norm_label": "findoverlappingappointment()",
+      "source_file": "packages/athena-webapp/convex/serviceOps/appointments.ts",
+      "source_location": "L61"
+    },
+    {
+      "community": 350,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_serviceops_appointments_ts",
+      "label": "appointments.ts",
+      "norm_label": "appointments.ts",
+      "source_file": "packages/athena-webapp/convex/serviceOps/appointments.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 351,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_serviceops_servicecases_test_ts",
+      "label": "serviceCases.test.ts",
+      "norm_label": "servicecases.test.ts",
+      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 351,
+      "file_type": "code",
+      "id": "servicecases_test_expectindex",
+      "label": "expectIndex()",
+      "norm_label": "expectindex()",
+      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.test.ts",
+      "source_location": "L23"
+    },
+    {
+      "community": 351,
+      "file_type": "code",
+      "id": "servicecases_test_gettableindexes",
+      "label": "getTableIndexes()",
+      "norm_label": "gettableindexes()",
+      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.test.ts",
+      "source_location": "L16"
+    },
+    {
+      "community": 352,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_purchaseorders_test_ts",
       "label": "purchaseOrders.test.ts",
       "norm_label": "purchaseorders.test.ts",
@@ -79507,7 +79699,7 @@
       "source_location": "L1"
     },
     {
-      "community": 350,
+      "community": 352,
       "file_type": "code",
       "id": "purchaseorders_test_createpurchaseordermutationctx",
       "label": "createPurchaseOrderMutationCtx()",
@@ -79516,7 +79708,7 @@
       "source_location": "L26"
     },
     {
-      "community": 350,
+      "community": 352,
       "file_type": "code",
       "id": "purchaseorders_test_getsource",
       "label": "getSource()",
@@ -79525,7 +79717,7 @@
       "source_location": "L22"
     },
     {
-      "community": 351,
+      "community": 353,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_receiving_test_ts",
       "label": "receiving.test.ts",
@@ -79534,7 +79726,7 @@
       "source_location": "L1"
     },
     {
-      "community": 351,
+      "community": 353,
       "file_type": "code",
       "id": "receiving_test_createreceivingmutationctx",
       "label": "createReceivingMutationCtx()",
@@ -79543,7 +79735,7 @@
       "source_location": "L28"
     },
     {
-      "community": 351,
+      "community": 353,
       "file_type": "code",
       "id": "receiving_test_getsource",
       "label": "getSource()",
@@ -79552,7 +79744,7 @@
       "source_location": "L24"
     },
     {
-      "community": 352,
+      "community": 354,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_vendors_test_ts",
       "label": "vendors.test.ts",
@@ -79561,7 +79753,7 @@
       "source_location": "L1"
     },
     {
-      "community": 352,
+      "community": 354,
       "file_type": "code",
       "id": "vendors_test_createvendormutationctx",
       "label": "createVendorMutationCtx()",
@@ -79570,7 +79762,7 @@
       "source_location": "L24"
     },
     {
-      "community": 352,
+      "community": 354,
       "file_type": "code",
       "id": "vendors_test_getsource",
       "label": "getSource()",
@@ -79579,7 +79771,7 @@
       "source_location": "L20"
     },
     {
-      "community": 353,
+      "community": 355,
       "file_type": "code",
       "id": "errorfoundation_test_gethandler",
       "label": "getHandler()",
@@ -79588,7 +79780,7 @@
       "source_location": "L25"
     },
     {
-      "community": 353,
+      "community": 355,
       "file_type": "code",
       "id": "errorfoundation_test_getsource",
       "label": "getSource()",
@@ -79597,7 +79789,7 @@
       "source_location": "L21"
     },
     {
-      "community": 353,
+      "community": 355,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_errorfoundation_test_ts",
       "label": "errorFoundation.test.ts",
@@ -79606,7 +79798,7 @@
       "source_location": "L1"
     },
     {
-      "community": 354,
+      "community": 356,
       "file_type": "code",
       "id": "bag_listbagitems",
       "label": "listBagItems()",
@@ -79615,7 +79807,7 @@
       "source_location": "L7"
     },
     {
-      "community": 354,
+      "community": 356,
       "file_type": "code",
       "id": "bag_loadbagwithitems",
       "label": "loadBagWithItems()",
@@ -79624,7 +79816,7 @@
       "source_location": "L14"
     },
     {
-      "community": 354,
+      "community": 356,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_helpers_bag_ts",
       "label": "bag.ts",
@@ -79633,7 +79825,7 @@
       "source_location": "L1"
     },
     {
-      "community": 355,
+      "community": 357,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_adapters_registersession_ts",
       "label": "registerSession.ts",
@@ -79642,7 +79834,7 @@
       "source_location": "L1"
     },
     {
-      "community": 355,
+      "community": 357,
       "file_type": "code",
       "id": "registersession_buildregistersessiontraceseed",
       "label": "buildRegisterSessionTraceSeed()",
@@ -79651,7 +79843,7 @@
       "source_location": "L45"
     },
     {
-      "community": 355,
+      "community": 357,
       "file_type": "code",
       "id": "registersession_formatregistersessionlabel",
       "label": "formatRegisterSessionLabel()",
@@ -79660,7 +79852,7 @@
       "source_location": "L37"
     },
     {
-      "community": 356,
+      "community": 358,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_public_ts",
       "label": "public.ts",
@@ -79669,7 +79861,7 @@
       "source_location": "L1"
     },
     {
-      "community": 356,
+      "community": 358,
       "file_type": "code",
       "id": "public_getworkflowtraceviewbyidwithctx",
       "label": "getWorkflowTraceViewByIdWithCtx()",
@@ -79678,7 +79870,7 @@
       "source_location": "L10"
     },
     {
-      "community": 356,
+      "community": 358,
       "file_type": "code",
       "id": "public_getworkflowtraceviewbylookupwithctx",
       "label": "getWorkflowTraceViewByLookupWithCtx()",
@@ -79687,7 +79879,7 @@
       "source_location": "L44"
     },
     {
-      "community": 357,
+      "community": 359,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_queryusage_test_ts",
       "label": "queryUsage.test.ts",
@@ -79696,7 +79888,7 @@
       "source_location": "L1"
     },
     {
-      "community": 357,
+      "community": 359,
       "file_type": "code",
       "id": "queryusage_test_comparebyfields",
       "label": "compareByFields()",
@@ -79705,67 +79897,13 @@
       "source_location": "L84"
     },
     {
-      "community": 357,
+      "community": 359,
       "file_type": "code",
       "id": "queryusage_test_createtestctx",
       "label": "createTestCtx()",
       "norm_label": "createtestctx()",
       "source_file": "packages/athena-webapp/convex/workflowTraces/queryUsage.test.ts",
       "source_location": "L100"
-    },
-    {
-      "community": 358,
-      "file_type": "code",
-      "id": "currencyformatter_currencydisplaysymbol",
-      "label": "currencyDisplaySymbol()",
-      "norm_label": "currencydisplaysymbol()",
-      "source_file": "packages/athena-webapp/shared/currencyFormatter.ts",
-      "source_location": "L5"
-    },
-    {
-      "community": 358,
-      "file_type": "code",
-      "id": "currencyformatter_currencyformatter",
-      "label": "currencyFormatter()",
-      "norm_label": "currencyformatter()",
-      "source_file": "packages/athena-webapp/shared/currencyFormatter.ts",
-      "source_location": "L25"
-    },
-    {
-      "community": 358,
-      "file_type": "code",
-      "id": "packages_athena_webapp_shared_currencyformatter_ts",
-      "label": "currencyFormatter.ts",
-      "norm_label": "currencyformatter.ts",
-      "source_file": "packages/athena-webapp/shared/currencyFormatter.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 359,
-      "file_type": "code",
-      "id": "packages_athena_webapp_shared_workflowtrace_ts",
-      "label": "workflowTrace.ts",
-      "norm_label": "workflowtrace.ts",
-      "source_file": "packages/athena-webapp/shared/workflowTrace.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 359,
-      "file_type": "code",
-      "id": "workflowtrace_createworkflowtraceid",
-      "label": "createWorkflowTraceId()",
-      "norm_label": "createworkflowtraceid()",
-      "source_file": "packages/athena-webapp/shared/workflowTrace.ts",
-      "source_location": "L35"
-    },
-    {
-      "community": 359,
-      "file_type": "code",
-      "id": "workflowtrace_normalizeworkflowtracelookupvalue",
-      "label": "normalizeWorkflowTraceLookupValue()",
-      "norm_label": "normalizeworkflowtracelookupvalue()",
-      "source_file": "packages/athena-webapp/shared/workflowTrace.ts",
-      "source_location": "L25"
     },
     {
       "community": 36,
@@ -79923,6 +80061,60 @@
     {
       "community": 360,
       "file_type": "code",
+      "id": "currencyformatter_currencydisplaysymbol",
+      "label": "currencyDisplaySymbol()",
+      "norm_label": "currencydisplaysymbol()",
+      "source_file": "packages/athena-webapp/shared/currencyFormatter.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 360,
+      "file_type": "code",
+      "id": "currencyformatter_currencyformatter",
+      "label": "currencyFormatter()",
+      "norm_label": "currencyformatter()",
+      "source_file": "packages/athena-webapp/shared/currencyFormatter.ts",
+      "source_location": "L25"
+    },
+    {
+      "community": 360,
+      "file_type": "code",
+      "id": "packages_athena_webapp_shared_currencyformatter_ts",
+      "label": "currencyFormatter.ts",
+      "norm_label": "currencyformatter.ts",
+      "source_file": "packages/athena-webapp/shared/currencyFormatter.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 361,
+      "file_type": "code",
+      "id": "packages_athena_webapp_shared_workflowtrace_ts",
+      "label": "workflowTrace.ts",
+      "norm_label": "workflowtrace.ts",
+      "source_file": "packages/athena-webapp/shared/workflowTrace.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 361,
+      "file_type": "code",
+      "id": "workflowtrace_createworkflowtraceid",
+      "label": "createWorkflowTraceId()",
+      "norm_label": "createworkflowtraceid()",
+      "source_file": "packages/athena-webapp/shared/workflowTrace.ts",
+      "source_location": "L35"
+    },
+    {
+      "community": 361,
+      "file_type": "code",
+      "id": "workflowtrace_normalizeworkflowtracelookupvalue",
+      "label": "normalizeWorkflowTraceLookupValue()",
+      "norm_label": "normalizeworkflowtracelookupvalue()",
+      "source_file": "packages/athena-webapp/shared/workflowTrace.ts",
+      "source_location": "L25"
+    },
+    {
+      "community": 362,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_view_tsx",
       "label": "View.tsx",
       "norm_label": "view.tsx",
@@ -79930,7 +80122,7 @@
       "source_location": "L1"
     },
     {
-      "community": 360,
+      "community": 362,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_view_tsx",
       "label": "View.tsx",
@@ -79939,7 +80131,7 @@
       "source_location": "L1"
     },
     {
-      "community": 360,
+      "community": 362,
       "file_type": "code",
       "id": "view_view",
       "label": "View()",
@@ -79948,7 +80140,7 @@
       "source_location": "L4"
     },
     {
-      "community": 361,
+      "community": 363,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productavailability_tsx",
       "label": "ProductAvailability.tsx",
@@ -79957,7 +80149,7 @@
       "source_location": "L1"
     },
     {
-      "community": 361,
+      "community": 363,
       "file_type": "code",
       "id": "productavailability_productavailability",
       "label": "ProductAvailability()",
@@ -79966,7 +80158,7 @@
       "source_location": "L19"
     },
     {
-      "community": 361,
+      "community": 363,
       "file_type": "code",
       "id": "productavailability_productavailabilityview",
       "label": "ProductAvailabilityView()",
@@ -79975,7 +80167,7 @@
       "source_location": "L5"
     },
     {
-      "community": 362,
+      "community": 364,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_sheetprovider_tsx",
       "label": "SheetProvider.tsx",
@@ -79984,7 +80176,7 @@
       "source_location": "L1"
     },
     {
-      "community": 362,
+      "community": 364,
       "file_type": "code",
       "id": "sheetprovider_sheetprovider",
       "label": "SheetProvider()",
@@ -79993,7 +80185,7 @@
       "source_location": "L19"
     },
     {
-      "community": 362,
+      "community": 364,
       "file_type": "code",
       "id": "sheetprovider_usesheet",
       "label": "useSheet()",
@@ -80002,7 +80194,7 @@
       "source_location": "L11"
     },
     {
-      "community": 363,
+      "community": 365,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_wigtype_tsx",
       "label": "WigType.tsx",
@@ -80011,7 +80203,7 @@
       "source_location": "L1"
     },
     {
-      "community": 363,
+      "community": 365,
       "file_type": "code",
       "id": "wigtype_wigtype",
       "label": "WigType()",
@@ -80020,7 +80212,7 @@
       "source_location": "L22"
     },
     {
-      "community": 363,
+      "community": 365,
       "file_type": "code",
       "id": "wigtype_wigtypeview",
       "label": "WigTypeView()",
@@ -80029,7 +80221,7 @@
       "source_location": "L8"
     },
     {
-      "community": 364,
+      "community": 366,
       "file_type": "code",
       "id": "copyimagesprovider_copyimagesprovider",
       "label": "CopyImagesProvider()",
@@ -80038,7 +80230,7 @@
       "source_location": "L21"
     },
     {
-      "community": 364,
+      "community": 366,
       "file_type": "code",
       "id": "copyimagesprovider_usecopyimages",
       "label": "useCopyImages()",
@@ -80047,7 +80239,7 @@
       "source_location": "L13"
     },
     {
-      "community": 364,
+      "community": 366,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_copyimagesprovider_tsx",
       "label": "CopyImagesProvider.tsx",
@@ -80056,7 +80248,7 @@
       "source_location": "L1"
     },
     {
-      "community": 365,
+      "community": 367,
       "file_type": "code",
       "id": "analyticstopusers_analyticstopusers",
       "label": "AnalyticsTopUsers()",
@@ -80065,7 +80257,7 @@
       "source_location": "L100"
     },
     {
-      "community": 365,
+      "community": 367,
       "file_type": "code",
       "id": "analyticstopusers_processanalyticstousers",
       "label": "processAnalyticsToUsers()",
@@ -80074,7 +80266,7 @@
       "source_location": "L10"
     },
     {
-      "community": 365,
+      "community": 367,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticstopusers_tsx",
       "label": "AnalyticsTopUsers.tsx",
@@ -80083,7 +80275,7 @@
       "source_location": "L1"
     },
     {
-      "community": 366,
+      "community": 368,
       "file_type": "code",
       "id": "log_items_provider_logitemsprovider",
       "label": "LogItemsProvider()",
@@ -80092,7 +80284,7 @@
       "source_location": "L15"
     },
     {
-      "community": 366,
+      "community": 368,
       "file_type": "code",
       "id": "log_items_provider_uselogitems",
       "label": "useLogItems()",
@@ -80101,7 +80293,7 @@
       "source_location": "L39"
     },
     {
-      "community": 366,
+      "community": 368,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_log_items_provider_tsx",
       "label": "log-items-provider.tsx",
@@ -80110,7 +80302,7 @@
       "source_location": "L1"
     },
     {
-      "community": 367,
+      "community": 369,
       "file_type": "code",
       "id": "fadein_fadein",
       "label": "FadeIn()",
@@ -80119,7 +80311,7 @@
       "source_location": "L3"
     },
     {
-      "community": 367,
+      "community": 369,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_common_fadein_tsx",
       "label": "FadeIn.tsx",
@@ -80128,66 +80320,12 @@
       "source_location": "L1"
     },
     {
-      "community": 367,
+      "community": 369,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_common_fadein_tsx",
       "label": "FadeIn.tsx",
       "norm_label": "fadein.tsx",
       "source_file": "packages/storefront-webapp/src/components/common/FadeIn.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 368,
-      "file_type": "code",
-      "id": "bestsellers_handleremovebestseller",
-      "label": "handleRemoveBestSeller()",
-      "norm_label": "handleremovebestseller()",
-      "source_file": "packages/athena-webapp/src/components/homepage/BestSellers.tsx",
-      "source_location": "L53"
-    },
-    {
-      "community": 368,
-      "file_type": "code",
-      "id": "bestsellers_ondragend",
-      "label": "onDragEnd()",
-      "norm_label": "ondragend()",
-      "source_file": "packages/athena-webapp/src/components/homepage/BestSellers.tsx",
-      "source_location": "L65"
-    },
-    {
-      "community": 368,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_homepage_bestsellers_tsx",
-      "label": "BestSellers.tsx",
-      "norm_label": "bestsellers.tsx",
-      "source_file": "packages/athena-webapp/src/components/homepage/BestSellers.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 369,
-      "file_type": "code",
-      "id": "featuredsection_handlehighlighteditem",
-      "label": "handleHighlightedItem()",
-      "norm_label": "handlehighlighteditem()",
-      "source_file": "packages/athena-webapp/src/components/homepage/FeaturedSection.tsx",
-      "source_location": "L47"
-    },
-    {
-      "community": 369,
-      "file_type": "code",
-      "id": "featuredsection_ondragend",
-      "label": "onDragEnd()",
-      "norm_label": "ondragend()",
-      "source_file": "packages/athena-webapp/src/components/homepage/FeaturedSection.tsx",
-      "source_location": "L53"
-    },
-    {
-      "community": 369,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_homepage_featuredsection_tsx",
-      "label": "FeaturedSection.tsx",
-      "norm_label": "featuredsection.tsx",
-      "source_file": "packages/athena-webapp/src/components/homepage/FeaturedSection.tsx",
       "source_location": "L1"
     },
     {
@@ -80346,6 +80484,60 @@
     {
       "community": 370,
       "file_type": "code",
+      "id": "bestsellers_handleremovebestseller",
+      "label": "handleRemoveBestSeller()",
+      "norm_label": "handleremovebestseller()",
+      "source_file": "packages/athena-webapp/src/components/homepage/BestSellers.tsx",
+      "source_location": "L53"
+    },
+    {
+      "community": 370,
+      "file_type": "code",
+      "id": "bestsellers_ondragend",
+      "label": "onDragEnd()",
+      "norm_label": "ondragend()",
+      "source_file": "packages/athena-webapp/src/components/homepage/BestSellers.tsx",
+      "source_location": "L65"
+    },
+    {
+      "community": 370,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_homepage_bestsellers_tsx",
+      "label": "BestSellers.tsx",
+      "norm_label": "bestsellers.tsx",
+      "source_file": "packages/athena-webapp/src/components/homepage/BestSellers.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 371,
+      "file_type": "code",
+      "id": "featuredsection_handlehighlighteditem",
+      "label": "handleHighlightedItem()",
+      "norm_label": "handlehighlighteditem()",
+      "source_file": "packages/athena-webapp/src/components/homepage/FeaturedSection.tsx",
+      "source_location": "L47"
+    },
+    {
+      "community": 371,
+      "file_type": "code",
+      "id": "featuredsection_ondragend",
+      "label": "onDragEnd()",
+      "norm_label": "ondragend()",
+      "source_file": "packages/athena-webapp/src/components/homepage/FeaturedSection.tsx",
+      "source_location": "L53"
+    },
+    {
+      "community": 371,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_homepage_featuredsection_tsx",
+      "label": "FeaturedSection.tsx",
+      "norm_label": "featuredsection.tsx",
+      "source_file": "packages/athena-webapp/src/components/homepage/FeaturedSection.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 372,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_videoplayer_tsx",
       "label": "VideoPlayer.tsx",
       "norm_label": "videoplayer.tsx",
@@ -80353,7 +80545,7 @@
       "source_location": "L1"
     },
     {
-      "community": 370,
+      "community": 372,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_videoplayer_tsx",
       "label": "VideoPlayer.tsx",
@@ -80362,7 +80554,7 @@
       "source_location": "L1"
     },
     {
-      "community": 370,
+      "community": 372,
       "file_type": "code",
       "id": "videoplayer_videoplayer",
       "label": "VideoPlayer()",
@@ -80371,7 +80563,7 @@
       "source_location": "L9"
     },
     {
-      "community": 371,
+      "community": 373,
       "file_type": "code",
       "id": "orderview_handlerefundorder",
       "label": "handleRefundOrder()",
@@ -80380,7 +80572,7 @@
       "source_location": "L70"
     },
     {
-      "community": 371,
+      "community": 373,
       "file_type": "code",
       "id": "orderview_toast",
       "label": "toast()",
@@ -80389,7 +80581,7 @@
       "source_location": "L227"
     },
     {
-      "community": 371,
+      "community": 373,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orderview_tsx",
       "label": "OrderView.tsx",
@@ -80398,7 +80590,7 @@
       "source_location": "L1"
     },
     {
-      "community": 372,
+      "community": 374,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_pickupdetailsview_tsx",
       "label": "PickupDetailsView.tsx",
@@ -80407,7 +80599,7 @@
       "source_location": "L1"
     },
     {
-      "community": 372,
+      "community": 374,
       "file_type": "code",
       "id": "pickupdetailsview_deliverydetails",
       "label": "DeliveryDetails()",
@@ -80416,7 +80608,7 @@
       "source_location": "L71"
     },
     {
-      "community": 372,
+      "community": 374,
       "file_type": "code",
       "id": "pickupdetailsview_pickupdetailsview",
       "label": "PickupDetailsView()",
@@ -80425,7 +80617,7 @@
       "source_location": "L9"
     },
     {
-      "community": 373,
+      "community": 375,
       "file_type": "code",
       "id": "cashierauthdialog_cashierauthdialog",
       "label": "CashierAuthDialog()",
@@ -80434,7 +80626,7 @@
       "source_location": "L33"
     },
     {
-      "community": 373,
+      "community": 375,
       "file_type": "code",
       "id": "cashierauthdialog_getstaffdisplayname",
       "label": "getStaffDisplayName()",
@@ -80443,7 +80635,7 @@
       "source_location": "L24"
     },
     {
-      "community": 373,
+      "community": 375,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_cashierauthdialog_tsx",
       "label": "CashierAuthDialog.tsx",
@@ -80452,7 +80644,7 @@
       "source_location": "L1"
     },
     {
-      "community": 374,
+      "community": 376,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_searchresultssection_tsx",
       "label": "SearchResultsSection.tsx",
@@ -80461,7 +80653,7 @@
       "source_location": "L1"
     },
     {
-      "community": 374,
+      "community": 376,
       "file_type": "code",
       "id": "searchresultssection_handlequickaddproductshortcut",
       "label": "handleQuickAddProductShortcut()",
@@ -80470,7 +80662,7 @@
       "source_location": "L117"
     },
     {
-      "community": 374,
+      "community": 376,
       "file_type": "code",
       "id": "searchresultssection_handlequickaddvariantshortcut",
       "label": "handleQuickAddVariantShortcut()",
@@ -80479,7 +80671,7 @@
       "source_location": "L84"
     },
     {
-      "community": 375,
+      "community": 377,
       "file_type": "code",
       "id": "expensereportsview_istoday",
       "label": "isToday()",
@@ -80488,7 +80680,7 @@
       "source_location": "L28"
     },
     {
-      "community": 375,
+      "community": 377,
       "file_type": "code",
       "id": "expensereportsview_toexpensereportrows",
       "label": "toExpenseReportRows()",
@@ -80497,7 +80689,7 @@
       "source_location": "L34"
     },
     {
-      "community": 375,
+      "community": 377,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportsview_tsx",
       "label": "ExpenseReportsView.tsx",
@@ -80506,7 +80698,7 @@
       "source_location": "L1"
     },
     {
-      "community": 376,
+      "community": 378,
       "file_type": "code",
       "id": "heldsessionslist_getsessioncartitemscount",
       "label": "getSessionCartItemsCount()",
@@ -80515,7 +80707,7 @@
       "source_location": "L36"
     },
     {
-      "community": 376,
+      "community": 378,
       "file_type": "code",
       "id": "heldsessionslist_hasexpired",
       "label": "hasExpired()",
@@ -80524,7 +80716,7 @@
       "source_location": "L32"
     },
     {
-      "community": 376,
+      "community": 378,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_session_heldsessionslist_tsx",
       "label": "HeldSessionsList.tsx",
@@ -80533,7 +80725,7 @@
       "source_location": "L1"
     },
     {
-      "community": 377,
+      "community": 379,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_settings_possettingsview_tsx",
       "label": "POSSettingsView.tsx",
@@ -80542,7 +80734,7 @@
       "source_location": "L1"
     },
     {
-      "community": 377,
+      "community": 379,
       "file_type": "code",
       "id": "possettingsview_fingerprintregistrationcard",
       "label": "FingerprintRegistrationCard()",
@@ -80551,67 +80743,13 @@
       "source_location": "L53"
     },
     {
-      "community": 377,
+      "community": 379,
       "file_type": "code",
       "id": "possettingsview_possettingsview",
       "label": "POSSettingsView()",
       "norm_label": "possettingsview()",
       "source_file": "packages/athena-webapp/src/components/pos/settings/POSSettingsView.tsx",
       "source_location": "L180"
-    },
-    {
-      "community": 378,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_product_productstatus_test_tsx",
-      "label": "ProductStatus.test.tsx",
-      "norm_label": "productstatus.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/product/ProductStatus.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 378,
-      "file_type": "code",
-      "id": "productstatus_test_makeproduct",
-      "label": "makeProduct()",
-      "norm_label": "makeproduct()",
-      "source_file": "packages/athena-webapp/src/components/product/ProductStatus.test.tsx",
-      "source_location": "L8"
-    },
-    {
-      "community": 378,
-      "file_type": "code",
-      "id": "productstatus_test_makevariant",
-      "label": "makeVariant()",
-      "norm_label": "makevariant()",
-      "source_file": "packages/athena-webapp/src/components/product/ProductStatus.test.tsx",
-      "source_location": "L18"
-    },
-    {
-      "community": 379,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_productslistview_tsx",
-      "label": "ProductsListView.tsx",
-      "norm_label": "productslistview.tsx",
-      "source_file": "packages/athena-webapp/src/components/products/ProductsListView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 379,
-      "file_type": "code",
-      "id": "productslistview_handleclearcache",
-      "label": "handleClearCache()",
-      "norm_label": "handleclearcache()",
-      "source_file": "packages/athena-webapp/src/components/products/ProductsListView.tsx",
-      "source_location": "L65"
-    },
-    {
-      "community": 379,
-      "file_type": "code",
-      "id": "productslistview_productactionstogglegroup",
-      "label": "ProductActionsToggleGroup()",
-      "norm_label": "productactionstogglegroup()",
-      "source_file": "packages/athena-webapp/src/components/products/ProductsListView.tsx",
-      "source_location": "L20"
     },
     {
       "community": 38,
@@ -80769,6 +80907,60 @@
     {
       "community": 380,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_product_productstatus_test_tsx",
+      "label": "ProductStatus.test.tsx",
+      "norm_label": "productstatus.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/product/ProductStatus.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 380,
+      "file_type": "code",
+      "id": "productstatus_test_makeproduct",
+      "label": "makeProduct()",
+      "norm_label": "makeproduct()",
+      "source_file": "packages/athena-webapp/src/components/product/ProductStatus.test.tsx",
+      "source_location": "L8"
+    },
+    {
+      "community": 380,
+      "file_type": "code",
+      "id": "productstatus_test_makevariant",
+      "label": "makeVariant()",
+      "norm_label": "makevariant()",
+      "source_file": "packages/athena-webapp/src/components/product/ProductStatus.test.tsx",
+      "source_location": "L18"
+    },
+    {
+      "community": 381,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_products_productslistview_tsx",
+      "label": "ProductsListView.tsx",
+      "norm_label": "productslistview.tsx",
+      "source_file": "packages/athena-webapp/src/components/products/ProductsListView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 381,
+      "file_type": "code",
+      "id": "productslistview_handleclearcache",
+      "label": "handleClearCache()",
+      "norm_label": "handleclearcache()",
+      "source_file": "packages/athena-webapp/src/components/products/ProductsListView.tsx",
+      "source_location": "L65"
+    },
+    {
+      "community": 381,
+      "file_type": "code",
+      "id": "productslistview_productactionstogglegroup",
+      "label": "ProductActionsToggleGroup()",
+      "norm_label": "productactionstogglegroup()",
+      "source_file": "packages/athena-webapp/src/components/products/ProductsListView.tsx",
+      "source_location": "L20"
+    },
+    {
+      "community": 382,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_productstablecontext_tsx",
       "label": "ProductsTableContext.tsx",
       "norm_label": "productstablecontext.tsx",
@@ -80776,7 +80968,7 @@
       "source_location": "L1"
     },
     {
-      "community": 380,
+      "community": 382,
       "file_type": "code",
       "id": "productstablecontext_productstableprovider",
       "label": "ProductsTableProvider()",
@@ -80785,7 +80977,7 @@
       "source_location": "L16"
     },
     {
-      "community": 380,
+      "community": 382,
       "file_type": "code",
       "id": "productstablecontext_useproductstablestate",
       "label": "useProductsTableState()",
@@ -80794,7 +80986,7 @@
       "source_location": "L60"
     },
     {
-      "community": 381,
+      "community": 383,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_storeproductsview_tsx",
       "label": "StoreProductsView.tsx",
@@ -80803,7 +80995,7 @@
       "source_location": "L1"
     },
     {
-      "community": 381,
+      "community": 383,
       "file_type": "code",
       "id": "storeproductsview_navigation",
       "label": "Navigation()",
@@ -80812,7 +81004,7 @@
       "source_location": "L45"
     },
     {
-      "community": 381,
+      "community": 383,
       "file_type": "code",
       "id": "storeproductsview_productactionstogglegroup",
       "label": "ProductActionsToggleGroup()",
@@ -80821,7 +81013,7 @@
       "source_location": "L19"
     },
     {
-      "community": 382,
+      "community": 384,
       "file_type": "code",
       "id": "addcomplimentaryproduct_addcomplimentaryproduct",
       "label": "AddComplimentaryProduct()",
@@ -80830,7 +81022,7 @@
       "source_location": "L128"
     },
     {
-      "community": 382,
+      "community": 384,
       "file_type": "code",
       "id": "addcomplimentaryproduct_handleaddcomplimentaryproducts",
       "label": "handleAddComplimentaryProducts()",
@@ -80839,7 +81031,7 @@
       "source_location": "L40"
     },
     {
-      "community": 382,
+      "community": 384,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_complimentary_addcomplimentaryproduct_tsx",
       "label": "AddComplimentaryProduct.tsx",
@@ -80848,7 +81040,7 @@
       "source_location": "L1"
     },
     {
-      "community": 383,
+      "community": 385,
       "file_type": "code",
       "id": "color_picker_handleblur",
       "label": "handleBlur()",
@@ -80857,7 +81049,7 @@
       "source_location": "L24"
     },
     {
-      "community": 383,
+      "community": 385,
       "file_type": "code",
       "id": "color_picker_handleinputchange",
       "label": "handleInputChange()",
@@ -80866,7 +81058,7 @@
       "source_location": "L20"
     },
     {
-      "community": 383,
+      "community": 385,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_modals_color_picker_tsx",
       "label": "color-picker.tsx",
@@ -80875,7 +81067,7 @@
       "source_location": "L1"
     },
     {
-      "community": 384,
+      "community": 386,
       "file_type": "code",
       "id": "currency_provider_currencyprovider",
       "label": "CurrencyProvider()",
@@ -80884,7 +81076,7 @@
       "source_location": "L25"
     },
     {
-      "community": 384,
+      "community": 386,
       "file_type": "code",
       "id": "currency_provider_usestorecurrency",
       "label": "useStoreCurrency()",
@@ -80893,7 +81085,7 @@
       "source_location": "L17"
     },
     {
-      "community": 384,
+      "community": 386,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_providers_currency_provider_tsx",
       "label": "currency-provider.tsx",
@@ -80902,7 +81094,7 @@
       "source_location": "L1"
     },
     {
-      "community": 385,
+      "community": 387,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_serviceappointmentsview_test_tsx",
       "label": "ServiceAppointmentsView.test.tsx",
@@ -80911,7 +81103,7 @@
       "source_location": "L1"
     },
     {
-      "community": 385,
+      "community": 387,
       "file_type": "code",
       "id": "serviceappointmentsview_test_choosedatetime",
       "label": "chooseDateTime()",
@@ -80920,7 +81112,7 @@
       "source_location": "L59"
     },
     {
-      "community": 385,
+      "community": 387,
       "file_type": "code",
       "id": "serviceappointmentsview_test_chooseselectoption",
       "label": "chooseSelectOption()",
@@ -80929,7 +81121,7 @@
       "source_location": "L50"
     },
     {
-      "community": 386,
+      "community": 388,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_serviceintakeview_tsx",
       "label": "ServiceIntakeView.tsx",
@@ -80938,7 +81130,7 @@
       "source_location": "L1"
     },
     {
-      "community": 386,
+      "community": 388,
       "file_type": "code",
       "id": "serviceintakeview_serviceintakeview",
       "label": "ServiceIntakeView()",
@@ -80947,7 +81139,7 @@
       "source_location": "L225"
     },
     {
-      "community": 386,
+      "community": 388,
       "file_type": "code",
       "id": "serviceintakeview_serviceintakeviewcontent",
       "label": "ServiceIntakeViewContent()",
@@ -80956,7 +81148,7 @@
       "source_location": "L80"
     },
     {
-      "community": 387,
+      "community": 389,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_staff_staffmanagement_test_tsx",
       "label": "StaffManagement.test.tsx",
@@ -80965,7 +81157,7 @@
       "source_location": "L1"
     },
     {
-      "community": 387,
+      "community": 389,
       "file_type": "code",
       "id": "staffmanagement_test_chooserole",
       "label": "chooseRole()",
@@ -80974,67 +81166,13 @@
       "source_location": "L163"
     },
     {
-      "community": 387,
+      "community": 389,
       "file_type": "code",
       "id": "staffmanagement_test_mockconvex",
       "label": "mockConvex()",
       "norm_label": "mockconvex()",
       "source_file": "packages/athena-webapp/src/components/staff/StaffManagement.test.tsx",
       "source_location": "L107"
-    },
-    {
-      "community": 388,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_staff_auth_staffauthenticationdialog_tsx",
-      "label": "StaffAuthenticationDialog.tsx",
-      "norm_label": "staffauthenticationdialog.tsx",
-      "source_file": "packages/athena-webapp/src/components/staff-auth/StaffAuthenticationDialog.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 388,
-      "file_type": "code",
-      "id": "staffauthenticationdialog_handlekeydown",
-      "label": "handleKeyDown()",
-      "norm_label": "handlekeydown()",
-      "source_file": "packages/athena-webapp/src/components/staff-auth/StaffAuthenticationDialog.tsx",
-      "source_location": "L168"
-    },
-    {
-      "community": 388,
-      "file_type": "code",
-      "id": "staffauthenticationdialog_handlesubmit",
-      "label": "handleSubmit()",
-      "norm_label": "handlesubmit()",
-      "source_file": "packages/athena-webapp/src/components/staff-auth/StaffAuthenticationDialog.tsx",
-      "source_location": "L110"
-    },
-    {
-      "community": 389,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_states_error_singlelineerror_tsx",
-      "label": "SingleLineError.tsx",
-      "norm_label": "singlelineerror.tsx",
-      "source_file": "packages/athena-webapp/src/components/states/error/SingleLineError.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 389,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_states_error_singlelineerror_tsx",
-      "label": "SingleLineError.tsx",
-      "norm_label": "singlelineerror.tsx",
-      "source_file": "packages/storefront-webapp/src/components/states/error/SingleLineError.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 389,
-      "file_type": "code",
-      "id": "singlelineerror_singlelineerror",
-      "label": "SingleLineError()",
-      "norm_label": "singlelineerror()",
-      "source_file": "packages/storefront-webapp/src/components/states/error/SingleLineError.tsx",
-      "source_location": "L3"
     },
     {
       "community": 39,
@@ -81192,6 +81330,60 @@
     {
       "community": 390,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_staff_auth_staffauthenticationdialog_tsx",
+      "label": "StaffAuthenticationDialog.tsx",
+      "norm_label": "staffauthenticationdialog.tsx",
+      "source_file": "packages/athena-webapp/src/components/staff-auth/StaffAuthenticationDialog.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 390,
+      "file_type": "code",
+      "id": "staffauthenticationdialog_handlekeydown",
+      "label": "handleKeyDown()",
+      "norm_label": "handlekeydown()",
+      "source_file": "packages/athena-webapp/src/components/staff-auth/StaffAuthenticationDialog.tsx",
+      "source_location": "L168"
+    },
+    {
+      "community": 390,
+      "file_type": "code",
+      "id": "staffauthenticationdialog_handlesubmit",
+      "label": "handleSubmit()",
+      "norm_label": "handlesubmit()",
+      "source_file": "packages/athena-webapp/src/components/staff-auth/StaffAuthenticationDialog.tsx",
+      "source_location": "L110"
+    },
+    {
+      "community": 391,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_states_error_singlelineerror_tsx",
+      "label": "SingleLineError.tsx",
+      "norm_label": "singlelineerror.tsx",
+      "source_file": "packages/athena-webapp/src/components/states/error/SingleLineError.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 391,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_states_error_singlelineerror_tsx",
+      "label": "SingleLineError.tsx",
+      "norm_label": "singlelineerror.tsx",
+      "source_file": "packages/storefront-webapp/src/components/states/error/SingleLineError.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 391,
+      "file_type": "code",
+      "id": "singlelineerror_singlelineerror",
+      "label": "SingleLineError()",
+      "norm_label": "singlelineerror()",
+      "source_file": "packages/storefront-webapp/src/components/states/error/SingleLineError.tsx",
+      "source_location": "L3"
+    },
+    {
+      "community": 392,
+      "file_type": "code",
       "id": "index_errorpage",
       "label": "ErrorPage()",
       "norm_label": "errorpage()",
@@ -81199,7 +81391,7 @@
       "source_location": "L9"
     },
     {
-      "community": 390,
+      "community": 392,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_error_index_tsx",
       "label": "index.tsx",
@@ -81208,7 +81400,7 @@
       "source_location": "L1"
     },
     {
-      "community": 390,
+      "community": 392,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_error_index_tsx",
       "label": "index.tsx",
@@ -81217,7 +81409,7 @@
       "source_location": "L1"
     },
     {
-      "community": 391,
+      "community": 393,
       "file_type": "code",
       "id": "app_skeleton_appskeleton",
       "label": "AppSkeleton()",
@@ -81226,7 +81418,7 @@
       "source_location": "L3"
     },
     {
-      "community": 391,
+      "community": 393,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_loading_app_skeleton_tsx",
       "label": "app-skeleton.tsx",
@@ -81235,7 +81427,7 @@
       "source_location": "L1"
     },
     {
-      "community": 391,
+      "community": 393,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_loading_app_skeleton_tsx",
       "label": "app-skeleton.tsx",
@@ -81244,7 +81436,7 @@
       "source_location": "L1"
     },
     {
-      "community": 392,
+      "community": 394,
       "file_type": "code",
       "id": "dashboard_skeleton_dashboardskeleton",
       "label": "DashboardSkeleton()",
@@ -81253,7 +81445,7 @@
       "source_location": "L3"
     },
     {
-      "community": 392,
+      "community": 394,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_loading_dashboard_skeleton_tsx",
       "label": "dashboard-skeleton.tsx",
@@ -81262,7 +81454,7 @@
       "source_location": "L1"
     },
     {
-      "community": 392,
+      "community": 394,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_loading_dashboard_skeleton_tsx",
       "label": "dashboard-skeleton.tsx",
@@ -81271,7 +81463,7 @@
       "source_location": "L1"
     },
     {
-      "community": 393,
+      "community": 395,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_loading_table_skeleton_tsx",
       "label": "table-skeleton.tsx",
@@ -81280,7 +81472,7 @@
       "source_location": "L1"
     },
     {
-      "community": 393,
+      "community": 395,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_loading_table_skeleton_tsx",
       "label": "table-skeleton.tsx",
@@ -81289,7 +81481,7 @@
       "source_location": "L1"
     },
     {
-      "community": 393,
+      "community": 395,
       "file_type": "code",
       "id": "table_skeleton_tableskeleton",
       "label": "TableSkeleton()",
@@ -81298,7 +81490,7 @@
       "source_location": "L3"
     },
     {
-      "community": 394,
+      "community": 396,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_loading_transactions_skeleton_tsx",
       "label": "transactions-skeleton.tsx",
@@ -81307,7 +81499,7 @@
       "source_location": "L1"
     },
     {
-      "community": 394,
+      "community": 396,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_loading_transactions_skeleton_tsx",
       "label": "transactions-skeleton.tsx",
@@ -81316,7 +81508,7 @@
       "source_location": "L1"
     },
     {
-      "community": 394,
+      "community": 396,
       "file_type": "code",
       "id": "transactions_skeleton_transactionsskeleton",
       "label": "TransactionsSkeleton()",
@@ -81325,7 +81517,7 @@
       "source_location": "L3"
     },
     {
-      "community": 395,
+      "community": 397,
       "file_type": "code",
       "id": "notfound_notfound",
       "label": "NotFound()",
@@ -81334,7 +81526,7 @@
       "source_location": "L4"
     },
     {
-      "community": 395,
+      "community": 397,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_not_found_notfound_tsx",
       "label": "NotFound.tsx",
@@ -81343,7 +81535,7 @@
       "source_location": "L1"
     },
     {
-      "community": 395,
+      "community": 397,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_not_found_notfound_tsx",
       "label": "NotFound.tsx",
@@ -81352,7 +81544,7 @@
       "source_location": "L1"
     },
     {
-      "community": 396,
+      "community": 398,
       "file_type": "code",
       "id": "feesview_handletoggleallfees",
       "label": "handleToggleAllFees()",
@@ -81361,7 +81553,7 @@
       "source_location": "L120"
     },
     {
-      "community": 396,
+      "community": 398,
       "file_type": "code",
       "id": "feesview_handleupdatefees",
       "label": "handleUpdateFees()",
@@ -81370,7 +81562,7 @@
       "source_location": "L36"
     },
     {
-      "community": 396,
+      "community": 398,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_feesview_tsx",
       "label": "FeesView.tsx",
@@ -81379,7 +81571,7 @@
       "source_location": "L1"
     },
     {
-      "community": 397,
+      "community": 399,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_traces_workflowtraceroutelink_tsx",
       "label": "WorkflowTraceRouteLink.tsx",
@@ -81388,7 +81580,7 @@
       "source_location": "L1"
     },
     {
-      "community": 397,
+      "community": 399,
       "file_type": "code",
       "id": "workflowtraceroutelink_getworkflowtraceroutetarget",
       "label": "getWorkflowTraceRouteTarget()",
@@ -81397,67 +81589,13 @@
       "source_location": "L23"
     },
     {
-      "community": 397,
+      "community": 399,
       "file_type": "code",
       "id": "workflowtraceroutelink_workflowtraceroutelink",
       "label": "WorkflowTraceRouteLink()",
       "norm_label": "workflowtraceroutelink()",
       "source_file": "packages/athena-webapp/src/components/traces/WorkflowTraceRouteLink.tsx",
       "source_location": "L41"
-    },
-    {
-      "community": 398,
-      "file_type": "code",
-      "id": "app_context_menu_appcontextmenu",
-      "label": "AppContextMenu()",
-      "norm_label": "appcontextmenu()",
-      "source_file": "packages/storefront-webapp/src/components/ui/app-context-menu.tsx",
-      "source_location": "L20"
-    },
-    {
-      "community": 398,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_app_context_menu_tsx",
-      "label": "app-context-menu.tsx",
-      "norm_label": "app-context-menu.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/app-context-menu.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 398,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_app_context_menu_tsx",
-      "label": "app-context-menu.tsx",
-      "norm_label": "app-context-menu.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/app-context-menu.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 399,
-      "file_type": "code",
-      "id": "badge_badge",
-      "label": "Badge()",
-      "norm_label": "badge()",
-      "source_file": "packages/storefront-webapp/src/components/ui/badge.tsx",
-      "source_location": "L30"
-    },
-    {
-      "community": 399,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_badge_tsx",
-      "label": "badge.tsx",
-      "norm_label": "badge.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/badge.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 399,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_badge_tsx",
-      "label": "badge.tsx",
-      "norm_label": "badge.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/badge.tsx",
-      "source_location": "L1"
     },
     {
       "community": 4,
@@ -81975,6 +82113,60 @@
     {
       "community": 400,
       "file_type": "code",
+      "id": "app_context_menu_appcontextmenu",
+      "label": "AppContextMenu()",
+      "norm_label": "appcontextmenu()",
+      "source_file": "packages/storefront-webapp/src/components/ui/app-context-menu.tsx",
+      "source_location": "L20"
+    },
+    {
+      "community": 400,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_app_context_menu_tsx",
+      "label": "app-context-menu.tsx",
+      "norm_label": "app-context-menu.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/app-context-menu.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 400,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_app_context_menu_tsx",
+      "label": "app-context-menu.tsx",
+      "norm_label": "app-context-menu.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/app-context-menu.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 401,
+      "file_type": "code",
+      "id": "badge_badge",
+      "label": "Badge()",
+      "norm_label": "badge()",
+      "source_file": "packages/storefront-webapp/src/components/ui/badge.tsx",
+      "source_location": "L30"
+    },
+    {
+      "community": 401,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_badge_tsx",
+      "label": "badge.tsx",
+      "norm_label": "badge.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/badge.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 401,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_badge_tsx",
+      "label": "badge.tsx",
+      "norm_label": "badge.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/badge.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 402,
+      "file_type": "code",
       "id": "loading_button_loadingbutton",
       "label": "LoadingButton()",
       "norm_label": "loadingbutton()",
@@ -81982,7 +82174,7 @@
       "source_location": "L9"
     },
     {
-      "community": 400,
+      "community": 402,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_loading_button_tsx",
       "label": "loading-button.tsx",
@@ -81991,7 +82183,7 @@
       "source_location": "L1"
     },
     {
-      "community": 400,
+      "community": 402,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_loading_button_tsx",
       "label": "loading-button.tsx",
@@ -82000,7 +82192,7 @@
       "source_location": "L1"
     },
     {
-      "community": 401,
+      "community": 403,
       "file_type": "code",
       "id": "modal_onchange",
       "label": "onChange()",
@@ -82009,7 +82201,7 @@
       "source_location": "L38"
     },
     {
-      "community": 401,
+      "community": 403,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modal_tsx",
       "label": "modal.tsx",
@@ -82018,7 +82210,7 @@
       "source_location": "L1"
     },
     {
-      "community": 401,
+      "community": 403,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modal_tsx",
       "label": "modal.tsx",
@@ -82027,7 +82219,7 @@
       "source_location": "L1"
     },
     {
-      "community": 402,
+      "community": 404,
       "file_type": "code",
       "id": "alert_modal_alertmodal",
       "label": "AlertModal()",
@@ -82036,7 +82228,7 @@
       "source_location": "L20"
     },
     {
-      "community": 402,
+      "community": 404,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_alert_modal_tsx",
       "label": "alert-modal.tsx",
@@ -82045,7 +82237,7 @@
       "source_location": "L1"
     },
     {
-      "community": 402,
+      "community": 404,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_alert_modal_tsx",
       "label": "alert-modal.tsx",
@@ -82054,7 +82246,7 @@
       "source_location": "L1"
     },
     {
-      "community": 403,
+      "community": 405,
       "file_type": "code",
       "id": "overlay_modal_overlaymodal",
       "label": "OverlayModal()",
@@ -82063,7 +82255,7 @@
       "source_location": "L12"
     },
     {
-      "community": 403,
+      "community": 405,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_overlay_modal_tsx",
       "label": "overlay-modal.tsx",
@@ -82072,7 +82264,7 @@
       "source_location": "L1"
     },
     {
-      "community": 403,
+      "community": 405,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_overlay_modal_tsx",
       "label": "overlay-modal.tsx",
@@ -82081,7 +82273,7 @@
       "source_location": "L1"
     },
     {
-      "community": 404,
+      "community": 406,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_skeleton_tsx",
       "label": "skeleton.tsx",
@@ -82090,7 +82282,7 @@
       "source_location": "L1"
     },
     {
-      "community": 404,
+      "community": 406,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_skeleton_tsx",
       "label": "skeleton.tsx",
@@ -82099,7 +82291,7 @@
       "source_location": "L1"
     },
     {
-      "community": 404,
+      "community": 406,
       "file_type": "code",
       "id": "skeleton_skeleton",
       "label": "Skeleton()",
@@ -82108,7 +82300,7 @@
       "source_location": "L3"
     },
     {
-      "community": 405,
+      "community": 407,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_sonner_tsx",
       "label": "sonner.tsx",
@@ -82117,7 +82309,7 @@
       "source_location": "L1"
     },
     {
-      "community": 405,
+      "community": 407,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_sonner_tsx",
       "label": "sonner.tsx",
@@ -82126,7 +82318,7 @@
       "source_location": "L1"
     },
     {
-      "community": 405,
+      "community": 407,
       "file_type": "code",
       "id": "sonner_toaster",
       "label": "Toaster()",
@@ -82135,7 +82327,7 @@
       "source_location": "L6"
     },
     {
-      "community": 406,
+      "community": 408,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_spinner_tsx",
       "label": "spinner.tsx",
@@ -82144,7 +82336,7 @@
       "source_location": "L1"
     },
     {
-      "community": 406,
+      "community": 408,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_spinner_tsx",
       "label": "spinner.tsx",
@@ -82153,7 +82345,7 @@
       "source_location": "L1"
     },
     {
-      "community": 406,
+      "community": 408,
       "file_type": "code",
       "id": "spinner_spinner",
       "label": "Spinner()",
@@ -82162,7 +82354,7 @@
       "source_location": "L3"
     },
     {
-      "community": 407,
+      "community": 409,
       "file_type": "code",
       "id": "activitysummarycards_activitysummarycards",
       "label": "ActivitySummaryCards()",
@@ -82171,7 +82363,7 @@
       "source_location": "L44"
     },
     {
-      "community": 407,
+      "community": 409,
       "file_type": "code",
       "id": "activitysummarycards_summarycard",
       "label": "SummaryCard()",
@@ -82180,67 +82372,13 @@
       "source_location": "L19"
     },
     {
-      "community": 407,
+      "community": 409,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_activitysummarycards_tsx",
       "label": "ActivitySummaryCards.tsx",
       "norm_label": "activitysummarycards.tsx",
       "source_file": "packages/athena-webapp/src/components/users/ActivitySummaryCards.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 408,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_users_timelineeventcard_tsx",
-      "label": "TimelineEventCard.tsx",
-      "norm_label": "timelineeventcard.tsx",
-      "source_file": "packages/athena-webapp/src/components/users/TimelineEventCard.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 408,
-      "file_type": "code",
-      "id": "timelineeventcard_formatobservabilitylabel",
-      "label": "formatObservabilityLabel()",
-      "norm_label": "formatobservabilitylabel()",
-      "source_file": "packages/athena-webapp/src/components/users/TimelineEventCard.tsx",
-      "source_location": "L159"
-    },
-    {
-      "community": 408,
-      "file_type": "code",
-      "id": "timelineeventcard_loadmore",
-      "label": "loadMore()",
-      "norm_label": "loadmore()",
-      "source_file": "packages/athena-webapp/src/components/users/TimelineEventCard.tsx",
-      "source_location": "L195"
-    },
-    {
-      "community": 409,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_users_useractivity_tsx",
-      "label": "UserActivity.tsx",
-      "norm_label": "useractivity.tsx",
-      "source_file": "packages/athena-webapp/src/components/users/UserActivity.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 409,
-      "file_type": "code",
-      "id": "useractivity_activityheader",
-      "label": "ActivityHeader()",
-      "norm_label": "activityheader()",
-      "source_file": "packages/athena-webapp/src/components/users/UserActivity.tsx",
-      "source_location": "L22"
-    },
-    {
-      "community": 409,
-      "file_type": "code",
-      "id": "useractivity_useractivity",
-      "label": "UserActivity()",
-      "norm_label": "useractivity()",
-      "source_file": "packages/athena-webapp/src/components/users/UserActivity.tsx",
-      "source_location": "L45"
     },
     {
       "community": 41,
@@ -82389,6 +82527,60 @@
     {
       "community": 410,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_users_timelineeventcard_tsx",
+      "label": "TimelineEventCard.tsx",
+      "norm_label": "timelineeventcard.tsx",
+      "source_file": "packages/athena-webapp/src/components/users/TimelineEventCard.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 410,
+      "file_type": "code",
+      "id": "timelineeventcard_formatobservabilitylabel",
+      "label": "formatObservabilityLabel()",
+      "norm_label": "formatobservabilitylabel()",
+      "source_file": "packages/athena-webapp/src/components/users/TimelineEventCard.tsx",
+      "source_location": "L159"
+    },
+    {
+      "community": 410,
+      "file_type": "code",
+      "id": "timelineeventcard_loadmore",
+      "label": "loadMore()",
+      "norm_label": "loadmore()",
+      "source_file": "packages/athena-webapp/src/components/users/TimelineEventCard.tsx",
+      "source_location": "L195"
+    },
+    {
+      "community": 411,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_users_useractivity_tsx",
+      "label": "UserActivity.tsx",
+      "norm_label": "useractivity.tsx",
+      "source_file": "packages/athena-webapp/src/components/users/UserActivity.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 411,
+      "file_type": "code",
+      "id": "useractivity_activityheader",
+      "label": "ActivityHeader()",
+      "norm_label": "activityheader()",
+      "source_file": "packages/athena-webapp/src/components/users/UserActivity.tsx",
+      "source_location": "L22"
+    },
+    {
+      "community": 411,
+      "file_type": "code",
+      "id": "useractivity_useractivity",
+      "label": "UserActivity()",
+      "norm_label": "useractivity()",
+      "source_file": "packages/athena-webapp/src/components/users/UserActivity.tsx",
+      "source_location": "L45"
+    },
+    {
+      "community": 412,
+      "file_type": "code",
       "id": "onlineordercontext_onlineorderprovider",
       "label": "OnlineOrderProvider()",
       "norm_label": "onlineorderprovider()",
@@ -82396,7 +82588,7 @@
       "source_location": "L24"
     },
     {
-      "community": 410,
+      "community": 412,
       "file_type": "code",
       "id": "onlineordercontext_useonlineorder",
       "label": "useOnlineOrder()",
@@ -82405,7 +82597,7 @@
       "source_location": "L38"
     },
     {
-      "community": 410,
+      "community": 412,
       "file_type": "code",
       "id": "packages_athena_webapp_src_contexts_onlineordercontext_tsx",
       "label": "OnlineOrderContext.tsx",
@@ -82414,7 +82606,7 @@
       "source_location": "L1"
     },
     {
-      "community": 411,
+      "community": 413,
       "file_type": "code",
       "id": "packages_athena_webapp_src_contexts_permissionscontext_tsx",
       "label": "PermissionsContext.tsx",
@@ -82423,7 +82615,7 @@
       "source_location": "L1"
     },
     {
-      "community": 411,
+      "community": 413,
       "file_type": "code",
       "id": "permissionscontext_permissionsprovider",
       "label": "PermissionsProvider()",
@@ -82432,7 +82624,7 @@
       "source_location": "L23"
     },
     {
-      "community": 411,
+      "community": 413,
       "file_type": "code",
       "id": "permissionscontext_usepermissionscontext",
       "label": "usePermissionsContext()",
@@ -82441,7 +82633,7 @@
       "source_location": "L51"
     },
     {
-      "community": 412,
+      "community": 414,
       "file_type": "code",
       "id": "packages_athena_webapp_src_contexts_productcontext_tsx",
       "label": "ProductContext.tsx",
@@ -82450,7 +82642,7 @@
       "source_location": "L1"
     },
     {
-      "community": 412,
+      "community": 414,
       "file_type": "code",
       "id": "productcontext_productprovider",
       "label": "ProductProvider()",
@@ -82459,7 +82651,7 @@
       "source_location": "L54"
     },
     {
-      "community": 412,
+      "community": 414,
       "file_type": "code",
       "id": "productcontext_useproduct",
       "label": "useProduct()",
@@ -82468,7 +82660,7 @@
       "source_location": "L282"
     },
     {
-      "community": 413,
+      "community": 415,
       "file_type": "code",
       "id": "packages_athena_webapp_src_contexts_usercontext_tsx",
       "label": "UserContext.tsx",
@@ -82477,7 +82669,7 @@
       "source_location": "L1"
     },
     {
-      "community": 413,
+      "community": 415,
       "file_type": "code",
       "id": "usercontext_userprovider",
       "label": "UserProvider()",
@@ -82486,7 +82678,7 @@
       "source_location": "L12"
     },
     {
-      "community": 413,
+      "community": 415,
       "file_type": "code",
       "id": "usercontext_useusercontext",
       "label": "useUserContext()",
@@ -82495,7 +82687,7 @@
       "source_location": "L37"
     },
     {
-      "community": 414,
+      "community": 416,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useauth_ts",
       "label": "useAuth.ts",
@@ -82504,7 +82696,7 @@
       "source_location": "L1"
     },
     {
-      "community": 414,
+      "community": 416,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useauth_ts",
       "label": "useAuth.ts",
@@ -82513,7 +82705,7 @@
       "source_location": "L1"
     },
     {
-      "community": 414,
+      "community": 416,
       "file_type": "code",
       "id": "useauth_useauth",
       "label": "useAuth()",
@@ -82522,7 +82714,7 @@
       "source_location": "L4"
     },
     {
-      "community": 415,
+      "community": 417,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetactivestore_ts",
       "label": "useGetActiveStore.ts",
@@ -82531,7 +82723,7 @@
       "source_location": "L1"
     },
     {
-      "community": 415,
+      "community": 417,
       "file_type": "code",
       "id": "usegetactivestore_usegetactivestore",
       "label": "useGetActiveStore()",
@@ -82540,7 +82732,7 @@
       "source_location": "L9"
     },
     {
-      "community": 415,
+      "community": 417,
       "file_type": "code",
       "id": "usegetactivestore_usegetstores",
       "label": "useGetStores()",
@@ -82549,7 +82741,7 @@
       "source_location": "L50"
     },
     {
-      "community": 416,
+      "community": 418,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetorganizations_ts",
       "label": "useGetOrganizations.ts",
@@ -82558,7 +82750,7 @@
       "source_location": "L1"
     },
     {
-      "community": 416,
+      "community": 418,
       "file_type": "code",
       "id": "usegetorganizations_usegetactiveorganization",
       "label": "useGetActiveOrganization()",
@@ -82567,7 +82759,7 @@
       "source_location": "L6"
     },
     {
-      "community": 416,
+      "community": 418,
       "file_type": "code",
       "id": "usegetorganizations_usegetorganizations",
       "label": "useGetOrganizations()",
@@ -82576,7 +82768,7 @@
       "source_location": "L31"
     },
     {
-      "community": 417,
+      "community": 419,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usesessionmanagementexpense_ts",
       "label": "useSessionManagementExpense.ts",
@@ -82585,7 +82777,7 @@
       "source_location": "L1"
     },
     {
-      "community": 417,
+      "community": 419,
       "file_type": "code",
       "id": "usesessionmanagementexpense_getcommanderrormessage",
       "label": "getCommandErrorMessage()",
@@ -82594,67 +82786,13 @@
       "source_location": "L19"
     },
     {
-      "community": 417,
+      "community": 419,
       "file_type": "code",
       "id": "usesessionmanagementexpense_usesessionmanagementexpense",
       "label": "useSessionManagementExpense()",
       "norm_label": "usesessionmanagementexpense()",
       "source_file": "packages/athena-webapp/src/hooks/useSessionManagementExpense.ts",
       "source_location": "L33"
-    },
-    {
-      "community": 418,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_errors_presentcommandtoast_ts",
-      "label": "presentCommandToast.ts",
-      "norm_label": "presentcommandtoast.ts",
-      "source_file": "packages/athena-webapp/src/lib/errors/presentCommandToast.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 418,
-      "file_type": "code",
-      "id": "presentcommandtoast_getapprovalguidance",
-      "label": "getApprovalGuidance()",
-      "norm_label": "getapprovalguidance()",
-      "source_file": "packages/athena-webapp/src/lib/errors/presentCommandToast.ts",
-      "source_location": "L9"
-    },
-    {
-      "community": 418,
-      "file_type": "code",
-      "id": "presentcommandtoast_presentcommandtoast",
-      "label": "presentCommandToast()",
-      "norm_label": "presentcommandtoast()",
-      "source_file": "packages/athena-webapp/src/lib/errors/presentCommandToast.ts",
-      "source_location": "L16"
-    },
-    {
-      "community": 419,
-      "file_type": "code",
-      "id": "maintenanceutils_isinmaintenancemode",
-      "label": "isInMaintenanceMode()",
-      "norm_label": "isinmaintenancemode()",
-      "source_file": "packages/storefront-webapp/src/lib/maintenanceUtils.ts",
-      "source_location": "L7"
-    },
-    {
-      "community": 419,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_maintenanceutils_ts",
-      "label": "maintenanceUtils.ts",
-      "norm_label": "maintenanceutils.ts",
-      "source_file": "packages/athena-webapp/src/lib/maintenanceUtils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 419,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_maintenanceutils_ts",
-      "label": "maintenanceUtils.ts",
-      "norm_label": "maintenanceutils.ts",
-      "source_file": "packages/storefront-webapp/src/lib/maintenanceUtils.ts",
-      "source_location": "L1"
     },
     {
       "community": 42,
@@ -82803,6 +82941,60 @@
     {
       "community": 420,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_errors_presentcommandtoast_ts",
+      "label": "presentCommandToast.ts",
+      "norm_label": "presentcommandtoast.ts",
+      "source_file": "packages/athena-webapp/src/lib/errors/presentCommandToast.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 420,
+      "file_type": "code",
+      "id": "presentcommandtoast_getapprovalguidance",
+      "label": "getApprovalGuidance()",
+      "norm_label": "getapprovalguidance()",
+      "source_file": "packages/athena-webapp/src/lib/errors/presentCommandToast.ts",
+      "source_location": "L9"
+    },
+    {
+      "community": 420,
+      "file_type": "code",
+      "id": "presentcommandtoast_presentcommandtoast",
+      "label": "presentCommandToast()",
+      "norm_label": "presentcommandtoast()",
+      "source_file": "packages/athena-webapp/src/lib/errors/presentCommandToast.ts",
+      "source_location": "L16"
+    },
+    {
+      "community": 421,
+      "file_type": "code",
+      "id": "maintenanceutils_isinmaintenancemode",
+      "label": "isInMaintenanceMode()",
+      "norm_label": "isinmaintenancemode()",
+      "source_file": "packages/storefront-webapp/src/lib/maintenanceUtils.ts",
+      "source_location": "L7"
+    },
+    {
+      "community": 421,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_maintenanceutils_ts",
+      "label": "maintenanceUtils.ts",
+      "norm_label": "maintenanceutils.ts",
+      "source_file": "packages/athena-webapp/src/lib/maintenanceUtils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 421,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_maintenanceutils_ts",
+      "label": "maintenanceUtils.ts",
+      "norm_label": "maintenanceutils.ts",
+      "source_file": "packages/storefront-webapp/src/lib/maintenanceUtils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 422,
+      "file_type": "code",
       "id": "bootstrapregister_test_drawer",
       "label": "drawer()",
       "norm_label": "drawer()",
@@ -82810,7 +83002,7 @@
       "source_location": "L9"
     },
     {
-      "community": 420,
+      "community": 422,
       "file_type": "code",
       "id": "bootstrapregister_test_state",
       "label": "state()",
@@ -82819,7 +83011,7 @@
       "source_location": "L23"
     },
     {
-      "community": 420,
+      "community": 422,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_bootstrapregister_test_ts",
       "label": "bootstrapRegister.test.ts",
@@ -82828,7 +83020,7 @@
       "source_location": "L1"
     },
     {
-      "community": 421,
+      "community": 423,
       "file_type": "code",
       "id": "displayamounts_formatstoredamount",
       "label": "formatStoredAmount()",
@@ -82837,7 +83029,7 @@
       "source_location": "L3"
     },
     {
-      "community": 421,
+      "community": 423,
       "file_type": "code",
       "id": "displayamounts_parsedisplayamountinput",
       "label": "parseDisplayAmountInput()",
@@ -82846,7 +83038,7 @@
       "source_location": "L10"
     },
     {
-      "community": 421,
+      "community": 423,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_displayamounts_ts",
       "label": "displayAmounts.ts",
@@ -82855,7 +83047,7 @@
       "source_location": "L1"
     },
     {
-      "community": 422,
+      "community": 424,
       "file_type": "code",
       "id": "commandgateway_useconvexcommandgateway",
       "label": "useConvexCommandGateway()",
@@ -82864,7 +83056,7 @@
       "source_location": "L18"
     },
     {
-      "community": 422,
+      "community": 424,
       "file_type": "code",
       "id": "commandgateway_useconvexdirecttransactionmutation",
       "label": "useConvexDirectTransactionMutation()",
@@ -82873,7 +83065,7 @@
       "source_location": "L60"
     },
     {
-      "community": 422,
+      "community": 424,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_commandgateway_ts",
       "label": "commandGateway.ts",
@@ -82882,34 +83074,7 @@
       "source_location": "L1"
     },
     {
-      "community": 423,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_presentation_expense_useexpenseregisterviewmodel_test_ts",
-      "label": "useExpenseRegisterViewModel.test.ts",
-      "norm_label": "useexpenseregisterviewmodel.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/expense/useExpenseRegisterViewModel.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 423,
-      "file_type": "code",
-      "id": "useexpenseregisterviewmodel_test_buildregistercatalogavailabilityrow",
-      "label": "buildRegisterCatalogAvailabilityRow()",
-      "norm_label": "buildregistercatalogavailabilityrow()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/expense/useExpenseRegisterViewModel.test.ts",
-      "source_location": "L149"
-    },
-    {
-      "community": 423,
-      "file_type": "code",
-      "id": "useexpenseregisterviewmodel_test_buildregistercatalogrow",
-      "label": "buildRegisterCatalogRow()",
-      "norm_label": "buildregistercatalogrow()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/expense/useExpenseRegisterViewModel.test.ts",
-      "source_location": "L126"
-    },
-    {
-      "community": 424,
+      "community": 425,
       "file_type": "code",
       "id": "catalogsearchpresentation_mapcatalogrowtoproduct",
       "label": "mapCatalogRowToProduct()",
@@ -82918,7 +83083,7 @@
       "source_location": "L10"
     },
     {
-      "community": 424,
+      "community": 425,
       "file_type": "code",
       "id": "catalogsearchpresentation_normalizeexactinput",
       "label": "normalizeExactInput()",
@@ -82927,7 +83092,7 @@
       "source_location": "L39"
     },
     {
-      "community": 424,
+      "community": 425,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_presentation_register_catalogsearchpresentation_ts",
       "label": "catalogSearchPresentation.ts",
@@ -82936,7 +83101,7 @@
       "source_location": "L1"
     },
     {
-      "community": 425,
+      "community": 426,
       "file_type": "code",
       "id": "main_app",
       "label": "App()",
@@ -82945,7 +83110,7 @@
       "source_location": "L31"
     },
     {
-      "community": 425,
+      "community": 426,
       "file_type": "code",
       "id": "packages_athena_webapp_src_main_tsx",
       "label": "main.tsx",
@@ -82954,7 +83119,7 @@
       "source_location": "L1"
     },
     {
-      "community": 425,
+      "community": 426,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_main_tsx",
       "label": "main.tsx",
@@ -82963,7 +83128,7 @@
       "source_location": "L1"
     },
     {
-      "community": 426,
+      "community": 427,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routetree_browser_boundary_test_ts",
       "label": "routeTree.browser-boundary.test.ts",
@@ -82972,7 +83137,7 @@
       "source_location": "L1"
     },
     {
-      "community": 426,
+      "community": 427,
       "file_type": "code",
       "id": "routetree_browser_boundary_test_collectsourcefiles",
       "label": "collectSourceFiles()",
@@ -82981,7 +83146,7 @@
       "source_location": "L28"
     },
     {
-      "community": 426,
+      "community": 427,
       "file_type": "code",
       "id": "routetree_browser_boundary_test_findillegalconveximports",
       "label": "findIllegalConvexImports()",
@@ -82990,7 +83155,7 @@
       "source_location": "L46"
     },
     {
-      "community": 427,
+      "community": 428,
       "file_type": "code",
       "id": "actioncolorreview_stories_swatch",
       "label": "Swatch()",
@@ -82999,7 +83164,7 @@
       "source_location": "L179"
     },
     {
-      "community": 427,
+      "community": 428,
       "file_type": "code",
       "id": "actioncolorreview_stories_tokenscope",
       "label": "TokenScope()",
@@ -83008,7 +83173,7 @@
       "source_location": "L168"
     },
     {
-      "community": 427,
+      "community": 428,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_foundations_actioncolorreview_stories_tsx",
       "label": "ActionColorReview.stories.tsx",
@@ -83017,7 +83182,7 @@
       "source_location": "L1"
     },
     {
-      "community": 428,
+      "community": 429,
       "file_type": "code",
       "id": "admin_shell_patterns_patterncard",
       "label": "PatternCard()",
@@ -83026,7 +83191,7 @@
       "source_location": "L127"
     },
     {
-      "community": 428,
+      "community": 429,
       "file_type": "code",
       "id": "admin_shell_patterns_patternshell",
       "label": "PatternShell()",
@@ -83035,40 +83200,13 @@
       "source_location": "L106"
     },
     {
-      "community": 428,
+      "community": 429,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_patterns_admin_shell_patterns_tsx",
       "label": "admin-shell-patterns.tsx",
       "norm_label": "admin-shell-patterns.tsx",
       "source_file": "packages/athena-webapp/src/stories/Patterns/admin-shell-patterns.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 429,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_storybook_theme_decorator_tsx",
-      "label": "storybook-theme-decorator.tsx",
-      "norm_label": "storybook-theme-decorator.tsx",
-      "source_file": "packages/athena-webapp/src/stories/storybook-theme-decorator.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 429,
-      "file_type": "code",
-      "id": "storybook_theme_decorator_getathenadesigntokenstyle",
-      "label": "getAthenaDesignTokenStyle()",
-      "norm_label": "getathenadesigntokenstyle()",
-      "source_file": "packages/athena-webapp/src/stories/storybook-theme-decorator.tsx",
-      "source_location": "L49"
-    },
-    {
-      "community": 429,
-      "file_type": "code",
-      "id": "storybook_theme_decorator_withathenatheme",
-      "label": "withAthenaTheme()",
-      "norm_label": "withathenatheme()",
-      "source_file": "packages/athena-webapp/src/stories/storybook-theme-decorator.tsx",
-      "source_location": "L62"
     },
     {
       "community": 43,
@@ -83217,6 +83355,33 @@
     {
       "community": 430,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_storybook_theme_decorator_tsx",
+      "label": "storybook-theme-decorator.tsx",
+      "norm_label": "storybook-theme-decorator.tsx",
+      "source_file": "packages/athena-webapp/src/stories/storybook-theme-decorator.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 430,
+      "file_type": "code",
+      "id": "storybook_theme_decorator_getathenadesigntokenstyle",
+      "label": "getAthenaDesignTokenStyle()",
+      "norm_label": "getathenadesigntokenstyle()",
+      "source_file": "packages/athena-webapp/src/stories/storybook-theme-decorator.tsx",
+      "source_location": "L49"
+    },
+    {
+      "community": 430,
+      "file_type": "code",
+      "id": "storybook_theme_decorator_withathenatheme",
+      "label": "withAthenaTheme()",
+      "norm_label": "withathenatheme()",
+      "source_file": "packages/athena-webapp/src/stories/storybook-theme-decorator.tsx",
+      "source_location": "L62"
+    },
+    {
+      "community": 431,
+      "file_type": "code",
       "id": "inventoryvalidationlogic_test_mockgetsku",
       "label": "mockGetSku()",
       "norm_label": "mockgetsku()",
@@ -83224,7 +83389,7 @@
       "source_location": "L66"
     },
     {
-      "community": 430,
+      "community": 431,
       "file_type": "code",
       "id": "inventoryvalidationlogic_test_validateinventoryfortransaction",
       "label": "validateInventoryForTransaction()",
@@ -83233,7 +83398,7 @@
       "source_location": "L20"
     },
     {
-      "community": 430,
+      "community": 431,
       "file_type": "code",
       "id": "packages_athena_webapp_src_tests_pos_inventoryvalidationlogic_test_ts",
       "label": "inventoryValidationLogic.test.ts",
@@ -83242,7 +83407,7 @@
       "source_location": "L1"
     },
     {
-      "community": 431,
+      "community": 432,
       "file_type": "code",
       "id": "index_hashpassword",
       "label": "hashPassword()",
@@ -83251,7 +83416,7 @@
       "source_location": "L1"
     },
     {
-      "community": 431,
+      "community": 432,
       "file_type": "code",
       "id": "packages_athena_webapp_src_utils_index_ts",
       "label": "index.ts",
@@ -83260,7 +83425,7 @@
       "source_location": "L1"
     },
     {
-      "community": 431,
+      "community": 432,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_utils_index_ts",
       "label": "index.ts",
@@ -83269,7 +83434,7 @@
       "source_location": "L1"
     },
     {
-      "community": 432,
+      "community": 433,
       "file_type": "code",
       "id": "packages_athena_webapp_src_utils_versionchecker_ts",
       "label": "versionChecker.ts",
@@ -83278,7 +83443,7 @@
       "source_location": "L1"
     },
     {
-      "community": 432,
+      "community": 433,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_utils_versionchecker_ts",
       "label": "versionChecker.ts",
@@ -83287,7 +83452,7 @@
       "source_location": "L1"
     },
     {
-      "community": 432,
+      "community": 433,
       "file_type": "code",
       "id": "versionchecker_createversionchecker",
       "label": "createVersionChecker()",
@@ -83296,7 +83461,7 @@
       "source_location": "L16"
     },
     {
-      "community": 433,
+      "community": 434,
       "file_type": "code",
       "id": "packages_athena_webapp_vite_config_ts",
       "label": "vite.config.ts",
@@ -83305,7 +83470,7 @@
       "source_location": "L1"
     },
     {
-      "community": 433,
+      "community": 434,
       "file_type": "code",
       "id": "packages_storefront_webapp_vite_config_ts",
       "label": "vite.config.ts",
@@ -83314,7 +83479,7 @@
       "source_location": "L1"
     },
     {
-      "community": 433,
+      "community": 434,
       "file_type": "code",
       "id": "vite_config_manualchunks",
       "label": "manualChunks()",
@@ -83323,7 +83488,7 @@
       "source_location": "L26"
     },
     {
-      "community": 434,
+      "community": 435,
       "file_type": "code",
       "id": "packages_athena_webapp_vitest_setup_ts",
       "label": "vitest.setup.ts",
@@ -83332,7 +83497,7 @@
       "source_location": "L1"
     },
     {
-      "community": 434,
+      "community": 435,
       "file_type": "code",
       "id": "vitest_setup_pointercapturestub",
       "label": "pointerCaptureStub()",
@@ -83341,7 +83506,7 @@
       "source_location": "L23"
     },
     {
-      "community": 434,
+      "community": 435,
       "file_type": "code",
       "id": "vitest_setup_pointerreleasestub",
       "label": "pointerReleaseStub()",
@@ -83350,7 +83515,7 @@
       "source_location": "L24"
     },
     {
-      "community": 435,
+      "community": 436,
       "file_type": "code",
       "id": "auth_logout",
       "label": "logout()",
@@ -83359,7 +83524,7 @@
       "source_location": "L32"
     },
     {
-      "community": 435,
+      "community": 436,
       "file_type": "code",
       "id": "auth_verifyuseraccount",
       "label": "verifyUserAccount()",
@@ -83368,7 +83533,7 @@
       "source_location": "L3"
     },
     {
-      "community": 435,
+      "community": 436,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_auth_ts",
       "label": "auth.ts",
@@ -83377,7 +83542,7 @@
       "source_location": "L1"
     },
     {
-      "community": 436,
+      "community": 437,
       "file_type": "code",
       "id": "color_getallcolors",
       "label": "getAllColors()",
@@ -83386,7 +83551,7 @@
       "source_location": "L7"
     },
     {
-      "community": 436,
+      "community": 437,
       "file_type": "code",
       "id": "color_getbaseurl",
       "label": "getBaseUrl()",
@@ -83395,7 +83560,7 @@
       "source_location": "L5"
     },
     {
-      "community": 436,
+      "community": 437,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_color_ts",
       "label": "color.ts",
@@ -83404,7 +83569,7 @@
       "source_location": "L1"
     },
     {
-      "community": 437,
+      "community": 438,
       "file_type": "code",
       "id": "organization_getallorganizations",
       "label": "getAllOrganizations()",
@@ -83413,7 +83578,7 @@
       "source_location": "L6"
     },
     {
-      "community": 437,
+      "community": 438,
       "file_type": "code",
       "id": "organization_getorganization",
       "label": "getOrganization()",
@@ -83422,7 +83587,7 @@
       "source_location": "L18"
     },
     {
-      "community": 437,
+      "community": 438,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_organization_ts",
       "label": "organization.ts",
@@ -83431,7 +83596,7 @@
       "source_location": "L1"
     },
     {
-      "community": 438,
+      "community": 439,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_upsells_ts",
       "label": "upsells.ts",
@@ -83440,7 +83605,7 @@
       "source_location": "L1"
     },
     {
-      "community": 438,
+      "community": 439,
       "file_type": "code",
       "id": "upsells_getbaseurl",
       "label": "getBaseUrl()",
@@ -83449,40 +83614,13 @@
       "source_location": "L3"
     },
     {
-      "community": 438,
+      "community": 439,
       "file_type": "code",
       "id": "upsells_getlastviewedproduct",
       "label": "getLastViewedProduct()",
       "norm_label": "getlastviewedproduct()",
       "source_file": "packages/storefront-webapp/src/api/upsells.ts",
       "source_location": "L5"
-    },
-    {
-      "community": 439,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_useroffers_ts",
-      "label": "userOffers.ts",
-      "norm_label": "useroffers.ts",
-      "source_file": "packages/storefront-webapp/src/api/userOffers.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 439,
-      "file_type": "code",
-      "id": "useroffers_getbaseurl",
-      "label": "getBaseUrl()",
-      "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/userOffers.ts",
-      "source_location": "L18"
-    },
-    {
-      "community": 439,
-      "file_type": "code",
-      "id": "useroffers_getuserofferseligibility",
-      "label": "getUserOffersEligibility()",
-      "norm_label": "getuserofferseligibility()",
-      "source_file": "packages/storefront-webapp/src/api/userOffers.ts",
-      "source_location": "L23"
     },
     {
       "community": 44,
@@ -83631,6 +83769,33 @@
     {
       "community": 440,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_api_useroffers_ts",
+      "label": "userOffers.ts",
+      "norm_label": "useroffers.ts",
+      "source_file": "packages/storefront-webapp/src/api/userOffers.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 440,
+      "file_type": "code",
+      "id": "useroffers_getbaseurl",
+      "label": "getBaseUrl()",
+      "norm_label": "getbaseurl()",
+      "source_file": "packages/storefront-webapp/src/api/userOffers.ts",
+      "source_location": "L18"
+    },
+    {
+      "community": 440,
+      "file_type": "code",
+      "id": "useroffers_getuserofferseligibility",
+      "label": "getUserOffersEligibility()",
+      "norm_label": "getuserofferseligibility()",
+      "source_file": "packages/storefront-webapp/src/api/userOffers.ts",
+      "source_location": "L23"
+    },
+    {
+      "community": 441,
+      "file_type": "code",
       "id": "customerdetails_enteredcustomerdetails",
       "label": "EnteredCustomerDetails()",
       "norm_label": "enteredcustomerdetails()",
@@ -83638,7 +83803,7 @@
       "source_location": "L22"
     },
     {
-      "community": 440,
+      "community": 441,
       "file_type": "code",
       "id": "customerdetails_onsubmit",
       "label": "onSubmit()",
@@ -83647,7 +83812,7 @@
       "source_location": "L55"
     },
     {
-      "community": 440,
+      "community": 441,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_customerdetails_tsx",
       "label": "CustomerDetails.tsx",
@@ -83656,7 +83821,7 @@
       "source_location": "L1"
     },
     {
-      "community": 441,
+      "community": 442,
       "file_type": "code",
       "id": "deliveryoptionsselector_handlechange",
       "label": "handleChange()",
@@ -83665,7 +83830,7 @@
       "source_location": "L77"
     },
     {
-      "community": 441,
+      "community": 442,
       "file_type": "code",
       "id": "deliveryoptionsselector_storeselector",
       "label": "StoreSelector()",
@@ -83674,7 +83839,7 @@
       "source_location": "L11"
     },
     {
-      "community": 441,
+      "community": 442,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_deliveryoptionsselector_tsx",
       "label": "DeliveryOptionsSelector.tsx",
@@ -83683,7 +83848,7 @@
       "source_location": "L1"
     },
     {
-      "community": 442,
+      "community": 443,
       "file_type": "code",
       "id": "deliverysection_deliverydetails",
       "label": "DeliveryDetails()",
@@ -83692,7 +83857,7 @@
       "source_location": "L11"
     },
     {
-      "community": 442,
+      "community": 443,
       "file_type": "code",
       "id": "deliverysection_deliveryoptions",
       "label": "DeliveryOptions()",
@@ -83701,7 +83866,7 @@
       "source_location": "L22"
     },
     {
-      "community": 442,
+      "community": 443,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_deliverysection_tsx",
       "label": "DeliverySection.tsx",
@@ -83710,7 +83875,7 @@
       "source_location": "L1"
     },
     {
-      "community": 443,
+      "community": 444,
       "file_type": "code",
       "id": "mobilebagsummary_handlekeydown",
       "label": "handleKeyDown()",
@@ -83719,7 +83884,7 @@
       "source_location": "L110"
     },
     {
-      "community": 443,
+      "community": 444,
       "file_type": "code",
       "id": "mobilebagsummary_handleredeempromocode",
       "label": "handleRedeemPromoCode()",
@@ -83728,7 +83893,7 @@
       "source_location": "L89"
     },
     {
-      "community": 443,
+      "community": 444,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_mobilebagsummary_tsx",
       "label": "MobileBagSummary.tsx",
@@ -83737,7 +83902,7 @@
       "source_location": "L1"
     },
     {
-      "community": 444,
+      "community": 445,
       "file_type": "code",
       "id": "checkoutstorage_loadcheckoutstate",
       "label": "loadCheckoutState()",
@@ -83746,7 +83911,7 @@
       "source_location": "L4"
     },
     {
-      "community": 444,
+      "community": 445,
       "file_type": "code",
       "id": "checkoutstorage_savecheckoutstate",
       "label": "saveCheckoutState()",
@@ -83755,7 +83920,7 @@
       "source_location": "L24"
     },
     {
-      "community": 444,
+      "community": 445,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkoutstorage_ts",
       "label": "checkoutStorage.ts",
@@ -83764,7 +83929,7 @@
       "source_location": "L1"
     },
     {
-      "community": 445,
+      "community": 446,
       "file_type": "code",
       "id": "footer_enablecategories",
       "label": "enableCategories()",
@@ -83773,7 +83938,7 @@
       "source_location": "L131"
     },
     {
-      "community": 445,
+      "community": 446,
       "file_type": "code",
       "id": "footer_linkgroup",
       "label": "LinkGroup()",
@@ -83782,7 +83947,7 @@
       "source_location": "L12"
     },
     {
-      "community": 445,
+      "community": 446,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_footer_footer_tsx",
       "label": "Footer.tsx",
@@ -83791,7 +83956,7 @@
       "source_location": "L1"
     },
     {
-      "community": 446,
+      "community": 447,
       "file_type": "code",
       "id": "featuredproductssection_featuredproductssection",
       "label": "FeaturedProductsSection()",
@@ -83800,7 +83965,7 @@
       "source_location": "L20"
     },
     {
-      "community": 446,
+      "community": 447,
       "file_type": "code",
       "id": "featuredproductssection_featuredsection",
       "label": "FeaturedSection()",
@@ -83809,7 +83974,7 @@
       "source_location": "L46"
     },
     {
-      "community": 446,
+      "community": 447,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_featuredproductssection_tsx",
       "label": "FeaturedProductsSection.tsx",
@@ -83818,7 +83983,7 @@
       "source_location": "L1"
     },
     {
-      "community": 447,
+      "community": 448,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_promoalert_tsx",
       "label": "PromoAlert.tsx",
@@ -83827,7 +83992,7 @@
       "source_location": "L1"
     },
     {
-      "community": 447,
+      "community": 448,
       "file_type": "code",
       "id": "promoalert_getpromoalertcopy",
       "label": "getPromoAlertCopy()",
@@ -83836,7 +84001,7 @@
       "source_location": "L20"
     },
     {
-      "community": 447,
+      "community": 448,
       "file_type": "code",
       "id": "promoalert_promoalert",
       "label": "PromoAlert()",
@@ -83845,7 +84010,7 @@
       "source_location": "L59"
     },
     {
-      "community": 448,
+      "community": 449,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_rewardsalert_tsx",
       "label": "RewardsAlert.tsx",
@@ -83854,7 +84019,7 @@
       "source_location": "L1"
     },
     {
-      "community": 448,
+      "community": 449,
       "file_type": "code",
       "id": "rewardsalert_handleshopnow",
       "label": "handleShopNow()",
@@ -83863,40 +84028,13 @@
       "source_location": "L25"
     },
     {
-      "community": 448,
+      "community": 449,
       "file_type": "code",
       "id": "rewardsalert_onrewardsalertclose",
       "label": "onRewardsAlertClose()",
       "norm_label": "onrewardsalertclose()",
       "source_file": "packages/storefront-webapp/src/components/home/RewardsAlert.tsx",
       "source_location": "L20"
-    },
-    {
-      "community": 449,
-      "file_type": "code",
-      "id": "navigationbar_navigationbar",
-      "label": "NavigationBar()",
-      "norm_label": "navigationbar()",
-      "source_file": "packages/storefront-webapp/src/components/navigation-bar/NavigationBar.tsx",
-      "source_location": "L30"
-    },
-    {
-      "community": 449,
-      "file_type": "code",
-      "id": "navigationbar_storecategoriessubmenu",
-      "label": "StoreCategoriesSubmenu()",
-      "norm_label": "storecategoriessubmenu()",
-      "source_file": "packages/storefront-webapp/src/components/navigation-bar/NavigationBar.tsx",
-      "source_location": "L95"
-    },
-    {
-      "community": 449,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_navigation_bar_navigationbar_tsx",
-      "label": "NavigationBar.tsx",
-      "norm_label": "navigationbar.tsx",
-      "source_file": "packages/storefront-webapp/src/components/navigation-bar/NavigationBar.tsx",
-      "source_location": "L1"
     },
     {
       "community": 45,
@@ -84045,6 +84183,33 @@
     {
       "community": 450,
       "file_type": "code",
+      "id": "navigationbar_navigationbar",
+      "label": "NavigationBar()",
+      "norm_label": "navigationbar()",
+      "source_file": "packages/storefront-webapp/src/components/navigation-bar/NavigationBar.tsx",
+      "source_location": "L30"
+    },
+    {
+      "community": 450,
+      "file_type": "code",
+      "id": "navigationbar_storecategoriessubmenu",
+      "label": "StoreCategoriesSubmenu()",
+      "norm_label": "storecategoriessubmenu()",
+      "source_file": "packages/storefront-webapp/src/components/navigation-bar/NavigationBar.tsx",
+      "source_location": "L95"
+    },
+    {
+      "community": 450,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_navigation_bar_navigationbar_tsx",
+      "label": "NavigationBar.tsx",
+      "norm_label": "navigationbar.tsx",
+      "source_file": "packages/storefront-webapp/src/components/navigation-bar/NavigationBar.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 451,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_revieweditor_tsx",
       "label": "ReviewEditor.tsx",
       "norm_label": "revieweditor.tsx",
@@ -84052,7 +84217,7 @@
       "source_location": "L1"
     },
     {
-      "community": 450,
+      "community": 451,
       "file_type": "code",
       "id": "revieweditor_handleformdatachange",
       "label": "handleFormDataChange()",
@@ -84061,7 +84226,7 @@
       "source_location": "L150"
     },
     {
-      "community": 450,
+      "community": 451,
       "file_type": "code",
       "id": "revieweditor_handlesubmit",
       "label": "handleSubmit()",
@@ -84070,7 +84235,7 @@
       "source_location": "L157"
     },
     {
-      "community": 451,
+      "community": 452,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_upsellmodalform_tsx",
       "label": "UpsellModalForm.tsx",
@@ -84079,7 +84244,7 @@
       "source_location": "L1"
     },
     {
-      "community": 451,
+      "community": 452,
       "file_type": "code",
       "id": "upsellmodalform_handleinputchange",
       "label": "handleInputChange()",
@@ -84088,7 +84253,7 @@
       "source_location": "L63"
     },
     {
-      "community": 451,
+      "community": 452,
       "file_type": "code",
       "id": "upsellmodalform_handlesubmit",
       "label": "handleSubmit()",
@@ -84097,7 +84262,7 @@
       "source_location": "L48"
     },
     {
-      "community": 452,
+      "community": 453,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_welcomebackmodal_tsx",
       "label": "WelcomeBackModal.tsx",
@@ -84106,7 +84271,7 @@
       "source_location": "L1"
     },
     {
-      "community": 452,
+      "community": 453,
       "file_type": "code",
       "id": "welcomebackmodal_handleclose",
       "label": "handleClose()",
@@ -84115,7 +84280,7 @@
       "source_location": "L63"
     },
     {
-      "community": 452,
+      "community": 453,
       "file_type": "code",
       "id": "welcomebackmodal_handlesuccess",
       "label": "handleSuccess()",
@@ -84124,7 +84289,7 @@
       "source_location": "L76"
     },
     {
-      "community": 453,
+      "community": 454,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_welcomebackmodalform_tsx",
       "label": "WelcomeBackModalForm.tsx",
@@ -84133,7 +84298,7 @@
       "source_location": "L1"
     },
     {
-      "community": 453,
+      "community": 454,
       "file_type": "code",
       "id": "welcomebackmodalform_handleinputchange",
       "label": "handleInputChange()",
@@ -84142,7 +84307,7 @@
       "source_location": "L51"
     },
     {
-      "community": 453,
+      "community": 454,
       "file_type": "code",
       "id": "welcomebackmodalform_handlesubmit",
       "label": "handleSubmit()",
@@ -84151,7 +84316,7 @@
       "source_location": "L36"
     },
     {
-      "community": 454,
+      "community": 455,
       "file_type": "code",
       "id": "navigationbarprovider_navigationbarprovider",
       "label": "NavigationBarProvider()",
@@ -84160,7 +84325,7 @@
       "source_location": "L16"
     },
     {
-      "community": 454,
+      "community": 455,
       "file_type": "code",
       "id": "navigationbarprovider_usenavigationbarcontext",
       "label": "useNavigationBarContext()",
@@ -84169,7 +84334,7 @@
       "source_location": "L39"
     },
     {
-      "community": 454,
+      "community": 455,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_contexts_navigationbarprovider_tsx",
       "label": "NavigationBarProvider.tsx",
@@ -84178,7 +84343,7 @@
       "source_location": "L1"
     },
     {
-      "community": 455,
+      "community": 456,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_contexts_storefrontobservabilityprovider_tsx",
       "label": "StorefrontObservabilityProvider.tsx",
@@ -84187,7 +84352,7 @@
       "source_location": "L1"
     },
     {
-      "community": 455,
+      "community": 456,
       "file_type": "code",
       "id": "storefrontobservabilityprovider_storefrontobservabilityprovider",
       "label": "StorefrontObservabilityProvider()",
@@ -84196,7 +84361,7 @@
       "source_location": "L20"
     },
     {
-      "community": 455,
+      "community": 456,
       "file_type": "code",
       "id": "storefrontobservabilityprovider_usestorefrontobservability",
       "label": "useStorefrontObservability()",
@@ -84205,7 +84370,7 @@
       "source_location": "L55"
     },
     {
-      "community": 456,
+      "community": 457,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useproductdiscount_ts",
       "label": "useProductDiscount.ts",
@@ -84214,7 +84379,7 @@
       "source_location": "L1"
     },
     {
-      "community": 456,
+      "community": 457,
       "file_type": "code",
       "id": "useproductdiscount_useproductdiscount",
       "label": "useProductDiscount()",
@@ -84223,7 +84388,7 @@
       "source_location": "L107"
     },
     {
-      "community": 456,
+      "community": 457,
       "file_type": "code",
       "id": "useproductdiscount_useproductdiscounts",
       "label": "useProductDiscounts()",
@@ -84232,7 +84397,7 @@
       "source_location": "L25"
     },
     {
-      "community": 457,
+      "community": 458,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useshoppingbag_ts",
       "label": "useShoppingBag.ts",
@@ -84241,7 +84406,7 @@
       "source_location": "L1"
     },
     {
-      "community": 457,
+      "community": 458,
       "file_type": "code",
       "id": "useshoppingbag_isunavailableproductlist",
       "label": "isUnavailableProductList()",
@@ -84250,7 +84415,7 @@
       "source_location": "L556"
     },
     {
-      "community": 457,
+      "community": 458,
       "file_type": "code",
       "id": "useshoppingbag_useshoppingbag",
       "label": "useShoppingBag()",
@@ -84259,7 +84424,7 @@
       "source_location": "L52"
     },
     {
-      "community": 458,
+      "community": 459,
       "file_type": "code",
       "id": "index_getordermessage",
       "label": "getOrderMessage()",
@@ -84268,7 +84433,7 @@
       "source_location": "L429"
     },
     {
-      "community": 458,
+      "community": 459,
       "file_type": "code",
       "id": "index_getpaymenttext",
       "label": "getPaymentText()",
@@ -84277,40 +84442,13 @@
       "source_location": "L102"
     },
     {
-      "community": 458,
+      "community": 459,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_orderid_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
       "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/index.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 459,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_orderid_review_tsx",
-      "label": "review.tsx",
-      "norm_label": "review.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/review.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 459,
-      "file_type": "code",
-      "id": "review_getordermessage",
-      "label": "getOrderMessage()",
-      "norm_label": "getordermessage()",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/review.tsx",
-      "source_location": "L250"
-    },
-    {
-      "community": 459,
-      "file_type": "code",
-      "id": "review_ordernavigation",
-      "label": "OrderNavigation()",
-      "norm_label": "ordernavigation()",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/review.tsx",
-      "source_location": "L46"
     },
     {
       "community": 46,
@@ -84450,6 +84588,33 @@
     {
       "community": 460,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_orderid_review_tsx",
+      "label": "review.tsx",
+      "norm_label": "review.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/review.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 460,
+      "file_type": "code",
+      "id": "review_getordermessage",
+      "label": "getOrderMessage()",
+      "norm_label": "getordermessage()",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/review.tsx",
+      "source_location": "L250"
+    },
+    {
+      "community": 460,
+      "file_type": "code",
+      "id": "review_ordernavigation",
+      "label": "OrderNavigation()",
+      "norm_label": "ordernavigation()",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/review.tsx",
+      "source_location": "L46"
+    },
+    {
+      "community": 461,
+      "file_type": "code",
       "id": "account_accountbeforeload",
       "label": "accountBeforeLoad()",
       "norm_label": "accountbeforeload()",
@@ -84457,7 +84622,7 @@
       "source_location": "L17"
     },
     {
-      "community": 460,
+      "community": 461,
       "file_type": "code",
       "id": "account_handleonsubmitform",
       "label": "handleOnSubmitForm()",
@@ -84466,7 +84631,7 @@
       "source_location": "L63"
     },
     {
-      "community": 460,
+      "community": 461,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_account_tsx",
       "label": "account.tsx",
@@ -84475,7 +84640,7 @@
       "source_location": "L1"
     },
     {
-      "community": 461,
+      "community": 462,
       "file_type": "code",
       "id": "login_loginbeforeload",
       "label": "loginBeforeLoad()",
@@ -84484,7 +84649,7 @@
       "source_location": "L47"
     },
     {
-      "community": 461,
+      "community": 462,
       "file_type": "code",
       "id": "login_onsubmit",
       "label": "onSubmit()",
@@ -84493,7 +84658,7 @@
       "source_location": "L141"
     },
     {
-      "community": 461,
+      "community": 462,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_login_tsx",
       "label": "login.tsx",
@@ -84502,7 +84667,7 @@
       "source_location": "L1"
     },
     {
-      "community": 462,
+      "community": 463,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_verify_index_tsx",
       "label": "verify.index.tsx",
@@ -84511,7 +84676,7 @@
       "source_location": "L1"
     },
     {
-      "community": 462,
+      "community": 463,
       "file_type": "code",
       "id": "verify_index_verify",
       "label": "Verify()",
@@ -84520,7 +84685,7 @@
       "source_location": "L21"
     },
     {
-      "community": 462,
+      "community": 463,
       "file_type": "code",
       "id": "verify_index_verifycheckoutsessionpayment",
       "label": "VerifyCheckoutSessionPayment()",
@@ -84529,7 +84694,7 @@
       "source_location": "L107"
     },
     {
-      "community": 463,
+      "community": 464,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_signup_tsx",
       "label": "signup.tsx",
@@ -84538,7 +84703,7 @@
       "source_location": "L1"
     },
     {
-      "community": 463,
+      "community": 464,
       "file_type": "code",
       "id": "signup_onsubmit",
       "label": "onSubmit()",
@@ -84547,7 +84712,7 @@
       "source_location": "L161"
     },
     {
-      "community": 463,
+      "community": 464,
       "file_type": "code",
       "id": "signup_signupbeforeload",
       "label": "signupBeforeLoad()",
@@ -84556,7 +84721,7 @@
       "source_location": "L66"
     },
     {
-      "community": 464,
+      "community": 465,
       "file_type": "code",
       "id": "env_optionalnumberenv",
       "label": "optionalNumberEnv()",
@@ -84565,7 +84730,7 @@
       "source_location": "L11"
     },
     {
-      "community": 464,
+      "community": 465,
       "file_type": "code",
       "id": "env_requireenv",
       "label": "requireEnv()",
@@ -84574,7 +84739,7 @@
       "source_location": "L1"
     },
     {
-      "community": 464,
+      "community": 465,
       "file_type": "code",
       "id": "packages_storefront_webapp_tests_e2e_helpers_env_ts",
       "label": "env.ts",
@@ -84583,7 +84748,7 @@
       "source_location": "L1"
     },
     {
-      "community": 465,
+      "community": 466,
       "file_type": "code",
       "id": "graphify_wiki_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -84592,7 +84757,7 @@
       "source_location": "L16"
     },
     {
-      "community": 465,
+      "community": 466,
       "file_type": "code",
       "id": "graphify_wiki_test_write",
       "label": "write()",
@@ -84601,7 +84766,7 @@
       "source_location": "L10"
     },
     {
-      "community": 465,
+      "community": 466,
       "file_type": "code",
       "id": "scripts_graphify_wiki_test_ts",
       "label": "graphify-wiki.test.ts",
@@ -84610,7 +84775,7 @@
       "source_location": "L1"
     },
     {
-      "community": 466,
+      "community": 467,
       "file_type": "code",
       "id": "harness_audit_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -84619,7 +84784,7 @@
       "source_location": "L17"
     },
     {
-      "community": 466,
+      "community": 467,
       "file_type": "code",
       "id": "harness_audit_test_write",
       "label": "write()",
@@ -84628,7 +84793,7 @@
       "source_location": "L11"
     },
     {
-      "community": 466,
+      "community": 467,
       "file_type": "code",
       "id": "scripts_harness_audit_test_ts",
       "label": "harness-audit.test.ts",
@@ -84637,7 +84802,7 @@
       "source_location": "L1"
     },
     {
-      "community": 467,
+      "community": 468,
       "file_type": "code",
       "id": "harness_check_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -84646,7 +84811,7 @@
       "source_location": "L48"
     },
     {
-      "community": 467,
+      "community": 468,
       "file_type": "code",
       "id": "harness_check_test_write",
       "label": "write()",
@@ -84655,7 +84820,7 @@
       "source_location": "L42"
     },
     {
-      "community": 467,
+      "community": 468,
       "file_type": "code",
       "id": "scripts_harness_check_test_ts",
       "label": "harness-check.test.ts",
@@ -84664,7 +84829,7 @@
       "source_location": "L1"
     },
     {
-      "community": 468,
+      "community": 469,
       "file_type": "code",
       "id": "harness_generate_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -84673,7 +84838,7 @@
       "source_location": "L16"
     },
     {
-      "community": 468,
+      "community": 469,
       "file_type": "code",
       "id": "harness_generate_test_write",
       "label": "write()",
@@ -84682,39 +84847,12 @@
       "source_location": "L10"
     },
     {
-      "community": 468,
+      "community": 469,
       "file_type": "code",
       "id": "scripts_harness_generate_test_ts",
       "label": "harness-generate.test.ts",
       "norm_label": "harness-generate.test.ts",
       "source_file": "scripts/harness-generate.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 469,
-      "file_type": "code",
-      "id": "harness_inferential_review_test_createfixturerepo",
-      "label": "createFixtureRepo()",
-      "norm_label": "createfixturerepo()",
-      "source_file": "scripts/harness-inferential-review.test.ts",
-      "source_location": "L19"
-    },
-    {
-      "community": 469,
-      "file_type": "code",
-      "id": "harness_inferential_review_test_write",
-      "label": "write()",
-      "norm_label": "write()",
-      "source_file": "scripts/harness-inferential-review.test.ts",
-      "source_location": "L13"
-    },
-    {
-      "community": 469,
-      "file_type": "code",
-      "id": "scripts_harness_inferential_review_test_ts",
-      "label": "harness-inferential-review.test.ts",
-      "norm_label": "harness-inferential-review.test.ts",
-      "source_file": "scripts/harness-inferential-review.test.ts",
       "source_location": "L1"
     },
     {
@@ -84855,6 +84993,33 @@
     {
       "community": 470,
       "file_type": "code",
+      "id": "harness_inferential_review_test_createfixturerepo",
+      "label": "createFixtureRepo()",
+      "norm_label": "createfixturerepo()",
+      "source_file": "scripts/harness-inferential-review.test.ts",
+      "source_location": "L19"
+    },
+    {
+      "community": 470,
+      "file_type": "code",
+      "id": "harness_inferential_review_test_write",
+      "label": "write()",
+      "norm_label": "write()",
+      "source_file": "scripts/harness-inferential-review.test.ts",
+      "source_location": "L13"
+    },
+    {
+      "community": 470,
+      "file_type": "code",
+      "id": "scripts_harness_inferential_review_test_ts",
+      "label": "harness-inferential-review.test.ts",
+      "norm_label": "harness-inferential-review.test.ts",
+      "source_file": "scripts/harness-inferential-review.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 471,
+      "file_type": "code",
       "id": "harness_self_review_test_createfixturerepo",
       "label": "createFixtureRepo()",
       "norm_label": "createfixturerepo()",
@@ -84862,7 +85027,7 @@
       "source_location": "L16"
     },
     {
-      "community": 470,
+      "community": 471,
       "file_type": "code",
       "id": "harness_self_review_test_write",
       "label": "write()",
@@ -84871,7 +85036,7 @@
       "source_location": "L10"
     },
     {
-      "community": 470,
+      "community": 471,
       "file_type": "code",
       "id": "scripts_harness_self_review_test_ts",
       "label": "harness-self-review.test.ts",
@@ -84880,7 +85045,7 @@
       "source_location": "L1"
     },
     {
-      "community": 471,
+      "community": 472,
       "file_type": "code",
       "id": "harness_test_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -84889,7 +85054,7 @@
       "source_location": "L20"
     },
     {
-      "community": 471,
+      "community": 472,
       "file_type": "code",
       "id": "harness_test_test_write",
       "label": "write()",
@@ -84898,7 +85063,7 @@
       "source_location": "L14"
     },
     {
-      "community": 471,
+      "community": 472,
       "file_type": "code",
       "id": "scripts_harness_test_test_ts",
       "label": "harness-test.test.ts",
@@ -84907,7 +85072,7 @@
       "source_location": "L1"
     },
     {
-      "community": 472,
+      "community": 473,
       "file_type": "code",
       "id": "root_scripts_coverage_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -84916,7 +85081,7 @@
       "source_location": "L10"
     },
     {
-      "community": 472,
+      "community": 473,
       "file_type": "code",
       "id": "root_scripts_coverage_test_write",
       "label": "write()",
@@ -84925,7 +85090,7 @@
       "source_location": "L16"
     },
     {
-      "community": 472,
+      "community": 473,
       "file_type": "code",
       "id": "scripts_root_scripts_coverage_test_ts",
       "label": "root-scripts-coverage.test.ts",
@@ -84934,7 +85099,7 @@
       "source_location": "L1"
     },
     {
-      "community": 473,
+      "community": 474,
       "file_type": "code",
       "id": "root_scripts_coverage_collectrootscripttestfiles",
       "label": "collectRootScriptTestFiles()",
@@ -84943,7 +85108,7 @@
       "source_location": "L4"
     },
     {
-      "community": 473,
+      "community": 474,
       "file_type": "code",
       "id": "root_scripts_coverage_runrootscriptscoverage",
       "label": "runRootScriptsCoverage()",
@@ -84952,7 +85117,7 @@
       "source_location": "L13"
     },
     {
-      "community": 473,
+      "community": 474,
       "file_type": "code",
       "id": "scripts_root_scripts_coverage_ts",
       "label": "root-scripts-coverage.ts",
@@ -84961,7 +85126,7 @@
       "source_location": "L1"
     },
     {
-      "community": 474,
+      "community": 475,
       "file_type": "code",
       "id": "deposits_test_getsource",
       "label": "getSource()",
@@ -84970,7 +85135,7 @@
       "source_location": "L9"
     },
     {
-      "community": 474,
+      "community": 475,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cashcontrols_deposits_test_ts",
       "label": "deposits.test.ts",
@@ -84979,7 +85144,7 @@
       "source_location": "L1"
     },
     {
-      "community": 475,
+      "community": 476,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cashcontrols_paymentallocationattribution_test_ts",
       "label": "paymentAllocationAttribution.test.ts",
@@ -84988,7 +85153,7 @@
       "source_location": "L1"
     },
     {
-      "community": 475,
+      "community": 476,
       "file_type": "code",
       "id": "paymentallocationattribution_test_readprojectfile",
       "label": "readProjectFile()",
@@ -84997,7 +85162,7 @@
       "source_location": "L12"
     },
     {
-      "community": 476,
+      "community": 477,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cloudflare_stream_ts",
       "label": "stream.ts",
@@ -85006,7 +85171,7 @@
       "source_location": "L1"
     },
     {
-      "community": 476,
+      "community": 477,
       "file_type": "code",
       "id": "stream_getcloudflareconfig",
       "label": "getCloudflareConfig()",
@@ -85015,7 +85180,7 @@
       "source_location": "L8"
     },
     {
-      "community": 477,
+      "community": 478,
       "file_type": "code",
       "id": "convexauditscript_test_createcommandshimbin",
       "label": "createCommandShimBin()",
@@ -85024,7 +85189,7 @@
       "source_location": "L10"
     },
     {
-      "community": 477,
+      "community": 478,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_convexauditscript_test_ts",
       "label": "convexAuditScript.test.ts",
@@ -85033,7 +85198,7 @@
       "source_location": "L1"
     },
     {
-      "community": 478,
+      "community": 479,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_customermessaging_policy_ts",
       "label": "policy.ts",
@@ -85042,31 +85207,13 @@
       "source_location": "L1"
     },
     {
-      "community": 478,
+      "community": 479,
       "file_type": "code",
       "id": "policy_assertsupportedcustomermessagepolicy",
       "label": "assertSupportedCustomerMessagePolicy()",
       "norm_label": "assertsupportedcustomermessagepolicy()",
       "source_file": "packages/athena-webapp/convex/customerMessaging/policy.ts",
       "source_location": "L8"
-    },
-    {
-      "community": 479,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_customermessaging_repository_test_ts",
-      "label": "repository.test.ts",
-      "norm_label": "repository.test.ts",
-      "source_file": "packages/athena-webapp/convex/customerMessaging/repository.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 479,
-      "file_type": "code",
-      "id": "repository_test_queryresult",
-      "label": "queryResult()",
-      "norm_label": "queryresult()",
-      "source_file": "packages/athena-webapp/convex/customerMessaging/repository.test.ts",
-      "source_location": "L12"
     },
     {
       "community": 48,
@@ -85206,6 +85353,24 @@
     {
       "community": 480,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_customermessaging_repository_test_ts",
+      "label": "repository.test.ts",
+      "norm_label": "repository.test.ts",
+      "source_file": "packages/athena-webapp/convex/customerMessaging/repository.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 480,
+      "file_type": "code",
+      "id": "repository_test_queryresult",
+      "label": "queryResult()",
+      "norm_label": "queryresult()",
+      "source_file": "packages/athena-webapp/convex/customerMessaging/repository.test.ts",
+      "source_location": "L12"
+    },
+    {
+      "community": 481,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_customermessaging_webhooksecurity_test_ts",
       "label": "webhookSecurity.test.ts",
       "norm_label": "webhooksecurity.test.ts",
@@ -85213,7 +85378,7 @@
       "source_location": "L1"
     },
     {
-      "community": 480,
+      "community": 481,
       "file_type": "code",
       "id": "webhooksecurity_test_sign",
       "label": "sign()",
@@ -85222,7 +85387,7 @@
       "source_location": "L5"
     },
     {
-      "community": 481,
+      "community": 482,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_verificationcode_tsx",
       "label": "VerificationCode.tsx",
@@ -85231,7 +85396,7 @@
       "source_location": "L1"
     },
     {
-      "community": 481,
+      "community": 482,
       "file_type": "code",
       "id": "verificationcode_verificationcode",
       "label": "VerificationCode()",
@@ -85240,7 +85405,7 @@
       "source_location": "L18"
     },
     {
-      "community": 482,
+      "community": 483,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_core_routes_subcategories_ts",
       "label": "subcategories.ts",
@@ -85249,7 +85414,7 @@
       "source_location": "L1"
     },
     {
-      "community": 482,
+      "community": 483,
       "file_type": "code",
       "id": "subcategories_removestorefronthiddensubcategorylist",
       "label": "removeStorefrontHiddenSubcategoryList()",
@@ -85258,7 +85423,7 @@
       "source_location": "L10"
     },
     {
-      "community": 483,
+      "community": 484,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_storefrontcors_test_ts",
       "label": "storefrontCors.test.ts",
@@ -85267,7 +85432,7 @@
       "source_location": "L1"
     },
     {
-      "community": 483,
+      "community": 484,
       "file_type": "code",
       "id": "storefrontcors_test_readroutefile",
       "label": "readRouteFile()",
@@ -85276,7 +85441,7 @@
       "source_location": "L6"
     },
     {
-      "community": 484,
+      "community": 485,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customermessaging_routes_whatsapp_ts",
       "label": "whatsapp.ts",
@@ -85285,7 +85450,7 @@
       "source_location": "L1"
     },
     {
-      "community": 484,
+      "community": 485,
       "file_type": "code",
       "id": "whatsapp_mapwebhookstatus",
       "label": "mapWebhookStatus()",
@@ -85294,7 +85459,7 @@
       "source_location": "L15"
     },
     {
-      "community": 485,
+      "community": 486,
       "file_type": "code",
       "id": "mtnmomo_handlecollectionnotification",
       "label": "handleCollectionNotification()",
@@ -85303,7 +85468,7 @@
       "source_location": "L10"
     },
     {
-      "community": 485,
+      "community": 486,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_moneymovement_routes_mtnmomo_ts",
       "label": "mtnMomo.ts",
@@ -85312,7 +85477,7 @@
       "source_location": "L1"
     },
     {
-      "community": 486,
+      "community": 487,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_routercomposition_test_ts",
       "label": "routerComposition.test.ts",
@@ -85321,7 +85486,7 @@
       "source_location": "L1"
     },
     {
-      "community": 486,
+      "community": 487,
       "file_type": "code",
       "id": "routercomposition_test_readprojectfile",
       "label": "readProjectFile()",
@@ -85330,7 +85495,7 @@
       "source_location": "L6"
     },
     {
-      "community": 487,
+      "community": 488,
       "file_type": "code",
       "id": "auth_mapathenaauthsyncerror",
       "label": "mapAthenaAuthSyncError()",
@@ -85339,7 +85504,7 @@
       "source_location": "L110"
     },
     {
-      "community": 487,
+      "community": 488,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_auth_ts",
       "label": "auth.ts",
@@ -85348,7 +85513,7 @@
       "source_location": "L1"
     },
     {
-      "community": 488,
+      "community": 489,
       "file_type": "code",
       "id": "bestseller_test_gethandler",
       "label": "getHandler()",
@@ -85357,30 +85522,12 @@
       "source_location": "L6"
     },
     {
-      "community": 488,
+      "community": 489,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_bestseller_test_ts",
       "label": "bestSeller.test.ts",
       "norm_label": "bestseller.test.ts",
       "source_file": "packages/athena-webapp/convex/inventory/bestSeller.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 489,
-      "file_type": "code",
-      "id": "expensesessionitems_usererrorfromexpenseitemcommandfailure",
-      "label": "userErrorFromExpenseItemCommandFailure()",
-      "norm_label": "usererrorfromexpenseitemcommandfailure()",
-      "source_file": "packages/athena-webapp/convex/inventory/expenseSessionItems.ts",
-      "source_location": "L14"
-    },
-    {
-      "community": 489,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_expensesessionitems_ts",
-      "label": "expenseSessionItems.ts",
-      "norm_label": "expensesessionitems.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/expenseSessionItems.ts",
       "source_location": "L1"
     },
     {
@@ -85512,6 +85659,24 @@
     {
       "community": 490,
       "file_type": "code",
+      "id": "expensesessionitems_usererrorfromexpenseitemcommandfailure",
+      "label": "userErrorFromExpenseItemCommandFailure()",
+      "norm_label": "usererrorfromexpenseitemcommandfailure()",
+      "source_file": "packages/athena-webapp/convex/inventory/expenseSessionItems.ts",
+      "source_location": "L14"
+    },
+    {
+      "community": 490,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_expensesessionitems_ts",
+      "label": "expenseSessionItems.ts",
+      "norm_label": "expensesessionitems.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/expenseSessionItems.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 491,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_posquerycleanup_test_ts",
       "label": "posQueryCleanup.test.ts",
       "norm_label": "posquerycleanup.test.ts",
@@ -85519,7 +85684,7 @@
       "source_location": "L1"
     },
     {
-      "community": 490,
+      "community": 491,
       "file_type": "code",
       "id": "posquerycleanup_test_readprojectfile",
       "label": "readProjectFile()",
@@ -85528,7 +85693,7 @@
       "source_location": "L8"
     },
     {
-      "community": 491,
+      "community": 492,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_possessionitems_ts",
       "label": "posSessionItems.ts",
@@ -85537,7 +85702,7 @@
       "source_location": "L1"
     },
     {
-      "community": 491,
+      "community": 492,
       "file_type": "code",
       "id": "possessionitems_usererrorfromsessionitemfailure",
       "label": "userErrorFromSessionItemFailure()",
@@ -85546,7 +85711,7 @@
       "source_location": "L22"
     },
     {
-      "community": 492,
+      "community": 493,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_productutil_ts",
       "label": "productUtil.ts",
@@ -85555,7 +85720,7 @@
       "source_location": "L1"
     },
     {
-      "community": 492,
+      "community": 493,
       "file_type": "code",
       "id": "productutil_buildallproductscachekey",
       "label": "buildAllProductsCacheKey()",
@@ -85564,7 +85729,7 @@
       "source_location": "L8"
     },
     {
-      "community": 493,
+      "community": 494,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_stores_ts",
       "label": "stores.ts",
@@ -85573,7 +85738,7 @@
       "source_location": "L1"
     },
     {
-      "community": 493,
+      "community": 494,
       "file_type": "code",
       "id": "stores_tov2onlyconfig",
       "label": "toV2OnlyConfig()",
@@ -85582,7 +85747,7 @@
       "source_location": "L29"
     },
     {
-      "community": 494,
+      "community": 495,
       "file_type": "code",
       "id": "commandresultvalidators_commandresultvalidator",
       "label": "commandResultValidator()",
@@ -85591,7 +85756,7 @@
       "source_location": "L73"
     },
     {
-      "community": 494,
+      "community": 495,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_lib_commandresultvalidators_ts",
       "label": "commandResultValidators.ts",
@@ -85600,7 +85765,7 @@
       "source_location": "L1"
     },
     {
-      "community": 495,
+      "community": 496,
       "file_type": "code",
       "id": "callllmprovider_callllmprovider",
       "label": "callLlmProvider()",
@@ -85609,7 +85774,7 @@
       "source_location": "L4"
     },
     {
-      "community": 495,
+      "community": 496,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_callllmprovider_ts",
       "label": "callLlmProvider.ts",
@@ -85618,7 +85783,7 @@
       "source_location": "L1"
     },
     {
-      "community": 496,
+      "community": 497,
       "file_type": "code",
       "id": "anthropic_callanthropic",
       "label": "callAnthropic()",
@@ -85627,7 +85792,7 @@
       "source_location": "L3"
     },
     {
-      "community": 496,
+      "community": 497,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_providers_anthropic_ts",
       "label": "anthropic.ts",
@@ -85636,7 +85801,7 @@
       "source_location": "L1"
     },
     {
-      "community": 497,
+      "community": 498,
       "file_type": "code",
       "id": "openai_callopenai",
       "label": "callOpenAi()",
@@ -85645,7 +85810,7 @@
       "source_location": "L3"
     },
     {
-      "community": 497,
+      "community": 498,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_providers_openai_ts",
       "label": "openai.ts",
@@ -85654,7 +85819,7 @@
       "source_location": "L1"
     },
     {
-      "community": 498,
+      "community": 499,
       "file_type": "code",
       "id": "foundation_test_readprojectfile",
       "label": "readProjectFile()",
@@ -85663,30 +85828,12 @@
       "source_location": "L6"
     },
     {
-      "community": 498,
+      "community": 499,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_foundation_test_ts",
       "label": "foundation.test.ts",
       "norm_label": "foundation.test.ts",
       "source_file": "packages/athena-webapp/convex/mtn/foundation.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 499,
-      "file_type": "code",
-      "id": "approvalactions_consumecommandapprovalproofwithctx",
-      "label": "consumeCommandApprovalProofWithCtx()",
-      "norm_label": "consumecommandapprovalproofwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/approvalActions.ts",
-      "source_location": "L38"
-    },
-    {
-      "community": 499,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_approvalactions_ts",
-      "label": "approvalActions.ts",
-      "norm_label": "approvalactions.ts",
-      "source_file": "packages/athena-webapp/convex/operations/approvalActions.ts",
       "source_location": "L1"
     },
     {
@@ -86115,6 +86262,24 @@
     {
       "community": 500,
       "file_type": "code",
+      "id": "approvalactions_consumecommandapprovalproofwithctx",
+      "label": "consumeCommandApprovalProofWithCtx()",
+      "norm_label": "consumecommandapprovalproofwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/approvalActions.ts",
+      "source_location": "L38"
+    },
+    {
+      "community": 500,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_approvalactions_ts",
+      "label": "approvalActions.ts",
+      "norm_label": "approvalactions.ts",
+      "source_file": "packages/athena-webapp/convex/operations/approvalActions.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 501,
+      "file_type": "code",
       "id": "approvalauditevents_test_createoperationaleventctx",
       "label": "createOperationalEventCtx()",
       "norm_label": "createoperationaleventctx()",
@@ -86122,7 +86287,7 @@
       "source_location": "L11"
     },
     {
-      "community": 500,
+      "community": 501,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_approvalauditevents_test_ts",
       "label": "approvalAuditEvents.test.ts",
@@ -86131,7 +86296,7 @@
       "source_location": "L1"
     },
     {
-      "community": 501,
+      "community": 502,
       "file_type": "code",
       "id": "approvalproofs_test_createapprovalproofmutationctx",
       "label": "createApprovalProofMutationCtx()",
@@ -86140,7 +86305,7 @@
       "source_location": "L11"
     },
     {
-      "community": 501,
+      "community": 502,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_approvalproofs_test_ts",
       "label": "approvalProofs.test.ts",
@@ -86149,7 +86314,7 @@
       "source_location": "L1"
     },
     {
-      "community": 502,
+      "community": 503,
       "file_type": "code",
       "id": "approvalrequesthelpers_buildapprovalrequest",
       "label": "buildApprovalRequest()",
@@ -86158,7 +86323,7 @@
       "source_location": "L3"
     },
     {
-      "community": 502,
+      "community": 503,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_approvalrequesthelpers_ts",
       "label": "approvalRequestHelpers.ts",
@@ -86167,7 +86332,7 @@
       "source_location": "L1"
     },
     {
-      "community": 503,
+      "community": 504,
       "file_type": "code",
       "id": "approvalrequests_test_createapprovalrequestmutationctx",
       "label": "createApprovalRequestMutationCtx()",
@@ -86176,7 +86341,7 @@
       "source_location": "L19"
     },
     {
-      "community": 503,
+      "community": 504,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_approvalrequests_test_ts",
       "label": "approvalRequests.test.ts",
@@ -86185,7 +86350,7 @@
       "source_location": "L1"
     },
     {
-      "community": 504,
+      "community": 505,
       "file_type": "code",
       "id": "eventbuilders_buildoperationaleventmessage",
       "label": "buildOperationalEventMessage()",
@@ -86194,7 +86359,7 @@
       "source_location": "L1"
     },
     {
-      "community": 504,
+      "community": 505,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_helpers_eventbuilders_ts",
       "label": "eventBuilders.ts",
@@ -86203,7 +86368,7 @@
       "source_location": "L1"
     },
     {
-      "community": 505,
+      "community": 506,
       "file_type": "code",
       "id": "emailotp_formatvalidtime",
       "label": "formatValidTime()",
@@ -86212,7 +86377,7 @@
       "source_location": "L9"
     },
     {
-      "community": 505,
+      "community": 506,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_otp_emailotp_ts",
       "label": "EmailOTP.ts",
@@ -86221,7 +86386,7 @@
       "source_location": "L1"
     },
     {
-      "community": 506,
+      "community": 507,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_commands_quickaddcatalogitem_test_ts",
       "label": "quickAddCatalogItem.test.ts",
@@ -86230,7 +86395,7 @@
       "source_location": "L1"
     },
     {
-      "community": 506,
+      "community": 507,
       "file_type": "code",
       "id": "quickaddcatalogitem_test_createquickaddctx",
       "label": "createQuickAddCtx()",
@@ -86239,7 +86404,7 @@
       "source_location": "L17"
     },
     {
-      "community": 507,
+      "community": 508,
       "file_type": "code",
       "id": "completetransaction_test_expectnocompletionsideeffects",
       "label": "expectNoCompletionSideEffects()",
@@ -86248,7 +86413,7 @@
       "source_location": "L82"
     },
     {
-      "community": 507,
+      "community": 508,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_completetransaction_test_ts",
       "label": "completeTransaction.test.ts",
@@ -86257,7 +86422,7 @@
       "source_location": "L1"
     },
     {
-      "community": 508,
+      "community": 509,
       "file_type": "code",
       "id": "correcttransactionpaymentmethod_test_createmutationctx",
       "label": "createMutationCtx()",
@@ -86266,30 +86431,12 @@
       "source_location": "L44"
     },
     {
-      "community": 508,
+      "community": 509,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_correcttransactionpaymentmethod_test_ts",
       "label": "correctTransactionPaymentMethod.test.ts",
       "norm_label": "correcttransactionpaymentmethod.test.ts",
       "source_file": "packages/athena-webapp/convex/pos/application/correctTransactionPaymentMethod.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 509,
-      "file_type": "code",
-      "id": "correctionevents_buildcorrectionoperationalevent",
-      "label": "buildCorrectionOperationalEvent()",
-      "norm_label": "buildcorrectionoperationalevent()",
-      "source_file": "packages/athena-webapp/convex/pos/application/corrections/correctionEvents.ts",
-      "source_location": "L35"
-    },
-    {
-      "community": 509,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_corrections_correctionevents_ts",
-      "label": "correctionEvents.ts",
-      "norm_label": "correctionevents.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/corrections/correctionEvents.ts",
       "source_location": "L1"
     },
     {
@@ -86421,6 +86568,24 @@
     {
       "community": 510,
       "file_type": "code",
+      "id": "correctionevents_buildcorrectionoperationalevent",
+      "label": "buildCorrectionOperationalEvent()",
+      "norm_label": "buildcorrectionoperationalevent()",
+      "source_file": "packages/athena-webapp/convex/pos/application/corrections/correctionEvents.ts",
+      "source_location": "L35"
+    },
+    {
+      "community": 510,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_corrections_correctionevents_ts",
+      "label": "correctionEvents.ts",
+      "norm_label": "correctionevents.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/corrections/correctionEvents.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 511,
+      "file_type": "code",
       "id": "gettransactions_test_mockcorrectionhistorydb",
       "label": "mockCorrectionHistoryDb()",
       "norm_label": "mockcorrectionhistorydb()",
@@ -86428,7 +86593,7 @@
       "source_location": "L33"
     },
     {
-      "community": 510,
+      "community": 511,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_gettransactions_test_ts",
       "label": "getTransactions.test.ts",
@@ -86437,7 +86602,7 @@
       "source_location": "L1"
     },
     {
-      "community": 511,
+      "community": 512,
       "file_type": "code",
       "id": "listregistercatalog_test_createregistercatalogctx",
       "label": "createRegisterCatalogCtx()",
@@ -86446,7 +86611,7 @@
       "source_location": "L22"
     },
     {
-      "community": 511,
+      "community": 512,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_queries_listregistercatalog_test_ts",
       "label": "listRegisterCatalog.test.ts",
@@ -86455,7 +86620,7 @@
       "source_location": "L1"
     },
     {
-      "community": 512,
+      "community": 513,
       "file_type": "code",
       "id": "cashierrepository_getcashierforregisterstate",
       "label": "getCashierForRegisterState()",
@@ -86464,7 +86629,7 @@
       "source_location": "L7"
     },
     {
-      "community": 512,
+      "community": 513,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_cashierrepository_ts",
       "label": "cashierRepository.ts",
@@ -86473,7 +86638,7 @@
       "source_location": "L1"
     },
     {
-      "community": 513,
+      "community": 514,
       "file_type": "code",
       "id": "expensesessioncommandrepository_createexpensesessioncommandrepository",
       "label": "createExpenseSessionCommandRepository()",
@@ -86482,7 +86647,7 @@
       "source_location": "L60"
     },
     {
-      "community": 513,
+      "community": 514,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_expensesessioncommandrepository_ts",
       "label": "expenseSessionCommandRepository.ts",
@@ -86491,7 +86656,7 @@
       "source_location": "L1"
     },
     {
-      "community": 514,
+      "community": 515,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_sessioncommandrepository_test_ts",
       "label": "sessionCommandRepository.test.ts",
@@ -86500,7 +86665,7 @@
       "source_location": "L1"
     },
     {
-      "community": 514,
+      "community": 515,
       "file_type": "code",
       "id": "sessioncommandrepository_test_readprojectfile",
       "label": "readProjectFile()",
@@ -86509,7 +86674,7 @@
       "source_location": "L9"
     },
     {
-      "community": 515,
+      "community": 516,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_sessionrepository_test_ts",
       "label": "sessionRepository.test.ts",
@@ -86518,7 +86683,7 @@
       "source_location": "L1"
     },
     {
-      "community": 515,
+      "community": 516,
       "file_type": "code",
       "id": "sessionrepository_test_buildsession",
       "label": "buildSession()",
@@ -86527,7 +86692,7 @@
       "source_location": "L88"
     },
     {
-      "community": 516,
+      "community": 517,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_transactions_ts",
       "label": "transactions.ts",
@@ -86536,7 +86701,7 @@
       "source_location": "L1"
     },
     {
-      "community": 516,
+      "community": 517,
       "file_type": "code",
       "id": "transactions_mapcorrectionerror",
       "label": "mapCorrectionError()",
@@ -86545,7 +86710,7 @@
       "source_location": "L60"
     },
     {
-      "community": 517,
+      "community": 518,
       "file_type": "code",
       "id": "catalog_buildservicecatalogitem",
       "label": "buildServiceCatalogItem()",
@@ -86554,7 +86719,7 @@
       "source_location": "L9"
     },
     {
-      "community": 517,
+      "community": 518,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_serviceops_catalog_ts",
       "label": "catalog.ts",
@@ -86563,7 +86728,7 @@
       "source_location": "L1"
     },
     {
-      "community": 518,
+      "community": 519,
       "file_type": "code",
       "id": "modulewiring_test_getsource",
       "label": "getSource()",
@@ -86572,30 +86737,12 @@
       "source_location": "L4"
     },
     {
-      "community": 518,
+      "community": 519,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_serviceops_modulewiring_test_ts",
       "label": "moduleWiring.test.ts",
       "norm_label": "modulewiring.test.ts",
       "source_file": "packages/athena-webapp/convex/serviceOps/moduleWiring.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 519,
-      "file_type": "code",
-      "id": "access_test_createstockopsaccessqueryctx",
-      "label": "createStockOpsAccessQueryCtx()",
-      "norm_label": "createstockopsaccessqueryctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/access.test.ts",
-      "source_location": "L15"
-    },
-    {
-      "community": 519,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_stockops_access_test_ts",
-      "label": "access.test.ts",
-      "norm_label": "access.test.ts",
-      "source_file": "packages/athena-webapp/convex/stockOps/access.test.ts",
       "source_location": "L1"
     },
     {
@@ -86727,6 +86874,24 @@
     {
       "community": 520,
       "file_type": "code",
+      "id": "access_test_createstockopsaccessqueryctx",
+      "label": "createStockOpsAccessQueryCtx()",
+      "norm_label": "createstockopsaccessqueryctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/access.test.ts",
+      "source_location": "L15"
+    },
+    {
+      "community": 520,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_stockops_access_test_ts",
+      "label": "access.test.ts",
+      "norm_label": "access.test.ts",
+      "source_file": "packages/athena-webapp/convex/stockOps/access.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 521,
+      "file_type": "code",
       "id": "access_requirestorefulladminaccess",
       "label": "requireStoreFullAdminAccess()",
       "norm_label": "requirestorefulladminaccess()",
@@ -86734,7 +86899,7 @@
       "source_location": "L7"
     },
     {
-      "community": 520,
+      "community": 521,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_access_ts",
       "label": "access.ts",
@@ -86743,7 +86908,7 @@
       "source_location": "L1"
     },
     {
-      "community": 521,
+      "community": 522,
       "file_type": "code",
       "id": "cyclecountdrafts_test_createcyclecountdraftctx",
       "label": "createCycleCountDraftCtx()",
@@ -86752,7 +86917,7 @@
       "source_location": "L22"
     },
     {
-      "community": 521,
+      "community": 522,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_cyclecountdrafts_test_ts",
       "label": "cycleCountDrafts.test.ts",
@@ -86761,7 +86926,7 @@
       "source_location": "L1"
     },
     {
-      "community": 522,
+      "community": 523,
       "file_type": "code",
       "id": "auth_getstorefrontactorbyid",
       "label": "getStoreFrontActorById()",
@@ -86770,7 +86935,7 @@
       "source_location": "L15"
     },
     {
-      "community": 522,
+      "community": 523,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_auth_ts",
       "label": "auth.ts",
@@ -86779,7 +86944,7 @@
       "source_location": "L1"
     },
     {
-      "community": 523,
+      "community": 524,
       "file_type": "code",
       "id": "customerbehaviortimeline_test_createqueryctx",
       "label": "createQueryCtx()",
@@ -86788,7 +86953,7 @@
       "source_location": "L8"
     },
     {
-      "community": 523,
+      "community": 524,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_customerbehaviortimeline_test_ts",
       "label": "customerBehaviorTimeline.test.ts",
@@ -86797,7 +86962,7 @@
       "source_location": "L1"
     },
     {
-      "community": 524,
+      "community": 525,
       "file_type": "code",
       "id": "customerobservabilitytimeline_test_createanalyticsevent",
       "label": "createAnalyticsEvent()",
@@ -86806,7 +86971,7 @@
       "source_location": "L17"
     },
     {
-      "community": 524,
+      "community": 525,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_customerobservabilitytimeline_test_ts",
       "label": "customerObservabilityTimeline.test.ts",
@@ -86815,7 +86980,7 @@
       "source_location": "L1"
     },
     {
-      "community": 525,
+      "community": 526,
       "file_type": "code",
       "id": "helperorchestration_test_readprojectfile",
       "label": "readProjectFile()",
@@ -86824,7 +86989,7 @@
       "source_location": "L6"
     },
     {
-      "community": 525,
+      "community": 526,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_helperorchestration_test_ts",
       "label": "helperOrchestration.test.ts",
@@ -86833,7 +86998,7 @@
       "source_location": "L1"
     },
     {
-      "community": 526,
+      "community": 527,
       "file_type": "code",
       "id": "customerengagementevents_test_createmutationctx",
       "label": "createMutationCtx()",
@@ -86842,7 +87007,7 @@
       "source_location": "L5"
     },
     {
-      "community": 526,
+      "community": 527,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_helpers_customerengagementevents_test_ts",
       "label": "customerEngagementEvents.test.ts",
@@ -86851,7 +87016,7 @@
       "source_location": "L1"
     },
     {
-      "community": 527,
+      "community": 528,
       "file_type": "code",
       "id": "onlineorderitem_updateonlineorderitem",
       "label": "updateOnlineOrderItem()",
@@ -86860,7 +87025,7 @@
       "source_location": "L25"
     },
     {
-      "community": 527,
+      "community": 528,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_onlineorderitem_ts",
       "label": "onlineOrderItem.ts",
@@ -86869,7 +87034,7 @@
       "source_location": "L1"
     },
     {
-      "community": 528,
+      "community": 529,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_reviews_ts",
       "label": "reviews.ts",
@@ -86878,31 +87043,13 @@
       "source_location": "L1"
     },
     {
-      "community": 528,
+      "community": 529,
       "file_type": "code",
       "id": "reviews_getstorefrontactorbyid",
       "label": "getStoreFrontActorById()",
       "norm_label": "getstorefrontactorbyid()",
       "source_file": "packages/athena-webapp/convex/storeFront/reviews.ts",
       "source_location": "L19"
-    },
-    {
-      "community": 529,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_rewards_ts",
-      "label": "rewards.ts",
-      "norm_label": "rewards.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/rewards.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 529,
-      "file_type": "code",
-      "id": "rewards_formatpointslabel",
-      "label": "formatPointsLabel()",
-      "norm_label": "formatpointslabel()",
-      "source_file": "packages/athena-webapp/convex/storeFront/rewards.ts",
-      "source_location": "L7"
     },
     {
       "community": 53,
@@ -87033,6 +87180,24 @@
     {
       "community": 530,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_rewards_ts",
+      "label": "rewards.ts",
+      "norm_label": "rewards.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/rewards.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 530,
+      "file_type": "code",
+      "id": "rewards_formatpointslabel",
+      "label": "formatPointsLabel()",
+      "norm_label": "formatpointslabel()",
+      "source_file": "packages/athena-webapp/convex/storeFront/rewards.ts",
+      "source_location": "L7"
+    },
+    {
+      "community": 531,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_savedbag_ts",
       "label": "savedBag.ts",
       "norm_label": "savedbag.ts",
@@ -87040,7 +87205,7 @@
       "source_location": "L1"
     },
     {
-      "community": 530,
+      "community": 531,
       "file_type": "code",
       "id": "savedbag_listsavedbagitems",
       "label": "listSavedBagItems()",
@@ -87049,7 +87214,7 @@
       "source_location": "L14"
     },
     {
-      "community": 531,
+      "community": 532,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_storefrontobservabilityreport_test_ts",
       "label": "storefrontObservabilityReport.test.ts",
@@ -87058,7 +87223,7 @@
       "source_location": "L1"
     },
     {
-      "community": 531,
+      "community": 532,
       "file_type": "code",
       "id": "storefrontobservabilityreport_test_createanalyticsevent",
       "label": "createAnalyticsEvent()",
@@ -87067,7 +87232,7 @@
       "source_location": "L8"
     },
     {
-      "community": 532,
+      "community": 533,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_syntheticmonitor_ts",
       "label": "syntheticMonitor.ts",
@@ -87076,7 +87241,7 @@
       "source_location": "L1"
     },
     {
-      "community": 532,
+      "community": 533,
       "file_type": "code",
       "id": "syntheticmonitor_issyntheticmonitororigin",
       "label": "isSyntheticMonitorOrigin()",
@@ -87085,7 +87250,7 @@
       "source_location": "L3"
     },
     {
-      "community": 533,
+      "community": 534,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_timequeryrefactors_test_ts",
       "label": "timeQueryRefactors.test.ts",
@@ -87094,7 +87259,7 @@
       "source_location": "L1"
     },
     {
-      "community": 533,
+      "community": 534,
       "file_type": "code",
       "id": "timequeryrefactors_test_readsource",
       "label": "readSource()",
@@ -87103,7 +87268,7 @@
       "source_location": "L5"
     },
     {
-      "community": 534,
+      "community": 535,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_user_ts",
       "label": "user.ts",
@@ -87112,7 +87277,7 @@
       "source_location": "L1"
     },
     {
-      "community": 534,
+      "community": 535,
       "file_type": "code",
       "id": "user_getstorefrontactorbyid",
       "label": "getStoreFrontActorById()",
@@ -87121,7 +87286,7 @@
       "source_location": "L16"
     },
     {
-      "community": 535,
+      "community": 536,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_useroffers_ts",
       "label": "userOffers.ts",
@@ -87130,7 +87295,7 @@
       "source_location": "L1"
     },
     {
-      "community": 535,
+      "community": 536,
       "file_type": "code",
       "id": "useroffers_determineoffereligibility",
       "label": "determineOfferEligibility()",
@@ -87139,7 +87304,7 @@
       "source_location": "L30"
     },
     {
-      "community": 536,
+      "community": 537,
       "file_type": "code",
       "id": "expensesession_buildexpensesessiontraceseed",
       "label": "buildExpenseSessionTraceSeed()",
@@ -87148,7 +87313,7 @@
       "source_location": "L42"
     },
     {
-      "community": 536,
+      "community": 537,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_adapters_expensesession_ts",
       "label": "expenseSession.ts",
@@ -87157,7 +87322,7 @@
       "source_location": "L1"
     },
     {
-      "community": 537,
+      "community": 538,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_adapters_possession_ts",
       "label": "posSession.ts",
@@ -87166,7 +87331,7 @@
       "source_location": "L1"
     },
     {
-      "community": 537,
+      "community": 538,
       "file_type": "code",
       "id": "possession_buildpossessiontraceseed",
       "label": "buildPosSessionTraceSeed()",
@@ -87175,7 +87340,7 @@
       "source_location": "L42"
     },
     {
-      "community": 538,
+      "community": 539,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_presentation_ts",
       "label": "presentation.ts",
@@ -87184,31 +87349,13 @@
       "source_location": "L1"
     },
     {
-      "community": 538,
+      "community": 539,
       "file_type": "code",
       "id": "presentation_buildworkflowtraceviewmodel",
       "label": "buildWorkflowTraceViewModel()",
       "norm_label": "buildworkflowtraceviewmodel()",
       "source_file": "packages/athena-webapp/convex/workflowTraces/presentation.ts",
       "source_location": "L31"
-    },
-    {
-      "community": 539,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_workflowtraces_schemaindexes_test_ts",
-      "label": "schemaIndexes.test.ts",
-      "norm_label": "schemaindexes.test.ts",
-      "source_file": "packages/athena-webapp/convex/workflowTraces/schemaIndexes.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 539,
-      "file_type": "code",
-      "id": "schemaindexes_test_gettableindexes",
-      "label": "getTableIndexes()",
-      "norm_label": "gettableindexes()",
-      "source_file": "packages/athena-webapp/convex/workflowTraces/schemaIndexes.test.ts",
-      "source_location": "L5"
     },
     {
       "community": 54,
@@ -87339,6 +87486,24 @@
     {
       "community": 540,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_workflowtraces_schemaindexes_test_ts",
+      "label": "schemaIndexes.test.ts",
+      "norm_label": "schemaindexes.test.ts",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/schemaIndexes.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 540,
+      "file_type": "code",
+      "id": "schemaindexes_test_gettableindexes",
+      "label": "getTableIndexes()",
+      "norm_label": "gettableindexes()",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/schemaIndexes.test.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 541,
+      "file_type": "code",
       "id": "packages_athena_webapp_shared_serviceintake_ts",
       "label": "serviceIntake.ts",
       "norm_label": "serviceintake.ts",
@@ -87346,7 +87511,7 @@
       "source_location": "L1"
     },
     {
-      "community": 540,
+      "community": 541,
       "file_type": "code",
       "id": "serviceintake_validateserviceintakeinput",
       "label": "validateServiceIntakeInput()",
@@ -87355,7 +87520,7 @@
       "source_location": "L1"
     },
     {
-      "community": 541,
+      "community": 542,
       "file_type": "code",
       "id": "organizationview_navigation",
       "label": "Navigation()",
@@ -87364,7 +87529,7 @@
       "source_location": "L7"
     },
     {
-      "community": 541,
+      "community": 542,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organizationview_tsx",
       "label": "OrganizationView.tsx",
@@ -87373,7 +87538,7 @@
       "source_location": "L1"
     },
     {
-      "community": 542,
+      "community": 543,
       "file_type": "code",
       "id": "organizationsview_navigation",
       "label": "Navigation()",
@@ -87382,7 +87547,7 @@
       "source_location": "L12"
     },
     {
-      "community": 542,
+      "community": 543,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organizationsview_tsx",
       "label": "OrganizationsView.tsx",
@@ -87391,7 +87556,7 @@
       "source_location": "L1"
     },
     {
-      "community": 543,
+      "community": 544,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_permissiongate_tsx",
       "label": "PermissionGate.tsx",
@@ -87400,7 +87565,7 @@
       "source_location": "L1"
     },
     {
-      "community": 543,
+      "community": 544,
       "file_type": "code",
       "id": "permissiongate_permissiongate",
       "label": "PermissionGate()",
@@ -87409,7 +87574,7 @@
       "source_location": "L11"
     },
     {
-      "community": 544,
+      "community": 545,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_protectedroute_tsx",
       "label": "ProtectedRoute.tsx",
@@ -87418,7 +87583,7 @@
       "source_location": "L1"
     },
     {
-      "community": 544,
+      "community": 545,
       "file_type": "code",
       "id": "protectedroute_protectedroute",
       "label": "ProtectedRoute()",
@@ -87427,7 +87592,7 @@
       "source_location": "L11"
     },
     {
-      "community": 545,
+      "community": 546,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_settingsview_tsx",
       "label": "SettingsView.tsx",
@@ -87436,7 +87601,7 @@
       "source_location": "L1"
     },
     {
-      "community": 545,
+      "community": 546,
       "file_type": "code",
       "id": "settingsview_settingsview",
       "label": "SettingsView()",
@@ -87445,7 +87610,7 @@
       "source_location": "L3"
     },
     {
-      "community": 546,
+      "community": 547,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storeactions_tsx",
       "label": "StoreActions.tsx",
@@ -87454,7 +87619,7 @@
       "source_location": "L1"
     },
     {
-      "community": 546,
+      "community": 547,
       "file_type": "code",
       "id": "storeactions_storeactions",
       "label": "StoreActions()",
@@ -87463,7 +87628,7 @@
       "source_location": "L12"
     },
     {
-      "community": 547,
+      "community": 548,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storedropdown_tsx",
       "label": "StoreDropdown.tsx",
@@ -87472,7 +87637,7 @@
       "source_location": "L1"
     },
     {
-      "community": 547,
+      "community": 548,
       "file_type": "code",
       "id": "storedropdown_storedropdown",
       "label": "StoreDropdown()",
@@ -87481,7 +87646,7 @@
       "source_location": "L42"
     },
     {
-      "community": 548,
+      "community": 549,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storeview_tsx",
       "label": "StoreView.tsx",
@@ -87490,31 +87655,13 @@
       "source_location": "L1"
     },
     {
-      "community": 548,
+      "community": 549,
       "file_type": "code",
       "id": "storeview_navigation",
       "label": "Navigation()",
       "norm_label": "navigation()",
       "source_file": "packages/athena-webapp/src/components/StoreView.tsx",
       "source_location": "L13"
-    },
-    {
-      "community": 549,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_storesdropdown_tsx",
-      "label": "StoresDropdown.tsx",
-      "norm_label": "storesdropdown.tsx",
-      "source_file": "packages/athena-webapp/src/components/StoresDropdown.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 549,
-      "file_type": "code",
-      "id": "storesdropdown_storesdropdown",
-      "label": "StoresDropdown()",
-      "norm_label": "storesdropdown()",
-      "source_file": "packages/athena-webapp/src/components/StoresDropdown.tsx",
-      "source_location": "L42"
     },
     {
       "community": 55,
@@ -87645,6 +87792,24 @@
     {
       "community": 550,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_storesdropdown_tsx",
+      "label": "StoresDropdown.tsx",
+      "norm_label": "storesdropdown.tsx",
+      "source_file": "packages/athena-webapp/src/components/StoresDropdown.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 550,
+      "file_type": "code",
+      "id": "storesdropdown_storesdropdown",
+      "label": "StoresDropdown()",
+      "norm_label": "storesdropdown()",
+      "source_file": "packages/athena-webapp/src/components/StoresDropdown.tsx",
+      "source_location": "L42"
+    },
+    {
+      "community": 551,
+      "file_type": "code",
       "id": "barcodeqrviewer_handleprint",
       "label": "handlePrint()",
       "norm_label": "handleprint()",
@@ -87652,7 +87817,7 @@
       "source_location": "L31"
     },
     {
-      "community": 550,
+      "community": 551,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_barcodeqrviewer_tsx",
       "label": "BarcodeQRViewer.tsx",
@@ -87661,7 +87826,7 @@
       "source_location": "L1"
     },
     {
-      "community": 551,
+      "community": 552,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_processingfees_tsx",
       "label": "ProcessingFees.tsx",
@@ -87670,7 +87835,7 @@
       "source_location": "L1"
     },
     {
-      "community": 551,
+      "community": 552,
       "file_type": "code",
       "id": "processingfees_processingfeesview",
       "label": "ProcessingFeesView()",
@@ -87679,7 +87844,7 @@
       "source_location": "L10"
     },
     {
-      "community": 552,
+      "community": 553,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productattributes_tsx",
       "label": "ProductAttributes.tsx",
@@ -87688,7 +87853,7 @@
       "source_location": "L1"
     },
     {
-      "community": 552,
+      "community": 553,
       "file_type": "code",
       "id": "productattributes_isallowedattribute",
       "label": "isAllowedAttribute()",
@@ -87697,7 +87862,7 @@
       "source_location": "L14"
     },
     {
-      "community": 553,
+      "community": 554,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productavailabilitytogglegroup_tsx",
       "label": "ProductAvailabilityToggleGroup.tsx",
@@ -87706,7 +87871,7 @@
       "source_location": "L1"
     },
     {
-      "community": 553,
+      "community": 554,
       "file_type": "code",
       "id": "productavailabilitytogglegroup_productavailabilitytogglegroup",
       "label": "ProductAvailabilityToggleGroup()",
@@ -87715,7 +87880,7 @@
       "source_location": "L5"
     },
     {
-      "community": 554,
+      "community": 555,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productdetails_tsx",
       "label": "ProductDetails.tsx",
@@ -87724,7 +87889,7 @@
       "source_location": "L1"
     },
     {
-      "community": 554,
+      "community": 555,
       "file_type": "code",
       "id": "productdetails_handlenamechange",
       "label": "handleNameChange()",
@@ -87733,7 +87898,7 @@
       "source_location": "L10"
     },
     {
-      "community": 555,
+      "community": 556,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productimages_tsx",
       "label": "ProductImages.tsx",
@@ -87742,7 +87907,7 @@
       "source_location": "L1"
     },
     {
-      "community": 555,
+      "community": 556,
       "file_type": "code",
       "id": "productimages_header",
       "label": "Header()",
@@ -87751,7 +87916,7 @@
       "source_location": "L15"
     },
     {
-      "community": 556,
+      "community": 557,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productpage_tsx",
       "label": "ProductPage.tsx",
@@ -87760,7 +87925,7 @@
       "source_location": "L1"
     },
     {
-      "community": 556,
+      "community": 557,
       "file_type": "code",
       "id": "productpage_productpage",
       "label": "ProductPage()",
@@ -87769,7 +87934,7 @@
       "source_location": "L13"
     },
     {
-      "community": 557,
+      "community": 558,
       "file_type": "code",
       "id": "copyimagesview_setisupdatingsku",
       "label": "setIsUpdatingSku()",
@@ -87778,7 +87943,7 @@
       "source_location": "L118"
     },
     {
-      "community": 557,
+      "community": 558,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_copyimagesview_tsx",
       "label": "CopyImagesView.tsx",
@@ -87787,7 +87952,7 @@
       "source_location": "L1"
     },
     {
-      "community": 558,
+      "community": 559,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_product_variant_columns_tsx",
       "label": "product-variant-columns.tsx",
@@ -87796,31 +87961,13 @@
       "source_location": "L1"
     },
     {
-      "community": 558,
+      "community": 559,
       "file_type": "code",
       "id": "product_variant_columns_setsourcevariant",
       "label": "setSourceVariant()",
       "norm_label": "setsourcevariant()",
       "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/product-variant-columns.tsx",
       "source_location": "L47"
-    },
-    {
-      "community": 559,
-      "file_type": "code",
-      "id": "activitytimeline_capitalizefirstletter",
-      "label": "capitalizeFirstLetter()",
-      "norm_label": "capitalizefirstletter()",
-      "source_file": "packages/athena-webapp/src/components/analytics/ActivityTimeline.tsx",
-      "source_location": "L151"
-    },
-    {
-      "community": 559,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_activitytimeline_tsx",
-      "label": "ActivityTimeline.tsx",
-      "norm_label": "activitytimeline.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/ActivityTimeline.tsx",
-      "source_location": "L1"
     },
     {
       "community": 56,
@@ -87942,6 +88089,24 @@
     {
       "community": 560,
       "file_type": "code",
+      "id": "activitytimeline_capitalizefirstletter",
+      "label": "capitalizeFirstLetter()",
+      "norm_label": "capitalizefirstletter()",
+      "source_file": "packages/athena-webapp/src/components/analytics/ActivityTimeline.tsx",
+      "source_location": "L151"
+    },
+    {
+      "community": 560,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_activitytimeline_tsx",
+      "label": "ActivityTimeline.tsx",
+      "norm_label": "activitytimeline.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/ActivityTimeline.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 561,
+      "file_type": "code",
       "id": "analyticscombinedusers_analyticscombinedusers",
       "label": "AnalyticsCombinedUsers()",
       "norm_label": "analyticscombinedusers()",
@@ -87949,7 +88114,7 @@
       "source_location": "L5"
     },
     {
-      "community": 560,
+      "community": 561,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticscombinedusers_tsx",
       "label": "AnalyticsCombinedUsers.tsx",
@@ -87958,7 +88123,7 @@
       "source_location": "L1"
     },
     {
-      "community": 561,
+      "community": 562,
       "file_type": "code",
       "id": "analyticsitems_analyticsitems",
       "label": "AnalyticsItems()",
@@ -87967,7 +88132,7 @@
       "source_location": "L6"
     },
     {
-      "community": 561,
+      "community": 562,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticsitems_tsx",
       "label": "AnalyticsItems.tsx",
@@ -87976,7 +88141,7 @@
       "source_location": "L1"
     },
     {
-      "community": 562,
+      "community": 563,
       "file_type": "code",
       "id": "analyticsproducts_analyticsproducts",
       "label": "AnalyticsProducts()",
@@ -87985,7 +88150,7 @@
       "source_location": "L13"
     },
     {
-      "community": 562,
+      "community": 563,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticsproducts_tsx",
       "label": "AnalyticsProducts.tsx",
@@ -87994,7 +88159,7 @@
       "source_location": "L1"
     },
     {
-      "community": 563,
+      "community": 564,
       "file_type": "code",
       "id": "analyticsusers_analyticsusers",
       "label": "AnalyticsUsers()",
@@ -88003,7 +88168,7 @@
       "source_location": "L7"
     },
     {
-      "community": 563,
+      "community": 564,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticsusers_tsx",
       "label": "AnalyticsUsers.tsx",
@@ -88012,7 +88177,7 @@
       "source_location": "L1"
     },
     {
-      "community": 564,
+      "community": 565,
       "file_type": "code",
       "id": "analyticsview_formatmetric",
       "label": "formatMetric()",
@@ -88021,7 +88186,7 @@
       "source_location": "L27"
     },
     {
-      "community": 564,
+      "community": 565,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticsview_tsx",
       "label": "AnalyticsView.tsx",
@@ -88030,7 +88195,7 @@
       "source_location": "L1"
     },
     {
-      "community": 565,
+      "community": 566,
       "file_type": "code",
       "id": "enhancedanalyticsview_getdaterangemilliseconds",
       "label": "getDateRangeMilliseconds()",
@@ -88039,7 +88204,7 @@
       "source_location": "L42"
     },
     {
-      "community": 565,
+      "community": 566,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_enhancedanalyticsview_tsx",
       "label": "EnhancedAnalyticsView.tsx",
@@ -88048,7 +88213,7 @@
       "source_location": "L1"
     },
     {
-      "community": 566,
+      "community": 567,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_storeinsights_tsx",
       "label": "StoreInsights.tsx",
@@ -88057,7 +88222,7 @@
       "source_location": "L1"
     },
     {
-      "community": 566,
+      "community": 567,
       "file_type": "code",
       "id": "storeinsights_gettrendicon",
       "label": "getTrendIcon()",
@@ -88066,7 +88231,7 @@
       "source_location": "L66"
     },
     {
-      "community": 567,
+      "community": 568,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_visitorchart_tsx",
       "label": "VisitorChart.tsx",
@@ -88075,7 +88240,7 @@
       "source_location": "L1"
     },
     {
-      "community": 567,
+      "community": 568,
       "file_type": "code",
       "id": "visitorchart_formathour",
       "label": "formatHour()",
@@ -88084,7 +88249,7 @@
       "source_location": "L18"
     },
     {
-      "community": 568,
+      "community": 569,
       "file_type": "code",
       "id": "analyticsworkspaceefficiency_test_readsource",
       "label": "readSource()",
@@ -88093,30 +88258,12 @@
       "source_location": "L5"
     },
     {
-      "community": 568,
+      "community": 569,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticsworkspaceefficiency_test_ts",
       "label": "analyticsWorkspaceEfficiency.test.ts",
       "norm_label": "analyticsworkspaceefficiency.test.ts",
       "source_file": "packages/athena-webapp/src/components/analytics/analyticsWorkspaceEfficiency.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 569,
-      "file_type": "code",
-      "id": "logitems_logitems",
-      "label": "LogItems()",
-      "norm_label": "logitems()",
-      "source_file": "packages/athena-webapp/src/components/app-logs/LogItems.tsx",
-      "source_location": "L6"
-    },
-    {
-      "community": 569,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_app_logs_logitems_tsx",
-      "label": "LogItems.tsx",
-      "norm_label": "logitems.tsx",
-      "source_file": "packages/athena-webapp/src/components/app-logs/LogItems.tsx",
       "source_location": "L1"
     },
     {
@@ -88239,6 +88386,24 @@
     {
       "community": 570,
       "file_type": "code",
+      "id": "logitems_logitems",
+      "label": "LogItems()",
+      "norm_label": "logitems()",
+      "source_file": "packages/athena-webapp/src/components/app-logs/LogItems.tsx",
+      "source_location": "L6"
+    },
+    {
+      "community": 570,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_app_logs_logitems_tsx",
+      "label": "LogItems.tsx",
+      "norm_label": "logitems.tsx",
+      "source_file": "packages/athena-webapp/src/components/app-logs/LogItems.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 571,
+      "file_type": "code",
       "id": "logview_header",
       "label": "Header()",
       "norm_label": "header()",
@@ -88246,7 +88411,7 @@
       "source_location": "L10"
     },
     {
-      "community": 570,
+      "community": 571,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_logview_tsx",
       "label": "LogView.tsx",
@@ -88255,7 +88420,7 @@
       "source_location": "L1"
     },
     {
-      "community": 571,
+      "community": 572,
       "file_type": "code",
       "id": "logsview_navigation",
       "label": "Navigation()",
@@ -88264,7 +88429,7 @@
       "source_location": "L27"
     },
     {
-      "community": 571,
+      "community": 572,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_logsview_tsx",
       "label": "LogsView.tsx",
@@ -88273,7 +88438,7 @@
       "source_location": "L1"
     },
     {
-      "community": 572,
+      "community": 573,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_hooks_useloadlogitems_ts",
       "label": "useLoadLogItems.ts",
@@ -88282,7 +88447,7 @@
       "source_location": "L1"
     },
     {
-      "community": 572,
+      "community": 573,
       "file_type": "code",
       "id": "useloadlogitems_useloadlogitems",
       "label": "useLoadLogItems()",
@@ -88291,7 +88456,7 @@
       "source_location": "L12"
     },
     {
-      "community": 573,
+      "community": 574,
       "file_type": "code",
       "id": "app_sidebar_sidebarmenucollapsible",
       "label": "SidebarMenuCollapsible()",
@@ -88300,7 +88465,7 @@
       "source_location": "L58"
     },
     {
-      "community": 573,
+      "community": 574,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_sidebar_tsx",
       "label": "app-sidebar.tsx",
@@ -88309,7 +88474,7 @@
       "source_location": "L1"
     },
     {
-      "community": 574,
+      "community": 575,
       "file_type": "code",
       "id": "auth_auth",
       "label": "Auth()",
@@ -88318,7 +88483,7 @@
       "source_location": "L3"
     },
     {
-      "community": 574,
+      "community": 575,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_auth_tsx",
       "label": "Auth.tsx",
@@ -88327,7 +88492,7 @@
       "source_location": "L1"
     },
     {
-      "community": 575,
+      "community": 576,
       "file_type": "code",
       "id": "inputotp_test_resolvesignin",
       "label": "resolveSignIn()",
@@ -88336,7 +88501,7 @@
       "source_location": "L102"
     },
     {
-      "community": 575,
+      "community": 576,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_login_inputotp_test_tsx",
       "label": "InputOTP.test.tsx",
@@ -88345,7 +88510,7 @@
       "source_location": "L1"
     },
     {
-      "community": 576,
+      "community": 577,
       "file_type": "code",
       "id": "index_login",
       "label": "Login()",
@@ -88354,7 +88519,7 @@
       "source_location": "L5"
     },
     {
-      "community": 576,
+      "community": 577,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_login_index_tsx",
       "label": "index.tsx",
@@ -88363,7 +88528,7 @@
       "source_location": "L1"
     },
     {
-      "community": 577,
+      "community": 578,
       "file_type": "code",
       "id": "data_table_column_header_datatablecolumnheader",
       "label": "DataTableColumnHeader()",
@@ -88372,7 +88537,7 @@
       "source_location": "L25"
     },
     {
-      "community": 577,
+      "community": 578,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_data_table_column_header_tsx",
       "label": "data-table-column-header.tsx",
@@ -88381,7 +88546,7 @@
       "source_location": "L1"
     },
     {
-      "community": 578,
+      "community": 579,
       "file_type": "code",
       "id": "bulkoperationsfilters_handleloadproducts",
       "label": "handleLoadProducts()",
@@ -88390,30 +88555,12 @@
       "source_location": "L49"
     },
     {
-      "community": 578,
+      "community": 579,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationsfilters_tsx",
       "label": "BulkOperationsFilters.tsx",
       "norm_label": "bulkoperationsfilters.tsx",
       "source_file": "packages/athena-webapp/src/components/bulk-operations/BulkOperationsFilters.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 579,
-      "file_type": "code",
-      "id": "bulkoperationspreview_test_makerow",
-      "label": "makeRow()",
-      "norm_label": "makerow()",
-      "source_file": "packages/athena-webapp/src/components/bulk-operations/BulkOperationsPreview.test.tsx",
-      "source_location": "L23"
-    },
-    {
-      "community": 579,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationspreview_test_tsx",
-      "label": "BulkOperationsPreview.test.tsx",
-      "norm_label": "bulkoperationspreview.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/bulk-operations/BulkOperationsPreview.test.tsx",
       "source_location": "L1"
     },
     {
@@ -88536,6 +88683,24 @@
     {
       "community": 580,
       "file_type": "code",
+      "id": "bulkoperationspreview_test_makerow",
+      "label": "makeRow()",
+      "norm_label": "makerow()",
+      "source_file": "packages/athena-webapp/src/components/bulk-operations/BulkOperationsPreview.test.tsx",
+      "source_location": "L23"
+    },
+    {
+      "community": 580,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationspreview_test_tsx",
+      "label": "BulkOperationsPreview.test.tsx",
+      "norm_label": "bulkoperationspreview.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/bulk-operations/BulkOperationsPreview.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 581,
+      "file_type": "code",
       "id": "bulkoperationspreview_formatprice",
       "label": "formatPrice()",
       "norm_label": "formatprice()",
@@ -88543,7 +88708,7 @@
       "source_location": "L50"
     },
     {
-      "community": 580,
+      "community": 581,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationspreview_tsx",
       "label": "BulkOperationsPreview.tsx",
@@ -88552,7 +88717,7 @@
       "source_location": "L1"
     },
     {
-      "community": 581,
+      "community": 582,
       "file_type": "code",
       "id": "formatreviewreason_formatreviewreason",
       "label": "formatReviewReason()",
@@ -88561,7 +88726,7 @@
       "source_location": "L3"
     },
     {
-      "community": 581,
+      "community": 582,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_formatreviewreason_ts",
       "label": "formatReviewReason.ts",
@@ -88570,7 +88735,7 @@
       "source_location": "L1"
     },
     {
-      "community": 582,
+      "community": 583,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_registersessioncolumns_tsx",
       "label": "registerSessionColumns.tsx",
@@ -88579,7 +88744,7 @@
       "source_location": "L1"
     },
     {
-      "community": 582,
+      "community": 583,
       "file_type": "code",
       "id": "registersessioncolumns_registersessionlink",
       "label": "RegisterSessionLink()",
@@ -88588,7 +88753,7 @@
       "source_location": "L33"
     },
     {
-      "community": 583,
+      "community": 584,
       "file_type": "code",
       "id": "checkoutsessionstable_checkoutsessionstable",
       "label": "CheckoutSessionsTable()",
@@ -88597,7 +88762,7 @@
       "source_location": "L13"
     },
     {
-      "community": 583,
+      "community": 584,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkoutsessionstable_tsx",
       "label": "CheckoutSessionsTable.tsx",
@@ -88606,7 +88771,7 @@
       "source_location": "L1"
     },
     {
-      "community": 584,
+      "community": 585,
       "file_type": "code",
       "id": "checkoutsesssionsview_navigation",
       "label": "Navigation()",
@@ -88615,7 +88780,7 @@
       "source_location": "L11"
     },
     {
-      "community": 584,
+      "community": 585,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkoutsesssionsview_tsx",
       "label": "CheckoutSesssionsView.tsx",
@@ -88624,7 +88789,7 @@
       "source_location": "L1"
     },
     {
-      "community": 585,
+      "community": 586,
       "file_type": "code",
       "id": "expensecompletion_expensecompletion",
       "label": "ExpenseCompletion()",
@@ -88633,7 +88798,7 @@
       "source_location": "L24"
     },
     {
-      "community": 585,
+      "community": 586,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_expense_expensecompletion_tsx",
       "label": "ExpenseCompletion.tsx",
@@ -88642,7 +88807,7 @@
       "source_location": "L1"
     },
     {
-      "community": 586,
+      "community": 587,
       "file_type": "code",
       "id": "expenseview_expenseview",
       "label": "ExpenseView()",
@@ -88651,7 +88816,7 @@
       "source_location": "L4"
     },
     {
-      "community": 586,
+      "community": 587,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_expense_expenseview_tsx",
       "label": "ExpenseView.tsx",
@@ -88660,7 +88825,7 @@
       "source_location": "L1"
     },
     {
-      "community": 587,
+      "community": 588,
       "file_type": "code",
       "id": "bestsellersdialog_handleaddbestseller",
       "label": "handleAddBestSeller()",
@@ -88669,7 +88834,7 @@
       "source_location": "L29"
     },
     {
-      "community": 587,
+      "community": 588,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_bestsellersdialog_tsx",
       "label": "BestSellersDialog.tsx",
@@ -88678,7 +88843,7 @@
       "source_location": "L1"
     },
     {
-      "community": 588,
+      "community": 589,
       "file_type": "code",
       "id": "featuredsectiondialog_handleaddfeatureditem",
       "label": "handleAddFeaturedItem()",
@@ -88687,30 +88852,12 @@
       "source_location": "L37"
     },
     {
-      "community": 588,
+      "community": 589,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_featuredsectiondialog_tsx",
       "label": "FeaturedSectionDialog.tsx",
       "norm_label": "featuredsectiondialog.tsx",
       "source_file": "packages/athena-webapp/src/components/homepage/FeaturedSectionDialog.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 589,
-      "file_type": "code",
-      "id": "home_navigation",
-      "label": "Navigation()",
-      "norm_label": "navigation()",
-      "source_file": "packages/athena-webapp/src/components/homepage/Home.tsx",
-      "source_location": "L25"
-    },
-    {
-      "community": 589,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_homepage_home_tsx",
-      "label": "Home.tsx",
-      "norm_label": "home.tsx",
-      "source_file": "packages/athena-webapp/src/components/homepage/Home.tsx",
       "source_location": "L1"
     },
     {
@@ -88833,6 +88980,24 @@
     {
       "community": 590,
       "file_type": "code",
+      "id": "home_navigation",
+      "label": "Navigation()",
+      "norm_label": "navigation()",
+      "source_file": "packages/athena-webapp/src/components/homepage/Home.tsx",
+      "source_location": "L25"
+    },
+    {
+      "community": 590,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_homepage_home_tsx",
+      "label": "Home.tsx",
+      "norm_label": "home.tsx",
+      "source_file": "packages/athena-webapp/src/components/homepage/Home.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 591,
+      "file_type": "code",
       "id": "landingpagereelversion_handleupdateconfig",
       "label": "handleUpdateConfig()",
       "norm_label": "handleupdateconfig()",
@@ -88840,7 +89005,7 @@
       "source_location": "L83"
     },
     {
-      "community": 590,
+      "community": 591,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_landingpagereelversion_tsx",
       "label": "LandingPageReelVersion.tsx",
@@ -88849,7 +89014,7 @@
       "source_location": "L1"
     },
     {
-      "community": 591,
+      "community": 592,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_shoplookdialog_tsx",
       "label": "ShopLookDialog.tsx",
@@ -88858,7 +89023,7 @@
       "source_location": "L1"
     },
     {
-      "community": 591,
+      "community": 592,
       "file_type": "code",
       "id": "shoplookdialog_handleaddfeatureditem",
       "label": "handleAddFeaturedItem()",
@@ -88867,7 +89032,7 @@
       "source_location": "L35"
     },
     {
-      "community": 592,
+      "community": 593,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_shoplookimageuploader_tsx",
       "label": "ShopLookImageUploader.tsx",
@@ -88876,7 +89041,7 @@
       "source_location": "L1"
     },
     {
-      "community": 592,
+      "community": 593,
       "file_type": "code",
       "id": "shoplookimageuploader_shoplookimageuploader",
       "label": "ShopLookImageUploader()",
@@ -88885,7 +89050,7 @@
       "source_location": "L28"
     },
     {
-      "community": 593,
+      "community": 594,
       "file_type": "code",
       "id": "index_jointeam",
       "label": "JoinTeam()",
@@ -88894,7 +89059,7 @@
       "source_location": "L12"
     },
     {
-      "community": 593,
+      "community": 594,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_join_team_index_tsx",
       "label": "index.tsx",
@@ -88903,7 +89068,7 @@
       "source_location": "L1"
     },
     {
-      "community": 594,
+      "community": 595,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_test_tsx",
       "label": "StockAdjustmentWorkspace.test.tsx",
@@ -88912,7 +89077,7 @@
       "source_location": "L1"
     },
     {
-      "community": 594,
+      "community": 595,
       "file_type": "code",
       "id": "stockadjustmentworkspace_test_renderstockadjustmentworkspace",
       "label": "renderStockAdjustmentWorkspace()",
@@ -88921,7 +89086,7 @@
       "source_location": "L88"
     },
     {
-      "community": 595,
+      "community": 596,
       "file_type": "code",
       "id": "customerdetailsview_customerdetailsview",
       "label": "CustomerDetailsView()",
@@ -88930,7 +89095,7 @@
       "source_location": "L13"
     },
     {
-      "community": 595,
+      "community": 596,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_customerdetailsview_tsx",
       "label": "CustomerDetailsView.tsx",
@@ -88939,7 +89104,7 @@
       "source_location": "L1"
     },
     {
-      "community": 596,
+      "community": 597,
       "file_type": "code",
       "id": "emailstatusview_handlesendorderemail",
       "label": "handleSendOrderEmail()",
@@ -88948,7 +89113,7 @@
       "source_location": "L43"
     },
     {
-      "community": 596,
+      "community": 597,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_emailstatusview_tsx",
       "label": "EmailStatusView.tsx",
@@ -88957,7 +89122,7 @@
       "source_location": "L1"
     },
     {
-      "community": 597,
+      "community": 598,
       "file_type": "code",
       "id": "ordermetricspanel_handletimerangechange",
       "label": "handleTimeRangeChange()",
@@ -88966,7 +89131,7 @@
       "source_location": "L33"
     },
     {
-      "community": 597,
+      "community": 598,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_ordermetricspanel_tsx",
       "label": "OrderMetricsPanel.tsx",
@@ -88975,7 +89140,7 @@
       "source_location": "L1"
     },
     {
-      "community": 598,
+      "community": 599,
       "file_type": "code",
       "id": "ordersview_gettimefilter",
       "label": "getTimeFilter()",
@@ -88984,31 +89149,13 @@
       "source_location": "L35"
     },
     {
-      "community": 598,
+      "community": 599,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_ordersview_tsx",
       "label": "OrdersView.tsx",
       "norm_label": "ordersview.tsx",
       "source_file": "packages/athena-webapp/src/components/orders/OrdersView.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 599,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_refundsview_tsx",
-      "label": "RefundsView.tsx",
-      "norm_label": "refundsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/RefundsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 599,
-      "file_type": "code",
-      "id": "refundsview_handlerefundorder",
-      "label": "handleRefundOrder()",
-      "norm_label": "handlerefundorder()",
-      "source_file": "packages/athena-webapp/src/components/orders/RefundsView.tsx",
-      "source_location": "L81"
     },
     {
       "community": 6,
@@ -89418,6 +89565,24 @@
     {
       "community": 600,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_refundsview_tsx",
+      "label": "RefundsView.tsx",
+      "norm_label": "refundsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/RefundsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 600,
+      "file_type": "code",
+      "id": "refundsview_handlerefundorder",
+      "label": "handleRefundOrder()",
+      "norm_label": "handlerefundorder()",
+      "source_file": "packages/athena-webapp/src/components/orders/RefundsView.tsx",
+      "source_location": "L81"
+    },
+    {
+      "community": 601,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_hooks_usegetactiveonlineorder_ts",
       "label": "useGetActiveOnlineOrder.ts",
       "norm_label": "usegetactiveonlineorder.ts",
@@ -89425,7 +89590,7 @@
       "source_location": "L1"
     },
     {
-      "community": 600,
+      "community": 601,
       "file_type": "code",
       "id": "usegetactiveonlineorder_usegetactiveonlineorder",
       "label": "useGetActiveOnlineOrder()",
@@ -89434,7 +89599,7 @@
       "source_location": "L6"
     },
     {
-      "community": 601,
+      "community": 602,
       "file_type": "code",
       "id": "data_table_toolbar_handleclearfilters",
       "label": "handleClearFilters()",
@@ -89443,7 +89608,7 @@
       "source_location": "L34"
     },
     {
-      "community": 601,
+      "community": 602,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -89452,7 +89617,7 @@
       "source_location": "L1"
     },
     {
-      "community": 602,
+      "community": 603,
       "file_type": "code",
       "id": "ordercolumns_if",
       "label": "if()",
@@ -89461,7 +89626,7 @@
       "source_location": "L89"
     },
     {
-      "community": 602,
+      "community": 603,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_ordercolumns_tsx",
       "label": "orderColumns.tsx",
@@ -89470,7 +89635,7 @@
       "source_location": "L1"
     },
     {
-      "community": 603,
+      "community": 604,
       "file_type": "code",
       "id": "organization_switcher_organizationswitcher",
       "label": "OrganizationSwitcher()",
@@ -89479,7 +89644,7 @@
       "source_location": "L37"
     },
     {
-      "community": 603,
+      "community": 604,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_switcher_tsx",
       "label": "organization-switcher.tsx",
@@ -89488,7 +89653,7 @@
       "source_location": "L1"
     },
     {
-      "community": 604,
+      "community": 605,
       "file_type": "code",
       "id": "cartitems_cn",
       "label": "cn()",
@@ -89497,7 +89662,7 @@
       "source_location": "L215"
     },
     {
-      "community": 604,
+      "community": 605,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_cartitems_tsx",
       "label": "CartItems.tsx",
@@ -89506,7 +89671,7 @@
       "source_location": "L1"
     },
     {
-      "community": 605,
+      "community": 606,
       "file_type": "code",
       "id": "debugproducts_debugproducts",
       "label": "DebugProducts()",
@@ -89515,7 +89680,7 @@
       "source_location": "L5"
     },
     {
-      "community": 605,
+      "community": 606,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_debugproducts_tsx",
       "label": "DebugProducts.tsx",
@@ -89524,7 +89689,7 @@
       "source_location": "L1"
     },
     {
-      "community": 606,
+      "community": 607,
       "file_type": "code",
       "id": "noresultsmessage_noresultsmessage",
       "label": "NoResultsMessage()",
@@ -89533,7 +89698,7 @@
       "source_location": "L7"
     },
     {
-      "community": 606,
+      "community": 607,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_noresultsmessage_tsx",
       "label": "NoResultsMessage.tsx",
@@ -89542,7 +89707,7 @@
       "source_location": "L1"
     },
     {
-      "community": 607,
+      "community": 608,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_pininput_tsx",
       "label": "PinInput.tsx",
@@ -89551,7 +89716,7 @@
       "source_location": "L1"
     },
     {
-      "community": 607,
+      "community": 608,
       "file_type": "code",
       "id": "pininput_pininput",
       "label": "PinInput()",
@@ -89560,7 +89725,7 @@
       "source_location": "L13"
     },
     {
-      "community": 608,
+      "community": 609,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_pointofsaleview_tsx",
       "label": "PointOfSaleView.tsx",
@@ -89569,31 +89734,13 @@
       "source_location": "L1"
     },
     {
-      "community": 608,
+      "community": 609,
       "file_type": "code",
       "id": "pointofsaleview_navigation",
       "label": "Navigation()",
       "norm_label": "navigation()",
       "source_file": "packages/athena-webapp/src/components/pos/PointOfSaleView.tsx",
       "source_location": "L39"
-    },
-    {
-      "community": 609,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_printinstructions_tsx",
-      "label": "PrintInstructions.tsx",
-      "norm_label": "printinstructions.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/PrintInstructions.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 609,
-      "file_type": "code",
-      "id": "printinstructions_printinstructions",
-      "label": "PrintInstructions()",
-      "norm_label": "printinstructions()",
-      "source_file": "packages/athena-webapp/src/components/pos/PrintInstructions.tsx",
-      "source_location": "L3"
     },
     {
       "community": 61,
@@ -89715,6 +89862,24 @@
     {
       "community": 610,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_printinstructions_tsx",
+      "label": "PrintInstructions.tsx",
+      "norm_label": "printinstructions.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/PrintInstructions.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 610,
+      "file_type": "code",
+      "id": "printinstructions_printinstructions",
+      "label": "PrintInstructions()",
+      "norm_label": "printinstructions()",
+      "source_file": "packages/athena-webapp/src/components/pos/PrintInstructions.tsx",
+      "source_location": "L3"
+    },
+    {
+      "community": 611,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_productcard_tsx",
       "label": "ProductCard.tsx",
       "norm_label": "productcard.tsx",
@@ -89722,7 +89887,7 @@
       "source_location": "L1"
     },
     {
-      "community": 610,
+      "community": 611,
       "file_type": "code",
       "id": "productcard_productcard",
       "label": "ProductCard()",
@@ -89731,7 +89896,7 @@
       "source_location": "L14"
     },
     {
-      "community": 611,
+      "community": 612,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_searchresultssection_test_tsx",
       "label": "SearchResultsSection.test.tsx",
@@ -89740,7 +89905,7 @@
       "source_location": "L1"
     },
     {
-      "community": 611,
+      "community": 612,
       "file_type": "code",
       "id": "searchresultssection_test_buildproduct",
       "label": "buildProduct()",
@@ -89749,7 +89914,7 @@
       "source_location": "L12"
     },
     {
-      "community": 612,
+      "community": 613,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_sessiondemo_tsx",
       "label": "SessionDemo.tsx",
@@ -89758,7 +89923,7 @@
       "source_location": "L1"
     },
     {
-      "community": 612,
+      "community": 613,
       "file_type": "code",
       "id": "sessiondemo_sessiondemo",
       "label": "SessionDemo()",
@@ -89767,7 +89932,7 @@
       "source_location": "L15"
     },
     {
-      "community": 613,
+      "community": 614,
       "file_type": "code",
       "id": "expensecompletionpanel_expensecompletionpanel",
       "label": "ExpenseCompletionPanel()",
@@ -89776,7 +89941,7 @@
       "source_location": "L9"
     },
     {
-      "community": 613,
+      "community": 614,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_expensecompletionpanel_tsx",
       "label": "ExpenseCompletionPanel.tsx",
@@ -89785,7 +89950,7 @@
       "source_location": "L1"
     },
     {
-      "community": 614,
+      "community": 615,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_registercustomerattribution_test_tsx",
       "label": "RegisterCustomerAttribution.test.tsx",
@@ -89794,7 +89959,7 @@
       "source_location": "L1"
     },
     {
-      "community": 614,
+      "community": 615,
       "file_type": "code",
       "id": "registercustomerattribution_test_makecustomer",
       "label": "makeCustomer()",
@@ -89803,7 +89968,7 @@
       "source_location": "L28"
     },
     {
-      "community": 615,
+      "community": 616,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_registercustomerpanel_tsx",
       "label": "RegisterCustomerPanel.tsx",
@@ -89812,7 +89977,7 @@
       "source_location": "L1"
     },
     {
-      "community": 615,
+      "community": 616,
       "file_type": "code",
       "id": "registercustomerpanel_registercustomerpanel",
       "label": "RegisterCustomerPanel()",
@@ -89821,7 +89986,7 @@
       "source_location": "L9"
     },
     {
-      "community": 616,
+      "community": 617,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_registerdrawergate_test_tsx",
       "label": "RegisterDrawerGate.test.tsx",
@@ -89830,7 +89995,7 @@
       "source_location": "L1"
     },
     {
-      "community": 616,
+      "community": 617,
       "file_type": "code",
       "id": "registerdrawergate_test_rendergate",
       "label": "renderGate()",
@@ -89839,7 +90004,7 @@
       "source_location": "L26"
     },
     {
-      "community": 617,
+      "community": 618,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_registersessionpanel_tsx",
       "label": "RegisterSessionPanel.tsx",
@@ -89848,7 +90013,7 @@
       "source_location": "L1"
     },
     {
-      "community": 617,
+      "community": 618,
       "file_type": "code",
       "id": "registersessionpanel_registersessionpanel",
       "label": "RegisterSessionPanel()",
@@ -89857,7 +90022,7 @@
       "source_location": "L9"
     },
     {
-      "community": 618,
+      "community": 619,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_transactions_transactioncolumns_test_tsx",
       "label": "transactionColumns.test.tsx",
@@ -89866,31 +90031,13 @@
       "source_location": "L1"
     },
     {
-      "community": 618,
+      "community": 619,
       "file_type": "code",
       "id": "transactioncolumns_test_rendertransactioncell",
       "label": "renderTransactionCell()",
       "norm_label": "rendertransactioncell()",
       "source_file": "packages/athena-webapp/src/components/pos/transactions/transactionColumns.test.tsx",
       "source_location": "L34"
-    },
-    {
-      "community": 619,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_transactions_transactioncolumns_tsx",
-      "label": "transactionColumns.tsx",
-      "norm_label": "transactioncolumns.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/transactionColumns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 619,
-      "file_type": "code",
-      "id": "transactioncolumns_getpaymentmethodicon",
-      "label": "getPaymentMethodIcon()",
-      "norm_label": "getpaymentmethodicon()",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/transactionColumns.tsx",
-      "source_location": "L26"
     },
     {
       "community": 62,
@@ -90012,6 +90159,24 @@
     {
       "community": 620,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_transactions_transactioncolumns_tsx",
+      "label": "transactionColumns.tsx",
+      "norm_label": "transactioncolumns.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/transactionColumns.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 620,
+      "file_type": "code",
+      "id": "transactioncolumns_getpaymentmethodicon",
+      "label": "getPaymentMethodIcon()",
+      "norm_label": "getpaymentmethodicon()",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/transactionColumns.tsx",
+      "source_location": "L26"
+    },
+    {
+      "community": 621,
+      "file_type": "code",
       "id": "barcodeview_barcodeview",
       "label": "BarcodeView()",
       "norm_label": "barcodeview()",
@@ -90019,7 +90184,7 @@
       "source_location": "L14"
     },
     {
-      "community": 620,
+      "community": 621,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_barcodeview_tsx",
       "label": "BarcodeView.tsx",
@@ -90028,7 +90193,7 @@
       "source_location": "L1"
     },
     {
-      "community": 621,
+      "community": 622,
       "file_type": "code",
       "id": "categorizationview_categorizationview",
       "label": "CategorizationView()",
@@ -90037,7 +90202,7 @@
       "source_location": "L6"
     },
     {
-      "community": 621,
+      "community": 622,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_categorizationview_tsx",
       "label": "CategorizationView.tsx",
@@ -90046,7 +90211,7 @@
       "source_location": "L1"
     },
     {
-      "community": 622,
+      "community": 623,
       "file_type": "code",
       "id": "imagesview_handlekeydown",
       "label": "handleKeyDown()",
@@ -90055,7 +90220,7 @@
       "source_location": "L37"
     },
     {
-      "community": 622,
+      "community": 623,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_imagesview_tsx",
       "label": "ImagesView.tsx",
@@ -90064,7 +90229,7 @@
       "source_location": "L1"
     },
     {
-      "community": 623,
+      "community": 624,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_productstatus_tsx",
       "label": "ProductStatus.tsx",
@@ -90073,7 +90238,7 @@
       "source_location": "L1"
     },
     {
-      "community": 623,
+      "community": 624,
       "file_type": "code",
       "id": "productstatus_productstatus",
       "label": "ProductStatus()",
@@ -90082,7 +90247,7 @@
       "source_location": "L11"
     },
     {
-      "community": 624,
+      "community": 625,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_skuselector_tsx",
       "label": "SKUSelector.tsx",
@@ -90091,7 +90256,7 @@
       "source_location": "L1"
     },
     {
-      "community": 624,
+      "community": 625,
       "file_type": "code",
       "id": "skuselector_skuselector",
       "label": "SKUSelector()",
@@ -90100,7 +90265,7 @@
       "source_location": "L10"
     },
     {
-      "community": 625,
+      "community": 626,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_actions_tsx",
       "label": "product-actions.tsx",
@@ -90109,7 +90274,7 @@
       "source_location": "L1"
     },
     {
-      "community": 625,
+      "community": 626,
       "file_type": "code",
       "id": "product_actions_usearchiveproduct",
       "label": "useArchiveProduct()",
@@ -90118,7 +90283,7 @@
       "source_location": "L6"
     },
     {
-      "community": 626,
+      "community": 627,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_productsview_tsx",
       "label": "ProductsView.tsx",
@@ -90127,7 +90292,7 @@
       "source_location": "L1"
     },
     {
-      "community": 626,
+      "community": 627,
       "file_type": "code",
       "id": "productsview_productsview",
       "label": "ProductsView()",
@@ -90136,7 +90301,7 @@
       "source_location": "L5"
     },
     {
-      "community": 627,
+      "community": 628,
       "file_type": "code",
       "id": "add_product_command_addproductcommand",
       "label": "AddProductCommand()",
@@ -90145,7 +90310,7 @@
       "source_location": "L17"
     },
     {
-      "community": 627,
+      "community": 628,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_add_product_command_tsx",
       "label": "add-product-command.tsx",
@@ -90154,7 +90319,7 @@
       "source_location": "L1"
     },
     {
-      "community": 628,
+      "community": 629,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_products_tsx",
       "label": "Products.tsx",
@@ -90163,31 +90328,13 @@
       "source_location": "L1"
     },
     {
-      "community": 628,
+      "community": 629,
       "file_type": "code",
       "id": "products_products",
       "label": "Products()",
       "norm_label": "products()",
       "source_file": "packages/athena-webapp/src/components/promo-codes/Products.tsx",
       "source_location": "L4"
-    },
-    {
-      "community": 629,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_promocodeform_tsx",
-      "label": "PromoCodeForm.tsx",
-      "norm_label": "promocodeform.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeForm.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 629,
-      "file_type": "code",
-      "id": "promocodeform_togglediscounttype",
-      "label": "toggleDiscountType()",
-      "norm_label": "togglediscounttype()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeForm.tsx",
-      "source_location": "L84"
     },
     {
       "community": 63,
@@ -90309,6 +90456,24 @@
     {
       "community": 630,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_promocodeform_tsx",
+      "label": "PromoCodeForm.tsx",
+      "norm_label": "promocodeform.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeForm.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 630,
+      "file_type": "code",
+      "id": "promocodeform_togglediscounttype",
+      "label": "toggleDiscountType()",
+      "norm_label": "togglediscounttype()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeForm.tsx",
+      "source_location": "L84"
+    },
+    {
+      "community": 631,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodeheader_tsx",
       "label": "PromoCodeHeader.tsx",
       "norm_label": "promocodeheader.tsx",
@@ -90316,7 +90481,7 @@
       "source_location": "L1"
     },
     {
-      "community": 630,
+      "community": 631,
       "file_type": "code",
       "id": "promocodeheader_handledeletepromocode",
       "label": "handleDeletePromoCode()",
@@ -90325,7 +90490,7 @@
       "source_location": "L23"
     },
     {
-      "community": 631,
+      "community": 632,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodepreview_tsx",
       "label": "PromoCodePreview.tsx",
@@ -90334,7 +90499,7 @@
       "source_location": "L1"
     },
     {
-      "community": 631,
+      "community": 632,
       "file_type": "code",
       "id": "promocodepreview_discount",
       "label": "Discount()",
@@ -90343,7 +90508,7 @@
       "source_location": "L37"
     },
     {
-      "community": 632,
+      "community": 633,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodesview_tsx",
       "label": "PromoCodesView.tsx",
@@ -90352,7 +90517,7 @@
       "source_location": "L1"
     },
     {
-      "community": 632,
+      "community": 633,
       "file_type": "code",
       "id": "promocodesview_promocodesview",
       "label": "PromoCodesView()",
@@ -90361,7 +90526,7 @@
       "source_location": "L9"
     },
     {
-      "community": 633,
+      "community": 634,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectablecategories_tsx",
       "label": "SelectableCategories.tsx",
@@ -90370,7 +90535,7 @@
       "source_location": "L1"
     },
     {
-      "community": 633,
+      "community": 634,
       "file_type": "code",
       "id": "selectablecategories_toggle",
       "label": "toggle()",
@@ -90379,7 +90544,7 @@
       "source_location": "L23"
     },
     {
-      "community": 634,
+      "community": 635,
       "file_type": "code",
       "id": "discounttypetogglegroup_discounttypetogglegroup",
       "label": "DiscountTypeToggleGroup()",
@@ -90388,7 +90553,7 @@
       "source_location": "L5"
     },
     {
-      "community": 634,
+      "community": 635,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_add_promo_code_discounttypetogglegroup_tsx",
       "label": "DiscountTypeToggleGroup.tsx",
@@ -90397,7 +90562,7 @@
       "source_location": "L1"
     },
     {
-      "community": 635,
+      "community": 636,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_add_promo_code_promocodespantogglegroup_tsx",
       "label": "PromoCodeSpanToggleGroup.tsx",
@@ -90406,7 +90571,7 @@
       "source_location": "L1"
     },
     {
-      "community": 635,
+      "community": 636,
       "file_type": "code",
       "id": "promocodespantogglegroup_promocodespantogglegroup",
       "label": "PromoCodeSpanToggleGroup()",
@@ -90415,7 +90580,7 @@
       "source_location": "L4"
     },
     {
-      "community": 636,
+      "community": 637,
       "file_type": "code",
       "id": "capturedemails_capturedemails",
       "label": "CapturedEmails()",
@@ -90424,7 +90589,7 @@
       "source_location": "L13"
     },
     {
-      "community": 636,
+      "community": 637,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_captured_capturedemails_tsx",
       "label": "CapturedEmails.tsx",
@@ -90433,7 +90598,7 @@
       "source_location": "L1"
     },
     {
-      "community": 637,
+      "community": 638,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_modals_promo_code_modal_tsx",
       "label": "promo-code-modal.tsx",
@@ -90442,7 +90607,7 @@
       "source_location": "L1"
     },
     {
-      "community": 637,
+      "community": 638,
       "file_type": "code",
       "id": "promo_code_modal_promocodemodal",
       "label": "PromoCodeModal()",
@@ -90451,7 +90616,7 @@
       "source_location": "L29"
     },
     {
-      "community": 638,
+      "community": 639,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reviews_reviewactions_tsx",
       "label": "ReviewActions.tsx",
@@ -90460,31 +90625,13 @@
       "source_location": "L1"
     },
     {
-      "community": 638,
+      "community": 639,
       "file_type": "code",
       "id": "reviewactions_reviewactions",
       "label": "ReviewActions()",
       "norm_label": "reviewactions()",
       "source_file": "packages/athena-webapp/src/components/reviews/ReviewActions.tsx",
       "source_location": "L20"
-    },
-    {
-      "community": 639,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_services_servicecasesview_test_tsx",
-      "label": "ServiceCasesView.test.tsx",
-      "norm_label": "servicecasesview.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceCasesView.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 639,
-      "file_type": "code",
-      "id": "servicecasesview_test_chooseselectoption",
-      "label": "chooseSelectOption()",
-      "norm_label": "chooseselectoption()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceCasesView.test.tsx",
-      "source_location": "L63"
     },
     {
       "community": 64,
@@ -90597,6 +90744,24 @@
     {
       "community": 640,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_services_servicecasesview_test_tsx",
+      "label": "ServiceCasesView.test.tsx",
+      "norm_label": "servicecasesview.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceCasesView.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 640,
+      "file_type": "code",
+      "id": "servicecasesview_test_chooseselectoption",
+      "label": "chooseSelectOption()",
+      "norm_label": "chooseselectoption()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceCasesView.test.tsx",
+      "source_location": "L63"
+    },
+    {
+      "community": 641,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_servicecatalogview_test_tsx",
       "label": "ServiceCatalogView.test.tsx",
       "norm_label": "servicecatalogview.test.tsx",
@@ -90604,7 +90769,7 @@
       "source_location": "L1"
     },
     {
-      "community": 640,
+      "community": 641,
       "file_type": "code",
       "id": "servicecatalogview_test_chooseselectoption",
       "label": "chooseSelectOption()",
@@ -90613,7 +90778,7 @@
       "source_location": "L30"
     },
     {
-      "community": 641,
+      "community": 642,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_serviceintakeform_tsx",
       "label": "ServiceIntakeForm.tsx",
@@ -90622,7 +90787,7 @@
       "source_location": "L1"
     },
     {
-      "community": 641,
+      "community": 642,
       "file_type": "code",
       "id": "serviceintakeform_serviceintakeform",
       "label": "ServiceIntakeForm()",
@@ -90631,7 +90796,7 @@
       "source_location": "L59"
     },
     {
-      "community": 642,
+      "community": 643,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_serviceintakeview_auth_test_tsx",
       "label": "ServiceIntakeView.auth.test.tsx",
@@ -90640,7 +90805,7 @@
       "source_location": "L1"
     },
     {
-      "community": 642,
+      "community": 643,
       "file_type": "code",
       "id": "serviceintakeview_auth_test_chooseselectoption",
       "label": "chooseSelectOption()",
@@ -90649,7 +90814,7 @@
       "source_location": "L45"
     },
     {
-      "community": 643,
+      "community": 644,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_serviceintakeview_test_tsx",
       "label": "ServiceIntakeView.test.tsx",
@@ -90658,7 +90823,7 @@
       "source_location": "L1"
     },
     {
-      "community": 643,
+      "community": 644,
       "file_type": "code",
       "id": "serviceintakeview_test_chooseselectoption",
       "label": "chooseSelectOption()",
@@ -90667,7 +90832,7 @@
       "source_location": "L47"
     },
     {
-      "community": 644,
+      "community": 645,
       "file_type": "code",
       "id": "empty_state_onclick",
       "label": "onClick()",
@@ -90676,7 +90841,7 @@
       "source_location": "L29"
     },
     {
-      "community": 644,
+      "community": 645,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_empty_empty_state_tsx",
       "label": "empty-state.tsx",
@@ -90685,7 +90850,7 @@
       "source_location": "L1"
     },
     {
-      "community": 645,
+      "community": 646,
       "file_type": "code",
       "id": "nopermission_nopermission",
       "label": "NoPermission()",
@@ -90694,7 +90859,7 @@
       "source_location": "L3"
     },
     {
-      "community": 645,
+      "community": 646,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_no_permission_nopermission_tsx",
       "label": "NoPermission.tsx",
@@ -90703,7 +90868,7 @@
       "source_location": "L1"
     },
     {
-      "community": 646,
+      "community": 647,
       "file_type": "code",
       "id": "nopermissionview_nopermissionview",
       "label": "NoPermissionView()",
@@ -90712,7 +90877,7 @@
       "source_location": "L4"
     },
     {
-      "community": 646,
+      "community": 647,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_no_permission_nopermissionview_tsx",
       "label": "NoPermissionView.tsx",
@@ -90721,7 +90886,7 @@
       "source_location": "L1"
     },
     {
-      "community": 647,
+      "community": 648,
       "file_type": "code",
       "id": "notfoundview_notfoundview",
       "label": "NotFoundView()",
@@ -90730,7 +90895,7 @@
       "source_location": "L4"
     },
     {
-      "community": 647,
+      "community": 648,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_not_found_notfoundview_tsx",
       "label": "NotFoundView.tsx",
@@ -90739,7 +90904,7 @@
       "source_location": "L1"
     },
     {
-      "community": 648,
+      "community": 649,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_signed_out_protectedadminsigninview_tsx",
       "label": "ProtectedAdminSignInView.tsx",
@@ -90748,31 +90913,13 @@
       "source_location": "L1"
     },
     {
-      "community": 648,
+      "community": 649,
       "file_type": "code",
       "id": "protectedadminsigninview_protectedadminsigninview",
       "label": "ProtectedAdminSignInView()",
       "norm_label": "protectedadminsigninview()",
       "source_file": "packages/athena-webapp/src/components/states/signed-out/ProtectedAdminSignInView.tsx",
       "source_location": "L9"
-    },
-    {
-      "community": 649,
-      "file_type": "code",
-      "id": "contactview_contactview",
-      "label": "ContactView()",
-      "norm_label": "contactview()",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/ContactView.tsx",
-      "source_location": "L9"
-    },
-    {
-      "community": 649,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_store_configuration_components_contactview_tsx",
-      "label": "ContactView.tsx",
-      "norm_label": "contactview.tsx",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/ContactView.tsx",
-      "source_location": "L1"
     },
     {
       "community": 65,
@@ -90876,6 +91023,24 @@
     {
       "community": 650,
       "file_type": "code",
+      "id": "contactview_contactview",
+      "label": "ContactView()",
+      "norm_label": "contactview()",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/ContactView.tsx",
+      "source_location": "L9"
+    },
+    {
+      "community": 650,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_store_configuration_components_contactview_tsx",
+      "label": "ContactView.tsx",
+      "norm_label": "contactview.tsx",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/ContactView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 651,
+      "file_type": "code",
       "id": "header_header",
       "label": "Header()",
       "norm_label": "header()",
@@ -90883,7 +91048,7 @@
       "source_location": "L1"
     },
     {
-      "community": 650,
+      "community": 651,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_header_tsx",
       "label": "Header.tsx",
@@ -90892,7 +91057,7 @@
       "source_location": "L1"
     },
     {
-      "community": 651,
+      "community": 652,
       "file_type": "code",
       "id": "maintenanceview_maintenanceview",
       "label": "MaintenanceView()",
@@ -90901,7 +91066,7 @@
       "source_location": "L11"
     },
     {
-      "community": 651,
+      "community": 652,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_maintenanceview_tsx",
       "label": "MaintenanceView.tsx",
@@ -90910,7 +91075,7 @@
       "source_location": "L1"
     },
     {
-      "community": 652,
+      "community": 653,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_taxview_tsx",
       "label": "TaxView.tsx",
@@ -90919,7 +91084,7 @@
       "source_location": "L1"
     },
     {
-      "community": 652,
+      "community": 653,
       "file_type": "code",
       "id": "taxview_handleupdatetaxsettings",
       "label": "handleUpdateTaxSettings()",
@@ -90928,7 +91093,7 @@
       "source_location": "L25"
     },
     {
-      "community": 653,
+      "community": 654,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_hooks_usestoreconfigupdate_ts",
       "label": "useStoreConfigUpdate.ts",
@@ -90937,7 +91102,7 @@
       "source_location": "L1"
     },
     {
-      "community": 653,
+      "community": 654,
       "file_type": "code",
       "id": "usestoreconfigupdate_usestoreconfigupdate",
       "label": "useStoreConfigUpdate()",
@@ -90946,7 +91111,7 @@
       "source_location": "L21"
     },
     {
-      "community": 654,
+      "community": 655,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_switcher_tsx",
       "label": "store-switcher.tsx",
@@ -90955,7 +91120,7 @@
       "source_location": "L1"
     },
     {
-      "community": 654,
+      "community": 655,
       "file_type": "code",
       "id": "store_switcher_onstoreselect",
       "label": "onStoreSelect()",
@@ -90964,7 +91129,7 @@
       "source_location": "L63"
     },
     {
-      "community": 655,
+      "community": 656,
       "file_type": "code",
       "id": "calendar_calendar",
       "label": "Calendar()",
@@ -90973,7 +91138,7 @@
       "source_location": "L7"
     },
     {
-      "community": 655,
+      "community": 656,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_calendar_tsx",
       "label": "calendar.tsx",
@@ -90982,7 +91147,7 @@
       "source_location": "L1"
     },
     {
-      "community": 656,
+      "community": 657,
       "file_type": "code",
       "id": "chart_usechart",
       "label": "useChart()",
@@ -90991,7 +91156,7 @@
       "source_location": "L25"
     },
     {
-      "community": 656,
+      "community": 657,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_chart_tsx",
       "label": "chart.tsx",
@@ -91000,7 +91165,7 @@
       "source_location": "L1"
     },
     {
-      "community": 657,
+      "community": 658,
       "file_type": "code",
       "id": "copy_button_handlecopy",
       "label": "handleCopy()",
@@ -91009,7 +91174,7 @@
       "source_location": "L15"
     },
     {
-      "community": 657,
+      "community": 658,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_copy_button_tsx",
       "label": "copy-button.tsx",
@@ -91018,7 +91183,7 @@
       "source_location": "L1"
     },
     {
-      "community": 658,
+      "community": 659,
       "file_type": "code",
       "id": "copy_wrapper_handlecopy",
       "label": "handleCopy()",
@@ -91027,30 +91192,12 @@
       "source_location": "L21"
     },
     {
-      "community": 658,
+      "community": 659,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_copy_wrapper_tsx",
       "label": "copy-wrapper.tsx",
       "norm_label": "copy-wrapper.tsx",
       "source_file": "packages/athena-webapp/src/components/ui/copy-wrapper.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 659,
-      "file_type": "code",
-      "id": "label_label",
-      "label": "Label()",
-      "norm_label": "label()",
-      "source_file": "packages/athena-webapp/src/components/ui/label.tsx",
-      "source_location": "L6"
-    },
-    {
-      "community": 659,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_label_tsx",
-      "label": "label.tsx",
-      "norm_label": "label.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/label.tsx",
       "source_location": "L1"
     },
     {
@@ -91155,6 +91302,24 @@
     {
       "community": 660,
       "file_type": "code",
+      "id": "label_label",
+      "label": "Label()",
+      "norm_label": "label()",
+      "source_file": "packages/athena-webapp/src/components/ui/label.tsx",
+      "source_location": "L6"
+    },
+    {
+      "community": 660,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_label_tsx",
+      "label": "label.tsx",
+      "norm_label": "label.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/label.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 661,
+      "file_type": "code",
       "id": "custom_modal_custommodal",
       "label": "CustomModal()",
       "norm_label": "custommodal()",
@@ -91162,7 +91327,7 @@
       "source_location": "L25"
     },
     {
-      "community": 660,
+      "community": 661,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_custom_modal_tsx",
       "label": "custom-modal.tsx",
@@ -91171,7 +91336,7 @@
       "source_location": "L1"
     },
     {
-      "community": 661,
+      "community": 662,
       "file_type": "code",
       "id": "organization_modal_onsubmit",
       "label": "onSubmit()",
@@ -91180,7 +91345,7 @@
       "source_location": "L49"
     },
     {
-      "community": 661,
+      "community": 662,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_organization_modal_tsx",
       "label": "organization-modal.tsx",
@@ -91189,7 +91354,7 @@
       "source_location": "L1"
     },
     {
-      "community": 662,
+      "community": 663,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_store_modal_tsx",
       "label": "store-modal.tsx",
@@ -91198,7 +91363,7 @@
       "source_location": "L1"
     },
     {
-      "community": 662,
+      "community": 663,
       "file_type": "code",
       "id": "store_modal_onsubmit",
       "label": "onSubmit()",
@@ -91207,7 +91372,7 @@
       "source_location": "L63"
     },
     {
-      "community": 663,
+      "community": 664,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_welcome_back_modal_example_tsx",
       "label": "welcome-back-modal-example.tsx",
@@ -91216,7 +91381,7 @@
       "source_location": "L1"
     },
     {
-      "community": 663,
+      "community": 664,
       "file_type": "code",
       "id": "welcome_back_modal_example_welcomebackmodalexample",
       "label": "WelcomeBackModalExample()",
@@ -91225,7 +91390,7 @@
       "source_location": "L5"
     },
     {
-      "community": 664,
+      "community": 665,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_welcome_back_modal_tsx",
       "label": "welcome-back-modal.tsx",
@@ -91234,7 +91399,7 @@
       "source_location": "L1"
     },
     {
-      "community": 664,
+      "community": 665,
       "file_type": "code",
       "id": "welcome_back_modal_welcomebackmodal",
       "label": "WelcomeBackModal()",
@@ -91243,7 +91408,7 @@
       "source_location": "L12"
     },
     {
-      "community": 665,
+      "community": 666,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_select_native_tsx",
       "label": "select-native.tsx",
@@ -91252,7 +91417,7 @@
       "source_location": "L1"
     },
     {
-      "community": 665,
+      "community": 666,
       "file_type": "code",
       "id": "select_native_cn",
       "label": "cn()",
@@ -91261,7 +91426,7 @@
       "source_location": "L15"
     },
     {
-      "community": 666,
+      "community": 667,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_timeline_item_tsx",
       "label": "timeline-item.tsx",
@@ -91270,7 +91435,7 @@
       "source_location": "L1"
     },
     {
-      "community": 666,
+      "community": 667,
       "file_type": "code",
       "id": "timeline_item_timelineitem",
       "label": "TimelineItem()",
@@ -91279,7 +91444,7 @@
       "source_location": "L3"
     },
     {
-      "community": 667,
+      "community": 668,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_webp_image_tsx",
       "label": "webp-image.tsx",
@@ -91288,7 +91453,7 @@
       "source_location": "L1"
     },
     {
-      "community": 667,
+      "community": 668,
       "file_type": "code",
       "id": "webp_image_webpimage",
       "label": "WebpImage()",
@@ -91297,7 +91462,7 @@
       "source_location": "L1"
     },
     {
-      "community": 668,
+      "community": 669,
       "file_type": "code",
       "id": "bagitems_bagitems",
       "label": "BagItems()",
@@ -91306,30 +91471,12 @@
       "source_location": "L5"
     },
     {
-      "community": 668,
+      "community": 669,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_bagitems_tsx",
       "label": "BagItems.tsx",
       "norm_label": "bagitems.tsx",
       "source_file": "packages/athena-webapp/src/components/user-bags/BagItems.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 669,
-      "file_type": "code",
-      "id": "bagitemsview_bagitemsview",
-      "label": "BagItemsView()",
-      "norm_label": "bagitemsview()",
-      "source_file": "packages/athena-webapp/src/components/user-bags/BagItemsView.tsx",
-      "source_location": "L11"
-    },
-    {
-      "community": 669,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_bagitemsview_tsx",
-      "label": "BagItemsView.tsx",
-      "norm_label": "bagitemsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/BagItemsView.tsx",
       "source_location": "L1"
     },
     {
@@ -91434,6 +91581,24 @@
     {
       "community": 670,
       "file_type": "code",
+      "id": "bagitemsview_bagitemsview",
+      "label": "BagItemsView()",
+      "norm_label": "bagitemsview()",
+      "source_file": "packages/athena-webapp/src/components/user-bags/BagItemsView.tsx",
+      "source_location": "L11"
+    },
+    {
+      "community": 670,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_bagitemsview_tsx",
+      "label": "BagItemsView.tsx",
+      "norm_label": "bagitemsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/BagItemsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 671,
+      "file_type": "code",
       "id": "bags_bags",
       "label": "Bags()",
       "norm_label": "bags()",
@@ -91441,7 +91606,7 @@
       "source_location": "L4"
     },
     {
-      "community": 670,
+      "community": 671,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_bags_tsx",
       "label": "Bags.tsx",
@@ -91450,7 +91615,7 @@
       "source_location": "L1"
     },
     {
-      "community": 671,
+      "community": 672,
       "file_type": "code",
       "id": "customerbehaviortimeline_string",
       "label": "String()",
@@ -91459,7 +91624,7 @@
       "source_location": "L102"
     },
     {
-      "community": 671,
+      "community": 672,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_customerbehaviortimeline_tsx",
       "label": "CustomerBehaviorTimeline.tsx",
@@ -91468,7 +91633,7 @@
       "source_location": "L1"
     },
     {
-      "community": 672,
+      "community": 673,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_useranalyticsname_tsx",
       "label": "UserAnalyticsName.tsx",
@@ -91477,7 +91642,7 @@
       "source_location": "L1"
     },
     {
-      "community": 672,
+      "community": 673,
       "file_type": "code",
       "id": "useranalyticsname_useranalyticsname",
       "label": "UserAnalyticsName()",
@@ -91486,7 +91651,7 @@
       "source_location": "L13"
     },
     {
-      "community": 673,
+      "community": 674,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_userbag_tsx",
       "label": "UserBag.tsx",
@@ -91495,7 +91660,7 @@
       "source_location": "L1"
     },
     {
-      "community": 673,
+      "community": 674,
       "file_type": "code",
       "id": "userbag_userbag",
       "label": "UserBag()",
@@ -91504,7 +91669,7 @@
       "source_location": "L7"
     },
     {
-      "community": 674,
+      "community": 675,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_useronlineorders_tsx",
       "label": "UserOnlineOrders.tsx",
@@ -91513,7 +91678,7 @@
       "source_location": "L1"
     },
     {
-      "community": 674,
+      "community": 675,
       "file_type": "code",
       "id": "useronlineorders_useronlineorders",
       "label": "UserOnlineOrders()",
@@ -91522,7 +91687,7 @@
       "source_location": "L11"
     },
     {
-      "community": 675,
+      "community": 676,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_userstatus_tsx",
       "label": "UserStatus.tsx",
@@ -91531,7 +91696,7 @@
       "source_location": "L1"
     },
     {
-      "community": 675,
+      "community": 676,
       "file_type": "code",
       "id": "userstatus_userstatus",
       "label": "UserStatus()",
@@ -91540,7 +91705,7 @@
       "source_location": "L7"
     },
     {
-      "community": 676,
+      "community": 677,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_userview_tsx",
       "label": "UserView.tsx",
@@ -91549,7 +91714,7 @@
       "source_location": "L1"
     },
     {
-      "community": 676,
+      "community": 677,
       "file_type": "code",
       "id": "userview_useractions",
       "label": "UserActions()",
@@ -91558,7 +91723,7 @@
       "source_location": "L45"
     },
     {
-      "community": 677,
+      "community": 678,
       "file_type": "code",
       "id": "customerjourneystage_customerjourneystagecard",
       "label": "CustomerJourneyStageCard()",
@@ -91567,7 +91732,7 @@
       "source_location": "L13"
     },
     {
-      "community": 677,
+      "community": 678,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_customerjourneystage_tsx",
       "label": "CustomerJourneyStage.tsx",
@@ -91576,7 +91741,7 @@
       "source_location": "L1"
     },
     {
-      "community": 678,
+      "community": 679,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_image_upload_ts",
       "label": "use-image-upload.ts",
@@ -91585,31 +91750,13 @@
       "source_location": "L1"
     },
     {
-      "community": 678,
+      "community": 679,
       "file_type": "code",
       "id": "use_image_upload_useimageupload",
       "label": "useImageUpload()",
       "norm_label": "useimageupload()",
       "source_file": "packages/athena-webapp/src/hooks/use-image-upload.ts",
       "source_location": "L7"
-    },
-    {
-      "community": 679,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_use_mobile_tsx",
-      "label": "use-mobile.tsx",
-      "norm_label": "use-mobile.tsx",
-      "source_file": "packages/athena-webapp/src/hooks/use-mobile.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 679,
-      "file_type": "code",
-      "id": "use_mobile_useismobile",
-      "label": "useIsMobile()",
-      "norm_label": "useismobile()",
-      "source_file": "packages/athena-webapp/src/hooks/use-mobile.tsx",
-      "source_location": "L5"
     },
     {
       "community": 68,
@@ -91713,6 +91860,24 @@
     {
       "community": 680,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_use_mobile_tsx",
+      "label": "use-mobile.tsx",
+      "norm_label": "use-mobile.tsx",
+      "source_file": "packages/athena-webapp/src/hooks/use-mobile.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 680,
+      "file_type": "code",
+      "id": "use_mobile_useismobile",
+      "label": "useIsMobile()",
+      "norm_label": "useismobile()",
+      "source_file": "packages/athena-webapp/src/hooks/use-mobile.tsx",
+      "source_location": "L5"
+    },
+    {
+      "community": 681,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_navigate_back_ts",
       "label": "use-navigate-back.ts",
       "norm_label": "use-navigate-back.ts",
@@ -91720,7 +91885,7 @@
       "source_location": "L1"
     },
     {
-      "community": 680,
+      "community": 681,
       "file_type": "code",
       "id": "use_navigate_back_usenavigateback",
       "label": "useNavigateBack()",
@@ -91729,7 +91894,7 @@
       "source_location": "L5"
     },
     {
-      "community": 681,
+      "community": 682,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_navigation_keyboard_shortcuts_ts",
       "label": "use-navigation-keyboard-shortcuts.ts",
@@ -91738,7 +91903,7 @@
       "source_location": "L1"
     },
     {
-      "community": 681,
+      "community": 682,
       "file_type": "code",
       "id": "use_navigation_keyboard_shortcuts_usenavigationkeyboardshortcuts",
       "label": "useNavigationKeyboardShortcuts()",
@@ -91747,7 +91912,7 @@
       "source_location": "L7"
     },
     {
-      "community": 682,
+      "community": 683,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_pagination_persistence_ts",
       "label": "use-pagination-persistence.ts",
@@ -91756,7 +91921,7 @@
       "source_location": "L1"
     },
     {
-      "community": 682,
+      "community": 683,
       "file_type": "code",
       "id": "use_pagination_persistence_usepaginationpersistence",
       "label": "usePaginationPersistence()",
@@ -91765,7 +91930,7 @@
       "source_location": "L11"
     },
     {
-      "community": 683,
+      "community": 684,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_table_keyboard_pagination_ts",
       "label": "use-table-keyboard-pagination.ts",
@@ -91774,7 +91939,7 @@
       "source_location": "L1"
     },
     {
-      "community": 683,
+      "community": 684,
       "file_type": "code",
       "id": "use_table_keyboard_pagination_usetablekeyboardpagination",
       "label": "useTableKeyboardPagination()",
@@ -91783,7 +91948,7 @@
       "source_location": "L6"
     },
     {
-      "community": 684,
+      "community": 685,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usebulkoperations_test_ts",
       "label": "useBulkOperations.test.ts",
@@ -91792,7 +91957,7 @@
       "source_location": "L1"
     },
     {
-      "community": 684,
+      "community": 685,
       "file_type": "code",
       "id": "usebulkoperations_test_makesku",
       "label": "makeSku()",
@@ -91801,7 +91966,7 @@
       "source_location": "L168"
     },
     {
-      "community": 685,
+      "community": 686,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useconvexauthidentity_ts",
       "label": "useConvexAuthIdentity.ts",
@@ -91810,7 +91975,7 @@
       "source_location": "L1"
     },
     {
-      "community": 685,
+      "community": 686,
       "file_type": "code",
       "id": "useconvexauthidentity_useconvexauthidentity",
       "label": "useConvexAuthIdentity()",
@@ -91819,7 +91984,7 @@
       "source_location": "L5"
     },
     {
-      "community": 686,
+      "community": 687,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usecopytext_ts",
       "label": "useCopyText.ts",
@@ -91828,7 +91993,7 @@
       "source_location": "L1"
     },
     {
-      "community": 686,
+      "community": 687,
       "file_type": "code",
       "id": "usecopytext_usecopytext",
       "label": "useCopyText()",
@@ -91837,7 +92002,7 @@
       "source_location": "L1"
     },
     {
-      "community": 687,
+      "community": 688,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usecreatecomplimentaryproduct_ts",
       "label": "useCreateComplimentaryProduct.ts",
@@ -91846,7 +92011,7 @@
       "source_location": "L1"
     },
     {
-      "community": 687,
+      "community": 688,
       "file_type": "code",
       "id": "usecreatecomplimentaryproduct_usecreatecomplimentaryproduct",
       "label": "useCreateComplimentaryProduct()",
@@ -91855,7 +92020,7 @@
       "source_location": "L6"
     },
     {
-      "community": 688,
+      "community": 689,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usedebounce_ts",
       "label": "useDebounce.ts",
@@ -91864,31 +92029,13 @@
       "source_location": "L1"
     },
     {
-      "community": 688,
+      "community": 689,
       "file_type": "code",
       "id": "usedebounce_usedebounce",
       "label": "useDebounce()",
       "norm_label": "usedebounce()",
       "source_file": "packages/athena-webapp/src/hooks/useDebounce.ts",
       "source_location": "L12"
-    },
-    {
-      "community": 689,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_useexpenseoperations_ts",
-      "label": "useExpenseOperations.ts",
-      "norm_label": "useexpenseoperations.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseOperations.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 689,
-      "file_type": "code",
-      "id": "useexpenseoperations_useexpenseoperations",
-      "label": "useExpenseOperations()",
-      "norm_label": "useexpenseoperations()",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseOperations.ts",
-      "source_location": "L24"
     },
     {
       "community": 69,
@@ -98850,73 +98997,73 @@
     {
       "community": 95,
       "file_type": "code",
-      "id": "config_buildmtncollectionscallbackurl",
-      "label": "buildMtnCollectionsCallbackUrl()",
-      "norm_label": "buildmtncollectionscallbackurl()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
-      "source_location": "L135"
+      "id": "index_senddiscountcodeemail",
+      "label": "sendDiscountCodeEmail()",
+      "norm_label": "senddiscountcodeemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L255"
     },
     {
       "community": 95,
       "file_type": "code",
-      "id": "config_buildmtncollectionslookupprefixes",
-      "label": "buildMtnCollectionsLookupPrefixes()",
-      "norm_label": "buildmtncollectionslookupprefixes()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "id": "index_senddiscountreminderemail",
+      "label": "sendDiscountReminderEmail()",
+      "norm_label": "senddiscountreminderemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L334"
+    },
+    {
+      "community": 95,
+      "file_type": "code",
+      "id": "index_sendfeedbackrequestemail",
+      "label": "sendFeedbackRequestEmail()",
+      "norm_label": "sendfeedbackrequestemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L167"
+    },
+    {
+      "community": 95,
+      "file_type": "code",
+      "id": "index_sendneworderemail",
+      "label": "sendNewOrderEmail()",
+      "norm_label": "sendneworderemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L117"
+    },
+    {
+      "community": 95,
+      "file_type": "code",
+      "id": "index_sendorderemail",
+      "label": "sendOrderEmail()",
+      "norm_label": "sendorderemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
       "source_location": "L43"
     },
     {
       "community": 95,
       "file_type": "code",
-      "id": "config_istargetenvironment",
-      "label": "isTargetEnvironment()",
-      "norm_label": "istargetenvironment()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
-      "source_location": "L67"
+      "id": "index_sendverificationcode",
+      "label": "sendVerificationCode()",
+      "norm_label": "sendverificationcode()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L3"
     },
     {
       "community": 95,
       "file_type": "code",
-      "id": "config_readscopedvalue",
-      "label": "readScopedValue()",
-      "norm_label": "readscopedvalue()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
-      "source_location": "L56"
+      "id": "packages_athena_webapp_convex_mailersend_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/convex/mailersend/index.tsx",
+      "source_location": "L1"
     },
     {
       "community": 95,
       "file_type": "code",
-      "id": "config_resolveconfigforprefix",
-      "label": "resolveConfigForPrefix()",
-      "norm_label": "resolveconfigforprefix()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
-      "source_location": "L73"
-    },
-    {
-      "community": 95,
-      "file_type": "code",
-      "id": "config_resolvemtncollectionsconfigfromenv",
-      "label": "resolveMtnCollectionsConfigFromEnv()",
-      "norm_label": "resolvemtncollectionsconfigfromenv()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
-      "source_location": "L108"
-    },
-    {
-      "community": 95,
-      "file_type": "code",
-      "id": "config_toenvsegment",
-      "label": "toEnvSegment()",
-      "norm_label": "toenvsegment()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
-      "source_location": "L29"
-    },
-    {
-      "community": 95,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_mtn_config_ts",
-      "label": "config.ts",
-      "norm_label": "config.ts",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "id": "packages_athena_webapp_convex_sendgrid_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
       "source_location": "L1"
     },
     {
@@ -99012,73 +99159,73 @@
     {
       "community": 96,
       "file_type": "code",
-      "id": "approvalauditevents_recordapprovalauditeventwithctx",
-      "label": "recordApprovalAuditEventWithCtx()",
-      "norm_label": "recordapprovalauditeventwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
-      "source_location": "L30"
+      "id": "config_buildmtncollectionscallbackurl",
+      "label": "buildMtnCollectionsCallbackUrl()",
+      "norm_label": "buildmtncollectionscallbackurl()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "source_location": "L135"
     },
     {
       "community": 96,
       "file_type": "code",
-      "id": "approvalauditevents_recordapprovaldecisionrecordedauditeventwithctx",
-      "label": "recordApprovalDecisionRecordedAuditEventWithCtx()",
-      "norm_label": "recordapprovaldecisionrecordedauditeventwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
-      "source_location": "L107"
+      "id": "config_buildmtncollectionslookupprefixes",
+      "label": "buildMtnCollectionsLookupPrefixes()",
+      "norm_label": "buildmtncollectionslookupprefixes()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "source_location": "L43"
     },
     {
       "community": 96,
       "file_type": "code",
-      "id": "approvalauditevents_recordapprovalproofconsumedauditeventwithctx",
-      "label": "recordApprovalProofConsumedAuditEventWithCtx()",
-      "norm_label": "recordapprovalproofconsumedauditeventwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
-      "source_location": "L87"
-    },
-    {
-      "community": 96,
-      "file_type": "code",
-      "id": "approvalauditevents_recordapprovalrequiredauditeventwithctx",
-      "label": "recordApprovalRequiredAuditEventWithCtx()",
-      "norm_label": "recordapprovalrequiredauditeventwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
+      "id": "config_istargetenvironment",
+      "label": "isTargetEnvironment()",
+      "norm_label": "istargetenvironment()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
       "source_location": "L67"
     },
     {
       "community": 96,
       "file_type": "code",
-      "id": "approvalauditevents_recordapprovedcommandappliedauditeventwithctx",
-      "label": "recordApprovedCommandAppliedAuditEventWithCtx()",
-      "norm_label": "recordapprovedcommandappliedauditeventwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
-      "source_location": "L117"
+      "id": "config_readscopedvalue",
+      "label": "readScopedValue()",
+      "norm_label": "readscopedvalue()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "source_location": "L56"
     },
     {
       "community": 96,
       "file_type": "code",
-      "id": "approvalauditevents_recordasyncapprovalrequestcreatedauditeventwithctx",
-      "label": "recordAsyncApprovalRequestCreatedAuditEventWithCtx()",
-      "norm_label": "recordasyncapprovalrequestcreatedauditeventwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
-      "source_location": "L97"
+      "id": "config_resolveconfigforprefix",
+      "label": "resolveConfigForPrefix()",
+      "norm_label": "resolveconfigforprefix()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "source_location": "L73"
     },
     {
       "community": 96,
       "file_type": "code",
-      "id": "approvalauditevents_recordmanagerapprovalgrantedauditeventwithctx",
-      "label": "recordManagerApprovalGrantedAuditEventWithCtx()",
-      "norm_label": "recordmanagerapprovalgrantedauditeventwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
-      "source_location": "L77"
+      "id": "config_resolvemtncollectionsconfigfromenv",
+      "label": "resolveMtnCollectionsConfigFromEnv()",
+      "norm_label": "resolvemtncollectionsconfigfromenv()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "source_location": "L108"
     },
     {
       "community": 96,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_approvalauditevents_ts",
-      "label": "approvalAuditEvents.ts",
-      "norm_label": "approvalauditevents.ts",
-      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
+      "id": "config_toenvsegment",
+      "label": "toEnvSegment()",
+      "norm_label": "toenvsegment()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "source_location": "L29"
+    },
+    {
+      "community": 96,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_mtn_config_ts",
+      "label": "config.ts",
+      "norm_label": "config.ts",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
       "source_location": "L1"
     },
     {
@@ -99174,73 +99321,73 @@
     {
       "community": 97,
       "file_type": "code",
-      "id": "approvalrequests_buildapprovaldecisionrequirement",
-      "label": "buildApprovalDecisionRequirement()",
-      "norm_label": "buildapprovaldecisionrequirement()",
-      "source_file": "packages/athena-webapp/convex/operations/approvalRequests.ts",
-      "source_location": "L54"
+      "id": "approvalauditevents_recordapprovalauditeventwithctx",
+      "label": "recordApprovalAuditEventWithCtx()",
+      "norm_label": "recordapprovalauditeventwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
+      "source_location": "L30"
     },
     {
       "community": 97,
       "file_type": "code",
-      "id": "approvalrequests_buildapprovaldecisionsubject",
-      "label": "buildApprovalDecisionSubject()",
-      "norm_label": "buildapprovaldecisionsubject()",
-      "source_file": "packages/athena-webapp/convex/operations/approvalRequests.ts",
-      "source_location": "L42"
+      "id": "approvalauditevents_recordapprovaldecisionrecordedauditeventwithctx",
+      "label": "recordApprovalDecisionRecordedAuditEventWithCtx()",
+      "norm_label": "recordapprovaldecisionrecordedauditeventwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
+      "source_location": "L107"
     },
     {
       "community": 97,
       "file_type": "code",
-      "id": "approvalrequests_consumeapprovaldecisionproofwithctx",
-      "label": "consumeApprovalDecisionProofWithCtx()",
-      "norm_label": "consumeapprovaldecisionproofwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/approvalRequests.ts",
-      "source_location": "L78"
+      "id": "approvalauditevents_recordapprovalproofconsumedauditeventwithctx",
+      "label": "recordApprovalProofConsumedAuditEventWithCtx()",
+      "norm_label": "recordapprovalproofconsumedauditeventwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
+      "source_location": "L87"
     },
     {
       "community": 97,
       "file_type": "code",
-      "id": "approvalrequests_decideapprovalrequestasauthenticateduserwithctx",
-      "label": "decideApprovalRequestAsAuthenticatedUserWithCtx()",
-      "norm_label": "decideapprovalrequestasauthenticateduserwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/approvalRequests.ts",
-      "source_location": "L167"
+      "id": "approvalauditevents_recordapprovalrequiredauditeventwithctx",
+      "label": "recordApprovalRequiredAuditEventWithCtx()",
+      "norm_label": "recordapprovalrequiredauditeventwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
+      "source_location": "L67"
     },
     {
       "community": 97,
       "file_type": "code",
-      "id": "approvalrequests_decideapprovalrequestascommandwithctx",
-      "label": "decideApprovalRequestAsCommandWithCtx()",
-      "norm_label": "decideapprovalrequestascommandwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/approvalRequests.ts",
-      "source_location": "L283"
+      "id": "approvalauditevents_recordapprovedcommandappliedauditeventwithctx",
+      "label": "recordApprovedCommandAppliedAuditEventWithCtx()",
+      "norm_label": "recordapprovedcommandappliedauditeventwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
+      "source_location": "L117"
     },
     {
       "community": 97,
       "file_type": "code",
-      "id": "approvalrequests_decideapprovalrequestwithctx",
-      "label": "decideApprovalRequestWithCtx()",
-      "norm_label": "decideapprovalrequestwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/approvalRequests.ts",
-      "source_location": "L105"
+      "id": "approvalauditevents_recordasyncapprovalrequestcreatedauditeventwithctx",
+      "label": "recordAsyncApprovalRequestCreatedAuditEventWithCtx()",
+      "norm_label": "recordasyncapprovalrequestcreatedauditeventwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
+      "source_location": "L97"
     },
     {
       "community": 97,
       "file_type": "code",
-      "id": "approvalrequests_mapdecideapprovalrequesterror",
-      "label": "mapDecideApprovalRequestError()",
-      "norm_label": "mapdecideapprovalrequesterror()",
-      "source_file": "packages/athena-webapp/convex/operations/approvalRequests.ts",
-      "source_location": "L217"
+      "id": "approvalauditevents_recordmanagerapprovalgrantedauditeventwithctx",
+      "label": "recordManagerApprovalGrantedAuditEventWithCtx()",
+      "norm_label": "recordmanagerapprovalgrantedauditeventwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
+      "source_location": "L77"
     },
     {
       "community": 97,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_approvalrequests_ts",
-      "label": "approvalRequests.ts",
-      "norm_label": "approvalrequests.ts",
-      "source_file": "packages/athena-webapp/convex/operations/approvalRequests.ts",
+      "id": "packages_athena_webapp_convex_operations_approvalauditevents_ts",
+      "label": "approvalAuditEvents.ts",
+      "norm_label": "approvalauditevents.ts",
+      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
       "source_location": "L1"
     },
     {
@@ -99336,74 +99483,74 @@
     {
       "community": 98,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_paymentallocations_ts",
-      "label": "paymentAllocations.ts",
-      "norm_label": "paymentallocations.ts",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "id": "approvalrequests_buildapprovaldecisionrequirement",
+      "label": "buildApprovalDecisionRequirement()",
+      "norm_label": "buildapprovaldecisionrequirement()",
+      "source_file": "packages/athena-webapp/convex/operations/approvalRequests.ts",
+      "source_location": "L54"
+    },
+    {
+      "community": 98,
+      "file_type": "code",
+      "id": "approvalrequests_buildapprovaldecisionsubject",
+      "label": "buildApprovalDecisionSubject()",
+      "norm_label": "buildapprovaldecisionsubject()",
+      "source_file": "packages/athena-webapp/convex/operations/approvalRequests.ts",
+      "source_location": "L42"
+    },
+    {
+      "community": 98,
+      "file_type": "code",
+      "id": "approvalrequests_consumeapprovaldecisionproofwithctx",
+      "label": "consumeApprovalDecisionProofWithCtx()",
+      "norm_label": "consumeapprovaldecisionproofwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/approvalRequests.ts",
+      "source_location": "L78"
+    },
+    {
+      "community": 98,
+      "file_type": "code",
+      "id": "approvalrequests_decideapprovalrequestasauthenticateduserwithctx",
+      "label": "decideApprovalRequestAsAuthenticatedUserWithCtx()",
+      "norm_label": "decideapprovalrequestasauthenticateduserwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/approvalRequests.ts",
+      "source_location": "L167"
+    },
+    {
+      "community": 98,
+      "file_type": "code",
+      "id": "approvalrequests_decideapprovalrequestascommandwithctx",
+      "label": "decideApprovalRequestAsCommandWithCtx()",
+      "norm_label": "decideapprovalrequestascommandwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/approvalRequests.ts",
+      "source_location": "L283"
+    },
+    {
+      "community": 98,
+      "file_type": "code",
+      "id": "approvalrequests_decideapprovalrequestwithctx",
+      "label": "decideApprovalRequestWithCtx()",
+      "norm_label": "decideapprovalrequestwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/approvalRequests.ts",
+      "source_location": "L105"
+    },
+    {
+      "community": 98,
+      "file_type": "code",
+      "id": "approvalrequests_mapdecideapprovalrequesterror",
+      "label": "mapDecideApprovalRequestError()",
+      "norm_label": "mapdecideapprovalrequesterror()",
+      "source_file": "packages/athena-webapp/convex/operations/approvalRequests.ts",
+      "source_location": "L217"
+    },
+    {
+      "community": 98,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_approvalrequests_ts",
+      "label": "approvalRequests.ts",
+      "norm_label": "approvalrequests.ts",
+      "source_file": "packages/athena-webapp/convex/operations/approvalRequests.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 98,
-      "file_type": "code",
-      "id": "paymentallocations_buildpaymentallocation",
-      "label": "buildPaymentAllocation()",
-      "norm_label": "buildpaymentallocation()",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
-      "source_location": "L27"
-    },
-    {
-      "community": 98,
-      "file_type": "code",
-      "id": "paymentallocations_correctsameamountsinglepaymentallocationwithctx",
-      "label": "correctSameAmountSinglePaymentAllocationWithCtx()",
-      "norm_label": "correctsameamountsinglepaymentallocationwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
-      "source_location": "L153"
-    },
-    {
-      "community": 98,
-      "file_type": "code",
-      "id": "paymentallocations_findsameamountsinglepaymentallocation",
-      "label": "findSameAmountSinglePaymentAllocation()",
-      "norm_label": "findsameamountsinglepaymentallocation()",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
-      "source_location": "L57"
-    },
-    {
-      "community": 98,
-      "file_type": "code",
-      "id": "paymentallocations_listpaymentallocationsfortargetwithctx",
-      "label": "listPaymentAllocationsForTargetWithCtx()",
-      "norm_label": "listpaymentallocationsfortargetwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
-      "source_location": "L133"
-    },
-    {
-      "community": 98,
-      "file_type": "code",
-      "id": "paymentallocations_matchesexistingallocation",
-      "label": "matchesExistingAllocation()",
-      "norm_label": "matchesexistingallocation()",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
-      "source_location": "L81"
-    },
-    {
-      "community": 98,
-      "file_type": "code",
-      "id": "paymentallocations_recordpaymentallocationwithctx",
-      "label": "recordPaymentAllocationWithCtx()",
-      "norm_label": "recordpaymentallocationwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
-      "source_location": "L102"
-    },
-    {
-      "community": 98,
-      "file_type": "code",
-      "id": "paymentallocations_summarizepaymentallocations",
-      "label": "summarizePaymentAllocations()",
-      "norm_label": "summarizepaymentallocations()",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
-      "source_location": "L41"
     },
     {
       "community": 980,
@@ -99498,74 +99645,74 @@
     {
       "community": 99,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_commands_possessiontracing_ts",
-      "label": "posSessionTracing.ts",
-      "norm_label": "possessiontracing.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "id": "packages_athena_webapp_convex_operations_paymentallocations_ts",
+      "label": "paymentAllocations.ts",
+      "norm_label": "paymentallocations.ts",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
       "source_location": "L1"
     },
     {
       "community": 99,
       "file_type": "code",
-      "id": "possessiontracing_buildpossessiontraceevent",
-      "label": "buildPosSessionTraceEvent()",
-      "norm_label": "buildpossessiontraceevent()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L226"
+      "id": "paymentallocations_buildpaymentallocation",
+      "label": "buildPaymentAllocation()",
+      "norm_label": "buildpaymentallocation()",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "source_location": "L27"
     },
     {
       "community": 99,
       "file_type": "code",
-      "id": "possessiontracing_buildpossessiontracerecord",
-      "label": "buildPosSessionTraceRecord()",
-      "norm_label": "buildpossessiontracerecord()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L142"
+      "id": "paymentallocations_correctsameamountsinglepaymentallocationwithctx",
+      "label": "correctSameAmountSinglePaymentAllocationWithCtx()",
+      "norm_label": "correctsameamountsinglepaymentallocationwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "source_location": "L153"
     },
     {
       "community": 99,
       "file_type": "code",
-      "id": "possessiontracing_buildtracesummary",
-      "label": "buildTraceSummary()",
-      "norm_label": "buildtracesummary()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L105"
+      "id": "paymentallocations_findsameamountsinglepaymentallocation",
+      "label": "findSameAmountSinglePaymentAllocation()",
+      "norm_label": "findsameamountsinglepaymentallocation()",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "source_location": "L57"
     },
     {
       "community": 99,
       "file_type": "code",
-      "id": "possessiontracing_createpossessiontracerecorder",
-      "label": "createPosSessionTraceRecorder()",
-      "norm_label": "createpossessiontracerecorder()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L559"
+      "id": "paymentallocations_listpaymentallocationsfortargetwithctx",
+      "label": "listPaymentAllocationsForTargetWithCtx()",
+      "norm_label": "listpaymentallocationsfortargetwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "source_location": "L133"
     },
     {
       "community": 99,
       "file_type": "code",
-      "id": "possessiontracing_formatpaymentmethod",
-      "label": "formatPaymentMethod()",
-      "norm_label": "formatpaymentmethod()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L218"
+      "id": "paymentallocations_matchesexistingallocation",
+      "label": "matchesExistingAllocation()",
+      "norm_label": "matchesexistingallocation()",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "source_location": "L81"
     },
     {
       "community": 99,
       "file_type": "code",
-      "id": "possessiontracing_recordpossessiontracebesteffort",
-      "label": "recordPosSessionTraceBestEffort()",
-      "norm_label": "recordpossessiontracebesteffort()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L532"
+      "id": "paymentallocations_recordpaymentallocationwithctx",
+      "label": "recordPaymentAllocationWithCtx()",
+      "norm_label": "recordpaymentallocationwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "source_location": "L102"
     },
     {
       "community": 99,
       "file_type": "code",
-      "id": "possessiontracing_safetracewrite",
-      "label": "safeTraceWrite()",
-      "norm_label": "safetracewrite()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L524"
+      "id": "paymentallocations_summarizepaymentallocations",
+      "label": "summarizePaymentAllocations()",
+      "norm_label": "summarizepaymentallocations()",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "source_location": "L41"
     },
     {
       "community": 990,

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,8 +8,8 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 1636
-- Graph nodes: 4795
-- Graph edges: 4708
+- Graph nodes: 4802
+- Graph edges: 4715
 - Communities: 1564
 
 ## Graph Hotspots

--- a/packages/athena-webapp/src/hooks/useExpenseOperations.ts
+++ b/packages/athena-webapp/src/hooks/useExpenseOperations.ts
@@ -3,6 +3,7 @@ import { useMutation } from "convex/react";
 import { api } from "../../convex/_generated/api";
 import { useExpenseStore } from "../stores/expenseStore";
 import { Product } from "../components/pos/types";
+import type { CartItem } from "../components/pos/types";
 import { Id } from "../../convex/_generated/dataModel";
 import { validateProduct, validateQuantity } from "../lib/pos/validation";
 import { presentCommandToast } from "../lib/errors/presentCommandToast";
@@ -14,6 +15,31 @@ import {
   showValidationError,
   showNoActiveSessionError,
 } from "../lib/pos/toastService";
+
+function cloneCartItems(items: CartItem[]): CartItem[] {
+  return items.map((item) => ({ ...item }));
+}
+
+function mapProductToExpenseCartItem(
+  product: Product,
+  id: Id<"expenseSessionItem">,
+  quantity: number,
+): CartItem {
+  return {
+    id,
+    name: product.name,
+    barcode: product.barcode || "",
+    sku: product.sku || "",
+    price: product.price,
+    quantity,
+    image: product.image || undefined,
+    size: product.size || undefined,
+    length: product.length,
+    color: product.color,
+    productId: product.productId!,
+    skuId: product.skuId!,
+  };
+}
 
 /**
  * Hook for Expense Cart Operations
@@ -82,14 +108,7 @@ export const useExpenseOperations = () => {
     }
 
     return sessionId;
-  }, [
-    store.session.currentSessionId,
-    store.session.activeSession,
-    store.storeId,
-    store.ui.registerNumber,
-    createSession,
-    store,
-  ]);
+  }, [createSession, store]);
 
   /**
    * Adds a product to the expense cart
@@ -112,6 +131,11 @@ export const useExpenseOperations = () => {
           errors: validation.errors,
         });
         showValidationError(validation.errors);
+        return false;
+      }
+
+      if (store.session.isUpdating) {
+        logger.warn("[Expense] Cart update already in progress");
         return false;
       }
 
@@ -138,27 +162,9 @@ export const useExpenseOperations = () => {
           throw new Error("Staff profile missing");
         }
 
-        const result = await runCommand(() =>
-          addOrUpdateItemMutation({
-            sessionId: sessionId as Id<"expenseSession">,
-            staffProfileId: currentStaffProfileId,
-            productId: product.productId!,
-            productSkuId: product.skuId!,
-            productSku: product.sku || "",
-            barcode: product.barcode || undefined,
-            productName: product.name,
-            price: product.price,
-            quantity: newQuantity,
-            image: product.image || undefined,
-            size: product.size || undefined,
-            length: product.length || undefined,
-          }),
-        );
-
-        if (result.kind !== "ok") {
-          presentCommandToast(result);
-          return false;
-        }
+        const previousCartItems = cloneCartItems(store.cart.items);
+        const optimisticItemId =
+          `optimistic:${product.skuId}` as Id<"expenseSessionItem">;
 
         if (existingItem) {
           store.updateCartQuantity(
@@ -166,24 +172,52 @@ export const useExpenseOperations = () => {
             newQuantity,
           );
         } else {
-          store.addToCart({
-            id: result.data.itemId as Id<"expenseSessionItem">,
-            name: product.name,
-            barcode: product.barcode || "",
-            sku: product.sku || "",
-            price: product.price,
-            quantity: 1,
-            image: product.image || undefined,
-            size: product.size || undefined,
-            length: product.length,
-            color: product.color,
-            productId: product.productId!,
-            skuId: product.skuId!,
-          });
+          store.addToCart(
+            mapProductToExpenseCartItem(product, optimisticItemId, newQuantity),
+          );
         }
-        store.setSessionExpiresAt(result.data.expiresAt);
+        store.setSessionUpdating(true);
 
-        {
+        try {
+          const result = await runCommand(() =>
+            addOrUpdateItemMutation({
+              sessionId: sessionId as Id<"expenseSession">,
+              staffProfileId: currentStaffProfileId,
+              productId: product.productId!,
+              productSkuId: product.skuId!,
+              productSku: product.sku || "",
+              barcode: product.barcode || undefined,
+              productName: product.name,
+              price: product.price,
+              quantity: newQuantity,
+              image: product.image || undefined,
+              size: product.size || undefined,
+              length: product.length || undefined,
+            }),
+          );
+
+          if (result.kind !== "ok") {
+            store.replaceCartItems(previousCartItems);
+            presentCommandToast(result);
+            return false;
+          }
+
+          if (!existingItem) {
+            const currentOptimisticItem = useExpenseStore
+              .getState()
+              .cart.items.find((item) => item.id === optimisticItemId);
+
+            store.removeFromCart(optimisticItemId);
+            store.addToCart(
+              mapProductToExpenseCartItem(
+                product,
+                result.data.itemId as Id<"expenseSessionItem">,
+                currentOptimisticItem?.quantity ?? newQuantity,
+              ),
+            );
+          }
+          store.setSessionExpiresAt(result.data.expiresAt);
+
           logger.info("[Expense] Product added to cart successfully", {
             productName: product.name,
             itemId: result.data.itemId,
@@ -191,8 +225,10 @@ export const useExpenseOperations = () => {
             wasUpdate: isUpdate,
             sessionExpiresAt: result.data.expiresAt,
           });
+          return true;
+        } finally {
+          store.setSessionUpdating(false);
         }
-        return true;
       } catch (error) {
         logger.error("[Expense] Exception while adding product", {
           productName: product.name,
@@ -297,28 +333,38 @@ export const useExpenseOperations = () => {
         return;
       }
 
-      const result = await runCommand(() =>
-        removeItemMutation({
-          sessionId: sessionId as Id<"expenseSession">,
-          staffProfileId: currentStaffProfileId,
-          itemId,
-        }),
-      );
-
-      if (result.kind !== "ok") {
-        presentCommandToast(result);
+      if (store.session.isUpdating) {
+        logger.warn("[Expense] Cart update already in progress");
         return;
       }
 
+      const previousCartItems = cloneCartItems(store.cart.items);
       store.removeFromCart(itemId);
-      store.setSessionExpiresAt(result.data.expiresAt);
+      store.setSessionUpdating(true);
 
-      {
+      try {
+        const result = await runCommand(() =>
+          removeItemMutation({
+            sessionId: sessionId as Id<"expenseSession">,
+            staffProfileId: currentStaffProfileId,
+            itemId,
+          }),
+        );
+
+        if (result.kind !== "ok") {
+          store.replaceCartItems(previousCartItems);
+          presentCommandToast(result);
+          return;
+        }
+
+        store.setSessionExpiresAt(result.data.expiresAt);
         logger.info("[Expense] Item removed successfully", {
           itemName: item.name,
           itemId,
           sessionExpiresAt: result.data.expiresAt,
         });
+      } finally {
+        store.setSessionUpdating(false);
       }
     },
     [store, removeItemMutation, currentStaffProfileId]
@@ -383,37 +429,47 @@ export const useExpenseOperations = () => {
         return;
       }
 
-      const result = await runCommand(() =>
-        addOrUpdateItemMutation({
-          sessionId: sessionId as Id<"expenseSession">,
-          staffProfileId: currentStaffProfileId,
-          productId: item.productId!,
-          productSkuId: item.skuId!,
-          productSku: item.sku || "",
-          barcode: item.barcode || undefined,
-          productName: item.name,
-          price: item.price,
-          quantity,
-          image: item.image || undefined,
-          size: item.size || undefined,
-          length: item.length || undefined,
-        }),
-      );
-
-      if (result.kind !== "ok") {
-        presentCommandToast(result);
+      if (store.session.isUpdating) {
+        logger.warn("[Expense] Cart update already in progress");
         return;
       }
 
+      const previousCartItems = cloneCartItems(store.cart.items);
       store.updateCartQuantity(itemId, quantity);
-      store.setSessionExpiresAt(result.data.expiresAt);
+      store.setSessionUpdating(true);
 
-      {
+      try {
+        const result = await runCommand(() =>
+          addOrUpdateItemMutation({
+            sessionId: sessionId as Id<"expenseSession">,
+            staffProfileId: currentStaffProfileId,
+            productId: item.productId!,
+            productSkuId: item.skuId!,
+            productSku: item.sku || "",
+            barcode: item.barcode || undefined,
+            productName: item.name,
+            price: item.price,
+            quantity,
+            image: item.image || undefined,
+            size: item.size || undefined,
+            length: item.length || undefined,
+          }),
+        );
+
+        if (result.kind !== "ok") {
+          store.replaceCartItems(previousCartItems);
+          presentCommandToast(result);
+          return;
+        }
+
+        store.setSessionExpiresAt(result.data.expiresAt);
         logger.info("[Expense] Quantity updated successfully", {
           itemName: item.name,
           quantity,
           sessionExpiresAt: result.data.expiresAt,
         });
+      } finally {
+        store.setSessionUpdating(false);
       }
     },
     [store, addOrUpdateItemMutation, removeItem, currentStaffProfileId]

--- a/packages/athena-webapp/src/lib/pos/presentation/expense/useExpenseRegisterViewModel.test.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/expense/useExpenseRegisterViewModel.test.ts
@@ -1,4 +1,5 @@
 import { act, renderHook, waitFor } from "@testing-library/react";
+import { getFunctionName } from "convex/server";
 import { useMutation, useQuery } from "convex/react";
 import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
@@ -7,10 +8,19 @@ import { toast } from "sonner";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { Id } from "~/convex/_generated/dataModel";
+import { ok, userError } from "~/shared/commandResult";
 import { useExpenseStore } from "@/stores/expenseStore";
 import { useExpenseRegisterViewModel } from "./useExpenseRegisterViewModel";
 
 const mockCreateExpenseSession = vi.fn();
+const mockUpdateExpenseSession = vi.fn();
+const mockHoldExpenseSession = vi.fn();
+const mockResumeExpenseSession = vi.fn();
+const mockVoidExpenseSession = vi.fn();
+const mockReleaseExpenseSessionInventoryHoldsAndDeleteItems = vi.fn();
+const mockCompleteExpenseSession = vi.fn();
+const mockAddOrUpdateExpenseItem = vi.fn();
+const mockRemoveExpenseItem = vi.fn();
 const mockNavigateBack = vi.fn();
 const catalogGatewayMocks = vi.hoisted(() => ({
   useConvexRegisterCatalog: vi.fn(),
@@ -158,6 +168,93 @@ function buildRegisterCatalogAvailabilityRow(
   };
 }
 
+function buildActiveExpenseSession(
+  cartItems: NonNullable<typeof mockActiveSessionQuery>["cartItems"] = [],
+  overrides: Partial<NonNullable<typeof mockActiveSessionQuery>> = {},
+) {
+  return {
+    _id: "expense-session-1" as Id<"expenseSession">,
+    status: "active" as const,
+    expiresAt: Date.now() + 60_000,
+    sessionNumber: "EXP-0001",
+    updatedAt: 100,
+    cartItems,
+    ...overrides,
+  };
+}
+
+function buildExpenseCartItem(
+  overrides: Partial<
+    NonNullable<typeof mockActiveSessionQuery>["cartItems"][number]
+  > = {},
+): NonNullable<typeof mockActiveSessionQuery>["cartItems"][number] {
+  return {
+    _id: "expense-item-1" as Id<"expenseSessionItem">,
+    quantity: 1,
+    updatedAt: 100,
+    productName: "Repair kit",
+    productSku: "KIT-1",
+    barcode: "1234567890123",
+    price: 3600,
+    image: null,
+    size: "",
+    length: null,
+    color: "",
+    productId: "product-1" as Id<"product">,
+    productSkuId: "product-sku-1" as Id<"productSku">,
+    ...overrides,
+  };
+}
+
+function buildProduct(overrides = {}) {
+  return {
+    id: "product-sku-2",
+    name: "Shop towels",
+    price: 1200,
+    barcode: "9876543210123",
+    productId: "product-2" as Id<"product">,
+    skuId: "product-sku-2" as Id<"productSku">,
+    sku: "TOWEL-1",
+    category: "Supplies",
+    description: "",
+    image: null,
+    inStock: true,
+    quantityAvailable: 5,
+    ...overrides,
+  };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((nextResolve, nextReject) => {
+    resolve = nextResolve;
+    reject = nextReject;
+  });
+
+  return { promise, resolve, reject };
+}
+
+function seedActiveExpenseCart() {
+  const store = useExpenseStore.getState();
+  store.setCurrentSessionId("expense-session-1" as Id<"expenseSession">);
+  store.setSessionExpiresAt(Date.now() + 60_000);
+  store.addToCart({
+    id: "expense-item-1" as Id<"expenseSessionItem">,
+    name: "Repair kit",
+    barcode: "1234567890123",
+    sku: "KIT-1",
+    price: 3600,
+    quantity: 1,
+    image: null,
+    size: "",
+    length: null,
+    color: "",
+    productId: "product-1" as Id<"product">,
+    skuId: "product-sku-1" as Id<"productSku">,
+  });
+}
+
 describe("useExpenseRegisterViewModel", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -195,7 +292,65 @@ describe("useExpenseRegisterViewModel", () => {
         },
       };
     });
-    vi.mocked(useMutation).mockReturnValue(mockCreateExpenseSession as never);
+    mockAddOrUpdateExpenseItem.mockResolvedValue(
+      ok({
+        itemId: "expense-item-1" as Id<"expenseSessionItem">,
+        expiresAt: Date.now() + 60_000,
+      }),
+    );
+    mockRemoveExpenseItem.mockResolvedValue(
+      ok({
+        expiresAt: Date.now() + 60_000,
+      }),
+    );
+    mockReleaseExpenseSessionInventoryHoldsAndDeleteItems.mockResolvedValue(
+      ok({
+        sessionId: "expense-session-1" as Id<"expenseSession">,
+      }),
+    );
+    mockCompleteExpenseSession.mockResolvedValue(
+      ok({
+        transactionNumber: "EXP-TXN-1",
+      }),
+    );
+    vi.mocked(useMutation).mockImplementation((mutation) => {
+      const mutationName = getFunctionName(mutation);
+      if (mutationName === "inventory/expenseSessions:createExpenseSession") {
+        return mockCreateExpenseSession as never;
+      }
+      if (mutationName === "inventory/expenseSessions:updateExpenseSession") {
+        return mockUpdateExpenseSession as never;
+      }
+      if (mutationName === "inventory/expenseSessions:holdExpenseSession") {
+        return mockHoldExpenseSession as never;
+      }
+      if (mutationName === "inventory/expenseSessions:resumeExpenseSession") {
+        return mockResumeExpenseSession as never;
+      }
+      if (mutationName === "inventory/expenseSessions:voidExpenseSession") {
+        return mockVoidExpenseSession as never;
+      }
+      if (
+        mutationName ===
+        "inventory/expenseSessions:releaseExpenseSessionInventoryHoldsAndDeleteItems"
+      ) {
+        return mockReleaseExpenseSessionInventoryHoldsAndDeleteItems as never;
+      }
+      if (mutationName === "inventory/expenseSessions:completeExpenseSession") {
+        return mockCompleteExpenseSession as never;
+      }
+      if (
+        mutationName ===
+        "inventory/expenseSessionItems:addOrUpdateExpenseItem"
+      ) {
+        return mockAddOrUpdateExpenseItem as never;
+      }
+      if (mutationName === "inventory/expenseSessionItems:removeExpenseItem") {
+        return mockRemoveExpenseItem as never;
+      }
+
+      return vi.fn() as never;
+    });
     vi.mocked(useQuery).mockImplementation(() => mockActiveSessionQuery);
   });
 
@@ -337,7 +492,7 @@ describe("useExpenseRegisterViewModel", () => {
     rerender();
 
     await waitFor(() => {
-      expect(mockCreateExpenseSession).toHaveBeenCalledTimes(1);
+      expect(mockAddOrUpdateExpenseItem).toHaveBeenCalledTimes(1);
     });
     expect(useExpenseStore.getState().ui.productSearchQuery).toBe("");
   });
@@ -437,12 +592,12 @@ describe("useExpenseRegisterViewModel", () => {
     });
 
     await waitFor(() => {
-      expect(mockCreateExpenseSession).toHaveBeenCalledTimes(1);
+      expect(mockAddOrUpdateExpenseItem).toHaveBeenCalledTimes(1);
     });
     expect(useExpenseStore.getState().ui.productSearchQuery).toBe("");
 
     rerender();
-    expect(mockCreateExpenseSession).toHaveBeenCalledTimes(1);
+    expect(mockAddOrUpdateExpenseItem).toHaveBeenCalledTimes(1);
   });
 
   it("does not depend on legacy POS product search hooks", () => {
@@ -454,6 +609,526 @@ describe("useExpenseRegisterViewModel", () => {
 
     expect(source).not.toContain("usePOSProductSearch");
     expect(source).not.toContain("usePOSBarcodeSearch");
+  });
+
+  it("optimistically adds expense product selections while the server mutation is pending", async () => {
+    const pendingAdd = deferred<ReturnType<typeof ok>>();
+    mockAddOrUpdateExpenseItem.mockReturnValueOnce(pendingAdd.promise);
+    mockActiveSessionQuery = buildActiveExpenseSession();
+
+    const { result, rerender } = renderHook(() => useExpenseRegisterViewModel());
+
+    let addPromise: Promise<boolean> | undefined;
+    await act(async () => {
+      addPromise = result.current.productEntry.onAddProduct(buildProduct());
+    });
+
+    expect(result.current.cart.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: "Shop towels",
+          skuId: "product-sku-2",
+          quantity: 1,
+        }),
+      ]),
+    );
+    expect(result.current.checkout.cartItems).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          skuId: "product-sku-2",
+          quantity: 1,
+        }),
+      ]),
+    );
+
+    mockActiveSessionQuery = buildActiveExpenseSession([], {
+      updatedAt: 101,
+    });
+    rerender();
+    expect(result.current.cart.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          skuId: "product-sku-2",
+          quantity: 1,
+        }),
+      ]),
+    );
+
+    pendingAdd.resolve(
+      ok({
+        itemId: "expense-item-2" as Id<"expenseSessionItem">,
+        expiresAt: Date.now() + 60_000,
+      }),
+    );
+    await act(async () => {
+      await addPromise;
+    });
+
+    expect(result.current.cart.items).toEqual([
+      expect.objectContaining({
+        id: "expense-item-2",
+        skuId: "product-sku-2",
+        quantity: 1,
+      }),
+    ]);
+    expect(result.current.cart.items).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "optimistic:product-sku-2",
+        }),
+      ]),
+    );
+  });
+
+  it("rolls back optimistic expense product selections when add fails", async () => {
+    const pendingAdd = deferred<ReturnType<typeof userError>>();
+    mockAddOrUpdateExpenseItem.mockReturnValueOnce(pendingAdd.promise);
+    mockActiveSessionQuery = buildActiveExpenseSession();
+
+    const { result } = renderHook(() => useExpenseRegisterViewModel());
+
+    let addPromise: Promise<boolean> | undefined;
+    await act(async () => {
+      addPromise = result.current.productEntry.onAddProduct(buildProduct());
+    });
+
+    expect(result.current.cart.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          skuId: "product-sku-2",
+        }),
+      ]),
+    );
+
+    pendingAdd.resolve(
+      userError({
+        code: "conflict",
+        message: "Shop towels are no longer available.",
+      }),
+    );
+    await act(async () => {
+      await addPromise;
+    });
+
+    expect(result.current.cart.items).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          skuId: "product-sku-2",
+        }),
+      ]),
+    );
+    expect(result.current.checkout.cartItems).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          skuId: "product-sku-2",
+        }),
+      ]),
+    );
+    expect(toast.error).toHaveBeenCalledWith(
+      "Shop towels are no longer available.",
+    );
+  });
+
+  it("rolls back optimistic expense product selections when the add mutation rejects", async () => {
+    const pendingAdd = deferred<ReturnType<typeof ok>>();
+    mockAddOrUpdateExpenseItem.mockReturnValueOnce(pendingAdd.promise);
+    mockActiveSessionQuery = buildActiveExpenseSession();
+
+    const { result } = renderHook(() => useExpenseRegisterViewModel());
+
+    let addPromise: Promise<boolean> | undefined;
+    await act(async () => {
+      addPromise = result.current.productEntry.onAddProduct(buildProduct());
+    });
+
+    expect(result.current.cart.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          skuId: "product-sku-2",
+        }),
+      ]),
+    );
+
+    pendingAdd.reject(new Error("network unavailable"));
+    await act(async () => {
+      await addPromise;
+    });
+
+    expect(result.current.cart.items).toEqual([]);
+    expect(useExpenseStore.getState().session.isUpdating).toBe(false);
+    expect(toast.error).toHaveBeenCalled();
+  });
+
+  it("optimistically updates expense cart quantity while the server mutation is pending", async () => {
+    const pendingUpdate = deferred<ReturnType<typeof ok>>();
+    mockAddOrUpdateExpenseItem.mockReturnValueOnce(pendingUpdate.promise);
+    mockActiveSessionQuery = buildActiveExpenseSession([
+      buildExpenseCartItem(),
+    ]);
+    seedActiveExpenseCart();
+
+    const { result } = renderHook(() => useExpenseRegisterViewModel());
+    await waitFor(() => {
+      expect(result.current.cart.items).toHaveLength(1);
+    });
+
+    let updatePromise: Promise<void> | undefined;
+    await act(async () => {
+      updatePromise = result.current.cart.onUpdateQuantity(
+        "expense-item-1" as Id<"expenseSessionItem">,
+        2,
+      );
+    });
+
+    expect(result.current.cart.items[0].quantity).toBe(2);
+    expect(result.current.checkout.cartItems[0].quantity).toBe(2);
+
+    pendingUpdate.resolve(
+      ok({
+        itemId: "expense-item-1" as Id<"expenseSessionItem">,
+        expiresAt: Date.now() + 60_000,
+      }),
+    );
+    await act(async () => {
+      await updatePromise;
+    });
+  });
+
+  it("rolls back optimistic expense quantity changes when the update fails", async () => {
+    const pendingUpdate = deferred<ReturnType<typeof userError>>();
+    mockAddOrUpdateExpenseItem.mockReturnValueOnce(pendingUpdate.promise);
+    mockActiveSessionQuery = buildActiveExpenseSession([
+      buildExpenseCartItem(),
+    ]);
+    seedActiveExpenseCart();
+
+    const { result } = renderHook(() => useExpenseRegisterViewModel());
+    await waitFor(() => {
+      expect(result.current.cart.items).toHaveLength(1);
+    });
+
+    let updatePromise: Promise<void> | undefined;
+    await act(async () => {
+      updatePromise = result.current.cart.onUpdateQuantity(
+        "expense-item-1" as Id<"expenseSessionItem">,
+        2,
+      );
+    });
+
+    expect(result.current.cart.items[0].quantity).toBe(2);
+
+    pendingUpdate.resolve(
+      userError({
+        code: "conflict",
+        message: "Only one Repair kit is available.",
+      }),
+    );
+    await act(async () => {
+      await updatePromise;
+    });
+
+    expect(result.current.cart.items[0].quantity).toBe(1);
+    expect(result.current.checkout.cartItems[0].quantity).toBe(1);
+    expect(toast.error).toHaveBeenCalledWith(
+      "Only one Repair kit is available.",
+    );
+  });
+
+  it("rolls back optimistic expense quantity changes when the update mutation rejects", async () => {
+    const pendingUpdate = deferred<ReturnType<typeof ok>>();
+    mockAddOrUpdateExpenseItem.mockReturnValueOnce(pendingUpdate.promise);
+    mockActiveSessionQuery = buildActiveExpenseSession([
+      buildExpenseCartItem(),
+    ]);
+    seedActiveExpenseCart();
+
+    const { result } = renderHook(() => useExpenseRegisterViewModel());
+    await waitFor(() => {
+      expect(result.current.cart.items).toHaveLength(1);
+    });
+
+    let updatePromise: Promise<void> | undefined;
+    await act(async () => {
+      updatePromise = result.current.cart.onUpdateQuantity(
+        "expense-item-1" as Id<"expenseSessionItem">,
+        2,
+      );
+    });
+
+    expect(result.current.cart.items[0].quantity).toBe(2);
+
+    pendingUpdate.reject(new Error("network unavailable"));
+    await act(async () => {
+      await updatePromise;
+    });
+
+    expect(result.current.cart.items[0].quantity).toBe(1);
+    expect(useExpenseStore.getState().session.isUpdating).toBe(false);
+    expect(toast.error).toHaveBeenCalled();
+  });
+
+  it("does not start a second expense cart mutation while one is pending", async () => {
+    const pendingUpdate = deferred<ReturnType<typeof ok>>();
+    mockAddOrUpdateExpenseItem.mockReturnValueOnce(pendingUpdate.promise);
+    mockActiveSessionQuery = buildActiveExpenseSession([
+      buildExpenseCartItem(),
+    ]);
+    seedActiveExpenseCart();
+
+    const { result, rerender } = renderHook(() => useExpenseRegisterViewModel());
+    await waitFor(() => {
+      expect(result.current.cart.items).toHaveLength(1);
+    });
+
+    let updatePromise: Promise<void> | undefined;
+    await act(async () => {
+      updatePromise = result.current.cart.onUpdateQuantity(
+        "expense-item-1" as Id<"expenseSessionItem">,
+        2,
+      );
+    });
+
+    expect(result.current.cart.items[0].quantity).toBe(2);
+
+    await act(async () => {
+      await result.current.cart.onRemoveItem(
+        "expense-item-1" as Id<"expenseSessionItem">,
+      );
+    });
+
+    expect(mockRemoveExpenseItem).not.toHaveBeenCalled();
+    expect(result.current.cart.items[0].quantity).toBe(2);
+
+    mockActiveSessionQuery = buildActiveExpenseSession([buildExpenseCartItem()], {
+      updatedAt: 101,
+    });
+    rerender();
+    expect(result.current.cart.items[0].quantity).toBe(2);
+
+    pendingUpdate.resolve(
+      ok({
+        itemId: "expense-item-1" as Id<"expenseSessionItem">,
+        expiresAt: Date.now() + 60_000,
+      }),
+    );
+    await act(async () => {
+      await updatePromise;
+    });
+  });
+
+  it("optimistically removes expense cart items while the server mutation is pending", async () => {
+    const pendingRemove = deferred<ReturnType<typeof ok>>();
+    mockRemoveExpenseItem.mockReturnValueOnce(pendingRemove.promise);
+    mockActiveSessionQuery = buildActiveExpenseSession([
+      buildExpenseCartItem(),
+    ]);
+    seedActiveExpenseCart();
+
+    const { result, rerender } = renderHook(() => useExpenseRegisterViewModel());
+    await waitFor(() => {
+      expect(result.current.cart.items).toHaveLength(1);
+    });
+
+    let removePromise: Promise<void> | undefined;
+    await act(async () => {
+      removePromise = result.current.cart.onRemoveItem(
+        "expense-item-1" as Id<"expenseSessionItem">,
+      );
+    });
+
+    expect(result.current.cart.items).toHaveLength(0);
+    expect(result.current.checkout.cartItems).toHaveLength(0);
+
+    mockActiveSessionQuery = buildActiveExpenseSession([buildExpenseCartItem()], {
+      updatedAt: 101,
+    });
+    rerender();
+    expect(result.current.cart.items).toHaveLength(0);
+    expect(result.current.checkout.cartItems).toHaveLength(0);
+
+    pendingRemove.resolve(
+      ok({
+        expiresAt: Date.now() + 60_000,
+      }),
+    );
+    await act(async () => {
+      await removePromise;
+    });
+  });
+
+  it("rolls back optimistic expense cart item removals when remove fails", async () => {
+    const pendingRemove = deferred<ReturnType<typeof userError>>();
+    mockRemoveExpenseItem.mockReturnValueOnce(pendingRemove.promise);
+    mockActiveSessionQuery = buildActiveExpenseSession([
+      buildExpenseCartItem(),
+    ]);
+    seedActiveExpenseCart();
+
+    const { result } = renderHook(() => useExpenseRegisterViewModel());
+    await waitFor(() => {
+      expect(result.current.cart.items).toHaveLength(1);
+    });
+
+    let removePromise: Promise<void> | undefined;
+    await act(async () => {
+      removePromise = result.current.cart.onRemoveItem(
+        "expense-item-1" as Id<"expenseSessionItem">,
+      );
+    });
+
+    expect(result.current.cart.items).toHaveLength(0);
+
+    pendingRemove.resolve(
+      userError({
+        code: "conflict",
+        message: "Could not remove this expense item.",
+      }),
+    );
+    await act(async () => {
+      await removePromise;
+    });
+
+    expect(result.current.cart.items).toHaveLength(1);
+    expect(result.current.cart.items[0].quantity).toBe(1);
+    expect(result.current.checkout.cartItems).toHaveLength(1);
+    expect(toast.error).toHaveBeenCalledWith(
+      "Could not remove this expense item.",
+    );
+  });
+
+  it("rolls back optimistic expense cart item removals when remove rejects", async () => {
+    const pendingRemove = deferred<ReturnType<typeof ok>>();
+    mockRemoveExpenseItem.mockReturnValueOnce(pendingRemove.promise);
+    mockActiveSessionQuery = buildActiveExpenseSession([
+      buildExpenseCartItem(),
+    ]);
+    seedActiveExpenseCart();
+
+    const { result } = renderHook(() => useExpenseRegisterViewModel());
+    await waitFor(() => {
+      expect(result.current.cart.items).toHaveLength(1);
+    });
+
+    let removePromise: Promise<void> | undefined;
+    await act(async () => {
+      removePromise = result.current.cart.onRemoveItem(
+        "expense-item-1" as Id<"expenseSessionItem">,
+      );
+    });
+
+    expect(result.current.cart.items).toHaveLength(0);
+
+    pendingRemove.reject(new Error("network unavailable"));
+    await act(async () => {
+      await removePromise;
+    });
+
+    expect(result.current.cart.items).toHaveLength(1);
+    expect(useExpenseStore.getState().session.isUpdating).toBe(false);
+    expect(toast.error).toHaveBeenCalled();
+  });
+
+  it("optimistically clears expense cart items while bulk removal is pending", async () => {
+    const pendingClear = deferred<ReturnType<typeof ok>>();
+    mockReleaseExpenseSessionInventoryHoldsAndDeleteItems.mockReturnValueOnce(
+      pendingClear.promise,
+    );
+    mockActiveSessionQuery = buildActiveExpenseSession([
+      buildExpenseCartItem(),
+    ]);
+    seedActiveExpenseCart();
+
+    const { result } = renderHook(() => useExpenseRegisterViewModel());
+    await waitFor(() => {
+      expect(result.current.cart.items).toHaveLength(1);
+    });
+
+    let clearPromise: Promise<void> | undefined;
+    await act(async () => {
+      clearPromise = result.current.cart.onClearCart();
+    });
+
+    expect(result.current.cart.items).toHaveLength(0);
+    expect(result.current.checkout.cartItems).toHaveLength(0);
+
+    pendingClear.resolve(
+      ok({
+        sessionId: "expense-session-1" as Id<"expenseSession">,
+      }),
+    );
+    await act(async () => {
+      await clearPromise;
+    });
+  });
+
+  it("rolls back optimistic expense clear-cart removals when bulk removal fails", async () => {
+    const pendingClear = deferred<ReturnType<typeof userError>>();
+    mockReleaseExpenseSessionInventoryHoldsAndDeleteItems.mockReturnValueOnce(
+      pendingClear.promise,
+    );
+    mockActiveSessionQuery = buildActiveExpenseSession([
+      buildExpenseCartItem(),
+    ]);
+    seedActiveExpenseCart();
+
+    const { result } = renderHook(() => useExpenseRegisterViewModel());
+    await waitFor(() => {
+      expect(result.current.cart.items).toHaveLength(1);
+    });
+
+    let clearPromise: Promise<void> | undefined;
+    await act(async () => {
+      clearPromise = result.current.cart.onClearCart();
+    });
+
+    expect(result.current.cart.items).toHaveLength(0);
+
+    pendingClear.resolve(
+      userError({
+        code: "conflict",
+        message: "Could not clear this expense cart.",
+      }),
+    );
+    await act(async () => {
+      await clearPromise;
+    });
+
+    expect(result.current.cart.items).toHaveLength(1);
+    expect(result.current.cart.items[0].quantity).toBe(1);
+    expect(result.current.checkout.cartItems).toHaveLength(1);
+    expect(toast.error).toHaveBeenCalled();
+  });
+
+  it("rolls back optimistic expense clear-cart removals when bulk removal rejects", async () => {
+    const pendingClear = deferred<{ success: true }>();
+    mockReleaseExpenseSessionInventoryHoldsAndDeleteItems.mockReturnValueOnce(
+      pendingClear.promise,
+    );
+    mockActiveSessionQuery = buildActiveExpenseSession([
+      buildExpenseCartItem(),
+    ]);
+    seedActiveExpenseCart();
+
+    const { result } = renderHook(() => useExpenseRegisterViewModel());
+    await waitFor(() => {
+      expect(result.current.cart.items).toHaveLength(1);
+    });
+
+    let clearPromise: Promise<void> | undefined;
+    await act(async () => {
+      clearPromise = result.current.cart.onClearCart();
+    });
+
+    expect(result.current.cart.items).toHaveLength(0);
+
+    pendingClear.reject(new Error("network unavailable"));
+    await act(async () => {
+      await clearPromise;
+    });
+
+    expect(result.current.cart.items).toHaveLength(1);
+    expect(useExpenseStore.getState().session.isUpdating).toBe(false);
+    expect(toast.error).toHaveBeenCalled();
   });
 
   it("clears expense totals and transaction state after completing a session", async () => {

--- a/packages/athena-webapp/src/lib/pos/presentation/expense/useExpenseRegisterViewModel.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/expense/useExpenseRegisterViewModel.ts
@@ -115,7 +115,7 @@ export function useExpenseRegisterViewModel(): RegisterViewModel {
   }, [handleSetTerminalId]);
 
   const handleSessionLoaded = useCallback(
-    (sessionData: ReturnType<typeof useExpenseActiveSession>) => {
+    (sessionData: NonNullable<ReturnType<typeof useExpenseActiveSession>>) => {
       store.loadSessionData(sessionData);
     },
     [store],
@@ -189,6 +189,10 @@ export function useExpenseRegisterViewModel(): RegisterViewModel {
           storeSessionId: store.session.currentSessionId,
           querySessionId: activeSessionQuery._id,
         });
+        return;
+      }
+
+      if (store.session.isUpdating) {
         return;
       }
 
@@ -269,9 +273,11 @@ export function useExpenseRegisterViewModel(): RegisterViewModel {
     activeSessionQuery,
     store.session.currentSessionId,
     store.session.isCreating,
+    store.session.isUpdating,
     createSession,
     handleSessionLoaded,
     store.storeId,
+    store,
   ]);
 
   const registerCatalogRows = useConvexRegisterCatalog({
@@ -406,19 +412,39 @@ export function useExpenseRegisterViewModel(): RegisterViewModel {
       return;
     }
 
-    const result = await releaseSessionInventoryHoldsAndDeleteItems(
-      sessionId as Id<"expenseSession">,
-    );
+    if (store.session.isUpdating) {
+      return;
+    }
 
-    if (result.success) {
-      toast.success("Cart cleared");
-      cart.clearCart();
+    const previousCartItems = [...store.cart.items];
+    cart.clearCart();
+    store.setSessionUpdating(true);
+
+    try {
+      const result = await releaseSessionInventoryHoldsAndDeleteItems(
+        sessionId as Id<"expenseSession">,
+      );
+
+      if (result.success) {
+        toast.success("Cart cleared");
+        return;
+      }
+
+      store.replaceCartItems(previousCartItems);
+    } catch (error) {
+      logger.error("[Expense] Failed to clear cart", error as Error);
+      store.replaceCartItems(previousCartItems);
+      toast.error("Could not clear this expense cart.");
+    } finally {
+      store.setSessionUpdating(false);
     }
   }, [
     activeSessionQuery?._id,
     cart,
     releaseSessionInventoryHoldsAndDeleteItems,
     store.session.currentSessionId,
+    store.session.isUpdating,
+    store,
   ]);
 
   const handleCompleteExpense = useCallback(async () => {
@@ -467,6 +493,7 @@ export function useExpenseRegisterViewModel(): RegisterViewModel {
     store.cart.total,
     store.ui.notes,
     store,
+    resetAutoSessionInitialized,
   ]);
 
   const handleNavigateBack = useCallback(async () => {

--- a/packages/athena-webapp/src/stores/expenseStore.ts
+++ b/packages/athena-webapp/src/stores/expenseStore.ts
@@ -14,10 +14,32 @@ interface CartState {
   total: number;
 }
 
+type ExpenseSessionCartItem = {
+  _id: Id<"expenseSessionItem">;
+  productName?: string;
+  barcode?: string | null;
+  productSku?: string | null;
+  price?: number;
+  quantity: number;
+  image?: string | null;
+  size?: string | null;
+  length?: number | null;
+  color?: string | null;
+  productId?: Id<"product">;
+  productSkuId?: Id<"productSku">;
+};
+
+type ExpenseSession = {
+  _id: Id<"expenseSession">;
+  expiresAt?: number | null;
+  notes?: string | null;
+  cartItems?: ExpenseSessionCartItem[];
+};
+
 interface SessionState {
   currentSessionId: string | null;
-  activeSession: any | null; // ExpenseSession type
-  heldSessions: any[];
+  activeSession: ExpenseSession | null;
+  heldSessions: ExpenseSession[];
   isCreating: boolean;
   isUpdating: boolean;
   expiresAt: number | null;
@@ -63,17 +85,18 @@ interface ExpenseState {
   addToCart: (item: CartItem) => void;
   updateCartQuantity: (id: Id<"expenseSessionItem">, quantity: number) => void;
   removeFromCart: (id: Id<"expenseSessionItem">) => void;
+  replaceCartItems: (items: CartItem[]) => void;
   clearCart: () => void;
   calculateTotals: () => void;
 
   // Session Actions
   setCurrentSessionId: (sessionId: string | null) => void;
-  setActiveSession: (session: any | null) => void;
-  setHeldSessions: (sessions: any[]) => void;
+  setActiveSession: (session: ExpenseSession | null) => void;
+  setHeldSessions: (sessions: ExpenseSession[]) => void;
   setSessionCreating: (isCreating: boolean) => void;
   setSessionUpdating: (isUpdating: boolean) => void;
   setSessionExpiresAt: (expiresAt: number | null) => void;
-  loadSessionData: (session: any) => void;
+  loadSessionData: (session: ExpenseSession) => void;
 
   // Transaction Actions
   setTransactionCompleting: (isCompleting: boolean) => void;
@@ -148,7 +171,7 @@ const initialState = {
 export const useExpenseStore = create<ExpenseState>()(
   devtools(
     subscribeWithSelector(
-      immer((set, get) => ({
+      immer((set) => ({
         ...initialState,
 
         // Cart Actions
@@ -196,6 +219,16 @@ export const useExpenseStore = create<ExpenseState>()(
             state.cart.items = state.cart.items.filter(
               (item: CartItem) => item.id !== id
             );
+
+            const totals = calculateCartTotals(state.cart.items);
+            state.cart.subtotal = totals.subtotal;
+            state.cart.tax = totals.tax;
+            state.cart.total = totals.total;
+          }),
+
+        replaceCartItems: (items) =>
+          set((state) => {
+            state.cart.items = items;
 
             const totals = calculateCartTotals(state.cart.items);
             state.cart.subtotal = totals.subtotal;
@@ -280,18 +313,18 @@ export const useExpenseStore = create<ExpenseState>()(
               return;
             }
 
-            const sessionCartItems = (session as any).cartItems || [];
-            state.cart.items = sessionCartItems.map((item: any) => ({
+            const sessionCartItems = session.cartItems || [];
+            state.cart.items = sessionCartItems.map((item) => ({
               id: item._id,
-              name: item.productName,
+              name: item.productName ?? "",
               barcode: item.barcode ?? "",
               sku: item.productSku ?? "",
-              price: item.price,
+              price: item.price ?? 0,
               quantity: item.quantity,
               image: item.image,
-              size: item.size,
+              size: item.size ?? undefined,
               length: item.length,
-              color: item.color,
+              color: item.color ?? undefined,
               productId: item.productId,
               skuId: item.productSkuId,
             }));


### PR DESCRIPTION
## Summary
- add optimistic add/update/remove behavior for the expense cart, including rollback on command errors
- prevent stale active-session query refreshes from clobbering pending optimistic cart state
- cover add, quantity, remove, clear-cart, stale-query, rejection, and server-id reconciliation paths

## Validation
- bun run --filter '@athena/webapp' test -- convex/inventory/expenseSessions.test.ts convex/inventory/sessionQueryIndexes.test.ts src/hooks/useExpenseSessions.test.ts src/lib/pos/presentation/expense/useExpenseRegisterViewModel.test.ts src/lib/pos/presentation/register/catalogSearch.test.ts\n- bunx tsc --noEmit -p packages/athena-webapp/tsconfig.json\n- bun run --filter '@athena/webapp' lint:frontend:changed\n- bun run --filter '@athena/webapp' build\n- bun run graphify:rebuild\n- bun run harness:review\n- git diff --check\n- pre-push validation suite