### PR TITLE
fix: move daily close report action

### DIFF
--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -27035,7 +27035,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L2121",
+      "source_location": "L2098",
       "target": "dailycloseview_cn",
       "weight": 1
     },
@@ -27659,7 +27659,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L2593",
+      "source_location": "L2571",
       "target": "dailycloseview_handlecomplete",
       "weight": 1
     },
@@ -58693,7 +58693,7 @@
       "label": "handleComplete()",
       "norm_label": "handlecomplete()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L2593"
+      "source_location": "L2571"
     },
     {
       "community": 0,

--- a/packages/athena-webapp/src/components/operations/DailyCloseView.test.tsx
+++ b/packages/athena-webapp/src/components/operations/DailyCloseView.test.tsx
@@ -660,25 +660,38 @@ describe("DailyCloseViewContent", () => {
 
     renderContent(readySnapshot);
 
-    const launcher = screen.getByRole("region", {
-      name: "POS and expense transaction report",
+    expect(
+      screen.queryByRole("region", {
+        name: "POS and expense transaction report",
+      }),
+    ).not.toBeInTheDocument();
+
+    const operatingDate = screen.getAllByText("May 7, 2026")[0];
+    const actionGroup = operatingDate.closest("div")?.parentElement;
+    expect(actionGroup).not.toBeNull();
+
+    const reportButton = within(actionGroup as HTMLElement).getByRole("button", {
+      name: /view report/i,
     });
 
     expect(
-      within(launcher).getByText("POS and expense transactions"),
-    ).toBeInTheDocument();
+      screen.queryByText("POS and expense transactions"),
+    ).not.toBeInTheDocument();
     expect(
-      within(launcher).getByText(
+      screen.queryByText(
         "14 POS sales, 1 expense transaction, no voided sales available for review.",
       ),
-    ).toBeInTheDocument();
+    ).not.toBeInTheDocument();
 
-    expect(within(launcher).queryByText("POS sale")).not.toBeInTheDocument();
-
-    await user.click(within(launcher).getByRole("button", { name: /view report/i }));
+    await user.click(reportButton);
 
     const report = await screen.findByRole("dialog");
 
+    expect(
+      within(report).getByText(
+        "14 POS sales, 1 expense transaction, no voided sales available from the End-of-Day Review workspace.",
+      ),
+    ).toBeInTheDocument();
     expect(within(report).getByText("Item")).toBeInTheDocument();
     expect(within(report).getByText("Staff")).toBeInTheDocument();
     expect(within(report).getByText("Payment")).toBeInTheDocument();

--- a/packages/athena-webapp/src/components/operations/DailyCloseView.tsx
+++ b/packages/athena-webapp/src/components/operations/DailyCloseView.tsx
@@ -1886,7 +1886,7 @@ function BucketTabs({
   );
 }
 
-function TransactionReportSection({
+function TransactionReportAction({
   currency,
   orgUrlSlug,
   snapshot,
@@ -1909,38 +1909,15 @@ function TransactionReportSection({
 
   return (
     <>
-      <section
-        aria-label="POS and expense transaction report"
-        className="rounded-lg border border-border bg-surface-raised p-layout-md shadow-surface"
+      <Button
+        className="shrink-0"
+        onClick={() => setIsOpen(true)}
+        type="button"
+        variant="outline"
       >
-        <div className="flex flex-col gap-layout-md lg:flex-row lg:items-center lg:justify-between">
-          <div className="flex min-w-0 gap-layout-sm">
-            <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-md bg-transaction-signal/10 text-transaction-signal">
-              <FileText aria-hidden="true" className="h-4 w-4" />
-            </div>
-            <div className="min-w-0">
-              <p className="text-[11px] font-medium uppercase tracking-[0.18em] text-muted-foreground">
-                Transaction report
-              </p>
-              <h2 className="mt-1 text-lg font-semibold text-foreground">
-                POS and expense transactions
-              </h2>
-              <p className="mt-1 max-w-3xl text-sm leading-6 text-muted-foreground">
-                {reportSummary} available for review.
-              </p>
-            </div>
-          </div>
-          <Button
-            className="shrink-0"
-            onClick={() => setIsOpen(true)}
-            type="button"
-            variant="outline"
-          >
-            <FileText aria-hidden="true" />
-            View report
-          </Button>
-        </div>
-      </section>
+        <FileText aria-hidden="true" />
+        View report
+      </Button>
 
       <Sheet open={isOpen} onOpenChange={setIsOpen}>
         <SheetContent
@@ -2388,11 +2365,19 @@ export function DailyCloseViewContent({
                       {displayCopy.description}
                     </p>
                   </div>
-                  <div className="rounded-lg border border-border bg-surface-raised px-layout-md py-layout-sm text-sm text-muted-foreground shadow-surface">
-                    Operating date{" "}
-                    <span className="font-medium text-foreground">
-                      {formatOperatingDate(snapshot.operatingDate)}
-                    </span>
+                  <div className="flex flex-col gap-layout-sm sm:flex-row sm:items-center">
+                    <TransactionReportAction
+                      currency={currency}
+                      orgUrlSlug={orgUrlSlug}
+                      snapshot={snapshot}
+                      storeUrlSlug={storeUrlSlug}
+                    />
+                    <div className="rounded-lg border border-border bg-surface-raised px-layout-md py-layout-sm text-sm text-muted-foreground shadow-surface">
+                      Operating date{" "}
+                      <span className="font-medium text-foreground">
+                        {formatOperatingDate(snapshot.operatingDate)}
+                      </span>
+                    </div>
                   </div>
                 </div>
 
@@ -2488,13 +2473,6 @@ export function DailyCloseViewContent({
                     )}
                   />
                 </div>
-
-                <TransactionReportSection
-                  currency={currency}
-                  orgUrlSlug={orgUrlSlug}
-                  snapshot={snapshot}
-                  storeUrlSlug={storeUrlSlug}
-                />
               </section>
 
               <PageWorkspaceGrid>


### PR DESCRIPTION
## Summary
- Moves the Daily Close transaction report action out of the standalone rail and into the operating-date header actions.
- Keeps the transaction report sheet behavior intact while removing the embedded report card from the workspace flow.
- Updates Daily Close tests for the new action placement.

## Validation
- Full pre-push validation suite