### PR TITLE
Update receipt policy copy

### DIFF
--- a/packages/athena-webapp/convex/emails/PosReceiptEmail.tsx
+++ b/packages/athena-webapp/convex/emails/PosReceiptEmail.tsx
@@ -285,11 +285,25 @@ export default function PosReceiptEmail({
           <Spacer height={16} />
 
           <Section>
+            <SectionLabel>Store policy</SectionLabel>
+            <Text style={{ ...styles.baseTextStyle, ...styles.policyLine }}>
+              In-store purchases may be returned or exchanged within 7 days when
+              items are unused and in original condition.
+            </Text>
+            <Text style={{ ...styles.baseTextStyle, ...styles.policyLine }}>
+              Used wigs or worn products are not eligible for return or
+              exchange.
+            </Text>
+          </Section>
+
+          <Spacer height={16} />
+
+          <Section>
             <Text style={{ ...styles.baseTextStyle, ...styles.footerLine }}>
               Thank you for your business!
             </Text>
             <Text style={{ ...styles.baseTextStyle, ...styles.footerLine }}>
-              Please keep this receipt for your records.
+              Keep this receipt for returns, exchanges, and your records.
             </Text>
           </Section>
         </Container>
@@ -514,6 +528,12 @@ const styles: Record<string, CSSProperties> = {
   },
   paymentMethod: {
     fontWeight: 900,
+  },
+  policyLine: {
+    color: "#444444",
+    fontSize: "10px",
+    lineHeight: "15px",
+    marginBottom: "6px",
   },
   footerLine: {
     textAlign: "center" as const,

--- a/packages/storefront-webapp/src/routes/shop/receipt/-PosReceiptPage.tsx
+++ b/packages/storefront-webapp/src/routes/shop/receipt/-PosReceiptPage.tsx
@@ -261,6 +261,20 @@ export const PosReceiptPage = ({ queryOptions }: PosReceiptPageProps) => {
           <div className="line" />
 
           <section className="space-y-2">
+            <h2 className="section-title">Store policy</h2>
+            <p className="small-muted">
+              In-store purchases may be returned or exchanged within 7 days when
+              items are unused and in original condition.
+            </p>
+            <p className="small-muted">
+              Used wigs or worn products are not eligible for return or
+              exchange.
+            </p>
+          </section>
+
+          <div className="line" />
+
+          <section className="space-y-2">
             <h2 className="section-title">Payment</h2>
             {data.payments.length > 0
               ? data.payments.map((payment, idx) => (
@@ -289,7 +303,9 @@ export const PosReceiptPage = ({ queryOptions }: PosReceiptPageProps) => {
 
           <div className="mt-4 pt-3 text-center">
             <p className="text-xs font-bold">Thank you for your business!</p>
-            <p className="small-muted">Please keep this receipt for your records.</p>
+            <p className="small-muted">
+              Keep this receipt for returns, exchanges, and your records.
+            </p>
           </div>
         </div>
       </article>


### PR DESCRIPTION
## Summary
- add in-store return and exchange policy copy to POS receipt email
- add the same policy copy to the storefront receipt view
- update receipt footer copy to mention returns and exchanges once

## Validation
- bun run pr:athena