### PR TITLE
fix: label checkout stock reservations

### DIFF
--- a/docs/solutions/logic-errors/athena-stock-adjustments-checkout-reservations-2026-05-08.md
+++ b/docs/solutions/logic-errors/athena-stock-adjustments-checkout-reservations-2026-05-08.md
@@ -1,0 +1,63 @@
+---
+title: Athena Stock Adjustments Should Name Checkout And POS Reservation Sources
+date: 2026-05-08
+category: logic-errors
+module: athena-webapp
+problem_type: reservation_source_visibility
+component: stock-adjustments
+symptoms:
+  - "Stock adjustments can show fewer available units than on-hand units without explaining the reservation source"
+  - "Active checkout sessions reserve stock by decrementing productSku.quantityAvailable, while POS sessions reserve stock through inventoryHold rows"
+  - "Operators cannot tell whether reserved stock is in checkout or POS from the stock-adjustment table"
+root_cause: stock_adjustment_snapshot_exposed_pos_holds_but_not_active_checkout_session_reservations
+resolution_type: source_aware_read_model_and_labels
+severity: medium
+tags:
+  - operations
+  - stock-adjustments
+  - checkout
+  - point-of-sale
+  - inventory
+---
+
+# Athena Stock Adjustments Should Name Checkout And POS Reservation Sources
+
+## Problem
+
+Athena has two active reservation models. Storefront checkout sessions reserve
+stock by reducing `productSku.quantityAvailable`, while POS sessions reserve
+stock through `inventoryHold` ledger rows. A stock-adjustment workspace that
+only summarizes inventory holds can still show available quantity below on-hand
+quantity, but the row-level reservation label is missing for checkout-held SKUs.
+
+That makes the count table look inconsistent: operators see a numeric gap, but
+not whether the reserved units are held by customer checkout or by POS activity.
+
+## Solution
+
+Keep the stock-adjustment snapshot source-aware:
+
+- Read active, unexpired checkout sessions for the store and sum their
+  `checkoutSessionItem.quantity` values by `productSkuId`.
+- Keep POS hold quantities separate from checkout quantities.
+- Report `reservedQuantity` as the total of checkout plus POS reservations.
+- Compute sellable availability by subtracting POS holds from the durable SKU
+  availability, because checkout reservations are already reflected in
+  `productSku.quantityAvailable`.
+- Render compact row labels for each source, such as `1 checkout` and `2 POS`,
+  and make the page summary name checkout sessions and POS sessions separately.
+
+## Prevention
+
+- Do not treat every stock reservation as an `inventoryHold`; checkout sessions
+  already reserve availability through SKU quantity updates.
+- Do not subtract checkout reservation totals from `productSku.quantityAvailable`
+  a second time in read models.
+- When a UI explains reserved stock, include the source whenever multiple
+  reservation systems can affect the same SKU.
+
+## Related Validation
+
+- `bun run --filter '@athena/webapp' test -- convex/stockOps/adjustments.test.ts`
+- `bun run --filter '@athena/webapp' test -- src/components/operations/StockAdjustmentWorkspace.test.tsx`
+- `bun run pr:athena`

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 4847 nodes · 4769 edges · 1571 communities detected
+- 4850 nodes · 4775 edges · 1571 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -1701,60 +1701,60 @@ Cohesion: 0.11
 Nodes (2): isSkuReserved(), shouldDisable()
 
 ### Community 23 - "Community 23"
+Cohesion: 0.13
+Nodes (8): formatInventoryNumber(), formatReservationSourceSummary(), getInventoryItemDisplayName(), getReservationLabels(), getSkuDetailEntries(), handleDraftChange(), rowMatchesStockAdjustmentSearch(), setDraftValue()
+
+### Community 24 - "Community 24"
 Cohesion: 0.15
 Nodes (10): capitalizeFirstLetter(), capitalizeWords(), cn(), currencyFormatter(), formatDate(), getErrorForField(), getProductName(), getRelativeTime() (+2 more)
 
-### Community 24 - "Community 24"
+### Community 25 - "Community 25"
 Cohesion: 0.21
 Nodes (16): commandForPort(), defaultCommand(), isProcessAlive(), isReachable(), listPreviews(), optionsFromEnv(), pruneState(), readState() (+8 more)
 
-### Community 25 - "Community 25"
+### Community 26 - "Community 26"
 Cohesion: 0.18
 Nodes (15): assertRegisterSessionIdentity(), assertRegisterSessionMatchesTransaction(), assertValidRegisterSessionTransition(), buildClosedRegisterSessionPatch(), buildRegisterSession(), buildRegisterSessionCloseoutPatch(), buildRegisterSessionDepositPatch(), buildRegisterSessionOpeningFloatCorrectionPatch() (+7 more)
 
-### Community 26 - "Community 26"
+### Community 27 - "Community 27"
 Cohesion: 0.12
 Nodes (4): listCompletedTransactionsForDay(), listSessionItems(), listTransactionItems(), readAllQueryResults()
 
-### Community 27 - "Community 27"
+### Community 28 - "Community 28"
+Cohesion: 0.19
+Nodes (16): applyStockAdjustmentBatchWithCtx(), assertDistinctStockAdjustmentLineItems(), buildResolvedStockAdjustmentStatus(), buildStockAdjustmentDecisionEventType(), buildStockAdjustmentSourceId(), buildStockAdjustmentTitle(), listInventorySnapshotWithCtx(), listProductSkusForStockAdjustmentScopeWithCtx() (+8 more)
+
+### Community 29 - "Community 29"
 Cohesion: 0.17
 Nodes (13): buildSkuContinuityContextById(), deriveContinuityStatus(), getPlannedActionAt(), getStartOfCurrentDay(), hasLateInbound(), hasRelatedPurchaseOrderContext(), hasStalePlannedAction(), isInboundStatus() (+5 more)
 
-### Community 28 - "Community 28"
+### Community 30 - "Community 30"
 Cohesion: 0.17
 Nodes (15): ancestorChain(), collectRawMoneyParses(), collectRawMoneyParsesFromSource(), collectRawNumericHelperNames(), collectSourceFiles(), containsDisallowedRawNumericParse(), containsTerm(), isAllowedDisplayConversion() (+7 more)
 
-### Community 29 - "Community 29"
+### Community 31 - "Community 31"
 Cohesion: 0.19
 Nodes (16): bestFuzzyTokenScore(), extractIdentifierFromUrl(), findExactMatches(), firstNonEmpty(), isProbablySameToken(), levenshteinDistance(), normalizeIdentifier(), normalizeSearchText() (+8 more)
 
-### Community 30 - "Community 30"
+### Community 32 - "Community 32"
 Cohesion: 0.22
 Nodes (15): acquireInventoryHold(), acquireInventoryHoldsBatch(), adjustInventoryHold(), consumeInventoryHoldsForSession(), getActiveHoldForSessionSku(), listActiveSessionHolds(), markHoldExpired(), readActiveHeldQuantitiesForSkus() (+7 more)
 
-### Community 31 - "Community 31"
+### Community 33 - "Community 33"
 Cohesion: 0.25
 Nodes (16): assertStaffProfileReadyForCredential(), authenticateStaffCredentialForApprovalWithCtx(), authenticateStaffCredentialForTerminalWithCtx(), authenticateStaffCredentialWithCtx(), createStaffCredentialWithCtx(), getActiveRolesForStaffProfile(), getCredentialById(), getCredentialByUsername() (+8 more)
 
-### Community 32 - "Community 32"
+### Community 34 - "Community 34"
 Cohesion: 0.11
 Nodes (0):
 
-### Community 33 - "Community 33"
-Cohesion: 0.2
-Nodes (15): applyStockAdjustmentBatchWithCtx(), assertDistinctStockAdjustmentLineItems(), buildResolvedStockAdjustmentStatus(), buildStockAdjustmentDecisionEventType(), buildStockAdjustmentSourceId(), buildStockAdjustmentTitle(), listInventorySnapshotWithCtx(), listProductSkusForStockAdjustmentScopeWithCtx() (+7 more)
-
-### Community 34 - "Community 34"
+### Community 35 - "Community 35"
 Cohesion: 0.16
 Nodes (9): checkIfItemsHaveChanged(), createOnlineOrder(), findBestValuePromoCode(), handleExistingSession(), handleOrderCreation(), handlePlaceOrder(), listSessionItems(), updateExistingSession() (+1 more)
 
-### Community 35 - "Community 35"
+### Community 36 - "Community 36"
 Cohesion: 0.12
 Nodes (2): getLocalOperatingDate(), getLocalOperatingDateRange()
-
-### Community 36 - "Community 36"
-Cohesion: 0.13
-Nodes (6): formatInventoryNumber(), getInventoryItemDisplayName(), getSkuDetailEntries(), handleDraftChange(), rowMatchesStockAdjustmentSearch(), setDraftValue()
 
 ### Community 37 - "Community 37"
 Cohesion: 0.22
@@ -2169,16 +2169,16 @@ Cohesion: 0.29
 Nodes (0):
 
 ### Community 140 - "Community 140"
-Cohesion: 0.33
-Nodes (2): getProductName(), sortProduct()
-
-### Community 141 - "Community 141"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 142 - "Community 142"
+### Community 141 - "Community 141"
 Cohesion: 0.52
 Nodes (6): addItemToSavedBag(), getActiveSavedBag(), getBaseUrl(), removeItemFromSavedBag(), updateSavedBagItem(), updateSavedBagOwner()
+
+### Community 142 - "Community 142"
+Cohesion: 0.33
+Nodes (2): getProductName(), sortProduct()
 
 ### Community 143 - "Community 143"
 Cohesion: 0.43
@@ -2265,16 +2265,16 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 164 - "Community 164"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.47
+Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
 
 ### Community 165 - "Community 165"
-Cohesion: 0.4
-Nodes (2): useBulkOperations(), validateOperationValue()
-
-### Community 166 - "Community 166"
 Cohesion: 0.33
 Nodes (0):
+
+### Community 166 - "Community 166"
+Cohesion: 0.4
+Nodes (2): useBulkOperations(), validateOperationValue()
 
 ### Community 167 - "Community 167"
 Cohesion: 0.33
@@ -2289,12 +2289,12 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 170 - "Community 170"
-Cohesion: 0.53
-Nodes (4): calculatePosChange(), calculatePosRemainingDue(), calculatePosTotalPaid(), roundPosAmount()
-
-### Community 171 - "Community 171"
 Cohesion: 0.33
 Nodes (0):
+
+### Community 171 - "Community 171"
+Cohesion: 0.53
+Nodes (4): calculatePosChange(), calculatePosRemainingDue(), calculatePosTotalPaid(), roundPosAmount()
 
 ### Community 172 - "Community 172"
 Cohesion: 0.33
@@ -2305,40 +2305,40 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 174 - "Community 174"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 175 - "Community 175"
 Cohesion: 0.4
 Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 176 - "Community 176"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 177 - "Community 177"
-Cohesion: 0.47
-Nodes (4): fetchPosTransaction(), getBaseUrl(), getPosTransactionByReceiptToken(), PosTransactionReceiptError
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 178 - "Community 178"
 Cohesion: 0.47
-Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
+Nodes (4): fetchPosTransaction(), getBaseUrl(), getPosTransactionByReceiptToken(), PosTransactionReceiptError
 
 ### Community 179 - "Community 179"
+Cohesion: 0.47
+Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
+
+### Community 180 - "Community 180"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 180 - "Community 180"
+### Community 181 - "Community 181"
 Cohesion: 0.4
 Nodes (2): handleConfirm(), handlePrimaryAction()
 
-### Community 181 - "Community 181"
+### Community 182 - "Community 182"
 Cohesion: 0.33
 Nodes (0):
-
-### Community 182 - "Community 182"
-Cohesion: 0.47
-Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
 
 ### Community 183 - "Community 183"
 Cohesion: 0.53

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -11,8 +11,20 @@
       "relation": "calls",
       "source": "adjustments_buildstockadjustmentsourceid",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L227",
+      "source_location": "L229",
       "target": "adjustments_applystockadjustmentbatchwithctx",
+      "weight": 1
+    },
+    {
+      "_src": "adjustments_listinventorysnapshotwithctx",
+      "_tgt": "adjustments_readactivecheckoutreservedquantitiesforstockopssnapshot",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "adjustments_readactivecheckoutreservedquantitiesforstockopssnapshot",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L473",
+      "target": "adjustments_listinventorysnapshotwithctx",
       "weight": 1
     },
     {
@@ -23,7 +35,7 @@
       "relation": "calls",
       "source": "adjustments_readactiveheldquantitiesforstockopssnapshot",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L414",
+      "source_location": "L468",
       "target": "adjustments_listinventorysnapshotwithctx",
       "weight": 1
     },
@@ -35,7 +47,7 @@
       "relation": "calls",
       "source": "adjustments_applystockadjustmentbatchwithctx",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L318",
+      "source_location": "L320",
       "target": "adjustments_resolvestockadjustmentapprovaldecisionwithctx",
       "weight": 1
     },
@@ -47,7 +59,7 @@
       "relation": "calls",
       "source": "adjustments_buildresolvedstockadjustmentstatus",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L331",
+      "source_location": "L333",
       "target": "adjustments_resolvestockadjustmentapprovaldecisionwithctx",
       "weight": 1
     },
@@ -59,7 +71,7 @@
       "relation": "calls",
       "source": "adjustments_buildstockadjustmentdecisioneventtype",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L348",
+      "source_location": "L350",
       "target": "adjustments_resolvestockadjustmentapprovaldecisionwithctx",
       "weight": 1
     },
@@ -71,7 +83,7 @@
       "relation": "calls",
       "source": "adjustments_buildstockadjustmenttitle",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L361",
+      "source_location": "L363",
       "target": "adjustments_resolvestockadjustmentapprovaldecisionwithctx",
       "weight": 1
     },
@@ -83,7 +95,7 @@
       "relation": "calls",
       "source": "adjustments_trimoptional",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L358",
+      "source_location": "L360",
       "target": "adjustments_resolvestockadjustmentapprovaldecisionwithctx",
       "weight": 1
     },
@@ -95,7 +107,7 @@
       "relation": "calls",
       "source": "adjustments_mapsubmitstockadjustmentbatcherror",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L860",
+      "source_location": "L925",
       "target": "adjustments_submitstockadjustmentbatchcommandwithctx",
       "weight": 1
     },
@@ -107,7 +119,7 @@
       "relation": "calls",
       "source": "adjustments_submitstockadjustmentbatchwithctx",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L858",
+      "source_location": "L923",
       "target": "adjustments_submitstockadjustmentbatchcommandwithctx",
       "weight": 1
     },
@@ -119,7 +131,7 @@
       "relation": "calls",
       "source": "adjustments_applystockadjustmentbatchwithctx",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L759",
+      "source_location": "L824",
       "target": "adjustments_submitstockadjustmentbatchwithctx",
       "weight": 1
     },
@@ -131,7 +143,7 @@
       "relation": "calls",
       "source": "adjustments_assertdistinctstockadjustmentlineitems",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L619",
+      "source_location": "L684",
       "target": "adjustments_submitstockadjustmentbatchwithctx",
       "weight": 1
     },
@@ -143,7 +155,7 @@
       "relation": "calls",
       "source": "adjustments_buildstockadjustmenttitle",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L715",
+      "source_location": "L780",
       "target": "adjustments_submitstockadjustmentbatchwithctx",
       "weight": 1
     },
@@ -155,7 +167,7 @@
       "relation": "calls",
       "source": "adjustments_trimoptional",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L607",
+      "source_location": "L672",
       "target": "adjustments_submitstockadjustmentbatchwithctx",
       "weight": 1
     },
@@ -167,7 +179,7 @@
       "relation": "calls",
       "source": "adjustments_listproductskusforstockadjustmentscopewithctx",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L552",
+      "source_location": "L617",
       "target": "adjustments_temporarydeletestockadjustmentscopeskuswithctx",
       "weight": 1
     },
@@ -20543,7 +20555,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_stockops_adjustments_test_ts",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.test.ts",
-      "source_location": "L173",
+      "source_location": "L175",
       "target": "adjustments_test_createapprovaldecisionmutationctx",
       "weight": 1
     },
@@ -20567,7 +20579,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_stockops_adjustments_test_ts",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.test.ts",
-      "source_location": "L318",
+      "source_location": "L320",
       "target": "adjustments_test_createsubmissionmutationctx",
       "weight": 1
     },
@@ -20591,7 +20603,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_stockops_adjustments_ts",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L214",
+      "source_location": "L216",
       "target": "adjustments_applystockadjustmentbatchwithctx",
       "weight": 1
     },
@@ -20603,7 +20615,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_stockops_adjustments_ts",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L138",
+      "source_location": "L140",
       "target": "adjustments_assertdistinctstockadjustmentlineitems",
       "weight": 1
     },
@@ -20615,7 +20627,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_stockops_adjustments_ts",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L168",
+      "source_location": "L170",
       "target": "adjustments_assertnormalizedlineitem",
       "weight": 1
     },
@@ -20627,7 +20639,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_stockops_adjustments_ts",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L272",
+      "source_location": "L274",
       "target": "adjustments_buildresolvedstockadjustmentstatus",
       "weight": 1
     },
@@ -20639,7 +20651,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_stockops_adjustments_ts",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L262",
+      "source_location": "L264",
       "target": "adjustments_buildstockadjustmentdecisioneventtype",
       "weight": 1
     },
@@ -20651,7 +20663,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_stockops_adjustments_ts",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L154",
+      "source_location": "L156",
       "target": "adjustments_buildstockadjustmentsourceid",
       "weight": 1
     },
@@ -20663,7 +20675,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_stockops_adjustments_ts",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L158",
+      "source_location": "L160",
       "target": "adjustments_buildstockadjustmenttitle",
       "weight": 1
     },
@@ -20675,7 +20687,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_stockops_adjustments_ts",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L77",
+      "source_location": "L79",
       "target": "adjustments_getstockadjustmentscopekey",
       "weight": 1
     },
@@ -20687,7 +20699,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_stockops_adjustments_ts",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L401",
+      "source_location": "L455",
       "target": "adjustments_listinventorysnapshotwithctx",
       "weight": 1
     },
@@ -20699,7 +20711,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_stockops_adjustments_ts",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L81",
+      "source_location": "L83",
       "target": "adjustments_listproductskusforstockadjustmentscopewithctx",
       "weight": 1
     },
@@ -20711,8 +20723,20 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_stockops_adjustments_ts",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L800",
+      "source_location": "L865",
       "target": "adjustments_mapsubmitstockadjustmentbatcherror",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_convex_stockops_adjustments_ts",
+      "_tgt": "adjustments_readactivecheckoutreservedquantitiesforstockopssnapshot",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_convex_stockops_adjustments_ts",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L403",
+      "target": "adjustments_readactivecheckoutreservedquantitiesforstockopssnapshot",
       "weight": 1
     },
     {
@@ -20723,7 +20747,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_stockops_adjustments_ts",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L372",
+      "source_location": "L374",
       "target": "adjustments_readactiveheldquantitiesforstockopssnapshot",
       "weight": 1
     },
@@ -20735,7 +20759,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_stockops_adjustments_ts",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L278",
+      "source_location": "L280",
       "target": "adjustments_resolvestockadjustmentapprovaldecisionwithctx",
       "weight": 1
     },
@@ -20747,7 +20771,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_stockops_adjustments_ts",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L853",
+      "source_location": "L918",
       "target": "adjustments_submitstockadjustmentbatchcommandwithctx",
       "weight": 1
     },
@@ -20759,7 +20783,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_stockops_adjustments_ts",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L603",
+      "source_location": "L668",
       "target": "adjustments_submitstockadjustmentbatchwithctx",
       "weight": 1
     },
@@ -20771,7 +20795,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_stockops_adjustments_ts",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L522",
+      "source_location": "L587",
       "target": "adjustments_temporarydeletestockadjustmentscopeskuswithctx",
       "weight": 1
     },
@@ -20783,7 +20807,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_stockops_adjustments_ts",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L72",
+      "source_location": "L74",
       "target": "adjustments_trimoptional",
       "weight": 1
     },
@@ -28103,7 +28127,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L221",
+      "source_location": "L223",
       "target": "stockadjustmentworkspace_buildcyclecountdrafts",
       "weight": 1
     },
@@ -28115,7 +28139,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L217",
+      "source_location": "L219",
       "target": "stockadjustmentworkspace_buildmanualdrafts",
       "weight": 1
     },
@@ -28127,7 +28151,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L239",
+      "source_location": "L241",
       "target": "stockadjustmentworkspace_buildstockadjustmentsubmissionkey",
       "weight": 1
     },
@@ -28139,8 +28163,20 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L254",
+      "source_location": "L256",
       "target": "stockadjustmentworkspace_formatinventorynumber",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_tsx",
+      "_tgt": "stockadjustmentworkspace_formatreservationsourcesummary",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_tsx",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L298",
+      "target": "stockadjustmentworkspace_formatreservationsourcesummary",
       "weight": 1
     },
     {
@@ -28151,7 +28187,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L209",
+      "source_location": "L211",
       "target": "stockadjustmentworkspace_getcountscopekey",
       "weight": 1
     },
@@ -28163,7 +28199,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L213",
+      "source_location": "L215",
       "target": "stockadjustmentworkspace_getcountscopelabel",
       "weight": 1
     },
@@ -28175,8 +28211,20 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L258",
+      "source_location": "L260",
       "target": "stockadjustmentworkspace_getinventoryitemdisplayname",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_tsx",
+      "_tgt": "stockadjustmentworkspace_getreservationlabels",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_tsx",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L264",
+      "target": "stockadjustmentworkspace_getreservationlabels",
       "weight": 1
     },
     {
@@ -28187,7 +28235,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L262",
+      "source_location": "L320",
       "target": "stockadjustmentworkspace_getskudetailentries",
       "weight": 1
     },
@@ -28199,7 +28247,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L1069",
+      "source_location": "L1148",
       "target": "stockadjustmentworkspace_handledraftchange",
       "weight": 1
     },
@@ -28211,7 +28259,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L287",
+      "source_location": "L345",
       "target": "stockadjustmentworkspace_normalizestockadjustmentsearch",
       "weight": 1
     },
@@ -28223,7 +28271,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L291",
+      "source_location": "L349",
       "target": "stockadjustmentworkspace_parsecountscopekeys",
       "weight": 1
     },
@@ -28235,7 +28283,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L250",
+      "source_location": "L252",
       "target": "stockadjustmentworkspace_pluralize",
       "weight": 1
     },
@@ -28247,7 +28295,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L328",
+      "source_location": "L386",
       "target": "stockadjustmentworkspace_rowmatchesavailabilityfilter",
       "weight": 1
     },
@@ -28259,7 +28307,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L304",
+      "source_location": "L362",
       "target": "stockadjustmentworkspace_rowmatchesstockadjustmentsearch",
       "weight": 1
     },
@@ -28271,7 +28319,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L300",
+      "source_location": "L358",
       "target": "stockadjustmentworkspace_serializecountscopekeys",
       "weight": 1
     },
@@ -28283,7 +28331,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L1059",
+      "source_location": "L1138",
       "target": "stockadjustmentworkspace_setdraftvalue",
       "weight": 1
     },
@@ -28295,7 +28343,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L245",
+      "source_location": "L247",
       "target": "stockadjustmentworkspace_trimoptional",
       "weight": 1
     },
@@ -54976,14 +55024,38 @@
       "weight": 1
     },
     {
-      "_src": "stockadjustmentworkspace_getskudetailentries",
+      "_src": "stockadjustmentworkspace_formatreservationsourcesummary",
       "_tgt": "stockadjustmentworkspace_formatinventorynumber",
       "confidence": "EXTRACTED",
       "confidence_score": 1,
       "relation": "calls",
       "source": "stockadjustmentworkspace_formatinventorynumber",
       "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L278",
+      "source_location": "L305",
+      "target": "stockadjustmentworkspace_formatreservationsourcesummary",
+      "weight": 1
+    },
+    {
+      "_src": "stockadjustmentworkspace_getreservationlabels",
+      "_tgt": "stockadjustmentworkspace_formatinventorynumber",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "stockadjustmentworkspace_formatinventorynumber",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L277",
+      "target": "stockadjustmentworkspace_getreservationlabels",
+      "weight": 1
+    },
+    {
+      "_src": "stockadjustmentworkspace_getskudetailentries",
+      "_tgt": "stockadjustmentworkspace_getreservationlabels",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "stockadjustmentworkspace_getreservationlabels",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L321",
       "target": "stockadjustmentworkspace_getskudetailentries",
       "weight": 1
     },
@@ -54995,7 +55067,7 @@
       "relation": "calls",
       "source": "stockadjustmentworkspace_setdraftvalue",
       "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L1070",
+      "source_location": "L1149",
       "target": "stockadjustmentworkspace_handledraftchange",
       "weight": 1
     },
@@ -55007,7 +55079,7 @@
       "relation": "calls",
       "source": "stockadjustmentworkspace_getinventoryitemdisplayname",
       "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L312",
+      "source_location": "L370",
       "target": "stockadjustmentworkspace_rowmatchesstockadjustmentsearch",
       "weight": 1
     },
@@ -65580,65 +65652,65 @@
     {
       "community": 140,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_productutils_ts",
-      "label": "productUtils.ts",
-      "norm_label": "productutils.ts",
-      "source_file": "packages/athena-webapp/src/lib/productUtils.ts",
+      "id": "packages_athena_webapp_src_stories_templates_reference_fixtures_tsx",
+      "label": "reference-fixtures.tsx",
+      "norm_label": "reference-fixtures.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
       "source_location": "L1"
     },
     {
       "community": 140,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_productutils_ts",
-      "label": "productUtils.ts",
-      "norm_label": "productutils.ts",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L1"
+      "id": "reference_fixtures_compacttable",
+      "label": "CompactTable()",
+      "norm_label": "compacttable()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L263"
     },
     {
       "community": 140,
       "file_type": "code",
-      "id": "productutils_getproductname",
-      "label": "getProductName()",
-      "norm_label": "getproductname()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L18"
+      "id": "reference_fixtures_framecard",
+      "label": "FrameCard()",
+      "norm_label": "framecard()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L163"
     },
     {
       "community": 140,
       "file_type": "code",
-      "id": "productutils_haslowstock",
-      "label": "hasLowStock()",
-      "norm_label": "haslowstock()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L52"
+      "id": "reference_fixtures_lanecard",
+      "label": "LaneCard()",
+      "norm_label": "lanecard()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L213"
     },
     {
       "community": 140,
       "file_type": "code",
-      "id": "productutils_issoldout",
-      "label": "isSoldOut()",
-      "norm_label": "issoldout()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L45"
+      "id": "reference_fixtures_metrictile",
+      "label": "MetricTile()",
+      "norm_label": "metrictile()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L194"
     },
     {
       "community": 140,
       "file_type": "code",
-      "id": "productutils_sortproduct",
-      "label": "sortProduct()",
-      "norm_label": "sortproduct()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L66"
+      "id": "reference_fixtures_minitrendchart",
+      "label": "MiniTrendChart()",
+      "norm_label": "minitrendchart()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L240"
     },
     {
       "community": 140,
       "file_type": "code",
-      "id": "productutils_sortskusbylength",
-      "label": "sortSkusByLength()",
-      "norm_label": "sortskusbylength()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L62"
+      "id": "reference_fixtures_referencepageshell",
+      "label": "ReferencePageShell()",
+      "norm_label": "referencepageshell()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L145"
     },
     {
       "community": 1400,
@@ -65733,65 +65805,65 @@
     {
       "community": 141,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_templates_reference_fixtures_tsx",
-      "label": "reference-fixtures.tsx",
-      "norm_label": "reference-fixtures.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "id": "packages_storefront_webapp_src_api_savedbag_ts",
+      "label": "savedBag.ts",
+      "norm_label": "savedbag.ts",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
       "source_location": "L1"
     },
     {
       "community": 141,
       "file_type": "code",
-      "id": "reference_fixtures_compacttable",
-      "label": "CompactTable()",
-      "norm_label": "compacttable()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L263"
+      "id": "savedbag_additemtosavedbag",
+      "label": "addItemToSavedBag()",
+      "norm_label": "additemtosavedbag()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L25"
     },
     {
       "community": 141,
       "file_type": "code",
-      "id": "reference_fixtures_framecard",
-      "label": "FrameCard()",
-      "norm_label": "framecard()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L163"
+      "id": "savedbag_getactivesavedbag",
+      "label": "getActiveSavedBag()",
+      "norm_label": "getactivesavedbag()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L10"
     },
     {
       "community": 141,
       "file_type": "code",
-      "id": "reference_fixtures_lanecard",
-      "label": "LaneCard()",
-      "norm_label": "lanecard()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L213"
+      "id": "savedbag_getbaseurl",
+      "label": "getBaseUrl()",
+      "norm_label": "getbaseurl()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L8"
     },
     {
       "community": 141,
       "file_type": "code",
-      "id": "reference_fixtures_metrictile",
-      "label": "MetricTile()",
-      "norm_label": "metrictile()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L194"
+      "id": "savedbag_removeitemfromsavedbag",
+      "label": "removeItemFromSavedBag()",
+      "norm_label": "removeitemfromsavedbag()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L91"
     },
     {
       "community": 141,
       "file_type": "code",
-      "id": "reference_fixtures_minitrendchart",
-      "label": "MiniTrendChart()",
-      "norm_label": "minitrendchart()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L240"
+      "id": "savedbag_updatesavedbagitem",
+      "label": "updateSavedBagItem()",
+      "norm_label": "updatesavedbagitem()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L61"
     },
     {
       "community": 141,
       "file_type": "code",
-      "id": "reference_fixtures_referencepageshell",
-      "label": "ReferencePageShell()",
-      "norm_label": "referencepageshell()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L145"
+      "id": "savedbag_updatesavedbagowner",
+      "label": "updateSavedBagOwner()",
+      "norm_label": "updatesavedbagowner()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L109"
     },
     {
       "community": 1410,
@@ -65886,65 +65958,65 @@
     {
       "community": 142,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_savedbag_ts",
-      "label": "savedBag.ts",
-      "norm_label": "savedbag.ts",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "id": "packages_athena_webapp_src_lib_productutils_ts",
+      "label": "productUtils.ts",
+      "norm_label": "productutils.ts",
+      "source_file": "packages/athena-webapp/src/lib/productUtils.ts",
       "source_location": "L1"
     },
     {
       "community": 142,
       "file_type": "code",
-      "id": "savedbag_additemtosavedbag",
-      "label": "addItemToSavedBag()",
-      "norm_label": "additemtosavedbag()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L25"
+      "id": "packages_storefront_webapp_src_lib_productutils_ts",
+      "label": "productUtils.ts",
+      "norm_label": "productutils.ts",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L1"
     },
     {
       "community": 142,
       "file_type": "code",
-      "id": "savedbag_getactivesavedbag",
-      "label": "getActiveSavedBag()",
-      "norm_label": "getactivesavedbag()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L10"
+      "id": "productutils_getproductname",
+      "label": "getProductName()",
+      "norm_label": "getproductname()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L18"
     },
     {
       "community": 142,
       "file_type": "code",
-      "id": "savedbag_getbaseurl",
-      "label": "getBaseUrl()",
-      "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L8"
+      "id": "productutils_haslowstock",
+      "label": "hasLowStock()",
+      "norm_label": "haslowstock()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L52"
     },
     {
       "community": 142,
       "file_type": "code",
-      "id": "savedbag_removeitemfromsavedbag",
-      "label": "removeItemFromSavedBag()",
-      "norm_label": "removeitemfromsavedbag()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L91"
+      "id": "productutils_issoldout",
+      "label": "isSoldOut()",
+      "norm_label": "issoldout()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L45"
     },
     {
       "community": 142,
       "file_type": "code",
-      "id": "savedbag_updatesavedbagitem",
-      "label": "updateSavedBagItem()",
-      "norm_label": "updatesavedbagitem()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L61"
+      "id": "productutils_sortproduct",
+      "label": "sortProduct()",
+      "norm_label": "sortproduct()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L66"
     },
     {
       "community": 142,
       "file_type": "code",
-      "id": "savedbag_updatesavedbagowner",
-      "label": "updateSavedBagOwner()",
-      "norm_label": "updatesavedbagowner()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L109"
+      "id": "productutils_sortskusbylength",
+      "label": "sortSkusByLength()",
+      "norm_label": "sortskusbylength()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L62"
     },
     {
       "community": 1420,
@@ -68910,6 +68982,60 @@
     {
       "community": 164,
       "file_type": "code",
+      "id": "image_uploader_ondragend",
+      "label": "onDragEnd()",
+      "norm_label": "ondragend()",
+      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L100"
+    },
+    {
+      "community": 164,
+      "file_type": "code",
+      "id": "image_uploader_ondrop",
+      "label": "onDrop()",
+      "norm_label": "ondrop()",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L20"
+    },
+    {
+      "community": 164,
+      "file_type": "code",
+      "id": "image_uploader_removeimage",
+      "label": "removeImage()",
+      "norm_label": "removeimage()",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L31"
+    },
+    {
+      "community": 164,
+      "file_type": "code",
+      "id": "image_uploader_unmarkfordeletion",
+      "label": "unmarkForDeletion()",
+      "norm_label": "unmarkfordeletion()",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L46"
+    },
+    {
+      "community": 164,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_image_uploader_tsx",
+      "label": "image-uploader.tsx",
+      "norm_label": "image-uploader.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 164,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_image_uploader_tsx",
+      "label": "image-uploader.tsx",
+      "norm_label": "image-uploader.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 165,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_sidebar_tsx",
       "label": "sidebar.tsx",
       "norm_label": "sidebar.tsx",
@@ -68917,7 +69043,7 @@
       "source_location": "L1"
     },
     {
-      "community": 164,
+      "community": 165,
       "file_type": "code",
       "id": "sidebar_cn",
       "label": "cn()",
@@ -68926,7 +69052,7 @@
       "source_location": "L147"
     },
     {
-      "community": 164,
+      "community": 165,
       "file_type": "code",
       "id": "sidebar_handlekeydown",
       "label": "handleKeyDown()",
@@ -68935,7 +69061,7 @@
       "source_location": "L105"
     },
     {
-      "community": 164,
+      "community": 165,
       "file_type": "code",
       "id": "sidebar_handleonhover",
       "label": "handleOnHover()",
@@ -68944,7 +69070,7 @@
       "source_location": "L224"
     },
     {
-      "community": 164,
+      "community": 165,
       "file_type": "code",
       "id": "sidebar_handleonmouseleave",
       "label": "handleOnMouseLeave()",
@@ -68953,7 +69079,7 @@
       "source_location": "L228"
     },
     {
-      "community": 164,
+      "community": 165,
       "file_type": "code",
       "id": "sidebar_usesidebar",
       "label": "useSidebar()",
@@ -68962,7 +69088,7 @@
       "source_location": "L45"
     },
     {
-      "community": 165,
+      "community": 166,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usebulkoperations_ts",
       "label": "useBulkOperations.ts",
@@ -68971,7 +69097,7 @@
       "source_location": "L1"
     },
     {
-      "community": 165,
+      "community": 166,
       "file_type": "code",
       "id": "usebulkoperations_applyoperation",
       "label": "applyOperation()",
@@ -68980,7 +69106,7 @@
       "source_location": "L56"
     },
     {
-      "community": 165,
+      "community": 166,
       "file_type": "code",
       "id": "usebulkoperations_calculatepricewithfee",
       "label": "calculatePriceWithFee()",
@@ -68989,7 +69115,7 @@
       "source_location": "L87"
     },
     {
-      "community": 165,
+      "community": 166,
       "file_type": "code",
       "id": "usebulkoperations_computepreview",
       "label": "computePreview()",
@@ -68998,7 +69124,7 @@
       "source_location": "L101"
     },
     {
-      "community": 165,
+      "community": 166,
       "file_type": "code",
       "id": "usebulkoperations_usebulkoperations",
       "label": "useBulkOperations()",
@@ -69007,7 +69133,7 @@
       "source_location": "L158"
     },
     {
-      "community": 165,
+      "community": 166,
       "file_type": "code",
       "id": "usebulkoperations_validateoperationvalue",
       "label": "validateOperationValue()",
@@ -69016,7 +69142,7 @@
       "source_location": "L139"
     },
     {
-      "community": 166,
+      "community": 167,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useexpensesessions_ts",
       "label": "useExpenseSessions.ts",
@@ -69025,7 +69151,7 @@
       "source_location": "L1"
     },
     {
-      "community": 166,
+      "community": 167,
       "file_type": "code",
       "id": "useexpensesessions_useexpenseactivesession",
       "label": "useExpenseActiveSession()",
@@ -69034,7 +69160,7 @@
       "source_location": "L42"
     },
     {
-      "community": 166,
+      "community": 167,
       "file_type": "code",
       "id": "useexpensesessions_useexpensesession",
       "label": "useExpenseSession()",
@@ -69043,7 +69169,7 @@
       "source_location": "L32"
     },
     {
-      "community": 166,
+      "community": 167,
       "file_type": "code",
       "id": "useexpensesessions_useexpensesessioncreate",
       "label": "useExpenseSessionCreate()",
@@ -69052,7 +69178,7 @@
       "source_location": "L62"
     },
     {
-      "community": 166,
+      "community": 167,
       "file_type": "code",
       "id": "useexpensesessions_useexpensesessionupdate",
       "label": "useExpenseSessionUpdate()",
@@ -69061,7 +69187,7 @@
       "source_location": "L101"
     },
     {
-      "community": 166,
+      "community": 167,
       "file_type": "code",
       "id": "useexpensesessions_useexpensestoresessions",
       "label": "useExpenseStoreSessions()",
@@ -69070,7 +69196,7 @@
       "source_location": "L10"
     },
     {
-      "community": 167,
+      "community": 168,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useposproducts_ts",
       "label": "usePOSProducts.ts",
@@ -69079,7 +69205,7 @@
       "source_location": "L1"
     },
     {
-      "community": 167,
+      "community": 168,
       "file_type": "code",
       "id": "useposproducts_useposbarcodesearch",
       "label": "usePOSBarcodeSearch()",
@@ -69088,7 +69214,7 @@
       "source_location": "L17"
     },
     {
-      "community": 167,
+      "community": 168,
       "file_type": "code",
       "id": "useposproducts_useposproductidsearch",
       "label": "usePOSProductIdSearch()",
@@ -69097,7 +69223,7 @@
       "source_location": "L24"
     },
     {
-      "community": 167,
+      "community": 168,
       "file_type": "code",
       "id": "useposproducts_useposproductsearch",
       "label": "usePOSProductSearch()",
@@ -69106,7 +69232,7 @@
       "source_location": "L10"
     },
     {
-      "community": 167,
+      "community": 168,
       "file_type": "code",
       "id": "useposproducts_useposquickaddproductsku",
       "label": "usePOSQuickAddProductSku()",
@@ -69115,7 +69241,7 @@
       "source_location": "L33"
     },
     {
-      "community": 167,
+      "community": 168,
       "file_type": "code",
       "id": "useposproducts_usepostransactioncomplete",
       "label": "usePOSTransactionComplete()",
@@ -69124,7 +69250,7 @@
       "source_location": "L31"
     },
     {
-      "community": 168,
+      "community": 169,
       "file_type": "code",
       "id": "behaviorutils_calculateengagementmetrics",
       "label": "calculateEngagementMetrics()",
@@ -69133,7 +69259,7 @@
       "source_location": "L173"
     },
     {
-      "community": 168,
+      "community": 169,
       "file_type": "code",
       "id": "behaviorutils_calculateriskindicators",
       "label": "calculateRiskIndicators()",
@@ -69142,7 +69268,7 @@
       "source_location": "L71"
     },
     {
-      "community": 168,
+      "community": 169,
       "file_type": "code",
       "id": "behaviorutils_getactivitypriority",
       "label": "getActivityPriority()",
@@ -69151,7 +69277,7 @@
       "source_location": "L251"
     },
     {
-      "community": 168,
+      "community": 169,
       "file_type": "code",
       "id": "behaviorutils_getcustomerjourneystage",
       "label": "getCustomerJourneyStage()",
@@ -69160,7 +69286,7 @@
       "source_location": "L36"
     },
     {
-      "community": 168,
+      "community": 169,
       "file_type": "code",
       "id": "behaviorutils_getjourneystageinfo",
       "label": "getJourneyStageInfo()",
@@ -69169,67 +69295,13 @@
       "source_location": "L277"
     },
     {
-      "community": 168,
+      "community": 169,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_behaviorutils_ts",
       "label": "behaviorUtils.ts",
       "norm_label": "behaviorutils.ts",
       "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 169,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_application_results_ts",
-      "label": "results.ts",
-      "norm_label": "results.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 169,
-      "file_type": "code",
-      "id": "results_isposusecasesuccess",
-      "label": "isPosUseCaseSuccess()",
-      "norm_label": "isposusecasesuccess()",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
-      "source_location": "L122"
-    },
-    {
-      "community": 169,
-      "file_type": "code",
-      "id": "results_mapcommandoutcome",
-      "label": "mapCommandOutcome()",
-      "norm_label": "mapcommandoutcome()",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
-      "source_location": "L68"
-    },
-    {
-      "community": 169,
-      "file_type": "code",
-      "id": "results_mapcommandresult",
-      "label": "mapCommandResult()",
-      "norm_label": "mapcommandresult()",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
-      "source_location": "L85"
-    },
-    {
-      "community": 169,
-      "file_type": "code",
-      "id": "results_maplegacymutationresult",
-      "label": "mapLegacyMutationResult()",
-      "norm_label": "maplegacymutationresult()",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
-      "source_location": "L51"
-    },
-    {
-      "community": 169,
-      "file_type": "code",
-      "id": "results_mapthrownerror",
-      "label": "mapThrownError()",
-      "norm_label": "mapthrownerror()",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
-      "source_location": "L102"
     },
     {
       "community": 17,
@@ -69432,6 +69504,60 @@
     {
       "community": 170,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_application_results_ts",
+      "label": "results.ts",
+      "norm_label": "results.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 170,
+      "file_type": "code",
+      "id": "results_isposusecasesuccess",
+      "label": "isPosUseCaseSuccess()",
+      "norm_label": "isposusecasesuccess()",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
+      "source_location": "L122"
+    },
+    {
+      "community": 170,
+      "file_type": "code",
+      "id": "results_mapcommandoutcome",
+      "label": "mapCommandOutcome()",
+      "norm_label": "mapcommandoutcome()",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
+      "source_location": "L68"
+    },
+    {
+      "community": 170,
+      "file_type": "code",
+      "id": "results_mapcommandresult",
+      "label": "mapCommandResult()",
+      "norm_label": "mapcommandresult()",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
+      "source_location": "L85"
+    },
+    {
+      "community": 170,
+      "file_type": "code",
+      "id": "results_maplegacymutationresult",
+      "label": "mapLegacyMutationResult()",
+      "norm_label": "maplegacymutationresult()",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
+      "source_location": "L51"
+    },
+    {
+      "community": 170,
+      "file_type": "code",
+      "id": "results_mapthrownerror",
+      "label": "mapThrownError()",
+      "norm_label": "mapthrownerror()",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
+      "source_location": "L102"
+    },
+    {
+      "community": 171,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_domain_payments_ts",
       "label": "payments.ts",
       "norm_label": "payments.ts",
@@ -69439,7 +69565,7 @@
       "source_location": "L1"
     },
     {
-      "community": 170,
+      "community": 171,
       "file_type": "code",
       "id": "payments_calculateposchange",
       "label": "calculatePosChange()",
@@ -69448,7 +69574,7 @@
       "source_location": "L3"
     },
     {
-      "community": 170,
+      "community": 171,
       "file_type": "code",
       "id": "payments_calculateposremainingdue",
       "label": "calculatePosRemainingDue()",
@@ -69457,7 +69583,7 @@
       "source_location": "L20"
     },
     {
-      "community": 170,
+      "community": 171,
       "file_type": "code",
       "id": "payments_calculatepostotalpaid",
       "label": "calculatePosTotalPaid()",
@@ -69466,7 +69592,7 @@
       "source_location": "L14"
     },
     {
-      "community": 170,
+      "community": 171,
       "file_type": "code",
       "id": "payments_ispospaymentsufficient",
       "label": "isPosPaymentSufficient()",
@@ -69475,7 +69601,7 @@
       "source_location": "L7"
     },
     {
-      "community": 170,
+      "community": 171,
       "file_type": "code",
       "id": "payments_roundposamount",
       "label": "roundPosAmount()",
@@ -69484,7 +69610,7 @@
       "source_location": "L27"
     },
     {
-      "community": 171,
+      "community": 172,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_presentation_register_selectors_ts",
       "label": "selectors.ts",
@@ -69493,7 +69619,7 @@
       "source_location": "L1"
     },
     {
-      "community": 171,
+      "community": 172,
       "file_type": "code",
       "id": "selectors_buildregisterheaderstate",
       "label": "buildRegisterHeaderState()",
@@ -69502,7 +69628,7 @@
       "source_location": "L28"
     },
     {
-      "community": 171,
+      "community": 172,
       "file_type": "code",
       "id": "selectors_buildregisterinfostate",
       "label": "buildRegisterInfoState()",
@@ -69511,7 +69637,7 @@
       "source_location": "L37"
     },
     {
-      "community": 171,
+      "community": 172,
       "file_type": "code",
       "id": "selectors_getcashierdisplayname",
       "label": "getCashierDisplayName()",
@@ -69520,7 +69646,7 @@
       "source_location": "L12"
     },
     {
-      "community": 171,
+      "community": 172,
       "file_type": "code",
       "id": "selectors_getregistercustomerinfo",
       "label": "getRegisterCustomerInfo()",
@@ -69529,7 +69655,7 @@
       "source_location": "L6"
     },
     {
-      "community": 171,
+      "community": 172,
       "file_type": "code",
       "id": "selectors_isregistersessionactive",
       "label": "isRegisterSessionActive()",
@@ -69538,7 +69664,7 @@
       "source_location": "L49"
     },
     {
-      "community": 172,
+      "community": 173,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_toastservice_ts",
       "label": "toastService.ts",
@@ -69547,7 +69673,7 @@
       "source_location": "L1"
     },
     {
-      "community": 172,
+      "community": 173,
       "file_type": "code",
       "id": "toastservice_handleposoperation",
       "label": "handlePOSOperation()",
@@ -69556,7 +69682,7 @@
       "source_location": "L171"
     },
     {
-      "community": 172,
+      "community": 173,
       "file_type": "code",
       "id": "toastservice_showinventoryerror",
       "label": "showInventoryError()",
@@ -69565,7 +69691,7 @@
       "source_location": "L302"
     },
     {
-      "community": 172,
+      "community": 173,
       "file_type": "code",
       "id": "toastservice_shownoactivesessionerror",
       "label": "showNoActiveSessionError()",
@@ -69574,7 +69700,7 @@
       "source_location": "L319"
     },
     {
-      "community": 172,
+      "community": 173,
       "file_type": "code",
       "id": "toastservice_showsessionexpirederror",
       "label": "showSessionExpiredError()",
@@ -69583,7 +69709,7 @@
       "source_location": "L312"
     },
     {
-      "community": 172,
+      "community": 173,
       "file_type": "code",
       "id": "toastservice_showvalidationerror",
       "label": "showValidationError()",
@@ -69592,7 +69718,7 @@
       "source_location": "L293"
     },
     {
-      "community": 173,
+      "community": 174,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_traces_traceid_tsx",
       "label": "$traceId.tsx",
@@ -69601,7 +69727,7 @@
       "source_location": "L1"
     },
     {
-      "community": 173,
+      "community": 174,
       "file_type": "code",
       "id": "traceid_hasorgnotfoundpayload",
       "label": "hasOrgNotFoundPayload()",
@@ -69610,7 +69736,7 @@
       "source_location": "L12"
     },
     {
-      "community": 173,
+      "community": 174,
       "file_type": "code",
       "id": "traceid_workflowtraceloadingstate",
       "label": "WorkflowTraceLoadingState()",
@@ -69619,7 +69745,7 @@
       "source_location": "L21"
     },
     {
-      "community": 173,
+      "community": 174,
       "file_type": "code",
       "id": "traceid_workflowtraceroute",
       "label": "WorkflowTraceRoute()",
@@ -69628,7 +69754,7 @@
       "source_location": "L101"
     },
     {
-      "community": 173,
+      "community": 174,
       "file_type": "code",
       "id": "traceid_workflowtraceroutecontent",
       "label": "WorkflowTraceRouteContent()",
@@ -69637,7 +69763,7 @@
       "source_location": "L35"
     },
     {
-      "community": 173,
+      "community": 174,
       "file_type": "code",
       "id": "traceid_workflowtracerouteshell",
       "label": "WorkflowTraceRouteShell()",
@@ -69646,7 +69772,7 @@
       "source_location": "L66"
     },
     {
-      "community": 174,
+      "community": 175,
       "file_type": "code",
       "id": "organizationsettingsview_handledeletestore",
       "label": "handleDeleteStore()",
@@ -69655,7 +69781,7 @@
       "source_location": "L155"
     },
     {
-      "community": 174,
+      "community": 175,
       "file_type": "code",
       "id": "organizationsettingsview_navigation",
       "label": "Navigation()",
@@ -69664,7 +69790,7 @@
       "source_location": "L197"
     },
     {
-      "community": 174,
+      "community": 175,
       "file_type": "code",
       "id": "organizationsettingsview_onsubmit",
       "label": "onSubmit()",
@@ -69673,7 +69799,7 @@
       "source_location": "L104"
     },
     {
-      "community": 174,
+      "community": 175,
       "file_type": "code",
       "id": "organizationsettingsview_organizationsettings",
       "label": "OrganizationSettings()",
@@ -69682,7 +69808,7 @@
       "source_location": "L25"
     },
     {
-      "community": 174,
+      "community": 175,
       "file_type": "code",
       "id": "organizationsettingsview_savestorechanges",
       "label": "saveStoreChanges()",
@@ -69691,7 +69817,7 @@
       "source_location": "L72"
     },
     {
-      "community": 174,
+      "community": 175,
       "file_type": "code",
       "id": "packages_athena_webapp_src_settings_organization_components_organizationsettingsview_tsx",
       "label": "OrganizationSettingsView.tsx",
@@ -69700,7 +69826,7 @@
       "source_location": "L1"
     },
     {
-      "community": 175,
+      "community": 176,
       "file_type": "code",
       "id": "packages_athena_webapp_src_settings_store_storesettingsview_tsx",
       "label": "StoreSettingsView.tsx",
@@ -69709,7 +69835,7 @@
       "source_location": "L1"
     },
     {
-      "community": 175,
+      "community": 176,
       "file_type": "code",
       "id": "storesettingsview_handledeleteallproductsinstore",
       "label": "handleDeleteAllProductsInStore()",
@@ -69718,7 +69844,7 @@
       "source_location": "L231"
     },
     {
-      "community": 175,
+      "community": 176,
       "file_type": "code",
       "id": "storesettingsview_handledeletestore",
       "label": "handleDeleteStore()",
@@ -69727,7 +69853,7 @@
       "source_location": "L167"
     },
     {
-      "community": 175,
+      "community": 176,
       "file_type": "code",
       "id": "storesettingsview_onsubmit",
       "label": "onSubmit()",
@@ -69736,7 +69862,7 @@
       "source_location": "L116"
     },
     {
-      "community": 175,
+      "community": 176,
       "file_type": "code",
       "id": "storesettingsview_savestorechanges",
       "label": "saveStoreChanges()",
@@ -69745,7 +69871,7 @@
       "source_location": "L83"
     },
     {
-      "community": 175,
+      "community": 176,
       "file_type": "code",
       "id": "storesettingsview_storesettings",
       "label": "StoreSettings()",
@@ -69754,7 +69880,7 @@
       "source_location": "L29"
     },
     {
-      "community": 176,
+      "community": 177,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_storybook_shell_tsx",
       "label": "storybook-shell.tsx",
@@ -69763,7 +69889,7 @@
       "source_location": "L1"
     },
     {
-      "community": 176,
+      "community": 177,
       "file_type": "code",
       "id": "storybook_shell_storybookcallout",
       "label": "StorybookCallout()",
@@ -69772,7 +69898,7 @@
       "source_location": "L76"
     },
     {
-      "community": 176,
+      "community": 177,
       "file_type": "code",
       "id": "storybook_shell_storybooklist",
       "label": "StorybookList()",
@@ -69781,7 +69907,7 @@
       "source_location": "L55"
     },
     {
-      "community": 176,
+      "community": 177,
       "file_type": "code",
       "id": "storybook_shell_storybookpillrow",
       "label": "StorybookPillRow()",
@@ -69790,7 +69916,7 @@
       "source_location": "L88"
     },
     {
-      "community": 176,
+      "community": 177,
       "file_type": "code",
       "id": "storybook_shell_storybooksection",
       "label": "StorybookSection()",
@@ -69799,7 +69925,7 @@
       "source_location": "L34"
     },
     {
-      "community": 176,
+      "community": 177,
       "file_type": "code",
       "id": "storybook_shell_storybookshell",
       "label": "StorybookShell()",
@@ -69808,7 +69934,7 @@
       "source_location": "L13"
     },
     {
-      "community": 177,
+      "community": 178,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_postransaction_ts",
       "label": "posTransaction.ts",
@@ -69817,7 +69943,7 @@
       "source_location": "L1"
     },
     {
-      "community": 177,
+      "community": 178,
       "file_type": "code",
       "id": "postransaction_fetchpostransaction",
       "label": "fetchPosTransaction()",
@@ -69826,7 +69952,7 @@
       "source_location": "L69"
     },
     {
-      "community": 177,
+      "community": 178,
       "file_type": "code",
       "id": "postransaction_getbaseurl",
       "label": "getBaseUrl()",
@@ -69835,7 +69961,7 @@
       "source_location": "L57"
     },
     {
-      "community": 177,
+      "community": 178,
       "file_type": "code",
       "id": "postransaction_getpostransactionbyreceipttoken",
       "label": "getPosTransactionByReceiptToken()",
@@ -69844,7 +69970,7 @@
       "source_location": "L90"
     },
     {
-      "community": 177,
+      "community": 178,
       "file_type": "code",
       "id": "postransaction_postransactionreceipterror",
       "label": "PosTransactionReceiptError",
@@ -69853,7 +69979,7 @@
       "source_location": "L59"
     },
     {
-      "community": 177,
+      "community": 178,
       "file_type": "code",
       "id": "postransaction_postransactionreceipterror_constructor",
       "label": ".constructor()",
@@ -69862,7 +69988,7 @@
       "source_location": "L62"
     },
     {
-      "community": 178,
+      "community": 179,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_promocodes_ts",
       "label": "promoCodes.ts",
@@ -69871,7 +69997,7 @@
       "source_location": "L1"
     },
     {
-      "community": 178,
+      "community": 179,
       "file_type": "code",
       "id": "promocodes_getbaseurl",
       "label": "getBaseUrl()",
@@ -69880,7 +70006,7 @@
       "source_location": "L4"
     },
     {
-      "community": 178,
+      "community": 179,
       "file_type": "code",
       "id": "promocodes_getpromocodeitems",
       "label": "getPromoCodeItems()",
@@ -69889,7 +70015,7 @@
       "source_location": "L49"
     },
     {
-      "community": 178,
+      "community": 179,
       "file_type": "code",
       "id": "promocodes_getpromocodes",
       "label": "getPromoCodes()",
@@ -69898,7 +70024,7 @@
       "source_location": "L34"
     },
     {
-      "community": 178,
+      "community": 179,
       "file_type": "code",
       "id": "promocodes_getredeemedpromocodes",
       "label": "getRedeemedPromoCodes()",
@@ -69907,67 +70033,13 @@
       "source_location": "L74"
     },
     {
-      "community": 178,
+      "community": 179,
       "file_type": "code",
       "id": "promocodes_redeempromocode",
       "label": "redeemPromoCode()",
       "norm_label": "redeempromocode()",
       "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
       "source_location": "L6"
-    },
-    {
-      "community": 179,
-      "file_type": "code",
-      "id": "billingdetails_clearform",
-      "label": "clearForm()",
-      "norm_label": "clearform()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
-      "source_location": "L173"
-    },
-    {
-      "community": 179,
-      "file_type": "code",
-      "id": "billingdetails_enteredbillingaddressdetails",
-      "label": "EnteredBillingAddressDetails()",
-      "norm_label": "enteredbillingaddressdetails()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
-      "source_location": "L102"
-    },
-    {
-      "community": 179,
-      "file_type": "code",
-      "id": "billingdetails_handleusebillingaddressonfile",
-      "label": "handleUseBillingAddressOnFile()",
-      "norm_label": "handleusebillingaddressonfile()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
-      "source_location": "L201"
-    },
-    {
-      "community": 179,
-      "file_type": "code",
-      "id": "billingdetails_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
-      "source_location": "L150"
-    },
-    {
-      "community": 179,
-      "file_type": "code",
-      "id": "billingdetails_togglesameasdelivery",
-      "label": "toggleSameAsDelivery()",
-      "norm_label": "togglesameasdelivery()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
-      "source_location": "L155"
-    },
-    {
-      "community": 179,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_billingdetails_tsx",
-      "label": "BillingDetails.tsx",
-      "norm_label": "billingdetails.tsx",
-      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
-      "source_location": "L1"
     },
     {
       "community": 18,
@@ -70170,6 +70242,60 @@
     {
       "community": 180,
       "file_type": "code",
+      "id": "billingdetails_clearform",
+      "label": "clearForm()",
+      "norm_label": "clearform()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
+      "source_location": "L173"
+    },
+    {
+      "community": 180,
+      "file_type": "code",
+      "id": "billingdetails_enteredbillingaddressdetails",
+      "label": "EnteredBillingAddressDetails()",
+      "norm_label": "enteredbillingaddressdetails()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
+      "source_location": "L102"
+    },
+    {
+      "community": 180,
+      "file_type": "code",
+      "id": "billingdetails_handleusebillingaddressonfile",
+      "label": "handleUseBillingAddressOnFile()",
+      "norm_label": "handleusebillingaddressonfile()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
+      "source_location": "L201"
+    },
+    {
+      "community": 180,
+      "file_type": "code",
+      "id": "billingdetails_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
+      "source_location": "L150"
+    },
+    {
+      "community": 180,
+      "file_type": "code",
+      "id": "billingdetails_togglesameasdelivery",
+      "label": "toggleSameAsDelivery()",
+      "norm_label": "togglesameasdelivery()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
+      "source_location": "L155"
+    },
+    {
+      "community": 180,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_billingdetails_tsx",
+      "label": "BillingDetails.tsx",
+      "norm_label": "billingdetails.tsx",
+      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 181,
+      "file_type": "code",
       "id": "mobileproductactions_collapseonpageclick",
       "label": "collapseOnPageClick()",
       "norm_label": "collapseonpageclick()",
@@ -70177,7 +70303,7 @@
       "source_location": "L76"
     },
     {
-      "community": 180,
+      "community": 181,
       "file_type": "code",
       "id": "mobileproductactions_handleconfirm",
       "label": "handleConfirm()",
@@ -70186,7 +70312,7 @@
       "source_location": "L120"
     },
     {
-      "community": 180,
+      "community": 181,
       "file_type": "code",
       "id": "mobileproductactions_handleprimaryaction",
       "label": "handlePrimaryAction()",
@@ -70195,7 +70321,7 @@
       "source_location": "L129"
     },
     {
-      "community": 180,
+      "community": 181,
       "file_type": "code",
       "id": "mobileproductactions_handlesecondaryaction",
       "label": "handleSecondaryAction()",
@@ -70204,7 +70330,7 @@
       "source_location": "L133"
     },
     {
-      "community": 180,
+      "community": 181,
       "file_type": "code",
       "id": "mobileproductactions_updateposition",
       "label": "updatePosition()",
@@ -70213,7 +70339,7 @@
       "source_location": "L44"
     },
     {
-      "community": 180,
+      "community": 181,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_mobileproductactions_tsx",
       "label": "MobileProductActions.tsx",
@@ -70222,7 +70348,7 @@
       "source_location": "L1"
     },
     {
-      "community": 181,
+      "community": 182,
       "file_type": "code",
       "id": "checkoutexpired_checkoutexpired",
       "label": "CheckoutExpired()",
@@ -70231,7 +70357,7 @@
       "source_location": "L9"
     },
     {
-      "community": 181,
+      "community": 182,
       "file_type": "code",
       "id": "checkoutexpired_checkoutsessiongeneric",
       "label": "CheckoutSessionGeneric()",
@@ -70240,7 +70366,7 @@
       "source_location": "L73"
     },
     {
-      "community": 181,
+      "community": 182,
       "file_type": "code",
       "id": "checkoutexpired_checkoutsessionnotfound",
       "label": "CheckoutSessionNotFound()",
@@ -70249,7 +70375,7 @@
       "source_location": "L54"
     },
     {
-      "community": 181,
+      "community": 182,
       "file_type": "code",
       "id": "checkoutexpired_handlesendemail",
       "label": "handleSendEmail()",
@@ -70258,7 +70384,7 @@
       "source_location": "L98"
     },
     {
-      "community": 181,
+      "community": 182,
       "file_type": "code",
       "id": "checkoutexpired_nocheckoutsession",
       "label": "NoCheckoutSession()",
@@ -70267,66 +70393,12 @@
       "source_location": "L33"
     },
     {
-      "community": 181,
+      "community": 182,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_checkout_expired_checkoutexpired_tsx",
       "label": "CheckoutExpired.tsx",
       "norm_label": "checkoutexpired.tsx",
       "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 182,
-      "file_type": "code",
-      "id": "image_uploader_ondragend",
-      "label": "onDragEnd()",
-      "norm_label": "ondragend()",
-      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L100"
-    },
-    {
-      "community": 182,
-      "file_type": "code",
-      "id": "image_uploader_ondrop",
-      "label": "onDrop()",
-      "norm_label": "ondrop()",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L20"
-    },
-    {
-      "community": 182,
-      "file_type": "code",
-      "id": "image_uploader_removeimage",
-      "label": "removeImage()",
-      "norm_label": "removeimage()",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L31"
-    },
-    {
-      "community": 182,
-      "file_type": "code",
-      "id": "image_uploader_unmarkfordeletion",
-      "label": "unmarkForDeletion()",
-      "norm_label": "unmarkfordeletion()",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L46"
-    },
-    {
-      "community": 182,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_image_uploader_tsx",
-      "label": "image-uploader.tsx",
-      "norm_label": "image-uploader.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 182,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_image_uploader_tsx",
-      "label": "image-uploader.tsx",
-      "norm_label": "image-uploader.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
       "source_location": "L1"
     },
     {
@@ -71209,7 +71281,7 @@
       "label": "createApprovalDecisionMutationCtx()",
       "norm_label": "createapprovaldecisionmutationctx()",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.test.ts",
-      "source_location": "L173"
+      "source_location": "L175"
     },
     {
       "community": 197,
@@ -71227,7 +71299,7 @@
       "label": "createSubmissionMutationCtx()",
       "norm_label": "createsubmissionmutationctx()",
       "source_file": "packages/athena-webapp/convex/stockOps/adjustments.test.ts",
-      "source_location": "L318"
+      "source_location": "L320"
     },
     {
       "community": 197,
@@ -73662,182 +73734,182 @@
     {
       "community": 23,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_utils_ts",
-      "label": "utils.ts",
-      "norm_label": "utils.ts",
-      "source_file": "packages/athena-webapp/convex/utils.ts",
+      "id": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_tsx",
+      "label": "StockAdjustmentWorkspace.tsx",
+      "norm_label": "stockadjustmentworkspace.tsx",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
       "source_location": "L1"
     },
     {
       "community": 23,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_utils_ts",
-      "label": "utils.ts",
-      "norm_label": "utils.ts",
-      "source_file": "packages/athena-webapp/src/lib/utils.ts",
-      "source_location": "L1"
+      "id": "stockadjustmentworkspace_buildcyclecountdrafts",
+      "label": "buildCycleCountDrafts()",
+      "norm_label": "buildcyclecountdrafts()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L223"
     },
     {
       "community": 23,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_utils_ts",
-      "label": "utils.ts",
-      "norm_label": "utils.ts",
-      "source_file": "packages/storefront-webapp/src/lib/utils.ts",
-      "source_location": "L1"
+      "id": "stockadjustmentworkspace_buildmanualdrafts",
+      "label": "buildManualDrafts()",
+      "norm_label": "buildmanualdrafts()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L219"
     },
     {
       "community": 23,
       "file_type": "code",
-      "id": "utils_capitalizefirstletter",
-      "label": "capitalizeFirstLetter()",
-      "norm_label": "capitalizefirstletter()",
-      "source_file": "packages/storefront-webapp/src/lib/utils.ts",
-      "source_location": "L18"
+      "id": "stockadjustmentworkspace_buildstockadjustmentsubmissionkey",
+      "label": "buildStockAdjustmentSubmissionKey()",
+      "norm_label": "buildstockadjustmentsubmissionkey()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L241"
     },
     {
       "community": 23,
       "file_type": "code",
-      "id": "utils_capitalizewords",
-      "label": "capitalizeWords()",
-      "norm_label": "capitalizewords()",
-      "source_file": "packages/storefront-webapp/src/lib/utils.ts",
-      "source_location": "L23"
+      "id": "stockadjustmentworkspace_formatinventorynumber",
+      "label": "formatInventoryNumber()",
+      "norm_label": "formatinventorynumber()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L256"
     },
     {
       "community": 23,
       "file_type": "code",
-      "id": "utils_cn",
-      "label": "cn()",
-      "norm_label": "cn()",
-      "source_file": "packages/storefront-webapp/src/lib/utils.ts",
-      "source_location": "L9"
+      "id": "stockadjustmentworkspace_formatreservationsourcesummary",
+      "label": "formatReservationSourceSummary()",
+      "norm_label": "formatreservationsourcesummary()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L298"
     },
     {
       "community": 23,
       "file_type": "code",
-      "id": "utils_currencyformatter",
-      "label": "currencyFormatter()",
-      "norm_label": "currencyformatter()",
-      "source_file": "packages/storefront-webapp/src/lib/utils.ts",
-      "source_location": "L39"
+      "id": "stockadjustmentworkspace_getcountscopekey",
+      "label": "getCountScopeKey()",
+      "norm_label": "getcountscopekey()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L211"
     },
     {
       "community": 23,
       "file_type": "code",
-      "id": "utils_enablequery",
-      "label": "enableQuery()",
-      "norm_label": "enablequery()",
-      "source_file": "packages/storefront-webapp/src/lib/utils.ts",
-      "source_location": "L86"
+      "id": "stockadjustmentworkspace_getcountscopelabel",
+      "label": "getCountScopeLabel()",
+      "norm_label": "getcountscopelabel()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L215"
     },
     {
       "community": 23,
       "file_type": "code",
-      "id": "utils_formatdate",
-      "label": "formatDate()",
-      "norm_label": "formatdate()",
-      "source_file": "packages/storefront-webapp/src/lib/utils.ts",
-      "source_location": "L70"
+      "id": "stockadjustmentworkspace_getinventoryitemdisplayname",
+      "label": "getInventoryItemDisplayName()",
+      "norm_label": "getinventoryitemdisplayname()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L260"
     },
     {
       "community": 23,
       "file_type": "code",
-      "id": "utils_formatuserid",
-      "label": "formatUserId()",
-      "norm_label": "formatuserid()",
-      "source_file": "packages/athena-webapp/src/lib/utils.ts",
-      "source_location": "L87"
+      "id": "stockadjustmentworkspace_getreservationlabels",
+      "label": "getReservationLabels()",
+      "norm_label": "getreservationlabels()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L264"
     },
     {
       "community": 23,
       "file_type": "code",
-      "id": "utils_generatetransactionnumber",
-      "label": "generateTransactionNumber()",
-      "norm_label": "generatetransactionnumber()",
-      "source_file": "packages/athena-webapp/convex/utils.ts",
-      "source_location": "L73"
+      "id": "stockadjustmentworkspace_getskudetailentries",
+      "label": "getSkuDetailEntries()",
+      "norm_label": "getskudetailentries()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L320"
     },
     {
       "community": 23,
       "file_type": "code",
-      "id": "utils_getaddressstring",
-      "label": "getAddressString()",
-      "norm_label": "getaddressstring()",
-      "source_file": "packages/athena-webapp/convex/utils.ts",
-      "source_location": "L15"
+      "id": "stockadjustmentworkspace_handledraftchange",
+      "label": "handleDraftChange()",
+      "norm_label": "handledraftchange()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L1148"
     },
     {
       "community": 23,
       "file_type": "code",
-      "id": "utils_geterrorforfield",
-      "label": "getErrorForField()",
-      "norm_label": "geterrorforfield()",
-      "source_file": "packages/storefront-webapp/src/lib/utils.ts",
-      "source_location": "L14"
+      "id": "stockadjustmentworkspace_normalizestockadjustmentsearch",
+      "label": "normalizeStockAdjustmentSearch()",
+      "norm_label": "normalizestockadjustmentsearch()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L345"
     },
     {
       "community": 23,
       "file_type": "code",
-      "id": "utils_getproductname",
-      "label": "getProductName()",
-      "norm_label": "getproductname()",
-      "source_file": "packages/athena-webapp/convex/utils.ts",
-      "source_location": "L60"
+      "id": "stockadjustmentworkspace_parsecountscopekeys",
+      "label": "parseCountScopeKeys()",
+      "norm_label": "parsecountscopekeys()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L349"
     },
     {
       "community": 23,
       "file_type": "code",
-      "id": "utils_getrelativetime",
-      "label": "getRelativeTime()",
-      "norm_label": "getrelativetime()",
-      "source_file": "packages/storefront-webapp/src/lib/utils.ts",
-      "source_location": "L93"
+      "id": "stockadjustmentworkspace_pluralize",
+      "label": "pluralize()",
+      "norm_label": "pluralize()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L252"
     },
     {
       "community": 23,
       "file_type": "code",
-      "id": "utils_getstoredetails",
-      "label": "getStoreDetails()",
-      "norm_label": "getstoredetails()",
-      "source_file": "packages/storefront-webapp/src/lib/utils.ts",
-      "source_location": "L79"
+      "id": "stockadjustmentworkspace_rowmatchesavailabilityfilter",
+      "label": "rowMatchesAvailabilityFilter()",
+      "norm_label": "rowmatchesavailabilityfilter()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L386"
     },
     {
       "community": 23,
       "file_type": "code",
-      "id": "utils_gettimeremaining",
-      "label": "getTimeRemaining()",
-      "norm_label": "gettimeremaining()",
-      "source_file": "packages/athena-webapp/src/lib/utils.ts",
-      "source_location": "L67"
+      "id": "stockadjustmentworkspace_rowmatchesstockadjustmentsearch",
+      "label": "rowMatchesStockAdjustmentSearch()",
+      "norm_label": "rowmatchesstockadjustmentsearch()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L362"
     },
     {
       "community": 23,
       "file_type": "code",
-      "id": "utils_slugtowords",
-      "label": "slugToWords()",
-      "norm_label": "slugtowords()",
-      "source_file": "packages/storefront-webapp/src/lib/utils.ts",
-      "source_location": "L31"
+      "id": "stockadjustmentworkspace_serializecountscopekeys",
+      "label": "serializeCountScopeKeys()",
+      "norm_label": "serializecountscopekeys()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L358"
     },
     {
       "community": 23,
       "file_type": "code",
-      "id": "utils_snakecasetowords",
-      "label": "snakeCaseToWords()",
-      "norm_label": "snakecasetowords()",
-      "source_file": "packages/athena-webapp/src/lib/utils.ts",
-      "source_location": "L46"
+      "id": "stockadjustmentworkspace_setdraftvalue",
+      "label": "setDraftValue()",
+      "norm_label": "setdraftvalue()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L1138"
     },
     {
       "community": 23,
       "file_type": "code",
-      "id": "utils_toslug",
-      "label": "toSlug()",
-      "norm_label": "toslug()",
-      "source_file": "packages/athena-webapp/src/lib/utils.ts",
-      "source_location": "L33"
+      "id": "stockadjustmentworkspace_trimoptional",
+      "label": "trimOptional()",
+      "norm_label": "trimoptional()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L247"
     },
     {
       "community": 230,
@@ -74292,182 +74364,182 @@
     {
       "community": 24,
       "file_type": "code",
-      "id": "preview_worktree_commandforport",
-      "label": "commandForPort()",
-      "norm_label": "commandforport()",
-      "source_file": "scripts/preview-worktree.ts",
-      "source_location": "L188"
+      "id": "packages_athena_webapp_convex_utils_ts",
+      "label": "utils.ts",
+      "norm_label": "utils.ts",
+      "source_file": "packages/athena-webapp/convex/utils.ts",
+      "source_location": "L1"
     },
     {
       "community": 24,
       "file_type": "code",
-      "id": "preview_worktree_defaultcommand",
-      "label": "defaultCommand()",
-      "norm_label": "defaultcommand()",
-      "source_file": "scripts/preview-worktree.ts",
-      "source_location": "L48"
+      "id": "packages_athena_webapp_src_lib_utils_ts",
+      "label": "utils.ts",
+      "norm_label": "utils.ts",
+      "source_file": "packages/athena-webapp/src/lib/utils.ts",
+      "source_location": "L1"
     },
     {
       "community": 24,
       "file_type": "code",
-      "id": "preview_worktree_findport",
-      "label": "findPort()",
-      "norm_label": "findport()",
-      "source_file": "scripts/preview-worktree.ts",
-      "source_location": "L166"
+      "id": "packages_storefront_webapp_src_lib_utils_ts",
+      "label": "utils.ts",
+      "norm_label": "utils.ts",
+      "source_file": "packages/storefront-webapp/src/lib/utils.ts",
+      "source_location": "L1"
     },
     {
       "community": 24,
       "file_type": "code",
-      "id": "preview_worktree_isprocessalive",
-      "label": "isProcessAlive()",
-      "norm_label": "isprocessalive()",
-      "source_file": "scripts/preview-worktree.ts",
-      "source_location": "L92"
+      "id": "utils_capitalizefirstletter",
+      "label": "capitalizeFirstLetter()",
+      "norm_label": "capitalizefirstletter()",
+      "source_file": "packages/storefront-webapp/src/lib/utils.ts",
+      "source_location": "L18"
     },
     {
       "community": 24,
       "file_type": "code",
-      "id": "preview_worktree_isreachable",
-      "label": "isReachable()",
-      "norm_label": "isreachable()",
-      "source_file": "scripts/preview-worktree.ts",
-      "source_location": "L101"
+      "id": "utils_capitalizewords",
+      "label": "capitalizeWords()",
+      "norm_label": "capitalizewords()",
+      "source_file": "packages/storefront-webapp/src/lib/utils.ts",
+      "source_location": "L23"
     },
     {
       "community": 24,
       "file_type": "code",
-      "id": "preview_worktree_listpreviews",
-      "label": "listPreviews()",
-      "norm_label": "listpreviews()",
-      "source_file": "scripts/preview-worktree.ts",
-      "source_location": "L267"
+      "id": "utils_cn",
+      "label": "cn()",
+      "norm_label": "cn()",
+      "source_file": "packages/storefront-webapp/src/lib/utils.ts",
+      "source_location": "L9"
     },
     {
       "community": 24,
       "file_type": "code",
-      "id": "preview_worktree_logpathfor",
-      "label": "logPathFor()",
-      "norm_label": "logpathfor()",
-      "source_file": "scripts/preview-worktree.ts",
-      "source_location": "L193"
+      "id": "utils_currencyformatter",
+      "label": "currencyFormatter()",
+      "norm_label": "currencyformatter()",
+      "source_file": "packages/storefront-webapp/src/lib/utils.ts",
+      "source_location": "L39"
     },
     {
       "community": 24,
       "file_type": "code",
-      "id": "preview_worktree_optionsfromenv",
-      "label": "optionsFromEnv()",
-      "norm_label": "optionsfromenv()",
-      "source_file": "scripts/preview-worktree.ts",
-      "source_location": "L301"
+      "id": "utils_enablequery",
+      "label": "enableQuery()",
+      "norm_label": "enablequery()",
+      "source_file": "packages/storefront-webapp/src/lib/utils.ts",
+      "source_location": "L86"
     },
     {
       "community": 24,
       "file_type": "code",
-      "id": "preview_worktree_prunestate",
-      "label": "pruneState()",
-      "norm_label": "prunestate()",
-      "source_file": "scripts/preview-worktree.ts",
-      "source_location": "L128"
+      "id": "utils_formatdate",
+      "label": "formatDate()",
+      "norm_label": "formatdate()",
+      "source_file": "packages/storefront-webapp/src/lib/utils.ts",
+      "source_location": "L70"
     },
     {
       "community": 24,
       "file_type": "code",
-      "id": "preview_worktree_readstate",
-      "label": "readState()",
-      "norm_label": "readstate()",
-      "source_file": "scripts/preview-worktree.ts",
-      "source_location": "L79"
-    },
-    {
-      "community": 24,
-      "file_type": "code",
-      "id": "preview_worktree_resolvestatedir",
-      "label": "resolveStateDir()",
-      "norm_label": "resolvestatedir()",
-      "source_file": "scripts/preview-worktree.ts",
-      "source_location": "L67"
-    },
-    {
-      "community": 24,
-      "file_type": "code",
-      "id": "preview_worktree_resolveworktreeroot",
-      "label": "resolveWorktreeRoot()",
-      "norm_label": "resolveworktreeroot()",
-      "source_file": "scripts/preview-worktree.ts",
-      "source_location": "L63"
-    },
-    {
-      "community": 24,
-      "file_type": "code",
-      "id": "preview_worktree_runpreviewcli",
-      "label": "runPreviewCli()",
-      "norm_label": "runpreviewcli()",
-      "source_file": "scripts/preview-worktree.ts",
-      "source_location": "L325"
-    },
-    {
-      "community": 24,
-      "file_type": "code",
-      "id": "preview_worktree_startpreview",
-      "label": "startPreview()",
-      "norm_label": "startpreview()",
-      "source_file": "scripts/preview-worktree.ts",
-      "source_location": "L198"
-    },
-    {
-      "community": 24,
-      "file_type": "code",
-      "id": "preview_worktree_statepath",
-      "label": "statePath()",
-      "norm_label": "statepath()",
-      "source_file": "scripts/preview-worktree.ts",
-      "source_location": "L75"
-    },
-    {
-      "community": 24,
-      "file_type": "code",
-      "id": "preview_worktree_stoppreview",
-      "label": "stopPreview()",
-      "norm_label": "stoppreview()",
-      "source_file": "scripts/preview-worktree.ts",
-      "source_location": "L274"
-    },
-    {
-      "community": 24,
-      "file_type": "code",
-      "id": "preview_worktree_waitforreachable",
-      "label": "waitForReachable()",
-      "norm_label": "waitforreachable()",
-      "source_file": "scripts/preview-worktree.ts",
-      "source_location": "L110"
-    },
-    {
-      "community": 24,
-      "file_type": "code",
-      "id": "preview_worktree_withlock",
-      "label": "withLock()",
-      "norm_label": "withlock()",
-      "source_file": "scripts/preview-worktree.ts",
-      "source_location": "L144"
-    },
-    {
-      "community": 24,
-      "file_type": "code",
-      "id": "preview_worktree_writestate",
-      "label": "writeState()",
-      "norm_label": "writestate()",
-      "source_file": "scripts/preview-worktree.ts",
+      "id": "utils_formatuserid",
+      "label": "formatUserId()",
+      "norm_label": "formatuserid()",
+      "source_file": "packages/athena-webapp/src/lib/utils.ts",
       "source_location": "L87"
     },
     {
       "community": 24,
       "file_type": "code",
-      "id": "scripts_preview_worktree_ts",
-      "label": "preview-worktree.ts",
-      "norm_label": "preview-worktree.ts",
-      "source_file": "scripts/preview-worktree.ts",
-      "source_location": "L1"
+      "id": "utils_generatetransactionnumber",
+      "label": "generateTransactionNumber()",
+      "norm_label": "generatetransactionnumber()",
+      "source_file": "packages/athena-webapp/convex/utils.ts",
+      "source_location": "L73"
+    },
+    {
+      "community": 24,
+      "file_type": "code",
+      "id": "utils_getaddressstring",
+      "label": "getAddressString()",
+      "norm_label": "getaddressstring()",
+      "source_file": "packages/athena-webapp/convex/utils.ts",
+      "source_location": "L15"
+    },
+    {
+      "community": 24,
+      "file_type": "code",
+      "id": "utils_geterrorforfield",
+      "label": "getErrorForField()",
+      "norm_label": "geterrorforfield()",
+      "source_file": "packages/storefront-webapp/src/lib/utils.ts",
+      "source_location": "L14"
+    },
+    {
+      "community": 24,
+      "file_type": "code",
+      "id": "utils_getproductname",
+      "label": "getProductName()",
+      "norm_label": "getproductname()",
+      "source_file": "packages/athena-webapp/convex/utils.ts",
+      "source_location": "L60"
+    },
+    {
+      "community": 24,
+      "file_type": "code",
+      "id": "utils_getrelativetime",
+      "label": "getRelativeTime()",
+      "norm_label": "getrelativetime()",
+      "source_file": "packages/storefront-webapp/src/lib/utils.ts",
+      "source_location": "L93"
+    },
+    {
+      "community": 24,
+      "file_type": "code",
+      "id": "utils_getstoredetails",
+      "label": "getStoreDetails()",
+      "norm_label": "getstoredetails()",
+      "source_file": "packages/storefront-webapp/src/lib/utils.ts",
+      "source_location": "L79"
+    },
+    {
+      "community": 24,
+      "file_type": "code",
+      "id": "utils_gettimeremaining",
+      "label": "getTimeRemaining()",
+      "norm_label": "gettimeremaining()",
+      "source_file": "packages/athena-webapp/src/lib/utils.ts",
+      "source_location": "L67"
+    },
+    {
+      "community": 24,
+      "file_type": "code",
+      "id": "utils_slugtowords",
+      "label": "slugToWords()",
+      "norm_label": "slugtowords()",
+      "source_file": "packages/storefront-webapp/src/lib/utils.ts",
+      "source_location": "L31"
+    },
+    {
+      "community": 24,
+      "file_type": "code",
+      "id": "utils_snakecasetowords",
+      "label": "snakeCaseToWords()",
+      "norm_label": "snakecasetowords()",
+      "source_file": "packages/athena-webapp/src/lib/utils.ts",
+      "source_location": "L46"
+    },
+    {
+      "community": 24,
+      "file_type": "code",
+      "id": "utils_toslug",
+      "label": "toSlug()",
+      "norm_label": "toslug()",
+      "source_file": "packages/athena-webapp/src/lib/utils.ts",
+      "source_location": "L33"
     },
     {
       "community": 240,
@@ -74850,173 +74922,182 @@
     {
       "community": 25,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_registersessions_ts",
-      "label": "registerSessions.ts",
-      "norm_label": "registersessions.ts",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 25,
-      "file_type": "code",
-      "id": "registersessions_assertregistersessionidentity",
-      "label": "assertRegisterSessionIdentity()",
-      "norm_label": "assertregistersessionidentity()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L61"
-    },
-    {
-      "community": 25,
-      "file_type": "code",
-      "id": "registersessions_assertregistersessionmatchestransaction",
-      "label": "assertRegisterSessionMatchesTransaction()",
-      "norm_label": "assertregistersessionmatchestransaction()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L71"
-    },
-    {
-      "community": 25,
-      "file_type": "code",
-      "id": "registersessions_assertvalidregistersessiontransition",
-      "label": "assertValidRegisterSessionTransition()",
-      "norm_label": "assertvalidregistersessiontransition()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L128"
-    },
-    {
-      "community": 25,
-      "file_type": "code",
-      "id": "registersessions_buildclosedregistersessionpatch",
-      "label": "buildClosedRegisterSessionPatch()",
-      "norm_label": "buildclosedregistersessionpatch()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L297"
-    },
-    {
-      "community": 25,
-      "file_type": "code",
-      "id": "registersessions_buildregistersession",
-      "label": "buildRegisterSession()",
-      "norm_label": "buildregistersession()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L93"
-    },
-    {
-      "community": 25,
-      "file_type": "code",
-      "id": "registersessions_buildregistersessioncloseoutpatch",
-      "label": "buildRegisterSessionCloseoutPatch()",
-      "norm_label": "buildregistersessioncloseoutpatch()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
+      "id": "preview_worktree_commandforport",
+      "label": "commandForPort()",
+      "norm_label": "commandforport()",
+      "source_file": "scripts/preview-worktree.ts",
       "source_location": "L188"
     },
     {
       "community": 25,
       "file_type": "code",
-      "id": "registersessions_buildregistersessiondepositpatch",
-      "label": "buildRegisterSessionDepositPatch()",
-      "norm_label": "buildregistersessiondepositpatch()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L227"
+      "id": "preview_worktree_defaultcommand",
+      "label": "defaultCommand()",
+      "norm_label": "defaultcommand()",
+      "source_file": "scripts/preview-worktree.ts",
+      "source_location": "L48"
     },
     {
       "community": 25,
       "file_type": "code",
-      "id": "registersessions_buildregistersessionopeningfloatcorrectionpatch",
-      "label": "buildRegisterSessionOpeningFloatCorrectionPatch()",
-      "norm_label": "buildregistersessionopeningfloatcorrectionpatch()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L256"
+      "id": "preview_worktree_findport",
+      "label": "findPort()",
+      "norm_label": "findport()",
+      "source_file": "scripts/preview-worktree.ts",
+      "source_location": "L166"
     },
     {
       "community": 25,
       "file_type": "code",
-      "id": "registersessions_buildregistersessiontransactionpatch",
-      "label": "buildRegisterSessionTransactionPatch()",
-      "norm_label": "buildregistersessiontransactionpatch()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L147"
+      "id": "preview_worktree_isprocessalive",
+      "label": "isProcessAlive()",
+      "norm_label": "isprocessalive()",
+      "source_file": "scripts/preview-worktree.ts",
+      "source_location": "L92"
     },
     {
       "community": 25,
       "file_type": "code",
-      "id": "registersessions_buildreopenedregistersessionpatch",
-      "label": "buildReopenedRegisterSessionPatch()",
-      "norm_label": "buildreopenedregistersessionpatch()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L214"
+      "id": "preview_worktree_isreachable",
+      "label": "isReachable()",
+      "norm_label": "isreachable()",
+      "source_file": "scripts/preview-worktree.ts",
+      "source_location": "L101"
     },
     {
       "community": 25,
       "file_type": "code",
-      "id": "registersessions_calculateregistersessioncashdelta",
-      "label": "calculateRegisterSessionCashDelta()",
-      "norm_label": "calculateregistersessioncashdelta()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L115"
+      "id": "preview_worktree_listpreviews",
+      "label": "listPreviews()",
+      "norm_label": "listpreviews()",
+      "source_file": "scripts/preview-worktree.ts",
+      "source_location": "L267"
     },
     {
       "community": 25,
       "file_type": "code",
-      "id": "registersessions_correctregistersessionopeningfloatwithctx",
-      "label": "correctRegisterSessionOpeningFloatWithCtx()",
-      "norm_label": "correctregistersessionopeningfloatwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L654"
+      "id": "preview_worktree_logpathfor",
+      "label": "logPathFor()",
+      "norm_label": "logpathfor()",
+      "source_file": "scripts/preview-worktree.ts",
+      "source_location": "L193"
     },
     {
       "community": 25,
       "file_type": "code",
-      "id": "registersessions_findconflictingregistersession",
-      "label": "findConflictingRegisterSession()",
-      "norm_label": "findconflictingregistersession()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L323"
+      "id": "preview_worktree_optionsfromenv",
+      "label": "optionsFromEnv()",
+      "norm_label": "optionsfromenv()",
+      "source_file": "scripts/preview-worktree.ts",
+      "source_location": "L301"
     },
     {
       "community": 25,
       "file_type": "code",
-      "id": "registersessions_normalizeregistersessionidentity",
-      "label": "normalizeRegisterSessionIdentity()",
-      "norm_label": "normalizeregistersessionidentity()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L54"
+      "id": "preview_worktree_prunestate",
+      "label": "pruneState()",
+      "norm_label": "prunestate()",
+      "source_file": "scripts/preview-worktree.ts",
+      "source_location": "L128"
     },
     {
       "community": 25,
       "file_type": "code",
-      "id": "registersessions_persistregistersessionworkflowtraceidbesteffort",
-      "label": "persistRegisterSessionWorkflowTraceIdBestEffort()",
-      "norm_label": "persistregistersessionworkflowtraceidbesteffort()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L32"
+      "id": "preview_worktree_readstate",
+      "label": "readState()",
+      "norm_label": "readstate()",
+      "source_file": "scripts/preview-worktree.ts",
+      "source_location": "L79"
     },
     {
       "community": 25,
       "file_type": "code",
-      "id": "registersessions_recordregistersessiondepositwithctx",
-      "label": "recordRegisterSessionDepositWithCtx()",
-      "norm_label": "recordregistersessiondepositwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L620"
+      "id": "preview_worktree_resolvestatedir",
+      "label": "resolveStateDir()",
+      "norm_label": "resolvestatedir()",
+      "source_file": "scripts/preview-worktree.ts",
+      "source_location": "L67"
     },
     {
       "community": 25,
       "file_type": "code",
-      "id": "registersessions_registersessionstatusset",
-      "label": "registerSessionStatusSet()",
-      "norm_label": "registersessionstatusset()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L11"
+      "id": "preview_worktree_resolveworktreeroot",
+      "label": "resolveWorktreeRoot()",
+      "norm_label": "resolveworktreeroot()",
+      "source_file": "scripts/preview-worktree.ts",
+      "source_location": "L63"
     },
     {
       "community": 25,
       "file_type": "code",
-      "id": "registersessions_trimoptional",
-      "label": "trimOptional()",
-      "norm_label": "trimoptional()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
-      "source_location": "L27"
+      "id": "preview_worktree_runpreviewcli",
+      "label": "runPreviewCli()",
+      "norm_label": "runpreviewcli()",
+      "source_file": "scripts/preview-worktree.ts",
+      "source_location": "L325"
+    },
+    {
+      "community": 25,
+      "file_type": "code",
+      "id": "preview_worktree_startpreview",
+      "label": "startPreview()",
+      "norm_label": "startpreview()",
+      "source_file": "scripts/preview-worktree.ts",
+      "source_location": "L198"
+    },
+    {
+      "community": 25,
+      "file_type": "code",
+      "id": "preview_worktree_statepath",
+      "label": "statePath()",
+      "norm_label": "statepath()",
+      "source_file": "scripts/preview-worktree.ts",
+      "source_location": "L75"
+    },
+    {
+      "community": 25,
+      "file_type": "code",
+      "id": "preview_worktree_stoppreview",
+      "label": "stopPreview()",
+      "norm_label": "stoppreview()",
+      "source_file": "scripts/preview-worktree.ts",
+      "source_location": "L274"
+    },
+    {
+      "community": 25,
+      "file_type": "code",
+      "id": "preview_worktree_waitforreachable",
+      "label": "waitForReachable()",
+      "norm_label": "waitforreachable()",
+      "source_file": "scripts/preview-worktree.ts",
+      "source_location": "L110"
+    },
+    {
+      "community": 25,
+      "file_type": "code",
+      "id": "preview_worktree_withlock",
+      "label": "withLock()",
+      "norm_label": "withlock()",
+      "source_file": "scripts/preview-worktree.ts",
+      "source_location": "L144"
+    },
+    {
+      "community": 25,
+      "file_type": "code",
+      "id": "preview_worktree_writestate",
+      "label": "writeState()",
+      "norm_label": "writestate()",
+      "source_file": "scripts/preview-worktree.ts",
+      "source_location": "L87"
+    },
+    {
+      "community": 25,
+      "file_type": "code",
+      "id": "scripts_preview_worktree_ts",
+      "label": "preview-worktree.ts",
+      "norm_label": "preview-worktree.ts",
+      "source_file": "scripts/preview-worktree.ts",
+      "source_location": "L1"
     },
     {
       "community": 250,
@@ -75381,173 +75462,173 @@
     {
       "community": 26,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_transactionrepository_ts",
-      "label": "transactionRepository.ts",
-      "norm_label": "transactionrepository.ts",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
+      "id": "packages_athena_webapp_convex_operations_registersessions_ts",
+      "label": "registerSessions.ts",
+      "norm_label": "registersessions.ts",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
       "source_location": "L1"
     },
     {
       "community": 26,
       "file_type": "code",
-      "id": "transactionrepository_createpostransaction",
-      "label": "createPosTransaction()",
-      "norm_label": "createpostransaction()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
-      "source_location": "L152"
+      "id": "registersessions_assertregistersessionidentity",
+      "label": "assertRegisterSessionIdentity()",
+      "norm_label": "assertregistersessionidentity()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
+      "source_location": "L61"
     },
     {
       "community": 26,
       "file_type": "code",
-      "id": "transactionrepository_createpostransactionitem",
-      "label": "createPosTransactionItem()",
-      "norm_label": "createpostransactionitem()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
-      "source_location": "L159"
+      "id": "registersessions_assertregistersessionmatchestransaction",
+      "label": "assertRegisterSessionMatchesTransaction()",
+      "norm_label": "assertregistersessionmatchestransaction()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
+      "source_location": "L71"
     },
     {
       "community": 26,
       "file_type": "code",
-      "id": "transactionrepository_getcashierbyid",
-      "label": "getCashierById()",
-      "norm_label": "getcashierbyid()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
-      "source_location": "L51"
+      "id": "registersessions_assertvalidregistersessiontransition",
+      "label": "assertValidRegisterSessionTransition()",
+      "norm_label": "assertvalidregistersessiontransition()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
+      "source_location": "L128"
     },
     {
       "community": 26,
       "file_type": "code",
-      "id": "transactionrepository_getcustomerbyid",
-      "label": "getCustomerById()",
-      "norm_label": "getcustomerbyid()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
-      "source_location": "L58"
+      "id": "registersessions_buildclosedregistersessionpatch",
+      "label": "buildClosedRegisterSessionPatch()",
+      "norm_label": "buildclosedregistersessionpatch()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
+      "source_location": "L297"
     },
     {
       "community": 26,
       "file_type": "code",
-      "id": "transactionrepository_getpossessionbyid",
-      "label": "getPosSessionById()",
-      "norm_label": "getpossessionbyid()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
-      "source_location": "L37"
+      "id": "registersessions_buildregistersession",
+      "label": "buildRegisterSession()",
+      "norm_label": "buildregistersession()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
+      "source_location": "L93"
     },
     {
       "community": 26,
       "file_type": "code",
-      "id": "transactionrepository_getpostransactionbyid",
-      "label": "getPosTransactionById()",
-      "norm_label": "getpostransactionbyid()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
-      "source_location": "L30"
+      "id": "registersessions_buildregistersessioncloseoutpatch",
+      "label": "buildRegisterSessionCloseoutPatch()",
+      "norm_label": "buildregistersessioncloseoutpatch()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
+      "source_location": "L188"
     },
     {
       "community": 26,
       "file_type": "code",
-      "id": "transactionrepository_getproductskubyid",
-      "label": "getProductSkuById()",
-      "norm_label": "getproductskubyid()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
-      "source_location": "L23"
+      "id": "registersessions_buildregistersessiondepositpatch",
+      "label": "buildRegisterSessionDepositPatch()",
+      "norm_label": "buildregistersessiondepositpatch()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
+      "source_location": "L227"
     },
     {
       "community": 26,
       "file_type": "code",
-      "id": "transactionrepository_getregistersessionbyid",
-      "label": "getRegisterSessionById()",
-      "norm_label": "getregistersessionbyid()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
-      "source_location": "L44"
+      "id": "registersessions_buildregistersessionopeningfloatcorrectionpatch",
+      "label": "buildRegisterSessionOpeningFloatCorrectionPatch()",
+      "norm_label": "buildregistersessionopeningfloatcorrectionpatch()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
+      "source_location": "L256"
     },
     {
       "community": 26,
       "file_type": "code",
-      "id": "transactionrepository_getstorebyid",
-      "label": "getStoreById()",
-      "norm_label": "getstorebyid()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
-      "source_location": "L16"
+      "id": "registersessions_buildregistersessiontransactionpatch",
+      "label": "buildRegisterSessionTransactionPatch()",
+      "norm_label": "buildregistersessiontransactionpatch()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
+      "source_location": "L147"
     },
     {
       "community": 26,
       "file_type": "code",
-      "id": "transactionrepository_listcompletedtransactions",
-      "label": "listCompletedTransactions()",
-      "norm_label": "listcompletedtransactions()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
-      "source_location": "L101"
+      "id": "registersessions_buildreopenedregistersessionpatch",
+      "label": "buildReopenedRegisterSessionPatch()",
+      "norm_label": "buildreopenedregistersessionpatch()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
+      "source_location": "L214"
     },
     {
       "community": 26,
       "file_type": "code",
-      "id": "transactionrepository_listcompletedtransactionsforday",
-      "label": "listCompletedTransactionsForDay()",
-      "norm_label": "listcompletedtransactionsforday()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
-      "source_location": "L131"
+      "id": "registersessions_calculateregistersessioncashdelta",
+      "label": "calculateRegisterSessionCashDelta()",
+      "norm_label": "calculateregistersessioncashdelta()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
+      "source_location": "L115"
     },
     {
       "community": 26,
       "file_type": "code",
-      "id": "transactionrepository_listsessionitems",
-      "label": "listSessionItems()",
-      "norm_label": "listsessionitems()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
-      "source_location": "L76"
+      "id": "registersessions_correctregistersessionopeningfloatwithctx",
+      "label": "correctRegisterSessionOpeningFloatWithCtx()",
+      "norm_label": "correctregistersessionopeningfloatwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
+      "source_location": "L654"
     },
     {
       "community": 26,
       "file_type": "code",
-      "id": "transactionrepository_listtransactionitems",
-      "label": "listTransactionItems()",
-      "norm_label": "listtransactionitems()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
-      "source_location": "L65"
+      "id": "registersessions_findconflictingregistersession",
+      "label": "findConflictingRegisterSession()",
+      "norm_label": "findconflictingregistersession()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
+      "source_location": "L323"
     },
     {
       "community": 26,
       "file_type": "code",
-      "id": "transactionrepository_listtransactionsbystore",
-      "label": "listTransactionsByStore()",
-      "norm_label": "listtransactionsbystore()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
-      "source_location": "L87"
+      "id": "registersessions_normalizeregistersessionidentity",
+      "label": "normalizeRegisterSessionIdentity()",
+      "norm_label": "normalizeregistersessionidentity()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
+      "source_location": "L54"
     },
     {
       "community": 26,
       "file_type": "code",
-      "id": "transactionrepository_patchpossession",
-      "label": "patchPosSession()",
-      "norm_label": "patchpossession()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
-      "source_location": "L182"
+      "id": "registersessions_persistregistersessionworkflowtraceidbesteffort",
+      "label": "persistRegisterSessionWorkflowTraceIdBestEffort()",
+      "norm_label": "persistregistersessionworkflowtraceidbesteffort()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
+      "source_location": "L32"
     },
     {
       "community": 26,
       "file_type": "code",
-      "id": "transactionrepository_patchpostransaction",
-      "label": "patchPosTransaction()",
-      "norm_label": "patchpostransaction()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
-      "source_location": "L174"
+      "id": "registersessions_recordregistersessiondepositwithctx",
+      "label": "recordRegisterSessionDepositWithCtx()",
+      "norm_label": "recordregistersessiondepositwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
+      "source_location": "L620"
     },
     {
       "community": 26,
       "file_type": "code",
-      "id": "transactionrepository_patchproductsku",
-      "label": "patchProductSku()",
-      "norm_label": "patchproductsku()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
-      "source_location": "L166"
+      "id": "registersessions_registersessionstatusset",
+      "label": "registerSessionStatusSet()",
+      "norm_label": "registersessionstatusset()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
+      "source_location": "L11"
     },
     {
       "community": 26,
       "file_type": "code",
-      "id": "transactionrepository_readallqueryresults",
-      "label": "readAllQueryResults()",
-      "norm_label": "readallqueryresults()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
-      "source_location": "L6"
+      "id": "registersessions_trimoptional",
+      "label": "trimOptional()",
+      "norm_label": "trimoptional()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessions.ts",
+      "source_location": "L27"
     },
     {
       "community": 260,
@@ -75912,173 +75993,173 @@
     {
       "community": 27,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_stockops_replenishment_ts",
-      "label": "replenishment.ts",
-      "norm_label": "replenishment.ts",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
+      "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_transactionrepository_ts",
+      "label": "transactionRepository.ts",
+      "norm_label": "transactionrepository.ts",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
       "source_location": "L1"
     },
     {
       "community": 27,
       "file_type": "code",
-      "id": "replenishment_buildguidance",
-      "label": "buildGuidance()",
-      "norm_label": "buildguidance()",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
+      "id": "transactionrepository_createpostransaction",
+      "label": "createPosTransaction()",
+      "norm_label": "createpostransaction()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
+      "source_location": "L152"
+    },
+    {
+      "community": 27,
+      "file_type": "code",
+      "id": "transactionrepository_createpostransactionitem",
+      "label": "createPosTransactionItem()",
+      "norm_label": "createpostransactionitem()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
+      "source_location": "L159"
+    },
+    {
+      "community": 27,
+      "file_type": "code",
+      "id": "transactionrepository_getcashierbyid",
+      "label": "getCashierById()",
+      "norm_label": "getcashierbyid()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
+      "source_location": "L51"
+    },
+    {
+      "community": 27,
+      "file_type": "code",
+      "id": "transactionrepository_getcustomerbyid",
+      "label": "getCustomerById()",
+      "norm_label": "getcustomerbyid()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
+      "source_location": "L58"
+    },
+    {
+      "community": 27,
+      "file_type": "code",
+      "id": "transactionrepository_getpossessionbyid",
+      "label": "getPosSessionById()",
+      "norm_label": "getpossessionbyid()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
+      "source_location": "L37"
+    },
+    {
+      "community": 27,
+      "file_type": "code",
+      "id": "transactionrepository_getpostransactionbyid",
+      "label": "getPosTransactionById()",
+      "norm_label": "getpostransactionbyid()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
+      "source_location": "L30"
+    },
+    {
+      "community": 27,
+      "file_type": "code",
+      "id": "transactionrepository_getproductskubyid",
+      "label": "getProductSkuById()",
+      "norm_label": "getproductskubyid()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
+      "source_location": "L23"
+    },
+    {
+      "community": 27,
+      "file_type": "code",
+      "id": "transactionrepository_getregistersessionbyid",
+      "label": "getRegisterSessionById()",
+      "norm_label": "getregistersessionbyid()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
+      "source_location": "L44"
+    },
+    {
+      "community": 27,
+      "file_type": "code",
+      "id": "transactionrepository_getstorebyid",
+      "label": "getStoreById()",
+      "norm_label": "getstorebyid()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
+      "source_location": "L16"
+    },
+    {
+      "community": 27,
+      "file_type": "code",
+      "id": "transactionrepository_listcompletedtransactions",
+      "label": "listCompletedTransactions()",
+      "norm_label": "listcompletedtransactions()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
       "source_location": "L101"
     },
     {
       "community": 27,
       "file_type": "code",
-      "id": "replenishment_buildskucontinuitycontextbyid",
-      "label": "buildSkuContinuityContextById()",
-      "norm_label": "buildskucontinuitycontextbyid()",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
-      "source_location": "L292"
+      "id": "transactionrepository_listcompletedtransactionsforday",
+      "label": "listCompletedTransactionsForDay()",
+      "norm_label": "listcompletedtransactionsforday()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
+      "source_location": "L131"
     },
     {
       "community": 27,
       "file_type": "code",
-      "id": "replenishment_derivecontinuitystatus",
-      "label": "deriveContinuityStatus()",
-      "norm_label": "derivecontinuitystatus()",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
-      "source_location": "L416"
-    },
-    {
-      "community": 27,
-      "file_type": "code",
-      "id": "replenishment_deriverecommendationstatus",
-      "label": "deriveRecommendationStatus()",
-      "norm_label": "deriverecommendationstatus()",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
-      "source_location": "L405"
-    },
-    {
-      "community": 27,
-      "file_type": "code",
-      "id": "replenishment_getcontinuitystatusrank",
-      "label": "getContinuityStatusRank()",
-      "norm_label": "getcontinuitystatusrank()",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
+      "id": "transactionrepository_listsessionitems",
+      "label": "listSessionItems()",
+      "norm_label": "listsessionitems()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
       "source_location": "L76"
     },
     {
       "community": 27,
       "file_type": "code",
-      "id": "replenishment_getplannedactionat",
-      "label": "getPlannedActionAt()",
-      "norm_label": "getplannedactionat()",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
-      "source_location": "L224"
+      "id": "transactionrepository_listtransactionitems",
+      "label": "listTransactionItems()",
+      "norm_label": "listtransactionitems()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
+      "source_location": "L65"
     },
     {
       "community": 27,
       "file_type": "code",
-      "id": "replenishment_getstartofcurrentday",
-      "label": "getStartOfCurrentDay()",
-      "norm_label": "getstartofcurrentday()",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
-      "source_location": "L236"
+      "id": "transactionrepository_listtransactionsbystore",
+      "label": "listTransactionsByStore()",
+      "norm_label": "listtransactionsbystore()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
+      "source_location": "L87"
     },
     {
       "community": 27,
       "file_type": "code",
-      "id": "replenishment_haslateinbound",
-      "label": "hasLateInbound()",
-      "norm_label": "haslateinbound()",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
-      "source_location": "L254"
+      "id": "transactionrepository_patchpossession",
+      "label": "patchPosSession()",
+      "norm_label": "patchpossession()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
+      "source_location": "L182"
     },
     {
       "community": 27,
       "file_type": "code",
-      "id": "replenishment_hasrelatedpurchaseordercontext",
-      "label": "hasRelatedPurchaseOrderContext()",
-      "norm_label": "hasrelatedpurchaseordercontext()",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
-      "source_location": "L396"
+      "id": "transactionrepository_patchpostransaction",
+      "label": "patchPosTransaction()",
+      "norm_label": "patchpostransaction()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
+      "source_location": "L174"
     },
     {
       "community": 27,
       "file_type": "code",
-      "id": "replenishment_hasstaleplannedaction",
-      "label": "hasStalePlannedAction()",
-      "norm_label": "hasstaleplannedaction()",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
-      "source_location": "L246"
+      "id": "transactionrepository_patchproductsku",
+      "label": "patchProductSku()",
+      "norm_label": "patchproductsku()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
+      "source_location": "L166"
     },
     {
       "community": 27,
       "file_type": "code",
-      "id": "replenishment_isinboundstatus",
-      "label": "isInboundStatus()",
-      "norm_label": "isinboundstatus()",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
-      "source_location": "L218"
-    },
-    {
-      "community": 27,
-      "file_type": "code",
-      "id": "replenishment_isplannedstatus",
-      "label": "isPlannedStatus()",
-      "norm_label": "isplannedstatus()",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
-      "source_location": "L212"
-    },
-    {
-      "community": 27,
-      "file_type": "code",
-      "id": "replenishment_listactivestorevendors",
-      "label": "listActiveStoreVendors()",
-      "norm_label": "listactivestorevendors()",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
-      "source_location": "L177"
-    },
-    {
-      "community": 27,
-      "file_type": "code",
-      "id": "replenishment_listpurchaseorderlineitems",
-      "label": "listPurchaseOrderLineItems()",
-      "norm_label": "listpurchaseorderlineitems()",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
-      "source_location": "L195"
-    },
-    {
-      "community": 27,
-      "file_type": "code",
-      "id": "replenishment_listreplenishmentrecommendationswithctx",
-      "label": "listReplenishmentRecommendationsWithCtx()",
-      "norm_label": "listreplenishmentrecommendationswithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
-      "source_location": "L473"
-    },
-    {
-      "community": 27,
-      "file_type": "code",
-      "id": "replenishment_liststoreproductskus",
-      "label": "listStoreProductSkus()",
-      "norm_label": "liststoreproductskus()",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
-      "source_location": "L145"
-    },
-    {
-      "community": 27,
-      "file_type": "code",
-      "id": "replenishment_liststorepurchaseordersbystatus",
-      "label": "listStorePurchaseOrdersByStatus()",
-      "norm_label": "liststorepurchaseordersbystatus()",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
-      "source_location": "L157"
-    },
-    {
-      "community": 27,
-      "file_type": "code",
-      "id": "replenishment_sortpurchaseordercontexts",
-      "label": "sortPurchaseOrderContexts()",
-      "norm_label": "sortpurchaseordercontexts()",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
-      "source_location": "L265"
+      "id": "transactionrepository_readallqueryresults",
+      "label": "readAllQueryResults()",
+      "norm_label": "readallqueryresults()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts",
+      "source_location": "L6"
     },
     {
       "community": 270,
@@ -76443,172 +76524,172 @@
     {
       "community": 28,
       "file_type": "code",
-      "id": "moneyentryaudit_test_ancestorchain",
-      "label": "ancestorChain()",
-      "norm_label": "ancestorchain()",
-      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
-      "source_location": "L197"
+      "id": "adjustments_applystockadjustmentbatchwithctx",
+      "label": "applyStockAdjustmentBatchWithCtx()",
+      "norm_label": "applystockadjustmentbatchwithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L216"
     },
     {
       "community": 28,
       "file_type": "code",
-      "id": "moneyentryaudit_test_collectrawmoneyparses",
-      "label": "collectRawMoneyParses()",
-      "norm_label": "collectrawmoneyparses()",
-      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
-      "source_location": "L394"
+      "id": "adjustments_assertdistinctstockadjustmentlineitems",
+      "label": "assertDistinctStockAdjustmentLineItems()",
+      "norm_label": "assertdistinctstockadjustmentlineitems()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L140"
     },
     {
       "community": 28,
       "file_type": "code",
-      "id": "moneyentryaudit_test_collectrawmoneyparsesfromsource",
-      "label": "collectRawMoneyParsesFromSource()",
-      "norm_label": "collectrawmoneyparsesfromsource()",
-      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
-      "source_location": "L321"
+      "id": "adjustments_assertnormalizedlineitem",
+      "label": "assertNormalizedLineItem()",
+      "norm_label": "assertnormalizedlineitem()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L170"
     },
     {
       "community": 28,
       "file_type": "code",
-      "id": "moneyentryaudit_test_collectrawnumerichelpernames",
-      "label": "collectRawNumericHelperNames()",
-      "norm_label": "collectrawnumerichelpernames()",
-      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
-      "source_location": "L295"
+      "id": "adjustments_buildresolvedstockadjustmentstatus",
+      "label": "buildResolvedStockAdjustmentStatus()",
+      "norm_label": "buildresolvedstockadjustmentstatus()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L274"
     },
     {
       "community": 28,
       "file_type": "code",
-      "id": "moneyentryaudit_test_collectsourcefiles",
-      "label": "collectSourceFiles()",
-      "norm_label": "collectsourcefiles()",
-      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
-      "source_location": "L105"
+      "id": "adjustments_buildstockadjustmentdecisioneventtype",
+      "label": "buildStockAdjustmentDecisionEventType()",
+      "norm_label": "buildstockadjustmentdecisioneventtype()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L264"
     },
     {
       "community": 28,
       "file_type": "code",
-      "id": "moneyentryaudit_test_containsdisallowedrawnumericparse",
-      "label": "containsDisallowedRawNumericParse()",
-      "norm_label": "containsdisallowedrawnumericparse()",
-      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
-      "source_location": "L260"
+      "id": "adjustments_buildstockadjustmentsourceid",
+      "label": "buildStockAdjustmentSourceId()",
+      "norm_label": "buildstockadjustmentsourceid()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L156"
     },
     {
       "community": 28,
       "file_type": "code",
-      "id": "moneyentryaudit_test_containsterm",
-      "label": "containsTerm()",
-      "norm_label": "containsterm()",
-      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
-      "source_location": "L149"
+      "id": "adjustments_buildstockadjustmenttitle",
+      "label": "buildStockAdjustmentTitle()",
+      "norm_label": "buildstockadjustmenttitle()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L160"
     },
     {
       "community": 28,
       "file_type": "code",
-      "id": "moneyentryaudit_test_isalloweddisplayconversion",
-      "label": "isAllowedDisplayConversion()",
-      "norm_label": "isalloweddisplayconversion()",
-      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
-      "source_location": "L239"
+      "id": "adjustments_getstockadjustmentscopekey",
+      "label": "getStockAdjustmentScopeKey()",
+      "norm_label": "getstockadjustmentscopekey()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L79"
     },
     {
       "community": 28,
       "file_type": "code",
-      "id": "moneyentryaudit_test_isallowednumericrounding",
-      "label": "isAllowedNumericRounding()",
-      "norm_label": "isallowednumericrounding()",
-      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
-      "source_location": "L249"
+      "id": "adjustments_listinventorysnapshotwithctx",
+      "label": "listInventorySnapshotWithCtx()",
+      "norm_label": "listinventorysnapshotwithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L455"
     },
     {
       "community": 28,
       "file_type": "code",
-      "id": "moneyentryaudit_test_isallowedpercentagebranch",
-      "label": "isAllowedPercentageBranch()",
-      "norm_label": "isallowedpercentagebranch()",
-      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
-      "source_location": "L225"
+      "id": "adjustments_listproductskusforstockadjustmentscopewithctx",
+      "label": "listProductSkusForStockAdjustmentScopeWithCtx()",
+      "norm_label": "listproductskusforstockadjustmentscopewithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L83"
     },
     {
       "community": 28,
       "file_type": "code",
-      "id": "moneyentryaudit_test_israwnumericparse",
-      "label": "isRawNumericParse()",
-      "norm_label": "israwnumericparse()",
-      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
-      "source_location": "L128"
+      "id": "adjustments_mapsubmitstockadjustmentbatcherror",
+      "label": "mapSubmitStockAdjustmentBatchError()",
+      "norm_label": "mapsubmitstockadjustmentbatcherror()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L865"
     },
     {
       "community": 28,
       "file_type": "code",
-      "id": "moneyentryaudit_test_nearestcontextnode",
-      "label": "nearestContextNode()",
-      "norm_label": "nearestcontextnode()",
-      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
-      "source_location": "L209"
+      "id": "adjustments_readactivecheckoutreservedquantitiesforstockopssnapshot",
+      "label": "readActiveCheckoutReservedQuantitiesForStockOpsSnapshot()",
+      "norm_label": "readactivecheckoutreservedquantitiesforstockopssnapshot()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L403"
     },
     {
       "community": 28,
       "file_type": "code",
-      "id": "moneyentryaudit_test_nodeline",
-      "label": "nodeLine()",
-      "norm_label": "nodeline()",
-      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
-      "source_location": "L186"
+      "id": "adjustments_readactiveheldquantitiesforstockopssnapshot",
+      "label": "readActiveHeldQuantitiesForStockOpsSnapshot()",
+      "norm_label": "readactiveheldquantitiesforstockopssnapshot()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L374"
     },
     {
       "community": 28,
       "file_type": "code",
-      "id": "moneyentryaudit_test_readwebappfile",
-      "label": "readWebappFile()",
-      "norm_label": "readwebappfile()",
-      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
-      "source_location": "L101"
+      "id": "adjustments_resolvestockadjustmentapprovaldecisionwithctx",
+      "label": "resolveStockAdjustmentApprovalDecisionWithCtx()",
+      "norm_label": "resolvestockadjustmentapprovaldecisionwithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L280"
     },
     {
       "community": 28,
       "file_type": "code",
-      "id": "moneyentryaudit_test_referencesmoney",
-      "label": "referencesMoney()",
-      "norm_label": "referencesmoney()",
-      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
-      "source_location": "L154"
+      "id": "adjustments_submitstockadjustmentbatchcommandwithctx",
+      "label": "submitStockAdjustmentBatchCommandWithCtx()",
+      "norm_label": "submitstockadjustmentbatchcommandwithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L918"
     },
     {
       "community": 28,
       "file_type": "code",
-      "id": "moneyentryaudit_test_referencesonlynonmoneynumericcontext",
-      "label": "referencesOnlyNonMoneyNumericContext()",
-      "norm_label": "referencesonlynonmoneynumericcontext()",
-      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
-      "source_location": "L168"
+      "id": "adjustments_submitstockadjustmentbatchwithctx",
+      "label": "submitStockAdjustmentBatchWithCtx()",
+      "norm_label": "submitstockadjustmentbatchwithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L668"
     },
     {
       "community": 28,
       "file_type": "code",
-      "id": "moneyentryaudit_test_returnsrawnumericparse",
-      "label": "returnsRawNumericParse()",
-      "norm_label": "returnsrawnumericparse()",
-      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
-      "source_location": "L275"
+      "id": "adjustments_temporarydeletestockadjustmentscopeskuswithctx",
+      "label": "temporaryDeleteStockAdjustmentScopeSkusWithCtx()",
+      "norm_label": "temporarydeletestockadjustmentscopeskuswithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L587"
     },
     {
       "community": 28,
       "file_type": "code",
-      "id": "moneyentryaudit_test_reviewedreason",
-      "label": "reviewedReason()",
-      "norm_label": "reviewedreason()",
-      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
-      "source_location": "L172"
+      "id": "adjustments_trimoptional",
+      "label": "trimOptional()",
+      "norm_label": "trimoptional()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L74"
     },
     {
       "community": 28,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_moneyentryaudit_test_ts",
-      "label": "moneyEntryAudit.test.ts",
-      "norm_label": "moneyentryaudit.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
+      "id": "packages_athena_webapp_convex_stockops_adjustments_ts",
+      "label": "adjustments.ts",
+      "norm_label": "adjustments.ts",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
       "source_location": "L1"
     },
     {
@@ -76974,173 +77055,173 @@
     {
       "community": 29,
       "file_type": "code",
-      "id": "catalogsearch_addkey",
-      "label": "addKey()",
-      "norm_label": "addkey()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/catalogSearch.ts",
-      "source_location": "L394"
+      "id": "packages_athena_webapp_convex_stockops_replenishment_ts",
+      "label": "replenishment.ts",
+      "norm_label": "replenishment.ts",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
+      "source_location": "L1"
     },
     {
       "community": 29,
       "file_type": "code",
-      "id": "catalogsearch_bestfuzzytokenscore",
-      "label": "bestFuzzyTokenScore()",
-      "norm_label": "bestfuzzytokenscore()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/catalogSearch.ts",
-      "source_location": "L275"
+      "id": "replenishment_buildguidance",
+      "label": "buildGuidance()",
+      "norm_label": "buildguidance()",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
+      "source_location": "L101"
     },
     {
       "community": 29,
       "file_type": "code",
-      "id": "catalogsearch_buildregistercatalogindex",
-      "label": "buildRegisterCatalogIndex()",
-      "norm_label": "buildregistercatalogindex()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/catalogSearch.ts",
-      "source_location": "L65"
-    },
-    {
-      "community": 29,
-      "file_type": "code",
-      "id": "catalogsearch_extractidentifierfromurl",
-      "label": "extractIdentifierFromUrl()",
-      "norm_label": "extractidentifierfromurl()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/catalogSearch.ts",
-      "source_location": "L186"
-    },
-    {
-      "community": 29,
-      "file_type": "code",
-      "id": "catalogsearch_findexactmatches",
-      "label": "findExactMatches()",
-      "norm_label": "findexactmatches()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/catalogSearch.ts",
-      "source_location": "L152"
-    },
-    {
-      "community": 29,
-      "file_type": "code",
-      "id": "catalogsearch_firstnonempty",
-      "label": "firstNonEmpty()",
-      "norm_label": "firstnonempty()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/catalogSearch.ts",
-      "source_location": "L412"
-    },
-    {
-      "community": 29,
-      "file_type": "code",
-      "id": "catalogsearch_isprobablysametoken",
-      "label": "isProbablySameToken()",
-      "norm_label": "isprobablysametoken()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/catalogSearch.ts",
-      "source_location": "L323"
-    },
-    {
-      "community": 29,
-      "file_type": "code",
-      "id": "catalogsearch_levenshteindistance",
-      "label": "levenshteinDistance()",
-      "norm_label": "levenshteindistance()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/catalogSearch.ts",
-      "source_location": "L331"
-    },
-    {
-      "community": 29,
-      "file_type": "code",
-      "id": "catalogsearch_normalizeidentifier",
-      "label": "normalizeIdentifier()",
-      "norm_label": "normalizeidentifier()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/catalogSearch.ts",
-      "source_location": "L366"
-    },
-    {
-      "community": 29,
-      "file_type": "code",
-      "id": "catalogsearch_normalizesearchtext",
-      "label": "normalizeSearchText()",
-      "norm_label": "normalizesearchtext()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/catalogSearch.ts",
-      "source_location": "L370"
-    },
-    {
-      "community": 29,
-      "file_type": "code",
-      "id": "catalogsearch_parsecatalogsearchinput",
-      "label": "parseCatalogSearchInput()",
-      "norm_label": "parsecatalogsearchinput()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/catalogSearch.ts",
-      "source_location": "L170"
-    },
-    {
-      "community": 29,
-      "file_type": "code",
-      "id": "catalogsearch_scorefieldcontains",
-      "label": "scoreFieldContains()",
-      "norm_label": "scorefieldcontains()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/catalogSearch.ts",
-      "source_location": "L271"
-    },
-    {
-      "community": 29,
-      "file_type": "code",
-      "id": "catalogsearch_scorefuzzytokenmatch",
-      "label": "scoreFuzzyTokenMatch()",
-      "norm_label": "scorefuzzytokenmatch()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/catalogSearch.ts",
+      "id": "replenishment_buildskucontinuitycontextbyid",
+      "label": "buildSkuContinuityContextById()",
+      "norm_label": "buildskucontinuitycontextbyid()",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
       "source_location": "L292"
     },
     {
       "community": 29,
       "file_type": "code",
-      "id": "catalogsearch_scorequerytokenforentry",
-      "label": "scoreQueryTokenForEntry()",
-      "norm_label": "scorequerytokenforentry()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/catalogSearch.ts",
-      "source_location": "L252"
+      "id": "replenishment_derivecontinuitystatus",
+      "label": "deriveContinuityStatus()",
+      "norm_label": "derivecontinuitystatus()",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
+      "source_location": "L416"
     },
     {
       "community": 29,
       "file_type": "code",
-      "id": "catalogsearch_scoresearchrow",
-      "label": "scoreSearchRow()",
-      "norm_label": "scoresearchrow()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/catalogSearch.ts",
-      "source_location": "L233"
+      "id": "replenishment_deriverecommendationstatus",
+      "label": "deriveRecommendationStatus()",
+      "norm_label": "deriverecommendationstatus()",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
+      "source_location": "L405"
     },
     {
       "community": 29,
       "file_type": "code",
-      "id": "catalogsearch_searchbytext",
-      "label": "searchByText()",
-      "norm_label": "searchbytext()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/catalogSearch.ts",
-      "source_location": "L207"
+      "id": "replenishment_getcontinuitystatusrank",
+      "label": "getContinuityStatusRank()",
+      "norm_label": "getcontinuitystatusrank()",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
+      "source_location": "L76"
     },
     {
       "community": 29,
       "file_type": "code",
-      "id": "catalogsearch_searchregistercatalog",
-      "label": "searchRegisterCatalog()",
-      "norm_label": "searchregistercatalog()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/catalogSearch.ts",
-      "source_location": "L109"
+      "id": "replenishment_getplannedactionat",
+      "label": "getPlannedActionAt()",
+      "norm_label": "getplannedactionat()",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
+      "source_location": "L224"
     },
     {
       "community": 29,
       "file_type": "code",
-      "id": "catalogsearch_tokenizesearchtext",
-      "label": "tokenizeSearchText()",
-      "norm_label": "tokenizesearchtext()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/catalogSearch.ts",
-      "source_location": "L380"
+      "id": "replenishment_getstartofcurrentday",
+      "label": "getStartOfCurrentDay()",
+      "norm_label": "getstartofcurrentday()",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
+      "source_location": "L236"
     },
     {
       "community": 29,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_presentation_register_catalogsearch_ts",
-      "label": "catalogSearch.ts",
-      "norm_label": "catalogsearch.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/catalogSearch.ts",
-      "source_location": "L1"
+      "id": "replenishment_haslateinbound",
+      "label": "hasLateInbound()",
+      "norm_label": "haslateinbound()",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
+      "source_location": "L254"
+    },
+    {
+      "community": 29,
+      "file_type": "code",
+      "id": "replenishment_hasrelatedpurchaseordercontext",
+      "label": "hasRelatedPurchaseOrderContext()",
+      "norm_label": "hasrelatedpurchaseordercontext()",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
+      "source_location": "L396"
+    },
+    {
+      "community": 29,
+      "file_type": "code",
+      "id": "replenishment_hasstaleplannedaction",
+      "label": "hasStalePlannedAction()",
+      "norm_label": "hasstaleplannedaction()",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
+      "source_location": "L246"
+    },
+    {
+      "community": 29,
+      "file_type": "code",
+      "id": "replenishment_isinboundstatus",
+      "label": "isInboundStatus()",
+      "norm_label": "isinboundstatus()",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
+      "source_location": "L218"
+    },
+    {
+      "community": 29,
+      "file_type": "code",
+      "id": "replenishment_isplannedstatus",
+      "label": "isPlannedStatus()",
+      "norm_label": "isplannedstatus()",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
+      "source_location": "L212"
+    },
+    {
+      "community": 29,
+      "file_type": "code",
+      "id": "replenishment_listactivestorevendors",
+      "label": "listActiveStoreVendors()",
+      "norm_label": "listactivestorevendors()",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
+      "source_location": "L177"
+    },
+    {
+      "community": 29,
+      "file_type": "code",
+      "id": "replenishment_listpurchaseorderlineitems",
+      "label": "listPurchaseOrderLineItems()",
+      "norm_label": "listpurchaseorderlineitems()",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
+      "source_location": "L195"
+    },
+    {
+      "community": 29,
+      "file_type": "code",
+      "id": "replenishment_listreplenishmentrecommendationswithctx",
+      "label": "listReplenishmentRecommendationsWithCtx()",
+      "norm_label": "listreplenishmentrecommendationswithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
+      "source_location": "L473"
+    },
+    {
+      "community": 29,
+      "file_type": "code",
+      "id": "replenishment_liststoreproductskus",
+      "label": "listStoreProductSkus()",
+      "norm_label": "liststoreproductskus()",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
+      "source_location": "L145"
+    },
+    {
+      "community": 29,
+      "file_type": "code",
+      "id": "replenishment_liststorepurchaseordersbystatus",
+      "label": "listStorePurchaseOrdersByStatus()",
+      "norm_label": "liststorepurchaseordersbystatus()",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
+      "source_location": "L157"
+    },
+    {
+      "community": 29,
+      "file_type": "code",
+      "id": "replenishment_sortpurchaseordercontexts",
+      "label": "sortPurchaseOrderContexts()",
+      "norm_label": "sortpurchaseordercontexts()",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
+      "source_location": "L265"
     },
     {
       "community": 290,
@@ -77883,163 +77964,172 @@
     {
       "community": 30,
       "file_type": "code",
-      "id": "inventoryholds_acquireinventoryhold",
-      "label": "acquireInventoryHold()",
-      "norm_label": "acquireinventoryhold()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
-      "source_location": "L140"
+      "id": "moneyentryaudit_test_ancestorchain",
+      "label": "ancestorChain()",
+      "norm_label": "ancestorchain()",
+      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
+      "source_location": "L197"
     },
     {
       "community": 30,
       "file_type": "code",
-      "id": "inventoryholds_acquireinventoryholdsbatch",
-      "label": "acquireInventoryHoldsBatch()",
-      "norm_label": "acquireinventoryholdsbatch()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
-      "source_location": "L318"
+      "id": "moneyentryaudit_test_collectrawmoneyparses",
+      "label": "collectRawMoneyParses()",
+      "norm_label": "collectrawmoneyparses()",
+      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
+      "source_location": "L394"
     },
     {
       "community": 30,
       "file_type": "code",
-      "id": "inventoryholds_adjustinventoryhold",
-      "label": "adjustInventoryHold()",
-      "norm_label": "adjustinventoryhold()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
-      "source_location": "L241"
+      "id": "moneyentryaudit_test_collectrawmoneyparsesfromsource",
+      "label": "collectRawMoneyParsesFromSource()",
+      "norm_label": "collectrawmoneyparsesfromsource()",
+      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
+      "source_location": "L321"
     },
     {
       "community": 30,
       "file_type": "code",
-      "id": "inventoryholds_consumeinventoryholdsforsession",
-      "label": "consumeInventoryHoldsForSession()",
-      "norm_label": "consumeinventoryholdsforsession()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
-      "source_location": "L445"
+      "id": "moneyentryaudit_test_collectrawnumerichelpernames",
+      "label": "collectRawNumericHelperNames()",
+      "norm_label": "collectrawnumerichelpernames()",
+      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
+      "source_location": "L295"
     },
     {
       "community": 30,
       "file_type": "code",
-      "id": "inventoryholds_getactiveholdforsessionsku",
-      "label": "getActiveHoldForSessionSku()",
-      "norm_label": "getactiveholdforsessionsku()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
-      "source_location": "L610"
+      "id": "moneyentryaudit_test_collectsourcefiles",
+      "label": "collectSourceFiles()",
+      "norm_label": "collectsourcefiles()",
+      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
+      "source_location": "L105"
     },
     {
       "community": 30,
       "file_type": "code",
-      "id": "inventoryholds_listactivesessionholds",
-      "label": "listActiveSessionHolds()",
-      "norm_label": "listactivesessionholds()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
-      "source_location": "L639"
+      "id": "moneyentryaudit_test_containsdisallowedrawnumericparse",
+      "label": "containsDisallowedRawNumericParse()",
+      "norm_label": "containsdisallowedrawnumericparse()",
+      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
+      "source_location": "L260"
     },
     {
       "community": 30,
       "file_type": "code",
-      "id": "inventoryholds_markholdexpired",
-      "label": "markHoldExpired()",
-      "norm_label": "markholdexpired()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
-      "source_location": "L667"
+      "id": "moneyentryaudit_test_containsterm",
+      "label": "containsTerm()",
+      "norm_label": "containsterm()",
+      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
+      "source_location": "L149"
     },
     {
       "community": 30,
       "file_type": "code",
-      "id": "inventoryholds_readactiveheldquantitiesforskus",
-      "label": "readActiveHeldQuantitiesForSkus()",
-      "norm_label": "readactiveheldquantitiesforskus()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
-      "source_location": "L546"
+      "id": "moneyentryaudit_test_isalloweddisplayconversion",
+      "label": "isAllowedDisplayConversion()",
+      "norm_label": "isalloweddisplayconversion()",
+      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
+      "source_location": "L239"
     },
     {
       "community": 30,
       "file_type": "code",
-      "id": "inventoryholds_readactiveinventoryholddetailsforsession",
-      "label": "readActiveInventoryHoldDetailsForSession()",
-      "norm_label": "readactiveinventoryholddetailsforsession()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
-      "source_location": "L516"
+      "id": "moneyentryaudit_test_isallowednumericrounding",
+      "label": "isAllowedNumericRounding()",
+      "norm_label": "isallowednumericrounding()",
+      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
+      "source_location": "L249"
     },
     {
       "community": 30,
       "file_type": "code",
-      "id": "inventoryholds_readactiveinventoryholdquantitiesforsession",
-      "label": "readActiveInventoryHoldQuantitiesForSession()",
-      "norm_label": "readactiveinventoryholdquantitiesforsession()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
-      "source_location": "L489"
+      "id": "moneyentryaudit_test_isallowedpercentagebranch",
+      "label": "isAllowedPercentageBranch()",
+      "norm_label": "isallowedpercentagebranch()",
+      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
+      "source_location": "L225"
     },
     {
       "community": 30,
       "file_type": "code",
-      "id": "inventoryholds_releaseactiveinventoryholdsforsession",
-      "label": "releaseActiveInventoryHoldsForSession()",
-      "norm_label": "releaseactiveinventoryholdsforsession()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
-      "source_location": "L409"
+      "id": "moneyentryaudit_test_israwnumericparse",
+      "label": "isRawNumericParse()",
+      "norm_label": "israwnumericparse()",
+      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
+      "source_location": "L128"
     },
     {
       "community": 30,
       "file_type": "code",
-      "id": "inventoryholds_releaseinventoryhold",
-      "label": "releaseInventoryHold()",
-      "norm_label": "releaseinventoryhold()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
-      "source_location": "L191"
+      "id": "moneyentryaudit_test_nearestcontextnode",
+      "label": "nearestContextNode()",
+      "norm_label": "nearestcontextnode()",
+      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
+      "source_location": "L209"
     },
     {
       "community": 30,
       "file_type": "code",
-      "id": "inventoryholds_releaseinventoryholdsbatch",
-      "label": "releaseInventoryHoldsBatch()",
-      "norm_label": "releaseinventoryholdsbatch()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
-      "source_location": "L347"
+      "id": "moneyentryaudit_test_nodeline",
+      "label": "nodeLine()",
+      "norm_label": "nodeline()",
+      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
+      "source_location": "L186"
     },
     {
       "community": 30,
       "file_type": "code",
-      "id": "inventoryholds_releaseinventoryholdsforsession",
-      "label": "releaseInventoryHoldsForSession()",
-      "norm_label": "releaseinventoryholdsforsession()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
-      "source_location": "L385"
+      "id": "moneyentryaudit_test_readwebappfile",
+      "label": "readWebappFile()",
+      "norm_label": "readwebappfile()",
+      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
+      "source_location": "L101"
     },
     {
       "community": 30,
       "file_type": "code",
-      "id": "inventoryholds_releaselegacyexpensequantitypatchholds",
-      "label": "releaseLegacyExpenseQuantityPatchHolds()",
-      "norm_label": "releaselegacyexpensequantitypatchholds()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
-      "source_location": "L367"
+      "id": "moneyentryaudit_test_referencesmoney",
+      "label": "referencesMoney()",
+      "norm_label": "referencesmoney()",
+      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
+      "source_location": "L154"
     },
     {
       "community": 30,
       "file_type": "code",
-      "id": "inventoryholds_sumactiveheldquantity",
-      "label": "sumActiveHeldQuantity()",
-      "norm_label": "sumactiveheldquantity()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
-      "source_location": "L577"
+      "id": "moneyentryaudit_test_referencesonlynonmoneynumericcontext",
+      "label": "referencesOnlyNonMoneyNumericContext()",
+      "norm_label": "referencesonlynonmoneynumericcontext()",
+      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
+      "source_location": "L168"
     },
     {
       "community": 30,
       "file_type": "code",
-      "id": "inventoryholds_validateinventoryavailability",
-      "label": "validateInventoryAvailability()",
-      "norm_label": "validateinventoryavailability()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
-      "source_location": "L77"
+      "id": "moneyentryaudit_test_returnsrawnumericparse",
+      "label": "returnsRawNumericParse()",
+      "norm_label": "returnsrawnumericparse()",
+      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
+      "source_location": "L275"
     },
     {
       "community": 30,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_helpers_inventoryholds_ts",
-      "label": "inventoryHolds.ts",
-      "norm_label": "inventoryholds.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
+      "id": "moneyentryaudit_test_reviewedreason",
+      "label": "reviewedReason()",
+      "norm_label": "reviewedreason()",
+      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
+      "source_location": "L172"
+    },
+    {
+      "community": 30,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_moneyentryaudit_test_ts",
+      "label": "moneyEntryAudit.test.ts",
+      "norm_label": "moneyentryaudit.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
       "source_location": "L1"
     },
     {
@@ -78405,164 +78495,173 @@
     {
       "community": 31,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_staffcredentials_ts",
-      "label": "staffCredentials.ts",
-      "norm_label": "staffcredentials.ts",
-      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
-      "source_location": "L1"
+      "id": "catalogsearch_addkey",
+      "label": "addKey()",
+      "norm_label": "addkey()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/catalogSearch.ts",
+      "source_location": "L394"
     },
     {
       "community": 31,
       "file_type": "code",
-      "id": "staffcredentials_assertstaffprofilereadyforcredential",
-      "label": "assertStaffProfileReadyForCredential()",
-      "norm_label": "assertstaffprofilereadyforcredential()",
-      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
-      "source_location": "L173"
+      "id": "catalogsearch_bestfuzzytokenscore",
+      "label": "bestFuzzyTokenScore()",
+      "norm_label": "bestfuzzytokenscore()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/catalogSearch.ts",
+      "source_location": "L275"
     },
     {
       "community": 31,
       "file_type": "code",
-      "id": "staffcredentials_authenticatestaffcredentialforapprovalwithctx",
-      "label": "authenticateStaffCredentialForApprovalWithCtx()",
-      "norm_label": "authenticatestaffcredentialforapprovalwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
-      "source_location": "L566"
+      "id": "catalogsearch_buildregistercatalogindex",
+      "label": "buildRegisterCatalogIndex()",
+      "norm_label": "buildregistercatalogindex()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/catalogSearch.ts",
+      "source_location": "L65"
     },
     {
       "community": 31,
       "file_type": "code",
-      "id": "staffcredentials_authenticatestaffcredentialforterminalwithctx",
-      "label": "authenticateStaffCredentialForTerminalWithCtx()",
-      "norm_label": "authenticatestaffcredentialforterminalwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
-      "source_location": "L505"
+      "id": "catalogsearch_extractidentifierfromurl",
+      "label": "extractIdentifierFromUrl()",
+      "norm_label": "extractidentifierfromurl()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/catalogSearch.ts",
+      "source_location": "L186"
     },
     {
       "community": 31,
       "file_type": "code",
-      "id": "staffcredentials_authenticatestaffcredentialwithctx",
-      "label": "authenticateStaffCredentialWithCtx()",
-      "norm_label": "authenticatestaffcredentialwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
-      "source_location": "L415"
+      "id": "catalogsearch_findexactmatches",
+      "label": "findExactMatches()",
+      "norm_label": "findexactmatches()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/catalogSearch.ts",
+      "source_location": "L152"
     },
     {
       "community": 31,
       "file_type": "code",
-      "id": "staffcredentials_createstaffcredentialwithctx",
-      "label": "createStaffCredentialWithCtx()",
-      "norm_label": "createstaffcredentialwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
-      "source_location": "L277"
+      "id": "catalogsearch_firstnonempty",
+      "label": "firstNonEmpty()",
+      "norm_label": "firstnonempty()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/catalogSearch.ts",
+      "source_location": "L412"
     },
     {
       "community": 31,
       "file_type": "code",
-      "id": "staffcredentials_getactiverolesforstaffprofile",
-      "label": "getActiveRolesForStaffProfile()",
-      "norm_label": "getactiverolesforstaffprofile()",
-      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
-      "source_location": "L150"
+      "id": "catalogsearch_isprobablysametoken",
+      "label": "isProbablySameToken()",
+      "norm_label": "isprobablysametoken()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/catalogSearch.ts",
+      "source_location": "L323"
     },
     {
       "community": 31,
       "file_type": "code",
-      "id": "staffcredentials_getcredentialbyid",
-      "label": "getCredentialById()",
-      "norm_label": "getcredentialbyid()",
-      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
-      "source_location": "L122"
+      "id": "catalogsearch_levenshteindistance",
+      "label": "levenshteinDistance()",
+      "norm_label": "levenshteindistance()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/catalogSearch.ts",
+      "source_location": "L331"
     },
     {
       "community": 31,
       "file_type": "code",
-      "id": "staffcredentials_getcredentialbyusername",
-      "label": "getCredentialByUsername()",
-      "norm_label": "getcredentialbyusername()",
-      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
-      "source_location": "L129"
+      "id": "catalogsearch_normalizeidentifier",
+      "label": "normalizeIdentifier()",
+      "norm_label": "normalizeidentifier()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/catalogSearch.ts",
+      "source_location": "L366"
     },
     {
       "community": 31,
       "file_type": "code",
-      "id": "staffcredentials_getstaffcredentialbystaffprofileidwithctx",
-      "label": "getStaffCredentialByStaffProfileIdWithCtx()",
-      "norm_label": "getstaffcredentialbystaffprofileidwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
-      "source_location": "L87"
+      "id": "catalogsearch_normalizesearchtext",
+      "label": "normalizeSearchText()",
+      "norm_label": "normalizesearchtext()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/catalogSearch.ts",
+      "source_location": "L370"
     },
     {
       "community": 31,
       "file_type": "code",
-      "id": "staffcredentials_getstaffcredentialusernameavailabilitywithctx",
-      "label": "getStaffCredentialUsernameAvailabilityWithCtx()",
-      "norm_label": "getstaffcredentialusernameavailabilitywithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
+      "id": "catalogsearch_parsecatalogsearchinput",
+      "label": "parseCatalogSearchInput()",
+      "norm_label": "parsecatalogsearchinput()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/catalogSearch.ts",
+      "source_location": "L170"
+    },
+    {
+      "community": 31,
+      "file_type": "code",
+      "id": "catalogsearch_scorefieldcontains",
+      "label": "scoreFieldContains()",
+      "norm_label": "scorefieldcontains()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/catalogSearch.ts",
+      "source_location": "L271"
+    },
+    {
+      "community": 31,
+      "file_type": "code",
+      "id": "catalogsearch_scorefuzzytokenmatch",
+      "label": "scoreFuzzyTokenMatch()",
+      "norm_label": "scorefuzzytokenmatch()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/catalogSearch.ts",
+      "source_location": "L292"
+    },
+    {
+      "community": 31,
+      "file_type": "code",
+      "id": "catalogsearch_scorequerytokenforentry",
+      "label": "scoreQueryTokenForEntry()",
+      "norm_label": "scorequerytokenforentry()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/catalogSearch.ts",
+      "source_location": "L252"
+    },
+    {
+      "community": 31,
+      "file_type": "code",
+      "id": "catalogsearch_scoresearchrow",
+      "label": "scoreSearchRow()",
+      "norm_label": "scoresearchrow()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/catalogSearch.ts",
+      "source_location": "L233"
+    },
+    {
+      "community": 31,
+      "file_type": "code",
+      "id": "catalogsearch_searchbytext",
+      "label": "searchByText()",
+      "norm_label": "searchbytext()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/catalogSearch.ts",
       "source_location": "L207"
     },
     {
       "community": 31,
       "file_type": "code",
-      "id": "staffcredentials_invalidstaffcredentialsresult",
-      "label": "invalidStaffCredentialsResult()",
-      "norm_label": "invalidstaffcredentialsresult()",
-      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
-      "source_location": "L62"
+      "id": "catalogsearch_searchregistercatalog",
+      "label": "searchRegisterCatalog()",
+      "norm_label": "searchregistercatalog()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/catalogSearch.ts",
+      "source_location": "L109"
     },
     {
       "community": 31,
       "file_type": "code",
-      "id": "staffcredentials_liststaffcredentialsbystorewithctx",
-      "label": "listStaffCredentialsByStoreWithCtx()",
-      "norm_label": "liststaffcredentialsbystorewithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
-      "source_location": "L226"
+      "id": "catalogsearch_tokenizesearchtext",
+      "label": "tokenizeSearchText()",
+      "norm_label": "tokenizesearchtext()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/catalogSearch.ts",
+      "source_location": "L380"
     },
     {
       "community": 31,
       "file_type": "code",
-      "id": "staffcredentials_normalizeusername",
-      "label": "normalizeUsername()",
-      "norm_label": "normalizeusername()",
-      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
-      "source_location": "L48"
-    },
-    {
-      "community": 31,
-      "file_type": "code",
-      "id": "staffcredentials_requirenonemptyusername",
-      "label": "requireNonEmptyUsername()",
-      "norm_label": "requirenonemptyusername()",
-      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
-      "source_location": "L52"
-    },
-    {
-      "community": 31,
-      "file_type": "code",
-      "id": "staffcredentials_staffauthorizationfailedresult",
-      "label": "staffAuthorizationFailedResult()",
-      "norm_label": "staffauthorizationfailedresult()",
-      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
-      "source_location": "L69"
-    },
-    {
-      "community": 31,
-      "file_type": "code",
-      "id": "staffcredentials_staffpreconditionfailedresult",
-      "label": "staffPreconditionFailedResult()",
-      "norm_label": "staffpreconditionfailedresult()",
-      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
-      "source_location": "L78"
-    },
-    {
-      "community": 31,
-      "file_type": "code",
-      "id": "staffcredentials_updatestaffcredentialwithctx",
-      "label": "updateStaffCredentialWithCtx()",
-      "norm_label": "updatestaffcredentialwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
-      "source_location": "L319"
+      "id": "packages_athena_webapp_src_lib_pos_presentation_register_catalogsearch_ts",
+      "label": "catalogSearch.ts",
+      "norm_label": "catalogsearch.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/catalogSearch.ts",
+      "source_location": "L1"
     },
     {
       "community": 310,
@@ -78927,163 +79026,163 @@
     {
       "community": 32,
       "file_type": "code",
-      "id": "customerrepository_createposcustomer",
-      "label": "createPosCustomer()",
-      "norm_label": "createposcustomer()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
-      "source_location": "L57"
+      "id": "inventoryholds_acquireinventoryhold",
+      "label": "acquireInventoryHold()",
+      "norm_label": "acquireinventoryhold()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
+      "source_location": "L140"
     },
     {
       "community": 32,
       "file_type": "code",
-      "id": "customerrepository_ensurecustomerprofilefromsources",
-      "label": "ensureCustomerProfileFromSources()",
-      "norm_label": "ensurecustomerprofilefromsources()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
-      "source_location": "L240"
+      "id": "inventoryholds_acquireinventoryholdsbatch",
+      "label": "acquireInventoryHoldsBatch()",
+      "norm_label": "acquireinventoryholdsbatch()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
+      "source_location": "L318"
     },
     {
       "community": 32,
       "file_type": "code",
-      "id": "customerrepository_findcustomerbyemail",
-      "label": "findCustomerByEmail()",
-      "norm_label": "findcustomerbyemail()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
-      "source_location": "L27"
+      "id": "inventoryholds_adjustinventoryhold",
+      "label": "adjustInventoryHold()",
+      "norm_label": "adjustinventoryhold()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
+      "source_location": "L241"
     },
     {
       "community": 32,
       "file_type": "code",
-      "id": "customerrepository_findcustomerbyphone",
-      "label": "findCustomerByPhone()",
-      "norm_label": "findcustomerbyphone()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
-      "source_location": "L42"
+      "id": "inventoryholds_consumeinventoryholdsforsession",
+      "label": "consumeInventoryHoldsForSession()",
+      "norm_label": "consumeinventoryholdsforsession()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
+      "source_location": "L445"
     },
     {
       "community": 32,
       "file_type": "code",
-      "id": "customerrepository_findguestbyemail",
-      "label": "findGuestByEmail()",
-      "norm_label": "findguestbyemail()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
-      "source_location": "L186"
+      "id": "inventoryholds_getactiveholdforsessionsku",
+      "label": "getActiveHoldForSessionSku()",
+      "norm_label": "getactiveholdforsessionsku()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
+      "source_location": "L610"
     },
     {
       "community": 32,
       "file_type": "code",
-      "id": "customerrepository_findguestbyphone",
-      "label": "findGuestByPhone()",
-      "norm_label": "findguestbyphone()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
-      "source_location": "L222"
+      "id": "inventoryholds_listactivesessionholds",
+      "label": "listActiveSessionHolds()",
+      "norm_label": "listactivesessionholds()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
+      "source_location": "L639"
     },
     {
       "community": 32,
       "file_type": "code",
-      "id": "customerrepository_findposcustomerbyguest",
-      "label": "findPosCustomerByGuest()",
-      "norm_label": "findposcustomerbyguest()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
-      "source_location": "L154"
+      "id": "inventoryholds_markholdexpired",
+      "label": "markHoldExpired()",
+      "norm_label": "markholdexpired()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
+      "source_location": "L667"
     },
     {
       "community": 32,
       "file_type": "code",
-      "id": "customerrepository_findposcustomerbystorefrontuser",
-      "label": "findPosCustomerByStoreFrontUser()",
-      "norm_label": "findposcustomerbystorefrontuser()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
-      "source_location": "L142"
+      "id": "inventoryholds_readactiveheldquantitiesforskus",
+      "label": "readActiveHeldQuantitiesForSkus()",
+      "norm_label": "readactiveheldquantitiesforskus()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
+      "source_location": "L546"
     },
     {
       "community": 32,
       "file_type": "code",
-      "id": "customerrepository_findstorefrontuserbyemail",
-      "label": "findStoreFrontUserByEmail()",
-      "norm_label": "findstorefrontuserbyemail()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
-      "source_location": "L168"
+      "id": "inventoryholds_readactiveinventoryholddetailsforsession",
+      "label": "readActiveInventoryHoldDetailsForSession()",
+      "norm_label": "readactiveinventoryholddetailsforsession()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
+      "source_location": "L516"
     },
     {
       "community": 32,
       "file_type": "code",
-      "id": "customerrepository_findstorefrontuserbyphone",
-      "label": "findStoreFrontUserByPhone()",
-      "norm_label": "findstorefrontuserbyphone()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
-      "source_location": "L204"
+      "id": "inventoryholds_readactiveinventoryholdquantitiesforsession",
+      "label": "readActiveInventoryHoldQuantitiesForSession()",
+      "norm_label": "readactiveinventoryholdquantitiesforsession()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
+      "source_location": "L489"
     },
     {
       "community": 32,
       "file_type": "code",
-      "id": "customerrepository_getguestbyid",
-      "label": "getGuestById()",
-      "norm_label": "getguestbyid()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
-      "source_location": "L135"
+      "id": "inventoryholds_releaseactiveinventoryholdsforsession",
+      "label": "releaseActiveInventoryHoldsForSession()",
+      "norm_label": "releaseactiveinventoryholdsforsession()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
+      "source_location": "L409"
     },
     {
       "community": 32,
       "file_type": "code",
-      "id": "customerrepository_getposcustomerbyid",
-      "label": "getPosCustomerById()",
-      "norm_label": "getposcustomerbyid()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
-      "source_location": "L20"
+      "id": "inventoryholds_releaseinventoryhold",
+      "label": "releaseInventoryHold()",
+      "norm_label": "releaseinventoryhold()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
+      "source_location": "L191"
     },
     {
       "community": 32,
       "file_type": "code",
-      "id": "customerrepository_getstorefrontuserbyid",
-      "label": "getStoreFrontUserById()",
-      "norm_label": "getstorefrontuserbyid()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
-      "source_location": "L128"
+      "id": "inventoryholds_releaseinventoryholdsbatch",
+      "label": "releaseInventoryHoldsBatch()",
+      "norm_label": "releaseinventoryholdsbatch()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
+      "source_location": "L347"
     },
     {
       "community": 32,
       "file_type": "code",
-      "id": "customerrepository_listactivecustomersforstore",
-      "label": "listActiveCustomersForStore()",
-      "norm_label": "listactivecustomersforstore()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
-      "source_location": "L8"
+      "id": "inventoryholds_releaseinventoryholdsforsession",
+      "label": "releaseInventoryHoldsForSession()",
+      "norm_label": "releaseinventoryholdsforsession()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
+      "source_location": "L385"
     },
     {
       "community": 32,
       "file_type": "code",
-      "id": "customerrepository_listcompletedtransactionsforcustomer",
-      "label": "listCompletedTransactionsForCustomer()",
-      "norm_label": "listcompletedtransactionsforcustomer()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
-      "source_location": "L94"
+      "id": "inventoryholds_releaselegacyexpensequantitypatchholds",
+      "label": "releaseLegacyExpenseQuantityPatchHolds()",
+      "norm_label": "releaselegacyexpensequantitypatchholds()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
+      "source_location": "L367"
     },
     {
       "community": 32,
       "file_type": "code",
-      "id": "customerrepository_patchposcustomer",
-      "label": "patchPosCustomer()",
-      "norm_label": "patchposcustomer()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
-      "source_location": "L64"
+      "id": "inventoryholds_sumactiveheldquantity",
+      "label": "sumActiveHeldQuantity()",
+      "norm_label": "sumactiveheldquantity()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
+      "source_location": "L577"
     },
     {
       "community": 32,
       "file_type": "code",
-      "id": "customerrepository_updatecustomerstats",
-      "label": "updateCustomerStats()",
-      "norm_label": "updatecustomerstats()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
-      "source_location": "L72"
+      "id": "inventoryholds_validateinventoryavailability",
+      "label": "validateInventoryAvailability()",
+      "norm_label": "validateinventoryavailability()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
+      "source_location": "L77"
     },
     {
       "community": 32,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_customerrepository_ts",
-      "label": "customerRepository.ts",
-      "norm_label": "customerrepository.ts",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
+      "id": "packages_athena_webapp_convex_inventory_helpers_inventoryholds_ts",
+      "label": "inventoryHolds.ts",
+      "norm_label": "inventoryholds.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
       "source_location": "L1"
     },
     {
@@ -79440,164 +79539,164 @@
     {
       "community": 33,
       "file_type": "code",
-      "id": "adjustments_applystockadjustmentbatchwithctx",
-      "label": "applyStockAdjustmentBatchWithCtx()",
-      "norm_label": "applystockadjustmentbatchwithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L214"
-    },
-    {
-      "community": 33,
-      "file_type": "code",
-      "id": "adjustments_assertdistinctstockadjustmentlineitems",
-      "label": "assertDistinctStockAdjustmentLineItems()",
-      "norm_label": "assertdistinctstockadjustmentlineitems()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L138"
-    },
-    {
-      "community": 33,
-      "file_type": "code",
-      "id": "adjustments_assertnormalizedlineitem",
-      "label": "assertNormalizedLineItem()",
-      "norm_label": "assertnormalizedlineitem()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L168"
-    },
-    {
-      "community": 33,
-      "file_type": "code",
-      "id": "adjustments_buildresolvedstockadjustmentstatus",
-      "label": "buildResolvedStockAdjustmentStatus()",
-      "norm_label": "buildresolvedstockadjustmentstatus()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L272"
-    },
-    {
-      "community": 33,
-      "file_type": "code",
-      "id": "adjustments_buildstockadjustmentdecisioneventtype",
-      "label": "buildStockAdjustmentDecisionEventType()",
-      "norm_label": "buildstockadjustmentdecisioneventtype()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L262"
-    },
-    {
-      "community": 33,
-      "file_type": "code",
-      "id": "adjustments_buildstockadjustmentsourceid",
-      "label": "buildStockAdjustmentSourceId()",
-      "norm_label": "buildstockadjustmentsourceid()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L154"
-    },
-    {
-      "community": 33,
-      "file_type": "code",
-      "id": "adjustments_buildstockadjustmenttitle",
-      "label": "buildStockAdjustmentTitle()",
-      "norm_label": "buildstockadjustmenttitle()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L158"
-    },
-    {
-      "community": 33,
-      "file_type": "code",
-      "id": "adjustments_getstockadjustmentscopekey",
-      "label": "getStockAdjustmentScopeKey()",
-      "norm_label": "getstockadjustmentscopekey()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L77"
-    },
-    {
-      "community": 33,
-      "file_type": "code",
-      "id": "adjustments_listinventorysnapshotwithctx",
-      "label": "listInventorySnapshotWithCtx()",
-      "norm_label": "listinventorysnapshotwithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L401"
-    },
-    {
-      "community": 33,
-      "file_type": "code",
-      "id": "adjustments_listproductskusforstockadjustmentscopewithctx",
-      "label": "listProductSkusForStockAdjustmentScopeWithCtx()",
-      "norm_label": "listproductskusforstockadjustmentscopewithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L81"
-    },
-    {
-      "community": 33,
-      "file_type": "code",
-      "id": "adjustments_mapsubmitstockadjustmentbatcherror",
-      "label": "mapSubmitStockAdjustmentBatchError()",
-      "norm_label": "mapsubmitstockadjustmentbatcherror()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L800"
-    },
-    {
-      "community": 33,
-      "file_type": "code",
-      "id": "adjustments_readactiveheldquantitiesforstockopssnapshot",
-      "label": "readActiveHeldQuantitiesForStockOpsSnapshot()",
-      "norm_label": "readactiveheldquantitiesforstockopssnapshot()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L372"
-    },
-    {
-      "community": 33,
-      "file_type": "code",
-      "id": "adjustments_resolvestockadjustmentapprovaldecisionwithctx",
-      "label": "resolveStockAdjustmentApprovalDecisionWithCtx()",
-      "norm_label": "resolvestockadjustmentapprovaldecisionwithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L278"
-    },
-    {
-      "community": 33,
-      "file_type": "code",
-      "id": "adjustments_submitstockadjustmentbatchcommandwithctx",
-      "label": "submitStockAdjustmentBatchCommandWithCtx()",
-      "norm_label": "submitstockadjustmentbatchcommandwithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L853"
-    },
-    {
-      "community": 33,
-      "file_type": "code",
-      "id": "adjustments_submitstockadjustmentbatchwithctx",
-      "label": "submitStockAdjustmentBatchWithCtx()",
-      "norm_label": "submitstockadjustmentbatchwithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L603"
-    },
-    {
-      "community": 33,
-      "file_type": "code",
-      "id": "adjustments_temporarydeletestockadjustmentscopeskuswithctx",
-      "label": "temporaryDeleteStockAdjustmentScopeSkusWithCtx()",
-      "norm_label": "temporarydeletestockadjustmentscopeskuswithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L522"
-    },
-    {
-      "community": 33,
-      "file_type": "code",
-      "id": "adjustments_trimoptional",
-      "label": "trimOptional()",
-      "norm_label": "trimoptional()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L72"
-    },
-    {
-      "community": 33,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_stockops_adjustments_ts",
-      "label": "adjustments.ts",
-      "norm_label": "adjustments.ts",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "id": "packages_athena_webapp_convex_operations_staffcredentials_ts",
+      "label": "staffCredentials.ts",
+      "norm_label": "staffcredentials.ts",
+      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 33,
+      "file_type": "code",
+      "id": "staffcredentials_assertstaffprofilereadyforcredential",
+      "label": "assertStaffProfileReadyForCredential()",
+      "norm_label": "assertstaffprofilereadyforcredential()",
+      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
+      "source_location": "L173"
+    },
+    {
+      "community": 33,
+      "file_type": "code",
+      "id": "staffcredentials_authenticatestaffcredentialforapprovalwithctx",
+      "label": "authenticateStaffCredentialForApprovalWithCtx()",
+      "norm_label": "authenticatestaffcredentialforapprovalwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
+      "source_location": "L566"
+    },
+    {
+      "community": 33,
+      "file_type": "code",
+      "id": "staffcredentials_authenticatestaffcredentialforterminalwithctx",
+      "label": "authenticateStaffCredentialForTerminalWithCtx()",
+      "norm_label": "authenticatestaffcredentialforterminalwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
+      "source_location": "L505"
+    },
+    {
+      "community": 33,
+      "file_type": "code",
+      "id": "staffcredentials_authenticatestaffcredentialwithctx",
+      "label": "authenticateStaffCredentialWithCtx()",
+      "norm_label": "authenticatestaffcredentialwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
+      "source_location": "L415"
+    },
+    {
+      "community": 33,
+      "file_type": "code",
+      "id": "staffcredentials_createstaffcredentialwithctx",
+      "label": "createStaffCredentialWithCtx()",
+      "norm_label": "createstaffcredentialwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
+      "source_location": "L277"
+    },
+    {
+      "community": 33,
+      "file_type": "code",
+      "id": "staffcredentials_getactiverolesforstaffprofile",
+      "label": "getActiveRolesForStaffProfile()",
+      "norm_label": "getactiverolesforstaffprofile()",
+      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
+      "source_location": "L150"
+    },
+    {
+      "community": 33,
+      "file_type": "code",
+      "id": "staffcredentials_getcredentialbyid",
+      "label": "getCredentialById()",
+      "norm_label": "getcredentialbyid()",
+      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
+      "source_location": "L122"
+    },
+    {
+      "community": 33,
+      "file_type": "code",
+      "id": "staffcredentials_getcredentialbyusername",
+      "label": "getCredentialByUsername()",
+      "norm_label": "getcredentialbyusername()",
+      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
+      "source_location": "L129"
+    },
+    {
+      "community": 33,
+      "file_type": "code",
+      "id": "staffcredentials_getstaffcredentialbystaffprofileidwithctx",
+      "label": "getStaffCredentialByStaffProfileIdWithCtx()",
+      "norm_label": "getstaffcredentialbystaffprofileidwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
+      "source_location": "L87"
+    },
+    {
+      "community": 33,
+      "file_type": "code",
+      "id": "staffcredentials_getstaffcredentialusernameavailabilitywithctx",
+      "label": "getStaffCredentialUsernameAvailabilityWithCtx()",
+      "norm_label": "getstaffcredentialusernameavailabilitywithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
+      "source_location": "L207"
+    },
+    {
+      "community": 33,
+      "file_type": "code",
+      "id": "staffcredentials_invalidstaffcredentialsresult",
+      "label": "invalidStaffCredentialsResult()",
+      "norm_label": "invalidstaffcredentialsresult()",
+      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
+      "source_location": "L62"
+    },
+    {
+      "community": 33,
+      "file_type": "code",
+      "id": "staffcredentials_liststaffcredentialsbystorewithctx",
+      "label": "listStaffCredentialsByStoreWithCtx()",
+      "norm_label": "liststaffcredentialsbystorewithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
+      "source_location": "L226"
+    },
+    {
+      "community": 33,
+      "file_type": "code",
+      "id": "staffcredentials_normalizeusername",
+      "label": "normalizeUsername()",
+      "norm_label": "normalizeusername()",
+      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
+      "source_location": "L48"
+    },
+    {
+      "community": 33,
+      "file_type": "code",
+      "id": "staffcredentials_requirenonemptyusername",
+      "label": "requireNonEmptyUsername()",
+      "norm_label": "requirenonemptyusername()",
+      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
+      "source_location": "L52"
+    },
+    {
+      "community": 33,
+      "file_type": "code",
+      "id": "staffcredentials_staffauthorizationfailedresult",
+      "label": "staffAuthorizationFailedResult()",
+      "norm_label": "staffauthorizationfailedresult()",
+      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
+      "source_location": "L69"
+    },
+    {
+      "community": 33,
+      "file_type": "code",
+      "id": "staffcredentials_staffpreconditionfailedresult",
+      "label": "staffPreconditionFailedResult()",
+      "norm_label": "staffpreconditionfailedresult()",
+      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
+      "source_location": "L78"
+    },
+    {
+      "community": 33,
+      "file_type": "code",
+      "id": "staffcredentials_updatestaffcredentialwithctx",
+      "label": "updateStaffCredentialWithCtx()",
+      "norm_label": "updatestaffcredentialwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.ts",
+      "source_location": "L319"
     },
     {
       "community": 330,
@@ -79872,163 +79971,163 @@
     {
       "community": 34,
       "file_type": "code",
-      "id": "checkoutsession_calculatepromocodevalue",
-      "label": "calculatePromoCodeValue()",
-      "norm_label": "calculatepromocodevalue()",
-      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L1449"
+      "id": "customerrepository_createposcustomer",
+      "label": "createPosCustomer()",
+      "norm_label": "createposcustomer()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
+      "source_location": "L57"
     },
     {
       "community": 34,
       "file_type": "code",
-      "id": "checkoutsession_checkadjustedavailability",
-      "label": "checkAdjustedAvailability()",
-      "norm_label": "checkadjustedavailability()",
-      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L992"
+      "id": "customerrepository_ensurecustomerprofilefromsources",
+      "label": "ensureCustomerProfileFromSources()",
+      "norm_label": "ensurecustomerprofilefromsources()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
+      "source_location": "L240"
     },
     {
       "community": 34,
       "file_type": "code",
-      "id": "checkoutsession_checkifitemshavechanged",
-      "label": "checkIfItemsHaveChanged()",
-      "norm_label": "checkifitemshavechanged()",
-      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L50"
+      "id": "customerrepository_findcustomerbyemail",
+      "label": "findCustomerByEmail()",
+      "norm_label": "findcustomerbyemail()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
+      "source_location": "L27"
     },
     {
       "community": 34,
       "file_type": "code",
-      "id": "checkoutsession_createonlineorder",
-      "label": "createOnlineOrder()",
-      "norm_label": "createonlineorder()",
-      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L767"
+      "id": "customerrepository_findcustomerbyphone",
+      "label": "findCustomerByPhone()",
+      "norm_label": "findcustomerbyphone()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
+      "source_location": "L42"
     },
     {
       "community": 34,
       "file_type": "code",
-      "id": "checkoutsession_createpatchobject",
-      "label": "createPatchObject()",
-      "norm_label": "createpatchobject()",
-      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L653"
+      "id": "customerrepository_findguestbyemail",
+      "label": "findGuestByEmail()",
+      "norm_label": "findguestbyemail()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
+      "source_location": "L186"
     },
     {
       "community": 34,
       "file_type": "code",
-      "id": "checkoutsession_createsessionitems",
-      "label": "createSessionItems()",
-      "norm_label": "createsessionitems()",
-      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L1104"
+      "id": "customerrepository_findguestbyphone",
+      "label": "findGuestByPhone()",
+      "norm_label": "findguestbyphone()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
+      "source_location": "L222"
     },
     {
       "community": 34,
       "file_type": "code",
-      "id": "checkoutsession_fetchproductskus",
-      "label": "fetchProductSkus()",
-      "norm_label": "fetchproductskus()",
-      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L981"
+      "id": "customerrepository_findposcustomerbyguest",
+      "label": "findPosCustomerByGuest()",
+      "norm_label": "findposcustomerbyguest()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
+      "source_location": "L154"
     },
     {
       "community": 34,
       "file_type": "code",
-      "id": "checkoutsession_findbestvaluepromocode",
-      "label": "findBestValuePromoCode()",
-      "norm_label": "findbestvaluepromocode()",
-      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L1497"
+      "id": "customerrepository_findposcustomerbystorefrontuser",
+      "label": "findPosCustomerByStoreFrontUser()",
+      "norm_label": "findposcustomerbystorefrontuser()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
+      "source_location": "L142"
     },
     {
       "community": 34,
       "file_type": "code",
-      "id": "checkoutsession_handleexistingsession",
-      "label": "handleExistingSession()",
-      "norm_label": "handleexistingsession()",
-      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L1163"
+      "id": "customerrepository_findstorefrontuserbyemail",
+      "label": "findStoreFrontUserByEmail()",
+      "norm_label": "findstorefrontuserbyemail()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
+      "source_location": "L168"
     },
     {
       "community": 34,
       "file_type": "code",
-      "id": "checkoutsession_handleordercreation",
-      "label": "handleOrderCreation()",
-      "norm_label": "handleordercreation()",
-      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L736"
+      "id": "customerrepository_findstorefrontuserbyphone",
+      "label": "findStoreFrontUserByPhone()",
+      "norm_label": "findstorefrontuserbyphone()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
+      "source_location": "L204"
     },
     {
       "community": 34,
       "file_type": "code",
-      "id": "checkoutsession_handleplaceorder",
-      "label": "handlePlaceOrder()",
-      "norm_label": "handleplaceorder()",
-      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L700"
+      "id": "customerrepository_getguestbyid",
+      "label": "getGuestById()",
+      "norm_label": "getguestbyid()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
+      "source_location": "L135"
     },
     {
       "community": 34,
       "file_type": "code",
-      "id": "checkoutsession_listsessionitems",
-      "label": "listSessionItems()",
-      "norm_label": "listsessionitems()",
-      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L40"
+      "id": "customerrepository_getposcustomerbyid",
+      "label": "getPosCustomerById()",
+      "norm_label": "getposcustomerbyid()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
+      "source_location": "L20"
     },
     {
       "community": 34,
       "file_type": "code",
-      "id": "checkoutsession_retrieveactivecheckoutsession",
-      "label": "retrieveActiveCheckoutSession()",
-      "norm_label": "retrieveactivecheckoutsession()",
-      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L953"
+      "id": "customerrepository_getstorefrontuserbyid",
+      "label": "getStoreFrontUserById()",
+      "norm_label": "getstorefrontuserbyid()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
+      "source_location": "L128"
     },
     {
       "community": 34,
       "file_type": "code",
-      "id": "checkoutsession_updateavailability",
-      "label": "updateAvailability()",
-      "norm_label": "updateavailability()",
-      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L1142"
+      "id": "customerrepository_listactivecustomersforstore",
+      "label": "listActiveCustomersForStore()",
+      "norm_label": "listactivecustomersforstore()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
+      "source_location": "L8"
     },
     {
       "community": 34,
       "file_type": "code",
-      "id": "checkoutsession_updateexistingsession",
-      "label": "updateExistingSession()",
-      "norm_label": "updateexistingsession()",
-      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L1022"
+      "id": "customerrepository_listcompletedtransactionsforcustomer",
+      "label": "listCompletedTransactionsForCustomer()",
+      "norm_label": "listcompletedtransactionsforcustomer()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
+      "source_location": "L94"
     },
     {
       "community": 34,
       "file_type": "code",
-      "id": "checkoutsession_updateproductavailability",
-      "label": "updateProductAvailability()",
-      "norm_label": "updateproductavailability()",
-      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L1125"
+      "id": "customerrepository_patchposcustomer",
+      "label": "patchPosCustomer()",
+      "norm_label": "patchposcustomer()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
+      "source_location": "L64"
     },
     {
       "community": 34,
       "file_type": "code",
-      "id": "checkoutsession_validateexistingdiscount",
-      "label": "validateExistingDiscount()",
-      "norm_label": "validateexistingdiscount()",
-      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
-      "source_location": "L1323"
+      "id": "customerrepository_updatecustomerstats",
+      "label": "updateCustomerStats()",
+      "norm_label": "updatecustomerstats()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
+      "source_location": "L72"
     },
     {
       "community": 34,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_checkoutsession_ts",
-      "label": "checkoutSession.ts",
-      "norm_label": "checkoutsession.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
+      "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_customerrepository_ts",
+      "label": "customerRepository.ts",
+      "norm_label": "customerrepository.ts",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
       "source_location": "L1"
     },
     {
@@ -80304,163 +80403,163 @@
     {
       "community": 35,
       "file_type": "code",
-      "id": "dailyoperationsview_buildparams",
-      "label": "buildParams()",
-      "norm_label": "buildparams()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L280"
+      "id": "checkoutsession_calculatepromocodevalue",
+      "label": "calculatePromoCodeValue()",
+      "norm_label": "calculatepromocodevalue()",
+      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
+      "source_location": "L1449"
     },
     {
       "community": 35,
       "file_type": "code",
-      "id": "dailyoperationsview_formatcarriedoverregistercount",
-      "label": "formatCarriedOverRegisterCount()",
-      "norm_label": "formatcarriedoverregistercount()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L239"
+      "id": "checkoutsession_checkadjustedavailability",
+      "label": "checkAdjustedAvailability()",
+      "norm_label": "checkadjustedavailability()",
+      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
+      "source_location": "L992"
     },
     {
       "community": 35,
       "file_type": "code",
-      "id": "dailyoperationsview_formatentitycount",
-      "label": "formatEntityCount()",
-      "norm_label": "formatentitycount()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L223"
+      "id": "checkoutsession_checkifitemshavechanged",
+      "label": "checkIfItemsHaveChanged()",
+      "norm_label": "checkifitemshavechanged()",
+      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
+      "source_location": "L50"
     },
     {
       "community": 35,
       "file_type": "code",
-      "id": "dailyoperationsview_formateventtime",
-      "label": "formatEventTime()",
-      "norm_label": "formateventtime()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L193"
+      "id": "checkoutsession_createonlineorder",
+      "label": "createOnlineOrder()",
+      "norm_label": "createonlineorder()",
+      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
+      "source_location": "L767"
     },
     {
       "community": 35,
       "file_type": "code",
-      "id": "dailyoperationsview_formatmoney",
-      "label": "formatMoney()",
-      "norm_label": "formatmoney()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L251"
+      "id": "checkoutsession_createpatchobject",
+      "label": "createPatchObject()",
+      "norm_label": "createpatchobject()",
+      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
+      "source_location": "L653"
     },
     {
       "community": 35,
       "file_type": "code",
-      "id": "dailyoperationsview_formatoperatingdate",
-      "label": "formatOperatingDate()",
-      "norm_label": "formatoperatingdate()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L177"
+      "id": "checkoutsession_createsessionitems",
+      "label": "createSessionItems()",
+      "norm_label": "createsessionitems()",
+      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
+      "source_location": "L1104"
     },
     {
       "community": 35,
       "file_type": "code",
-      "id": "dailyoperationsview_formatregistervariancecount",
-      "label": "formatRegisterVarianceCount()",
-      "norm_label": "formatregistervariancecount()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L245"
+      "id": "checkoutsession_fetchproductskus",
+      "label": "fetchProductSkus()",
+      "norm_label": "fetchproductskus()",
+      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
+      "source_location": "L981"
     },
     {
       "community": 35,
       "file_type": "code",
-      "id": "dailyoperationsview_formattimelinemessage",
-      "label": "formatTimelineMessage()",
-      "norm_label": "formattimelinemessage()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L200"
+      "id": "checkoutsession_findbestvaluepromocode",
+      "label": "findBestValuePromoCode()",
+      "norm_label": "findbestvaluepromocode()",
+      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
+      "source_location": "L1497"
     },
     {
       "community": 35,
       "file_type": "code",
-      "id": "dailyoperationsview_formattodaycashtransactioncount",
-      "label": "formatTodayCashTransactionCount()",
-      "norm_label": "formattodaycashtransactioncount()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L233"
+      "id": "checkoutsession_handleexistingsession",
+      "label": "handleExistingSession()",
+      "norm_label": "handleexistingsession()",
+      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
+      "source_location": "L1163"
     },
     {
       "community": 35,
       "file_type": "code",
-      "id": "dailyoperationsview_getdailyoperationsapi",
-      "label": "getDailyOperationsApi()",
-      "norm_label": "getdailyoperationsapi()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L140"
+      "id": "checkoutsession_handleordercreation",
+      "label": "handleOrderCreation()",
+      "norm_label": "handleordercreation()",
+      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
+      "source_location": "L736"
     },
     {
       "community": 35,
       "file_type": "code",
-      "id": "dailyoperationsview_getlocaloperatingdate",
-      "label": "getLocalOperatingDate()",
-      "norm_label": "getlocaloperatingdate()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L150"
+      "id": "checkoutsession_handleplaceorder",
+      "label": "handlePlaceOrder()",
+      "norm_label": "handleplaceorder()",
+      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
+      "source_location": "L700"
     },
     {
       "community": 35,
       "file_type": "code",
-      "id": "dailyoperationsview_getlocaloperatingdaterange",
-      "label": "getLocalOperatingDateRange()",
-      "norm_label": "getlocaloperatingdaterange()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L158"
+      "id": "checkoutsession_listsessionitems",
+      "label": "listSessionItems()",
+      "norm_label": "listsessionitems()",
+      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
+      "source_location": "L40"
     },
     {
       "community": 35,
       "file_type": "code",
-      "id": "dailyoperationsview_loadingworkspace",
-      "label": "LoadingWorkspace()",
-      "norm_label": "loadingworkspace()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L292"
+      "id": "checkoutsession_retrieveactivecheckoutsession",
+      "label": "retrieveActiveCheckoutSession()",
+      "norm_label": "retrieveactivecheckoutsession()",
+      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
+      "source_location": "L953"
     },
     {
       "community": 35,
       "file_type": "code",
-      "id": "dailyoperationsview_ownerlabel",
-      "label": "ownerLabel()",
-      "norm_label": "ownerlabel()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L255"
+      "id": "checkoutsession_updateavailability",
+      "label": "updateAvailability()",
+      "norm_label": "updateavailability()",
+      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
+      "source_location": "L1142"
     },
     {
       "community": 35,
       "file_type": "code",
-      "id": "dailyoperationsview_statusclassname",
-      "label": "statusClassName()",
-      "norm_label": "statusclassname()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L263"
+      "id": "checkoutsession_updateexistingsession",
+      "label": "updateExistingSession()",
+      "norm_label": "updateexistingsession()",
+      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
+      "source_location": "L1022"
     },
     {
       "community": 35,
       "file_type": "code",
-      "id": "dailyoperationsview_statuslabel",
-      "label": "statusLabel()",
-      "norm_label": "statuslabel()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L275"
+      "id": "checkoutsession_updateproductavailability",
+      "label": "updateProductAvailability()",
+      "norm_label": "updateproductavailability()",
+      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
+      "source_location": "L1125"
     },
     {
       "community": 35,
       "file_type": "code",
-      "id": "dailyoperationsview_timelineeventitem",
-      "label": "TimelineEventItem()",
-      "norm_label": "timelineeventitem()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L307"
+      "id": "checkoutsession_validateexistingdiscount",
+      "label": "validateExistingDiscount()",
+      "norm_label": "validateexistingdiscount()",
+      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
+      "source_location": "L1323"
     },
     {
       "community": 35,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_operations_dailyoperationsview_tsx",
-      "label": "DailyOperationsView.tsx",
-      "norm_label": "dailyoperationsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
+      "id": "packages_athena_webapp_convex_storefront_checkoutsession_ts",
+      "label": "checkoutSession.ts",
+      "norm_label": "checkoutsession.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
       "source_location": "L1"
     },
     {
@@ -80736,164 +80835,164 @@
     {
       "community": 36,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_tsx",
-      "label": "StockAdjustmentWorkspace.tsx",
-      "norm_label": "stockadjustmentworkspace.tsx",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L1"
+      "id": "dailyoperationsview_buildparams",
+      "label": "buildParams()",
+      "norm_label": "buildparams()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
+      "source_location": "L280"
     },
     {
       "community": 36,
       "file_type": "code",
-      "id": "stockadjustmentworkspace_buildcyclecountdrafts",
-      "label": "buildCycleCountDrafts()",
-      "norm_label": "buildcyclecountdrafts()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L221"
-    },
-    {
-      "community": 36,
-      "file_type": "code",
-      "id": "stockadjustmentworkspace_buildmanualdrafts",
-      "label": "buildManualDrafts()",
-      "norm_label": "buildmanualdrafts()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L217"
-    },
-    {
-      "community": 36,
-      "file_type": "code",
-      "id": "stockadjustmentworkspace_buildstockadjustmentsubmissionkey",
-      "label": "buildStockAdjustmentSubmissionKey()",
-      "norm_label": "buildstockadjustmentsubmissionkey()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "id": "dailyoperationsview_formatcarriedoverregistercount",
+      "label": "formatCarriedOverRegisterCount()",
+      "norm_label": "formatcarriedoverregistercount()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
       "source_location": "L239"
     },
     {
       "community": 36,
       "file_type": "code",
-      "id": "stockadjustmentworkspace_formatinventorynumber",
-      "label": "formatInventoryNumber()",
-      "norm_label": "formatinventorynumber()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L254"
+      "id": "dailyoperationsview_formatentitycount",
+      "label": "formatEntityCount()",
+      "norm_label": "formatentitycount()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
+      "source_location": "L223"
     },
     {
       "community": 36,
       "file_type": "code",
-      "id": "stockadjustmentworkspace_getcountscopekey",
-      "label": "getCountScopeKey()",
-      "norm_label": "getcountscopekey()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L209"
+      "id": "dailyoperationsview_formateventtime",
+      "label": "formatEventTime()",
+      "norm_label": "formateventtime()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
+      "source_location": "L193"
     },
     {
       "community": 36,
       "file_type": "code",
-      "id": "stockadjustmentworkspace_getcountscopelabel",
-      "label": "getCountScopeLabel()",
-      "norm_label": "getcountscopelabel()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L213"
+      "id": "dailyoperationsview_formatmoney",
+      "label": "formatMoney()",
+      "norm_label": "formatmoney()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
+      "source_location": "L251"
     },
     {
       "community": 36,
       "file_type": "code",
-      "id": "stockadjustmentworkspace_getinventoryitemdisplayname",
-      "label": "getInventoryItemDisplayName()",
-      "norm_label": "getinventoryitemdisplayname()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L258"
+      "id": "dailyoperationsview_formatoperatingdate",
+      "label": "formatOperatingDate()",
+      "norm_label": "formatoperatingdate()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
+      "source_location": "L177"
     },
     {
       "community": 36,
       "file_type": "code",
-      "id": "stockadjustmentworkspace_getskudetailentries",
-      "label": "getSkuDetailEntries()",
-      "norm_label": "getskudetailentries()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L262"
-    },
-    {
-      "community": 36,
-      "file_type": "code",
-      "id": "stockadjustmentworkspace_handledraftchange",
-      "label": "handleDraftChange()",
-      "norm_label": "handledraftchange()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L1069"
-    },
-    {
-      "community": 36,
-      "file_type": "code",
-      "id": "stockadjustmentworkspace_normalizestockadjustmentsearch",
-      "label": "normalizeStockAdjustmentSearch()",
-      "norm_label": "normalizestockadjustmentsearch()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L287"
-    },
-    {
-      "community": 36,
-      "file_type": "code",
-      "id": "stockadjustmentworkspace_parsecountscopekeys",
-      "label": "parseCountScopeKeys()",
-      "norm_label": "parsecountscopekeys()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L291"
-    },
-    {
-      "community": 36,
-      "file_type": "code",
-      "id": "stockadjustmentworkspace_pluralize",
-      "label": "pluralize()",
-      "norm_label": "pluralize()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L250"
-    },
-    {
-      "community": 36,
-      "file_type": "code",
-      "id": "stockadjustmentworkspace_rowmatchesavailabilityfilter",
-      "label": "rowMatchesAvailabilityFilter()",
-      "norm_label": "rowmatchesavailabilityfilter()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L328"
-    },
-    {
-      "community": 36,
-      "file_type": "code",
-      "id": "stockadjustmentworkspace_rowmatchesstockadjustmentsearch",
-      "label": "rowMatchesStockAdjustmentSearch()",
-      "norm_label": "rowmatchesstockadjustmentsearch()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L304"
-    },
-    {
-      "community": 36,
-      "file_type": "code",
-      "id": "stockadjustmentworkspace_serializecountscopekeys",
-      "label": "serializeCountScopeKeys()",
-      "norm_label": "serializecountscopekeys()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L300"
-    },
-    {
-      "community": 36,
-      "file_type": "code",
-      "id": "stockadjustmentworkspace_setdraftvalue",
-      "label": "setDraftValue()",
-      "norm_label": "setdraftvalue()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L1059"
-    },
-    {
-      "community": 36,
-      "file_type": "code",
-      "id": "stockadjustmentworkspace_trimoptional",
-      "label": "trimOptional()",
-      "norm_label": "trimoptional()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "id": "dailyoperationsview_formatregistervariancecount",
+      "label": "formatRegisterVarianceCount()",
+      "norm_label": "formatregistervariancecount()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
       "source_location": "L245"
+    },
+    {
+      "community": 36,
+      "file_type": "code",
+      "id": "dailyoperationsview_formattimelinemessage",
+      "label": "formatTimelineMessage()",
+      "norm_label": "formattimelinemessage()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
+      "source_location": "L200"
+    },
+    {
+      "community": 36,
+      "file_type": "code",
+      "id": "dailyoperationsview_formattodaycashtransactioncount",
+      "label": "formatTodayCashTransactionCount()",
+      "norm_label": "formattodaycashtransactioncount()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
+      "source_location": "L233"
+    },
+    {
+      "community": 36,
+      "file_type": "code",
+      "id": "dailyoperationsview_getdailyoperationsapi",
+      "label": "getDailyOperationsApi()",
+      "norm_label": "getdailyoperationsapi()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
+      "source_location": "L140"
+    },
+    {
+      "community": 36,
+      "file_type": "code",
+      "id": "dailyoperationsview_getlocaloperatingdate",
+      "label": "getLocalOperatingDate()",
+      "norm_label": "getlocaloperatingdate()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
+      "source_location": "L150"
+    },
+    {
+      "community": 36,
+      "file_type": "code",
+      "id": "dailyoperationsview_getlocaloperatingdaterange",
+      "label": "getLocalOperatingDateRange()",
+      "norm_label": "getlocaloperatingdaterange()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
+      "source_location": "L158"
+    },
+    {
+      "community": 36,
+      "file_type": "code",
+      "id": "dailyoperationsview_loadingworkspace",
+      "label": "LoadingWorkspace()",
+      "norm_label": "loadingworkspace()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
+      "source_location": "L292"
+    },
+    {
+      "community": 36,
+      "file_type": "code",
+      "id": "dailyoperationsview_ownerlabel",
+      "label": "ownerLabel()",
+      "norm_label": "ownerlabel()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
+      "source_location": "L255"
+    },
+    {
+      "community": 36,
+      "file_type": "code",
+      "id": "dailyoperationsview_statusclassname",
+      "label": "statusClassName()",
+      "norm_label": "statusclassname()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
+      "source_location": "L263"
+    },
+    {
+      "community": 36,
+      "file_type": "code",
+      "id": "dailyoperationsview_statuslabel",
+      "label": "statusLabel()",
+      "norm_label": "statuslabel()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
+      "source_location": "L275"
+    },
+    {
+      "community": 36,
+      "file_type": "code",
+      "id": "dailyoperationsview_timelineeventitem",
+      "label": "TimelineEventItem()",
+      "norm_label": "timelineeventitem()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
+      "source_location": "L307"
+    },
+    {
+      "community": 36,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_operations_dailyoperationsview_tsx",
+      "label": "DailyOperationsView.tsx",
+      "norm_label": "dailyoperationsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
+      "source_location": "L1"
     },
     {
       "community": 360,

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,8 +8,8 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 1643
-- Graph nodes: 4847
-- Graph edges: 4769
+- Graph nodes: 4850
+- Graph edges: 4775
 - Communities: 1571
 
 ## Graph Hotspots

--- a/packages/athena-webapp/convex/stockOps/adjustments.test.ts
+++ b/packages/athena-webapp/convex/stockOps/adjustments.test.ts
@@ -38,6 +38,8 @@ function createInventorySnapshotQueryCtx() {
     color: new Map<string, Record<string, unknown>>([
       ["color-1", { _id: "color-1", name: "Black" }],
     ]),
+    checkoutSession: new Map<string, Record<string, unknown>>(),
+    checkoutSessionItem: new Map<string, Record<string, unknown>>(),
     inventoryHold: new Map<string, Record<string, unknown>>([
       [
         "hold-active",
@@ -540,6 +542,64 @@ describe("stock ops adjustments", () => {
         inventoryCount: 10,
         quantityAvailable: 6,
         reservedQuantity: 2,
+      }),
+    ]);
+  });
+
+  it("labels active checkout reservations without double subtracting availability", async () => {
+    const { ctx, tables } = createInventorySnapshotQueryCtx();
+
+    tables.checkoutSession.set("checkout-active", {
+      _id: "checkout-active",
+      expiresAt: 2_000,
+      hasCompletedCheckoutSession: false,
+      storeId: "store-1",
+    });
+    tables.checkoutSession.set("checkout-completed", {
+      _id: "checkout-completed",
+      expiresAt: 2_000,
+      hasCompletedCheckoutSession: true,
+      storeId: "store-1",
+    });
+    tables.checkoutSession.set("checkout-expired", {
+      _id: "checkout-expired",
+      expiresAt: 500,
+      hasCompletedCheckoutSession: false,
+      storeId: "store-1",
+    });
+    tables.checkoutSessionItem.set("checkout-item-active", {
+      _id: "checkout-item-active",
+      productSkuId: "sku-1",
+      quantity: 1,
+      sesionId: "checkout-active",
+    });
+    tables.checkoutSessionItem.set("checkout-item-completed", {
+      _id: "checkout-item-completed",
+      productSkuId: "sku-1",
+      quantity: 3,
+      sesionId: "checkout-completed",
+    });
+    tables.checkoutSessionItem.set("checkout-item-expired", {
+      _id: "checkout-item-expired",
+      productSkuId: "sku-1",
+      quantity: 5,
+      sesionId: "checkout-expired",
+    });
+
+    const rows = await listInventorySnapshotWithCtx(ctx, {
+      now: 1_000,
+      storeId: "store-1" as Id<"store">,
+    });
+
+    expect(rows).toEqual([
+      expect.objectContaining({
+        _id: "sku-1",
+        checkoutReservedQuantity: 1,
+        durableQuantityAvailable: 8,
+        inventoryCount: 10,
+        posReservedQuantity: 2,
+        quantityAvailable: 6,
+        reservedQuantity: 3,
       }),
     ]);
   });

--- a/packages/athena-webapp/convex/stockOps/adjustments.ts
+++ b/packages/athena-webapp/convex/stockOps/adjustments.ts
@@ -68,6 +68,8 @@ const UNCATEGORIZED_SCOPE_KEY = "__uncategorized";
 const TEMPORARY_DELETE_SCOPE_CONFIRMATION =
   "delete-stock-adjustment-scope-skus";
 const ACTIVE_STORE_HOLD_SUM_LIMIT = 5000;
+const ACTIVE_CHECKOUT_SESSION_SUM_LIMIT = 1000;
+const ACTIVE_CHECKOUT_ITEM_SUM_LIMIT = 5000;
 
 function trimOptional(value?: string | null) {
   const nextValue = value?.trim();
@@ -398,6 +400,58 @@ async function readActiveHeldQuantitiesForStockOpsSnapshot(
   }, new Map<Id<"productSku">, number>());
 }
 
+async function readActiveCheckoutReservedQuantitiesForStockOpsSnapshot(
+  ctx: QueryCtx,
+  args: {
+    now: number;
+    storeId: Id<"store">;
+  }
+) {
+  const activeSessionCandidates = await ctx.db
+    .query("checkoutSession")
+    .withIndex("by_storeId_hasCompletedCheckoutSession", (q) =>
+      q.eq("storeId", args.storeId).eq("hasCompletedCheckoutSession", false)
+    )
+    .take(ACTIVE_CHECKOUT_SESSION_SUM_LIMIT + 1);
+
+  if (activeSessionCandidates.length > ACTIVE_CHECKOUT_SESSION_SUM_LIMIT) {
+    throw new Error(
+      "Stock operations has too many active checkout sessions to summarize. Expire stale checkout sessions and retry."
+    );
+  }
+
+  const activeSessions = activeSessionCandidates.filter(
+    (session) => session.expiresAt > args.now
+  );
+
+  const checkoutItemGroups = await Promise.all(
+    activeSessions.map((session) =>
+      ctx.db
+        .query("checkoutSessionItem")
+        .withIndex("by_sessionId", (q) => q.eq("sesionId", session._id))
+        .take(ACTIVE_CHECKOUT_ITEM_SUM_LIMIT + 1)
+    )
+  );
+
+  for (const items of checkoutItemGroups) {
+    if (items.length > ACTIVE_CHECKOUT_ITEM_SUM_LIMIT) {
+      throw new Error(
+        "Stock operations has too many checkout items in one active session to summarize. Expire stale checkout sessions and retry."
+      );
+    }
+  }
+
+  const checkoutItems = checkoutItemGroups.flat();
+
+  return checkoutItems.reduce((quantities, item) => {
+    quantities.set(
+      item.productSkuId,
+      (quantities.get(item.productSkuId) ?? 0) + Math.max(0, item.quantity)
+    );
+    return quantities;
+  }, new Map<Id<"productSku">, number>());
+}
+
 export async function listInventorySnapshotWithCtx(
   ctx: QueryCtx,
   args: {
@@ -415,6 +469,11 @@ export async function listInventorySnapshotWithCtx(
     now,
     storeId: args.storeId,
   });
+  const checkoutReservedQuantities =
+    await readActiveCheckoutReservedQuantitiesForStockOpsSnapshot(ctx, {
+      now,
+      storeId: args.storeId,
+    });
 
   const productIds = Array.from(
     new Set(productSkus.map((productSku) => productSku.productId))
@@ -471,11 +530,15 @@ export async function listInventorySnapshotWithCtx(
           ? categoryMap.get(product.categoryId)
           : null;
         const color = productSku.color ? colorMap.get(productSku.color) : null;
-        const reservedQuantity = heldQuantities.get(productSku._id) ?? 0;
+        const posReservedQuantity = heldQuantities.get(productSku._id) ?? 0;
+        const checkoutReservedQuantity =
+          checkoutReservedQuantities.get(productSku._id) ?? 0;
+        const reservedQuantity =
+          posReservedQuantity + checkoutReservedQuantity;
         const durableQuantityAvailable = productSku.quantityAvailable;
         const quantityAvailable = Math.max(
           0,
-          durableQuantityAvailable - reservedQuantity
+          durableQuantityAvailable - posReservedQuantity
         );
 
         return {
@@ -493,6 +556,8 @@ export async function listInventorySnapshotWithCtx(
             productSku.productName ??
             productSku.sku ??
             String(productSku._id),
+          checkoutReservedQuantity,
+          posReservedQuantity,
           quantityAvailable,
           reservedQuantity,
           sku: productSku.sku ?? null,

--- a/packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.test.tsx
+++ b/packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.test.tsx
@@ -777,6 +777,7 @@ describe("StockAdjustmentWorkspaceContent", () => {
           _id: "sku-held" as Id<"productSku">,
           durableQuantityAvailable: 8,
           inventoryCount: 10,
+          posReservedQuantity: 2,
           productCategory: "Hair",
           productName: "Held Closure",
           quantityAvailable: 6,
@@ -791,7 +792,32 @@ describe("StockAdjustmentWorkspaceContent", () => {
         /6 of 10 units are available to sell\. 2 reserved in POS sessions\./i,
       ),
     ).toBeInTheDocument();
-    expect(screen.getByText("2 reserved")).toBeInTheDocument();
+    expect(screen.getByText("2 POS")).toBeInTheDocument();
+  });
+
+  it("shows active checkout reservations beside reduced availability", () => {
+    renderStockAdjustmentWorkspace({
+      inventoryItems: [
+        {
+          _id: "sku-checkout-held" as Id<"productSku">,
+          checkoutReservedQuantity: 1,
+          durableQuantityAvailable: 9,
+          inventoryCount: 10,
+          productCategory: "Hair",
+          productName: "Checkout Held Closure",
+          quantityAvailable: 9,
+          reservedQuantity: 1,
+          sku: "CHC-18",
+        },
+      ],
+    });
+
+    expect(
+      screen.getByText(
+        /9 of 10 units are available to sell\. 1 reserved in active checkout sessions\./i,
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByText("1 checkout")).toBeInTheDocument();
   });
 
   it("formats inventory status numbers with compact k notation", () => {

--- a/packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx
+++ b/packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx
@@ -52,10 +52,12 @@ export type InventorySnapshotItem = {
   _id: Id<"productSku">;
   barcode?: string | null;
   colorName?: string | null;
+  checkoutReservedQuantity?: number;
   durableQuantityAvailable?: number;
   imageUrl?: string | null;
   inventoryCount: number;
   length?: number | null;
+  posReservedQuantity?: number;
   productCategory?: string | null;
   productId?: Id<"product"> | null;
   productName: string;
@@ -259,8 +261,64 @@ function getInventoryItemDisplayName(item: InventorySnapshotItem) {
   return getProductName(item) || item.sku || String(item._id);
 }
 
+function getReservationLabels(item: InventorySnapshotItem) {
+  const checkoutReservedQuantity = item.checkoutReservedQuantity ?? 0;
+  const posReservedQuantity = item.posReservedQuantity ?? 0;
+  const knownReservedQuantity =
+    checkoutReservedQuantity + posReservedQuantity;
+  const fallbackReservedQuantity = Math.max(
+    0,
+    (item.reservedQuantity ?? 0) - knownReservedQuantity,
+  );
+
+  return [
+    checkoutReservedQuantity > 0
+      ? {
+          title: `${formatInventoryNumber(checkoutReservedQuantity)} reserved in active checkout sessions`,
+          value: `${formatInventoryNumber(checkoutReservedQuantity)} checkout`,
+        }
+      : null,
+    posReservedQuantity > 0
+      ? {
+          title: `${formatInventoryNumber(posReservedQuantity)} reserved in POS sessions`,
+          value: `${formatInventoryNumber(posReservedQuantity)} POS`,
+        }
+      : null,
+    fallbackReservedQuantity > 0
+      ? {
+          title: `${formatInventoryNumber(fallbackReservedQuantity)} reserved`,
+          value: `${formatInventoryNumber(fallbackReservedQuantity)} reserved`,
+        }
+      : null,
+  ].filter(
+    (label): label is { title: string; value: string } => label !== null,
+  );
+}
+
+function formatReservationSourceSummary(args: {
+  checkoutReservedUnits: number;
+  fallbackReservedUnits: number;
+  posReservedUnits: number;
+}) {
+  return [
+    args.checkoutReservedUnits > 0
+      ? `${formatInventoryNumber(
+          args.checkoutReservedUnits,
+        )} reserved in active checkout sessions.`
+      : null,
+    args.posReservedUnits > 0
+      ? `${formatInventoryNumber(args.posReservedUnits)} reserved in POS sessions.`
+      : null,
+    args.fallbackReservedUnits > 0
+      ? `${formatInventoryNumber(args.fallbackReservedUnits)} reserved.`
+      : null,
+  ]
+    .filter(Boolean)
+    .join(" ");
+}
+
 function getSkuDetailEntries(item: InventorySnapshotItem) {
-  const reservedQuantity = item.reservedQuantity ?? 0;
+  const reservationLabels = getReservationLabels(item);
 
   return [
     item.sku ? { label: "SKU", value: item.sku } : null,
@@ -272,10 +330,10 @@ function getSkuDetailEntries(item: InventorySnapshotItem) {
       ? { label: "Length", value: `${item.length}"` }
       : null,
     item.colorName ? { label: "Color", value: item.colorName } : null,
-    reservedQuantity > 0
+    reservationLabels.length > 0
       ? {
           label: "Reserved",
-          value: `${formatInventoryNumber(reservedQuantity)} in POS sessions`,
+          value: reservationLabels.map((entry) => entry.title).join(", "),
         }
       : null,
   ].filter(
@@ -775,10 +833,24 @@ export function StockAdjustmentWorkspaceContent({
           item.inventoryCount - item.quantityAvailable,
         );
         const reservedUnits = Math.max(0, item.reservedQuantity ?? 0);
+        const checkoutReservedUnits = Math.max(
+          0,
+          item.checkoutReservedQuantity ?? 0,
+        );
+        const posReservedUnits = Math.max(0, item.posReservedQuantity ?? 0);
+        const fallbackReservedUnits = Math.max(
+          0,
+          reservedUnits - checkoutReservedUnits - posReservedUnits,
+        );
 
         return {
           availableUnits: current.availableUnits + item.quantityAvailable,
+          checkoutReservedUnits:
+            current.checkoutReservedUnits + checkoutReservedUnits,
+          fallbackReservedUnits:
+            current.fallbackReservedUnits + fallbackReservedUnits,
           onHandUnits: current.onHandUnits + item.inventoryCount,
+          posReservedUnits: current.posReservedUnits + posReservedUnits,
           reservedUnits: current.reservedUnits + reservedUnits,
           unavailableSkuCount:
             current.unavailableSkuCount + (unavailableUnits > 0 ? 1 : 0),
@@ -787,7 +859,10 @@ export function StockAdjustmentWorkspaceContent({
       },
       {
         availableUnits: 0,
+        checkoutReservedUnits: 0,
+        fallbackReservedUnits: 0,
         onHandUnits: 0,
+        posReservedUnits: 0,
         reservedUnits: 0,
         unavailableSkuCount: 0,
         unavailableUnits: 0,
@@ -796,6 +871,7 @@ export function StockAdjustmentWorkspaceContent({
 
     const itemCount = inventoryItems.length;
     const hasUnavailableUnits = totals.unavailableUnits > 0;
+    const reservationSummary = formatReservationSourceSummary(totals);
 
     return {
       ...totals,
@@ -810,9 +886,7 @@ export function StockAdjustmentWorkspaceContent({
               "unit",
             )} are available to sell.${
               totals.reservedUnits > 0
-                ? ` ${formatInventoryNumber(
-                    totals.reservedUnits,
-                  )} reserved in POS sessions.`
+                ? ` ${reservationSummary}`
                 : ""
             }`,
       title:
@@ -984,6 +1058,7 @@ export function StockAdjustmentWorkspaceContent({
         ),
         cell: ({ row }) => {
           const item = row.original.inventoryItem;
+          const reservationLabels = getReservationLabels(item);
           const availabilityMatchesOnHand =
             item.quantityAvailable === item.inventoryCount;
 
@@ -1020,11 +1095,15 @@ export function StockAdjustmentWorkspaceContent({
                 <span className="block">
                   {formatInventoryNumber(item.quantityAvailable)}
                 </span>
-                {(item.reservedQuantity ?? 0) > 0 ? (
-                  <span className="block text-[11px] font-medium uppercase tracking-[0.12em] text-warning">
-                    {formatInventoryNumber(item.reservedQuantity ?? 0)} reserved
+                {reservationLabels.map((label) => (
+                  <span
+                    className="block text-[11px] font-medium uppercase tracking-[0.12em] text-warning"
+                    key={label.value}
+                    title={label.title}
+                  >
+                    {label.value}
                   </span>
-                ) : null}
+                ))}
               </span>
             </div>
           );


### PR DESCRIPTION
## Summary

Stock adjustments now explain checkout-held inventory instead of showing a silent on-hand versus available mismatch. The inventory snapshot separates active checkout reservations from POS inventory holds, keeps sellable availability from double-subtracting checkout units, and renders source-aware labels in the summary, table, and SKU detail rail.

The change also adds bounded Convex reads for active checkout-session reservation totals, regression coverage for checkout and POS reservation labeling, and a solution note documenting the two reservation models.

## Validation

- `bun run --filter '@athena/webapp' test -- convex/stockOps/adjustments.test.ts`
- `bun run --filter '@athena/webapp' test -- src/components/operations/StockAdjustmentWorkspace.test.tsx`
- `bun run --filter '@athena/webapp' lint:convex:changed`
- `bun run pr:athena`
- Pre-push validation suite

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-10a37f?logo=openai&logoColor=white)