### PR TITLE
fix: preserve completed daily close snapshots

### DIFF
--- a/docs/solutions/logic-errors/athena-store-ops-workspace-state-boundaries-2026-05-09.md
+++ b/docs/solutions/logic-errors/athena-store-ops-workspace-state-boundaries-2026-05-09.md
@@ -56,6 +56,8 @@ Keep the raw snapshot for command submission and audit data. Presentation normal
 ## Prevention
 
 - Treat terminal states as presentation boundaries. If a workflow is completed or started, stale blocker/review details should not drive the primary UI.
+- Completed End-of-Day Review pages must render the persisted `dailyClose.reportSnapshot` instead of recomputing blockers from live register, approval, POS session, transaction, or work-item tables.
+- Live End-of-Day Review blocker sources must be scoped to the selected operating date. Approval blockers should follow their linked transaction or register session when available; unresolved POS sessions should intersect the operating-day range instead of using store-wide active/held state.
 - Keep current-day and historical operating-date copy separate. Historical reports should say "Net sales" and "Cash"; current-day operational views can say "Today's net sales" and "Today's cash".
 - Omit default current-day filters from navigation links. Include an operating date only when the target needs a historical date.
 - Surface human-entered notes near requester or actor identity, before linked technical details.

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 4976 nodes · 4942 edges · 1596 communities detected
+- 4982 nodes · 4951 edges · 1596 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -1609,7 +1609,7 @@
 
 ## God Nodes (most connected - your core abstractions)
 1. `createJourneyEvent()` - 40 edges
-2. `buildDailyCloseSnapshotWithCtx()` - 24 edges
+2. `buildDailyCloseSnapshotWithCtx()` - 25 edges
 3. `getStoreConfigV2()` - 17 edges
 4. `DataTableViewOptions()` - 16 edges
 5. `buildDailyOpeningSnapshotWithCtx()` - 15 edges
@@ -1638,8 +1638,8 @@ Cohesion: 0.05
 Nodes (45): buildDailyCloseTransactionSearch(), cn(), formatCarriedOverRegisterCount(), formatDailyCloseMoney(), formatExpenseTransactionCount(), formatMetadataDisplayValue(), formatMetadataValue(), formatTimestampMetadata() (+37 more)
 
 ### Community 1 - "Community 1"
-Cohesion: 0.08
-Nodes (41): approvalRequestTypeLabel(), buildDailyCloseApprovalSubject(), buildDailyCloseCompletionApprovalRequirement(), buildDailyCloseReportSnapshot(), buildDailyCloseSnapshotWithCtx(), buildExpenseSessionsById(), buildPaymentTotals(), buildReadiness() (+33 more)
+Cohesion: 0.07
+Nodes (45): approvalBelongsToRange(), approvalRequestTypeLabel(), buildDailyCloseApprovalSubject(), buildDailyCloseCompletionApprovalRequirement(), buildDailyCloseReportSnapshot(), buildDailyCloseSnapshotWithCtx(), buildExpenseSessionsById(), buildPaymentTotals() (+37 more)
 
 ### Community 2 - "Community 2"
 Cohesion: 0.1
@@ -2031,39 +2031,39 @@ Nodes (6): findAthenaUserByEmailWithCtx(), getAuthenticatedAthenaUserWithCtx(), 
 
 ### Community 99 - "Community 99"
 Cohesion: 0.43
-Nodes (6): sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
-
-### Community 100 - "Community 100"
-Cohesion: 0.43
 Nodes (6): buildMtnCollectionsLookupPrefixes(), isTargetEnvironment(), readScopedValue(), resolveConfigForPrefix(), resolveMtnCollectionsConfigFromEnv(), toEnvSegment()
 
-### Community 101 - "Community 101"
+### Community 100 - "Community 100"
 Cohesion: 0.46
 Nodes (7): recordApprovalAuditEventWithCtx(), recordApprovalDecisionRecordedAuditEventWithCtx(), recordApprovalProofConsumedAuditEventWithCtx(), recordApprovalRequiredAuditEventWithCtx(), recordApprovedCommandAppliedAuditEventWithCtx(), recordAsyncApprovalRequestCreatedAuditEventWithCtx(), recordManagerApprovalGrantedAuditEventWithCtx()
 
-### Community 102 - "Community 102"
+### Community 101 - "Community 101"
 Cohesion: 0.5
 Nodes (7): buildApprovalDecisionRequirement(), buildApprovalDecisionSubject(), consumeApprovalDecisionProofWithCtx(), decideApprovalRequestAsAuthenticatedUserWithCtx(), decideApprovalRequestAsCommandWithCtx(), decideApprovalRequestWithCtx(), mapDecideApprovalRequestError()
 
-### Community 103 - "Community 103"
+### Community 102 - "Community 102"
 Cohesion: 0.36
 Nodes (5): buildPaymentAllocation(), correctSameAmountSinglePaymentAllocationWithCtx(), findSameAmountSinglePaymentAllocation(), listPaymentAllocationsForTargetWithCtx(), recordPaymentAllocationWithCtx()
 
-### Community 104 - "Community 104"
+### Community 103 - "Community 103"
 Cohesion: 0.43
 Nodes (6): buildPosSessionTraceEvent(), buildPosSessionTraceRecord(), buildTraceSummary(), formatPaymentMethod(), recordPosSessionTraceBestEffort(), safeTraceWrite()
 
-### Community 105 - "Community 105"
+### Community 104 - "Community 104"
 Cohesion: 0.5
 Nodes (7): findExistingSku(), findOrCreateQuickAddCategory(), findOrCreateQuickAddSubcategory(), generateSKU(), isBarcodeLike(), mapSkuToCatalogResult(), quickAddCatalogItem()
+
+### Community 105 - "Community 105"
+Cohesion: 0.25
+Nodes (0):
 
 ### Community 106 - "Community 106"
 Cohesion: 0.25
 Nodes (0):
 
 ### Community 107 - "Community 107"
-Cohesion: 0.25
-Nodes (0):
+Cohesion: 0.43
+Nodes (6): sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
 
 ### Community 108 - "Community 108"
 Cohesion: 0.39
@@ -2278,12 +2278,12 @@ Cohesion: 0.33
 Nodes (1): DataTableToolbar()
 
 ### Community 161 - "Community 161"
-Cohesion: 0.53
-Nodes (2): SelectedProductsProvider(), useSelectedProducts()
-
-### Community 162 - "Community 162"
 Cohesion: 0.4
 Nodes (2): handlePinChange(), normalizeOtpCode()
+
+### Community 162 - "Community 162"
+Cohesion: 0.53
+Nodes (2): SelectedProductsProvider(), useSelectedProducts()
 
 ### Community 163 - "Community 163"
 Cohesion: 0.33
@@ -2318,8 +2318,8 @@ Cohesion: 0.53
 Nodes (3): handleUpdateFees(), parseDeliveryFeeInputs(), parseOptionalDeliveryFeeInput()
 
 ### Community 171 - "Community 171"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.47
+Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
 
 ### Community 172 - "Community 172"
 Cohesion: 0.33
@@ -2338,12 +2338,12 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 176 - "Community 176"
-Cohesion: 0.53
-Nodes (4): calculatePosChange(), calculatePosRemainingDue(), calculatePosTotalPaid(), roundPosAmount()
-
-### Community 177 - "Community 177"
 Cohesion: 0.33
 Nodes (0):
+
+### Community 177 - "Community 177"
+Cohesion: 0.53
+Nodes (4): calculatePosChange(), calculatePosRemainingDue(), calculatePosTotalPaid(), roundPosAmount()
 
 ### Community 178 - "Community 178"
 Cohesion: 0.33
@@ -2354,40 +2354,40 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 180 - "Community 180"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 181 - "Community 181"
 Cohesion: 0.4
 Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 182 - "Community 182"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 183 - "Community 183"
-Cohesion: 0.47
-Nodes (4): fetchPosTransaction(), getBaseUrl(), getPosTransactionByReceiptToken(), PosTransactionReceiptError
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 184 - "Community 184"
 Cohesion: 0.47
-Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
+Nodes (4): fetchPosTransaction(), getBaseUrl(), getPosTransactionByReceiptToken(), PosTransactionReceiptError
 
 ### Community 185 - "Community 185"
+Cohesion: 0.47
+Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
+
+### Community 186 - "Community 186"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 186 - "Community 186"
+### Community 187 - "Community 187"
 Cohesion: 0.4
 Nodes (2): handleConfirm(), handlePrimaryAction()
 
-### Community 187 - "Community 187"
+### Community 188 - "Community 188"
 Cohesion: 0.33
 Nodes (0):
-
-### Community 188 - "Community 188"
-Cohesion: 0.47
-Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
 
 ### Community 189 - "Community 189"
 Cohesion: 0.53
@@ -2678,48 +2678,48 @@ Cohesion: 0.67
 Nodes (2): consumeApprovalProofWithCtx(), invalidApprovalProofResult()
 
 ### Community 261 - "Community 261"
-Cohesion: 0.67
-Nodes (2): buildOperationalEvent(), recordOperationalEventWithCtx()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 262 - "Community 262"
 Cohesion: 0.67
-Nodes (2): buildOperationalWorkItem(), createOperationalWorkItemWithCtx()
+Nodes (2): buildOperationalEvent(), recordOperationalEventWithCtx()
 
 ### Community 263 - "Community 263"
 Cohesion: 0.67
-Nodes (2): expectIndex(), getTableIndexes()
+Nodes (2): buildOperationalWorkItem(), createOperationalWorkItemWithCtx()
 
 ### Community 264 - "Community 264"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): expectIndex(), getTableIndexes()
 
 ### Community 265 - "Community 265"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 266 - "Community 266"
-Cohesion: 0.83
-Nodes (3): resolveServiceIntakeCustomerProfile(), splitFullName(), trimOptional()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 267 - "Community 267"
 Cohesion: 0.83
-Nodes (3): mapOpenDrawerUserError(), normalizeRegisterNumber(), openDrawer()
+Nodes (3): resolveServiceIntakeCustomerProfile(), splitFullName(), trimOptional()
 
 ### Community 268 - "Community 268"
 Cohesion: 0.83
-Nodes (3): createDbGetMock(), createDbMock(), createDbQueryMock()
+Nodes (3): mapOpenDrawerUserError(), normalizeRegisterNumber(), openDrawer()
 
 ### Community 269 - "Community 269"
 Cohesion: 0.83
-Nodes (3): buildRegisterState(), getActiveSessionConflictForRegisterState(), getRegisterState()
+Nodes (3): createDbGetMock(), createDbMock(), createDbQueryMock()
 
 ### Community 270 - "Community 270"
-Cohesion: 0.67
-Nodes (2): lookupByBarcode(), mapSkuToCatalogResult()
+Cohesion: 0.83
+Nodes (3): buildRegisterState(), getActiveSessionConflictForRegisterState(), getRegisterState()
 
 ### Community 271 - "Community 271"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): lookupByBarcode(), mapSkuToCatalogResult()
 
 ### Community 272 - "Community 272"
 Cohesion: 0.5
@@ -2730,24 +2730,24 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 274 - "Community 274"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 275 - "Community 275"
 Cohesion: 0.67
 Nodes (2): expectIndex(), getTableIndexes()
 
-### Community 275 - "Community 275"
+### Community 276 - "Community 276"
 Cohesion: 0.83
 Nodes (3): findExistingCustomerProfileId(), getStoreOrganizationId(), recordStoreFrontCustomerMilestone()
 
-### Community 276 - "Community 276"
+### Community 277 - "Community 277"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 277 - "Community 277"
-Cohesion: 0.83
-Nodes (3): formatStaffDisplayName(), formatStaffDisplayNameOrFallback(), normalizeNamePart()
 
 ### Community 278 - "Community 278"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): formatStaffDisplayName(), formatStaffDisplayNameOrFallback(), normalizeNamePart()
 
 ### Community 279 - "Community 279"
 Cohesion: 0.5
@@ -2762,12 +2762,12 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 282 - "Community 282"
-Cohesion: 0.67
-Nodes (2): countGroupedAnalytics(), groupAnalytics()
-
-### Community 283 - "Community 283"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 283 - "Community 283"
+Cohesion: 0.67
+Nodes (2): countGroupedAnalytics(), groupAnalytics()
 
 ### Community 284 - "Community 284"
 Cohesion: 0.5
@@ -2786,12 +2786,12 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 288 - "Community 288"
-Cohesion: 0.67
-Nodes (2): handleSubmit(), resetReplacementFields()
-
-### Community 289 - "Community 289"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 289 - "Community 289"
+Cohesion: 0.67
+Nodes (2): handleSubmit(), resetReplacementFields()
 
 ### Community 290 - "Community 290"
 Cohesion: 0.5
@@ -2814,80 +2814,80 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 295 - "Community 295"
-Cohesion: 0.67
-Nodes (2): applyCommandResult(), handleCreateCase()
-
-### Community 296 - "Community 296"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 296 - "Community 296"
+Cohesion: 0.67
+Nodes (2): applyCommandResult(), handleCreateCase()
 
 ### Community 297 - "Community 297"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 298 - "Community 298"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 299 - "Community 299"
 Cohesion: 0.67
 Nodes (2): getRiskStyles(), RiskIndicators()
 
-### Community 299 - "Community 299"
+### Community 300 - "Community 300"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 300 - "Community 300"
+### Community 301 - "Community 301"
 Cohesion: 0.67
 Nodes (2): useGetArchivedProducts(), useGetProducts()
 
-### Community 301 - "Community 301"
+### Community 302 - "Community 302"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 302 - "Community 302"
+### Community 303 - "Community 303"
 Cohesion: 0.67
 Nodes (2): extractTraceId(), runCommand()
 
-### Community 303 - "Community 303"
+### Community 304 - "Community 304"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 304 - "Community 304"
+### Community 305 - "Community 305"
 Cohesion: 0.67
 Nodes (2): formatStoredAmount(), formatStoredCurrencyAmount()
 
-### Community 305 - "Community 305"
+### Community 306 - "Community 306"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 306 - "Community 306"
+### Community 307 - "Community 307"
 Cohesion: 0.67
 Nodes (2): mapActiveSessionDto(), normalizeCartItems()
 
-### Community 307 - "Community 307"
+### Community 308 - "Community 308"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 308 - "Community 308"
+### Community 309 - "Community 309"
 Cohesion: 0.83
 Nodes (3): isBrowserFingerprintResult(), readStoredTerminalFingerprint(), readStoredTerminalFingerprintHash()
 
-### Community 309 - "Community 309"
+### Community 310 - "Community 310"
 Cohesion: 0.67
 Nodes (2): getCashierDisplayName(), useExpenseRegisterViewModel()
 
-### Community 310 - "Community 310"
+### Community 311 - "Community 311"
 Cohesion: 0.83
 Nodes (3): getBaseUrl(), getUserRedeemedOffers(), submitOffer()
 
-### Community 311 - "Community 311"
+### Community 312 - "Community 312"
 Cohesion: 0.83
 Nodes (3): getAllStores(), getBaseUrl(), getStore()
 
-### Community 312 - "Community 312"
+### Community 313 - "Community 313"
 Cohesion: 0.83
 Nodes (3): getAllSubcategories(), getBaseUrl(), getSubategory()
-
-### Community 313 - "Community 313"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 314 - "Community 314"
 Cohesion: 0.5
@@ -2918,63 +2918,63 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 321 - "Community 321"
-Cohesion: 0.67
-Nodes (2): useOptionalStoreContext(), useStoreContext()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 322 - "Community 322"
 Cohesion: 0.67
-Nodes (2): clearFilters(), onMobileFiltersCloseClick()
+Nodes (2): useOptionalStoreContext(), useStoreContext()
 
 ### Community 323 - "Community 323"
+Cohesion: 0.67
+Nodes (2): clearFilters(), onMobileFiltersCloseClick()
+
+### Community 324 - "Community 324"
 Cohesion: 0.83
 Nodes (3): cancelOrder(), getErrorMessage(), placeOrder()
 
-### Community 324 - "Community 324"
+### Community 325 - "Community 325"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 325 - "Community 325"
+### Community 326 - "Community 326"
 Cohesion: 0.83
 Nodes (3): bootstrapCheckout(), createBootstrapToken(), createMarker()
 
-### Community 326 - "Community 326"
+### Community 327 - "Community 327"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 327 - "Community 327"
+### Community 328 - "Community 328"
 Cohesion: 0.83
 Nodes (3): createFixtureRoot(), write(), writeGraphifyWikiArtifacts()
 
-### Community 328 - "Community 328"
+### Community 329 - "Community 329"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 329 - "Community 329"
-Cohesion: 0.67
-Nodes (2): buildHarnessDocPaths(), buildHarnessDocPathsForArchetype()
 
 ### Community 330 - "Community 330"
 Cohesion: 0.67
-Nodes (2): shutdown(), stopValkeyRuntimeServer()
+Nodes (2): buildHarnessDocPaths(), buildHarnessDocPathsForArchetype()
 
 ### Community 331 - "Community 331"
+Cohesion: 0.67
+Nodes (2): shutdown(), stopValkeyRuntimeServer()
+
+### Community 332 - "Community 332"
 Cohesion: 0.83
 Nodes (3): createFixtureRepo(), createInferentialArtifact(), write()
 
-### Community 332 - "Community 332"
+### Community 333 - "Community 333"
 Cohesion: 0.67
 Nodes (2): collectHarnessTestTargets(), runHarnessTest()
-
-### Community 333 - "Community 333"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 334 - "Community 334"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 335 - "Community 335"
-Cohesion: 0.67
+Cohesion: 0.5
 Nodes (0):
 
 ### Community 336 - "Community 336"
@@ -2982,12 +2982,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 337 - "Community 337"
-Cohesion: 1.0
-Nodes (2): providerErrorCategory(), sendWhatsAppReceiptTemplate()
-
-### Community 338 - "Community 338"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 338 - "Community 338"
+Cohesion: 1.0
+Nodes (2): providerErrorCategory(), sendWhatsAppReceiptTemplate()
 
 ### Community 339 - "Community 339"
 Cohesion: 0.67
@@ -10253,7 +10253,7 @@ _Questions this graph is uniquely positioned to answer:_
 - **Should `Community 0` be split into smaller, more focused modules?**
   _Cohesion score 0.05 - nodes in this community are weakly interconnected._
 - **Should `Community 1` be split into smaller, more focused modules?**
-  _Cohesion score 0.08 - nodes in this community are weakly interconnected._
+  _Cohesion score 0.07 - nodes in this community are weakly interconnected._
 - **Should `Community 2` be split into smaller, more focused modules?**
   _Cohesion score 0.1 - nodes in this community are weakly interconnected._
 - **Should `Community 3` be split into smaller, more focused modules?**

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -3568,6 +3568,30 @@
       "weight": 1
     },
     {
+      "_src": "dailyclose_approvalbelongstorange",
+      "_tgt": "dailyclose_isinrange",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "dailyclose_isinrange",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
+      "source_location": "L613",
+      "target": "dailyclose_approvalbelongstorange",
+      "weight": 1
+    },
+    {
+      "_src": "dailyclose_approvalbelongstorange",
+      "_tgt": "dailyclose_registersessionintersectsrange",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "dailyclose_registersessionintersectsrange",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
+      "source_location": "L630",
+      "target": "dailyclose_approvalbelongstorange",
+      "weight": 1
+    },
+    {
       "_src": "dailyclose_approvalrequesttypelabel",
       "_tgt": "dailyclose_formatpaymentmethodlabel",
       "confidence": "EXTRACTED",
@@ -3575,7 +3599,7 @@
       "relation": "calls",
       "source": "dailyclose_formatpaymentmethodlabel",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L345",
+      "source_location": "L384",
       "target": "dailyclose_approvalrequesttypelabel",
       "weight": 1
     },
@@ -3587,7 +3611,7 @@
       "relation": "calls",
       "source": "dailyclose_builddailycloseapprovalsubject",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L206",
+      "source_location": "L245",
       "target": "dailyclose_builddailyclosecompletionapprovalrequirement",
       "weight": 1
     },
@@ -3599,7 +3623,7 @@
       "relation": "calls",
       "source": "dailyclose_builddailyclosereportsnapshot",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L762",
+      "source_location": "L889",
       "target": "dailyclose_snapshotrevieweditems",
       "weight": 1
     },
@@ -3611,7 +3635,7 @@
       "relation": "calls",
       "source": "dailyclose_uniquedailycloseitems",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L763",
+      "source_location": "L890",
       "target": "dailyclose_builddailyclosereportsnapshot",
       "weight": 1
     },
@@ -3623,7 +3647,7 @@
       "relation": "calls",
       "source": "dailyclose_buildexpensesessionsbyid",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L961",
+      "source_location": "L1111",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -3635,7 +3659,7 @@
       "relation": "calls",
       "source": "dailyclose_buildpaymenttotals",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1504",
+      "source_location": "L1655",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -3647,7 +3671,7 @@
       "relation": "calls",
       "source": "dailyclose_buildreadiness",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1506",
+      "source_location": "L1657",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -3659,7 +3683,7 @@
       "relation": "calls",
       "source": "dailyclose_buildregistersessionsbyid",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L954",
+      "source_location": "L1104",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -3671,7 +3695,7 @@
       "relation": "calls",
       "source": "dailyclose_buildstaffnamesbyid",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L985",
+      "source_location": "L1043",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -3683,7 +3707,7 @@
       "relation": "calls",
       "source": "dailyclose_buildterminallabelsbyid",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L976",
+      "source_location": "L1126",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -3695,7 +3719,7 @@
       "relation": "calls",
       "source": "dailyclose_cashdeltasbyregistersessionid",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L951",
+      "source_location": "L1101",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -3707,7 +3731,7 @@
       "relation": "calls",
       "source": "dailyclose_emptysummary",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L902",
+      "source_location": "L1029",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -3719,7 +3743,7 @@
       "relation": "calls",
       "source": "dailyclose_getdailyclosecompletioneventstaffprofileid",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L971",
+      "source_location": "L1039",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -3731,7 +3755,7 @@
       "relation": "calls",
       "source": "dailyclose_getdailyclosefordate",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L937",
+      "source_location": "L1034",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -3743,7 +3767,7 @@
       "relation": "calls",
       "source": "dailyclose_getpriorcompleteddailyclose",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L938",
+      "source_location": "L1088",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -3755,7 +3779,7 @@
       "relation": "calls",
       "source": "dailyclose_getstore",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L866",
+      "source_location": "L993",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -3767,7 +3791,7 @@
       "relation": "calls",
       "source": "dailyclose_listactiveregistersessions",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L920",
+      "source_location": "L1071",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -3779,7 +3803,7 @@
       "relation": "calls",
       "source": "dailyclose_listclosedregistersessionsforday",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L921",
+      "source_location": "L1072",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -3791,7 +3815,7 @@
       "relation": "calls",
       "source": "dailyclose_listdepositsforday",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L936",
+      "source_location": "L1087",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -3803,7 +3827,7 @@
       "relation": "calls",
       "source": "dailyclose_listexpensesforday",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L935",
+      "source_location": "L1086",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -3815,7 +3839,7 @@
       "relation": "calls",
       "source": "dailyclose_listopenoperationalworkitems",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L924",
+      "source_location": "L1075",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -3827,7 +3851,7 @@
       "relation": "calls",
       "source": "dailyclose_listopenpossessions",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L923",
+      "source_location": "L1074",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -3839,7 +3863,7 @@
       "relation": "calls",
       "source": "dailyclose_listpendingcloseoutapprovals",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L922",
+      "source_location": "L1073",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -3851,7 +3875,19 @@
       "relation": "calls",
       "source": "dailyclose_listtransactionsforday",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L925",
+      "source_location": "L1076",
+      "target": "dailyclose_builddailyclosesnapshotwithctx",
+      "weight": 1
+    },
+    {
+      "_src": "dailyclose_builddailyclosesnapshotwithctx",
+      "_tgt": "dailyclose_normalizecompleteddailyclosesnapshot",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "dailyclose_normalizecompleteddailyclosesnapshot",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
+      "source_location": "L1046",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -3863,7 +3899,7 @@
       "relation": "calls",
       "source": "dailyclose_resolveoperatingdaterange",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L865",
+      "source_location": "L992",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -3875,7 +3911,7 @@
       "relation": "calls",
       "source": "dailyclose_uniquesourcesubjects",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1552",
+      "source_location": "L1703",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -3887,7 +3923,7 @@
       "relation": "calls",
       "source": "dailyclose_builddailycloseapprovalsubject",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1767",
+      "source_location": "L1918",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -3899,7 +3935,7 @@
       "relation": "calls",
       "source": "dailyclose_builddailyclosecompletionapprovalrequirement",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1754",
+      "source_location": "L1905",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -3911,7 +3947,7 @@
       "relation": "calls",
       "source": "dailyclose_builddailyclosereportsnapshot",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1820",
+      "source_location": "L1971",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -3923,7 +3959,7 @@
       "relation": "calls",
       "source": "dailyclose_builddailyclosesnapshotwithctx",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1689",
+      "source_location": "L1840",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -3935,7 +3971,7 @@
       "relation": "calls",
       "source": "dailyclose_createcarryforwardworkitems",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1777",
+      "source_location": "L1928",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -3947,7 +3983,7 @@
       "relation": "calls",
       "source": "dailyclose_getstore",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1664",
+      "source_location": "L1815",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -3959,7 +3995,7 @@
       "relation": "calls",
       "source": "dailyclose_markotherdailyclosesnotcurrent",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1852",
+      "source_location": "L2003",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -3971,7 +4007,7 @@
       "relation": "calls",
       "source": "dailyclose_resolveoperatingdaterange",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1680",
+      "source_location": "L1831",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -3983,7 +4019,7 @@
       "relation": "calls",
       "source": "dailyclose_trimoptional",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1802",
+      "source_location": "L1953",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -3995,7 +4031,7 @@
       "relation": "calls",
       "source": "dailyclose_validatecarryforwardworkitemids",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1740",
+      "source_location": "L1891",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -4007,7 +4043,7 @@
       "relation": "calls",
       "source": "dailyclose_trimoptional",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1598",
+      "source_location": "L1749",
       "target": "dailyclose_createcarryforwardworkitems",
       "weight": 1
     },
@@ -4019,7 +4055,7 @@
       "relation": "calls",
       "source": "dailyclose_buildstaffnamesbyid",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2021",
+      "source_location": "L2172",
       "target": "dailyclose_getcompleteddailyclosehistorydetailwithctx",
       "weight": 1
     },
@@ -4031,7 +4067,7 @@
       "relation": "calls",
       "source": "dailyclose_getdailyclosecompletioneventstaffprofileid",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2017",
+      "source_location": "L2168",
       "target": "dailyclose_getcompleteddailyclosehistorydetailwithctx",
       "weight": 1
     },
@@ -4043,7 +4079,7 @@
       "relation": "calls",
       "source": "dailyclose_getpriorcompleteddailyclose",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1919",
+      "source_location": "L2070",
       "target": "dailyclose_getdailycloseopeningcontextwithctx",
       "weight": 1
     },
@@ -4055,7 +4091,7 @@
       "relation": "calls",
       "source": "dailyclose_buildstaffnamesbyid",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1979",
+      "source_location": "L2130",
       "target": "dailyclose_listcompleteddailyclosehistorywithctx",
       "weight": 1
     },
@@ -4067,7 +4103,7 @@
       "relation": "calls",
       "source": "dailyclose_isvalidoperatingdaterange",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L269",
+      "source_location": "L308",
       "target": "dailyclose_resolveoperatingdaterange",
       "weight": 1
     },
@@ -4079,7 +4115,7 @@
       "relation": "calls",
       "source": "dailyclose_safeoperatingdaterange",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L263",
+      "source_location": "L302",
       "target": "dailyclose_resolveoperatingdaterange",
       "weight": 1
     },
@@ -4091,7 +4127,7 @@
       "relation": "calls",
       "source": "dailyclose_formatpaymentmethodlabel",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L324",
+      "source_location": "L363",
       "target": "dailyclose_transactionpaymentsummary",
       "weight": 1
     },
@@ -4151,7 +4187,7 @@
       "relation": "calls",
       "source": "dailycloseview_getlocaloperatingdate",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L470",
+      "source_location": "L489",
       "target": "dailycloseview_builddailyclosetransactionsearch",
       "weight": 1
     },
@@ -4163,7 +4199,7 @@
       "relation": "calls",
       "source": "dailycloseview_formatcarriedoverregistercount",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L2713",
+      "source_location": "L2782",
       "target": "dailycloseview_formatdailyclosemoney",
       "weight": 1
     },
@@ -4175,7 +4211,7 @@
       "relation": "calls",
       "source": "dailycloseview_formatdailyclosemoney",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L2714",
+      "source_location": "L2783",
       "target": "dailycloseview_getsummarycount",
       "weight": 1
     },
@@ -4187,7 +4223,7 @@
       "relation": "calls",
       "source": "dailycloseview_formatmetadatavalue",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L897",
+      "source_location": "L916",
       "target": "dailycloseview_formatmetadatadisplayvalue",
       "weight": 1
     },
@@ -4199,7 +4235,7 @@
       "relation": "calls",
       "source": "dailycloseview_getmetadatastringvalue",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L899",
+      "source_location": "L918",
       "target": "dailycloseview_formatmetadatadisplayvalue",
       "weight": 1
     },
@@ -4211,7 +4247,7 @@
       "relation": "calls",
       "source": "dailycloseview_getnumericmetadatavalue",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L948",
+      "source_location": "L967",
       "target": "dailycloseview_formatmetadatadisplayvalue",
       "weight": 1
     },
@@ -4223,7 +4259,7 @@
       "relation": "calls",
       "source": "dailycloseview_getvariancetone",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L953",
+      "source_location": "L972",
       "target": "dailycloseview_formatmetadatadisplayvalue",
       "weight": 1
     },
@@ -4235,7 +4271,7 @@
       "relation": "calls",
       "source": "dailycloseview_normalizemetadatalabel",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L907",
+      "source_location": "L926",
       "target": "dailycloseview_formatmetadatadisplayvalue",
       "weight": 1
     },
@@ -4247,7 +4283,7 @@
       "relation": "calls",
       "source": "dailycloseview_formatdailyclosemoney",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L841",
+      "source_location": "L860",
       "target": "dailycloseview_formatmetadatavalue",
       "weight": 1
     },
@@ -4259,7 +4295,7 @@
       "relation": "calls",
       "source": "dailycloseview_formattimestampmetadata",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L837",
+      "source_location": "L856",
       "target": "dailycloseview_formatmetadatavalue",
       "weight": 1
     },
@@ -4271,7 +4307,7 @@
       "relation": "calls",
       "source": "dailycloseview_humanizemetadatalabel",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L869",
+      "source_location": "L888",
       "target": "dailycloseview_formatmetadatavalue",
       "weight": 1
     },
@@ -4283,7 +4319,7 @@
       "relation": "calls",
       "source": "dailycloseview_ismoneymetadatalabel",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L840",
+      "source_location": "L859",
       "target": "dailycloseview_formatmetadatavalue",
       "weight": 1
     },
@@ -4295,7 +4331,7 @@
       "relation": "calls",
       "source": "dailycloseview_istimestampmetadatalabel",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L836",
+      "source_location": "L855",
       "target": "dailycloseview_formatmetadatavalue",
       "weight": 1
     },
@@ -4307,7 +4343,7 @@
       "relation": "calls",
       "source": "dailycloseview_normalizemetadatalabel",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L829",
+      "source_location": "L848",
       "target": "dailycloseview_formatmetadatavalue",
       "weight": 1
     },
@@ -4319,7 +4355,7 @@
       "relation": "calls",
       "source": "dailycloseview_iszeroactivitydailyclose",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1331",
+      "source_location": "L1388",
       "target": "dailycloseview_getbucketconfigs",
       "weight": 1
     },
@@ -4331,7 +4367,7 @@
       "relation": "calls",
       "source": "dailycloseview_getbucketcountclassname",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L363",
+      "source_location": "L382",
       "target": "dailycloseview_cn",
       "weight": 1
     },
@@ -4343,7 +4379,7 @@
       "relation": "calls",
       "source": "dailycloseview_getitemid",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L557",
+      "source_location": "L576",
       "target": "dailycloseview_getcarryforwardworkitemid",
       "weight": 1
     },
@@ -4355,7 +4391,7 @@
       "relation": "calls",
       "source": "dailycloseview_getlocaloperatingdate",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L476",
+      "source_location": "L495",
       "target": "dailycloseview_getdailyclosesalesmetriclabels",
       "weight": 1
     },
@@ -4367,7 +4403,7 @@
       "relation": "calls",
       "source": "dailycloseview_humanizemetadatalabel",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L805",
+      "source_location": "L824",
       "target": "dailycloseview_getdisplaymetadatalabel",
       "weight": 1
     },
@@ -4379,7 +4415,7 @@
       "relation": "calls",
       "source": "dailycloseview_normalizemetadatalabel",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L793",
+      "source_location": "L812",
       "target": "dailycloseview_getdisplaymetadatalabel",
       "weight": 1
     },
@@ -4391,7 +4427,7 @@
       "relation": "calls",
       "source": "dailycloseview_getitemcontextlabel",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L576",
+      "source_location": "L595",
       "target": "dailycloseview_humanizemetadatalabel",
       "weight": 1
     },
@@ -4403,7 +4439,7 @@
       "relation": "calls",
       "source": "dailycloseview_getlocaloperatingdate",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L497",
+      "source_location": "L516",
       "target": "dailycloseview_getlocaloperatingdaterange",
       "weight": 1
     },
@@ -4415,7 +4451,7 @@
       "relation": "calls",
       "source": "dailycloseview_getlocaldatefromoperatingdate",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L505",
+      "source_location": "L524",
       "target": "dailycloseview_getlocaloperatingdaterangefromsearch",
       "weight": 1
     },
@@ -4427,7 +4463,7 @@
       "relation": "calls",
       "source": "dailycloseview_getlocaloperatingdaterange",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L508",
+      "source_location": "L527",
       "target": "dailycloseview_getlocaloperatingdaterangefromsearch",
       "weight": 1
     },
@@ -4439,7 +4475,7 @@
       "relation": "calls",
       "source": "dailycloseview_normalizemetadatalabel",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L972",
+      "source_location": "L991",
       "target": "dailycloseview_getmetadataentries",
       "weight": 1
     },
@@ -4451,7 +4487,7 @@
       "relation": "calls",
       "source": "dailycloseview_getmetadatavalue",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1403",
+      "source_location": "L1460",
       "target": "dailycloseview_getmetadatastringornumber",
       "weight": 1
     },
@@ -4463,7 +4499,7 @@
       "relation": "calls",
       "source": "dailycloseview_normalizemetadatalabel",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L819",
+      "source_location": "L838",
       "target": "dailycloseview_getmetadatavalue",
       "weight": 1
     },
@@ -4475,7 +4511,7 @@
       "relation": "calls",
       "source": "dailycloseview_iszeroactivitydailyclose",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1295",
+      "source_location": "L1314",
       "target": "dailycloseview_getstatusdisplaycopy",
       "weight": 1
     },
@@ -4487,7 +4523,7 @@
       "relation": "calls",
       "source": "dailycloseview_getstatuslabelclassname",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L331",
+      "source_location": "L350",
       "target": "dailycloseview_cn",
       "weight": 1
     },
@@ -4499,7 +4535,7 @@
       "relation": "calls",
       "source": "dailycloseview_getstatusrailbadgeclassname",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L354",
+      "source_location": "L373",
       "target": "dailycloseview_cn",
       "weight": 1
     },
@@ -4511,7 +4547,7 @@
       "relation": "calls",
       "source": "dailycloseview_getstatusrailiconclassname",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L343",
+      "source_location": "L362",
       "target": "dailycloseview_cn",
       "weight": 1
     },
@@ -4523,7 +4559,7 @@
       "relation": "calls",
       "source": "dailycloseview_formatexpensetransactioncount",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L2731",
+      "source_location": "L2800",
       "target": "dailycloseview_getsummaryamount",
       "weight": 1
     },
@@ -4535,7 +4571,7 @@
       "relation": "calls",
       "source": "dailycloseview_getsummaryamount",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L2732",
+      "source_location": "L2801",
       "target": "dailycloseview_getexpensetransactioncount",
       "weight": 1
     },
@@ -4547,7 +4583,7 @@
       "relation": "calls",
       "source": "dailycloseview_getsummaryamount",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1218",
+      "source_location": "L1237",
       "target": "dailycloseview_getsummaryregistervariancecount",
       "weight": 1
     },
@@ -4559,7 +4595,7 @@
       "relation": "calls",
       "source": "dailycloseview_formatdailyclosemoney",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1422",
+      "source_location": "L1479",
       "target": "dailycloseview_gettransactionreportamount",
       "weight": 1
     },
@@ -4571,7 +4607,7 @@
       "relation": "calls",
       "source": "dailycloseview_getmetadatastringornumber",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1419",
+      "source_location": "L1476",
       "target": "dailycloseview_gettransactionreportamount",
       "weight": 1
     },
@@ -4583,7 +4619,7 @@
       "relation": "calls",
       "source": "dailycloseview_getnumericmetadatavalue",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1418",
+      "source_location": "L1475",
       "target": "dailycloseview_gettransactionreportamount",
       "weight": 1
     },
@@ -4595,7 +4631,7 @@
       "relation": "calls",
       "source": "dailycloseview_getmetadatastringornumber",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1409",
+      "source_location": "L1466",
       "target": "dailycloseview_gettransactionreportidentifier",
       "weight": 1
     },
@@ -4607,7 +4643,7 @@
       "relation": "calls",
       "source": "dailycloseview_getmetadatastringornumber",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1431",
+      "source_location": "L1488",
       "target": "dailycloseview_gettransactionreportpayment",
       "weight": 1
     },
@@ -4619,7 +4655,7 @@
       "relation": "calls",
       "source": "dailycloseview_getmetadatastringornumber",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1426",
+      "source_location": "L1483",
       "target": "dailycloseview_gettransactionreportstaff",
       "weight": 1
     },
@@ -4631,7 +4667,7 @@
       "relation": "calls",
       "source": "dailycloseview_formattimestampmetadata",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1484",
+      "source_location": "L1541",
       "target": "dailycloseview_gettransactionreporttime",
       "weight": 1
     },
@@ -4643,7 +4679,7 @@
       "relation": "calls",
       "source": "dailycloseview_getmetadatastringornumber",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1480",
+      "source_location": "L1537",
       "target": "dailycloseview_gettransactionreporttime",
       "weight": 1
     },
@@ -4655,7 +4691,7 @@
       "relation": "calls",
       "source": "dailycloseview_getnumericmetadatavalue",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1479",
+      "source_location": "L1536",
       "target": "dailycloseview_gettransactionreporttime",
       "weight": 1
     },
@@ -4667,7 +4703,7 @@
       "relation": "calls",
       "source": "dailycloseview_normalizemetadatalabel",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L739",
+      "source_location": "L758",
       "target": "dailycloseview_ismoneymetadatalabel",
       "weight": 1
     },
@@ -4679,7 +4715,7 @@
       "relation": "calls",
       "source": "dailycloseview_normalizemetadatalabel",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L743",
+      "source_location": "L762",
       "target": "dailycloseview_istimestampmetadatalabel",
       "weight": 1
     },
@@ -4691,7 +4727,7 @@
       "relation": "calls",
       "source": "dailycloseview_getexpensestaffcount",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1273",
+      "source_location": "L1292",
       "target": "dailycloseview_iszeroactivitydailyclose",
       "weight": 1
     },
@@ -4703,7 +4739,7 @@
       "relation": "calls",
       "source": "dailycloseview_getsummaryamount",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1275",
+      "source_location": "L1294",
       "target": "dailycloseview_iszeroactivitydailyclose",
       "weight": 1
     },
@@ -4715,7 +4751,7 @@
       "relation": "calls",
       "source": "dailycloseview_getsummarycount",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1258",
+      "source_location": "L1277",
       "target": "dailycloseview_iszeroactivitydailyclose",
       "weight": 1
     },
@@ -4727,7 +4763,7 @@
       "relation": "calls",
       "source": "dailycloseview_getsummaryregistervariancecount",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1274",
+      "source_location": "L1293",
       "target": "dailycloseview_iszeroactivitydailyclose",
       "weight": 1
     },
@@ -4739,7 +4775,7 @@
       "relation": "calls",
       "source": "dailycloseview_getnumericmetadatavalue",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L775",
+      "source_location": "L794",
       "target": "dailycloseview_shouldshowmetadataentry",
       "weight": 1
     },
@@ -4751,7 +4787,7 @@
       "relation": "calls",
       "source": "dailycloseview_normalizemetadatalabel",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L768",
+      "source_location": "L787",
       "target": "dailycloseview_shouldshowmetadataentry",
       "weight": 1
     },
@@ -15443,8 +15479,32 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_test_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
-      "source_location": "L215",
+      "source_location": "L240",
       "target": "dailyclose_test_dailycloseapprovalproof",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_convex_operations_dailyclose_test_ts",
+      "_tgt": "dailyclose_test_dailyclosesummary",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_convex_operations_dailyclose_test_ts",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
+      "source_location": "L215",
+      "target": "dailyclose_test_dailyclosesummary",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_convex_operations_dailyclose_ts",
+      "_tgt": "dailyclose_approvalbelongstorange",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
+      "source_location": "L597",
+      "target": "dailyclose_approvalbelongstorange",
       "weight": 1
     },
     {
@@ -15455,7 +15515,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L332",
+      "source_location": "L371",
       "target": "dailyclose_approvalrequesttypelabel",
       "weight": 1
     },
@@ -15467,7 +15527,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L428",
+      "source_location": "L467",
       "target": "dailyclose_ascarryforwarditem",
       "weight": 1
     },
@@ -15479,7 +15539,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L186",
+      "source_location": "L225",
       "target": "dailyclose_builddailycloseapprovalsubject",
       "weight": 1
     },
@@ -15491,7 +15551,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L197",
+      "source_location": "L236",
       "target": "dailyclose_builddailyclosecompletionapprovalrequirement",
       "weight": 1
     },
@@ -15503,7 +15563,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L734",
+      "source_location": "L861",
       "target": "dailyclose_builddailyclosereportsnapshot",
       "weight": 1
     },
@@ -15515,7 +15575,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L856",
+      "source_location": "L983",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -15527,7 +15587,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L408",
+      "source_location": "L447",
       "target": "dailyclose_buildexpensesessionsbyid",
       "weight": 1
     },
@@ -15539,7 +15599,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L649",
+      "source_location": "L776",
       "target": "dailyclose_buildpaymenttotals",
       "weight": 1
     },
@@ -15551,7 +15611,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L696",
+      "source_location": "L823",
       "target": "dailyclose_buildreadiness",
       "weight": 1
     },
@@ -15563,7 +15623,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L388",
+      "source_location": "L427",
       "target": "dailyclose_buildregistersessionsbyid",
       "weight": 1
     },
@@ -15575,7 +15635,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L368",
+      "source_location": "L407",
       "target": "dailyclose_buildstaffnamesbyid",
       "weight": 1
     },
@@ -15587,7 +15647,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L348",
+      "source_location": "L387",
       "target": "dailyclose_buildterminallabelsbyid",
       "weight": 1
     },
@@ -15599,7 +15659,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L678",
+      "source_location": "L805",
       "target": "dailyclose_cashdeltasbyregistersessionid",
       "weight": 1
     },
@@ -15611,7 +15671,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1660",
+      "source_location": "L1811",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -15623,7 +15683,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1584",
+      "source_location": "L1735",
       "target": "dailyclose_createcarryforwardworkitems",
       "weight": 1
     },
@@ -15635,7 +15695,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L832",
+      "source_location": "L959",
       "target": "dailyclose_emptysummary",
       "weight": 1
     },
@@ -15647,7 +15707,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L304",
+      "source_location": "L343",
       "target": "dailyclose_formatpaymentmethodlabel",
       "weight": 1
     },
@@ -15659,7 +15719,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1997",
+      "source_location": "L2148",
       "target": "dailyclose_getcompleteddailyclosehistorydetailwithctx",
       "weight": 1
     },
@@ -15671,7 +15731,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L805",
+      "source_location": "L932",
       "target": "dailyclose_getdailyclosecompletioneventstaffprofileid",
       "weight": 1
     },
@@ -15683,7 +15743,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L457",
+      "source_location": "L496",
       "target": "dailyclose_getdailyclosefordate",
       "weight": 1
     },
@@ -15695,7 +15755,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1912",
+      "source_location": "L2063",
       "target": "dailyclose_getdailycloseopeningcontextwithctx",
       "weight": 1
     },
@@ -15707,7 +15767,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L472",
+      "source_location": "L511",
       "target": "dailyclose_getpriorcompleteddailyclose",
       "weight": 1
     },
@@ -15719,7 +15779,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L450",
+      "source_location": "L489",
       "target": "dailyclose_getstore",
       "weight": 1
     },
@@ -15731,7 +15791,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L279",
+      "source_location": "L318",
       "target": "dailyclose_isinrange",
       "weight": 1
     },
@@ -15743,7 +15803,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L247",
+      "source_location": "L286",
       "target": "dailyclose_isvalidoperatingdaterange",
       "weight": 1
     },
@@ -15755,7 +15815,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L494",
+      "source_location": "L533",
       "target": "dailyclose_listactiveregistersessions",
       "weight": 1
     },
@@ -15767,7 +15827,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L512",
+      "source_location": "L551",
       "target": "dailyclose_listclosedregistersessionsforday",
       "weight": 1
     },
@@ -15779,7 +15839,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1948",
+      "source_location": "L2099",
       "target": "dailyclose_listcompleteddailyclosehistorywithctx",
       "weight": 1
     },
@@ -15791,7 +15851,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L627",
+      "source_location": "L754",
       "target": "dailyclose_listdepositsforday",
       "weight": 1
     },
@@ -15803,7 +15863,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L607",
+      "source_location": "L734",
       "target": "dailyclose_listexpensesforday",
       "weight": 1
     },
@@ -15815,7 +15875,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L572",
+      "source_location": "L699",
       "target": "dailyclose_listopenoperationalworkitems",
       "weight": 1
     },
@@ -15827,7 +15887,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L551",
+      "source_location": "L671",
       "target": "dailyclose_listopenpossessions",
       "weight": 1
     },
@@ -15839,7 +15899,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L532",
+      "source_location": "L637",
       "target": "dailyclose_listpendingcloseoutapprovals",
       "weight": 1
     },
@@ -15851,7 +15911,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L586",
+      "source_location": "L713",
       "target": "dailyclose_listtransactionsforday",
       "weight": 1
     },
@@ -15863,7 +15923,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1637",
+      "source_location": "L1788",
       "target": "dailyclose_markotherdailyclosesnotcurrent",
       "weight": 1
     },
@@ -15875,8 +15935,32 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L328",
+      "source_location": "L367",
       "target": "dailyclose_nonzerovariancemetadata",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_convex_operations_dailyclose_ts",
+      "_tgt": "dailyclose_normalizecompleteddailyclosesnapshot",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
+      "source_location": "L143",
+      "target": "dailyclose_normalizecompleteddailyclosesnapshot",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_convex_operations_dailyclose_ts",
+      "_tgt": "dailyclose_possessionintersectsrange",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
+      "source_location": "L581",
+      "target": "dailyclose_possessionintersectsrange",
       "weight": 1
     },
     {
@@ -15887,8 +15971,20 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L291",
+      "source_location": "L330",
       "target": "dailyclose_registermetadatalabel",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_convex_operations_dailyclose_ts",
+      "_tgt": "dailyclose_registersessionintersectsrange",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
+      "source_location": "L571",
+      "target": "dailyclose_registersessionintersectsrange",
       "weight": 1
     },
     {
@@ -15899,7 +15995,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L283",
+      "source_location": "L322",
       "target": "dailyclose_registersessionlabel",
       "weight": 1
     },
@@ -15911,7 +16007,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L258",
+      "source_location": "L297",
       "target": "dailyclose_resolveoperatingdaterange",
       "weight": 1
     },
@@ -15923,7 +16019,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L230",
+      "source_location": "L269",
       "target": "dailyclose_safeoperatingdaterange",
       "weight": 1
     },
@@ -15935,7 +16031,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L772",
+      "source_location": "L899",
       "target": "dailyclose_snapshotrevieweditems",
       "weight": 1
     },
@@ -15947,7 +16043,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L784",
+      "source_location": "L911",
       "target": "dailyclose_todailyclosehistorylistitem",
       "weight": 1
     },
@@ -15959,7 +16055,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L667",
+      "source_location": "L794",
       "target": "dailyclose_transactioncashdelta",
       "weight": 1
     },
@@ -15971,7 +16067,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L310",
+      "source_location": "L349",
       "target": "dailyclose_transactionpaymentsummary",
       "weight": 1
     },
@@ -15983,7 +16079,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L225",
+      "source_location": "L264",
       "target": "dailyclose_trimoptional",
       "weight": 1
     },
@@ -15995,7 +16091,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L726",
+      "source_location": "L853",
       "target": "dailyclose_uniquedailycloseitems",
       "weight": 1
     },
@@ -16007,7 +16103,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L716",
+      "source_location": "L843",
       "target": "dailyclose_uniquesourcesubjects",
       "weight": 1
     },
@@ -16019,7 +16115,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1556",
+      "source_location": "L1707",
       "target": "dailyclose_validatecarryforwardworkitemids",
       "weight": 1
     },
@@ -27767,7 +27863,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L461",
+      "source_location": "L480",
       "target": "dailycloseview_builddailyclosetransactionsearch",
       "weight": 1
     },
@@ -27779,7 +27875,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L2361",
+      "source_location": "L2423",
       "target": "dailycloseview_cn",
       "weight": 1
     },
@@ -27791,7 +27887,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L318",
+      "source_location": "L337",
       "target": "dailycloseview_formatcarriedoverregistercount",
       "weight": 1
     },
@@ -27803,7 +27899,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L301",
+      "source_location": "L320",
       "target": "dailycloseview_formatchecklistcount",
       "weight": 1
     },
@@ -27815,7 +27911,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L441",
+      "source_location": "L460",
       "target": "dailycloseview_formatdailyclosecompletedat",
       "weight": 1
     },
@@ -27827,7 +27923,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L2703",
+      "source_location": "L2772",
       "target": "dailycloseview_formatdailyclosemoney",
       "weight": 1
     },
@@ -27839,7 +27935,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L407",
+      "source_location": "L426",
       "target": "dailycloseview_formatdailycloseoperatingdate",
       "weight": 1
     },
@@ -27851,7 +27947,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L291",
+      "source_location": "L310",
       "target": "dailycloseview_formatentitycount",
       "weight": 1
     },
@@ -27863,7 +27959,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L374",
+      "source_location": "L393",
       "target": "dailycloseview_formatexpensetransactioncount",
       "weight": 1
     },
@@ -27875,7 +27971,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L882",
+      "source_location": "L901",
       "target": "dailycloseview_formatmetadatadisplayvalue",
       "weight": 1
     },
@@ -27887,7 +27983,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L826",
+      "source_location": "L845",
       "target": "dailycloseview_formatmetadatavalue",
       "weight": 1
     },
@@ -27899,7 +27995,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L380",
+      "source_location": "L399",
       "target": "dailycloseview_formatpossalecount",
       "weight": 1
     },
@@ -27911,7 +28007,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L324",
+      "source_location": "L343",
       "target": "dailycloseview_formatregistervariancecount",
       "weight": 1
     },
@@ -27923,7 +28019,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L782",
+      "source_location": "L801",
       "target": "dailycloseview_formattimestampmetadata",
       "weight": 1
     },
@@ -27935,7 +28031,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L312",
+      "source_location": "L331",
       "target": "dailycloseview_formattodaycashtransactioncount",
       "weight": 1
     },
@@ -27947,7 +28043,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L386",
+      "source_location": "L405",
       "target": "dailycloseview_formatvoidedsalecount",
       "weight": 1
     },
@@ -27959,7 +28055,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1330",
+      "source_location": "L1387",
       "target": "dailycloseview_getbucketconfigs",
       "weight": 1
     },
@@ -27971,7 +28067,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L362",
+      "source_location": "L381",
       "target": "dailycloseview_getbucketcountclassname",
       "weight": 1
     },
@@ -27983,7 +28079,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L554",
+      "source_location": "L573",
       "target": "dailycloseview_getcarryforwardworkitemid",
       "weight": 1
     },
@@ -27995,7 +28091,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L560",
+      "source_location": "L579",
       "target": "dailycloseview_getcarryforwardworkitemids",
       "weight": 1
     },
@@ -28007,7 +28103,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1157",
+      "source_location": "L1176",
       "target": "dailycloseview_getcollapsedmetadataentries",
       "weight": 1
     },
@@ -28019,7 +28115,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L281",
+      "source_location": "L300",
       "target": "dailycloseview_getdailycloseapi",
       "weight": 1
     },
@@ -28031,7 +28127,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L475",
+      "source_location": "L494",
       "target": "dailycloseview_getdailyclosesalesmetriclabels",
       "weight": 1
     },
@@ -28043,7 +28139,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L528",
+      "source_location": "L547",
       "target": "dailycloseview_getdailyclosestatus",
       "weight": 1
     },
@@ -28055,7 +28151,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1307",
+      "source_location": "L1364",
       "target": "dailycloseview_getdefaultbucketvalue",
       "weight": 1
     },
@@ -28067,7 +28163,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L792",
+      "source_location": "L811",
       "target": "dailycloseview_getdisplaymetadatalabel",
       "weight": 1
     },
@@ -28079,7 +28175,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1226",
+      "source_location": "L1245",
       "target": "dailycloseview_getexpensestaffcount",
       "weight": 1
     },
@@ -28091,7 +28187,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1238",
+      "source_location": "L1257",
       "target": "dailycloseview_getexpensetransactioncount",
       "weight": 1
     },
@@ -28103,7 +28199,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L574",
+      "source_location": "L593",
       "target": "dailycloseview_getitemcontextlabel",
       "weight": 1
     },
@@ -28115,7 +28211,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L564",
+      "source_location": "L583",
       "target": "dailycloseview_getitemdescription",
       "weight": 1
     },
@@ -28127,7 +28223,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L542",
+      "source_location": "L561",
       "target": "dailycloseview_getitemid",
       "weight": 1
     },
@@ -28139,7 +28235,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L422",
+      "source_location": "L441",
       "target": "dailycloseview_getlocaldatefromoperatingdate",
       "weight": 1
     },
@@ -28151,7 +28247,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L453",
+      "source_location": "L472",
       "target": "dailycloseview_getlocaloperatingdate",
       "weight": 1
     },
@@ -28163,7 +28259,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L484",
+      "source_location": "L503",
       "target": "dailycloseview_getlocaloperatingdaterange",
       "weight": 1
     },
@@ -28175,7 +28271,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L503",
+      "source_location": "L522",
       "target": "dailycloseview_getlocaloperatingdaterangefromsearch",
       "weight": 1
     },
@@ -28187,7 +28283,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L964",
+      "source_location": "L983",
       "target": "dailycloseview_getmetadataentries",
       "weight": 1
     },
@@ -28199,7 +28295,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1397",
+      "source_location": "L1454",
       "target": "dailycloseview_getmetadatastringornumber",
       "weight": 1
     },
@@ -28211,7 +28307,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L808",
+      "source_location": "L827",
       "target": "dailycloseview_getmetadatastringvalue",
       "weight": 1
     },
@@ -28223,7 +28319,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L818",
+      "source_location": "L837",
       "target": "dailycloseview_getmetadatavalue",
       "weight": 1
     },
@@ -28235,7 +28331,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L754",
+      "source_location": "L773",
       "target": "dailycloseview_getnumericmetadatavalue",
       "weight": 1
     },
@@ -28247,7 +28343,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L550",
+      "source_location": "L569",
       "target": "dailycloseview_getrevieweditemkeys",
       "weight": 1
     },
@@ -28259,7 +28355,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1291",
+      "source_location": "L1310",
       "target": "dailycloseview_getstatusdisplaycopy",
       "weight": 1
     },
@@ -28271,7 +28367,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L330",
+      "source_location": "L349",
       "target": "dailycloseview_getstatuslabelclassname",
       "weight": 1
     },
@@ -28283,7 +28379,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L353",
+      "source_location": "L372",
       "target": "dailycloseview_getstatusrailbadgeclassname",
       "weight": 1
     },
@@ -28295,7 +28391,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L342",
+      "source_location": "L361",
       "target": "dailycloseview_getstatusrailiconclassname",
       "weight": 1
     },
@@ -28307,7 +28403,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L2723",
+      "source_location": "L2792",
       "target": "dailycloseview_getsummaryamount",
       "weight": 1
     },
@@ -28319,7 +28415,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1196",
+      "source_location": "L1215",
       "target": "dailycloseview_getsummarycount",
       "weight": 1
     },
@@ -28331,7 +28427,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1211",
+      "source_location": "L1230",
       "target": "dailycloseview_getsummaryregistervariancecount",
       "weight": 1
     },
@@ -28343,7 +28439,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1417",
+      "source_location": "L1474",
       "target": "dailycloseview_gettransactionreportamount",
       "weight": 1
     },
@@ -28355,7 +28451,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1407",
+      "source_location": "L1464",
       "target": "dailycloseview_gettransactionreportidentifier",
       "weight": 1
     },
@@ -28367,7 +28463,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1378",
+      "source_location": "L1435",
       "target": "dailycloseview_gettransactionreportitems",
       "weight": 1
     },
@@ -28379,7 +28475,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1487",
+      "source_location": "L1544",
       "target": "dailycloseview_gettransactionreportlink",
       "weight": 1
     },
@@ -28391,7 +28487,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1430",
+      "source_location": "L1487",
       "target": "dailycloseview_gettransactionreportpayment",
       "weight": 1
     },
@@ -28403,7 +28499,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1425",
+      "source_location": "L1482",
       "target": "dailycloseview_gettransactionreportstaff",
       "weight": 1
     },
@@ -28415,7 +28511,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1478",
+      "source_location": "L1535",
       "target": "dailycloseview_gettransactionreporttime",
       "weight": 1
     },
@@ -28427,7 +28523,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L746",
+      "source_location": "L765",
       "target": "dailycloseview_getvariancetone",
       "weight": 1
     },
@@ -28439,7 +28535,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1722",
+      "source_location": "L1779",
       "target": "dailycloseview_handlepagechange",
       "weight": 1
     },
@@ -28451,7 +28547,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L582",
+      "source_location": "L601",
       "target": "dailycloseview_humanizemetadatalabel",
       "weight": 1
     },
@@ -28463,7 +28559,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L738",
+      "source_location": "L757",
       "target": "dailycloseview_ismoneymetadatalabel",
       "weight": 1
     },
@@ -28475,7 +28571,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L742",
+      "source_location": "L761",
       "target": "dailycloseview_istimestampmetadatalabel",
       "weight": 1
     },
@@ -28487,7 +28583,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1252",
+      "source_location": "L1271",
       "target": "dailycloseview_iszeroactivitydailyclose",
       "weight": 1
     },
@@ -28499,7 +28595,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1317",
+      "source_location": "L1374",
       "target": "dailycloseview_normalizebuckettab",
       "weight": 1
     },
@@ -28511,8 +28607,20 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L515",
+      "source_location": "L534",
       "target": "dailycloseview_normalizecommandmessage",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
+      "_tgt": "dailycloseview_normalizecompletedreportsnapshot",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
+      "source_location": "L1326",
+      "target": "dailycloseview_normalizecompletedreportsnapshot",
       "weight": 1
     },
     {
@@ -28523,7 +28631,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L734",
+      "source_location": "L753",
       "target": "dailycloseview_normalizemetadatalabel",
       "weight": 1
     },
@@ -28535,7 +28643,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1324",
+      "source_location": "L1381",
       "target": "dailycloseview_normalizepage",
       "weight": 1
     },
@@ -28547,7 +28655,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1443",
+      "source_location": "L1500",
       "target": "dailycloseview_normalizetransactionreportpaymentmethod",
       "weight": 1
     },
@@ -28559,7 +28667,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L392",
+      "source_location": "L411",
       "target": "dailycloseview_sentencefragment",
       "weight": 1
     },
@@ -28571,7 +28679,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L568",
+      "source_location": "L587",
       "target": "dailycloseview_shouldshowcollapseddescription",
       "weight": 1
     },
@@ -28583,7 +28691,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L767",
+      "source_location": "L786",
       "target": "dailycloseview_shouldshowmetadataentry",
       "weight": 1
     },
@@ -28595,7 +28703,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1450",
+      "source_location": "L1507",
       "target": "dailycloseview_transactionreportpaymenticon",
       "weight": 1
     },
@@ -59317,7 +59425,7 @@
       "label": "buildDailyCloseTransactionSearch()",
       "norm_label": "builddailyclosetransactionsearch()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L461"
+      "source_location": "L480"
     },
     {
       "community": 0,
@@ -59326,7 +59434,7 @@
       "label": "cn()",
       "norm_label": "cn()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1844"
+      "source_location": "L1901"
     },
     {
       "community": 0,
@@ -59335,7 +59443,7 @@
       "label": "formatCarriedOverRegisterCount()",
       "norm_label": "formatcarriedoverregistercount()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L318"
+      "source_location": "L337"
     },
     {
       "community": 0,
@@ -59344,7 +59452,7 @@
       "label": "formatChecklistCount()",
       "norm_label": "formatchecklistcount()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L301"
+      "source_location": "L320"
     },
     {
       "community": 0,
@@ -59353,7 +59461,7 @@
       "label": "formatDailyCloseCompletedAt()",
       "norm_label": "formatdailyclosecompletedat()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L441"
+      "source_location": "L460"
     },
     {
       "community": 0,
@@ -59362,7 +59470,7 @@
       "label": "formatDailyCloseMoney()",
       "norm_label": "formatdailyclosemoney()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L396"
+      "source_location": "L415"
     },
     {
       "community": 0,
@@ -59371,7 +59479,7 @@
       "label": "formatDailyCloseOperatingDate()",
       "norm_label": "formatdailycloseoperatingdate()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L407"
+      "source_location": "L426"
     },
     {
       "community": 0,
@@ -59380,7 +59488,7 @@
       "label": "formatEntityCount()",
       "norm_label": "formatentitycount()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L291"
+      "source_location": "L310"
     },
     {
       "community": 0,
@@ -59389,7 +59497,7 @@
       "label": "formatExpenseTransactionCount()",
       "norm_label": "formatexpensetransactioncount()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L374"
+      "source_location": "L393"
     },
     {
       "community": 0,
@@ -59398,7 +59506,7 @@
       "label": "formatMetadataDisplayValue()",
       "norm_label": "formatmetadatadisplayvalue()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L882"
+      "source_location": "L901"
     },
     {
       "community": 0,
@@ -59407,7 +59515,7 @@
       "label": "formatMetadataValue()",
       "norm_label": "formatmetadatavalue()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L826"
+      "source_location": "L845"
     },
     {
       "community": 0,
@@ -59416,7 +59524,7 @@
       "label": "formatPosSaleCount()",
       "norm_label": "formatpossalecount()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L380"
+      "source_location": "L399"
     },
     {
       "community": 0,
@@ -59425,7 +59533,7 @@
       "label": "formatRegisterVarianceCount()",
       "norm_label": "formatregistervariancecount()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L324"
+      "source_location": "L343"
     },
     {
       "community": 0,
@@ -59434,7 +59542,7 @@
       "label": "formatTimestampMetadata()",
       "norm_label": "formattimestampmetadata()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L782"
+      "source_location": "L801"
     },
     {
       "community": 0,
@@ -59443,7 +59551,7 @@
       "label": "formatTodayCashTransactionCount()",
       "norm_label": "formattodaycashtransactioncount()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L312"
+      "source_location": "L331"
     },
     {
       "community": 0,
@@ -59452,7 +59560,7 @@
       "label": "formatVoidedSaleCount()",
       "norm_label": "formatvoidedsalecount()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L386"
+      "source_location": "L405"
     },
     {
       "community": 0,
@@ -59461,7 +59569,7 @@
       "label": "getBucketConfigs()",
       "norm_label": "getbucketconfigs()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1330"
+      "source_location": "L1387"
     },
     {
       "community": 0,
@@ -59470,7 +59578,7 @@
       "label": "getBucketCountClassName()",
       "norm_label": "getbucketcountclassname()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L362"
+      "source_location": "L381"
     },
     {
       "community": 0,
@@ -59479,7 +59587,7 @@
       "label": "getCarryForwardWorkItemId()",
       "norm_label": "getcarryforwardworkitemid()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L554"
+      "source_location": "L573"
     },
     {
       "community": 0,
@@ -59488,7 +59596,7 @@
       "label": "getCarryForwardWorkItemIds()",
       "norm_label": "getcarryforwardworkitemids()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L560"
+      "source_location": "L579"
     },
     {
       "community": 0,
@@ -59497,7 +59605,7 @@
       "label": "getCollapsedMetadataEntries()",
       "norm_label": "getcollapsedmetadataentries()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1157"
+      "source_location": "L1176"
     },
     {
       "community": 0,
@@ -59506,7 +59614,7 @@
       "label": "getDailyCloseApi()",
       "norm_label": "getdailycloseapi()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L281"
+      "source_location": "L300"
     },
     {
       "community": 0,
@@ -59515,7 +59623,7 @@
       "label": "getDailyCloseSalesMetricLabels()",
       "norm_label": "getdailyclosesalesmetriclabels()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L475"
+      "source_location": "L494"
     },
     {
       "community": 0,
@@ -59524,7 +59632,7 @@
       "label": "getDailyCloseStatus()",
       "norm_label": "getdailyclosestatus()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L528"
+      "source_location": "L547"
     },
     {
       "community": 0,
@@ -59533,7 +59641,7 @@
       "label": "getDefaultBucketValue()",
       "norm_label": "getdefaultbucketvalue()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1307"
+      "source_location": "L1364"
     },
     {
       "community": 0,
@@ -59542,7 +59650,7 @@
       "label": "getDisplayMetadataLabel()",
       "norm_label": "getdisplaymetadatalabel()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L792"
+      "source_location": "L811"
     },
     {
       "community": 0,
@@ -59551,7 +59659,7 @@
       "label": "getExpenseStaffCount()",
       "norm_label": "getexpensestaffcount()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1226"
+      "source_location": "L1245"
     },
     {
       "community": 0,
@@ -59560,7 +59668,7 @@
       "label": "getExpenseTransactionCount()",
       "norm_label": "getexpensetransactioncount()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1238"
+      "source_location": "L1257"
     },
     {
       "community": 0,
@@ -59569,7 +59677,7 @@
       "label": "getItemContextLabel()",
       "norm_label": "getitemcontextlabel()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L574"
+      "source_location": "L593"
     },
     {
       "community": 0,
@@ -59578,7 +59686,7 @@
       "label": "getItemDescription()",
       "norm_label": "getitemdescription()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L564"
+      "source_location": "L583"
     },
     {
       "community": 0,
@@ -59587,7 +59695,7 @@
       "label": "getItemId()",
       "norm_label": "getitemid()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L542"
+      "source_location": "L561"
     },
     {
       "community": 0,
@@ -59596,7 +59704,7 @@
       "label": "getLocalDateFromOperatingDate()",
       "norm_label": "getlocaldatefromoperatingdate()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L422"
+      "source_location": "L441"
     },
     {
       "community": 0,
@@ -59605,7 +59713,7 @@
       "label": "getLocalOperatingDate()",
       "norm_label": "getlocaloperatingdate()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L453"
+      "source_location": "L472"
     },
     {
       "community": 0,
@@ -59614,7 +59722,7 @@
       "label": "getLocalOperatingDateRange()",
       "norm_label": "getlocaloperatingdaterange()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L484"
+      "source_location": "L503"
     },
     {
       "community": 0,
@@ -59623,7 +59731,7 @@
       "label": "getLocalOperatingDateRangeFromSearch()",
       "norm_label": "getlocaloperatingdaterangefromsearch()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L503"
+      "source_location": "L522"
     },
     {
       "community": 0,
@@ -59632,7 +59740,7 @@
       "label": "getMetadataEntries()",
       "norm_label": "getmetadataentries()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L964"
+      "source_location": "L983"
     },
     {
       "community": 0,
@@ -59641,7 +59749,7 @@
       "label": "getMetadataStringOrNumber()",
       "norm_label": "getmetadatastringornumber()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1397"
+      "source_location": "L1454"
     },
     {
       "community": 0,
@@ -59650,7 +59758,7 @@
       "label": "getMetadataStringValue()",
       "norm_label": "getmetadatastringvalue()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L808"
+      "source_location": "L827"
     },
     {
       "community": 0,
@@ -59659,7 +59767,7 @@
       "label": "getMetadataValue()",
       "norm_label": "getmetadatavalue()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L818"
+      "source_location": "L837"
     },
     {
       "community": 0,
@@ -59668,7 +59776,7 @@
       "label": "getNumericMetadataValue()",
       "norm_label": "getnumericmetadatavalue()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L754"
+      "source_location": "L773"
     },
     {
       "community": 0,
@@ -59677,7 +59785,7 @@
       "label": "getReviewedItemKeys()",
       "norm_label": "getrevieweditemkeys()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L550"
+      "source_location": "L569"
     },
     {
       "community": 0,
@@ -59686,7 +59794,7 @@
       "label": "getStatusDisplayCopy()",
       "norm_label": "getstatusdisplaycopy()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1291"
+      "source_location": "L1310"
     },
     {
       "community": 0,
@@ -59695,7 +59803,7 @@
       "label": "getStatusLabelClassName()",
       "norm_label": "getstatuslabelclassname()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L330"
+      "source_location": "L349"
     },
     {
       "community": 0,
@@ -59704,7 +59812,7 @@
       "label": "getStatusRailBadgeClassName()",
       "norm_label": "getstatusrailbadgeclassname()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L353"
+      "source_location": "L372"
     },
     {
       "community": 0,
@@ -59713,7 +59821,7 @@
       "label": "getStatusRailIconClassName()",
       "norm_label": "getstatusrailiconclassname()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L342"
+      "source_location": "L361"
     },
     {
       "community": 0,
@@ -59722,7 +59830,7 @@
       "label": "getSummaryAmount()",
       "norm_label": "getsummaryamount()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1181"
+      "source_location": "L1200"
     },
     {
       "community": 0,
@@ -59731,7 +59839,7 @@
       "label": "getSummaryCount()",
       "norm_label": "getsummarycount()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1196"
+      "source_location": "L1215"
     },
     {
       "community": 0,
@@ -59740,7 +59848,7 @@
       "label": "getSummaryRegisterVarianceCount()",
       "norm_label": "getsummaryregistervariancecount()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1211"
+      "source_location": "L1230"
     },
     {
       "community": 0,
@@ -59749,7 +59857,7 @@
       "label": "getTransactionReportAmount()",
       "norm_label": "gettransactionreportamount()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1417"
+      "source_location": "L1474"
     },
     {
       "community": 0,
@@ -59758,7 +59866,7 @@
       "label": "getTransactionReportIdentifier()",
       "norm_label": "gettransactionreportidentifier()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1407"
+      "source_location": "L1464"
     },
     {
       "community": 0,
@@ -59767,7 +59875,7 @@
       "label": "getTransactionReportItems()",
       "norm_label": "gettransactionreportitems()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1378"
+      "source_location": "L1435"
     },
     {
       "community": 0,
@@ -59776,7 +59884,7 @@
       "label": "getTransactionReportLink()",
       "norm_label": "gettransactionreportlink()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1487"
+      "source_location": "L1544"
     },
     {
       "community": 0,
@@ -59785,7 +59893,7 @@
       "label": "getTransactionReportPayment()",
       "norm_label": "gettransactionreportpayment()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1430"
+      "source_location": "L1487"
     },
     {
       "community": 0,
@@ -59794,7 +59902,7 @@
       "label": "getTransactionReportStaff()",
       "norm_label": "gettransactionreportstaff()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1425"
+      "source_location": "L1482"
     },
     {
       "community": 0,
@@ -59803,7 +59911,7 @@
       "label": "getTransactionReportTime()",
       "norm_label": "gettransactionreporttime()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1478"
+      "source_location": "L1535"
     },
     {
       "community": 0,
@@ -59812,7 +59920,7 @@
       "label": "getVarianceTone()",
       "norm_label": "getvariancetone()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L746"
+      "source_location": "L765"
     },
     {
       "community": 0,
@@ -59821,7 +59929,7 @@
       "label": "handlePageChange()",
       "norm_label": "handlepagechange()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1722"
+      "source_location": "L1779"
     },
     {
       "community": 0,
@@ -59830,7 +59938,7 @@
       "label": "humanizeMetadataLabel()",
       "norm_label": "humanizemetadatalabel()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L582"
+      "source_location": "L601"
     },
     {
       "community": 0,
@@ -59839,7 +59947,7 @@
       "label": "isMoneyMetadataLabel()",
       "norm_label": "ismoneymetadatalabel()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L738"
+      "source_location": "L757"
     },
     {
       "community": 0,
@@ -59848,7 +59956,7 @@
       "label": "isTimestampMetadataLabel()",
       "norm_label": "istimestampmetadatalabel()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L742"
+      "source_location": "L761"
     },
     {
       "community": 0,
@@ -59857,7 +59965,7 @@
       "label": "isZeroActivityDailyClose()",
       "norm_label": "iszeroactivitydailyclose()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1252"
+      "source_location": "L1271"
     },
     {
       "community": 0,
@@ -59866,7 +59974,7 @@
       "label": "normalizeBucketTab()",
       "norm_label": "normalizebuckettab()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1317"
+      "source_location": "L1374"
     },
     {
       "community": 0,
@@ -59875,7 +59983,16 @@
       "label": "normalizeCommandMessage()",
       "norm_label": "normalizecommandmessage()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L515"
+      "source_location": "L534"
+    },
+    {
+      "community": 0,
+      "file_type": "code",
+      "id": "dailycloseview_normalizecompletedreportsnapshot",
+      "label": "normalizeCompletedReportSnapshot()",
+      "norm_label": "normalizecompletedreportsnapshot()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
+      "source_location": "L1326"
     },
     {
       "community": 0,
@@ -59884,7 +60001,7 @@
       "label": "normalizeMetadataLabel()",
       "norm_label": "normalizemetadatalabel()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L734"
+      "source_location": "L753"
     },
     {
       "community": 0,
@@ -59893,7 +60010,7 @@
       "label": "normalizePage()",
       "norm_label": "normalizepage()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1324"
+      "source_location": "L1381"
     },
     {
       "community": 0,
@@ -59902,7 +60019,7 @@
       "label": "normalizeTransactionReportPaymentMethod()",
       "norm_label": "normalizetransactionreportpaymentmethod()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1443"
+      "source_location": "L1500"
     },
     {
       "community": 0,
@@ -59911,7 +60028,7 @@
       "label": "sentenceFragment()",
       "norm_label": "sentencefragment()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L392"
+      "source_location": "L411"
     },
     {
       "community": 0,
@@ -59920,7 +60037,7 @@
       "label": "shouldShowCollapsedDescription()",
       "norm_label": "shouldshowcollapseddescription()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L568"
+      "source_location": "L587"
     },
     {
       "community": 0,
@@ -59929,7 +60046,7 @@
       "label": "shouldShowMetadataEntry()",
       "norm_label": "shouldshowmetadataentry()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L767"
+      "source_location": "L786"
     },
     {
       "community": 0,
@@ -59938,7 +60055,7 @@
       "label": "TransactionReportPaymentIcon()",
       "norm_label": "transactionreportpaymenticon()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1450"
+      "source_location": "L1507"
     },
     {
       "community": 0,
@@ -59952,11 +60069,20 @@
     {
       "community": 1,
       "file_type": "code",
+      "id": "dailyclose_approvalbelongstorange",
+      "label": "approvalBelongsToRange()",
+      "norm_label": "approvalbelongstorange()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
+      "source_location": "L597"
+    },
+    {
+      "community": 1,
+      "file_type": "code",
       "id": "dailyclose_approvalrequesttypelabel",
       "label": "approvalRequestTypeLabel()",
       "norm_label": "approvalrequesttypelabel()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L332"
+      "source_location": "L371"
     },
     {
       "community": 1,
@@ -59965,7 +60091,7 @@
       "label": "asCarryForwardItem()",
       "norm_label": "ascarryforwarditem()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L428"
+      "source_location": "L467"
     },
     {
       "community": 1,
@@ -59974,7 +60100,7 @@
       "label": "buildDailyCloseApprovalSubject()",
       "norm_label": "builddailycloseapprovalsubject()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L186"
+      "source_location": "L225"
     },
     {
       "community": 1,
@@ -59983,7 +60109,7 @@
       "label": "buildDailyCloseCompletionApprovalRequirement()",
       "norm_label": "builddailyclosecompletionapprovalrequirement()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L197"
+      "source_location": "L236"
     },
     {
       "community": 1,
@@ -59992,7 +60118,7 @@
       "label": "buildDailyCloseReportSnapshot()",
       "norm_label": "builddailyclosereportsnapshot()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L734"
+      "source_location": "L861"
     },
     {
       "community": 1,
@@ -60001,7 +60127,7 @@
       "label": "buildDailyCloseSnapshotWithCtx()",
       "norm_label": "builddailyclosesnapshotwithctx()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L856"
+      "source_location": "L983"
     },
     {
       "community": 1,
@@ -60010,7 +60136,7 @@
       "label": "buildExpenseSessionsById()",
       "norm_label": "buildexpensesessionsbyid()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L408"
+      "source_location": "L447"
     },
     {
       "community": 1,
@@ -60019,7 +60145,7 @@
       "label": "buildPaymentTotals()",
       "norm_label": "buildpaymenttotals()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L649"
+      "source_location": "L776"
     },
     {
       "community": 1,
@@ -60028,7 +60154,7 @@
       "label": "buildReadiness()",
       "norm_label": "buildreadiness()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L696"
+      "source_location": "L823"
     },
     {
       "community": 1,
@@ -60037,7 +60163,7 @@
       "label": "buildRegisterSessionsById()",
       "norm_label": "buildregistersessionsbyid()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L388"
+      "source_location": "L427"
     },
     {
       "community": 1,
@@ -60046,7 +60172,7 @@
       "label": "buildStaffNamesById()",
       "norm_label": "buildstaffnamesbyid()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L368"
+      "source_location": "L407"
     },
     {
       "community": 1,
@@ -60055,7 +60181,7 @@
       "label": "buildTerminalLabelsById()",
       "norm_label": "buildterminallabelsbyid()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L348"
+      "source_location": "L387"
     },
     {
       "community": 1,
@@ -60064,7 +60190,7 @@
       "label": "cashDeltasByRegisterSessionId()",
       "norm_label": "cashdeltasbyregistersessionid()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L678"
+      "source_location": "L805"
     },
     {
       "community": 1,
@@ -60073,7 +60199,7 @@
       "label": "completeDailyCloseWithCtx()",
       "norm_label": "completedailyclosewithctx()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1660"
+      "source_location": "L1811"
     },
     {
       "community": 1,
@@ -60082,7 +60208,7 @@
       "label": "createCarryForwardWorkItems()",
       "norm_label": "createcarryforwardworkitems()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1584"
+      "source_location": "L1735"
     },
     {
       "community": 1,
@@ -60091,7 +60217,7 @@
       "label": "emptySummary()",
       "norm_label": "emptysummary()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L832"
+      "source_location": "L959"
     },
     {
       "community": 1,
@@ -60100,7 +60226,7 @@
       "label": "formatPaymentMethodLabel()",
       "norm_label": "formatpaymentmethodlabel()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L304"
+      "source_location": "L343"
     },
     {
       "community": 1,
@@ -60109,7 +60235,7 @@
       "label": "getCompletedDailyCloseHistoryDetailWithCtx()",
       "norm_label": "getcompleteddailyclosehistorydetailwithctx()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1997"
+      "source_location": "L2148"
     },
     {
       "community": 1,
@@ -60118,7 +60244,7 @@
       "label": "getDailyCloseCompletionEventStaffProfileId()",
       "norm_label": "getdailyclosecompletioneventstaffprofileid()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L805"
+      "source_location": "L932"
     },
     {
       "community": 1,
@@ -60127,7 +60253,7 @@
       "label": "getDailyCloseForDate()",
       "norm_label": "getdailyclosefordate()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L457"
+      "source_location": "L496"
     },
     {
       "community": 1,
@@ -60136,7 +60262,7 @@
       "label": "getDailyCloseOpeningContextWithCtx()",
       "norm_label": "getdailycloseopeningcontextwithctx()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1912"
+      "source_location": "L2063"
     },
     {
       "community": 1,
@@ -60145,7 +60271,7 @@
       "label": "getPriorCompletedDailyClose()",
       "norm_label": "getpriorcompleteddailyclose()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L472"
+      "source_location": "L511"
     },
     {
       "community": 1,
@@ -60154,7 +60280,7 @@
       "label": "getStore()",
       "norm_label": "getstore()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L450"
+      "source_location": "L489"
     },
     {
       "community": 1,
@@ -60163,7 +60289,7 @@
       "label": "isInRange()",
       "norm_label": "isinrange()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L279"
+      "source_location": "L318"
     },
     {
       "community": 1,
@@ -60172,7 +60298,7 @@
       "label": "isValidOperatingDateRange()",
       "norm_label": "isvalidoperatingdaterange()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L247"
+      "source_location": "L286"
     },
     {
       "community": 1,
@@ -60181,7 +60307,7 @@
       "label": "listActiveRegisterSessions()",
       "norm_label": "listactiveregistersessions()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L494"
+      "source_location": "L533"
     },
     {
       "community": 1,
@@ -60190,7 +60316,7 @@
       "label": "listClosedRegisterSessionsForDay()",
       "norm_label": "listclosedregistersessionsforday()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L512"
+      "source_location": "L551"
     },
     {
       "community": 1,
@@ -60199,7 +60325,7 @@
       "label": "listCompletedDailyCloseHistoryWithCtx()",
       "norm_label": "listcompleteddailyclosehistorywithctx()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1948"
+      "source_location": "L2099"
     },
     {
       "community": 1,
@@ -60208,7 +60334,7 @@
       "label": "listDepositsForDay()",
       "norm_label": "listdepositsforday()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L627"
+      "source_location": "L754"
     },
     {
       "community": 1,
@@ -60217,7 +60343,7 @@
       "label": "listExpensesForDay()",
       "norm_label": "listexpensesforday()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L607"
+      "source_location": "L734"
     },
     {
       "community": 1,
@@ -60226,7 +60352,7 @@
       "label": "listOpenOperationalWorkItems()",
       "norm_label": "listopenoperationalworkitems()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L572"
+      "source_location": "L699"
     },
     {
       "community": 1,
@@ -60235,7 +60361,7 @@
       "label": "listOpenPosSessions()",
       "norm_label": "listopenpossessions()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L551"
+      "source_location": "L671"
     },
     {
       "community": 1,
@@ -60244,7 +60370,7 @@
       "label": "listPendingCloseoutApprovals()",
       "norm_label": "listpendingcloseoutapprovals()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L532"
+      "source_location": "L637"
     },
     {
       "community": 1,
@@ -60253,7 +60379,7 @@
       "label": "listTransactionsForDay()",
       "norm_label": "listtransactionsforday()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L586"
+      "source_location": "L713"
     },
     {
       "community": 1,
@@ -60262,7 +60388,7 @@
       "label": "markOtherDailyClosesNotCurrent()",
       "norm_label": "markotherdailyclosesnotcurrent()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1637"
+      "source_location": "L1788"
     },
     {
       "community": 1,
@@ -60271,7 +60397,25 @@
       "label": "nonZeroVarianceMetadata()",
       "norm_label": "nonzerovariancemetadata()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L328"
+      "source_location": "L367"
+    },
+    {
+      "community": 1,
+      "file_type": "code",
+      "id": "dailyclose_normalizecompleteddailyclosesnapshot",
+      "label": "normalizeCompletedDailyCloseSnapshot()",
+      "norm_label": "normalizecompleteddailyclosesnapshot()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
+      "source_location": "L143"
+    },
+    {
+      "community": 1,
+      "file_type": "code",
+      "id": "dailyclose_possessionintersectsrange",
+      "label": "posSessionIntersectsRange()",
+      "norm_label": "possessionintersectsrange()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
+      "source_location": "L581"
     },
     {
       "community": 1,
@@ -60280,7 +60424,16 @@
       "label": "registerMetadataLabel()",
       "norm_label": "registermetadatalabel()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L291"
+      "source_location": "L330"
+    },
+    {
+      "community": 1,
+      "file_type": "code",
+      "id": "dailyclose_registersessionintersectsrange",
+      "label": "registerSessionIntersectsRange()",
+      "norm_label": "registersessionintersectsrange()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
+      "source_location": "L571"
     },
     {
       "community": 1,
@@ -60289,7 +60442,7 @@
       "label": "registerSessionLabel()",
       "norm_label": "registersessionlabel()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L283"
+      "source_location": "L322"
     },
     {
       "community": 1,
@@ -60298,7 +60451,7 @@
       "label": "resolveOperatingDateRange()",
       "norm_label": "resolveoperatingdaterange()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L258"
+      "source_location": "L297"
     },
     {
       "community": 1,
@@ -60307,7 +60460,7 @@
       "label": "safeOperatingDateRange()",
       "norm_label": "safeoperatingdaterange()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L230"
+      "source_location": "L269"
     },
     {
       "community": 1,
@@ -60316,7 +60469,7 @@
       "label": "snapshotReviewedItems()",
       "norm_label": "snapshotrevieweditems()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L772"
+      "source_location": "L899"
     },
     {
       "community": 1,
@@ -60325,7 +60478,7 @@
       "label": "toDailyCloseHistoryListItem()",
       "norm_label": "todailyclosehistorylistitem()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L784"
+      "source_location": "L911"
     },
     {
       "community": 1,
@@ -60334,7 +60487,7 @@
       "label": "transactionCashDelta()",
       "norm_label": "transactioncashdelta()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L667"
+      "source_location": "L794"
     },
     {
       "community": 1,
@@ -60343,7 +60496,7 @@
       "label": "transactionPaymentSummary()",
       "norm_label": "transactionpaymentsummary()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L310"
+      "source_location": "L349"
     },
     {
       "community": 1,
@@ -60352,7 +60505,7 @@
       "label": "trimOptional()",
       "norm_label": "trimoptional()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L225"
+      "source_location": "L264"
     },
     {
       "community": 1,
@@ -60361,7 +60514,7 @@
       "label": "uniqueDailyCloseItems()",
       "norm_label": "uniquedailycloseitems()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L726"
+      "source_location": "L853"
     },
     {
       "community": 1,
@@ -60370,7 +60523,7 @@
       "label": "uniqueSourceSubjects()",
       "norm_label": "uniquesourcesubjects()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L716"
+      "source_location": "L843"
     },
     {
       "community": 1,
@@ -60379,7 +60532,7 @@
       "label": "validateCarryForwardWorkItemIds()",
       "norm_label": "validatecarryforwardworkitemids()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1556"
+      "source_location": "L1707"
     },
     {
       "community": 1,
@@ -60645,73 +60798,73 @@
     {
       "community": 100,
       "file_type": "code",
-      "id": "config_buildmtncollectionscallbackurl",
-      "label": "buildMtnCollectionsCallbackUrl()",
-      "norm_label": "buildmtncollectionscallbackurl()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
-      "source_location": "L135"
+      "id": "approvalauditevents_recordapprovalauditeventwithctx",
+      "label": "recordApprovalAuditEventWithCtx()",
+      "norm_label": "recordapprovalauditeventwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
+      "source_location": "L30"
     },
     {
       "community": 100,
       "file_type": "code",
-      "id": "config_buildmtncollectionslookupprefixes",
-      "label": "buildMtnCollectionsLookupPrefixes()",
-      "norm_label": "buildmtncollectionslookupprefixes()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
-      "source_location": "L43"
+      "id": "approvalauditevents_recordapprovaldecisionrecordedauditeventwithctx",
+      "label": "recordApprovalDecisionRecordedAuditEventWithCtx()",
+      "norm_label": "recordapprovaldecisionrecordedauditeventwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
+      "source_location": "L107"
     },
     {
       "community": 100,
       "file_type": "code",
-      "id": "config_istargetenvironment",
-      "label": "isTargetEnvironment()",
-      "norm_label": "istargetenvironment()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "id": "approvalauditevents_recordapprovalproofconsumedauditeventwithctx",
+      "label": "recordApprovalProofConsumedAuditEventWithCtx()",
+      "norm_label": "recordapprovalproofconsumedauditeventwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
+      "source_location": "L87"
+    },
+    {
+      "community": 100,
+      "file_type": "code",
+      "id": "approvalauditevents_recordapprovalrequiredauditeventwithctx",
+      "label": "recordApprovalRequiredAuditEventWithCtx()",
+      "norm_label": "recordapprovalrequiredauditeventwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
       "source_location": "L67"
     },
     {
       "community": 100,
       "file_type": "code",
-      "id": "config_readscopedvalue",
-      "label": "readScopedValue()",
-      "norm_label": "readscopedvalue()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
-      "source_location": "L56"
+      "id": "approvalauditevents_recordapprovedcommandappliedauditeventwithctx",
+      "label": "recordApprovedCommandAppliedAuditEventWithCtx()",
+      "norm_label": "recordapprovedcommandappliedauditeventwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
+      "source_location": "L117"
     },
     {
       "community": 100,
       "file_type": "code",
-      "id": "config_resolveconfigforprefix",
-      "label": "resolveConfigForPrefix()",
-      "norm_label": "resolveconfigforprefix()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
-      "source_location": "L73"
+      "id": "approvalauditevents_recordasyncapprovalrequestcreatedauditeventwithctx",
+      "label": "recordAsyncApprovalRequestCreatedAuditEventWithCtx()",
+      "norm_label": "recordasyncapprovalrequestcreatedauditeventwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
+      "source_location": "L97"
     },
     {
       "community": 100,
       "file_type": "code",
-      "id": "config_resolvemtncollectionsconfigfromenv",
-      "label": "resolveMtnCollectionsConfigFromEnv()",
-      "norm_label": "resolvemtncollectionsconfigfromenv()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
-      "source_location": "L108"
+      "id": "approvalauditevents_recordmanagerapprovalgrantedauditeventwithctx",
+      "label": "recordManagerApprovalGrantedAuditEventWithCtx()",
+      "norm_label": "recordmanagerapprovalgrantedauditeventwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
+      "source_location": "L77"
     },
     {
       "community": 100,
       "file_type": "code",
-      "id": "config_toenvsegment",
-      "label": "toEnvSegment()",
-      "norm_label": "toenvsegment()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
-      "source_location": "L29"
-    },
-    {
-      "community": 100,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_mtn_config_ts",
-      "label": "config.ts",
-      "norm_label": "config.ts",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "id": "packages_athena_webapp_convex_operations_approvalauditevents_ts",
+      "label": "approvalAuditEvents.ts",
+      "norm_label": "approvalauditevents.ts",
+      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
       "source_location": "L1"
     },
     {
@@ -60807,73 +60960,73 @@
     {
       "community": 101,
       "file_type": "code",
-      "id": "approvalauditevents_recordapprovalauditeventwithctx",
-      "label": "recordApprovalAuditEventWithCtx()",
-      "norm_label": "recordapprovalauditeventwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
-      "source_location": "L30"
+      "id": "approvalrequests_buildapprovaldecisionrequirement",
+      "label": "buildApprovalDecisionRequirement()",
+      "norm_label": "buildapprovaldecisionrequirement()",
+      "source_file": "packages/athena-webapp/convex/operations/approvalRequests.ts",
+      "source_location": "L54"
     },
     {
       "community": 101,
       "file_type": "code",
-      "id": "approvalauditevents_recordapprovaldecisionrecordedauditeventwithctx",
-      "label": "recordApprovalDecisionRecordedAuditEventWithCtx()",
-      "norm_label": "recordapprovaldecisionrecordedauditeventwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
-      "source_location": "L107"
+      "id": "approvalrequests_buildapprovaldecisionsubject",
+      "label": "buildApprovalDecisionSubject()",
+      "norm_label": "buildapprovaldecisionsubject()",
+      "source_file": "packages/athena-webapp/convex/operations/approvalRequests.ts",
+      "source_location": "L42"
     },
     {
       "community": 101,
       "file_type": "code",
-      "id": "approvalauditevents_recordapprovalproofconsumedauditeventwithctx",
-      "label": "recordApprovalProofConsumedAuditEventWithCtx()",
-      "norm_label": "recordapprovalproofconsumedauditeventwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
-      "source_location": "L87"
+      "id": "approvalrequests_consumeapprovaldecisionproofwithctx",
+      "label": "consumeApprovalDecisionProofWithCtx()",
+      "norm_label": "consumeapprovaldecisionproofwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/approvalRequests.ts",
+      "source_location": "L78"
     },
     {
       "community": 101,
       "file_type": "code",
-      "id": "approvalauditevents_recordapprovalrequiredauditeventwithctx",
-      "label": "recordApprovalRequiredAuditEventWithCtx()",
-      "norm_label": "recordapprovalrequiredauditeventwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
-      "source_location": "L67"
+      "id": "approvalrequests_decideapprovalrequestasauthenticateduserwithctx",
+      "label": "decideApprovalRequestAsAuthenticatedUserWithCtx()",
+      "norm_label": "decideapprovalrequestasauthenticateduserwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/approvalRequests.ts",
+      "source_location": "L167"
     },
     {
       "community": 101,
       "file_type": "code",
-      "id": "approvalauditevents_recordapprovedcommandappliedauditeventwithctx",
-      "label": "recordApprovedCommandAppliedAuditEventWithCtx()",
-      "norm_label": "recordapprovedcommandappliedauditeventwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
-      "source_location": "L117"
+      "id": "approvalrequests_decideapprovalrequestascommandwithctx",
+      "label": "decideApprovalRequestAsCommandWithCtx()",
+      "norm_label": "decideapprovalrequestascommandwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/approvalRequests.ts",
+      "source_location": "L283"
     },
     {
       "community": 101,
       "file_type": "code",
-      "id": "approvalauditevents_recordasyncapprovalrequestcreatedauditeventwithctx",
-      "label": "recordAsyncApprovalRequestCreatedAuditEventWithCtx()",
-      "norm_label": "recordasyncapprovalrequestcreatedauditeventwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
-      "source_location": "L97"
+      "id": "approvalrequests_decideapprovalrequestwithctx",
+      "label": "decideApprovalRequestWithCtx()",
+      "norm_label": "decideapprovalrequestwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/approvalRequests.ts",
+      "source_location": "L105"
     },
     {
       "community": 101,
       "file_type": "code",
-      "id": "approvalauditevents_recordmanagerapprovalgrantedauditeventwithctx",
-      "label": "recordManagerApprovalGrantedAuditEventWithCtx()",
-      "norm_label": "recordmanagerapprovalgrantedauditeventwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
-      "source_location": "L77"
+      "id": "approvalrequests_mapdecideapprovalrequesterror",
+      "label": "mapDecideApprovalRequestError()",
+      "norm_label": "mapdecideapprovalrequesterror()",
+      "source_file": "packages/athena-webapp/convex/operations/approvalRequests.ts",
+      "source_location": "L217"
     },
     {
       "community": 101,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_approvalauditevents_ts",
-      "label": "approvalAuditEvents.ts",
-      "norm_label": "approvalauditevents.ts",
-      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
+      "id": "packages_athena_webapp_convex_operations_approvalrequests_ts",
+      "label": "approvalRequests.ts",
+      "norm_label": "approvalrequests.ts",
+      "source_file": "packages/athena-webapp/convex/operations/approvalRequests.ts",
       "source_location": "L1"
     },
     {
@@ -60969,74 +61122,74 @@
     {
       "community": 102,
       "file_type": "code",
-      "id": "approvalrequests_buildapprovaldecisionrequirement",
-      "label": "buildApprovalDecisionRequirement()",
-      "norm_label": "buildapprovaldecisionrequirement()",
-      "source_file": "packages/athena-webapp/convex/operations/approvalRequests.ts",
-      "source_location": "L54"
-    },
-    {
-      "community": 102,
-      "file_type": "code",
-      "id": "approvalrequests_buildapprovaldecisionsubject",
-      "label": "buildApprovalDecisionSubject()",
-      "norm_label": "buildapprovaldecisionsubject()",
-      "source_file": "packages/athena-webapp/convex/operations/approvalRequests.ts",
-      "source_location": "L42"
-    },
-    {
-      "community": 102,
-      "file_type": "code",
-      "id": "approvalrequests_consumeapprovaldecisionproofwithctx",
-      "label": "consumeApprovalDecisionProofWithCtx()",
-      "norm_label": "consumeapprovaldecisionproofwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/approvalRequests.ts",
-      "source_location": "L78"
-    },
-    {
-      "community": 102,
-      "file_type": "code",
-      "id": "approvalrequests_decideapprovalrequestasauthenticateduserwithctx",
-      "label": "decideApprovalRequestAsAuthenticatedUserWithCtx()",
-      "norm_label": "decideapprovalrequestasauthenticateduserwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/approvalRequests.ts",
-      "source_location": "L167"
-    },
-    {
-      "community": 102,
-      "file_type": "code",
-      "id": "approvalrequests_decideapprovalrequestascommandwithctx",
-      "label": "decideApprovalRequestAsCommandWithCtx()",
-      "norm_label": "decideapprovalrequestascommandwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/approvalRequests.ts",
-      "source_location": "L283"
-    },
-    {
-      "community": 102,
-      "file_type": "code",
-      "id": "approvalrequests_decideapprovalrequestwithctx",
-      "label": "decideApprovalRequestWithCtx()",
-      "norm_label": "decideapprovalrequestwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/approvalRequests.ts",
-      "source_location": "L105"
-    },
-    {
-      "community": 102,
-      "file_type": "code",
-      "id": "approvalrequests_mapdecideapprovalrequesterror",
-      "label": "mapDecideApprovalRequestError()",
-      "norm_label": "mapdecideapprovalrequesterror()",
-      "source_file": "packages/athena-webapp/convex/operations/approvalRequests.ts",
-      "source_location": "L217"
-    },
-    {
-      "community": 102,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_approvalrequests_ts",
-      "label": "approvalRequests.ts",
-      "norm_label": "approvalrequests.ts",
-      "source_file": "packages/athena-webapp/convex/operations/approvalRequests.ts",
+      "id": "packages_athena_webapp_convex_operations_paymentallocations_ts",
+      "label": "paymentAllocations.ts",
+      "norm_label": "paymentallocations.ts",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 102,
+      "file_type": "code",
+      "id": "paymentallocations_buildpaymentallocation",
+      "label": "buildPaymentAllocation()",
+      "norm_label": "buildpaymentallocation()",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "source_location": "L27"
+    },
+    {
+      "community": 102,
+      "file_type": "code",
+      "id": "paymentallocations_correctsameamountsinglepaymentallocationwithctx",
+      "label": "correctSameAmountSinglePaymentAllocationWithCtx()",
+      "norm_label": "correctsameamountsinglepaymentallocationwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "source_location": "L153"
+    },
+    {
+      "community": 102,
+      "file_type": "code",
+      "id": "paymentallocations_findsameamountsinglepaymentallocation",
+      "label": "findSameAmountSinglePaymentAllocation()",
+      "norm_label": "findsameamountsinglepaymentallocation()",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "source_location": "L57"
+    },
+    {
+      "community": 102,
+      "file_type": "code",
+      "id": "paymentallocations_listpaymentallocationsfortargetwithctx",
+      "label": "listPaymentAllocationsForTargetWithCtx()",
+      "norm_label": "listpaymentallocationsfortargetwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "source_location": "L133"
+    },
+    {
+      "community": 102,
+      "file_type": "code",
+      "id": "paymentallocations_matchesexistingallocation",
+      "label": "matchesExistingAllocation()",
+      "norm_label": "matchesexistingallocation()",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "source_location": "L81"
+    },
+    {
+      "community": 102,
+      "file_type": "code",
+      "id": "paymentallocations_recordpaymentallocationwithctx",
+      "label": "recordPaymentAllocationWithCtx()",
+      "norm_label": "recordpaymentallocationwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "source_location": "L102"
+    },
+    {
+      "community": 102,
+      "file_type": "code",
+      "id": "paymentallocations_summarizepaymentallocations",
+      "label": "summarizePaymentAllocations()",
+      "norm_label": "summarizepaymentallocations()",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "source_location": "L41"
     },
     {
       "community": 1020,
@@ -61131,74 +61284,74 @@
     {
       "community": 103,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_paymentallocations_ts",
-      "label": "paymentAllocations.ts",
-      "norm_label": "paymentallocations.ts",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "id": "packages_athena_webapp_convex_pos_application_commands_possessiontracing_ts",
+      "label": "posSessionTracing.ts",
+      "norm_label": "possessiontracing.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
       "source_location": "L1"
     },
     {
       "community": 103,
       "file_type": "code",
-      "id": "paymentallocations_buildpaymentallocation",
-      "label": "buildPaymentAllocation()",
-      "norm_label": "buildpaymentallocation()",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
-      "source_location": "L27"
+      "id": "possessiontracing_buildpossessiontraceevent",
+      "label": "buildPosSessionTraceEvent()",
+      "norm_label": "buildpossessiontraceevent()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L226"
     },
     {
       "community": 103,
       "file_type": "code",
-      "id": "paymentallocations_correctsameamountsinglepaymentallocationwithctx",
-      "label": "correctSameAmountSinglePaymentAllocationWithCtx()",
-      "norm_label": "correctsameamountsinglepaymentallocationwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
-      "source_location": "L153"
+      "id": "possessiontracing_buildpossessiontracerecord",
+      "label": "buildPosSessionTraceRecord()",
+      "norm_label": "buildpossessiontracerecord()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L142"
     },
     {
       "community": 103,
       "file_type": "code",
-      "id": "paymentallocations_findsameamountsinglepaymentallocation",
-      "label": "findSameAmountSinglePaymentAllocation()",
-      "norm_label": "findsameamountsinglepaymentallocation()",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
-      "source_location": "L57"
+      "id": "possessiontracing_buildtracesummary",
+      "label": "buildTraceSummary()",
+      "norm_label": "buildtracesummary()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L105"
     },
     {
       "community": 103,
       "file_type": "code",
-      "id": "paymentallocations_listpaymentallocationsfortargetwithctx",
-      "label": "listPaymentAllocationsForTargetWithCtx()",
-      "norm_label": "listpaymentallocationsfortargetwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
-      "source_location": "L133"
+      "id": "possessiontracing_createpossessiontracerecorder",
+      "label": "createPosSessionTraceRecorder()",
+      "norm_label": "createpossessiontracerecorder()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L559"
     },
     {
       "community": 103,
       "file_type": "code",
-      "id": "paymentallocations_matchesexistingallocation",
-      "label": "matchesExistingAllocation()",
-      "norm_label": "matchesexistingallocation()",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
-      "source_location": "L81"
+      "id": "possessiontracing_formatpaymentmethod",
+      "label": "formatPaymentMethod()",
+      "norm_label": "formatpaymentmethod()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L218"
     },
     {
       "community": 103,
       "file_type": "code",
-      "id": "paymentallocations_recordpaymentallocationwithctx",
-      "label": "recordPaymentAllocationWithCtx()",
-      "norm_label": "recordpaymentallocationwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
-      "source_location": "L102"
+      "id": "possessiontracing_recordpossessiontracebesteffort",
+      "label": "recordPosSessionTraceBestEffort()",
+      "norm_label": "recordpossessiontracebesteffort()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L532"
     },
     {
       "community": 103,
       "file_type": "code",
-      "id": "paymentallocations_summarizepaymentallocations",
-      "label": "summarizePaymentAllocations()",
-      "norm_label": "summarizepaymentallocations()",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
-      "source_location": "L41"
+      "id": "possessiontracing_safetracewrite",
+      "label": "safeTraceWrite()",
+      "norm_label": "safetracewrite()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L524"
     },
     {
       "community": 1030,
@@ -61293,74 +61446,74 @@
     {
       "community": 104,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_commands_possessiontracing_ts",
-      "label": "posSessionTracing.ts",
-      "norm_label": "possessiontracing.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "id": "packages_athena_webapp_convex_pos_application_commands_quickaddcatalogitem_ts",
+      "label": "quickAddCatalogItem.ts",
+      "norm_label": "quickaddcatalogitem.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
       "source_location": "L1"
     },
     {
       "community": 104,
       "file_type": "code",
-      "id": "possessiontracing_buildpossessiontraceevent",
-      "label": "buildPosSessionTraceEvent()",
-      "norm_label": "buildpossessiontraceevent()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L226"
+      "id": "quickaddcatalogitem_findexistingsku",
+      "label": "findExistingSku()",
+      "norm_label": "findexistingsku()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
+      "source_location": "L125"
     },
     {
       "community": 104,
       "file_type": "code",
-      "id": "possessiontracing_buildpossessiontracerecord",
-      "label": "buildPosSessionTraceRecord()",
-      "norm_label": "buildpossessiontracerecord()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L142"
+      "id": "quickaddcatalogitem_findorcreatequickaddcategory",
+      "label": "findOrCreateQuickAddCategory()",
+      "norm_label": "findorcreatequickaddcategory()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
+      "source_location": "L29"
     },
     {
       "community": 104,
       "file_type": "code",
-      "id": "possessiontracing_buildtracesummary",
-      "label": "buildTraceSummary()",
-      "norm_label": "buildtracesummary()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L105"
+      "id": "quickaddcatalogitem_findorcreatequickaddsubcategory",
+      "label": "findOrCreateQuickAddSubcategory()",
+      "norm_label": "findorcreatequickaddsubcategory()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
+      "source_location": "L56"
     },
     {
       "community": 104,
       "file_type": "code",
-      "id": "possessiontracing_createpossessiontracerecorder",
-      "label": "createPosSessionTraceRecorder()",
-      "norm_label": "createpossessiontracerecorder()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L559"
+      "id": "quickaddcatalogitem_generatesku",
+      "label": "generateSKU()",
+      "norm_label": "generatesku()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
+      "source_location": "L153"
     },
     {
       "community": 104,
       "file_type": "code",
-      "id": "possessiontracing_formatpaymentmethod",
-      "label": "formatPaymentMethod()",
-      "norm_label": "formatpaymentmethod()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L218"
+      "id": "quickaddcatalogitem_isbarcodelike",
+      "label": "isBarcodeLike()",
+      "norm_label": "isbarcodelike()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
+      "source_location": "L149"
     },
     {
       "community": 104,
       "file_type": "code",
-      "id": "possessiontracing_recordpossessiontracebesteffort",
-      "label": "recordPosSessionTraceBestEffort()",
-      "norm_label": "recordpossessiontracebesteffort()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L532"
+      "id": "quickaddcatalogitem_mapskutocatalogresult",
+      "label": "mapSkuToCatalogResult()",
+      "norm_label": "mapskutocatalogresult()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
+      "source_location": "L88"
     },
     {
       "community": 104,
       "file_type": "code",
-      "id": "possessiontracing_safetracewrite",
-      "label": "safeTraceWrite()",
-      "norm_label": "safetracewrite()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L524"
+      "id": "quickaddcatalogitem_quickaddcatalogitem",
+      "label": "quickAddCatalogItem()",
+      "norm_label": "quickaddcatalogitem()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
+      "source_location": "L174"
     },
     {
       "community": 1040,
@@ -61455,74 +61608,74 @@
     {
       "community": 105,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_commands_quickaddcatalogitem_ts",
-      "label": "quickAddCatalogItem.ts",
-      "norm_label": "quickaddcatalogitem.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
+      "id": "expensesessioncommands_test_builditem",
+      "label": "buildItem()",
+      "norm_label": "builditem()",
+      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
+      "source_location": "L645"
+    },
+    {
+      "community": 105,
+      "file_type": "code",
+      "id": "expensesessioncommands_test_buildregistersession",
+      "label": "buildRegisterSession()",
+      "norm_label": "buildregistersession()",
+      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
+      "source_location": "L639"
+    },
+    {
+      "community": 105,
+      "file_type": "code",
+      "id": "expensesessioncommands_test_buildsession",
+      "label": "buildSession()",
+      "norm_label": "buildsession()",
+      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
+      "source_location": "L635"
+    },
+    {
+      "community": 105,
+      "file_type": "code",
+      "id": "expensesessioncommands_test_createcommandservice",
+      "label": "createCommandService()",
+      "norm_label": "createcommandservice()",
+      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
+      "source_location": "L655"
+    },
+    {
+      "community": 105,
+      "file_type": "code",
+      "id": "expensesessioncommands_test_createdependencies",
+      "label": "createDependencies()",
+      "norm_label": "createdependencies()",
+      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
+      "source_location": "L424"
+    },
+    {
+      "community": 105,
+      "file_type": "code",
+      "id": "expensesessioncommands_test_createfakerepository",
+      "label": "createFakeRepository()",
+      "norm_label": "createfakerepository()",
+      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
+      "source_location": "L492"
+    },
+    {
+      "community": 105,
+      "file_type": "code",
+      "id": "expensesessioncommands_test_loadcommandservice",
+      "label": "loadCommandService()",
+      "norm_label": "loadcommandservice()",
+      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
+      "source_location": "L404"
+    },
+    {
+      "community": 105,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_expensesessioncommands_test_ts",
+      "label": "expenseSessionCommands.test.ts",
+      "norm_label": "expensesessioncommands.test.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 105,
-      "file_type": "code",
-      "id": "quickaddcatalogitem_findexistingsku",
-      "label": "findExistingSku()",
-      "norm_label": "findexistingsku()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
-      "source_location": "L125"
-    },
-    {
-      "community": 105,
-      "file_type": "code",
-      "id": "quickaddcatalogitem_findorcreatequickaddcategory",
-      "label": "findOrCreateQuickAddCategory()",
-      "norm_label": "findorcreatequickaddcategory()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
-      "source_location": "L29"
-    },
-    {
-      "community": 105,
-      "file_type": "code",
-      "id": "quickaddcatalogitem_findorcreatequickaddsubcategory",
-      "label": "findOrCreateQuickAddSubcategory()",
-      "norm_label": "findorcreatequickaddsubcategory()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
-      "source_location": "L56"
-    },
-    {
-      "community": 105,
-      "file_type": "code",
-      "id": "quickaddcatalogitem_generatesku",
-      "label": "generateSKU()",
-      "norm_label": "generatesku()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
-      "source_location": "L153"
-    },
-    {
-      "community": 105,
-      "file_type": "code",
-      "id": "quickaddcatalogitem_isbarcodelike",
-      "label": "isBarcodeLike()",
-      "norm_label": "isbarcodelike()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
-      "source_location": "L149"
-    },
-    {
-      "community": 105,
-      "file_type": "code",
-      "id": "quickaddcatalogitem_mapskutocatalogresult",
-      "label": "mapSkuToCatalogResult()",
-      "norm_label": "mapskutocatalogresult()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
-      "source_location": "L88"
-    },
-    {
-      "community": 105,
-      "file_type": "code",
-      "id": "quickaddcatalogitem_quickaddcatalogitem",
-      "label": "quickAddCatalogItem()",
-      "norm_label": "quickaddcatalogitem()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts",
-      "source_location": "L174"
     },
     {
       "community": 1050,
@@ -61617,74 +61770,74 @@
     {
       "community": 106,
       "file_type": "code",
-      "id": "expensesessioncommands_test_builditem",
+      "id": "packages_athena_webapp_convex_pos_application_sessioncommands_test_ts",
+      "label": "sessionCommands.test.ts",
+      "norm_label": "sessioncommands.test.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 106,
+      "file_type": "code",
+      "id": "sessioncommands_test_builditem",
       "label": "buildItem()",
       "norm_label": "builditem()",
-      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
-      "source_location": "L645"
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L2406"
     },
     {
       "community": 106,
       "file_type": "code",
-      "id": "expensesessioncommands_test_buildregistersession",
+      "id": "sessioncommands_test_buildregistersession",
       "label": "buildRegisterSession()",
       "norm_label": "buildregistersession()",
-      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
-      "source_location": "L639"
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L2400"
     },
     {
       "community": 106,
       "file_type": "code",
-      "id": "expensesessioncommands_test_buildsession",
+      "id": "sessioncommands_test_buildsession",
       "label": "buildSession()",
       "norm_label": "buildsession()",
-      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
-      "source_location": "L635"
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L2396"
     },
     {
       "community": 106,
       "file_type": "code",
-      "id": "expensesessioncommands_test_createcommandservice",
+      "id": "sessioncommands_test_createcommandservice",
       "label": "createCommandService()",
       "norm_label": "createcommandservice()",
-      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
-      "source_location": "L655"
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L2416"
     },
     {
       "community": 106,
       "file_type": "code",
-      "id": "expensesessioncommands_test_createdependencies",
+      "id": "sessioncommands_test_createdependencies",
       "label": "createDependencies()",
       "norm_label": "createdependencies()",
-      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
-      "source_location": "L424"
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L2155"
     },
     {
       "community": 106,
       "file_type": "code",
-      "id": "expensesessioncommands_test_createfakerepository",
+      "id": "sessioncommands_test_createfakerepository",
       "label": "createFakeRepository()",
       "norm_label": "createfakerepository()",
-      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
-      "source_location": "L492"
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L2252"
     },
     {
       "community": 106,
       "file_type": "code",
-      "id": "expensesessioncommands_test_loadcommandservice",
+      "id": "sessioncommands_test_loadcommandservice",
       "label": "loadCommandService()",
       "norm_label": "loadcommandservice()",
-      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
-      "source_location": "L404"
-    },
-    {
-      "community": 106,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_expensesessioncommands_test_ts",
-      "label": "expenseSessionCommands.test.ts",
-      "norm_label": "expensesessioncommands.test.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
-      "source_location": "L1"
+      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "source_location": "L2137"
     },
     {
       "community": 1060,
@@ -61779,74 +61932,74 @@
     {
       "community": 107,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_sessioncommands_test_ts",
-      "label": "sessionCommands.test.ts",
-      "norm_label": "sessioncommands.test.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
+      "id": "index_senddiscountcodeemail",
+      "label": "sendDiscountCodeEmail()",
+      "norm_label": "senddiscountcodeemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L255"
+    },
+    {
+      "community": 107,
+      "file_type": "code",
+      "id": "index_senddiscountreminderemail",
+      "label": "sendDiscountReminderEmail()",
+      "norm_label": "senddiscountreminderemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L334"
+    },
+    {
+      "community": 107,
+      "file_type": "code",
+      "id": "index_sendfeedbackrequestemail",
+      "label": "sendFeedbackRequestEmail()",
+      "norm_label": "sendfeedbackrequestemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L167"
+    },
+    {
+      "community": 107,
+      "file_type": "code",
+      "id": "index_sendneworderemail",
+      "label": "sendNewOrderEmail()",
+      "norm_label": "sendneworderemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L117"
+    },
+    {
+      "community": 107,
+      "file_type": "code",
+      "id": "index_sendorderemail",
+      "label": "sendOrderEmail()",
+      "norm_label": "sendorderemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L43"
+    },
+    {
+      "community": 107,
+      "file_type": "code",
+      "id": "index_sendverificationcode",
+      "label": "sendVerificationCode()",
+      "norm_label": "sendverificationcode()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L3"
+    },
+    {
+      "community": 107,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_mailersend_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/convex/mailersend/index.tsx",
       "source_location": "L1"
     },
     {
       "community": 107,
       "file_type": "code",
-      "id": "sessioncommands_test_builditem",
-      "label": "buildItem()",
-      "norm_label": "builditem()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L2406"
-    },
-    {
-      "community": 107,
-      "file_type": "code",
-      "id": "sessioncommands_test_buildregistersession",
-      "label": "buildRegisterSession()",
-      "norm_label": "buildregistersession()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L2400"
-    },
-    {
-      "community": 107,
-      "file_type": "code",
-      "id": "sessioncommands_test_buildsession",
-      "label": "buildSession()",
-      "norm_label": "buildsession()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L2396"
-    },
-    {
-      "community": 107,
-      "file_type": "code",
-      "id": "sessioncommands_test_createcommandservice",
-      "label": "createCommandService()",
-      "norm_label": "createcommandservice()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L2416"
-    },
-    {
-      "community": 107,
-      "file_type": "code",
-      "id": "sessioncommands_test_createdependencies",
-      "label": "createDependencies()",
-      "norm_label": "createdependencies()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L2155"
-    },
-    {
-      "community": 107,
-      "file_type": "code",
-      "id": "sessioncommands_test_createfakerepository",
-      "label": "createFakeRepository()",
-      "norm_label": "createfakerepository()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L2252"
-    },
-    {
-      "community": 107,
-      "file_type": "code",
-      "id": "sessioncommands_test_loadcommandservice",
-      "label": "loadCommandService()",
-      "norm_label": "loadcommandservice()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
-      "source_location": "L2137"
+      "id": "packages_athena_webapp_convex_sendgrid_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L1"
     },
     {
       "community": 1070,
@@ -71355,60 +71508,6 @@
     {
       "community": 161,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_selectable_data_provider_tsx",
-      "label": "selectable-data-provider.tsx",
-      "norm_label": "selectable-data-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/selectable-data-provider.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 161,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_base_selectable_products_table_selectable_data_provider_tsx",
-      "label": "selectable-data-provider.tsx",
-      "norm_label": "selectable-data-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/selectable-data-provider.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 161,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_selectable_data_provider_tsx",
-      "label": "selectable-data-provider.tsx",
-      "norm_label": "selectable-data-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/selectable-data-provider.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 161,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_selectable_data_provider_tsx",
-      "label": "selectable-data-provider.tsx",
-      "norm_label": "selectable-data-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/selectable-data-provider.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 161,
-      "file_type": "code",
-      "id": "selectable_data_provider_selectedproductsprovider",
-      "label": "SelectedProductsProvider()",
-      "norm_label": "selectedproductsprovider()",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/selectable-data-provider.tsx",
-      "source_location": "L16"
-    },
-    {
-      "community": 161,
-      "file_type": "code",
-      "id": "selectable_data_provider_useselectedproducts",
-      "label": "useSelectedProducts()",
-      "norm_label": "useselectedproducts()",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/selectable-data-provider.tsx",
-      "source_location": "L37"
-    },
-    {
-      "community": 162,
-      "file_type": "code",
       "id": "inputotp_formatrequestdelay",
       "label": "formatRequestDelay()",
       "norm_label": "formatrequestdelay()",
@@ -71416,7 +71515,7 @@
       "source_location": "L46"
     },
     {
-      "community": 162,
+      "community": 161,
       "file_type": "code",
       "id": "inputotp_handlepinchange",
       "label": "handlePinChange()",
@@ -71425,7 +71524,7 @@
       "source_location": "L95"
     },
     {
-      "community": 162,
+      "community": 161,
       "file_type": "code",
       "id": "inputotp_handlerequestnewcode",
       "label": "handleRequestNewCode()",
@@ -71434,7 +71533,7 @@
       "source_location": "L143"
     },
     {
-      "community": 162,
+      "community": 161,
       "file_type": "code",
       "id": "inputotp_normalizeotpcode",
       "label": "normalizeOtpCode()",
@@ -71443,7 +71542,7 @@
       "source_location": "L30"
     },
     {
-      "community": 162,
+      "community": 161,
       "file_type": "code",
       "id": "inputotp_onsubmit",
       "label": "onSubmit()",
@@ -71452,13 +71551,67 @@
       "source_location": "L105"
     },
     {
-      "community": 162,
+      "community": 161,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_login_inputotp_tsx",
       "label": "InputOTP.tsx",
       "norm_label": "inputotp.tsx",
       "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
       "source_location": "L1"
+    },
+    {
+      "community": 162,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_selectable_data_provider_tsx",
+      "label": "selectable-data-provider.tsx",
+      "norm_label": "selectable-data-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/selectable-data-provider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 162,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_base_selectable_products_table_selectable_data_provider_tsx",
+      "label": "selectable-data-provider.tsx",
+      "norm_label": "selectable-data-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/selectable-data-provider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 162,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_selectable_data_provider_tsx",
+      "label": "selectable-data-provider.tsx",
+      "norm_label": "selectable-data-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/selectable-data-provider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 162,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_selectable_data_provider_tsx",
+      "label": "selectable-data-provider.tsx",
+      "norm_label": "selectable-data-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/selectable-data-provider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 162,
+      "file_type": "code",
+      "id": "selectable_data_provider_selectedproductsprovider",
+      "label": "SelectedProductsProvider()",
+      "norm_label": "selectedproductsprovider()",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/selectable-data-provider.tsx",
+      "source_location": "L16"
+    },
+    {
+      "community": 162,
+      "file_type": "code",
+      "id": "selectable_data_provider_useselectedproducts",
+      "label": "useSelectedProducts()",
+      "norm_label": "useselectedproducts()",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/selectable-data-provider.tsx",
+      "source_location": "L37"
     },
     {
       "community": 163,
@@ -72111,6 +72264,60 @@
     {
       "community": 171,
       "file_type": "code",
+      "id": "image_uploader_ondragend",
+      "label": "onDragEnd()",
+      "norm_label": "ondragend()",
+      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L100"
+    },
+    {
+      "community": 171,
+      "file_type": "code",
+      "id": "image_uploader_ondrop",
+      "label": "onDrop()",
+      "norm_label": "ondrop()",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L20"
+    },
+    {
+      "community": 171,
+      "file_type": "code",
+      "id": "image_uploader_removeimage",
+      "label": "removeImage()",
+      "norm_label": "removeimage()",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L31"
+    },
+    {
+      "community": 171,
+      "file_type": "code",
+      "id": "image_uploader_unmarkfordeletion",
+      "label": "unmarkForDeletion()",
+      "norm_label": "unmarkfordeletion()",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L46"
+    },
+    {
+      "community": 171,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_image_uploader_tsx",
+      "label": "image-uploader.tsx",
+      "norm_label": "image-uploader.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 171,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_image_uploader_tsx",
+      "label": "image-uploader.tsx",
+      "norm_label": "image-uploader.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 172,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_sidebar_tsx",
       "label": "sidebar.tsx",
       "norm_label": "sidebar.tsx",
@@ -72118,7 +72325,7 @@
       "source_location": "L1"
     },
     {
-      "community": 171,
+      "community": 172,
       "file_type": "code",
       "id": "sidebar_cn",
       "label": "cn()",
@@ -72127,7 +72334,7 @@
       "source_location": "L147"
     },
     {
-      "community": 171,
+      "community": 172,
       "file_type": "code",
       "id": "sidebar_handlekeydown",
       "label": "handleKeyDown()",
@@ -72136,7 +72343,7 @@
       "source_location": "L105"
     },
     {
-      "community": 171,
+      "community": 172,
       "file_type": "code",
       "id": "sidebar_handleonhover",
       "label": "handleOnHover()",
@@ -72145,7 +72352,7 @@
       "source_location": "L224"
     },
     {
-      "community": 171,
+      "community": 172,
       "file_type": "code",
       "id": "sidebar_handleonmouseleave",
       "label": "handleOnMouseLeave()",
@@ -72154,7 +72361,7 @@
       "source_location": "L228"
     },
     {
-      "community": 171,
+      "community": 172,
       "file_type": "code",
       "id": "sidebar_usesidebar",
       "label": "useSidebar()",
@@ -72163,7 +72370,7 @@
       "source_location": "L45"
     },
     {
-      "community": 172,
+      "community": 173,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useexpensesessions_ts",
       "label": "useExpenseSessions.ts",
@@ -72172,7 +72379,7 @@
       "source_location": "L1"
     },
     {
-      "community": 172,
+      "community": 173,
       "file_type": "code",
       "id": "useexpensesessions_useexpenseactivesession",
       "label": "useExpenseActiveSession()",
@@ -72181,7 +72388,7 @@
       "source_location": "L42"
     },
     {
-      "community": 172,
+      "community": 173,
       "file_type": "code",
       "id": "useexpensesessions_useexpensesession",
       "label": "useExpenseSession()",
@@ -72190,7 +72397,7 @@
       "source_location": "L32"
     },
     {
-      "community": 172,
+      "community": 173,
       "file_type": "code",
       "id": "useexpensesessions_useexpensesessioncreate",
       "label": "useExpenseSessionCreate()",
@@ -72199,7 +72406,7 @@
       "source_location": "L62"
     },
     {
-      "community": 172,
+      "community": 173,
       "file_type": "code",
       "id": "useexpensesessions_useexpensesessionupdate",
       "label": "useExpenseSessionUpdate()",
@@ -72208,7 +72415,7 @@
       "source_location": "L101"
     },
     {
-      "community": 172,
+      "community": 173,
       "file_type": "code",
       "id": "useexpensesessions_useexpensestoresessions",
       "label": "useExpenseStoreSessions()",
@@ -72217,7 +72424,7 @@
       "source_location": "L10"
     },
     {
-      "community": 173,
+      "community": 174,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useposproducts_ts",
       "label": "usePOSProducts.ts",
@@ -72226,7 +72433,7 @@
       "source_location": "L1"
     },
     {
-      "community": 173,
+      "community": 174,
       "file_type": "code",
       "id": "useposproducts_useposbarcodesearch",
       "label": "usePOSBarcodeSearch()",
@@ -72235,7 +72442,7 @@
       "source_location": "L17"
     },
     {
-      "community": 173,
+      "community": 174,
       "file_type": "code",
       "id": "useposproducts_useposproductidsearch",
       "label": "usePOSProductIdSearch()",
@@ -72244,7 +72451,7 @@
       "source_location": "L24"
     },
     {
-      "community": 173,
+      "community": 174,
       "file_type": "code",
       "id": "useposproducts_useposproductsearch",
       "label": "usePOSProductSearch()",
@@ -72253,7 +72460,7 @@
       "source_location": "L10"
     },
     {
-      "community": 173,
+      "community": 174,
       "file_type": "code",
       "id": "useposproducts_useposquickaddproductsku",
       "label": "usePOSQuickAddProductSku()",
@@ -72262,7 +72469,7 @@
       "source_location": "L33"
     },
     {
-      "community": 173,
+      "community": 174,
       "file_type": "code",
       "id": "useposproducts_usepostransactioncomplete",
       "label": "usePOSTransactionComplete()",
@@ -72271,7 +72478,7 @@
       "source_location": "L31"
     },
     {
-      "community": 174,
+      "community": 175,
       "file_type": "code",
       "id": "behaviorutils_calculateengagementmetrics",
       "label": "calculateEngagementMetrics()",
@@ -72280,7 +72487,7 @@
       "source_location": "L173"
     },
     {
-      "community": 174,
+      "community": 175,
       "file_type": "code",
       "id": "behaviorutils_calculateriskindicators",
       "label": "calculateRiskIndicators()",
@@ -72289,7 +72496,7 @@
       "source_location": "L71"
     },
     {
-      "community": 174,
+      "community": 175,
       "file_type": "code",
       "id": "behaviorutils_getactivitypriority",
       "label": "getActivityPriority()",
@@ -72298,7 +72505,7 @@
       "source_location": "L251"
     },
     {
-      "community": 174,
+      "community": 175,
       "file_type": "code",
       "id": "behaviorutils_getcustomerjourneystage",
       "label": "getCustomerJourneyStage()",
@@ -72307,7 +72514,7 @@
       "source_location": "L36"
     },
     {
-      "community": 174,
+      "community": 175,
       "file_type": "code",
       "id": "behaviorutils_getjourneystageinfo",
       "label": "getJourneyStageInfo()",
@@ -72316,7 +72523,7 @@
       "source_location": "L277"
     },
     {
-      "community": 174,
+      "community": 175,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_behaviorutils_ts",
       "label": "behaviorUtils.ts",
@@ -72325,7 +72532,7 @@
       "source_location": "L1"
     },
     {
-      "community": 175,
+      "community": 176,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_results_ts",
       "label": "results.ts",
@@ -72334,7 +72541,7 @@
       "source_location": "L1"
     },
     {
-      "community": 175,
+      "community": 176,
       "file_type": "code",
       "id": "results_isposusecasesuccess",
       "label": "isPosUseCaseSuccess()",
@@ -72343,7 +72550,7 @@
       "source_location": "L122"
     },
     {
-      "community": 175,
+      "community": 176,
       "file_type": "code",
       "id": "results_mapcommandoutcome",
       "label": "mapCommandOutcome()",
@@ -72352,7 +72559,7 @@
       "source_location": "L68"
     },
     {
-      "community": 175,
+      "community": 176,
       "file_type": "code",
       "id": "results_mapcommandresult",
       "label": "mapCommandResult()",
@@ -72361,7 +72568,7 @@
       "source_location": "L85"
     },
     {
-      "community": 175,
+      "community": 176,
       "file_type": "code",
       "id": "results_maplegacymutationresult",
       "label": "mapLegacyMutationResult()",
@@ -72370,7 +72577,7 @@
       "source_location": "L51"
     },
     {
-      "community": 175,
+      "community": 176,
       "file_type": "code",
       "id": "results_mapthrownerror",
       "label": "mapThrownError()",
@@ -72379,7 +72586,7 @@
       "source_location": "L102"
     },
     {
-      "community": 176,
+      "community": 177,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_domain_payments_ts",
       "label": "payments.ts",
@@ -72388,7 +72595,7 @@
       "source_location": "L1"
     },
     {
-      "community": 176,
+      "community": 177,
       "file_type": "code",
       "id": "payments_calculateposchange",
       "label": "calculatePosChange()",
@@ -72397,7 +72604,7 @@
       "source_location": "L3"
     },
     {
-      "community": 176,
+      "community": 177,
       "file_type": "code",
       "id": "payments_calculateposremainingdue",
       "label": "calculatePosRemainingDue()",
@@ -72406,7 +72613,7 @@
       "source_location": "L20"
     },
     {
-      "community": 176,
+      "community": 177,
       "file_type": "code",
       "id": "payments_calculatepostotalpaid",
       "label": "calculatePosTotalPaid()",
@@ -72415,7 +72622,7 @@
       "source_location": "L14"
     },
     {
-      "community": 176,
+      "community": 177,
       "file_type": "code",
       "id": "payments_ispospaymentsufficient",
       "label": "isPosPaymentSufficient()",
@@ -72424,7 +72631,7 @@
       "source_location": "L7"
     },
     {
-      "community": 176,
+      "community": 177,
       "file_type": "code",
       "id": "payments_roundposamount",
       "label": "roundPosAmount()",
@@ -72433,7 +72640,7 @@
       "source_location": "L27"
     },
     {
-      "community": 177,
+      "community": 178,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_presentation_register_selectors_ts",
       "label": "selectors.ts",
@@ -72442,7 +72649,7 @@
       "source_location": "L1"
     },
     {
-      "community": 177,
+      "community": 178,
       "file_type": "code",
       "id": "selectors_buildregisterheaderstate",
       "label": "buildRegisterHeaderState()",
@@ -72451,7 +72658,7 @@
       "source_location": "L28"
     },
     {
-      "community": 177,
+      "community": 178,
       "file_type": "code",
       "id": "selectors_buildregisterinfostate",
       "label": "buildRegisterInfoState()",
@@ -72460,7 +72667,7 @@
       "source_location": "L37"
     },
     {
-      "community": 177,
+      "community": 178,
       "file_type": "code",
       "id": "selectors_getcashierdisplayname",
       "label": "getCashierDisplayName()",
@@ -72469,7 +72676,7 @@
       "source_location": "L12"
     },
     {
-      "community": 177,
+      "community": 178,
       "file_type": "code",
       "id": "selectors_getregistercustomerinfo",
       "label": "getRegisterCustomerInfo()",
@@ -72478,7 +72685,7 @@
       "source_location": "L6"
     },
     {
-      "community": 177,
+      "community": 178,
       "file_type": "code",
       "id": "selectors_isregistersessionactive",
       "label": "isRegisterSessionActive()",
@@ -72487,7 +72694,7 @@
       "source_location": "L49"
     },
     {
-      "community": 178,
+      "community": 179,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_toastservice_ts",
       "label": "toastService.ts",
@@ -72496,7 +72703,7 @@
       "source_location": "L1"
     },
     {
-      "community": 178,
+      "community": 179,
       "file_type": "code",
       "id": "toastservice_handleposoperation",
       "label": "handlePOSOperation()",
@@ -72505,7 +72712,7 @@
       "source_location": "L171"
     },
     {
-      "community": 178,
+      "community": 179,
       "file_type": "code",
       "id": "toastservice_showinventoryerror",
       "label": "showInventoryError()",
@@ -72514,7 +72721,7 @@
       "source_location": "L302"
     },
     {
-      "community": 178,
+      "community": 179,
       "file_type": "code",
       "id": "toastservice_shownoactivesessionerror",
       "label": "showNoActiveSessionError()",
@@ -72523,7 +72730,7 @@
       "source_location": "L319"
     },
     {
-      "community": 178,
+      "community": 179,
       "file_type": "code",
       "id": "toastservice_showsessionexpirederror",
       "label": "showSessionExpiredError()",
@@ -72532,67 +72739,13 @@
       "source_location": "L312"
     },
     {
-      "community": 178,
+      "community": 179,
       "file_type": "code",
       "id": "toastservice_showvalidationerror",
       "label": "showValidationError()",
       "norm_label": "showvalidationerror()",
       "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
       "source_location": "L293"
-    },
-    {
-      "community": 179,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_traces_traceid_tsx",
-      "label": "$traceId.tsx",
-      "norm_label": "$traceid.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 179,
-      "file_type": "code",
-      "id": "traceid_hasorgnotfoundpayload",
-      "label": "hasOrgNotFoundPayload()",
-      "norm_label": "hasorgnotfoundpayload()",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
-      "source_location": "L12"
-    },
-    {
-      "community": 179,
-      "file_type": "code",
-      "id": "traceid_workflowtraceloadingstate",
-      "label": "WorkflowTraceLoadingState()",
-      "norm_label": "workflowtraceloadingstate()",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
-      "source_location": "L21"
-    },
-    {
-      "community": 179,
-      "file_type": "code",
-      "id": "traceid_workflowtraceroute",
-      "label": "WorkflowTraceRoute()",
-      "norm_label": "workflowtraceroute()",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
-      "source_location": "L101"
-    },
-    {
-      "community": 179,
-      "file_type": "code",
-      "id": "traceid_workflowtraceroutecontent",
-      "label": "WorkflowTraceRouteContent()",
-      "norm_label": "workflowtraceroutecontent()",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
-      "source_location": "L35"
-    },
-    {
-      "community": 179,
-      "file_type": "code",
-      "id": "traceid_workflowtracerouteshell",
-      "label": "WorkflowTraceRouteShell()",
-      "norm_label": "workflowtracerouteshell()",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
-      "source_location": "L66"
     },
     {
       "community": 18,
@@ -72795,6 +72948,60 @@
     {
       "community": 180,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_traces_traceid_tsx",
+      "label": "$traceId.tsx",
+      "norm_label": "$traceid.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 180,
+      "file_type": "code",
+      "id": "traceid_hasorgnotfoundpayload",
+      "label": "hasOrgNotFoundPayload()",
+      "norm_label": "hasorgnotfoundpayload()",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
+      "source_location": "L12"
+    },
+    {
+      "community": 180,
+      "file_type": "code",
+      "id": "traceid_workflowtraceloadingstate",
+      "label": "WorkflowTraceLoadingState()",
+      "norm_label": "workflowtraceloadingstate()",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
+      "source_location": "L21"
+    },
+    {
+      "community": 180,
+      "file_type": "code",
+      "id": "traceid_workflowtraceroute",
+      "label": "WorkflowTraceRoute()",
+      "norm_label": "workflowtraceroute()",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
+      "source_location": "L101"
+    },
+    {
+      "community": 180,
+      "file_type": "code",
+      "id": "traceid_workflowtraceroutecontent",
+      "label": "WorkflowTraceRouteContent()",
+      "norm_label": "workflowtraceroutecontent()",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
+      "source_location": "L35"
+    },
+    {
+      "community": 180,
+      "file_type": "code",
+      "id": "traceid_workflowtracerouteshell",
+      "label": "WorkflowTraceRouteShell()",
+      "norm_label": "workflowtracerouteshell()",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
+      "source_location": "L66"
+    },
+    {
+      "community": 181,
+      "file_type": "code",
       "id": "organizationsettingsview_handledeletestore",
       "label": "handleDeleteStore()",
       "norm_label": "handledeletestore()",
@@ -72802,7 +73009,7 @@
       "source_location": "L155"
     },
     {
-      "community": 180,
+      "community": 181,
       "file_type": "code",
       "id": "organizationsettingsview_navigation",
       "label": "Navigation()",
@@ -72811,7 +73018,7 @@
       "source_location": "L197"
     },
     {
-      "community": 180,
+      "community": 181,
       "file_type": "code",
       "id": "organizationsettingsview_onsubmit",
       "label": "onSubmit()",
@@ -72820,7 +73027,7 @@
       "source_location": "L104"
     },
     {
-      "community": 180,
+      "community": 181,
       "file_type": "code",
       "id": "organizationsettingsview_organizationsettings",
       "label": "OrganizationSettings()",
@@ -72829,7 +73036,7 @@
       "source_location": "L25"
     },
     {
-      "community": 180,
+      "community": 181,
       "file_type": "code",
       "id": "organizationsettingsview_savestorechanges",
       "label": "saveStoreChanges()",
@@ -72838,7 +73045,7 @@
       "source_location": "L72"
     },
     {
-      "community": 180,
+      "community": 181,
       "file_type": "code",
       "id": "packages_athena_webapp_src_settings_organization_components_organizationsettingsview_tsx",
       "label": "OrganizationSettingsView.tsx",
@@ -72847,7 +73054,7 @@
       "source_location": "L1"
     },
     {
-      "community": 181,
+      "community": 182,
       "file_type": "code",
       "id": "packages_athena_webapp_src_settings_store_storesettingsview_tsx",
       "label": "StoreSettingsView.tsx",
@@ -72856,7 +73063,7 @@
       "source_location": "L1"
     },
     {
-      "community": 181,
+      "community": 182,
       "file_type": "code",
       "id": "storesettingsview_handledeleteallproductsinstore",
       "label": "handleDeleteAllProductsInStore()",
@@ -72865,7 +73072,7 @@
       "source_location": "L231"
     },
     {
-      "community": 181,
+      "community": 182,
       "file_type": "code",
       "id": "storesettingsview_handledeletestore",
       "label": "handleDeleteStore()",
@@ -72874,7 +73081,7 @@
       "source_location": "L167"
     },
     {
-      "community": 181,
+      "community": 182,
       "file_type": "code",
       "id": "storesettingsview_onsubmit",
       "label": "onSubmit()",
@@ -72883,7 +73090,7 @@
       "source_location": "L116"
     },
     {
-      "community": 181,
+      "community": 182,
       "file_type": "code",
       "id": "storesettingsview_savestorechanges",
       "label": "saveStoreChanges()",
@@ -72892,7 +73099,7 @@
       "source_location": "L83"
     },
     {
-      "community": 181,
+      "community": 182,
       "file_type": "code",
       "id": "storesettingsview_storesettings",
       "label": "StoreSettings()",
@@ -72901,7 +73108,7 @@
       "source_location": "L29"
     },
     {
-      "community": 182,
+      "community": 183,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_storybook_shell_tsx",
       "label": "storybook-shell.tsx",
@@ -72910,7 +73117,7 @@
       "source_location": "L1"
     },
     {
-      "community": 182,
+      "community": 183,
       "file_type": "code",
       "id": "storybook_shell_storybookcallout",
       "label": "StorybookCallout()",
@@ -72919,7 +73126,7 @@
       "source_location": "L76"
     },
     {
-      "community": 182,
+      "community": 183,
       "file_type": "code",
       "id": "storybook_shell_storybooklist",
       "label": "StorybookList()",
@@ -72928,7 +73135,7 @@
       "source_location": "L55"
     },
     {
-      "community": 182,
+      "community": 183,
       "file_type": "code",
       "id": "storybook_shell_storybookpillrow",
       "label": "StorybookPillRow()",
@@ -72937,7 +73144,7 @@
       "source_location": "L88"
     },
     {
-      "community": 182,
+      "community": 183,
       "file_type": "code",
       "id": "storybook_shell_storybooksection",
       "label": "StorybookSection()",
@@ -72946,7 +73153,7 @@
       "source_location": "L34"
     },
     {
-      "community": 182,
+      "community": 183,
       "file_type": "code",
       "id": "storybook_shell_storybookshell",
       "label": "StorybookShell()",
@@ -72955,7 +73162,7 @@
       "source_location": "L13"
     },
     {
-      "community": 183,
+      "community": 184,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_postransaction_ts",
       "label": "posTransaction.ts",
@@ -72964,7 +73171,7 @@
       "source_location": "L1"
     },
     {
-      "community": 183,
+      "community": 184,
       "file_type": "code",
       "id": "postransaction_fetchpostransaction",
       "label": "fetchPosTransaction()",
@@ -72973,7 +73180,7 @@
       "source_location": "L69"
     },
     {
-      "community": 183,
+      "community": 184,
       "file_type": "code",
       "id": "postransaction_getbaseurl",
       "label": "getBaseUrl()",
@@ -72982,7 +73189,7 @@
       "source_location": "L57"
     },
     {
-      "community": 183,
+      "community": 184,
       "file_type": "code",
       "id": "postransaction_getpostransactionbyreceipttoken",
       "label": "getPosTransactionByReceiptToken()",
@@ -72991,7 +73198,7 @@
       "source_location": "L90"
     },
     {
-      "community": 183,
+      "community": 184,
       "file_type": "code",
       "id": "postransaction_postransactionreceipterror",
       "label": "PosTransactionReceiptError",
@@ -73000,7 +73207,7 @@
       "source_location": "L59"
     },
     {
-      "community": 183,
+      "community": 184,
       "file_type": "code",
       "id": "postransaction_postransactionreceipterror_constructor",
       "label": ".constructor()",
@@ -73009,7 +73216,7 @@
       "source_location": "L62"
     },
     {
-      "community": 184,
+      "community": 185,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_promocodes_ts",
       "label": "promoCodes.ts",
@@ -73018,7 +73225,7 @@
       "source_location": "L1"
     },
     {
-      "community": 184,
+      "community": 185,
       "file_type": "code",
       "id": "promocodes_getbaseurl",
       "label": "getBaseUrl()",
@@ -73027,7 +73234,7 @@
       "source_location": "L4"
     },
     {
-      "community": 184,
+      "community": 185,
       "file_type": "code",
       "id": "promocodes_getpromocodeitems",
       "label": "getPromoCodeItems()",
@@ -73036,7 +73243,7 @@
       "source_location": "L49"
     },
     {
-      "community": 184,
+      "community": 185,
       "file_type": "code",
       "id": "promocodes_getpromocodes",
       "label": "getPromoCodes()",
@@ -73045,7 +73252,7 @@
       "source_location": "L34"
     },
     {
-      "community": 184,
+      "community": 185,
       "file_type": "code",
       "id": "promocodes_getredeemedpromocodes",
       "label": "getRedeemedPromoCodes()",
@@ -73054,7 +73261,7 @@
       "source_location": "L74"
     },
     {
-      "community": 184,
+      "community": 185,
       "file_type": "code",
       "id": "promocodes_redeempromocode",
       "label": "redeemPromoCode()",
@@ -73063,7 +73270,7 @@
       "source_location": "L6"
     },
     {
-      "community": 185,
+      "community": 186,
       "file_type": "code",
       "id": "billingdetails_clearform",
       "label": "clearForm()",
@@ -73072,7 +73279,7 @@
       "source_location": "L173"
     },
     {
-      "community": 185,
+      "community": 186,
       "file_type": "code",
       "id": "billingdetails_enteredbillingaddressdetails",
       "label": "EnteredBillingAddressDetails()",
@@ -73081,7 +73288,7 @@
       "source_location": "L102"
     },
     {
-      "community": 185,
+      "community": 186,
       "file_type": "code",
       "id": "billingdetails_handleusebillingaddressonfile",
       "label": "handleUseBillingAddressOnFile()",
@@ -73090,7 +73297,7 @@
       "source_location": "L201"
     },
     {
-      "community": 185,
+      "community": 186,
       "file_type": "code",
       "id": "billingdetails_onsubmit",
       "label": "onSubmit()",
@@ -73099,7 +73306,7 @@
       "source_location": "L150"
     },
     {
-      "community": 185,
+      "community": 186,
       "file_type": "code",
       "id": "billingdetails_togglesameasdelivery",
       "label": "toggleSameAsDelivery()",
@@ -73108,7 +73315,7 @@
       "source_location": "L155"
     },
     {
-      "community": 185,
+      "community": 186,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_billingdetails_tsx",
       "label": "BillingDetails.tsx",
@@ -73117,7 +73324,7 @@
       "source_location": "L1"
     },
     {
-      "community": 186,
+      "community": 187,
       "file_type": "code",
       "id": "mobileproductactions_collapseonpageclick",
       "label": "collapseOnPageClick()",
@@ -73126,7 +73333,7 @@
       "source_location": "L76"
     },
     {
-      "community": 186,
+      "community": 187,
       "file_type": "code",
       "id": "mobileproductactions_handleconfirm",
       "label": "handleConfirm()",
@@ -73135,7 +73342,7 @@
       "source_location": "L120"
     },
     {
-      "community": 186,
+      "community": 187,
       "file_type": "code",
       "id": "mobileproductactions_handleprimaryaction",
       "label": "handlePrimaryAction()",
@@ -73144,7 +73351,7 @@
       "source_location": "L129"
     },
     {
-      "community": 186,
+      "community": 187,
       "file_type": "code",
       "id": "mobileproductactions_handlesecondaryaction",
       "label": "handleSecondaryAction()",
@@ -73153,7 +73360,7 @@
       "source_location": "L133"
     },
     {
-      "community": 186,
+      "community": 187,
       "file_type": "code",
       "id": "mobileproductactions_updateposition",
       "label": "updatePosition()",
@@ -73162,7 +73369,7 @@
       "source_location": "L44"
     },
     {
-      "community": 186,
+      "community": 187,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_mobileproductactions_tsx",
       "label": "MobileProductActions.tsx",
@@ -73171,7 +73378,7 @@
       "source_location": "L1"
     },
     {
-      "community": 187,
+      "community": 188,
       "file_type": "code",
       "id": "checkoutexpired_checkoutexpired",
       "label": "CheckoutExpired()",
@@ -73180,7 +73387,7 @@
       "source_location": "L9"
     },
     {
-      "community": 187,
+      "community": 188,
       "file_type": "code",
       "id": "checkoutexpired_checkoutsessiongeneric",
       "label": "CheckoutSessionGeneric()",
@@ -73189,7 +73396,7 @@
       "source_location": "L73"
     },
     {
-      "community": 187,
+      "community": 188,
       "file_type": "code",
       "id": "checkoutexpired_checkoutsessionnotfound",
       "label": "CheckoutSessionNotFound()",
@@ -73198,7 +73405,7 @@
       "source_location": "L54"
     },
     {
-      "community": 187,
+      "community": 188,
       "file_type": "code",
       "id": "checkoutexpired_handlesendemail",
       "label": "handleSendEmail()",
@@ -73207,7 +73414,7 @@
       "source_location": "L98"
     },
     {
-      "community": 187,
+      "community": 188,
       "file_type": "code",
       "id": "checkoutexpired_nocheckoutsession",
       "label": "NoCheckoutSession()",
@@ -73216,66 +73423,12 @@
       "source_location": "L33"
     },
     {
-      "community": 187,
+      "community": 188,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_checkout_expired_checkoutexpired_tsx",
       "label": "CheckoutExpired.tsx",
       "norm_label": "checkoutexpired.tsx",
       "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 188,
-      "file_type": "code",
-      "id": "image_uploader_ondragend",
-      "label": "onDragEnd()",
-      "norm_label": "ondragend()",
-      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L100"
-    },
-    {
-      "community": 188,
-      "file_type": "code",
-      "id": "image_uploader_ondrop",
-      "label": "onDrop()",
-      "norm_label": "ondrop()",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L20"
-    },
-    {
-      "community": 188,
-      "file_type": "code",
-      "id": "image_uploader_removeimage",
-      "label": "removeImage()",
-      "norm_label": "removeimage()",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L31"
-    },
-    {
-      "community": 188,
-      "file_type": "code",
-      "id": "image_uploader_unmarkfordeletion",
-      "label": "unmarkForDeletion()",
-      "norm_label": "unmarkfordeletion()",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L46"
-    },
-    {
-      "community": 188,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_image_uploader_tsx",
-      "label": "image-uploader.tsx",
-      "norm_label": "image-uploader.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 188,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_image_uploader_tsx",
-      "label": "image-uploader.tsx",
-      "norm_label": "image-uploader.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
       "source_location": "L1"
     },
     {
@@ -78366,6 +78519,42 @@
     {
       "community": 261,
       "file_type": "code",
+      "id": "dailyclose_test_createdb",
+      "label": "createDb()",
+      "norm_label": "createdb()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
+      "source_location": "L30"
+    },
+    {
+      "community": 261,
+      "file_type": "code",
+      "id": "dailyclose_test_dailycloseapprovalproof",
+      "label": "dailyCloseApprovalProof()",
+      "norm_label": "dailycloseapprovalproof()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
+      "source_location": "L240"
+    },
+    {
+      "community": 261,
+      "file_type": "code",
+      "id": "dailyclose_test_dailyclosesummary",
+      "label": "dailyCloseSummary()",
+      "norm_label": "dailyclosesummary()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
+      "source_location": "L215"
+    },
+    {
+      "community": 261,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_dailyclose_test_ts",
+      "label": "dailyClose.test.ts",
+      "norm_label": "dailyclose.test.ts",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 262,
+      "file_type": "code",
       "id": "operationalevents_buildoperationalevent",
       "label": "buildOperationalEvent()",
       "norm_label": "buildoperationalevent()",
@@ -78373,7 +78562,7 @@
       "source_location": "L28"
     },
     {
-      "community": 261,
+      "community": 262,
       "file_type": "code",
       "id": "operationalevents_matchesexistingevent",
       "label": "matchesExistingEvent()",
@@ -78382,7 +78571,7 @@
       "source_location": "L42"
     },
     {
-      "community": 261,
+      "community": 262,
       "file_type": "code",
       "id": "operationalevents_recordoperationaleventwithctx",
       "label": "recordOperationalEventWithCtx()",
@@ -78391,7 +78580,7 @@
       "source_location": "L73"
     },
     {
-      "community": 261,
+      "community": 262,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_operationalevents_ts",
       "label": "operationalEvents.ts",
@@ -78400,7 +78589,7 @@
       "source_location": "L1"
     },
     {
-      "community": 262,
+      "community": 263,
       "file_type": "code",
       "id": "operationalworkitems_buildoperationalworkitem",
       "label": "buildOperationalWorkItem()",
@@ -78409,7 +78598,7 @@
       "source_location": "L13"
     },
     {
-      "community": 262,
+      "community": 263,
       "file_type": "code",
       "id": "operationalworkitems_createoperationalworkitemwithctx",
       "label": "createOperationalWorkItemWithCtx()",
@@ -78418,7 +78607,7 @@
       "source_location": "L37"
     },
     {
-      "community": 262,
+      "community": 263,
       "file_type": "code",
       "id": "operationalworkitems_updateoperationalworkitemstatuswithctx",
       "label": "updateOperationalWorkItemStatusWithCtx()",
@@ -78427,7 +78616,7 @@
       "source_location": "L69"
     },
     {
-      "community": 262,
+      "community": 263,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_operationalworkitems_ts",
       "label": "operationalWorkItems.ts",
@@ -78436,7 +78625,7 @@
       "source_location": "L1"
     },
     {
-      "community": 263,
+      "community": 264,
       "file_type": "code",
       "id": "operationsqueryindexes_test_expectindex",
       "label": "expectIndex()",
@@ -78445,7 +78634,7 @@
       "source_location": "L18"
     },
     {
-      "community": 263,
+      "community": 264,
       "file_type": "code",
       "id": "operationsqueryindexes_test_getsource",
       "label": "getSource()",
@@ -78454,7 +78643,7 @@
       "source_location": "L25"
     },
     {
-      "community": 263,
+      "community": 264,
       "file_type": "code",
       "id": "operationsqueryindexes_test_gettableindexes",
       "label": "getTableIndexes()",
@@ -78463,7 +78652,7 @@
       "source_location": "L11"
     },
     {
-      "community": 263,
+      "community": 264,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_operationsqueryindexes_test_ts",
       "label": "operationsQueryIndexes.test.ts",
@@ -78472,7 +78661,7 @@
       "source_location": "L1"
     },
     {
-      "community": 264,
+      "community": 265,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_registersessiontracing_test_ts",
       "label": "registerSessionTracing.test.ts",
@@ -78481,7 +78670,7 @@
       "source_location": "L1"
     },
     {
-      "community": 264,
+      "community": 265,
       "file_type": "code",
       "id": "registersessiontracing_test_buildctx",
       "label": "buildCtx()",
@@ -78490,7 +78679,7 @@
       "source_location": "L33"
     },
     {
-      "community": 264,
+      "community": 265,
       "file_type": "code",
       "id": "registersessiontracing_test_buildsession",
       "label": "buildSession()",
@@ -78499,7 +78688,7 @@
       "source_location": "L19"
     },
     {
-      "community": 264,
+      "community": 265,
       "file_type": "code",
       "id": "registersessiontracing_test_formatstoredtraceamount",
       "label": "formatStoredTraceAmount()",
@@ -78508,7 +78697,7 @@
       "source_location": "L42"
     },
     {
-      "community": 265,
+      "community": 266,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_registersessions_trace_test_ts",
       "label": "registerSessions.trace.test.ts",
@@ -78517,7 +78706,7 @@
       "source_location": "L1"
     },
     {
-      "community": 265,
+      "community": 266,
       "file_type": "code",
       "id": "registersessions_trace_test_buildregistersession",
       "label": "buildRegisterSession()",
@@ -78526,7 +78715,7 @@
       "source_location": "L31"
     },
     {
-      "community": 265,
+      "community": 266,
       "file_type": "code",
       "id": "registersessions_trace_test_createmutationctx",
       "label": "createMutationCtx()",
@@ -78535,7 +78724,7 @@
       "source_location": "L48"
     },
     {
-      "community": 265,
+      "community": 266,
       "file_type": "code",
       "id": "registersessions_trace_test_gethandler",
       "label": "getHandler()",
@@ -78544,7 +78733,7 @@
       "source_location": "L131"
     },
     {
-      "community": 266,
+      "community": 267,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_serviceintake_ts",
       "label": "serviceIntake.ts",
@@ -78553,7 +78742,7 @@
       "source_location": "L1"
     },
     {
-      "community": 266,
+      "community": 267,
       "file_type": "code",
       "id": "serviceintake_resolveserviceintakecustomerprofile",
       "label": "resolveServiceIntakeCustomerProfile()",
@@ -78562,7 +78751,7 @@
       "source_location": "L37"
     },
     {
-      "community": 266,
+      "community": 267,
       "file_type": "code",
       "id": "serviceintake_splitfullname",
       "label": "splitFullName()",
@@ -78571,7 +78760,7 @@
       "source_location": "L24"
     },
     {
-      "community": 266,
+      "community": 267,
       "file_type": "code",
       "id": "serviceintake_trimoptional",
       "label": "trimOptional()",
@@ -78580,7 +78769,7 @@
       "source_location": "L19"
     },
     {
-      "community": 267,
+      "community": 268,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_commands_register_ts",
       "label": "register.ts",
@@ -78589,7 +78778,7 @@
       "source_location": "L1"
     },
     {
-      "community": 267,
+      "community": 268,
       "file_type": "code",
       "id": "register_mapopendrawerusererror",
       "label": "mapOpenDrawerUserError()",
@@ -78598,7 +78787,7 @@
       "source_location": "L31"
     },
     {
-      "community": 267,
+      "community": 268,
       "file_type": "code",
       "id": "register_normalizeregisternumber",
       "label": "normalizeRegisterNumber()",
@@ -78607,7 +78796,7 @@
       "source_location": "L26"
     },
     {
-      "community": 267,
+      "community": 268,
       "file_type": "code",
       "id": "register_opendrawer",
       "label": "openDrawer()",
@@ -78616,7 +78805,7 @@
       "source_location": "L53"
     },
     {
-      "community": 268,
+      "community": 269,
       "file_type": "code",
       "id": "opendrawer_test_createdbgetmock",
       "label": "createDbGetMock()",
@@ -78625,7 +78814,7 @@
       "source_location": "L36"
     },
     {
-      "community": 268,
+      "community": 269,
       "file_type": "code",
       "id": "opendrawer_test_createdbmock",
       "label": "createDbMock()",
@@ -78634,7 +78823,7 @@
       "source_location": "L96"
     },
     {
-      "community": 268,
+      "community": 269,
       "file_type": "code",
       "id": "opendrawer_test_createdbquerymock",
       "label": "createDbQueryMock()",
@@ -78643,48 +78832,12 @@
       "source_location": "L71"
     },
     {
-      "community": 268,
+      "community": 269,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_opendrawer_test_ts",
       "label": "openDrawer.test.ts",
       "norm_label": "opendrawer.test.ts",
       "source_file": "packages/athena-webapp/convex/pos/application/openDrawer.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 269,
-      "file_type": "code",
-      "id": "getregisterstate_buildregisterstate",
-      "label": "buildRegisterState()",
-      "norm_label": "buildregisterstate()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/getRegisterState.ts",
-      "source_location": "L21"
-    },
-    {
-      "community": 269,
-      "file_type": "code",
-      "id": "getregisterstate_getactivesessionconflictforregisterstate",
-      "label": "getActiveSessionConflictForRegisterState()",
-      "norm_label": "getactivesessionconflictforregisterstate()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/getRegisterState.ts",
-      "source_location": "L42"
-    },
-    {
-      "community": 269,
-      "file_type": "code",
-      "id": "getregisterstate_getregisterstate",
-      "label": "getRegisterState()",
-      "norm_label": "getregisterstate()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/getRegisterState.ts",
-      "source_location": "L80"
-    },
-    {
-      "community": 269,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_queries_getregisterstate_ts",
-      "label": "getRegisterState.ts",
-      "norm_label": "getregisterstate.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/getRegisterState.ts",
       "source_location": "L1"
     },
     {
@@ -78861,6 +79014,42 @@
     {
       "community": 270,
       "file_type": "code",
+      "id": "getregisterstate_buildregisterstate",
+      "label": "buildRegisterState()",
+      "norm_label": "buildregisterstate()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getRegisterState.ts",
+      "source_location": "L21"
+    },
+    {
+      "community": 270,
+      "file_type": "code",
+      "id": "getregisterstate_getactivesessionconflictforregisterstate",
+      "label": "getActiveSessionConflictForRegisterState()",
+      "norm_label": "getactivesessionconflictforregisterstate()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getRegisterState.ts",
+      "source_location": "L42"
+    },
+    {
+      "community": 270,
+      "file_type": "code",
+      "id": "getregisterstate_getregisterstate",
+      "label": "getRegisterState()",
+      "norm_label": "getregisterstate()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getRegisterState.ts",
+      "source_location": "L80"
+    },
+    {
+      "community": 270,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_queries_getregisterstate_ts",
+      "label": "getRegisterState.ts",
+      "norm_label": "getregisterstate.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getRegisterState.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 271,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_queries_searchcatalog_ts",
       "label": "searchCatalog.ts",
       "norm_label": "searchcatalog.ts",
@@ -78868,7 +79057,7 @@
       "source_location": "L1"
     },
     {
-      "community": 270,
+      "community": 271,
       "file_type": "code",
       "id": "searchcatalog_lookupbybarcode",
       "label": "lookupByBarcode()",
@@ -78877,7 +79066,7 @@
       "source_location": "L126"
     },
     {
-      "community": 270,
+      "community": 271,
       "file_type": "code",
       "id": "searchcatalog_mapskutocatalogresult",
       "label": "mapSkuToCatalogResult()",
@@ -78886,7 +79075,7 @@
       "source_location": "L34"
     },
     {
-      "community": 270,
+      "community": 271,
       "file_type": "code",
       "id": "searchcatalog_searchproducts",
       "label": "searchProducts()",
@@ -78895,7 +79084,7 @@
       "source_location": "L76"
     },
     {
-      "community": 271,
+      "community": 272,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_sessioncommandrepository_ts",
       "label": "sessionCommandRepository.ts",
@@ -78904,7 +79093,7 @@
       "source_location": "L1"
     },
     {
-      "community": 271,
+      "community": 272,
       "file_type": "code",
       "id": "sessioncommandrepository_collectsessionitemsfrompages",
       "label": "collectSessionItemsFromPages()",
@@ -78913,7 +79102,7 @@
       "source_location": "L159"
     },
     {
-      "community": 271,
+      "community": 272,
       "file_type": "code",
       "id": "sessioncommandrepository_createsessioncommandrepository",
       "label": "createSessionCommandRepository()",
@@ -78922,7 +79111,7 @@
       "source_location": "L56"
     },
     {
-      "community": 271,
+      "community": 272,
       "file_type": "code",
       "id": "sessioncommandrepository_scansessionitembyskuinpages",
       "label": "scanSessionItemBySkuInPages()",
@@ -78931,7 +79120,7 @@
       "source_location": "L177"
     },
     {
-      "community": 272,
+      "community": 273,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_transactions_test_ts",
       "label": "transactions.test.ts",
@@ -78940,7 +79129,7 @@
       "source_location": "L1"
     },
     {
-      "community": 272,
+      "community": 273,
       "file_type": "code",
       "id": "transactions_test_exportreturns",
       "label": "exportReturns()",
@@ -78949,7 +79138,7 @@
       "source_location": "L30"
     },
     {
-      "community": 272,
+      "community": 273,
       "file_type": "code",
       "id": "transactions_test_gethandler",
       "label": "getHandler()",
@@ -78958,7 +79147,7 @@
       "source_location": "L38"
     },
     {
-      "community": 272,
+      "community": 273,
       "file_type": "code",
       "id": "transactions_test_parsevalidator",
       "label": "parseValidator()",
@@ -78967,7 +79156,7 @@
       "source_location": "L34"
     },
     {
-      "community": 273,
+      "community": 274,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_replenishment_test_ts",
       "label": "replenishment.test.ts",
@@ -78976,7 +79165,7 @@
       "source_location": "L1"
     },
     {
-      "community": 273,
+      "community": 274,
       "file_type": "code",
       "id": "replenishment_test_createreplenishmentqueryctx",
       "label": "createReplenishmentQueryCtx()",
@@ -78985,7 +79174,7 @@
       "source_location": "L21"
     },
     {
-      "community": 273,
+      "community": 274,
       "file_type": "code",
       "id": "replenishment_test_getsource",
       "label": "getSource()",
@@ -78994,7 +79183,7 @@
       "source_location": "L7"
     },
     {
-      "community": 273,
+      "community": 274,
       "file_type": "code",
       "id": "replenishment_test_toasynciterable",
       "label": "toAsyncIterable()",
@@ -79003,7 +79192,7 @@
       "source_location": "L11"
     },
     {
-      "community": 274,
+      "community": 275,
       "file_type": "code",
       "id": "commercequeryindexes_test_expectindex",
       "label": "expectIndex()",
@@ -79012,7 +79201,7 @@
       "source_location": "L19"
     },
     {
-      "community": 274,
+      "community": 275,
       "file_type": "code",
       "id": "commercequeryindexes_test_getsource",
       "label": "getSource()",
@@ -79021,7 +79210,7 @@
       "source_location": "L26"
     },
     {
-      "community": 274,
+      "community": 275,
       "file_type": "code",
       "id": "commercequeryindexes_test_gettableindexes",
       "label": "getTableIndexes()",
@@ -79030,7 +79219,7 @@
       "source_location": "L12"
     },
     {
-      "community": 274,
+      "community": 275,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_commercequeryindexes_test_ts",
       "label": "commerceQueryIndexes.test.ts",
@@ -79039,7 +79228,7 @@
       "source_location": "L1"
     },
     {
-      "community": 275,
+      "community": 276,
       "file_type": "code",
       "id": "customerengagementevents_findexistingcustomerprofileid",
       "label": "findExistingCustomerProfileId()",
@@ -79048,7 +79237,7 @@
       "source_location": "L21"
     },
     {
-      "community": 275,
+      "community": 276,
       "file_type": "code",
       "id": "customerengagementevents_getstoreorganizationid",
       "label": "getStoreOrganizationId()",
@@ -79057,7 +79246,7 @@
       "source_location": "L63"
     },
     {
-      "community": 275,
+      "community": 276,
       "file_type": "code",
       "id": "customerengagementevents_recordstorefrontcustomermilestone",
       "label": "recordStoreFrontCustomerMilestone()",
@@ -79066,7 +79255,7 @@
       "source_location": "L71"
     },
     {
-      "community": 275,
+      "community": 276,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_helpers_customerengagementevents_ts",
       "label": "customerEngagementEvents.ts",
@@ -79075,7 +79264,7 @@
       "source_location": "L1"
     },
     {
-      "community": 276,
+      "community": 277,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_returnexchangeoperations_test_ts",
       "label": "returnExchangeOperations.test.ts",
@@ -79084,7 +79273,7 @@
       "source_location": "L1"
     },
     {
-      "community": 276,
+      "community": 277,
       "file_type": "code",
       "id": "returnexchangeoperations_test_createorderitem",
       "label": "createOrderItem()",
@@ -79093,7 +79282,7 @@
       "source_location": "L13"
     },
     {
-      "community": 276,
+      "community": 277,
       "file_type": "code",
       "id": "returnexchangeoperations_test_createreplacement",
       "label": "createReplacement()",
@@ -79102,7 +79291,7 @@
       "source_location": "L31"
     },
     {
-      "community": 276,
+      "community": 277,
       "file_type": "code",
       "id": "returnexchangeoperations_test_getsource",
       "label": "getSource()",
@@ -79111,7 +79300,7 @@
       "source_location": "L9"
     },
     {
-      "community": 277,
+      "community": 278,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_staffdisplayname_ts",
       "label": "staffDisplayName.ts",
@@ -79120,7 +79309,7 @@
       "source_location": "L1"
     },
     {
-      "community": 277,
+      "community": 278,
       "file_type": "code",
       "id": "staffdisplayname_formatstaffdisplayname",
       "label": "formatStaffDisplayName()",
@@ -79129,7 +79318,7 @@
       "source_location": "L12"
     },
     {
-      "community": 277,
+      "community": 278,
       "file_type": "code",
       "id": "staffdisplayname_formatstaffdisplaynameorfallback",
       "label": "formatStaffDisplayNameOrFallback()",
@@ -79138,7 +79327,7 @@
       "source_location": "L46"
     },
     {
-      "community": 277,
+      "community": 278,
       "file_type": "code",
       "id": "staffdisplayname_normalizenamepart",
       "label": "normalizeNamePart()",
@@ -79147,7 +79336,7 @@
       "source_location": "L7"
     },
     {
-      "community": 278,
+      "community": 279,
       "file_type": "code",
       "id": "attributesmanager_attributesmanager",
       "label": "AttributesManager()",
@@ -79156,7 +79345,7 @@
       "source_location": "L227"
     },
     {
-      "community": 278,
+      "community": 279,
       "file_type": "code",
       "id": "attributesmanager_colormanager",
       "label": "ColorManager()",
@@ -79165,7 +79354,7 @@
       "source_location": "L46"
     },
     {
-      "community": 278,
+      "community": 279,
       "file_type": "code",
       "id": "attributesmanager_sidebar",
       "label": "Sidebar()",
@@ -79174,48 +79363,12 @@
       "source_location": "L27"
     },
     {
-      "community": 278,
+      "community": 279,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_attributesmanager_tsx",
       "label": "AttributesManager.tsx",
       "norm_label": "attributesmanager.tsx",
       "source_file": "packages/athena-webapp/src/components/add-product/AttributesManager.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 279,
-      "file_type": "code",
-      "id": "attributestable_getproductattribute",
-      "label": "getProductAttribute()",
-      "norm_label": "getproductattribute()",
-      "source_file": "packages/athena-webapp/src/components/add-product/AttributesTable.tsx",
-      "source_location": "L55"
-    },
-    {
-      "community": 279,
-      "file_type": "code",
-      "id": "attributestable_handlechange",
-      "label": "handleChange()",
-      "norm_label": "handlechange()",
-      "source_file": "packages/athena-webapp/src/components/add-product/AttributesTable.tsx",
-      "source_location": "L32"
-    },
-    {
-      "community": 279,
-      "file_type": "code",
-      "id": "attributestable_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/athena-webapp/src/components/add-product/AttributesTable.tsx",
-      "source_location": "L211"
-    },
-    {
-      "community": 279,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_attributestable_tsx",
-      "label": "AttributesTable.tsx",
-      "norm_label": "attributestable.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/AttributesTable.tsx",
       "source_location": "L1"
     },
     {
@@ -79392,6 +79545,42 @@
     {
       "community": 280,
       "file_type": "code",
+      "id": "attributestable_getproductattribute",
+      "label": "getProductAttribute()",
+      "norm_label": "getproductattribute()",
+      "source_file": "packages/athena-webapp/src/components/add-product/AttributesTable.tsx",
+      "source_location": "L55"
+    },
+    {
+      "community": 280,
+      "file_type": "code",
+      "id": "attributestable_handlechange",
+      "label": "handleChange()",
+      "norm_label": "handlechange()",
+      "source_file": "packages/athena-webapp/src/components/add-product/AttributesTable.tsx",
+      "source_location": "L32"
+    },
+    {
+      "community": 280,
+      "file_type": "code",
+      "id": "attributestable_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/athena-webapp/src/components/add-product/AttributesTable.tsx",
+      "source_location": "L211"
+    },
+    {
+      "community": 280,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_attributestable_tsx",
+      "label": "AttributesTable.tsx",
+      "norm_label": "attributestable.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/AttributesTable.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 281,
+      "file_type": "code",
       "id": "categorysubcategorymanager_categorymanager",
       "label": "CategoryManager()",
       "norm_label": "categorymanager()",
@@ -79399,7 +79588,7 @@
       "source_location": "L52"
     },
     {
-      "community": 280,
+      "community": 281,
       "file_type": "code",
       "id": "categorysubcategorymanager_sidebar",
       "label": "Sidebar()",
@@ -79408,7 +79597,7 @@
       "source_location": "L27"
     },
     {
-      "community": 280,
+      "community": 281,
       "file_type": "code",
       "id": "categorysubcategorymanager_subcategorymanager",
       "label": "SubcategoryManager()",
@@ -79417,7 +79606,7 @@
       "source_location": "L288"
     },
     {
-      "community": 280,
+      "community": 281,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_categorysubcategorymanager_tsx",
       "label": "CategorySubcategoryManager.tsx",
@@ -79426,7 +79615,7 @@
       "source_location": "L1"
     },
     {
-      "community": 281,
+      "community": 282,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_storefrontobservabilitypanel_tsx",
       "label": "StorefrontObservabilityPanel.tsx",
@@ -79435,7 +79624,7 @@
       "source_location": "L1"
     },
     {
-      "community": 281,
+      "community": 282,
       "file_type": "code",
       "id": "storefrontobservabilitypanel_formatlabel",
       "label": "formatLabel()",
@@ -79444,7 +79633,7 @@
       "source_location": "L15"
     },
     {
-      "community": 281,
+      "community": 282,
       "file_type": "code",
       "id": "storefrontobservabilitypanel_gettrafficsourcebadge",
       "label": "getTrafficSourceBadge()",
@@ -79453,7 +79642,7 @@
       "source_location": "L32"
     },
     {
-      "community": 281,
+      "community": 282,
       "file_type": "code",
       "id": "storefrontobservabilitypanel_summarycard",
       "label": "SummaryCard()",
@@ -79462,7 +79651,7 @@
       "source_location": "L19"
     },
     {
-      "community": 282,
+      "community": 283,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_utils_ts",
       "label": "utils.ts",
@@ -79471,7 +79660,7 @@
       "source_location": "L1"
     },
     {
-      "community": 282,
+      "community": 283,
       "file_type": "code",
       "id": "utils_countgroupedanalytics",
       "label": "countGroupedAnalytics()",
@@ -79480,7 +79669,7 @@
       "source_location": "L52"
     },
     {
-      "community": 282,
+      "community": 283,
       "file_type": "code",
       "id": "utils_groupanalytics",
       "label": "groupAnalytics()",
@@ -79489,7 +79678,7 @@
       "source_location": "L3"
     },
     {
-      "community": 282,
+      "community": 283,
       "file_type": "code",
       "id": "utils_groupproductviewsbyday",
       "label": "groupProductViewsByDay()",
@@ -79498,7 +79687,7 @@
       "source_location": "L90"
     },
     {
-      "community": 283,
+      "community": 284,
       "file_type": "code",
       "id": "maintenancemessageeditor_getcountdownstatus",
       "label": "getCountdownStatus()",
@@ -79507,7 +79696,7 @@
       "source_location": "L86"
     },
     {
-      "community": 283,
+      "community": 284,
       "file_type": "code",
       "id": "maintenancemessageeditor_handlecountdownchange",
       "label": "handleCountdownChange()",
@@ -79516,7 +79705,7 @@
       "source_location": "L76"
     },
     {
-      "community": 283,
+      "community": 284,
       "file_type": "code",
       "id": "maintenancemessageeditor_handlesave",
       "label": "handleSave()",
@@ -79525,7 +79714,7 @@
       "source_location": "L52"
     },
     {
-      "community": 283,
+      "community": 284,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_maintenancemessageeditor_tsx",
       "label": "MaintenanceMessageEditor.tsx",
@@ -79534,7 +79723,7 @@
       "source_location": "L1"
     },
     {
-      "community": 284,
+      "community": 285,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_shoplook_tsx",
       "label": "ShopLook.tsx",
@@ -79543,7 +79732,7 @@
       "source_location": "L1"
     },
     {
-      "community": 284,
+      "community": 285,
       "file_type": "code",
       "id": "shoplook_handlehighlighteditem",
       "label": "handleHighlightedItem()",
@@ -79552,7 +79741,7 @@
       "source_location": "L67"
     },
     {
-      "community": 284,
+      "community": 285,
       "file_type": "code",
       "id": "shoplook_handleimageupdate",
       "label": "handleImageUpdate()",
@@ -79561,7 +79750,7 @@
       "source_location": "L90"
     },
     {
-      "community": 284,
+      "community": 285,
       "file_type": "code",
       "id": "shoplook_ondragend",
       "label": "onDragEnd()",
@@ -79570,7 +79759,7 @@
       "source_location": "L73"
     },
     {
-      "community": 285,
+      "community": 286,
       "file_type": "code",
       "id": "commandapprovaldialog_getasyncresolution",
       "label": "getAsyncResolution()",
@@ -79579,7 +79768,7 @@
       "source_location": "L78"
     },
     {
-      "community": 285,
+      "community": 286,
       "file_type": "code",
       "id": "commandapprovaldialog_getinlinemanagerresolution",
       "label": "getInlineManagerResolution()",
@@ -79588,7 +79777,7 @@
       "source_location": "L67"
     },
     {
-      "community": 285,
+      "community": 286,
       "file_type": "code",
       "id": "commandapprovaldialog_tostaffauthenticationresult",
       "label": "toStaffAuthenticationResult()",
@@ -79597,7 +79786,7 @@
       "source_location": "L85"
     },
     {
-      "community": 285,
+      "community": 286,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_commandapprovaldialog_tsx",
       "label": "CommandApprovalDialog.tsx",
@@ -79606,7 +79795,7 @@
       "source_location": "L1"
     },
     {
-      "community": 286,
+      "community": 287,
       "file_type": "code",
       "id": "dailycloseview_test_disconnect",
       "label": "disconnect()",
@@ -79615,7 +79804,7 @@
       "source_location": "L310"
     },
     {
-      "community": 286,
+      "community": 287,
       "file_type": "code",
       "id": "dailycloseview_test_observe",
       "label": "observe()",
@@ -79624,7 +79813,7 @@
       "source_location": "L311"
     },
     {
-      "community": 286,
+      "community": 287,
       "file_type": "code",
       "id": "dailycloseview_test_unobserve",
       "label": "unobserve()",
@@ -79633,7 +79822,7 @@
       "source_location": "L312"
     },
     {
-      "community": 286,
+      "community": 287,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_dailycloseview_test_tsx",
       "label": "DailyCloseView.test.tsx",
@@ -79642,7 +79831,7 @@
       "source_location": "L1"
     },
     {
-      "community": 287,
+      "community": 288,
       "file_type": "code",
       "id": "operationsqueueview_test_disconnect",
       "label": "disconnect()",
@@ -79651,7 +79840,7 @@
       "source_location": "L221"
     },
     {
-      "community": 287,
+      "community": 288,
       "file_type": "code",
       "id": "operationsqueueview_test_observe",
       "label": "observe()",
@@ -79660,7 +79849,7 @@
       "source_location": "L222"
     },
     {
-      "community": 287,
+      "community": 288,
       "file_type": "code",
       "id": "operationsqueueview_test_unobserve",
       "label": "unobserve()",
@@ -79669,7 +79858,7 @@
       "source_location": "L223"
     },
     {
-      "community": 287,
+      "community": 288,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_operationsqueueview_test_tsx",
       "label": "OperationsQueueView.test.tsx",
@@ -79678,7 +79867,7 @@
       "source_location": "L1"
     },
     {
-      "community": 288,
+      "community": 289,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_returnexchangeview_tsx",
       "label": "ReturnExchangeView.tsx",
@@ -79687,7 +79876,7 @@
       "source_location": "L1"
     },
     {
-      "community": 288,
+      "community": 289,
       "file_type": "code",
       "id": "returnexchangeview_handlesubmit",
       "label": "handleSubmit()",
@@ -79696,7 +79885,7 @@
       "source_location": "L125"
     },
     {
-      "community": 288,
+      "community": 289,
       "file_type": "code",
       "id": "returnexchangeview_resetreplacementfields",
       "label": "resetReplacementFields()",
@@ -79705,49 +79894,13 @@
       "source_location": "L117"
     },
     {
-      "community": 288,
+      "community": 289,
       "file_type": "code",
       "id": "returnexchangeview_toggleitem",
       "label": "toggleItem()",
       "norm_label": "toggleitem()",
       "source_file": "packages/athena-webapp/src/components/orders/ReturnExchangeView.tsx",
       "source_location": "L103"
-    },
-    {
-      "community": 289,
-      "file_type": "code",
-      "id": "newtransactionview_handlequickstart",
-      "label": "handleQuickStart()",
-      "norm_label": "handlequickstart()",
-      "source_file": "packages/athena-webapp/src/components/pos/NewTransactionView.tsx",
-      "source_location": "L91"
-    },
-    {
-      "community": 289,
-      "file_type": "code",
-      "id": "newtransactionview_handlestarttransaction",
-      "label": "handleStartTransaction()",
-      "norm_label": "handlestarttransaction()",
-      "source_file": "packages/athena-webapp/src/components/pos/NewTransactionView.tsx",
-      "source_location": "L68"
-    },
-    {
-      "community": 289,
-      "file_type": "code",
-      "id": "newtransactionview_navigation",
-      "label": "Navigation()",
-      "norm_label": "navigation()",
-      "source_file": "packages/athena-webapp/src/components/pos/NewTransactionView.tsx",
-      "source_location": "L22"
-    },
-    {
-      "community": 289,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_newtransactionview_tsx",
-      "label": "NewTransactionView.tsx",
-      "norm_label": "newtransactionview.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/NewTransactionView.tsx",
-      "source_location": "L1"
     },
     {
       "community": 29,
@@ -79923,6 +80076,42 @@
     {
       "community": 290,
       "file_type": "code",
+      "id": "newtransactionview_handlequickstart",
+      "label": "handleQuickStart()",
+      "norm_label": "handlequickstart()",
+      "source_file": "packages/athena-webapp/src/components/pos/NewTransactionView.tsx",
+      "source_location": "L91"
+    },
+    {
+      "community": 290,
+      "file_type": "code",
+      "id": "newtransactionview_handlestarttransaction",
+      "label": "handleStartTransaction()",
+      "norm_label": "handlestarttransaction()",
+      "source_file": "packages/athena-webapp/src/components/pos/NewTransactionView.tsx",
+      "source_location": "L68"
+    },
+    {
+      "community": 290,
+      "file_type": "code",
+      "id": "newtransactionview_navigation",
+      "label": "Navigation()",
+      "norm_label": "navigation()",
+      "source_file": "packages/athena-webapp/src/components/pos/NewTransactionView.tsx",
+      "source_location": "L22"
+    },
+    {
+      "community": 290,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_newtransactionview_tsx",
+      "label": "NewTransactionView.tsx",
+      "norm_label": "newtransactionview.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/NewTransactionView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 291,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_transactions_transactionview_test_tsx",
       "label": "TransactionView.test.tsx",
       "norm_label": "transactionview.test.tsx",
@@ -79930,7 +80119,7 @@
       "source_location": "L1"
     },
     {
-      "community": 290,
+      "community": 291,
       "file_type": "code",
       "id": "transactionview_test_async",
       "label": "async()",
@@ -79939,7 +80128,7 @@
       "source_location": "L164"
     },
     {
-      "community": 290,
+      "community": 291,
       "file_type": "code",
       "id": "transactionview_test_mocktransactionmutations",
       "label": "mockTransactionMutations()",
@@ -79948,7 +80137,7 @@
       "source_location": "L388"
     },
     {
-      "community": 290,
+      "community": 291,
       "file_type": "code",
       "id": "transactionview_test_paymentapprovalrequirement",
       "label": "paymentApprovalRequirement()",
@@ -79957,7 +80146,7 @@
       "source_location": "L347"
     },
     {
-      "community": 291,
+      "community": 292,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_procurement_procurementview_test_tsx",
       "label": "ProcurementView.test.tsx",
@@ -79966,7 +80155,7 @@
       "source_location": "L1"
     },
     {
-      "community": 291,
+      "community": 292,
       "file_type": "code",
       "id": "procurementview_test_choosedraftvendor",
       "label": "chooseDraftVendor()",
@@ -79975,7 +80164,7 @@
       "source_location": "L324"
     },
     {
-      "community": 291,
+      "community": 292,
       "file_type": "code",
       "id": "procurementview_test_installmutationmocks",
       "label": "installMutationMocks()",
@@ -79984,7 +80173,7 @@
       "source_location": "L290"
     },
     {
-      "community": 291,
+      "community": 292,
       "file_type": "code",
       "id": "procurementview_test_makerecommendation",
       "label": "makeRecommendation()",
@@ -79993,7 +80182,7 @@
       "source_location": "L279"
     },
     {
-      "community": 292,
+      "community": 293,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_productstock_tsx",
       "label": "ProductStock.tsx",
@@ -80002,7 +80191,7 @@
       "source_location": "L1"
     },
     {
-      "community": 292,
+      "community": 293,
       "file_type": "code",
       "id": "productstock_lowstockstatus",
       "label": "LowStockStatus()",
@@ -80011,7 +80200,7 @@
       "source_location": "L63"
     },
     {
-      "community": 292,
+      "community": 293,
       "file_type": "code",
       "id": "productstock_outofstockstatus",
       "label": "OutOfStockStatus()",
@@ -80020,7 +80209,7 @@
       "source_location": "L54"
     },
     {
-      "community": 292,
+      "community": 293,
       "file_type": "code",
       "id": "productstock_productstockstatus",
       "label": "ProductStockStatus()",
@@ -80029,7 +80218,7 @@
       "source_location": "L11"
     },
     {
-      "community": 293,
+      "community": 294,
       "file_type": "code",
       "id": "complimentaryproductsview_body",
       "label": "Body()",
@@ -80038,7 +80227,7 @@
       "source_location": "L16"
     },
     {
-      "community": 293,
+      "community": 294,
       "file_type": "code",
       "id": "complimentaryproductsview_complimentaryproductsview",
       "label": "ComplimentaryProductsView()",
@@ -80047,7 +80236,7 @@
       "source_location": "L35"
     },
     {
-      "community": 293,
+      "community": 294,
       "file_type": "code",
       "id": "complimentaryproductsview_navigation",
       "label": "Navigation()",
@@ -80056,7 +80245,7 @@
       "source_location": "L6"
     },
     {
-      "community": 293,
+      "community": 294,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_complimentary_complimentaryproductsview_tsx",
       "label": "ComplimentaryProductsView.tsx",
@@ -80065,7 +80254,7 @@
       "source_location": "L1"
     },
     {
-      "community": 294,
+      "community": 295,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodemoney_ts",
       "label": "promoCodeMoney.ts",
@@ -80074,7 +80263,7 @@
       "source_location": "L1"
     },
     {
-      "community": 294,
+      "community": 295,
       "file_type": "code",
       "id": "promocodemoney_parsepromodiscountinput",
       "label": "parsePromoDiscountInput()",
@@ -80083,7 +80272,7 @@
       "source_location": "L5"
     },
     {
-      "community": 294,
+      "community": 295,
       "file_type": "code",
       "id": "promocodemoney_promodiscountdisplaytext",
       "label": "promoDiscountDisplayText()",
@@ -80092,7 +80281,7 @@
       "source_location": "L30"
     },
     {
-      "community": 294,
+      "community": 295,
       "file_type": "code",
       "id": "promocodemoney_promodiscountinputvalue",
       "label": "promoDiscountInputValue()",
@@ -80101,7 +80290,7 @@
       "source_location": "L21"
     },
     {
-      "community": 295,
+      "community": 296,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_servicecasesview_tsx",
       "label": "ServiceCasesView.tsx",
@@ -80110,7 +80299,7 @@
       "source_location": "L1"
     },
     {
-      "community": 295,
+      "community": 296,
       "file_type": "code",
       "id": "servicecasesview_applycommandresult",
       "label": "applyCommandResult()",
@@ -80119,7 +80308,7 @@
       "source_location": "L194"
     },
     {
-      "community": 295,
+      "community": 296,
       "file_type": "code",
       "id": "servicecasesview_handlecreatecase",
       "label": "handleCreateCase()",
@@ -80128,7 +80317,7 @@
       "source_location": "L215"
     },
     {
-      "community": 295,
+      "community": 296,
       "file_type": "code",
       "id": "servicecasesview_withsavestate",
       "label": "withSaveState()",
@@ -80137,7 +80326,7 @@
       "source_location": "L910"
     },
     {
-      "community": 296,
+      "community": 297,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_traces_workflowtraceview_tsx",
       "label": "WorkflowTraceView.tsx",
@@ -80146,7 +80335,7 @@
       "source_location": "L1"
     },
     {
-      "community": 296,
+      "community": 297,
       "file_type": "code",
       "id": "workflowtraceview_formattracelabel",
       "label": "formatTraceLabel()",
@@ -80155,7 +80344,7 @@
       "source_location": "L41"
     },
     {
-      "community": 296,
+      "community": 297,
       "file_type": "code",
       "id": "workflowtraceview_getstatustone",
       "label": "getStatusTone()",
@@ -80164,7 +80353,7 @@
       "source_location": "L45"
     },
     {
-      "community": 296,
+      "community": 297,
       "file_type": "code",
       "id": "workflowtraceview_workflowtraceheader",
       "label": "WorkflowTraceHeader()",
@@ -80173,7 +80362,7 @@
       "source_location": "L65"
     },
     {
-      "community": 297,
+      "community": 298,
       "file_type": "code",
       "id": "engagementmetrics_formatlastactivity",
       "label": "formatLastActivity()",
@@ -80182,7 +80371,7 @@
       "source_location": "L75"
     },
     {
-      "community": 297,
+      "community": 298,
       "file_type": "code",
       "id": "engagementmetrics_getdeviceicon",
       "label": "getDeviceIcon()",
@@ -80191,7 +80380,7 @@
       "source_location": "L82"
     },
     {
-      "community": 297,
+      "community": 298,
       "file_type": "code",
       "id": "engagementmetrics_getdevicelabel",
       "label": "getDeviceLabel()",
@@ -80200,7 +80389,7 @@
       "source_location": "L93"
     },
     {
-      "community": 297,
+      "community": 298,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_engagementmetrics_tsx",
       "label": "EngagementMetrics.tsx",
@@ -80209,7 +80398,7 @@
       "source_location": "L1"
     },
     {
-      "community": 298,
+      "community": 299,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_riskindicators_tsx",
       "label": "RiskIndicators.tsx",
@@ -80218,7 +80407,7 @@
       "source_location": "L1"
     },
     {
-      "community": 298,
+      "community": 299,
       "file_type": "code",
       "id": "riskindicators_getriskicon",
       "label": "getRiskIcon()",
@@ -80227,7 +80416,7 @@
       "source_location": "L15"
     },
     {
-      "community": 298,
+      "community": 299,
       "file_type": "code",
       "id": "riskindicators_getriskstyles",
       "label": "getRiskStyles()",
@@ -80236,49 +80425,13 @@
       "source_location": "L28"
     },
     {
-      "community": 298,
+      "community": 299,
       "file_type": "code",
       "id": "riskindicators_riskindicators",
       "label": "RiskIndicators()",
       "norm_label": "riskindicators()",
       "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/RiskIndicators.tsx",
       "source_location": "L54"
-    },
-    {
-      "community": 299,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_useexpenseoperations_ts",
-      "label": "useExpenseOperations.ts",
-      "norm_label": "useexpenseoperations.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseOperations.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 299,
-      "file_type": "code",
-      "id": "useexpenseoperations_clonecartitems",
-      "label": "cloneCartItems()",
-      "norm_label": "clonecartitems()",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseOperations.ts",
-      "source_location": "L19"
-    },
-    {
-      "community": 299,
-      "file_type": "code",
-      "id": "useexpenseoperations_mapproducttoexpensecartitem",
-      "label": "mapProductToExpenseCartItem()",
-      "norm_label": "mapproducttoexpensecartitem()",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseOperations.ts",
-      "source_location": "L23"
-    },
-    {
-      "community": 299,
-      "file_type": "code",
-      "id": "useexpenseoperations_useexpenseoperations",
-      "label": "useExpenseOperations()",
-      "norm_label": "useexpenseoperations()",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseOperations.ts",
-      "source_location": "L50"
     },
     {
       "community": 3,
@@ -80868,6 +81021,42 @@
     {
       "community": 300,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_useexpenseoperations_ts",
+      "label": "useExpenseOperations.ts",
+      "norm_label": "useexpenseoperations.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseOperations.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 300,
+      "file_type": "code",
+      "id": "useexpenseoperations_clonecartitems",
+      "label": "cloneCartItems()",
+      "norm_label": "clonecartitems()",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseOperations.ts",
+      "source_location": "L19"
+    },
+    {
+      "community": 300,
+      "file_type": "code",
+      "id": "useexpenseoperations_mapproducttoexpensecartitem",
+      "label": "mapProductToExpenseCartItem()",
+      "norm_label": "mapproducttoexpensecartitem()",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseOperations.ts",
+      "source_location": "L23"
+    },
+    {
+      "community": 300,
+      "file_type": "code",
+      "id": "useexpenseoperations_useexpenseoperations",
+      "label": "useExpenseOperations()",
+      "norm_label": "useexpenseoperations()",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseOperations.ts",
+      "source_location": "L50"
+    },
+    {
+      "community": 301,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetproducts_ts",
       "label": "useGetProducts.ts",
       "norm_label": "usegetproducts.ts",
@@ -80875,7 +81064,7 @@
       "source_location": "L1"
     },
     {
-      "community": 300,
+      "community": 301,
       "file_type": "code",
       "id": "usegetproducts_usegetarchivedproducts",
       "label": "useGetArchivedProducts()",
@@ -80884,7 +81073,7 @@
       "source_location": "L36"
     },
     {
-      "community": 300,
+      "community": 301,
       "file_type": "code",
       "id": "usegetproducts_usegetproducts",
       "label": "useGetProducts()",
@@ -80893,7 +81082,7 @@
       "source_location": "L7"
     },
     {
-      "community": 300,
+      "community": 301,
       "file_type": "code",
       "id": "usegetproducts_usegetunresolvedproducts",
       "label": "useGetUnresolvedProducts()",
@@ -80902,7 +81091,7 @@
       "source_location": "L40"
     },
     {
-      "community": 301,
+      "community": 302,
       "file_type": "code",
       "id": "customerobservabilitytimeline_formatobservabilitylabel",
       "label": "formatObservabilityLabel()",
@@ -80911,7 +81100,7 @@
       "source_location": "L66"
     },
     {
-      "community": 301,
+      "community": 302,
       "file_type": "code",
       "id": "customerobservabilitytimeline_getdeviceicon",
       "label": "getDeviceIcon()",
@@ -80920,7 +81109,7 @@
       "source_location": "L121"
     },
     {
-      "community": 301,
+      "community": 302,
       "file_type": "code",
       "id": "customerobservabilitytimeline_getobservabilitystatusstyles",
       "label": "getObservabilityStatusStyles()",
@@ -80929,7 +81118,7 @@
       "source_location": "L74"
     },
     {
-      "community": 301,
+      "community": 302,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_customerobservabilitytimeline_ts",
       "label": "customerObservabilityTimeline.ts",
@@ -80938,7 +81127,7 @@
       "source_location": "L1"
     },
     {
-      "community": 302,
+      "community": 303,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_runcommand_ts",
       "label": "runCommand.ts",
@@ -80947,7 +81136,7 @@
       "source_location": "L1"
     },
     {
-      "community": 302,
+      "community": 303,
       "file_type": "code",
       "id": "runcommand_extracttraceid",
       "label": "extractTraceId()",
@@ -80956,7 +81145,7 @@
       "source_location": "L34"
     },
     {
-      "community": 302,
+      "community": 303,
       "file_type": "code",
       "id": "runcommand_isapprovalrequiredresult",
       "label": "isApprovalRequiredResult()",
@@ -80965,7 +81154,7 @@
       "source_location": "L28"
     },
     {
-      "community": 302,
+      "community": 303,
       "file_type": "code",
       "id": "runcommand_runcommand",
       "label": "runCommand()",
@@ -80974,7 +81163,7 @@
       "source_location": "L48"
     },
     {
-      "community": 303,
+      "community": 304,
       "file_type": "code",
       "id": "barcodeutils_extractbarcodefrominput",
       "label": "extractBarcodeFromInput()",
@@ -80983,7 +81172,7 @@
       "source_location": "L51"
     },
     {
-      "community": 303,
+      "community": 304,
       "file_type": "code",
       "id": "barcodeutils_isurlorbarcode",
       "label": "isUrlOrBarcode()",
@@ -80992,7 +81181,7 @@
       "source_location": "L92"
     },
     {
-      "community": 303,
+      "community": 304,
       "file_type": "code",
       "id": "barcodeutils_isvalidconvexid",
       "label": "isValidConvexId()",
@@ -81001,7 +81190,7 @@
       "source_location": "L16"
     },
     {
-      "community": 303,
+      "community": 304,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_barcodeutils_ts",
       "label": "barcodeUtils.ts",
@@ -81010,7 +81199,7 @@
       "source_location": "L1"
     },
     {
-      "community": 304,
+      "community": 305,
       "file_type": "code",
       "id": "displayamounts_formatstoredamount",
       "label": "formatStoredAmount()",
@@ -81019,7 +81208,7 @@
       "source_location": "L8"
     },
     {
-      "community": 304,
+      "community": 305,
       "file_type": "code",
       "id": "displayamounts_formatstoredcurrencyamount",
       "label": "formatStoredCurrencyAmount()",
@@ -81028,7 +81217,7 @@
       "source_location": "L15"
     },
     {
-      "community": 304,
+      "community": 305,
       "file_type": "code",
       "id": "displayamounts_parsedisplayamountinput",
       "label": "parseDisplayAmountInput()",
@@ -81037,7 +81226,7 @@
       "source_location": "L32"
     },
     {
-      "community": 304,
+      "community": 305,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_displayamounts_ts",
       "label": "displayAmounts.ts",
@@ -81046,7 +81235,7 @@
       "source_location": "L1"
     },
     {
-      "community": 305,
+      "community": 306,
       "file_type": "code",
       "id": "customergateway_useconvexposcustomercreate",
       "label": "useConvexPosCustomerCreate()",
@@ -81055,7 +81244,7 @@
       "source_location": "L22"
     },
     {
-      "community": 305,
+      "community": 306,
       "file_type": "code",
       "id": "customergateway_useconvexposcustomersearch",
       "label": "useConvexPosCustomerSearch()",
@@ -81064,7 +81253,7 @@
       "source_location": "L10"
     },
     {
-      "community": 305,
+      "community": 306,
       "file_type": "code",
       "id": "customergateway_useconvexposcustomerupdate",
       "label": "useConvexPosCustomerUpdate()",
@@ -81073,7 +81262,7 @@
       "source_location": "L57"
     },
     {
-      "community": 305,
+      "community": 306,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_customergateway_ts",
       "label": "customerGateway.ts",
@@ -81082,7 +81271,7 @@
       "source_location": "L1"
     },
     {
-      "community": 306,
+      "community": 307,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_sessiongateway_mapper_ts",
       "label": "sessionGateway.mapper.ts",
@@ -81091,7 +81280,7 @@
       "source_location": "L1"
     },
     {
-      "community": 306,
+      "community": 307,
       "file_type": "code",
       "id": "sessiongateway_mapper_mapactivesessiondto",
       "label": "mapActiveSessionDto()",
@@ -81100,7 +81289,7 @@
       "source_location": "L83"
     },
     {
-      "community": 306,
+      "community": 307,
       "file_type": "code",
       "id": "sessiongateway_mapper_mapheldsessionsdto",
       "label": "mapHeldSessionsDto()",
@@ -81109,7 +81298,7 @@
       "source_location": "L100"
     },
     {
-      "community": 306,
+      "community": 307,
       "file_type": "code",
       "id": "sessiongateway_mapper_normalizecartitems",
       "label": "normalizeCartItems()",
@@ -81118,7 +81307,7 @@
       "source_location": "L79"
     },
     {
-      "community": 307,
+      "community": 308,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_sessiongateway_ts",
       "label": "sessionGateway.ts",
@@ -81127,7 +81316,7 @@
       "source_location": "L1"
     },
     {
-      "community": 307,
+      "community": 308,
       "file_type": "code",
       "id": "sessiongateway_useconvexactivesession",
       "label": "useConvexActiveSession()",
@@ -81136,7 +81325,7 @@
       "source_location": "L38"
     },
     {
-      "community": 307,
+      "community": 308,
       "file_type": "code",
       "id": "sessiongateway_useconvexheldsessions",
       "label": "useConvexHeldSessions()",
@@ -81145,7 +81334,7 @@
       "source_location": "L65"
     },
     {
-      "community": 307,
+      "community": 308,
       "file_type": "code",
       "id": "sessiongateway_useconvexsessionactions",
       "label": "useConvexSessionActions()",
@@ -81154,7 +81343,7 @@
       "source_location": "L91"
     },
     {
-      "community": 308,
+      "community": 309,
       "file_type": "code",
       "id": "fingerprint_isbrowserfingerprintresult",
       "label": "isBrowserFingerprintResult()",
@@ -81163,7 +81352,7 @@
       "source_location": "L4"
     },
     {
-      "community": 308,
+      "community": 309,
       "file_type": "code",
       "id": "fingerprint_readstoredterminalfingerprint",
       "label": "readStoredTerminalFingerprint()",
@@ -81172,7 +81361,7 @@
       "source_location": "L20"
     },
     {
-      "community": 308,
+      "community": 309,
       "file_type": "code",
       "id": "fingerprint_readstoredterminalfingerprinthash",
       "label": "readStoredTerminalFingerprintHash()",
@@ -81181,49 +81370,13 @@
       "source_location": "L42"
     },
     {
-      "community": 308,
+      "community": 309,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_terminal_fingerprint_ts",
       "label": "fingerprint.ts",
       "norm_label": "fingerprint.ts",
       "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/terminal/fingerprint.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 309,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_presentation_expense_useexpenseregisterviewmodel_ts",
-      "label": "useExpenseRegisterViewModel.ts",
-      "norm_label": "useexpenseregisterviewmodel.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/expense/useExpenseRegisterViewModel.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 309,
-      "file_type": "code",
-      "id": "useexpenseregisterviewmodel_getcashierdisplayname",
-      "label": "getCashierDisplayName()",
-      "norm_label": "getcashierdisplayname()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/expense/useExpenseRegisterViewModel.ts",
-      "source_location": "L37"
-    },
-    {
-      "community": 309,
-      "file_type": "code",
-      "id": "useexpenseregisterviewmodel_getexpensesessionloadkey",
-      "label": "getExpenseSessionLoadKey()",
-      "norm_label": "getexpensesessionloadkey()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/expense/useExpenseRegisterViewModel.ts",
-      "source_location": "L49"
-    },
-    {
-      "community": 309,
-      "file_type": "code",
-      "id": "useexpenseregisterviewmodel_useexpenseregisterviewmodel",
-      "label": "useExpenseRegisterViewModel()",
-      "norm_label": "useexpenseregisterviewmodel()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/expense/useExpenseRegisterViewModel.ts",
-      "source_location": "L68"
     },
     {
       "community": 31,
@@ -81399,6 +81552,42 @@
     {
       "community": 310,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_presentation_expense_useexpenseregisterviewmodel_ts",
+      "label": "useExpenseRegisterViewModel.ts",
+      "norm_label": "useexpenseregisterviewmodel.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/expense/useExpenseRegisterViewModel.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 310,
+      "file_type": "code",
+      "id": "useexpenseregisterviewmodel_getcashierdisplayname",
+      "label": "getCashierDisplayName()",
+      "norm_label": "getcashierdisplayname()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/expense/useExpenseRegisterViewModel.ts",
+      "source_location": "L37"
+    },
+    {
+      "community": 310,
+      "file_type": "code",
+      "id": "useexpenseregisterviewmodel_getexpensesessionloadkey",
+      "label": "getExpenseSessionLoadKey()",
+      "norm_label": "getexpensesessionloadkey()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/expense/useExpenseRegisterViewModel.ts",
+      "source_location": "L49"
+    },
+    {
+      "community": 310,
+      "file_type": "code",
+      "id": "useexpenseregisterviewmodel_useexpenseregisterviewmodel",
+      "label": "useExpenseRegisterViewModel()",
+      "norm_label": "useexpenseregisterviewmodel()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/expense/useExpenseRegisterViewModel.ts",
+      "source_location": "L68"
+    },
+    {
+      "community": 311,
+      "file_type": "code",
       "id": "offers_getbaseurl",
       "label": "getBaseUrl()",
       "norm_label": "getbaseurl()",
@@ -81406,7 +81595,7 @@
       "source_location": "L13"
     },
     {
-      "community": 310,
+      "community": 311,
       "file_type": "code",
       "id": "offers_getuserredeemedoffers",
       "label": "getUserRedeemedOffers()",
@@ -81415,7 +81604,7 @@
       "source_location": "L46"
     },
     {
-      "community": 310,
+      "community": 311,
       "file_type": "code",
       "id": "offers_submitoffer",
       "label": "submitOffer()",
@@ -81424,7 +81613,7 @@
       "source_location": "L21"
     },
     {
-      "community": 310,
+      "community": 311,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_offers_ts",
       "label": "offers.ts",
@@ -81433,7 +81622,7 @@
       "source_location": "L1"
     },
     {
-      "community": 311,
+      "community": 312,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_stores_ts",
       "label": "stores.ts",
@@ -81442,7 +81631,7 @@
       "source_location": "L1"
     },
     {
-      "community": 311,
+      "community": 312,
       "file_type": "code",
       "id": "stores_getallstores",
       "label": "getAllStores()",
@@ -81451,7 +81640,7 @@
       "source_location": "L8"
     },
     {
-      "community": 311,
+      "community": 312,
       "file_type": "code",
       "id": "stores_getbaseurl",
       "label": "getBaseUrl()",
@@ -81460,7 +81649,7 @@
       "source_location": "L5"
     },
     {
-      "community": 311,
+      "community": 312,
       "file_type": "code",
       "id": "stores_getstore",
       "label": "getStore()",
@@ -81469,7 +81658,7 @@
       "source_location": "L20"
     },
     {
-      "community": 312,
+      "community": 313,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_subcategory_ts",
       "label": "subcategory.ts",
@@ -81478,7 +81667,7 @@
       "source_location": "L1"
     },
     {
-      "community": 312,
+      "community": 313,
       "file_type": "code",
       "id": "subcategory_getallsubcategories",
       "label": "getAllSubcategories()",
@@ -81487,7 +81676,7 @@
       "source_location": "L11"
     },
     {
-      "community": 312,
+      "community": 313,
       "file_type": "code",
       "id": "subcategory_getbaseurl",
       "label": "getBaseUrl()",
@@ -81496,7 +81685,7 @@
       "source_location": "L9"
     },
     {
-      "community": 312,
+      "community": 313,
       "file_type": "code",
       "id": "subcategory_getsubategory",
       "label": "getSubategory()",
@@ -81505,7 +81694,7 @@
       "source_location": "L25"
     },
     {
-      "community": 313,
+      "community": 314,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_productactionbar_tsx",
       "label": "ProductActionBar.tsx",
@@ -81514,7 +81703,7 @@
       "source_location": "L1"
     },
     {
-      "community": 313,
+      "community": 314,
       "file_type": "code",
       "id": "productactionbar_checkscroll",
       "label": "checkScroll()",
@@ -81523,7 +81712,7 @@
       "source_location": "L50"
     },
     {
-      "community": 313,
+      "community": 314,
       "file_type": "code",
       "id": "productactionbar_handleaction",
       "label": "handleAction()",
@@ -81532,7 +81721,7 @@
       "source_location": "L92"
     },
     {
-      "community": 313,
+      "community": 314,
       "file_type": "code",
       "id": "productactionbar_handledismiss",
       "label": "handleDismiss()",
@@ -81541,7 +81730,7 @@
       "source_location": "L74"
     },
     {
-      "community": 314,
+      "community": 315,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_productreminderbar_tsx",
       "label": "ProductReminderBar.tsx",
@@ -81550,7 +81739,7 @@
       "source_location": "L1"
     },
     {
-      "community": 314,
+      "community": 315,
       "file_type": "code",
       "id": "productreminderbar_checkscroll",
       "label": "checkScroll()",
@@ -81559,7 +81748,7 @@
       "source_location": "L62"
     },
     {
-      "community": 314,
+      "community": 315,
       "file_type": "code",
       "id": "productreminderbar_handleaddtobag",
       "label": "handleAddToBag()",
@@ -81568,7 +81757,7 @@
       "source_location": "L109"
     },
     {
-      "community": 314,
+      "community": 315,
       "file_type": "code",
       "id": "productreminderbar_handledismiss",
       "label": "handleDismiss()",
@@ -81577,7 +81766,7 @@
       "source_location": "L177"
     },
     {
-      "community": 315,
+      "community": 316,
       "file_type": "code",
       "id": "billingdetailssection_clearform",
       "label": "clearForm()",
@@ -81586,7 +81775,7 @@
       "source_location": "L18"
     },
     {
-      "community": 315,
+      "community": 316,
       "file_type": "code",
       "id": "billingdetailssection_handleusebillingaddressonfile",
       "label": "handleUseBillingAddressOnFile()",
@@ -81595,7 +81784,7 @@
       "source_location": "L52"
     },
     {
-      "community": 315,
+      "community": 316,
       "file_type": "code",
       "id": "billingdetailssection_togglesameasdelivery",
       "label": "toggleSameAsDelivery()",
@@ -81604,7 +81793,7 @@
       "source_location": "L68"
     },
     {
-      "community": 315,
+      "community": 316,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_billingdetailssection_tsx",
       "label": "BillingDetailsSection.tsx",
@@ -81613,7 +81802,7 @@
       "source_location": "L1"
     },
     {
-      "community": 316,
+      "community": 317,
       "file_type": "code",
       "id": "hooks_usegetshopsearchparams",
       "label": "useGetShopSearchParams()",
@@ -81622,7 +81811,7 @@
       "source_location": "L68"
     },
     {
-      "community": 316,
+      "community": 317,
       "file_type": "code",
       "id": "hooks_usegetstorecategories",
       "label": "useGetStoreCategories()",
@@ -81631,7 +81820,7 @@
       "source_location": "L26"
     },
     {
-      "community": 316,
+      "community": 317,
       "file_type": "code",
       "id": "hooks_usegetstoresubcategories",
       "label": "useGetStoreSubcategories()",
@@ -81640,7 +81829,7 @@
       "source_location": "L7"
     },
     {
-      "community": 316,
+      "community": 317,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_hooks_ts",
       "label": "hooks.ts",
@@ -81649,7 +81838,7 @@
       "source_location": "L1"
     },
     {
-      "community": 317,
+      "community": 318,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productattribute_tsx",
       "label": "ProductAttribute.tsx",
@@ -81658,7 +81847,7 @@
       "source_location": "L1"
     },
     {
-      "community": 317,
+      "community": 318,
       "file_type": "code",
       "id": "productattribute_findsize",
       "label": "findSize()",
@@ -81667,7 +81856,7 @@
       "source_location": "L81"
     },
     {
-      "community": 317,
+      "community": 318,
       "file_type": "code",
       "id": "productattribute_handleclick",
       "label": "handleClick()",
@@ -81676,7 +81865,7 @@
       "source_location": "L85"
     },
     {
-      "community": 317,
+      "community": 318,
       "file_type": "code",
       "id": "productattribute_optionclassname",
       "label": "optionClassName()",
@@ -81685,7 +81874,7 @@
       "source_location": "L27"
     },
     {
-      "community": 318,
+      "community": 319,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productdetails_tsx",
       "label": "ProductDetails.tsx",
@@ -81694,7 +81883,7 @@
       "source_location": "L1"
     },
     {
-      "community": 318,
+      "community": 319,
       "file_type": "code",
       "id": "productdetails_bagproduct",
       "label": "BagProduct()",
@@ -81703,7 +81892,7 @@
       "source_location": "L43"
     },
     {
-      "community": 318,
+      "community": 319,
       "file_type": "code",
       "id": "productdetails_pickupdetails",
       "label": "PickupDetails()",
@@ -81712,49 +81901,13 @@
       "source_location": "L13"
     },
     {
-      "community": 318,
+      "community": 319,
       "file_type": "code",
       "id": "productdetails_shippingpolicy",
       "label": "ShippingPolicy()",
       "norm_label": "shippingpolicy()",
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductDetails.tsx",
       "source_location": "L88"
-    },
-    {
-      "community": 319,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_modals_upsellmodal_tsx",
-      "label": "UpsellModal.tsx",
-      "norm_label": "upsellmodal.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModal.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 319,
-      "file_type": "code",
-      "id": "upsellmodal_handleclose",
-      "label": "handleClose()",
-      "norm_label": "handleclose()",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModal.tsx",
-      "source_location": "L111"
-    },
-    {
-      "community": 319,
-      "file_type": "code",
-      "id": "upsellmodal_handlescroll",
-      "label": "handleScroll()",
-      "norm_label": "handlescroll()",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModal.tsx",
-      "source_location": "L66"
-    },
-    {
-      "community": 319,
-      "file_type": "code",
-      "id": "upsellmodal_handlesuccess",
-      "label": "handleSuccess()",
-      "norm_label": "handlesuccess()",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModal.tsx",
-      "source_location": "L127"
     },
     {
       "community": 32,
@@ -81921,6 +82074,42 @@
     {
       "community": 320,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_modals_upsellmodal_tsx",
+      "label": "UpsellModal.tsx",
+      "norm_label": "upsellmodal.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModal.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 320,
+      "file_type": "code",
+      "id": "upsellmodal_handleclose",
+      "label": "handleClose()",
+      "norm_label": "handleclose()",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModal.tsx",
+      "source_location": "L111"
+    },
+    {
+      "community": 320,
+      "file_type": "code",
+      "id": "upsellmodal_handlescroll",
+      "label": "handleScroll()",
+      "norm_label": "handlescroll()",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModal.tsx",
+      "source_location": "L66"
+    },
+    {
+      "community": 320,
+      "file_type": "code",
+      "id": "upsellmodal_handlesuccess",
+      "label": "handleSuccess()",
+      "norm_label": "handlesuccess()",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModal.tsx",
+      "source_location": "L127"
+    },
+    {
+      "community": 321,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_upsellmodalform_tsx",
       "label": "UpsellModalForm.tsx",
       "norm_label": "upsellmodalform.tsx",
@@ -81928,7 +82117,7 @@
       "source_location": "L1"
     },
     {
-      "community": 320,
+      "community": 321,
       "file_type": "code",
       "id": "upsellmodalform_formatstoredamount",
       "label": "formatStoredAmount()",
@@ -81937,7 +82126,7 @@
       "source_location": "L92"
     },
     {
-      "community": 320,
+      "community": 321,
       "file_type": "code",
       "id": "upsellmodalform_handleinputchange",
       "label": "handleInputChange()",
@@ -81946,7 +82135,7 @@
       "source_location": "L64"
     },
     {
-      "community": 320,
+      "community": 321,
       "file_type": "code",
       "id": "upsellmodalform_handlesubmit",
       "label": "handleSubmit()",
@@ -81955,7 +82144,7 @@
       "source_location": "L49"
     },
     {
-      "community": 321,
+      "community": 322,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_contexts_storecontext_tsx",
       "label": "StoreContext.tsx",
@@ -81964,7 +82153,7 @@
       "source_location": "L1"
     },
     {
-      "community": 321,
+      "community": 322,
       "file_type": "code",
       "id": "storecontext_storeprovider",
       "label": "StoreProvider()",
@@ -81973,7 +82162,7 @@
       "source_location": "L25"
     },
     {
-      "community": 321,
+      "community": 322,
       "file_type": "code",
       "id": "storecontext_useoptionalstorecontext",
       "label": "useOptionalStoreContext()",
@@ -81982,7 +82171,7 @@
       "source_location": "L90"
     },
     {
-      "community": 321,
+      "community": 322,
       "file_type": "code",
       "id": "storecontext_usestorecontext",
       "label": "useStoreContext()",
@@ -81991,7 +82180,7 @@
       "source_location": "L82"
     },
     {
-      "community": 322,
+      "community": 323,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_shoplayout_tsx",
       "label": "_shopLayout.tsx",
@@ -82000,7 +82189,7 @@
       "source_location": "L1"
     },
     {
-      "community": 322,
+      "community": 323,
       "file_type": "code",
       "id": "shoplayout_clearfilters",
       "label": "clearFilters()",
@@ -82009,7 +82198,7 @@
       "source_location": "L115"
     },
     {
-      "community": 322,
+      "community": 323,
       "file_type": "code",
       "id": "shoplayout_onclickonmobilefilters",
       "label": "onClickOnMobileFilters()",
@@ -82018,7 +82207,7 @@
       "source_location": "L105"
     },
     {
-      "community": 322,
+      "community": 323,
       "file_type": "code",
       "id": "shoplayout_onmobilefilterscloseclick",
       "label": "onMobileFiltersCloseClick()",
@@ -82027,7 +82216,7 @@
       "source_location": "L110"
     },
     {
-      "community": 323,
+      "community": 324,
       "file_type": "code",
       "id": "index_cancelorder",
       "label": "cancelOrder()",
@@ -82036,7 +82225,7 @@
       "source_location": "L121"
     },
     {
-      "community": 323,
+      "community": 324,
       "file_type": "code",
       "id": "index_geterrormessage",
       "label": "getErrorMessage()",
@@ -82045,7 +82234,7 @@
       "source_location": "L26"
     },
     {
-      "community": 323,
+      "community": 324,
       "file_type": "code",
       "id": "index_placeorder",
       "label": "placeOrder()",
@@ -82054,7 +82243,7 @@
       "source_location": "L71"
     },
     {
-      "community": 323,
+      "community": 324,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_index_tsx",
       "label": "index.tsx",
@@ -82063,7 +82252,7 @@
       "source_location": "L1"
     },
     {
-      "community": 324,
+      "community": 325,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_receipt_posreceiptpage_tsx",
       "label": "-PosReceiptPage.tsx",
@@ -82072,7 +82261,7 @@
       "source_location": "L1"
     },
     {
-      "community": 324,
+      "community": 325,
       "file_type": "code",
       "id": "posreceiptpage_money",
       "label": "money()",
@@ -82081,7 +82270,7 @@
       "source_location": "L51"
     },
     {
-      "community": 324,
+      "community": 325,
       "file_type": "code",
       "id": "posreceiptpage_paymentlabel",
       "label": "paymentLabel()",
@@ -82090,7 +82279,7 @@
       "source_location": "L13"
     },
     {
-      "community": 324,
+      "community": 325,
       "file_type": "code",
       "id": "posreceiptpage_shouldretryreceiptlookup",
       "label": "shouldRetryReceiptLookup()",
@@ -82099,7 +82288,7 @@
       "source_location": "L21"
     },
     {
-      "community": 325,
+      "community": 326,
       "file_type": "code",
       "id": "bootstrap_bootstrapcheckout",
       "label": "bootstrapCheckout()",
@@ -82108,7 +82297,7 @@
       "source_location": "L46"
     },
     {
-      "community": 325,
+      "community": 326,
       "file_type": "code",
       "id": "bootstrap_createbootstraptoken",
       "label": "createBootstrapToken()",
@@ -82117,7 +82306,7 @@
       "source_location": "L24"
     },
     {
-      "community": 325,
+      "community": 326,
       "file_type": "code",
       "id": "bootstrap_createmarker",
       "label": "createMarker()",
@@ -82126,7 +82315,7 @@
       "source_location": "L20"
     },
     {
-      "community": 325,
+      "community": 326,
       "file_type": "code",
       "id": "packages_storefront_webapp_tests_e2e_helpers_bootstrap_ts",
       "label": "bootstrap.ts",
@@ -82135,7 +82324,7 @@
       "source_location": "L1"
     },
     {
-      "community": 326,
+      "community": 327,
       "file_type": "code",
       "id": "convex_node_env_test_resolvewithenv",
       "label": "resolveWithEnv()",
@@ -82144,7 +82333,7 @@
       "source_location": "L26"
     },
     {
-      "community": 326,
+      "community": 327,
       "file_type": "code",
       "id": "convex_node_env_test_withtempdir",
       "label": "withTempDir()",
@@ -82153,7 +82342,7 @@
       "source_location": "L6"
     },
     {
-      "community": 326,
+      "community": 327,
       "file_type": "code",
       "id": "convex_node_env_test_writenodeshim",
       "label": "writeNodeShim()",
@@ -82162,7 +82351,7 @@
       "source_location": "L16"
     },
     {
-      "community": 326,
+      "community": 327,
       "file_type": "code",
       "id": "scripts_convex_node_env_test_ts",
       "label": "convex-node-env.test.ts",
@@ -82171,7 +82360,7 @@
       "source_location": "L1"
     },
     {
-      "community": 327,
+      "community": 328,
       "file_type": "code",
       "id": "graphify_check_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -82180,7 +82369,7 @@
       "source_location": "L17"
     },
     {
-      "community": 327,
+      "community": 328,
       "file_type": "code",
       "id": "graphify_check_test_write",
       "label": "write()",
@@ -82189,7 +82378,7 @@
       "source_location": "L11"
     },
     {
-      "community": 327,
+      "community": 328,
       "file_type": "code",
       "id": "graphify_check_test_writegraphifywikiartifacts",
       "label": "writeGraphifyWikiArtifacts()",
@@ -82198,7 +82387,7 @@
       "source_location": "L24"
     },
     {
-      "community": 327,
+      "community": 328,
       "file_type": "code",
       "id": "scripts_graphify_check_test_ts",
       "label": "graphify-check.test.ts",
@@ -82207,7 +82396,7 @@
       "source_location": "L1"
     },
     {
-      "community": 328,
+      "community": 329,
       "file_type": "code",
       "id": "graphify_rebuild_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -82216,7 +82405,7 @@
       "source_location": "L20"
     },
     {
-      "community": 328,
+      "community": 329,
       "file_type": "code",
       "id": "graphify_rebuild_test_spawn",
       "label": "spawn()",
@@ -82225,7 +82414,7 @@
       "source_location": "L65"
     },
     {
-      "community": 328,
+      "community": 329,
       "file_type": "code",
       "id": "graphify_rebuild_test_write",
       "label": "write()",
@@ -82234,48 +82423,12 @@
       "source_location": "L14"
     },
     {
-      "community": 328,
+      "community": 329,
       "file_type": "code",
       "id": "scripts_graphify_rebuild_test_ts",
       "label": "graphify-rebuild.test.ts",
       "norm_label": "graphify-rebuild.test.ts",
       "source_file": "scripts/graphify-rebuild.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 329,
-      "file_type": "code",
-      "id": "harness_app_registry_buildharnessdocpaths",
-      "label": "buildHarnessDocPaths()",
-      "norm_label": "buildharnessdocpaths()",
-      "source_file": "scripts/harness-app-registry.ts",
-      "source_location": "L129"
-    },
-    {
-      "community": 329,
-      "file_type": "code",
-      "id": "harness_app_registry_buildharnessdocpathsforarchetype",
-      "label": "buildHarnessDocPathsForArchetype()",
-      "norm_label": "buildharnessdocpathsforarchetype()",
-      "source_file": "scripts/harness-app-registry.ts",
-      "source_location": "L133"
-    },
-    {
-      "community": 329,
-      "file_type": "code",
-      "id": "harness_app_registry_getharnesspackageregistration",
-      "label": "getHarnessPackageRegistration()",
-      "norm_label": "getharnesspackageregistration()",
-      "source_file": "scripts/harness-app-registry.ts",
-      "source_location": "L974"
-    },
-    {
-      "community": 329,
-      "file_type": "code",
-      "id": "scripts_harness_app_registry_ts",
-      "label": "harness-app-registry.ts",
-      "norm_label": "harness-app-registry.ts",
-      "source_file": "scripts/harness-app-registry.ts",
       "source_location": "L1"
     },
     {
@@ -82443,6 +82596,42 @@
     {
       "community": 330,
       "file_type": "code",
+      "id": "harness_app_registry_buildharnessdocpaths",
+      "label": "buildHarnessDocPaths()",
+      "norm_label": "buildharnessdocpaths()",
+      "source_file": "scripts/harness-app-registry.ts",
+      "source_location": "L129"
+    },
+    {
+      "community": 330,
+      "file_type": "code",
+      "id": "harness_app_registry_buildharnessdocpathsforarchetype",
+      "label": "buildHarnessDocPathsForArchetype()",
+      "norm_label": "buildharnessdocpathsforarchetype()",
+      "source_file": "scripts/harness-app-registry.ts",
+      "source_location": "L133"
+    },
+    {
+      "community": 330,
+      "file_type": "code",
+      "id": "harness_app_registry_getharnesspackageregistration",
+      "label": "getHarnessPackageRegistration()",
+      "norm_label": "getharnesspackageregistration()",
+      "source_file": "scripts/harness-app-registry.ts",
+      "source_location": "L974"
+    },
+    {
+      "community": 330,
+      "file_type": "code",
+      "id": "scripts_harness_app_registry_ts",
+      "label": "harness-app-registry.ts",
+      "norm_label": "harness-app-registry.ts",
+      "source_file": "scripts/harness-app-registry.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 331,
+      "file_type": "code",
       "id": "scripts_harness_behavior_fixtures_valkey_runtime_app_ts",
       "label": "valkey-runtime-app.ts",
       "norm_label": "valkey-runtime-app.ts",
@@ -82450,7 +82639,7 @@
       "source_location": "L1"
     },
     {
-      "community": 330,
+      "community": 331,
       "file_type": "code",
       "id": "valkey_runtime_app_createvalkeyruntimeserver",
       "label": "createValkeyRuntimeServer()",
@@ -82459,7 +82648,7 @@
       "source_location": "L8"
     },
     {
-      "community": 330,
+      "community": 331,
       "file_type": "code",
       "id": "valkey_runtime_app_shutdown",
       "label": "shutdown()",
@@ -82468,7 +82657,7 @@
       "source_location": "L79"
     },
     {
-      "community": 330,
+      "community": 331,
       "file_type": "code",
       "id": "valkey_runtime_app_stopvalkeyruntimeserver",
       "label": "stopValkeyRuntimeServer()",
@@ -82477,7 +82666,7 @@
       "source_location": "L61"
     },
     {
-      "community": 331,
+      "community": 332,
       "file_type": "code",
       "id": "harness_scorecard_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -82486,7 +82675,7 @@
       "source_location": "L49"
     },
     {
-      "community": 331,
+      "community": 332,
       "file_type": "code",
       "id": "harness_scorecard_test_createinferentialartifact",
       "label": "createInferentialArtifact()",
@@ -82495,7 +82684,7 @@
       "source_location": "L17"
     },
     {
-      "community": 331,
+      "community": 332,
       "file_type": "code",
       "id": "harness_scorecard_test_write",
       "label": "write()",
@@ -82504,7 +82693,7 @@
       "source_location": "L11"
     },
     {
-      "community": 331,
+      "community": 332,
       "file_type": "code",
       "id": "scripts_harness_scorecard_test_ts",
       "label": "harness-scorecard.test.ts",
@@ -82513,7 +82702,7 @@
       "source_location": "L1"
     },
     {
-      "community": 332,
+      "community": 333,
       "file_type": "code",
       "id": "harness_test_collectharnesstesttargets",
       "label": "collectHarnessTestTargets()",
@@ -82522,7 +82711,7 @@
       "source_location": "L26"
     },
     {
-      "community": 332,
+      "community": 333,
       "file_type": "code",
       "id": "harness_test_parseharnesstestcliargs",
       "label": "parseHarnessTestCliArgs()",
@@ -82531,7 +82720,7 @@
       "source_location": "L72"
     },
     {
-      "community": 332,
+      "community": 333,
       "file_type": "code",
       "id": "harness_test_runharnesstest",
       "label": "runHarnessTest()",
@@ -82540,7 +82729,7 @@
       "source_location": "L36"
     },
     {
-      "community": 332,
+      "community": 333,
       "file_type": "code",
       "id": "scripts_harness_test_ts",
       "label": "harness-test.ts",
@@ -82549,7 +82738,7 @@
       "source_location": "L1"
     },
     {
-      "community": 333,
+      "community": 334,
       "file_type": "code",
       "id": "pre_push_review_test_error",
       "label": "error()",
@@ -82558,7 +82747,7 @@
       "source_location": "L96"
     },
     {
-      "community": 333,
+      "community": 334,
       "file_type": "code",
       "id": "pre_push_review_test_log",
       "label": "log()",
@@ -82567,7 +82756,7 @@
       "source_location": "L94"
     },
     {
-      "community": 333,
+      "community": 334,
       "file_type": "code",
       "id": "pre_push_review_test_warn",
       "label": "warn()",
@@ -82576,7 +82765,7 @@
       "source_location": "L95"
     },
     {
-      "community": 333,
+      "community": 334,
       "file_type": "code",
       "id": "scripts_pre_push_review_test_ts",
       "label": "pre-push-review.test.ts",
@@ -82585,7 +82774,7 @@
       "source_location": "L1"
     },
     {
-      "community": 334,
+      "community": 335,
       "file_type": "code",
       "id": "preview_worktree_test_makedir",
       "label": "makeDir()",
@@ -82594,7 +82783,7 @@
       "source_location": "L17"
     },
     {
-      "community": 334,
+      "community": 335,
       "file_type": "code",
       "id": "preview_worktree_test_previewoptions",
       "label": "previewOptions()",
@@ -82603,7 +82792,7 @@
       "source_location": "L23"
     },
     {
-      "community": 334,
+      "community": 335,
       "file_type": "code",
       "id": "preview_worktree_test_real",
       "label": "real()",
@@ -82612,7 +82801,7 @@
       "source_location": "L40"
     },
     {
-      "community": 334,
+      "community": 335,
       "file_type": "code",
       "id": "scripts_preview_worktree_test_ts",
       "label": "preview-worktree.test.ts",
@@ -82621,7 +82810,7 @@
       "source_location": "L1"
     },
     {
-      "community": 335,
+      "community": 336,
       "file_type": "code",
       "id": "closeouts_test_gethandler",
       "label": "getHandler()",
@@ -82630,7 +82819,7 @@
       "source_location": "L15"
     },
     {
-      "community": 335,
+      "community": 336,
       "file_type": "code",
       "id": "closeouts_test_getsource",
       "label": "getSource()",
@@ -82639,7 +82828,7 @@
       "source_location": "L11"
     },
     {
-      "community": 335,
+      "community": 336,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cashcontrols_closeouts_test_ts",
       "label": "closeouts.test.ts",
@@ -82648,7 +82837,7 @@
       "source_location": "L1"
     },
     {
-      "community": 336,
+      "community": 337,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_customermessaging_public_ts",
       "label": "public.ts",
@@ -82657,7 +82846,7 @@
       "source_location": "L1"
     },
     {
-      "community": 336,
+      "community": 337,
       "file_type": "code",
       "id": "public_resolverecipient",
       "label": "resolveRecipient()",
@@ -82666,7 +82855,7 @@
       "source_location": "L57"
     },
     {
-      "community": 336,
+      "community": 337,
       "file_type": "code",
       "id": "public_topublicreceipttransaction",
       "label": "toPublicReceiptTransaction()",
@@ -82675,7 +82864,7 @@
       "source_location": "L29"
     },
     {
-      "community": 337,
+      "community": 338,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_customermessaging_whatsappclient_ts",
       "label": "whatsappClient.ts",
@@ -82684,7 +82873,7 @@
       "source_location": "L1"
     },
     {
-      "community": 337,
+      "community": 338,
       "file_type": "code",
       "id": "whatsappclient_providererrorcategory",
       "label": "providerErrorCategory()",
@@ -82693,7 +82882,7 @@
       "source_location": "L20"
     },
     {
-      "community": 337,
+      "community": 338,
       "file_type": "code",
       "id": "whatsappclient_sendwhatsappreceipttemplate",
       "label": "sendWhatsAppReceiptTemplate()",
@@ -82702,7 +82891,7 @@
       "source_location": "L27"
     },
     {
-      "community": 338,
+      "community": 339,
       "file_type": "code",
       "id": "discountcode_chunkproducts",
       "label": "chunkProducts()",
@@ -82711,7 +82900,7 @@
       "source_location": "L98"
     },
     {
-      "community": 338,
+      "community": 339,
       "file_type": "code",
       "id": "discountcode_productcard",
       "label": "ProductCard()",
@@ -82720,39 +82909,12 @@
       "source_location": "L33"
     },
     {
-      "community": 338,
+      "community": 339,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_discountcode_tsx",
       "label": "DiscountCode.tsx",
       "norm_label": "discountcode.tsx",
       "source_file": "packages/athena-webapp/convex/emails/DiscountCode.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 339,
-      "file_type": "code",
-      "id": "discountreminder_chunkproducts",
-      "label": "chunkProducts()",
-      "norm_label": "chunkproducts()",
-      "source_file": "packages/athena-webapp/convex/emails/DiscountReminder.tsx",
-      "source_location": "L85"
-    },
-    {
-      "community": 339,
-      "file_type": "code",
-      "id": "discountreminder_productcard",
-      "label": "ProductCard()",
-      "norm_label": "productcard()",
-      "source_file": "packages/athena-webapp/convex/emails/DiscountReminder.tsx",
-      "source_location": "L31"
-    },
-    {
-      "community": 339,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_emails_discountreminder_tsx",
-      "label": "DiscountReminder.tsx",
-      "norm_label": "discountreminder.tsx",
-      "source_file": "packages/athena-webapp/convex/emails/DiscountReminder.tsx",
       "source_location": "L1"
     },
     {
@@ -82920,6 +83082,33 @@
     {
       "community": 340,
       "file_type": "code",
+      "id": "discountreminder_chunkproducts",
+      "label": "chunkProducts()",
+      "norm_label": "chunkproducts()",
+      "source_file": "packages/athena-webapp/convex/emails/DiscountReminder.tsx",
+      "source_location": "L85"
+    },
+    {
+      "community": 340,
+      "file_type": "code",
+      "id": "discountreminder_productcard",
+      "label": "ProductCard()",
+      "norm_label": "productcard()",
+      "source_file": "packages/athena-webapp/convex/emails/DiscountReminder.tsx",
+      "source_location": "L31"
+    },
+    {
+      "community": 340,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_emails_discountreminder_tsx",
+      "label": "DiscountReminder.tsx",
+      "norm_label": "discountreminder.tsx",
+      "source_file": "packages/athena-webapp/convex/emails/DiscountReminder.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 341,
+      "file_type": "code",
       "id": "categories_removestorefronthiddencategories",
       "label": "removeStorefrontHiddenCategories()",
       "norm_label": "removestorefronthiddencategories()",
@@ -82927,7 +83116,7 @@
       "source_location": "L12"
     },
     {
-      "community": 340,
+      "community": 341,
       "file_type": "code",
       "id": "categories_removestorefronthiddensubcategories",
       "label": "removeStorefrontHiddenSubcategories()",
@@ -82936,7 +83125,7 @@
       "source_location": "L21"
     },
     {
-      "community": 340,
+      "community": 341,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_core_routes_categories_ts",
       "label": "categories.ts",
@@ -82945,7 +83134,7 @@
       "source_location": "L1"
     },
     {
-      "community": 341,
+      "community": 342,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_utils_ts",
       "label": "utils.ts",
@@ -82954,7 +83143,7 @@
       "source_location": "L1"
     },
     {
-      "community": 341,
+      "community": 342,
       "file_type": "code",
       "id": "utils_getstoredatafromrequest",
       "label": "getStoreDataFromRequest()",
@@ -82963,7 +83152,7 @@
       "source_location": "L5"
     },
     {
-      "community": 341,
+      "community": 342,
       "file_type": "code",
       "id": "utils_getstorefrontuserfromrequest",
       "label": "getStorefrontUserFromRequest()",
@@ -82972,7 +83161,7 @@
       "source_location": "L12"
     },
     {
-      "community": 342,
+      "community": 343,
       "file_type": "code",
       "id": "inventoryholds_test_buildhold",
       "label": "buildHold()",
@@ -82981,7 +83170,7 @@
       "source_location": "L566"
     },
     {
-      "community": 342,
+      "community": 343,
       "file_type": "code",
       "id": "inventoryholds_test_createdb",
       "label": "createDb()",
@@ -82990,7 +83179,7 @@
       "source_location": "L40"
     },
     {
-      "community": 342,
+      "community": 343,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_helpers_inventoryholds_test_ts",
       "label": "inventoryHolds.test.ts",
@@ -82999,7 +83188,7 @@
       "source_location": "L1"
     },
     {
-      "community": 343,
+      "community": 344,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_sessionqueryindexes_test_ts",
       "label": "sessionQueryIndexes.test.ts",
@@ -83008,7 +83197,7 @@
       "source_location": "L1"
     },
     {
-      "community": 343,
+      "community": 344,
       "file_type": "code",
       "id": "sessionqueryindexes_test_readprojectfile",
       "label": "readProjectFile()",
@@ -83017,7 +83206,7 @@
       "source_location": "L6"
     },
     {
-      "community": 343,
+      "community": 344,
       "file_type": "code",
       "id": "sessionqueryindexes_test_readsourceslice",
       "label": "readSourceSlice()",
@@ -83026,7 +83215,7 @@
       "source_location": "L9"
     },
     {
-      "community": 344,
+      "community": 345,
       "file_type": "code",
       "id": "analyticsutils_calculateactivitytrend",
       "label": "calculateActivityTrend()",
@@ -83035,7 +83224,7 @@
       "source_location": "L43"
     },
     {
-      "community": 344,
+      "community": 345,
       "file_type": "code",
       "id": "analyticsutils_calculatedevicedistribution",
       "label": "calculateDeviceDistribution()",
@@ -83044,39 +83233,12 @@
       "source_location": "L11"
     },
     {
-      "community": 344,
+      "community": 345,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_utils_analyticsutils_ts",
       "label": "analyticsUtils.ts",
       "norm_label": "analyticsutils.ts",
       "source_file": "packages/athena-webapp/convex/llm/utils/analyticsUtils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 345,
-      "file_type": "code",
-      "id": "dailyclose_test_createdb",
-      "label": "createDb()",
-      "norm_label": "createdb()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
-      "source_location": "L30"
-    },
-    {
-      "community": 345,
-      "file_type": "code",
-      "id": "dailyclose_test_dailycloseapprovalproof",
-      "label": "dailyCloseApprovalProof()",
-      "norm_label": "dailycloseapprovalproof()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
-      "source_location": "L215"
-    },
-    {
-      "community": 345,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_dailyclose_test_ts",
-      "label": "dailyClose.test.ts",
-      "norm_label": "dailyclose.test.ts",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
       "source_location": "L1"
     },
     {
@@ -103935,73 +104097,73 @@
     {
       "community": 99,
       "file_type": "code",
-      "id": "index_senddiscountcodeemail",
-      "label": "sendDiscountCodeEmail()",
-      "norm_label": "senddiscountcodeemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L255"
+      "id": "config_buildmtncollectionscallbackurl",
+      "label": "buildMtnCollectionsCallbackUrl()",
+      "norm_label": "buildmtncollectionscallbackurl()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "source_location": "L135"
     },
     {
       "community": 99,
       "file_type": "code",
-      "id": "index_senddiscountreminderemail",
-      "label": "sendDiscountReminderEmail()",
-      "norm_label": "senddiscountreminderemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L334"
-    },
-    {
-      "community": 99,
-      "file_type": "code",
-      "id": "index_sendfeedbackrequestemail",
-      "label": "sendFeedbackRequestEmail()",
-      "norm_label": "sendfeedbackrequestemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L167"
-    },
-    {
-      "community": 99,
-      "file_type": "code",
-      "id": "index_sendneworderemail",
-      "label": "sendNewOrderEmail()",
-      "norm_label": "sendneworderemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L117"
-    },
-    {
-      "community": 99,
-      "file_type": "code",
-      "id": "index_sendorderemail",
-      "label": "sendOrderEmail()",
-      "norm_label": "sendorderemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "id": "config_buildmtncollectionslookupprefixes",
+      "label": "buildMtnCollectionsLookupPrefixes()",
+      "norm_label": "buildmtncollectionslookupprefixes()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
       "source_location": "L43"
     },
     {
       "community": 99,
       "file_type": "code",
-      "id": "index_sendverificationcode",
-      "label": "sendVerificationCode()",
-      "norm_label": "sendverificationcode()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L3"
+      "id": "config_istargetenvironment",
+      "label": "isTargetEnvironment()",
+      "norm_label": "istargetenvironment()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "source_location": "L67"
     },
     {
       "community": 99,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_mailersend_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/convex/mailersend/index.tsx",
-      "source_location": "L1"
+      "id": "config_readscopedvalue",
+      "label": "readScopedValue()",
+      "norm_label": "readscopedvalue()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "source_location": "L56"
     },
     {
       "community": 99,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_sendgrid_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "id": "config_resolveconfigforprefix",
+      "label": "resolveConfigForPrefix()",
+      "norm_label": "resolveconfigforprefix()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "source_location": "L73"
+    },
+    {
+      "community": 99,
+      "file_type": "code",
+      "id": "config_resolvemtncollectionsconfigfromenv",
+      "label": "resolveMtnCollectionsConfigFromEnv()",
+      "norm_label": "resolvemtncollectionsconfigfromenv()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "source_location": "L108"
+    },
+    {
+      "community": 99,
+      "file_type": "code",
+      "id": "config_toenvsegment",
+      "label": "toEnvSegment()",
+      "norm_label": "toenvsegment()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "source_location": "L29"
+    },
+    {
+      "community": 99,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_mtn_config_ts",
+      "label": "config.ts",
+      "norm_label": "config.ts",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
       "source_location": "L1"
     },
     {

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,13 +8,13 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 1668
-- Graph nodes: 4976
-- Graph edges: 4942
+- Graph nodes: 4982
+- Graph edges: 4951
 - Communities: 1596
 
 ## Graph Hotspots
-- `DailyCloseView.tsx` (70 edges, Community 0) - [`packages/athena-webapp/src/components/operations/DailyCloseView.tsx`](../../packages/athena-webapp/src/components/operations/DailyCloseView.tsx)
-- `dailyClose.ts` (48 edges, Community 1) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../packages/athena-webapp/convex/operations/dailyClose.ts)
+- `DailyCloseView.tsx` (71 edges, Community 0) - [`packages/athena-webapp/src/components/operations/DailyCloseView.tsx`](../../packages/athena-webapp/src/components/operations/DailyCloseView.tsx)
+- `dailyClose.ts` (52 edges, Community 1) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../packages/athena-webapp/convex/operations/dailyClose.ts)
 - `harness-inferential-review.ts` (46 edges, Community 2) - [`scripts/harness-inferential-review.ts`](../../scripts/harness-inferential-review.ts)
 - `storefrontJourneyEvents.ts` (45 edges, Community 3) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
 - `createJourneyEvent()` (40 edges, Community 3) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)

--- a/graphify-out/wiki/packages/athena-webapp.md
+++ b/graphify-out/wiki/packages/athena-webapp.md
@@ -17,8 +17,8 @@ Landing page for packages/athena-webapp. Use this page to orient around graph ho
 - [validation-map.json](../../../packages/athena-webapp/docs/agent/validation-map.json)
 
 ## Graph Hotspots
-- `DailyCloseView.tsx` (70 edges, Community 0) - [`packages/athena-webapp/src/components/operations/DailyCloseView.tsx`](../../../packages/athena-webapp/src/components/operations/DailyCloseView.tsx)
-- `dailyClose.ts` (48 edges, Community 1) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../../packages/athena-webapp/convex/operations/dailyClose.ts)
+- `DailyCloseView.tsx` (71 edges, Community 0) - [`packages/athena-webapp/src/components/operations/DailyCloseView.tsx`](../../../packages/athena-webapp/src/components/operations/DailyCloseView.tsx)
+- `dailyClose.ts` (52 edges, Community 1) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../../packages/athena-webapp/convex/operations/dailyClose.ts)
 - `ProcurementView.tsx` (39 edges, Community 4) - [`packages/athena-webapp/src/components/procurement/ProcurementView.tsx`](../../../packages/athena-webapp/src/components/procurement/ProcurementView.tsx)
 - `DailyOpeningView.tsx` (35 edges, Community 5) - [`packages/athena-webapp/src/components/operations/DailyOpeningView.tsx`](../../../packages/athena-webapp/src/components/operations/DailyOpeningView.tsx)
 - `dailyOpening.ts` (31 edges, Community 7) - [`packages/athena-webapp/convex/operations/dailyOpening.ts`](../../../packages/athena-webapp/convex/operations/dailyOpening.ts)

--- a/packages/athena-webapp/convex/operations/dailyClose.test.ts
+++ b/packages/athena-webapp/convex/operations/dailyClose.test.ts
@@ -212,6 +212,31 @@ const store = {
   slug: "accra",
 };
 
+function dailyCloseSummary(overrides: Record<string, unknown> = {}) {
+  return {
+    carriedOverCashTotal: 0,
+    carriedOverRegisterCount: 0,
+    cashDepositTotal: 0,
+    closedRegisterSessionCount: 0,
+    currentDayCashTotal: 0,
+    currentDayCashTransactionCount: 0,
+    expectedCashTotal: 0,
+    expenseStaffCount: 0,
+    expenseTotal: 0,
+    expenseTransactionCount: 0,
+    netCashVariance: 0,
+    openWorkItemCount: 0,
+    paymentTotals: [],
+    pendingApprovalCount: 0,
+    registerCount: 0,
+    registerVarianceCount: 0,
+    salesTotal: 0,
+    transactionCount: 0,
+    voidedTransactionCount: 0,
+    ...overrides,
+  };
+}
+
 function dailyCloseApprovalProof(overrides: Partial<Row> = {}): Row {
   return {
     _id: "approval-proof-1",
@@ -259,6 +284,20 @@ describe("end-of-day review backend foundation", () => {
           status: "pending",
           storeId: "store-1",
           subjectId: "txn-1",
+          subjectType: "pos_transaction",
+        },
+        {
+          _id: "approval-next-day",
+          createdAt: Date.UTC(2026, 4, 8, 16),
+          metadata: {
+            transactionId: "txn-next-day",
+            transactionNumber: "TXN-NEXT",
+          },
+          registerSessionId: "register-next-day",
+          requestType: "payment_method_correction",
+          status: "pending",
+          storeId: "store-1",
+          subjectId: "txn-next-day",
           subjectType: "pos_transaction",
         },
       ],
@@ -366,6 +405,16 @@ describe("end-of-day review backend foundation", () => {
           terminalId: "terminal-1",
           updatedAt: 2,
         },
+        {
+          _id: "pos-next-day",
+          createdAt: Date.UTC(2026, 4, 8, 10),
+          expiresAt: Date.UTC(2026, 4, 8, 20),
+          sessionNumber: "SES-next",
+          status: "held",
+          storeId: "store-1",
+          terminalId: "terminal-1",
+          updatedAt: Date.UTC(2026, 4, 8, 10),
+        },
       ],
       posTerminal: [
         {
@@ -434,6 +483,19 @@ describe("end-of-day review backend foundation", () => {
           totalPaid: 5000,
           transactionNumber: "TXN-2",
         },
+        {
+          _id: "txn-next-day",
+          completedAt: Date.UTC(2026, 4, 8, 14),
+          payments: [{ amount: 7000, method: "cash", timestamp: 1 }],
+          registerSessionId: "register-next-day",
+          status: "completed",
+          storeId: "store-1",
+          subtotal: 7000,
+          tax: 0,
+          total: 7000,
+          totalPaid: 7000,
+          transactionNumber: "TXN-NEXT",
+        },
       ],
       registerSession: [
         {
@@ -473,6 +535,16 @@ describe("end-of-day review backend foundation", () => {
           storeId: "store-1",
           terminalId: "terminal-1",
           variance: -500,
+        },
+        {
+          _id: "register-next-day",
+          expectedCash: 17000,
+          openedAt: Date.UTC(2026, 4, 8, 9),
+          openingFloat: 10000,
+          registerNumber: "A4",
+          status: "closing",
+          storeId: "store-1",
+          terminalId: "terminal-1",
         },
       ],
       store: [store],
@@ -686,6 +758,171 @@ describe("end-of-day review backend foundation", () => {
         },
       ]),
     );
+  });
+
+  it("serves the persisted report snapshot for completed End-of-Day Reviews", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(Date.UTC(2026, 4, 9, 12));
+
+    const { db } = createDb({
+      approvalRequest: [
+        {
+          _id: "approval-current",
+          createdAt: Date.UTC(2026, 4, 9, 9),
+          registerSessionId: "register-current",
+          requestType: "payment_method_correction",
+          status: "pending",
+          storeId: "store-1",
+          subjectId: "txn-current",
+          subjectType: "pos_transaction",
+        },
+      ],
+      dailyClose: [
+        {
+          _id: "daily-close-1",
+          carryForwardWorkItemIds: [],
+          completedAt: Date.UTC(2026, 4, 8, 22),
+          completedByStaffProfileId: "staff-1",
+          createdAt: Date.UTC(2026, 4, 8, 22),
+          isCurrent: true,
+          notes: "Closed cleanly.",
+          operatingDate: "2026-05-08",
+          organizationId: "org-1",
+          readiness: {
+            blockerCount: 0,
+            carryForwardCount: 0,
+            readyCount: 1,
+            reviewCount: 0,
+            status: "ready",
+          },
+          reportSnapshot: {
+            closeMetadata: {
+              carryForwardWorkItemIds: [],
+              completedAt: Date.UTC(2026, 4, 8, 22),
+              completedByStaffProfileId: "staff-1",
+              endAt: Date.UTC(2026, 4, 9),
+              notes: "Closed cleanly.",
+              operatingDate: "2026-05-08",
+              organizationId: "org-1",
+              startAt: Date.UTC(2026, 4, 8),
+              storeId: "store-1",
+            },
+            carryForwardItems: [],
+            readiness: {
+              blockerCount: 0,
+              carryForwardCount: 0,
+              readyCount: 1,
+              reviewCount: 0,
+              status: "ready",
+            },
+            readyItems: [
+              {
+                category: "sale",
+                key: "pos_transaction:txn-closed-day:completed",
+                message: "Completed sale is included in End-of-Day Review.",
+                severity: "ready",
+                subject: {
+                  id: "txn-closed-day",
+                  label: "TXN-CLOSED",
+                  type: "pos_transaction",
+                },
+                title: "Completed sale",
+              },
+            ],
+            reviewedItems: [],
+            sourceSubjects: [
+              {
+                id: "txn-closed-day",
+                label: "TXN-CLOSED",
+                type: "pos_transaction",
+              },
+            ],
+            summary: {
+              ...dailyCloseSummary({
+                salesTotal: 46000,
+                transactionCount: 1,
+              }),
+            },
+          },
+          reviewedItemKeys: [],
+          sourceSubjects: [],
+          status: "completed",
+          storeId: "store-1",
+          summary: {
+            ...dailyCloseSummary({
+              salesTotal: 46000,
+              transactionCount: 1,
+            }),
+          },
+          updatedAt: Date.UTC(2026, 4, 8, 22),
+        },
+      ],
+      posSession: [
+        {
+          _id: "pos-current",
+          createdAt: Date.UTC(2026, 4, 9, 10),
+          expiresAt: Date.UTC(2026, 4, 9, 14),
+          sessionNumber: "SES-CURRENT",
+          status: "held",
+          storeId: "store-1",
+          terminalId: "terminal-1",
+          updatedAt: Date.UTC(2026, 4, 9, 10),
+        },
+      ],
+      posTransaction: [
+        {
+          _id: "txn-current",
+          completedAt: Date.UTC(2026, 4, 9, 10),
+          payments: [{ amount: 10000, method: "cash", timestamp: 1 }],
+          registerSessionId: "register-current",
+          status: "completed",
+          storeId: "store-1",
+          subtotal: 10000,
+          tax: 0,
+          total: 10000,
+          totalPaid: 10000,
+          transactionNumber: "TXN-CURRENT",
+        },
+      ],
+      registerSession: [
+        {
+          _id: "register-current",
+          expectedCash: 20000,
+          openedAt: Date.UTC(2026, 4, 9, 9),
+          openingFloat: 10000,
+          registerNumber: "A1",
+          status: "closing",
+          storeId: "store-1",
+        },
+      ],
+      staffProfile: [
+        {
+          _id: "staff-1",
+          firstName: "Ama",
+          fullName: "Ama Mensah",
+          lastName: "Mensah",
+          organizationId: "org-1",
+          status: "active",
+          storeId: "store-1",
+        },
+      ],
+      store: [store],
+    });
+
+    const snapshot = await buildDailyCloseSnapshotWithCtx(
+      { db } as unknown as QueryCtx,
+      { operatingDate: "2026-05-08", storeId: "store-1" as Id<"store"> },
+    );
+
+    expect(snapshot.status).toBe("completed");
+    expect(snapshot.blockers).toEqual([]);
+    expect(snapshot.readyItems.map((item) => item.key)).toEqual([
+      "pos_transaction:txn-closed-day:completed",
+    ]);
+    expect(snapshot.summary.transactionCount).toBe(1);
+    expect(snapshot.completedClose).toMatchObject({
+      completedByStaffName: "Ama Mensah",
+      notes: "Closed cleanly.",
+    });
   });
 
   it("does not repeat the register when the terminal label already includes it", async () => {

--- a/packages/athena-webapp/convex/operations/dailyClose.ts
+++ b/packages/athena-webapp/convex/operations/dailyClose.ts
@@ -140,6 +140,45 @@ type DailyCloseReportSnapshot = {
   sourceSubjects: DailyCloseSnapshot["sourceSubjects"];
 };
 
+function normalizeCompletedDailyCloseSnapshot(args: {
+  dailyClose: Doc<"dailyClose">;
+  completedByStaffName?: string | null;
+  completedByStaffProfileId?: Id<"staffProfile">;
+}): DailyCloseSnapshot | null {
+  const reportSnapshot = args.dailyClose.reportSnapshot as
+    | DailyCloseReportSnapshot
+    | undefined;
+
+  if (!reportSnapshot) {
+    return null;
+  }
+
+  return {
+    operatingDate: reportSnapshot.closeMetadata.operatingDate,
+    storeId: reportSnapshot.closeMetadata.storeId,
+    organizationId: reportSnapshot.closeMetadata.organizationId,
+    startAt: reportSnapshot.closeMetadata.startAt,
+    endAt: reportSnapshot.closeMetadata.endAt,
+    existingClose: args.dailyClose,
+    completedClose: {
+      completedAt: reportSnapshot.closeMetadata.completedAt,
+      completedByStaffProfileId: args.completedByStaffProfileId,
+      completedByStaffName: args.completedByStaffName ?? null,
+      completedByUserId: reportSnapshot.closeMetadata.completedByUserId,
+      notes: reportSnapshot.closeMetadata.notes,
+    },
+    priorClose: null,
+    status: "completed",
+    blockers: [],
+    reviewItems: reportSnapshot.reviewedItems,
+    carryForwardItems: reportSnapshot.carryForwardItems,
+    readyItems: reportSnapshot.readyItems,
+    readiness: reportSnapshot.readiness,
+    summary: reportSnapshot.summary as DailyCloseSummary,
+    sourceSubjects: reportSnapshot.sourceSubjects,
+  };
+}
+
 type DailyCloseHistoryListItem = {
   dailyCloseId: Id<"dailyClose">;
   operatingDate: string;
@@ -529,28 +568,113 @@ async function listClosedRegisterSessionsForDay(
   );
 }
 
+function registerSessionIntersectsRange(
+  session: Pick<Doc<"registerSession">, "closedAt" | "openedAt">,
+  range: { endAt: number; startAt: number },
+) {
+  return (
+    session.openedAt < range.endAt &&
+    (session.closedAt ?? Infinity) >= range.startAt
+  );
+}
+
+function posSessionIntersectsRange(
+  session: Pick<
+    Doc<"posSession">,
+    "createdAt" | "expiresAt" | "heldAt" | "resumedAt"
+  >,
+  range: { endAt: number; startAt: number },
+) {
+  const startsAt = Math.min(
+    session.createdAt,
+    session.heldAt ?? session.createdAt,
+    session.resumedAt ?? session.createdAt,
+  );
+
+  return startsAt < range.endAt && session.expiresAt >= range.startAt;
+}
+
+async function approvalBelongsToRange(
+  ctx: Pick<QueryCtx, "db">,
+  approval: Doc<"approvalRequest">,
+  range: { endAt: number; startAt: number },
+) {
+  const transactionId =
+    approval.subjectType === "pos_transaction"
+      ? (approval.subjectId as Id<"posTransaction">)
+      : typeof approval.metadata?.transactionId === "string"
+        ? (approval.metadata.transactionId as Id<"posTransaction">)
+        : null;
+
+  if (transactionId) {
+    const transaction = await ctx.db.get("posTransaction", transactionId);
+
+    if (typeof transaction?.completedAt === "number") {
+      return isInRange(transaction.completedAt, range.startAt, range.endAt);
+    }
+  }
+
+  const registerSessionId =
+    approval.registerSessionId ??
+    (approval.subjectType === "register_session"
+      ? (approval.subjectId as Id<"registerSession">)
+      : null);
+
+  if (registerSessionId) {
+    const registerSession = await ctx.db.get(
+      "registerSession",
+      registerSessionId,
+    );
+
+    if (registerSession) {
+      return registerSessionIntersectsRange(registerSession, range);
+    }
+  }
+
+  return isInRange(approval.createdAt, range.startAt, range.endAt);
+}
+
 async function listPendingCloseoutApprovals(
   ctx: Pick<QueryCtx, "db">,
-  storeId: Id<"store">,
+  args: {
+    endAt: number;
+    startAt: number;
+    storeId: Id<"store">;
+  },
 ) {
   const approvals = await ctx.db
     .query("approvalRequest")
     .withIndex("by_storeId_status", (q) =>
-      q.eq("storeId", storeId).eq("status", "pending"),
+      q.eq("storeId", args.storeId).eq("status", "pending"),
     )
     .take(DAILY_CLOSE_QUERY_LIMIT);
 
-  return approvals.filter(
+  const closeoutApprovals = approvals.filter(
     (approval) =>
       approval.registerSessionId ||
       approval.subjectType === "register_session" ||
       approval.requestType === "variance_review",
   );
+
+  const scopedApprovals = await Promise.all(
+    closeoutApprovals.map(async (approval) => ({
+      approval,
+      belongsToRange: await approvalBelongsToRange(ctx, approval, args),
+    })),
+  );
+
+  return scopedApprovals
+    .filter(({ belongsToRange }) => belongsToRange)
+    .map(({ approval }) => approval);
 }
 
 async function listOpenPosSessions(
   ctx: Pick<QueryCtx, "db">,
-  storeId: Id<"store">,
+  args: {
+    endAt: number;
+    startAt: number;
+    storeId: Id<"store">;
+  },
 ) {
   const now = Date.now();
   const sessions = await Promise.all(
@@ -558,7 +682,7 @@ async function listOpenPosSessions(
       ctx.db
         .query("posSession")
         .withIndex("by_storeId_and_status", (q) =>
-          q.eq("storeId", storeId).eq("status", status),
+          q.eq("storeId", args.storeId).eq("status", status),
         )
         .take(DAILY_CLOSE_QUERY_LIMIT),
     ),
@@ -566,7 +690,10 @@ async function listOpenPosSessions(
 
   return sessions
     .flat()
-    .filter((session) => !session.expiresAt || session.expiresAt >= now);
+    .filter(
+      (session) =>
+        session.expiresAt >= now && posSessionIntersectsRange(session, args),
+    );
 }
 
 async function listOpenOperationalWorkItems(
@@ -904,6 +1031,31 @@ export async function buildDailyCloseSnapshotWithCtx(
     };
   }
 
+  const existingClose = await getDailyCloseForDate(ctx, args);
+
+  if (existingClose?.status === "completed" && existingClose.reportSnapshot) {
+    const completedByStaffProfileId =
+      existingClose.completedByStaffProfileId ??
+      (await getDailyCloseCompletionEventStaffProfileId(ctx, {
+        dailyCloseId: existingClose._id,
+        storeId: args.storeId,
+      }));
+    const staffNamesById = await buildStaffNamesById(ctx, [
+      completedByStaffProfileId,
+    ]);
+    const completedSnapshot = normalizeCompletedDailyCloseSnapshot({
+      dailyClose: existingClose,
+      completedByStaffProfileId,
+      completedByStaffName: completedByStaffProfileId
+        ? staffNamesById.get(completedByStaffProfileId) ?? null
+        : null,
+    });
+
+    if (completedSnapshot) {
+      return completedSnapshot;
+    }
+  }
+
   const [
     activeRegisterSessionsForStore,
     closedRegisterSessions,
@@ -914,13 +1066,12 @@ export async function buildDailyCloseSnapshotWithCtx(
     voidedTransactions,
     expenseTransactions,
     cashDeposits,
-    existingClose,
     priorClose,
   ] = await Promise.all([
     listActiveRegisterSessions(ctx, args.storeId),
     listClosedRegisterSessionsForDay(ctx, { ...range, storeId: args.storeId }),
-    listPendingCloseoutApprovals(ctx, args.storeId),
-    listOpenPosSessions(ctx, args.storeId),
+    listPendingCloseoutApprovals(ctx, { ...range, storeId: args.storeId }),
+    listOpenPosSessions(ctx, { ...range, storeId: args.storeId }),
     listOpenOperationalWorkItems(ctx, args.storeId),
     listTransactionsForDay(ctx, {
       ...range,
@@ -934,7 +1085,6 @@ export async function buildDailyCloseSnapshotWithCtx(
     }),
     listExpensesForDay(ctx, { ...range, storeId: args.storeId }),
     listDepositsForDay(ctx, { ...range, storeId: args.storeId }),
-    getDailyCloseForDate(ctx, args),
     getPriorCompletedDailyClose(ctx, args),
   ]);
 
@@ -996,6 +1146,7 @@ export async function buildDailyCloseSnapshotWithCtx(
     ...pendingApprovals.map((approval) => approval.requestedByStaffProfileId),
     completedByStaffProfileId,
   ]);
+
   const blockers: DailyCloseItem[] = [];
   const reviewItems: DailyCloseItem[] = [];
   const readyItems: DailyCloseItem[] = [];

--- a/packages/athena-webapp/src/components/operations/DailyCloseView.test.tsx
+++ b/packages/athena-webapp/src/components/operations/DailyCloseView.test.tsx
@@ -1179,10 +1179,53 @@ describe("DailyCloseViewContent", () => {
   it("renders completed End-of-Day Review summary after reload", () => {
     renderContent({
       ...readySnapshot,
+      blockers: blockedSnapshot.blockers,
       completedClose: {
         completedAt: Date.UTC(2026, 4, 7, 23, 15),
         completedByStaffName: "Ama Mensah",
         notes: "Clean close.",
+      },
+      reportSnapshot: {
+        closeMetadata: {
+          completedAt: Date.UTC(2026, 4, 7, 23, 15),
+          completedByStaffName: "Ama Mensah",
+          endAt: readySnapshot.endAt,
+          notes: "Clean close.",
+          operatingDate: readySnapshot.operatingDate,
+          startAt: readySnapshot.startAt,
+        },
+        carryForwardItems: [],
+        readyItems: [
+          {
+            category: "sale",
+            description: "Completed sale is included in End-of-Day Review.",
+            id: "persisted-sale",
+            metadata: {
+              completedAt: Date.UTC(2026, 4, 7, 14),
+              total: 10000,
+              transaction: "TXN-SAVED",
+            },
+            subject: {
+              id: "txn-saved",
+              label: "TXN-SAVED",
+              type: "pos_transaction",
+            },
+            title: "Saved close sale",
+          },
+        ],
+        readiness: {
+          blockerCount: 0,
+          carryForwardCount: 0,
+          readyCount: 1,
+          reviewCount: 0,
+          status: "ready",
+        },
+        reviewedItems: [],
+        summary: {
+          ...baseSummary,
+          totalSales: 10000,
+          transactionCount: 1,
+        },
       },
       status: "completed",
     });
@@ -1190,6 +1233,11 @@ describe("DailyCloseViewContent", () => {
     expect(screen.getByText("End-of-day review completed")).toBeInTheDocument();
     expect(screen.getByText(/Ama Mensah/)).toBeInTheDocument();
     expect(screen.getByText("Clean close.")).toBeInTheDocument();
+    expect(
+      screen.queryByText("Payment method correction pending"),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText("Saved close sale")).toBeInTheDocument();
+    expect(screen.getAllByText("GH₵100").length).toBeGreaterThan(0);
   });
 
   it("renders protected access states consistently with operations pages", () => {

--- a/packages/athena-webapp/src/components/operations/DailyCloseView.tsx
+++ b/packages/athena-webapp/src/components/operations/DailyCloseView.tsx
@@ -133,6 +133,7 @@ export type DailyCloseSnapshot = {
   } | null;
   operatingDate: string;
   readyItems: DailyCloseItem[];
+  reportSnapshot?: DailyCloseStoredReportSnapshot | null;
   startAt: number;
   endAt: number;
   readiness?: {
@@ -174,6 +175,24 @@ export type DailyCloseSnapshot = {
     varianceTotal?: number | null;
     voidedTransactionCount?: number | null;
   };
+};
+
+type DailyCloseStoredReportSnapshot = {
+  closeMetadata?: {
+    completedAt?: number | null;
+    completedByStaffName?: string | null;
+    endAt: number;
+    notes?: string | null;
+    operatingDate: string;
+    startAt: number;
+  };
+  carryForwardItems?: DailyCloseSnapshot["carryForwardItems"];
+  readyItems?: DailyCloseSnapshot["readyItems"];
+  readiness?: DailyCloseSnapshot["readiness"];
+  reviewedItems?: DailyCloseSnapshot["reviewItems"];
+  reviewItems?: DailyCloseSnapshot["reviewItems"];
+  status?: DailyCloseSnapshot["status"];
+  summary?: DailyCloseSnapshot["summary"];
 };
 
 type CompletionArgs = {
@@ -1304,6 +1323,44 @@ function getStatusDisplayCopy(
   return statusCopy[status];
 }
 
+function normalizeCompletedReportSnapshot(
+  snapshot: DailyCloseSnapshot,
+): DailyCloseSnapshot {
+  if (snapshot.status !== "completed" || !snapshot.reportSnapshot) {
+    return snapshot;
+  }
+
+  const storedSnapshot = snapshot.reportSnapshot;
+
+  if (!storedSnapshot.closeMetadata) {
+    return snapshot;
+  }
+
+  return {
+    ...snapshot,
+    blockers: [],
+    carryForwardItems: storedSnapshot.carryForwardItems ?? [],
+    completedClose: {
+      completedAt:
+        storedSnapshot.closeMetadata.completedAt ??
+        snapshot.completedClose?.completedAt,
+      completedByStaffName:
+        storedSnapshot.closeMetadata.completedByStaffName ??
+        snapshot.completedClose?.completedByStaffName,
+      notes:
+        storedSnapshot.closeMetadata.notes ?? snapshot.completedClose?.notes,
+    },
+    endAt: storedSnapshot.closeMetadata.endAt,
+    operatingDate: storedSnapshot.closeMetadata.operatingDate,
+    readyItems: storedSnapshot.readyItems ?? [],
+    readiness: storedSnapshot.readiness ?? snapshot.readiness,
+    reviewItems:
+      storedSnapshot.reviewedItems ?? storedSnapshot.reviewItems ?? [],
+    startAt: storedSnapshot.closeMetadata.startAt,
+    summary: storedSnapshot.summary ?? snapshot.summary,
+  };
+}
+
 function getDefaultBucketValue(
   snapshot: DailyCloseSnapshot,
   status: DailyCloseStatus,
@@ -1997,10 +2054,11 @@ export function DailyCloseReadOnlyReport({
   snapshot: DailyCloseSnapshot;
   storeUrlSlug: string;
 }) {
-  const status = getDailyCloseStatus(snapshot);
-  const displayCopy = getStatusDisplayCopy(snapshot, status);
-  const buckets = getBucketConfigs(snapshot);
-  const defaultBucketValue = getDefaultBucketValue(snapshot, status);
+  const displaySnapshot = normalizeCompletedReportSnapshot(snapshot);
+  const status = getDailyCloseStatus(displaySnapshot);
+  const displayCopy = getStatusDisplayCopy(displaySnapshot, status);
+  const buckets = getBucketConfigs(displaySnapshot);
+  const defaultBucketValue = getDefaultBucketValue(displaySnapshot, status);
   const [selectedBucketValue, setSelectedBucketValue] =
     useState<BucketStatus>(defaultBucketValue);
   const [selectedBucketPage, setSelectedBucketPage] = useState(1);
@@ -2009,7 +2067,7 @@ export function DailyCloseReadOnlyReport({
     buckets.find((bucket) => bucket.value === defaultBucketValue) ??
     buckets[0];
   const salesMetricLabels = getDailyCloseSalesMetricLabels(
-    snapshot.operatingDate,
+    displaySnapshot.operatingDate,
   );
 
   return (
@@ -2028,13 +2086,13 @@ export function DailyCloseReadOnlyReport({
             <TransactionReportAction
               currency={currency}
               orgUrlSlug={orgUrlSlug}
-              snapshot={snapshot}
+              snapshot={displaySnapshot}
               storeUrlSlug={storeUrlSlug}
             />
             <div className="rounded-lg border border-border bg-surface-raised px-layout-md py-layout-sm text-sm text-muted-foreground shadow-surface">
               Operating date{" "}
               <span className="font-medium text-foreground">
-                {formatDailyCloseOperatingDate(snapshot.operatingDate)}
+                {formatDailyCloseOperatingDate(displaySnapshot.operatingDate)}
               </span>
             </div>
           </div>
@@ -2044,7 +2102,7 @@ export function DailyCloseReadOnlyReport({
           <OperationsSummaryMetric
             helper={formatEntityCount(
               getSummaryCount(
-                snapshot.summary,
+                displaySnapshot.summary,
                 "transactionCount",
                 "transactionCount",
               ),
@@ -2055,20 +2113,24 @@ export function DailyCloseReadOnlyReport({
               ariaLabel: "Open transactions",
               orgUrlSlug,
               search: buildDailyCloseTransactionSearch({
-                operatingDate: snapshot.operatingDate,
+                operatingDate: displaySnapshot.operatingDate,
               }),
               storeUrlSlug,
               to: "/$orgUrlSlug/store/$storeUrlSlug/pos/transactions",
             }}
             value={formatDailyCloseMoney(
               currency,
-              getSummaryAmount(snapshot.summary, "totalSales", "salesTotal"),
+              getSummaryAmount(
+                displaySnapshot.summary,
+                "totalSales",
+                "salesTotal",
+              ),
             )}
           />
           <OperationsSummaryMetric
             helper={formatTodayCashTransactionCount(
               getSummaryCount(
-                snapshot.summary,
+                displaySnapshot.summary,
                 "currentDayCashTransactionCount",
                 "transactionCount",
               ),
@@ -2078,7 +2140,7 @@ export function DailyCloseReadOnlyReport({
               ariaLabel: "Open cash transactions",
               orgUrlSlug,
               search: buildDailyCloseTransactionSearch({
-                operatingDate: snapshot.operatingDate,
+                operatingDate: displaySnapshot.operatingDate,
                 paymentMethod: "cash",
               }),
               storeUrlSlug,
@@ -2087,7 +2149,7 @@ export function DailyCloseReadOnlyReport({
             value={formatDailyCloseMoney(
               currency,
               getSummaryAmount(
-                snapshot.summary,
+                displaySnapshot.summary,
                 "currentDayCashTotal",
                 "cashExpected",
               ),
@@ -2096,7 +2158,7 @@ export function DailyCloseReadOnlyReport({
           <OperationsSummaryMetric
             helper={formatCarriedOverRegisterCount(
               getSummaryCount(
-                snapshot.summary,
+                displaySnapshot.summary,
                 "carriedOverRegisterCount",
                 "carriedOverRegisterCount",
               ),
@@ -2105,7 +2167,7 @@ export function DailyCloseReadOnlyReport({
             value={formatDailyCloseMoney(
               currency,
               getSummaryAmount(
-                snapshot.summary,
+                displaySnapshot.summary,
                 "carriedOverCashTotal",
                 "carriedOverCashTotal",
               ),
@@ -2113,23 +2175,23 @@ export function DailyCloseReadOnlyReport({
           />
           <OperationsSummaryMetric
             helper={formatExpenseTransactionCount(
-              getExpenseTransactionCount(snapshot.summary),
+              getExpenseTransactionCount(displaySnapshot.summary),
             )}
             label="Expenses"
             value={formatDailyCloseMoney(
               currency,
-              snapshot.summary.expenseTotal,
+              displaySnapshot.summary.expenseTotal,
             )}
           />
           <OperationsSummaryMetric
             helper={formatRegisterVarianceCount(
-              getSummaryRegisterVarianceCount(snapshot.summary),
+              getSummaryRegisterVarianceCount(displaySnapshot.summary),
             )}
             label="Variance"
             value={formatDailyCloseMoney(
               currency,
               getSummaryAmount(
-                snapshot.summary,
+                displaySnapshot.summary,
                 "varianceTotal",
                 "netCashVariance",
               ),
@@ -2534,18 +2596,21 @@ export function DailyCloseViewContent({
     );
   }
 
-  const status = snapshot ? getDailyCloseStatus(snapshot) : "ready";
+  const displaySnapshot = snapshot
+    ? normalizeCompletedReportSnapshot(snapshot)
+    : undefined;
+  const status = displaySnapshot ? getDailyCloseStatus(displaySnapshot) : "ready";
   const isBlocked = status === "blocked";
   const isCompleted = status === "completed";
-  const displayCopy = snapshot
-    ? getStatusDisplayCopy(snapshot, status)
+  const displayCopy = displaySnapshot
+    ? getStatusDisplayCopy(displaySnapshot, status)
     : statusCopy[status];
-  const salesMetricLabels = snapshot
-    ? getDailyCloseSalesMetricLabels(snapshot.operatingDate)
+  const salesMetricLabels = displaySnapshot
+    ? getDailyCloseSalesMetricLabels(displaySnapshot.operatingDate)
     : null;
-  const buckets = snapshot ? getBucketConfigs(snapshot) : [];
-  const defaultBucketValue = snapshot
-    ? getDefaultBucketValue(snapshot, status)
+  const buckets = displaySnapshot ? getBucketConfigs(displaySnapshot) : [];
+  const defaultBucketValue = displaySnapshot
+    ? getDefaultBucketValue(displaySnapshot, status)
     : "ready";
   const selectedBucketValue =
     normalizeBucketTab(search.tab) ?? defaultBucketValue;
@@ -2618,17 +2683,17 @@ export function DailyCloseViewContent({
   return (
     <OperationReviewWorkspace
       actions={
-        snapshot ? (
+        displaySnapshot ? (
           <>
             <TransactionReportAction
               currency={currency}
               orgUrlSlug={orgUrlSlug}
-              snapshot={snapshot}
+              snapshot={displaySnapshot}
               storeUrlSlug={storeUrlSlug}
             />
             <OperatingDatePicker
               latestSelectableDate={latestSelectableOperatingDate}
-              operatingDate={snapshot.operatingDate}
+              operatingDate={displaySnapshot.operatingDate}
               onChange={onOperatingDateChange}
             />
           </>
@@ -2637,9 +2702,9 @@ export function DailyCloseViewContent({
       afterGrid={completionApprovalRunner.dialog}
       description="Review the operating day, resolve blockers, and preserve follow-ups before saving the close summary."
       eyebrow="Store Ops"
-      isLoading={isLoadingSnapshot || !snapshot}
+      isLoading={isLoadingSnapshot || !displaySnapshot}
       main={
-        snapshot ? (
+        displaySnapshot ? (
           <BucketTabs
             buckets={buckets}
             currency={currency}
@@ -2655,12 +2720,12 @@ export function DailyCloseViewContent({
         ) : null
       }
       metrics={
-        snapshot ? (
+        displaySnapshot ? (
           <>
             <OperationsSummaryMetric
               helper={formatEntityCount(
                 getSummaryCount(
-                  snapshot.summary,
+                  displaySnapshot.summary,
                   "transactionCount",
                   "transactionCount",
                 ),
@@ -2671,20 +2736,24 @@ export function DailyCloseViewContent({
                 ariaLabel: "Open transactions",
                 orgUrlSlug,
                 search: buildDailyCloseTransactionSearch({
-                  operatingDate: snapshot.operatingDate,
+                  operatingDate: displaySnapshot.operatingDate,
                 }),
                 storeUrlSlug,
                 to: "/$orgUrlSlug/store/$storeUrlSlug/pos/transactions",
               }}
               value={formatDailyCloseMoney(
                 currency,
-                getSummaryAmount(snapshot.summary, "totalSales", "salesTotal"),
+                getSummaryAmount(
+                  displaySnapshot.summary,
+                  "totalSales",
+                  "salesTotal",
+                ),
               )}
             />
             <OperationsSummaryMetric
               helper={formatTodayCashTransactionCount(
                 getSummaryCount(
-                  snapshot.summary,
+                  displaySnapshot.summary,
                   "currentDayCashTransactionCount",
                   "transactionCount",
                 ),
@@ -2694,7 +2763,7 @@ export function DailyCloseViewContent({
                 ariaLabel: "Open cash transactions",
                 orgUrlSlug,
                 search: buildDailyCloseTransactionSearch({
-                  operatingDate: snapshot.operatingDate,
+                  operatingDate: displaySnapshot.operatingDate,
                   paymentMethod: "cash",
                 }),
                 storeUrlSlug,
@@ -2703,7 +2772,7 @@ export function DailyCloseViewContent({
               value={formatDailyCloseMoney(
                 currency,
                 getSummaryAmount(
-                  snapshot.summary,
+                  displaySnapshot.summary,
                   "currentDayCashTotal",
                   "cashExpected",
                 ),
@@ -2712,7 +2781,7 @@ export function DailyCloseViewContent({
             <OperationsSummaryMetric
               helper={formatCarriedOverRegisterCount(
                 getSummaryCount(
-                  snapshot.summary,
+                  displaySnapshot.summary,
                   "carriedOverRegisterCount",
                   "carriedOverRegisterCount",
                 ),
@@ -2721,7 +2790,7 @@ export function DailyCloseViewContent({
               value={formatDailyCloseMoney(
                 currency,
                 getSummaryAmount(
-                  snapshot.summary,
+                  displaySnapshot.summary,
                   "carriedOverCashTotal",
                   "carriedOverCashTotal",
                 ),
@@ -2729,23 +2798,23 @@ export function DailyCloseViewContent({
             />
             <OperationsSummaryMetric
               helper={formatExpenseTransactionCount(
-                getExpenseTransactionCount(snapshot.summary),
+                getExpenseTransactionCount(displaySnapshot.summary),
               )}
               label="Expenses"
               value={formatDailyCloseMoney(
                 currency,
-                snapshot.summary.expenseTotal,
+                displaySnapshot.summary.expenseTotal,
               )}
             />
             <OperationsSummaryMetric
               helper={formatRegisterVarianceCount(
-                getSummaryRegisterVarianceCount(snapshot.summary),
+                getSummaryRegisterVarianceCount(displaySnapshot.summary),
               )}
               label="Variance"
               value={formatDailyCloseMoney(
                 currency,
                 getSummaryAmount(
-                  snapshot.summary,
+                  displaySnapshot.summary,
                   "varianceTotal",
                   "netCashVariance",
                 ),
@@ -2755,7 +2824,7 @@ export function DailyCloseViewContent({
         ) : null
       }
       rail={
-        snapshot ? (
+        displaySnapshot ? (
           <CompletionRail
             commandMessage={commandMessage}
             isBlocked={isBlocked}
@@ -2764,7 +2833,7 @@ export function DailyCloseViewContent({
             notes={notes}
             onComplete={() => void handleComplete()}
             onNotesChange={setNotes}
-            snapshot={snapshot}
+            snapshot={displaySnapshot}
             status={status}
           />
         ) : null


### PR DESCRIPTION
## Summary

Completed End-of-Day Review pages now render the persisted close report snapshot instead of recomputing blockers from live store state. Live daily-close blocker sourcing is also tightened so pending approvals and active/held POS sessions must belong to the selected operating day before they can block closeout.

## Changes

- Return `dailyClose.reportSnapshot` early for completed daily-close records.
- Scope approval blockers by linked POS transaction date or register-session operating range.
- Scope unresolved POS session blockers to sessions that intersect the selected operating-day range.
- Normalize completed daily-close UI rendering to the stored report snapshot when present.
- Add regression coverage for completed snapshot rendering and cross-day blocker leakage.
- Refresh the store-ops solution note and Graphify artifacts.

## Validation

- `bun run --filter '@athena/webapp' test -- convex/operations/dailyClose.test.ts src/components/operations/DailyCloseView.test.tsx`
- `bun run --filter '@athena/webapp' typecheck`
- `bun run --filter '@athena/webapp' lint:convex:changed`
- `bun run --filter '@athena/webapp' lint:frontend:changed` (passes with existing fast-refresh warnings)
- `bun run compound:check`
- `bun run graphify:rebuild`
- `bun run graphify:check`
- `git diff --check`

Skipped with explicit operator approval: `pre-commit:generated-artifacts` / hook path, because `convex dev --once` is currently hanging and another agent is investigating that step.