### PR TITLE
Align members page headers with theme

### DIFF
--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 5020 nodes · 5027 edges · 1596 communities detected
+- 5021 nodes · 5027 edges · 1597 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -1606,6 +1606,7 @@
 - [[_COMMUNITY_Community 1593|Community 1593]]
 - [[_COMMUNITY_Community 1594|Community 1594]]
 - [[_COMMUNITY_Community 1595|Community 1595]]
+- [[_COMMUNITY_Community 1596|Community 1596]]
 
 ## God Nodes (most connected - your core abstractions)
 1. `createJourneyEvent()` - 40 edges
@@ -2210,16 +2211,16 @@ Cohesion: 0.29
 Nodes (0):
 
 ### Community 144 - "Community 144"
+Cohesion: 0.33
+Nodes (2): getProductName(), sortProduct()
+
+### Community 145 - "Community 145"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 145 - "Community 145"
+### Community 146 - "Community 146"
 Cohesion: 0.52
 Nodes (6): addItemToSavedBag(), getActiveSavedBag(), getBaseUrl(), removeItemFromSavedBag(), updateSavedBagItem(), updateSavedBagOwner()
-
-### Community 146 - "Community 146"
-Cohesion: 0.33
-Nodes (2): getProductName(), sortProduct()
 
 ### Community 147 - "Community 147"
 Cohesion: 0.43
@@ -2471,7 +2472,7 @@ Nodes (0):
 
 ### Community 209 - "Community 209"
 Cohesion: 0.4
-Nodes (1): Header()
+Nodes (0):
 
 ### Community 210 - "Community 210"
 Cohesion: 0.4
@@ -2486,12 +2487,12 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 213 - "Community 213"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 214 - "Community 214"
 Cohesion: 0.5
 Nodes (2): handleFileSelect(), validateFile()
+
+### Community 214 - "Community 214"
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 215 - "Community 215"
 Cohesion: 0.4
@@ -2506,20 +2507,20 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 218 - "Community 218"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 219 - "Community 219"
 Cohesion: 0.5
 Nodes (2): getBalanceDueLabel(), getBalanceDuePanel()
 
-### Community 220 - "Community 220"
+### Community 219 - "Community 219"
 Cohesion: 0.6
 Nodes (3): getSummaryAmount(), getSummaryLabel(), getSummaryPanel()
 
-### Community 221 - "Community 221"
+### Community 220 - "Community 220"
 Cohesion: 0.6
 Nodes (3): handleClearSearch(), handleQuickAddSubmit(), resetQuickAddForm()
+
+### Community 221 - "Community 221"
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 222 - "Community 222"
 Cohesion: 0.4
@@ -2534,32 +2535,32 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 225 - "Community 225"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 226 - "Community 226"
 Cohesion: 0.7
 Nodes (4): getRuntimeOrigin(), isLocalHost(), resolveStoreFrontUrl(), trimTrailingSlash()
 
-### Community 227 - "Community 227"
+### Community 226 - "Community 226"
 Cohesion: 0.7
 Nodes (4): bufferToHex(), collectBrowserInfo(), generateBrowserFingerprint(), hashFingerprintSource()
 
-### Community 228 - "Community 228"
+### Community 227 - "Community 227"
 Cohesion: 0.4
 Nodes (1): MockImage
 
-### Community 229 - "Community 229"
+### Community 228 - "Community 228"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 230 - "Community 230"
+### Community 229 - "Community 229"
 Cohesion: 0.6
 Nodes (3): calculatePosCartTotals(), calculatePosItemTotal(), roundPosAmount()
 
-### Community 231 - "Community 231"
+### Community 230 - "Community 230"
 Cohesion: 0.6
 Nodes (4): mapRegisterStateDto(), mapTerminalDto(), useConvexRegisterState(), useConvexTerminalByFingerprint()
+
+### Community 231 - "Community 231"
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 232 - "Community 232"
 Cohesion: 0.4
@@ -2574,88 +2575,88 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 235 - "Community 235"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 236 - "Community 236"
 Cohesion: 0.5
 Nodes (2): completePendingAuthSync(), sleep()
 
-### Community 237 - "Community 237"
+### Community 236 - "Community 236"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 238 - "Community 238"
+### Community 237 - "Community 237"
 Cohesion: 0.7
 Nodes (4): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory()
 
-### Community 239 - "Community 239"
+### Community 238 - "Community 238"
 Cohesion: 0.7
 Nodes (4): getBaseUrl(), getOrder(), getOrders(), updateOrdersOwner()
 
-### Community 240 - "Community 240"
+### Community 239 - "Community 239"
 Cohesion: 0.7
 Nodes (4): getActiveUser(), getBaseUrl(), getGuest(), updateUser()
+
+### Community 240 - "Community 240"
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 241 - "Community 241"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 242 - "Community 242"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 243 - "Community 243"
 Cohesion: 0.7
 Nodes (4): createStorefrontFailureEvent(), emitStorefrontFailure(), inferStorefrontJourneyFromRoute(), normalizeStorefrontError()
+
+### Community 243 - "Community 243"
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 244 - "Community 244"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 245 - "Community 245"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 246 - "Community 246"
 Cohesion: 0.6
 Nodes (4): collectHarnessRepoValidationSelection(), matchesHarnessRepoValidationPath(), normalizeRepoPath(), sortUniquePaths()
 
-### Community 247 - "Community 247"
+### Community 246 - "Community 246"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 248 - "Community 248"
+### Community 247 - "Community 247"
 Cohesion: 0.7
 Nodes (4): createFixtureRepo(), fixtureEnv(), runGit(), runWorktreeManager()
 
-### Community 249 - "Community 249"
+### Community 248 - "Community 248"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 250 - "Community 250"
+### Community 249 - "Community 249"
 Cohesion: 0.67
 Nodes (2): maskReceiptPhone(), normalizeReceiptPhone()
 
-### Community 251 - "Community 251"
+### Community 250 - "Community 250"
 Cohesion: 0.83
 Nodes (3): createReceiptShareToken(), hashReceiptShareToken(), toHex()
 
-### Community 252 - "Community 252"
+### Community 251 - "Community 251"
 Cohesion: 0.83
 Nodes (3): timingSafeEqual(), toHex(), verifyMetaWebhookSignature()
+
+### Community 252 - "Community 252"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 253 - "Community 253"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 254 - "Community 254"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 255 - "Community 255"
 Cohesion: 0.67
 Nodes (2): createExpenseTransactionFromSessionHandler(), expenseTransactionError()
+
+### Community 255 - "Community 255"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 256 - "Community 256"
 Cohesion: 0.5
@@ -2666,68 +2667,68 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 258 - "Community 258"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 259 - "Community 259"
 Cohesion: 0.67
 Nodes (2): createProductsQueryCtx(), createSkuMutationCtx()
 
-### Community 260 - "Community 260"
+### Community 259 - "Community 259"
 Cohesion: 0.83
 Nodes (3): getCachedTokenRecord(), resolveAccessTokenForStore(), resolveConfigForStore()
 
-### Community 261 - "Community 261"
+### Community 260 - "Community 260"
 Cohesion: 0.67
 Nodes (2): maskMtnPartyId(), normalizeCollectionsTransaction()
 
-### Community 262 - "Community 262"
+### Community 261 - "Community 261"
 Cohesion: 0.67
 Nodes (2): consumeApprovalProofWithCtx(), invalidApprovalProofResult()
 
-### Community 263 - "Community 263"
+### Community 262 - "Community 262"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 264 - "Community 264"
+### Community 263 - "Community 263"
 Cohesion: 0.67
 Nodes (2): buildOperationalEvent(), recordOperationalEventWithCtx()
 
-### Community 265 - "Community 265"
+### Community 264 - "Community 264"
 Cohesion: 0.67
 Nodes (2): buildOperationalWorkItem(), createOperationalWorkItemWithCtx()
 
-### Community 266 - "Community 266"
+### Community 265 - "Community 265"
 Cohesion: 0.67
 Nodes (2): expectIndex(), getTableIndexes()
+
+### Community 266 - "Community 266"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 267 - "Community 267"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 268 - "Community 268"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 269 - "Community 269"
 Cohesion: 0.83
 Nodes (3): resolveServiceIntakeCustomerProfile(), splitFullName(), trimOptional()
 
-### Community 270 - "Community 270"
+### Community 269 - "Community 269"
 Cohesion: 0.83
 Nodes (3): mapOpenDrawerUserError(), normalizeRegisterNumber(), openDrawer()
 
-### Community 271 - "Community 271"
+### Community 270 - "Community 270"
 Cohesion: 0.83
 Nodes (3): createDbGetMock(), createDbMock(), createDbQueryMock()
 
-### Community 272 - "Community 272"
+### Community 271 - "Community 271"
 Cohesion: 0.83
 Nodes (3): buildRegisterState(), getActiveSessionConflictForRegisterState(), getRegisterState()
 
-### Community 273 - "Community 273"
+### Community 272 - "Community 272"
 Cohesion: 0.67
 Nodes (2): lookupByBarcode(), mapSkuToCatalogResult()
+
+### Community 273 - "Community 273"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 274 - "Community 274"
 Cohesion: 0.5
@@ -2738,24 +2739,24 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 276 - "Community 276"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 277 - "Community 277"
 Cohesion: 0.67
 Nodes (2): expectIndex(), getTableIndexes()
 
-### Community 278 - "Community 278"
+### Community 277 - "Community 277"
 Cohesion: 0.83
 Nodes (3): findExistingCustomerProfileId(), getStoreOrganizationId(), recordStoreFrontCustomerMilestone()
 
-### Community 279 - "Community 279"
+### Community 278 - "Community 278"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 280 - "Community 280"
+### Community 279 - "Community 279"
 Cohesion: 0.83
 Nodes (3): formatStaffDisplayName(), formatStaffDisplayNameOrFallback(), normalizeNamePart()
+
+### Community 280 - "Community 280"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 281 - "Community 281"
 Cohesion: 0.5
@@ -2770,12 +2771,12 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 284 - "Community 284"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 285 - "Community 285"
 Cohesion: 0.67
 Nodes (2): countGroupedAnalytics(), groupAnalytics()
+
+### Community 285 - "Community 285"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 286 - "Community 286"
 Cohesion: 0.5
@@ -2794,12 +2795,12 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 290 - "Community 290"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 291 - "Community 291"
 Cohesion: 0.67
 Nodes (2): handleSubmit(), resetReplacementFields()
+
+### Community 291 - "Community 291"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 292 - "Community 292"
 Cohesion: 0.5
@@ -2822,80 +2823,80 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 297 - "Community 297"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 298 - "Community 298"
 Cohesion: 0.67
 Nodes (2): applyCommandResult(), handleCreateCase()
+
+### Community 298 - "Community 298"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 299 - "Community 299"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 300 - "Community 300"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 301 - "Community 301"
 Cohesion: 0.67
 Nodes (2): getRiskStyles(), RiskIndicators()
 
-### Community 302 - "Community 302"
+### Community 301 - "Community 301"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 303 - "Community 303"
+### Community 302 - "Community 302"
 Cohesion: 0.67
 Nodes (2): useGetArchivedProducts(), useGetProducts()
 
-### Community 304 - "Community 304"
+### Community 303 - "Community 303"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 305 - "Community 305"
+### Community 304 - "Community 304"
 Cohesion: 0.67
 Nodes (2): extractTraceId(), runCommand()
 
-### Community 306 - "Community 306"
+### Community 305 - "Community 305"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 307 - "Community 307"
+### Community 306 - "Community 306"
 Cohesion: 0.67
 Nodes (2): formatStoredAmount(), formatStoredCurrencyAmount()
 
-### Community 308 - "Community 308"
+### Community 307 - "Community 307"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 309 - "Community 309"
+### Community 308 - "Community 308"
 Cohesion: 0.67
 Nodes (2): mapActiveSessionDto(), normalizeCartItems()
 
-### Community 310 - "Community 310"
+### Community 309 - "Community 309"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 311 - "Community 311"
+### Community 310 - "Community 310"
 Cohesion: 0.83
 Nodes (3): isBrowserFingerprintResult(), readStoredTerminalFingerprint(), readStoredTerminalFingerprintHash()
 
-### Community 312 - "Community 312"
+### Community 311 - "Community 311"
 Cohesion: 0.67
 Nodes (2): getCashierDisplayName(), useExpenseRegisterViewModel()
 
-### Community 313 - "Community 313"
+### Community 312 - "Community 312"
 Cohesion: 0.83
 Nodes (3): getBaseUrl(), getUserRedeemedOffers(), submitOffer()
 
-### Community 314 - "Community 314"
+### Community 313 - "Community 313"
 Cohesion: 0.83
 Nodes (3): getAllStores(), getBaseUrl(), getStore()
 
-### Community 315 - "Community 315"
+### Community 314 - "Community 314"
 Cohesion: 0.83
 Nodes (3): getAllSubcategories(), getBaseUrl(), getSubategory()
+
+### Community 315 - "Community 315"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 316 - "Community 316"
 Cohesion: 0.5
@@ -2926,59 +2927,59 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 323 - "Community 323"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 324 - "Community 324"
 Cohesion: 0.67
 Nodes (2): useOptionalStoreContext(), useStoreContext()
 
-### Community 325 - "Community 325"
+### Community 324 - "Community 324"
 Cohesion: 0.67
 Nodes (2): clearFilters(), onMobileFiltersCloseClick()
 
-### Community 326 - "Community 326"
+### Community 325 - "Community 325"
 Cohesion: 0.83
 Nodes (3): cancelOrder(), getErrorMessage(), placeOrder()
 
-### Community 327 - "Community 327"
+### Community 326 - "Community 326"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 328 - "Community 328"
+### Community 327 - "Community 327"
 Cohesion: 0.83
 Nodes (3): bootstrapCheckout(), createBootstrapToken(), createMarker()
 
-### Community 329 - "Community 329"
+### Community 328 - "Community 328"
 Cohesion: 0.83
 Nodes (3): createFixtureRoot(), write(), writeGraphifyWikiArtifacts()
 
-### Community 330 - "Community 330"
+### Community 329 - "Community 329"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 331 - "Community 331"
+### Community 330 - "Community 330"
 Cohesion: 0.67
 Nodes (2): buildHarnessDocPaths(), buildHarnessDocPathsForArchetype()
 
-### Community 332 - "Community 332"
+### Community 331 - "Community 331"
 Cohesion: 0.67
 Nodes (2): shutdown(), stopValkeyRuntimeServer()
 
-### Community 333 - "Community 333"
+### Community 332 - "Community 332"
 Cohesion: 0.83
 Nodes (3): createFixtureRepo(), createInferentialArtifact(), write()
 
-### Community 334 - "Community 334"
+### Community 333 - "Community 333"
 Cohesion: 0.67
 Nodes (2): collectHarnessTestTargets(), runHarnessTest()
+
+### Community 334 - "Community 334"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 335 - "Community 335"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 336 - "Community 336"
-Cohesion: 0.5
+Cohesion: 0.67
 Nodes (0):
 
 ### Community 337 - "Community 337"
@@ -2986,12 +2987,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 338 - "Community 338"
-Cohesion: 0.67
-Nodes (0):
-
-### Community 339 - "Community 339"
 Cohesion: 1.0
 Nodes (2): providerErrorCategory(), sendWhatsAppReceiptTemplate()
+
+### Community 339 - "Community 339"
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 340 - "Community 340"
 Cohesion: 0.67
@@ -3022,12 +3023,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 347 - "Community 347"
-Cohesion: 0.67
-Nodes (0):
-
-### Community 348 - "Community 348"
 Cohesion: 1.0
 Nodes (2): buildCtx(), createDb()
+
+### Community 348 - "Community 348"
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 349 - "Community 349"
 Cohesion: 0.67
@@ -3047,11 +3048,11 @@ Nodes (0):
 
 ### Community 353 - "Community 353"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): PosServerError
 
 ### Community 354 - "Community 354"
 Cohesion: 0.67
-Nodes (1): PosServerError
+Nodes (0):
 
 ### Community 355 - "Community 355"
 Cohesion: 0.67
@@ -3066,24 +3067,24 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 358 - "Community 358"
-Cohesion: 0.67
-Nodes (0):
-
-### Community 359 - "Community 359"
 Cohesion: 1.0
 Nodes (2): getActiveRegisterSessionForRegisterState(), mapRegisterSessionToCashDrawerSummary()
 
-### Community 360 - "Community 360"
+### Community 359 - "Community 359"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 361 - "Community 361"
+### Community 360 - "Community 360"
 Cohesion: 1.0
 Nodes (2): buildServiceCatalogItem(), normalizeServiceCatalogNameKey()
 
-### Community 362 - "Community 362"
+### Community 361 - "Community 361"
 Cohesion: 1.0
 Nodes (2): expectIndex(), getTableIndexes()
+
+### Community 362 - "Community 362"
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 363 - "Community 363"
 Cohesion: 0.67
@@ -3098,36 +3099,36 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 366 - "Community 366"
-Cohesion: 0.67
-Nodes (0):
-
-### Community 367 - "Community 367"
 Cohesion: 1.0
 Nodes (2): listBagItems(), loadBagWithItems()
 
-### Community 368 - "Community 368"
+### Community 367 - "Community 367"
 Cohesion: 1.0
 Nodes (2): buildRegisterSessionTraceSeed(), formatRegisterSessionLabel()
 
-### Community 369 - "Community 369"
+### Community 368 - "Community 368"
 Cohesion: 1.0
 Nodes (2): getWorkflowTraceViewByIdWithCtx(), getWorkflowTraceViewByLookupWithCtx()
+
+### Community 369 - "Community 369"
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 370 - "Community 370"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 371 - "Community 371"
-Cohesion: 0.67
-Nodes (0):
-
-### Community 372 - "Community 372"
 Cohesion: 1.0
 Nodes (2): createWorkflowTraceId(), normalizeWorkflowTraceLookupValue()
 
-### Community 373 - "Community 373"
+### Community 372 - "Community 372"
 Cohesion: 0.67
 Nodes (1): View()
+
+### Community 373 - "Community 373"
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 374 - "Community 374"
 Cohesion: 0.67
@@ -3142,12 +3143,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 377 - "Community 377"
-Cohesion: 0.67
-Nodes (0):
-
-### Community 378 - "Community 378"
 Cohesion: 1.0
 Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
+
+### Community 378 - "Community 378"
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 379 - "Community 379"
 Cohesion: 0.67
@@ -3178,20 +3179,20 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 386 - "Community 386"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 387 - "Community 387"
 Cohesion: 1.0
 Nodes (2): CashierAuthDialog(), getStaffDisplayName()
 
-### Community 387 - "Community 387"
+### Community 388 - "Community 388"
 Cohesion: 0.67
 Nodes (0):
-
-### Community 388 - "Community 388"
-Cohesion: 1.0
-Nodes (2): getLocalOperatingDate(), getLocalOperatingDateRange()
 
 ### Community 389 - "Community 389"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getLocalOperatingDate(), getLocalOperatingDateRange()
 
 ### Community 390 - "Community 390"
 Cohesion: 0.67
@@ -3238,84 +3239,84 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 401 - "Community 401"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 402 - "Community 402"
 Cohesion: 1.0
 Nodes (2): handleKeyDown(), handleSubmit()
 
-### Community 402 - "Community 402"
+### Community 403 - "Community 403"
 Cohesion: 0.67
 Nodes (1): SingleLineError()
 
-### Community 403 - "Community 403"
+### Community 404 - "Community 404"
 Cohesion: 0.67
 Nodes (1): ErrorPage()
 
-### Community 404 - "Community 404"
+### Community 405 - "Community 405"
 Cohesion: 0.67
 Nodes (1): AppSkeleton()
 
-### Community 405 - "Community 405"
+### Community 406 - "Community 406"
 Cohesion: 0.67
 Nodes (1): DashboardSkeleton()
 
-### Community 406 - "Community 406"
+### Community 407 - "Community 407"
 Cohesion: 0.67
 Nodes (1): TableSkeleton()
 
-### Community 407 - "Community 407"
+### Community 408 - "Community 408"
 Cohesion: 0.67
 Nodes (1): TransactionsSkeleton()
 
-### Community 408 - "Community 408"
+### Community 409 - "Community 409"
 Cohesion: 0.67
 Nodes (1): NotFound()
 
-### Community 409 - "Community 409"
+### Community 410 - "Community 410"
 Cohesion: 1.0
 Nodes (2): getWorkflowTraceRouteTarget(), WorkflowTraceRouteLink()
 
-### Community 410 - "Community 410"
+### Community 411 - "Community 411"
 Cohesion: 0.67
 Nodes (1): AppContextMenu()
 
-### Community 411 - "Community 411"
+### Community 412 - "Community 412"
 Cohesion: 0.67
 Nodes (1): Badge()
 
-### Community 412 - "Community 412"
-Cohesion: 0.67
-Nodes (0):
-
 ### Community 413 - "Community 413"
 Cohesion: 0.67
-Nodes (1): LoadingButton()
+Nodes (0):
 
 ### Community 414 - "Community 414"
 Cohesion: 0.67
-Nodes (1): onChange()
+Nodes (1): LoadingButton()
 
 ### Community 415 - "Community 415"
 Cohesion: 0.67
-Nodes (1): AlertModal()
+Nodes (1): onChange()
 
 ### Community 416 - "Community 416"
 Cohesion: 0.67
-Nodes (1): OverlayModal()
+Nodes (1): AlertModal()
 
 ### Community 417 - "Community 417"
 Cohesion: 0.67
-Nodes (1): Skeleton()
+Nodes (1): OverlayModal()
 
 ### Community 418 - "Community 418"
 Cohesion: 0.67
-Nodes (1): Toaster()
+Nodes (1): Skeleton()
 
 ### Community 419 - "Community 419"
 Cohesion: 0.67
-Nodes (1): Spinner()
+Nodes (1): Toaster()
 
 ### Community 420 - "Community 420"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): Spinner()
 
 ### Community 421 - "Community 421"
 Cohesion: 0.67
@@ -3343,11 +3344,11 @@ Nodes (0):
 
 ### Community 427 - "Community 427"
 Cohesion: 0.67
-Nodes (1): useAuth()
+Nodes (0):
 
 ### Community 428 - "Community 428"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): useAuth()
 
 ### Community 429 - "Community 429"
 Cohesion: 0.67
@@ -3358,16 +3359,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 431 - "Community 431"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 432 - "Community 432"
 Cohesion: 1.0
 Nodes (2): getApprovalGuidance(), presentCommandToast()
 
-### Community 432 - "Community 432"
-Cohesion: 0.67
-Nodes (1): isInMaintenanceMode()
-
 ### Community 433 - "Community 433"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): isInMaintenanceMode()
 
 ### Community 434 - "Community 434"
 Cohesion: 0.67
@@ -3379,67 +3380,67 @@ Nodes (0):
 
 ### Community 436 - "Community 436"
 Cohesion: 0.67
-Nodes (1): App()
+Nodes (0):
 
 ### Community 437 - "Community 437"
-Cohesion: 1.0
-Nodes (2): collectSourceFiles(), findIllegalConvexImports()
+Cohesion: 0.67
+Nodes (1): App()
 
 ### Community 438 - "Community 438"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): collectSourceFiles(), findIllegalConvexImports()
 
 ### Community 439 - "Community 439"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 440 - "Community 440"
-Cohesion: 1.0
-Nodes (2): getAthenaDesignTokenStyle(), withAthenaTheme()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 441 - "Community 441"
 Cohesion: 1.0
-Nodes (2): mockGetSku(), validateInventoryForTransaction()
+Nodes (2): getAthenaDesignTokenStyle(), withAthenaTheme()
 
 ### Community 442 - "Community 442"
-Cohesion: 0.67
-Nodes (1): hashPassword()
+Cohesion: 1.0
+Nodes (2): mockGetSku(), validateInventoryForTransaction()
 
 ### Community 443 - "Community 443"
 Cohesion: 0.67
-Nodes (1): createVersionChecker()
+Nodes (1): hashPassword()
 
 ### Community 444 - "Community 444"
 Cohesion: 0.67
-Nodes (1): manualChunks()
+Nodes (1): createVersionChecker()
 
 ### Community 445 - "Community 445"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): manualChunks()
 
 ### Community 446 - "Community 446"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 447 - "Community 447"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 448 - "Community 448"
 Cohesion: 1.0
 Nodes (2): getAllColors(), getBaseUrl()
 
-### Community 448 - "Community 448"
+### Community 449 - "Community 449"
 Cohesion: 0.67
 Nodes (0):
-
-### Community 449 - "Community 449"
-Cohesion: 1.0
-Nodes (2): getBaseUrl(), getLastViewedProduct()
 
 ### Community 450 - "Community 450"
 Cohesion: 1.0
-Nodes (2): getBaseUrl(), getUserOffersEligibility()
+Nodes (2): getBaseUrl(), getLastViewedProduct()
 
 ### Community 451 - "Community 451"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getBaseUrl(), getUserOffersEligibility()
 
 ### Community 452 - "Community 452"
 Cohesion: 0.67
@@ -3454,12 +3455,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 455 - "Community 455"
-Cohesion: 1.0
-Nodes (2): handleKeyDown(), handleRedeemPromoCode()
-
-### Community 456 - "Community 456"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 456 - "Community 456"
+Cohesion: 1.0
+Nodes (2): handleKeyDown(), handleRedeemPromoCode()
 
 ### Community 457 - "Community 457"
 Cohesion: 0.67
@@ -3470,12 +3471,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 459 - "Community 459"
-Cohesion: 1.0
-Nodes (2): getPromoAlertCopy(), PromoAlert()
-
-### Community 460 - "Community 460"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 460 - "Community 460"
+Cohesion: 1.0
+Nodes (2): getPromoAlertCopy(), PromoAlert()
 
 ### Community 461 - "Community 461"
 Cohesion: 0.67
@@ -3542,8 +3543,8 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 477 - "Community 477"
-Cohesion: 1.0
-Nodes (2): createFixtureRepo(), write()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 478 - "Community 478"
 Cohesion: 1.0
@@ -3562,20 +3563,20 @@ Cohesion: 1.0
 Nodes (2): createFixtureRepo(), write()
 
 ### Community 482 - "Community 482"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): createFixtureRepo(), write()
 
 ### Community 483 - "Community 483"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 484 - "Community 484"
-Cohesion: 1.0
-Nodes (2): collectRootScriptTestFiles(), runRootScriptsCoverage()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 485 - "Community 485"
 Cohesion: 1.0
-Nodes (0):
+Nodes (2): collectRootScriptTestFiles(), runRootScriptsCoverage()
 
 ### Community 486 - "Community 486"
 Cohesion: 1.0
@@ -8017,2230 +8018,2234 @@ Nodes (0):
 Cohesion: 1.0
 Nodes (0):
 
+### Community 1596 - "Community 1596"
+Cohesion: 1.0
+Nodes (0):
+
 ## Knowledge Gaps
 - **1 isolated node(s):** `HelpRequested`
   These have ≤1 connection - possible missing edges or undocumented components.
-- **Thin community `Community 485`** (2 nodes): `getSource()`, `deposits.test.ts`
+- **Thin community `Community 486`** (2 nodes): `getSource()`, `deposits.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 486`** (2 nodes): `paymentAllocationAttribution.test.ts`, `readProjectFile()`
+- **Thin community `Community 487`** (2 nodes): `paymentAllocationAttribution.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 487`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
+- **Thin community `Community 488`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 488`** (2 nodes): `createCommandShimBin()`, `convexAuditScript.test.ts`
+- **Thin community `Community 489`** (2 nodes): `createCommandShimBin()`, `convexAuditScript.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 489`** (2 nodes): `policy.ts`, `assertSupportedCustomerMessagePolicy()`
+- **Thin community `Community 490`** (2 nodes): `policy.ts`, `assertSupportedCustomerMessagePolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 490`** (2 nodes): `repository.test.ts`, `queryResult()`
+- **Thin community `Community 491`** (2 nodes): `repository.test.ts`, `queryResult()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 491`** (2 nodes): `webhookSecurity.test.ts`, `sign()`
+- **Thin community `Community 492`** (2 nodes): `webhookSecurity.test.ts`, `sign()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 492`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
+- **Thin community `Community 493`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 493`** (2 nodes): `subcategories.ts`, `removeStorefrontHiddenSubcategoryList()`
+- **Thin community `Community 494`** (2 nodes): `subcategories.ts`, `removeStorefrontHiddenSubcategoryList()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 494`** (2 nodes): `storefrontCors.test.ts`, `readRouteFile()`
+- **Thin community `Community 495`** (2 nodes): `storefrontCors.test.ts`, `readRouteFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 495`** (2 nodes): `whatsapp.ts`, `mapWebhookStatus()`
+- **Thin community `Community 496`** (2 nodes): `whatsapp.ts`, `mapWebhookStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 496`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
+- **Thin community `Community 497`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 497`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
+- **Thin community `Community 498`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 498`** (2 nodes): `mapAthenaAuthSyncError()`, `auth.ts`
+- **Thin community `Community 499`** (2 nodes): `mapAthenaAuthSyncError()`, `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 499`** (2 nodes): `getHandler()`, `bestSeller.test.ts`
+- **Thin community `Community 500`** (2 nodes): `getHandler()`, `bestSeller.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 500`** (2 nodes): `userErrorFromExpenseItemCommandFailure()`, `expenseSessionItems.ts`
+- **Thin community `Community 501`** (2 nodes): `userErrorFromExpenseItemCommandFailure()`, `expenseSessionItems.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 501`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
+- **Thin community `Community 502`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 502`** (2 nodes): `posSessionItems.ts`, `userErrorFromSessionItemFailure()`
+- **Thin community `Community 503`** (2 nodes): `posSessionItems.ts`, `userErrorFromSessionItemFailure()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 503`** (2 nodes): `productUtil.ts`, `buildAllProductsCacheKey()`
+- **Thin community `Community 504`** (2 nodes): `productUtil.ts`, `buildAllProductsCacheKey()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 504`** (2 nodes): `promoCode.ts`, `calculateSelectedProductPromoDiscount()`
+- **Thin community `Community 505`** (2 nodes): `promoCode.ts`, `calculateSelectedProductPromoDiscount()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 505`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
+- **Thin community `Community 506`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 506`** (2 nodes): `commandResultValidator()`, `commandResultValidators.ts`
+- **Thin community `Community 507`** (2 nodes): `commandResultValidator()`, `commandResultValidators.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 507`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
+- **Thin community `Community 508`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 508`** (2 nodes): `callAnthropic()`, `anthropic.ts`
+- **Thin community `Community 509`** (2 nodes): `callAnthropic()`, `anthropic.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 509`** (2 nodes): `callOpenAi()`, `openai.ts`
+- **Thin community `Community 510`** (2 nodes): `callOpenAi()`, `openai.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 510`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
+- **Thin community `Community 511`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 511`** (2 nodes): `consumeCommandApprovalProofWithCtx()`, `approvalActions.ts`
+- **Thin community `Community 512`** (2 nodes): `consumeCommandApprovalProofWithCtx()`, `approvalActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 512`** (2 nodes): `createOperationalEventCtx()`, `approvalAuditEvents.test.ts`
+- **Thin community `Community 513`** (2 nodes): `createOperationalEventCtx()`, `approvalAuditEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 513`** (2 nodes): `createApprovalProofMutationCtx()`, `approvalProofs.test.ts`
+- **Thin community `Community 514`** (2 nodes): `createApprovalProofMutationCtx()`, `approvalProofs.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 514`** (2 nodes): `buildApprovalRequest()`, `approvalRequestHelpers.ts`
+- **Thin community `Community 515`** (2 nodes): `buildApprovalRequest()`, `approvalRequestHelpers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 515`** (2 nodes): `createApprovalRequestMutationCtx()`, `approvalRequests.test.ts`
+- **Thin community `Community 516`** (2 nodes): `createApprovalRequestMutationCtx()`, `approvalRequests.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 516`** (2 nodes): `buildOperationalEventMessage()`, `eventBuilders.ts`
+- **Thin community `Community 517`** (2 nodes): `buildOperationalEventMessage()`, `eventBuilders.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 517`** (2 nodes): `formatValidTime()`, `EmailOTP.ts`
+- **Thin community `Community 518`** (2 nodes): `formatValidTime()`, `EmailOTP.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 518`** (2 nodes): `quickAddCatalogItem.test.ts`, `createQuickAddCtx()`
+- **Thin community `Community 519`** (2 nodes): `quickAddCatalogItem.test.ts`, `createQuickAddCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 519`** (2 nodes): `expectNoCompletionSideEffects()`, `completeTransaction.test.ts`
+- **Thin community `Community 520`** (2 nodes): `expectNoCompletionSideEffects()`, `completeTransaction.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 520`** (2 nodes): `createMutationCtx()`, `correctTransactionPaymentMethod.test.ts`
+- **Thin community `Community 521`** (2 nodes): `createMutationCtx()`, `correctTransactionPaymentMethod.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 521`** (2 nodes): `buildCorrectionOperationalEvent()`, `correctionEvents.ts`
+- **Thin community `Community 522`** (2 nodes): `buildCorrectionOperationalEvent()`, `correctionEvents.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 522`** (2 nodes): `mockCorrectionHistoryDb()`, `getTransactions.test.ts`
+- **Thin community `Community 523`** (2 nodes): `mockCorrectionHistoryDb()`, `getTransactions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 523`** (2 nodes): `createRegisterCatalogCtx()`, `listRegisterCatalog.test.ts`
+- **Thin community `Community 524`** (2 nodes): `createRegisterCatalogCtx()`, `listRegisterCatalog.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 524`** (2 nodes): `getCashierForRegisterState()`, `cashierRepository.ts`
+- **Thin community `Community 525`** (2 nodes): `getCashierForRegisterState()`, `cashierRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 525`** (2 nodes): `createExpenseSessionCommandRepository()`, `expenseSessionCommandRepository.ts`
+- **Thin community `Community 526`** (2 nodes): `createExpenseSessionCommandRepository()`, `expenseSessionCommandRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 526`** (2 nodes): `sessionCommandRepository.test.ts`, `readProjectFile()`
+- **Thin community `Community 527`** (2 nodes): `sessionCommandRepository.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 527`** (2 nodes): `sessionRepository.test.ts`, `buildSession()`
+- **Thin community `Community 528`** (2 nodes): `sessionRepository.test.ts`, `buildSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 528`** (2 nodes): `transactions.ts`, `mapCorrectionError()`
+- **Thin community `Community 529`** (2 nodes): `transactions.ts`, `mapCorrectionError()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 529`** (2 nodes): `getSource()`, `moduleWiring.test.ts`
+- **Thin community `Community 530`** (2 nodes): `getSource()`, `moduleWiring.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 530`** (2 nodes): `createStockOpsAccessQueryCtx()`, `access.test.ts`
+- **Thin community `Community 531`** (2 nodes): `createStockOpsAccessQueryCtx()`, `access.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 531`** (2 nodes): `requireStoreFullAdminAccess()`, `access.ts`
+- **Thin community `Community 532`** (2 nodes): `requireStoreFullAdminAccess()`, `access.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 532`** (2 nodes): `createCycleCountDraftCtx()`, `cycleCountDrafts.test.ts`
+- **Thin community `Community 533`** (2 nodes): `createCycleCountDraftCtx()`, `cycleCountDrafts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 533`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
+- **Thin community `Community 534`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 534`** (2 nodes): `createQueryCtx()`, `customerBehaviorTimeline.test.ts`
+- **Thin community `Community 535`** (2 nodes): `createQueryCtx()`, `customerBehaviorTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 535`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
+- **Thin community `Community 536`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 536`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
+- **Thin community `Community 537`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 537`** (2 nodes): `createMutationCtx()`, `customerEngagementEvents.test.ts`
+- **Thin community `Community 538`** (2 nodes): `createMutationCtx()`, `customerEngagementEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 538`** (2 nodes): `getSource()`, `onlineOrder.test.ts`
+- **Thin community `Community 539`** (2 nodes): `getSource()`, `onlineOrder.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 539`** (2 nodes): `updateOnlineOrderItem()`, `onlineOrderItem.ts`
+- **Thin community `Community 540`** (2 nodes): `updateOnlineOrderItem()`, `onlineOrderItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 540`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
+- **Thin community `Community 541`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 541`** (2 nodes): `rewards.ts`, `formatPointsLabel()`
+- **Thin community `Community 542`** (2 nodes): `rewards.ts`, `formatPointsLabel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 542`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
+- **Thin community `Community 543`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 543`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
+- **Thin community `Community 544`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 544`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
+- **Thin community `Community 545`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 545`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
+- **Thin community `Community 546`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 546`** (2 nodes): `user.ts`, `getStoreFrontActorById()`
+- **Thin community `Community 547`** (2 nodes): `user.ts`, `getStoreFrontActorById()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 547`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
+- **Thin community `Community 548`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 548`** (2 nodes): `buildExpenseSessionTraceSeed()`, `expenseSession.ts`
+- **Thin community `Community 549`** (2 nodes): `buildExpenseSessionTraceSeed()`, `expenseSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 549`** (2 nodes): `posSession.ts`, `buildPosSessionTraceSeed()`
+- **Thin community `Community 550`** (2 nodes): `posSession.ts`, `buildPosSessionTraceSeed()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 550`** (2 nodes): `presentation.ts`, `buildWorkflowTraceViewModel()`
+- **Thin community `Community 551`** (2 nodes): `presentation.ts`, `buildWorkflowTraceViewModel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 551`** (2 nodes): `schemaIndexes.test.ts`, `getTableIndexes()`
+- **Thin community `Community 552`** (2 nodes): `schemaIndexes.test.ts`, `getTableIndexes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 552`** (2 nodes): `serviceIntake.ts`, `validateServiceIntakeInput()`
+- **Thin community `Community 553`** (2 nodes): `serviceIntake.ts`, `validateServiceIntakeInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 553`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
+- **Thin community `Community 554`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 554`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
+- **Thin community `Community 555`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 555`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
+- **Thin community `Community 556`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 556`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
+- **Thin community `Community 557`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 557`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
+- **Thin community `Community 558`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 558`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
+- **Thin community `Community 559`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 559`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
+- **Thin community `Community 560`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 560`** (2 nodes): `StoreView.tsx`, `Navigation()`
+- **Thin community `Community 561`** (2 nodes): `StoreView.tsx`, `Navigation()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 561`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
+- **Thin community `Community 562`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 562`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
+- **Thin community `Community 563`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 563`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
+- **Thin community `Community 564`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 564`** (2 nodes): `ProductAttributes.tsx`, `isAllowedAttribute()`
+- **Thin community `Community 565`** (2 nodes): `ProductAttributes.tsx`, `isAllowedAttribute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 565`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
+- **Thin community `Community 566`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 566`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
+- **Thin community `Community 567`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 567`** (2 nodes): `ProductImages.tsx`, `Header()`
+- **Thin community `Community 568`** (2 nodes): `ProductImages.tsx`, `Header()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 568`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
+- **Thin community `Community 569`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 569`** (2 nodes): `setIsUpdatingSku()`, `CopyImagesView.tsx`
+- **Thin community `Community 570`** (2 nodes): `setIsUpdatingSku()`, `CopyImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 570`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
+- **Thin community `Community 571`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 571`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
+- **Thin community `Community 572`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 572`** (2 nodes): `AnalyticsCombinedUsers()`, `AnalyticsCombinedUsers.tsx`
+- **Thin community `Community 573`** (2 nodes): `AnalyticsCombinedUsers()`, `AnalyticsCombinedUsers.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 573`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
+- **Thin community `Community 574`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 574`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
+- **Thin community `Community 575`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 575`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
+- **Thin community `Community 576`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 576`** (2 nodes): `formatMetric()`, `AnalyticsView.tsx`
+- **Thin community `Community 577`** (2 nodes): `formatMetric()`, `AnalyticsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 577`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
+- **Thin community `Community 578`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 578`** (2 nodes): `StoreInsights.tsx`, `getTrendIcon()`
+- **Thin community `Community 579`** (2 nodes): `StoreInsights.tsx`, `getTrendIcon()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 579`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
+- **Thin community `Community 580`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 580`** (2 nodes): `readSource()`, `analyticsWorkspaceEfficiency.test.ts`
+- **Thin community `Community 581`** (2 nodes): `readSource()`, `analyticsWorkspaceEfficiency.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 581`** (2 nodes): `LogItems()`, `LogItems.tsx`
+- **Thin community `Community 582`** (2 nodes): `LogItems()`, `LogItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 582`** (2 nodes): `Header()`, `LogView.tsx`
+- **Thin community `Community 583`** (2 nodes): `Header()`, `LogView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 583`** (2 nodes): `Navigation()`, `LogsView.tsx`
+- **Thin community `Community 584`** (2 nodes): `Navigation()`, `LogsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 584`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
+- **Thin community `Community 585`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 585`** (2 nodes): `SidebarMenuCollapsible()`, `app-sidebar.tsx`
+- **Thin community `Community 586`** (2 nodes): `SidebarMenuCollapsible()`, `app-sidebar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 586`** (2 nodes): `Auth()`, `Auth.tsx`
+- **Thin community `Community 587`** (2 nodes): `Auth()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 587`** (2 nodes): `resolveSignIn()`, `InputOTP.test.tsx`
+- **Thin community `Community 588`** (2 nodes): `resolveSignIn()`, `InputOTP.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 588`** (2 nodes): `Login()`, `index.tsx`
+- **Thin community `Community 589`** (2 nodes): `Login()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 589`** (2 nodes): `DataTableColumnHeader()`, `data-table-column-header.tsx`
+- **Thin community `Community 590`** (2 nodes): `DataTableColumnHeader()`, `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 590`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
+- **Thin community `Community 591`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 591`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
+- **Thin community `Community 592`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 592`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
+- **Thin community `Community 593`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 593`** (2 nodes): `formatReviewReason()`, `formatReviewReason.ts`
+- **Thin community `Community 594`** (2 nodes): `formatReviewReason()`, `formatReviewReason.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 594`** (2 nodes): `registerSessionColumns.tsx`, `RegisterSessionLink()`
+- **Thin community `Community 595`** (2 nodes): `registerSessionColumns.tsx`, `RegisterSessionLink()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 595`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
+- **Thin community `Community 596`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 596`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
+- **Thin community `Community 597`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 597`** (2 nodes): `ExpenseCompletion()`, `ExpenseCompletion.tsx`
+- **Thin community `Community 598`** (2 nodes): `ExpenseCompletion()`, `ExpenseCompletion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 598`** (2 nodes): `ExpenseView()`, `ExpenseView.tsx`
+- **Thin community `Community 599`** (2 nodes): `ExpenseView()`, `ExpenseView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 599`** (2 nodes): `handleAddBestSeller()`, `BestSellersDialog.tsx`
+- **Thin community `Community 600`** (2 nodes): `handleAddBestSeller()`, `BestSellersDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 600`** (2 nodes): `handleAddFeaturedItem()`, `FeaturedSectionDialog.tsx`
+- **Thin community `Community 601`** (2 nodes): `handleAddFeaturedItem()`, `FeaturedSectionDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 601`** (2 nodes): `Navigation()`, `Home.tsx`
+- **Thin community `Community 602`** (2 nodes): `Navigation()`, `Home.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 602`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
+- **Thin community `Community 603`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 603`** (2 nodes): `ShopLookDialog.tsx`, `handleAddFeaturedItem()`
+- **Thin community `Community 604`** (2 nodes): `ShopLookDialog.tsx`, `handleAddFeaturedItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 604`** (2 nodes): `ShopLookImageUploader.tsx`, `ShopLookImageUploader()`
+- **Thin community `Community 605`** (2 nodes): `ShopLookImageUploader.tsx`, `ShopLookImageUploader()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 605`** (2 nodes): `JoinTeam()`, `index.tsx`
+- **Thin community `Community 606`** (2 nodes): `JoinTeam()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 606`** (2 nodes): `cn()`, `OperationReviewItemCard.tsx`
+- **Thin community `Community 607`** (2 nodes): `cn()`, `OperationReviewItemCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 607`** (2 nodes): `buildParams()`, `OperationsSummaryMetric.tsx`
+- **Thin community `Community 608`** (2 nodes): `buildParams()`, `OperationsSummaryMetric.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 608`** (2 nodes): `StockAdjustmentWorkspace.test.tsx`, `renderStockAdjustmentWorkspace()`
+- **Thin community `Community 609`** (2 nodes): `StockAdjustmentWorkspace.test.tsx`, `renderStockAdjustmentWorkspace()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 609`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
+- **Thin community `Community 610`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 610`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
+- **Thin community `Community 611`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 611`** (2 nodes): `handleTimeRangeChange()`, `OrderMetricsPanel.tsx`
+- **Thin community `Community 612`** (2 nodes): `handleTimeRangeChange()`, `OrderMetricsPanel.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 612`** (2 nodes): `getTimeFilter()`, `OrdersView.tsx`
+- **Thin community `Community 613`** (2 nodes): `getTimeFilter()`, `OrdersView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 613`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
+- **Thin community `Community 614`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 614`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
+- **Thin community `Community 615`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 615`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
+- **Thin community `Community 616`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 616`** (2 nodes): `if()`, `orderColumns.tsx`
+- **Thin community `Community 617`** (2 nodes): `if()`, `orderColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 617`** (2 nodes): `OrganizationSwitcher()`, `organization-switcher.tsx`
+- **Thin community `Community 618`** (2 nodes): `OrganizationSwitcher()`, `organization-switcher.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 618`** (2 nodes): `cn()`, `CartItems.tsx`
+- **Thin community `Community 619`** (2 nodes): `cn()`, `CartItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 619`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
+- **Thin community `Community 620`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 620`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
+- **Thin community `Community 621`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 621`** (2 nodes): `PinInput.tsx`, `PinInput()`
+- **Thin community `Community 622`** (2 nodes): `PinInput.tsx`, `PinInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 622`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
+- **Thin community `Community 623`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 623`** (2 nodes): `ProductCard.tsx`, `ProductCard()`
+- **Thin community `Community 624`** (2 nodes): `ProductCard.tsx`, `ProductCard()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 624`** (2 nodes): `SearchResultsSection.test.tsx`, `buildProduct()`
+- **Thin community `Community 625`** (2 nodes): `SearchResultsSection.test.tsx`, `buildProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 625`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
+- **Thin community `Community 626`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 626`** (2 nodes): `isToday()`, `ExpenseReportsView.tsx`
+- **Thin community `Community 627`** (2 nodes): `isToday()`, `ExpenseReportsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 627`** (2 nodes): `toExpenseReportRows()`, `expenseReportRows.ts`
+- **Thin community `Community 628`** (2 nodes): `toExpenseReportRows()`, `expenseReportRows.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 628`** (2 nodes): `ExpenseCompletionPanel()`, `ExpenseCompletionPanel.tsx`
+- **Thin community `Community 629`** (2 nodes): `ExpenseCompletionPanel()`, `ExpenseCompletionPanel.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 629`** (2 nodes): `RegisterCustomerAttribution.test.tsx`, `makeCustomer()`
+- **Thin community `Community 630`** (2 nodes): `RegisterCustomerAttribution.test.tsx`, `makeCustomer()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 630`** (2 nodes): `RegisterCustomerPanel.tsx`, `RegisterCustomerPanel()`
+- **Thin community `Community 631`** (2 nodes): `RegisterCustomerPanel.tsx`, `RegisterCustomerPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 631`** (2 nodes): `RegisterDrawerGate.test.tsx`, `renderGate()`
+- **Thin community `Community 632`** (2 nodes): `RegisterDrawerGate.test.tsx`, `renderGate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 632`** (2 nodes): `RegisterSessionPanel.tsx`, `RegisterSessionPanel()`
+- **Thin community `Community 633`** (2 nodes): `RegisterSessionPanel.tsx`, `RegisterSessionPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 633`** (2 nodes): `transactionColumns.test.tsx`, `renderTransactionCell()`
+- **Thin community `Community 634`** (2 nodes): `transactionColumns.test.tsx`, `renderTransactionCell()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 634`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
+- **Thin community `Community 635`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 635`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
+- **Thin community `Community 636`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 636`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
+- **Thin community `Community 637`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 637`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
+- **Thin community `Community 638`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 638`** (2 nodes): `ProductStatus.tsx`, `ProductStatus()`
+- **Thin community `Community 639`** (2 nodes): `ProductStatus.tsx`, `ProductStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 639`** (2 nodes): `SKUSelector.tsx`, `SKUSelector()`
+- **Thin community `Community 640`** (2 nodes): `SKUSelector.tsx`, `SKUSelector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 640`** (2 nodes): `product-actions.tsx`, `useArchiveProduct()`
+- **Thin community `Community 641`** (2 nodes): `product-actions.tsx`, `useArchiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 641`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
+- **Thin community `Community 642`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 642`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
+- **Thin community `Community 643`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 643`** (2 nodes): `Products.tsx`, `Products()`
+- **Thin community `Community 644`** (2 nodes): `Products.tsx`, `Products()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 644`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
+- **Thin community `Community 645`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 645`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
+- **Thin community `Community 646`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 646`** (2 nodes): `PromoCodePreview.tsx`, `Discount()`
+- **Thin community `Community 647`** (2 nodes): `PromoCodePreview.tsx`, `Discount()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 647`** (2 nodes): `PromoCodesView.test.tsx`, `readSource()`
+- **Thin community `Community 648`** (2 nodes): `PromoCodesView.test.tsx`, `readSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 648`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
+- **Thin community `Community 649`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 649`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
+- **Thin community `Community 650`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 650`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
+- **Thin community `Community 651`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 651`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
+- **Thin community `Community 652`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 652`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
+- **Thin community `Community 653`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 653`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
+- **Thin community `Community 654`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 654`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
+- **Thin community `Community 655`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 655`** (2 nodes): `ServiceCasesView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 656`** (2 nodes): `ServiceCasesView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 656`** (2 nodes): `ServiceCatalogView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 657`** (2 nodes): `ServiceCatalogView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 657`** (2 nodes): `ServiceIntakeForm.tsx`, `ServiceIntakeForm()`
+- **Thin community `Community 658`** (2 nodes): `ServiceIntakeForm.tsx`, `ServiceIntakeForm()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 658`** (2 nodes): `ServiceIntakeView.auth.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 659`** (2 nodes): `ServiceIntakeView.auth.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 659`** (2 nodes): `ServiceIntakeView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 660`** (2 nodes): `ServiceIntakeView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 660`** (2 nodes): `onClick()`, `empty-state.tsx`
+- **Thin community `Community 661`** (2 nodes): `onClick()`, `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 661`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
+- **Thin community `Community 662`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 662`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
+- **Thin community `Community 663`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 663`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
+- **Thin community `Community 664`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 664`** (2 nodes): `ProtectedAdminSignInView.tsx`, `ProtectedAdminSignInView()`
+- **Thin community `Community 665`** (2 nodes): `ProtectedAdminSignInView.tsx`, `ProtectedAdminSignInView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 665`** (2 nodes): `ContactView()`, `ContactView.tsx`
+- **Thin community `Community 666`** (2 nodes): `ContactView()`, `ContactView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 666`** (2 nodes): `Header()`, `Header.tsx`
+- **Thin community `Community 667`** (2 nodes): `Header()`, `Header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 667`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
+- **Thin community `Community 668`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 668`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
+- **Thin community `Community 669`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 669`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
+- **Thin community `Community 670`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 670`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
+- **Thin community `Community 671`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 671`** (2 nodes): `useChart()`, `chart.tsx`
+- **Thin community `Community 672`** (2 nodes): `useChart()`, `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 672`** (2 nodes): `handleCopy()`, `copy-button.tsx`
+- **Thin community `Community 673`** (2 nodes): `handleCopy()`, `copy-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 673`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
+- **Thin community `Community 674`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 674`** (2 nodes): `Label()`, `label.tsx`
+- **Thin community `Community 675`** (2 nodes): `Label()`, `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 675`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
+- **Thin community `Community 676`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 676`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
+- **Thin community `Community 677`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 677`** (2 nodes): `store-modal.tsx`, `onSubmit()`
+- **Thin community `Community 678`** (2 nodes): `store-modal.tsx`, `onSubmit()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 678`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
+- **Thin community `Community 679`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 679`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
+- **Thin community `Community 680`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 680`** (2 nodes): `select-native.tsx`, `cn()`
+- **Thin community `Community 681`** (2 nodes): `select-native.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 681`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
+- **Thin community `Community 682`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 682`** (2 nodes): `webp-image.tsx`, `WebpImage()`
+- **Thin community `Community 683`** (2 nodes): `webp-image.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 683`** (2 nodes): `BagItems()`, `BagItems.tsx`
+- **Thin community `Community 684`** (2 nodes): `BagItems()`, `BagItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 684`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
+- **Thin community `Community 685`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 685`** (2 nodes): `Bags()`, `Bags.tsx`
+- **Thin community `Community 686`** (2 nodes): `Bags()`, `Bags.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 686`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
+- **Thin community `Community 687`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 687`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
+- **Thin community `Community 688`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 688`** (2 nodes): `UserBag.tsx`, `UserBag()`
+- **Thin community `Community 689`** (2 nodes): `UserBag.tsx`, `UserBag()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 689`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
+- **Thin community `Community 690`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 690`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
+- **Thin community `Community 691`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 691`** (2 nodes): `UserView.tsx`, `UserActions()`
+- **Thin community `Community 692`** (2 nodes): `UserView.tsx`, `UserActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 692`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
+- **Thin community `Community 693`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 693`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
+- **Thin community `Community 694`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 694`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
+- **Thin community `Community 695`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 695`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
+- **Thin community `Community 696`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 696`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
+- **Thin community `Community 697`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 697`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
+- **Thin community `Community 698`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 698`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
+- **Thin community `Community 699`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 699`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
+- **Thin community `Community 700`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 700`** (2 nodes): `useConvexAuthIdentity.ts`, `useConvexAuthIdentity()`
+- **Thin community `Community 701`** (2 nodes): `useConvexAuthIdentity.ts`, `useConvexAuthIdentity()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 701`** (2 nodes): `useCopyText.ts`, `useCopyText()`
+- **Thin community `Community 702`** (2 nodes): `useCopyText.ts`, `useCopyText()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 702`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
+- **Thin community `Community 703`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 703`** (2 nodes): `useDebounce.ts`, `useDebounce()`
+- **Thin community `Community 704`** (2 nodes): `useDebounce.ts`, `useDebounce()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 704`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
+- **Thin community `Community 705`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 705`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
+- **Thin community `Community 706`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 706`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
+- **Thin community `Community 707`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 707`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
+- **Thin community `Community 708`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 708`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
+- **Thin community `Community 709`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 709`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
+- **Thin community `Community 710`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 710`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
+- **Thin community `Community 711`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 711`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
+- **Thin community `Community 712`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 712`** (2 nodes): `usePermissions.ts`, `usePermissions()`
+- **Thin community `Community 713`** (2 nodes): `usePermissions.ts`, `usePermissions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 713`** (2 nodes): `usePrint.ts`, `usePrint()`
+- **Thin community `Community 714`** (2 nodes): `usePrint.ts`, `usePrint()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 714`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
+- **Thin community `Community 715`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 715`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
+- **Thin community `Community 716`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 716`** (2 nodes): `useProtectedAdminPageState.ts`, `useProtectedAdminPageState()`
+- **Thin community `Community 717`** (2 nodes): `useProtectedAdminPageState.ts`, `useProtectedAdminPageState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 717`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
+- **Thin community `Community 718`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 718`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
+- **Thin community `Community 719`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 719`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
+- **Thin community `Community 720`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 720`** (2 nodes): `toOperatorMessage()`, `operatorMessages.ts`
+- **Thin community `Community 721`** (2 nodes): `toOperatorMessage()`, `operatorMessages.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 721`** (2 nodes): `presentUnexpectedErrorToast.ts`, `presentUnexpectedErrorToast()`
+- **Thin community `Community 722`** (2 nodes): `presentUnexpectedErrorToast.ts`, `presentUnexpectedErrorToast()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 722`** (2 nodes): `getOrigin()`, `navigationUtils.ts`
+- **Thin community `Community 723`** (2 nodes): `getOrigin()`, `navigationUtils.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 723`** (2 nodes): `addItem()`, `addItem.ts`
+- **Thin community `Community 724`** (2 nodes): `addItem()`, `addItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 724`** (2 nodes): `bootstrapRegister()`, `bootstrapRegister.ts`
+- **Thin community `Community 725`** (2 nodes): `bootstrapRegister()`, `bootstrapRegister.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 725`** (2 nodes): `holdSession()`, `holdSession.ts`
+- **Thin community `Community 726`** (2 nodes): `holdSession()`, `holdSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 726`** (2 nodes): `openDrawer()`, `openDrawer.ts`
+- **Thin community `Community 727`** (2 nodes): `openDrawer()`, `openDrawer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 727`** (2 nodes): `startSession.ts`, `startSession()`
+- **Thin community `Community 728`** (2 nodes): `startSession.ts`, `startSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 728`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
+- **Thin community `Community 729`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 729`** (2 nodes): `useRegisterCatalogIndex.ts`, `useRegisterCatalogIndex()`
+- **Thin community `Community 730`** (2 nodes): `useRegisterCatalogIndex.ts`, `useRegisterCatalogIndex()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 730`** (2 nodes): `pinHash.ts`, `hashPin()`
+- **Thin community `Community 731`** (2 nodes): `pinHash.ts`, `hashPin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 731`** (2 nodes): `hasOrgNotFoundPayload()`, `index.tsx`
+- **Thin community `Community 732`** (2 nodes): `hasOrgNotFoundPayload()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 732`** (2 nodes): `$sessionId.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 733`** (2 nodes): `$sessionId.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 733`** (2 nodes): `registers.index.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 734`** (2 nodes): `registers.index.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 734`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
+- **Thin community `Community 735`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 735`** (2 nodes): `ApprovalsRoute()`, `approvals.tsx`
+- **Thin community `Community 736`** (2 nodes): `ApprovalsRoute()`, `approvals.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 736`** (2 nodes): `DailyCloseHistoryRoute()`, `daily-close-history.tsx`
+- **Thin community `Community 737`** (2 nodes): `DailyCloseHistoryRoute()`, `daily-close-history.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 737`** (2 nodes): `DailyCloseRoute()`, `daily-close.tsx`
+- **Thin community `Community 738`** (2 nodes): `DailyCloseRoute()`, `daily-close.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 738`** (2 nodes): `OpenWorkRoute()`, `open-work.tsx`
+- **Thin community `Community 739`** (2 nodes): `OpenWorkRoute()`, `open-work.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 739`** (2 nodes): `DailyOpeningRoute()`, `opening.tsx`
+- **Thin community `Community 740`** (2 nodes): `DailyOpeningRoute()`, `opening.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 740`** (2 nodes): `stock-adjustments.tsx`, `StockAdjustmentsRoute()`
+- **Thin community `Community 741`** (2 nodes): `stock-adjustments.tsx`, `StockAdjustmentsRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 741`** (2 nodes): `ExpenseRouteComponent()`, `expense.index.tsx`
+- **Thin community `Community 742`** (2 nodes): `ExpenseRouteComponent()`, `expense.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 742`** (2 nodes): `published.index.tsx`, `RouteComponent()`
+- **Thin community `Community 743`** (2 nodes): `published.index.tsx`, `RouteComponent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 743`** (2 nodes): `Index()`, `index.tsx`
+- **Thin community `Community 744`** (2 nodes): `Index()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 744`** (2 nodes): `AthenaLoginReadyView()`, `_layout.index.tsx`
+- **Thin community `Community 745`** (2 nodes): `AthenaLoginReadyView()`, `_layout.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 745`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
+- **Thin community `Community 746`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 746`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 747`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 747`** (2 nodes): `view-patterns.tsx`, `cn()`
+- **Thin community `Community 748`** (2 nodes): `view-patterns.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 748`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
+- **Thin community `Community 749`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 749`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
+- **Thin community `Community 750`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 750`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
+- **Thin community `Community 751`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 751`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 752`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 752`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
+- **Thin community `Community 753`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 753`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
+- **Thin community `Community 754`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 754`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
+- **Thin community `Community 755`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 755`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 756`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 756`** (2 nodes): `formatNumber()`, `formatNumber.ts`
+- **Thin community `Community 757`** (2 nodes): `formatNumber()`, `formatNumber.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 757`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
+- **Thin community `Community 758`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 758`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
+- **Thin community `Community 759`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 759`** (2 nodes): `updateGuest()`, `guest.ts`
+- **Thin community `Community 760`** (2 nodes): `updateGuest()`, `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 760`** (2 nodes): `posTransaction.test.ts`, `jsonResponse()`
+- **Thin community `Community 761`** (2 nodes): `posTransaction.test.ts`, `jsonResponse()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 761`** (2 nodes): `storefront.ts`, `getStore()`
+- **Thin community `Community 762`** (2 nodes): `storefront.ts`, `getStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 762`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
+- **Thin community `Community 763`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 763`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
+- **Thin community `Community 764`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 764`** (2 nodes): `AuthComponent()`, `Auth.tsx`
+- **Thin community `Community 765`** (2 nodes): `AuthComponent()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 765`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
+- **Thin community `Community 766`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 766`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
+- **Thin community `Community 767`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 767`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
+- **Thin community `Community 768`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 768`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
+- **Thin community `Community 769`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 769`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
+- **Thin community `Community 770`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 770`** (2 nodes): `PickupDetails()`, `index.tsx`
+- **Thin community `Community 771`** (2 nodes): `PickupDetails()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 771`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
+- **Thin community `Community 772`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 772`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
+- **Thin community `Community 773`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 773`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
+- **Thin community `Community 774`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 774`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
+- **Thin community `Community 775`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 775`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
+- **Thin community `Community 776`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 776`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
+- **Thin community `Community 777`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 777`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
+- **Thin community `Community 778`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 778`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
+- **Thin community `Community 779`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 779`** (2 nodes): `useCountdown()`, `hooks.ts`
+- **Thin community `Community 780`** (2 nodes): `useCountdown()`, `hooks.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 780`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
+- **Thin community `Community 781`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 781`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
+- **Thin community `Community 782`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 782`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
+- **Thin community `Community 783`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 783`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
+- **Thin community `Community 784`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 784`** (2 nodes): `resolveHomepageContent()`, `homePageContent.ts`
+- **Thin community `Community 785`** (2 nodes): `resolveHomepageContent()`, `homePageContent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 785`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
+- **Thin community `Community 786`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 786`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
+- **Thin community `Community 787`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 787`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
+- **Thin community `Community 788`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 788`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
+- **Thin community `Community 789`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 789`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
+- **Thin community `Community 790`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 790`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
+- **Thin community `Community 791`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 791`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
+- **Thin community `Community 792`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 792`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
+- **Thin community `Community 793`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 793`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
+- **Thin community `Community 794`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 794`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
+- **Thin community `Community 795`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 795`** (2 nodes): `ProductPage.test.tsx`, `makePageState()`
+- **Thin community `Community 796`** (2 nodes): `ProductPage.test.tsx`, `makePageState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 796`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
+- **Thin community `Community 797`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 797`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
+- **Thin community `Community 798`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 798`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
+- **Thin community `Community 799`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 799`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
+- **Thin community `Community 800`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 800`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
+- **Thin community `Community 801`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 801`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
+- **Thin community `Community 802`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 802`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
+- **Thin community `Community 803`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 803`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
+- **Thin community `Community 804`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 804`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
+- **Thin community `Community 805`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 805`** (2 nodes): `BagItem()`, `BagItem.tsx`
+- **Thin community `Community 806`** (2 nodes): `BagItem()`, `BagItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 806`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
+- **Thin community `Community 807`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 807`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
+- **Thin community `Community 808`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 808`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
+- **Thin community `Community 809`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 809`** (2 nodes): `CountrySelect()`, `country-select.tsx`
+- **Thin community `Community 810`** (2 nodes): `CountrySelect()`, `country-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 810`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
+- **Thin community `Community 811`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 811`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
+- **Thin community `Community 812`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 812`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
+- **Thin community `Community 813`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 813`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
+- **Thin community `Community 814`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 814`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
+- **Thin community `Community 815`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 815`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
+- **Thin community `Community 816`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 816`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
+- **Thin community `Community 817`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 817`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
+- **Thin community `Community 818`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 818`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
+- **Thin community `Community 819`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 819`** (2 nodes): `useCheckout.ts`, `useCheckout()`
+- **Thin community `Community 820`** (2 nodes): `useCheckout.ts`, `useCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 820`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
+- **Thin community `Community 821`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 821`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
+- **Thin community `Community 822`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 822`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
+- **Thin community `Community 823`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 823`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
+- **Thin community `Community 824`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 824`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
+- **Thin community `Community 825`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 825`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
+- **Thin community `Community 826`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 826`** (2 nodes): `useGetStore.ts`, `useGetStore()`
+- **Thin community `Community 827`** (2 nodes): `useGetStore.ts`, `useGetStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 827`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
+- **Thin community `Community 828`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 828`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
+- **Thin community `Community 829`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 829`** (2 nodes): `useLogout.ts`, `useLogout()`
+- **Thin community `Community 830`** (2 nodes): `useLogout.ts`, `useLogout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 830`** (2 nodes): `useModalState.tsx`, `useModalState()`
+- **Thin community `Community 831`** (2 nodes): `useModalState.tsx`, `useModalState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 831`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
+- **Thin community `Community 832`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 832`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
+- **Thin community `Community 833`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 833`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
+- **Thin community `Community 834`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 834`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
+- **Thin community `Community 835`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 835`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
+- **Thin community `Community 836`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 836`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
+- **Thin community `Community 837`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 837`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
+- **Thin community `Community 838`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 838`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
+- **Thin community `Community 839`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 839`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
+- **Thin community `Community 840`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 840`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
+- **Thin community `Community 841`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 841`** (2 nodes): `useBagQueries()`, `bag.ts`
+- **Thin community `Community 842`** (2 nodes): `useBagQueries()`, `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 842`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
+- **Thin community `Community 843`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 843`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
+- **Thin community `Community 844`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 844`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
+- **Thin community `Community 845`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 845`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
+- **Thin community `Community 846`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 846`** (2 nodes): `posTransaction.ts`, `usePosTransactionQueries()`
+- **Thin community `Community 847`** (2 nodes): `posTransaction.ts`, `usePosTransactionQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 847`** (2 nodes): `product.ts`, `useProductQueries()`
+- **Thin community `Community 848`** (2 nodes): `product.ts`, `useProductQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 848`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
+- **Thin community `Community 849`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 849`** (2 nodes): `reviews.ts`, `useReviewQueries()`
+- **Thin community `Community 850`** (2 nodes): `reviews.ts`, `useReviewQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 850`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
+- **Thin community `Community 851`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 851`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
+- **Thin community `Community 852`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 852`** (2 nodes): `user.ts`, `useUserQueries()`
+- **Thin community `Community 853`** (2 nodes): `user.ts`, `useUserQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 853`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
+- **Thin community `Community 854`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 854`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
+- **Thin community `Community 855`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 855`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
+- **Thin community `Community 856`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 856`** (2 nodes): `validateEmail()`, `email.ts`
+- **Thin community `Community 857`** (2 nodes): `validateEmail()`, `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 857`** (2 nodes): `router.tsx`, `createRouter()`
+- **Thin community `Community 858`** (2 nodes): `router.tsx`, `createRouter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 858`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
+- **Thin community `Community 859`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 859`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
+- **Thin community `Community 860`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 860`** (2 nodes): `ContactUs()`, `contact-us.tsx`
+- **Thin community `Community 861`** (2 nodes): `ContactUs()`, `contact-us.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 861`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
+- **Thin community `Community 862`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 862`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
+- **Thin community `Community 863`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 863`** (2 nodes): `tos.index.tsx`, `TosSection()`
+- **Thin community `Community 864`** (2 nodes): `tos.index.tsx`, `TosSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 864`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
+- **Thin community `Community 865`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 865`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
+- **Thin community `Community 866`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 866`** (2 nodes): `HomeRoute()`, `index.tsx`
+- **Thin community `Community 867`** (2 nodes): `HomeRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 867`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
+- **Thin community `Community 868`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 868`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
+- **Thin community `Community 869`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 869`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
+- **Thin community `Community 870`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 870`** (2 nodes): `ReceiptShareRoute()`, `index.tsx`
+- **Thin community `Community 871`** (2 nodes): `ReceiptShareRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 871`** (2 nodes): `test-connection.js`, `main()`
+- **Thin community `Community 872`** (2 nodes): `test-connection.js`, `main()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 872`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
+- **Thin community `Community 873`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 873`** (2 nodes): `run()`, `architecture-boundary-check.ts`
+- **Thin community `Community 874`** (2 nodes): `run()`, `architecture-boundary-check.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 874`** (2 nodes): `readRepoFile()`, `deploy-qa-vps.test.ts`
+- **Thin community `Community 875`** (2 nodes): `readRepoFile()`, `deploy-qa-vps.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 875`** (2 nodes): `runCommand()`, `github-pr-merge.test.ts`
+- **Thin community `Community 876`** (2 nodes): `runCommand()`, `github-pr-merge.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 876`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
+- **Thin community `Community 877`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 877`** (2 nodes): `shutdown()`, `sample-app.ts`
+- **Thin community `Community 878`** (2 nodes): `shutdown()`, `sample-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 878`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
+- **Thin community `Community 879`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 879`** (1 nodes): `api.d.ts`
+- **Thin community `Community 880`** (1 nodes): `api.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 880`** (1 nodes): `api.js`
+- **Thin community `Community 881`** (1 nodes): `api.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 881`** (1 nodes): `dataModel.d.ts`
+- **Thin community `Community 882`** (1 nodes): `dataModel.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 882`** (1 nodes): `server.d.ts`
+- **Thin community `Community 883`** (1 nodes): `server.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 883`** (1 nodes): `server.js`
+- **Thin community `Community 884`** (1 nodes): `server.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 884`** (1 nodes): `app.ts`
+- **Thin community `Community 885`** (1 nodes): `app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 885`** (1 nodes): `auth.config.js`
+- **Thin community `Community 886`** (1 nodes): `auth.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 886`** (1 nodes): `auth.ts`
+- **Thin community `Community 887`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 887`** (1 nodes): `registerSessions.test.ts`
+- **Thin community `Community 888`** (1 nodes): `registerSessions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 888`** (1 nodes): `r2.test.ts`
+- **Thin community `Community 889`** (1 nodes): `r2.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 889`** (1 nodes): `countries.ts`
+- **Thin community `Community 890`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 890`** (1 nodes): `email.ts`
+- **Thin community `Community 891`** (1 nodes): `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 891`** (1 nodes): `ghana.ts`
+- **Thin community `Community 892`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 892`** (1 nodes): `payment.ts`
+- **Thin community `Community 893`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 893`** (1 nodes): `crons.ts`
+- **Thin community `Community 894`** (1 nodes): `crons.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 894`** (1 nodes): `domain.test.ts`
+- **Thin community `Community 895`** (1 nodes): `domain.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 895`** (1 nodes): `internal.ts`
+- **Thin community `Community 896`** (1 nodes): `internal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 896`** (1 nodes): `public.test.ts`
+- **Thin community `Community 897`** (1 nodes): `public.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 897`** (1 nodes): `token.test.ts`
+- **Thin community `Community 898`** (1 nodes): `token.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 898`** (1 nodes): `whatsappClient.test.ts`
+- **Thin community `Community 899`** (1 nodes): `whatsappClient.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 899`** (1 nodes): `whatsappConfig.test.ts`
+- **Thin community `Community 900`** (1 nodes): `whatsappConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 900`** (1 nodes): `devPatchBadTransaction.ts`
+- **Thin community `Community 901`** (1 nodes): `devPatchBadTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 901`** (1 nodes): `FeedbackRequest.tsx`
+- **Thin community `Community 902`** (1 nodes): `FeedbackRequest.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 902`** (1 nodes): `NewOrderAdmin.tsx`
+- **Thin community `Community 903`** (1 nodes): `NewOrderAdmin.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 903`** (1 nodes): `OrderEmail.tsx`
+- **Thin community `Community 904`** (1 nodes): `OrderEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 904`** (1 nodes): `PosReceiptEmail.tsx`
+- **Thin community `Community 905`** (1 nodes): `PosReceiptEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 905`** (1 nodes): `env.ts`
+- **Thin community `Community 906`** (1 nodes): `env.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 906`** (1 nodes): `analytics.ts`
+- **Thin community `Community 907`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 907`** (1 nodes): `auth.ts`
+- **Thin community `Community 908`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 908`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 909`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 909`** (1 nodes): `colors.ts`
+- **Thin community `Community 910`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 910`** (1 nodes): `index.ts`
+- **Thin community `Community 911`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 911`** (1 nodes): `organizations.ts`
+- **Thin community `Community 912`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 912`** (1 nodes): `products.ts`
+- **Thin community `Community 913`** (1 nodes): `products.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 913`** (1 nodes): `storefrontHidden.test.ts`
+- **Thin community `Community 914`** (1 nodes): `storefrontHidden.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 914`** (1 nodes): `stores.ts`
+- **Thin community `Community 915`** (1 nodes): `stores.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 915`** (1 nodes): `bag.ts`
+- **Thin community `Community 916`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 916`** (1 nodes): `guest.ts`
+- **Thin community `Community 917`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 917`** (1 nodes): `index.ts`
+- **Thin community `Community 918`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 918`** (1 nodes): `me.ts`
+- **Thin community `Community 919`** (1 nodes): `me.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 919`** (1 nodes): `offers.ts`
+- **Thin community `Community 920`** (1 nodes): `offers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 920`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 921`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 921`** (1 nodes): `paystack.ts`
+- **Thin community `Community 922`** (1 nodes): `paystack.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 922`** (1 nodes): `posTransaction.ts`
+- **Thin community `Community 923`** (1 nodes): `posTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 923`** (1 nodes): `reviews.ts`
+- **Thin community `Community 924`** (1 nodes): `reviews.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 924`** (1 nodes): `rewards.ts`
+- **Thin community `Community 925`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 925`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 926`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 926`** (1 nodes): `security.test.ts`
+- **Thin community `Community 927`** (1 nodes): `security.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 927`** (1 nodes): `storefront.ts`
+- **Thin community `Community 928`** (1 nodes): `storefront.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 928`** (1 nodes): `upsells.ts`
+- **Thin community `Community 929`** (1 nodes): `upsells.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 929`** (1 nodes): `user.ts`
+- **Thin community `Community 930`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 930`** (1 nodes): `userOffers.ts`
+- **Thin community `Community 931`** (1 nodes): `userOffers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 931`** (1 nodes): `index.ts`
+- **Thin community `Community 932`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 932`** (1 nodes): `health.test.ts`
+- **Thin community `Community 933`** (1 nodes): `health.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 933`** (1 nodes): `http.ts`
+- **Thin community `Community 934`** (1 nodes): `http.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 934`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 935`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 935`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 936`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 936`** (1 nodes): `bestSeller.ts`
+- **Thin community `Community 937`** (1 nodes): `bestSeller.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 937`** (1 nodes): `categories.ts`
+- **Thin community `Community 938`** (1 nodes): `categories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 938`** (1 nodes): `colors.ts`
+- **Thin community `Community 939`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 939`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 940`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 940`** (1 nodes): `expenseTransactions.test.ts`
+- **Thin community `Community 941`** (1 nodes): `expenseTransactions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 941`** (1 nodes): `featuredItem.ts`
+- **Thin community `Community 942`** (1 nodes): `featuredItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 942`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 943`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 943`** (1 nodes): `organizationMembers.ts`
+- **Thin community `Community 944`** (1 nodes): `organizationMembers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 944`** (1 nodes): `organizations.ts`
+- **Thin community `Community 945`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 945`** (1 nodes): `pos.ts`
+- **Thin community `Community 946`** (1 nodes): `pos.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 946`** (1 nodes): `posCustomers.ts`
+- **Thin community `Community 947`** (1 nodes): `posCustomers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 947`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 948`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 948`** (1 nodes): `productSku.ts`
+- **Thin community `Community 949`** (1 nodes): `productSku.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 949`** (1 nodes): `productUtil.test.ts`
+- **Thin community `Community 950`** (1 nodes): `productUtil.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 950`** (1 nodes): `promoCode.test.ts`
+- **Thin community `Community 951`** (1 nodes): `promoCode.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 951`** (1 nodes): `stockValidation.ts`
+- **Thin community `Community 952`** (1 nodes): `stockValidation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 952`** (1 nodes): `storeConfigV2.test.ts`
+- **Thin community `Community 953`** (1 nodes): `storeConfigV2.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 953`** (1 nodes): `subcategories.ts`
+- **Thin community `Community 954`** (1 nodes): `subcategories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 954`** (1 nodes): `commandResultValidators.test.ts`
+- **Thin community `Community 955`** (1 nodes): `commandResultValidators.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 955`** (1 nodes): `currency.test.ts`
+- **Thin community `Community 956`** (1 nodes): `currency.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 956`** (1 nodes): `storeInsights.ts`
+- **Thin community `Community 957`** (1 nodes): `storeInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 957`** (1 nodes): `userInsights.ts`
+- **Thin community `Community 958`** (1 nodes): `userInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 958`** (1 nodes): `migrateAmountsToPesewas.ts`
+- **Thin community `Community 959`** (1 nodes): `migrateAmountsToPesewas.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 959`** (1 nodes): `client.test.ts`
+- **Thin community `Community 960`** (1 nodes): `client.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 960`** (1 nodes): `config.test.ts`
+- **Thin community `Community 961`** (1 nodes): `config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 961`** (1 nodes): `normalize.test.ts`
+- **Thin community `Community 962`** (1 nodes): `normalize.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 962`** (1 nodes): `types.ts`
+- **Thin community `Community 963`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 963`** (1 nodes): `customerProfiles.test.ts`
+- **Thin community `Community 964`** (1 nodes): `customerProfiles.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 964`** (1 nodes): `inventoryMovements.test.ts`
+- **Thin community `Community 965`** (1 nodes): `inventoryMovements.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 965`** (1 nodes): `paymentAllocations.test.ts`
+- **Thin community `Community 966`** (1 nodes): `paymentAllocations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 966`** (1 nodes): `EmailOTP.test.ts`
+- **Thin community `Community 967`** (1 nodes): `EmailOTP.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 967`** (1 nodes): `correctTransactionCustomer.test.ts`
+- **Thin community `Community 968`** (1 nodes): `correctTransactionCustomer.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 968`** (1 nodes): `correctionEvents.test.ts`
+- **Thin community `Community 969`** (1 nodes): `correctionEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 969`** (1 nodes): `correctionPolicy.test.ts`
+- **Thin community `Community 970`** (1 nodes): `correctionPolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 970`** (1 nodes): `dto.ts`
+- **Thin community `Community 971`** (1 nodes): `dto.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 971`** (1 nodes): `getRegisterState.test.ts`
+- **Thin community `Community 972`** (1 nodes): `getRegisterState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 972`** (1 nodes): `posSessionTracing.test.ts`
+- **Thin community `Community 973`** (1 nodes): `posSessionTracing.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 973`** (1 nodes): `terminals.test.ts`
+- **Thin community `Community 974`** (1 nodes): `terminals.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 974`** (1 nodes): `types.ts`
+- **Thin community `Community 975`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 975`** (1 nodes): `registerSessionRepository.test.ts`
+- **Thin community `Community 976`** (1 nodes): `registerSessionRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 976`** (1 nodes): `catalog.ts`
+- **Thin community `Community 977`** (1 nodes): `catalog.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 977`** (1 nodes): `customers.ts`
+- **Thin community `Community 978`** (1 nodes): `customers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 978`** (1 nodes): `register.ts`
+- **Thin community `Community 979`** (1 nodes): `register.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 979`** (1 nodes): `terminals.ts`
+- **Thin community `Community 980`** (1 nodes): `terminals.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 980`** (1 nodes): `schema.ts`
+- **Thin community `Community 981`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 981`** (1 nodes): `customerMessageDelivery.ts`
+- **Thin community `Community 982`** (1 nodes): `customerMessageDelivery.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 982`** (1 nodes): `index.ts`
+- **Thin community `Community 983`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 983`** (1 nodes): `receiptShareToken.ts`
+- **Thin community `Community 984`** (1 nodes): `receiptShareToken.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 984`** (1 nodes): `appVerificationCode.ts`
+- **Thin community `Community 985`** (1 nodes): `appVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 985`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 986`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 986`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 987`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 987`** (1 nodes): `bestSeller.ts`
+- **Thin community `Community 988`** (1 nodes): `bestSeller.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 988`** (1 nodes): `category.ts`
+- **Thin community `Community 989`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 989`** (1 nodes): `color.ts`
+- **Thin community `Community 990`** (1 nodes): `color.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 990`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 991`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 991`** (1 nodes): `featuredItem.ts`
+- **Thin community `Community 992`** (1 nodes): `featuredItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 992`** (1 nodes): `index.ts`
+- **Thin community `Community 993`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 993`** (1 nodes): `inventoryHold.ts`
+- **Thin community `Community 994`** (1 nodes): `inventoryHold.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 994`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 995`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 995`** (1 nodes): `organization.ts`
+- **Thin community `Community 996`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 996`** (1 nodes): `organizationMember.ts`
+- **Thin community `Community 997`** (1 nodes): `organizationMember.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 997`** (1 nodes): `product.ts`
+- **Thin community `Community 998`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 998`** (1 nodes): `promoCode.ts`
+- **Thin community `Community 999`** (1 nodes): `promoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 999`** (1 nodes): `redeemedPromoCode.ts`
+- **Thin community `Community 1000`** (1 nodes): `redeemedPromoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1000`** (1 nodes): `store.ts`
+- **Thin community `Community 1001`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1001`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1002`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1002`** (1 nodes): `index.ts`
+- **Thin community `Community 1003`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1003`** (1 nodes): `workflowTrace.ts`
+- **Thin community `Community 1004`** (1 nodes): `workflowTrace.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1004`** (1 nodes): `workflowTraceEvent.ts`
+- **Thin community `Community 1005`** (1 nodes): `workflowTraceEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1005`** (1 nodes): `workflowTraceLookup.ts`
+- **Thin community `Community 1006`** (1 nodes): `workflowTraceLookup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1006`** (1 nodes): `approvalRequest.ts`
+- **Thin community `Community 1007`** (1 nodes): `approvalRequest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1007`** (1 nodes): `customerProfile.ts`
+- **Thin community `Community 1008`** (1 nodes): `customerProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1008`** (1 nodes): `dailyClose.ts`
+- **Thin community `Community 1009`** (1 nodes): `dailyClose.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1009`** (1 nodes): `dailyOpening.ts`
+- **Thin community `Community 1010`** (1 nodes): `dailyOpening.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1010`** (1 nodes): `index.ts`
+- **Thin community `Community 1011`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1011`** (1 nodes): `inventoryMovement.ts`
+- **Thin community `Community 1012`** (1 nodes): `inventoryMovement.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1012`** (1 nodes): `operationalEvent.ts`
+- **Thin community `Community 1013`** (1 nodes): `operationalEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1013`** (1 nodes): `operationalWorkItem.ts`
+- **Thin community `Community 1014`** (1 nodes): `operationalWorkItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1014`** (1 nodes): `paymentAllocation.ts`
+- **Thin community `Community 1015`** (1 nodes): `paymentAllocation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1015`** (1 nodes): `registerSession.ts`
+- **Thin community `Community 1016`** (1 nodes): `registerSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1016`** (1 nodes): `staffCredential.ts`
+- **Thin community `Community 1017`** (1 nodes): `staffCredential.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1017`** (1 nodes): `staffProfile.ts`
+- **Thin community `Community 1018`** (1 nodes): `staffProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1018`** (1 nodes): `staffRoleAssignment.ts`
+- **Thin community `Community 1019`** (1 nodes): `staffRoleAssignment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1019`** (1 nodes): `mtnCollections.ts`
+- **Thin community `Community 1020`** (1 nodes): `mtnCollections.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1020`** (1 nodes): `customer.ts`
+- **Thin community `Community 1021`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1021`** (1 nodes): `expenseSession.ts`
+- **Thin community `Community 1022`** (1 nodes): `expenseSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1022`** (1 nodes): `expenseSessionItem.ts`
+- **Thin community `Community 1023`** (1 nodes): `expenseSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1023`** (1 nodes): `expenseTransaction.ts`
+- **Thin community `Community 1024`** (1 nodes): `expenseTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1024`** (1 nodes): `expenseTransactionItem.ts`
+- **Thin community `Community 1025`** (1 nodes): `expenseTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1025`** (1 nodes): `index.ts`
+- **Thin community `Community 1026`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1026`** (1 nodes): `posSession.ts`
+- **Thin community `Community 1027`** (1 nodes): `posSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1027`** (1 nodes): `posSessionItem.ts`
+- **Thin community `Community 1028`** (1 nodes): `posSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1028`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 1029`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1029`** (1 nodes): `posTransaction.ts`
+- **Thin community `Community 1030`** (1 nodes): `posTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1030`** (1 nodes): `posTransactionItem.ts`
+- **Thin community `Community 1031`** (1 nodes): `posTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1031`** (1 nodes): `index.ts`
+- **Thin community `Community 1032`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1032`** (1 nodes): `serviceAppointment.ts`
+- **Thin community `Community 1033`** (1 nodes): `serviceAppointment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1033`** (1 nodes): `serviceCase.ts`
+- **Thin community `Community 1034`** (1 nodes): `serviceCase.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1034`** (1 nodes): `serviceCaseLineItem.ts`
+- **Thin community `Community 1035`** (1 nodes): `serviceCaseLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1035`** (1 nodes): `serviceCatalog.ts`
+- **Thin community `Community 1036`** (1 nodes): `serviceCatalog.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1036`** (1 nodes): `serviceInventoryUsage.ts`
+- **Thin community `Community 1037`** (1 nodes): `serviceInventoryUsage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1037`** (1 nodes): `cycleCountDraft.ts`
+- **Thin community `Community 1038`** (1 nodes): `cycleCountDraft.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1038`** (1 nodes): `index.ts`
+- **Thin community `Community 1039`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1039`** (1 nodes): `purchaseOrder.ts`
+- **Thin community `Community 1040`** (1 nodes): `purchaseOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1040`** (1 nodes): `purchaseOrderLineItem.ts`
+- **Thin community `Community 1041`** (1 nodes): `purchaseOrderLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1041`** (1 nodes): `receivingBatch.ts`
+- **Thin community `Community 1042`** (1 nodes): `receivingBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1042`** (1 nodes): `stockAdjustmentBatch.ts`
+- **Thin community `Community 1043`** (1 nodes): `stockAdjustmentBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1043`** (1 nodes): `vendor.ts`
+- **Thin community `Community 1044`** (1 nodes): `vendor.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1044`** (1 nodes): `analytics.ts`
+- **Thin community `Community 1045`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1045`** (1 nodes): `bag.ts`
+- **Thin community `Community 1046`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1046`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1047`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1047`** (1 nodes): `checkoutSession.ts`
+- **Thin community `Community 1048`** (1 nodes): `checkoutSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1048`** (1 nodes): `checkoutSessionItem.ts`
+- **Thin community `Community 1049`** (1 nodes): `checkoutSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1049`** (1 nodes): `guest.ts`
+- **Thin community `Community 1050`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1050`** (1 nodes): `index.ts`
+- **Thin community `Community 1051`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1051`** (1 nodes): `offer.ts`
+- **Thin community `Community 1052`** (1 nodes): `offer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1052`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 1053`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1053`** (1 nodes): `onlineOrderItem.ts`
+- **Thin community `Community 1054`** (1 nodes): `onlineOrderItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1054`** (1 nodes): `review.ts`
+- **Thin community `Community 1055`** (1 nodes): `review.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1055`** (1 nodes): `rewards.ts`
+- **Thin community `Community 1056`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1056`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 1057`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1057`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 1058`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1058`** (1 nodes): `storeFrontSession.ts`
+- **Thin community `Community 1059`** (1 nodes): `storeFrontSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1059`** (1 nodes): `storeFrontUser.ts`
+- **Thin community `Community 1060`** (1 nodes): `storeFrontUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1060`** (1 nodes): `storeFrontVerificationCode.ts`
+- **Thin community `Community 1061`** (1 nodes): `storeFrontVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1061`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 1062`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1062`** (1 nodes): `catalogAppointments.test.ts`
+- **Thin community `Community 1063`** (1 nodes): `catalogAppointments.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1063`** (1 nodes): `bag.ts`
+- **Thin community `Community 1064`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1064`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1065`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1065`** (1 nodes): `checkoutSession.test.ts`
+- **Thin community `Community 1066`** (1 nodes): `checkoutSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1066`** (1 nodes): `customer.ts`
+- **Thin community `Community 1067`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1067`** (1 nodes): `guest.ts`
+- **Thin community `Community 1068`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1068`** (1 nodes): `offers.test.ts`
+- **Thin community `Community 1069`** (1 nodes): `offers.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1069`** (1 nodes): `onlineOrderUtilFns.ts`
+- **Thin community `Community 1070`** (1 nodes): `onlineOrderUtilFns.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1070`** (1 nodes): `orderOperations.test.ts`
+- **Thin community `Community 1071`** (1 nodes): `orderOperations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1071`** (1 nodes): `payment.test.ts`
+- **Thin community `Community 1072`** (1 nodes): `payment.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1072`** (1 nodes): `payment.ts`
+- **Thin community `Community 1073`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1073`** (1 nodes): `paystackActions.ts`
+- **Thin community `Community 1074`** (1 nodes): `paystackActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1074`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 1075`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1075`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 1076`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1076`** (1 nodes): `users.ts`
+- **Thin community `Community 1077`** (1 nodes): `users.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1077`** (1 nodes): `payment.ts`
+- **Thin community `Community 1078`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1078`** (1 nodes): `posSession.test.ts`
+- **Thin community `Community 1079`** (1 nodes): `posSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1079`** (1 nodes): `registerSession.test.ts`
+- **Thin community `Community 1080`** (1 nodes): `registerSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1080`** (1 nodes): `presentation.test.ts`
+- **Thin community `Community 1081`** (1 nodes): `presentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1081`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 1082`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1082`** (1 nodes): `index.ts`
+- **Thin community `Community 1083`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1083`** (1 nodes): `postcss.config.js`
+- **Thin community `Community 1084`** (1 nodes): `postcss.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1084`** (1 nodes): `approvalPolicy.ts`
+- **Thin community `Community 1085`** (1 nodes): `approvalPolicy.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1085`** (1 nodes): `auth.ts`
+- **Thin community `Community 1086`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1086`** (1 nodes): `commandResult.test.ts`
+- **Thin community `Community 1087`** (1 nodes): `commandResult.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1087`** (1 nodes): `currencyFormatter.test.ts`
+- **Thin community `Community 1088`** (1 nodes): `currencyFormatter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1088`** (1 nodes): `registerSessionStatus.test.ts`
+- **Thin community `Community 1089`** (1 nodes): `registerSessionStatus.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1089`** (1 nodes): `staffDisplayName.test.ts`
+- **Thin community `Community 1090`** (1 nodes): `staffDisplayName.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1090`** (1 nodes): `GenericComboBox.tsx`
+- **Thin community `Community 1091`** (1 nodes): `GenericComboBox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1091`** (1 nodes): `StoreAccordion.tsx`
+- **Thin community `Community 1092`** (1 nodes): `StoreAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1092`** (1 nodes): `StoresAccordion.tsx`
+- **Thin community `Community 1093`** (1 nodes): `StoresAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1093`** (1 nodes): `ThemeToggle.tsx`
+- **Thin community `Community 1094`** (1 nodes): `ThemeToggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1094`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
+- **Thin community `Community 1095`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1095`** (1 nodes): `ProductAttributesView.tsx`
+- **Thin community `Community 1096`** (1 nodes): `ProductAttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1096`** (1 nodes): `ProductStock.test.ts`
+- **Thin community `Community 1097`** (1 nodes): `ProductStock.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1097`** (1 nodes): `ProductView.test.tsx`
+- **Thin community `Community 1098`** (1 nodes): `ProductView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1098`** (1 nodes): `constants.ts`
+- **Thin community `Community 1099`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1099`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1100`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1100`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1101`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1101`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1102`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1102`** (1 nodes): `types.ts`
+- **Thin community `Community 1103`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1103`** (1 nodes): `ConversionFunnelChart.tsx`
+- **Thin community `Community 1104`** (1 nodes): `ConversionFunnelChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1104`** (1 nodes): `RevenueChart.tsx`
+- **Thin community `Community 1105`** (1 nodes): `RevenueChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1105`** (1 nodes): `analytics-columns.tsx`
+- **Thin community `Community 1106`** (1 nodes): `analytics-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1106`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1107`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1107`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1108`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1108`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1109`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1109`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1110`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1110`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1111`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1111`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1112`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1112`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1113`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1113`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1114`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1114`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1115`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1115`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1116`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1116`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1117`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1117`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1118`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1118`** (1 nodes): `chart.tsx`
+- **Thin community `Community 1119`** (1 nodes): `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1119`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1120`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1120`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1121`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1121`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1122`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1122`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1123`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1123`** (1 nodes): `constants.ts`
+- **Thin community `Community 1124`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1124`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1125`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1125`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1126`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1126`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1127`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1127`** (1 nodes): `data.ts`
+- **Thin community `Community 1128`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1128`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1129`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1129`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1130`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1130`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1131`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1131`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1132`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1132`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1133`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1133`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1134`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1134`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1135`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1135`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1136`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1136`** (1 nodes): `assetsColumns.tsx`
+- **Thin community `Community 1137`** (1 nodes): `assetsColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1137`** (1 nodes): `constants.ts`
+- **Thin community `Community 1138`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1138`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1139`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1139`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1140`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1140`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1141`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1141`** (1 nodes): `data.ts`
+- **Thin community `Community 1142`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1142`** (1 nodes): `DefaultCatchBoundary.test.tsx`
+- **Thin community `Community 1143`** (1 nodes): `DefaultCatchBoundary.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1143`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 1144`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1144`** (1 nodes): `LoginForm.test.tsx`
+- **Thin community `Community 1145`** (1 nodes): `LoginForm.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1145`** (1 nodes): `LoginForm.tsx`
+- **Thin community `Community 1146`** (1 nodes): `LoginForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1146`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1147`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1147`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1148`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1148`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1149`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1149`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1150`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1150`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1151`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1151`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1152`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1152`** (1 nodes): `constants.ts`
+- **Thin community `Community 1153`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1153`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1154`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1154`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1155`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1155`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1156`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1156`** (1 nodes): `BulkOperationsPage.tsx`
+- **Thin community `Community 1157`** (1 nodes): `BulkOperationsPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1157`** (1 nodes): `CashControlsDashboard.auth.test.tsx`
+- **Thin community `Community 1158`** (1 nodes): `CashControlsDashboard.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1158`** (1 nodes): `CashControlsDashboard.test.tsx`
+- **Thin community `Community 1159`** (1 nodes): `CashControlsDashboard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1159`** (1 nodes): `CashControlsWorkspaceHeader.tsx`
+- **Thin community `Community 1160`** (1 nodes): `CashControlsWorkspaceHeader.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1160`** (1 nodes): `RegisterSessionView.auth.test.tsx`
+- **Thin community `Community 1161`** (1 nodes): `RegisterSessionView.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1161`** (1 nodes): `RegisterSessionView.test.tsx`
+- **Thin community `Community 1162`** (1 nodes): `RegisterSessionView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1162`** (1 nodes): `RegisterSessionsView.test.tsx`
+- **Thin community `Community 1163`** (1 nodes): `RegisterSessionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1163`** (1 nodes): `formatReviewReason.test.ts`
+- **Thin community `Community 1164`** (1 nodes): `formatReviewReason.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1164`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1165`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1165`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1166`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1166`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1167`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1167`** (1 nodes): `ListPagination.tsx`
+- **Thin community `Community 1168`** (1 nodes): `ListPagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1168`** (1 nodes): `PageLevelHeader.test.tsx`
+- **Thin community `Community 1169`** (1 nodes): `PageLevelHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1169`** (1 nodes): `PageLevelHeader.tsx`
+- **Thin community `Community 1170`** (1 nodes): `PageLevelHeader.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1170`** (1 nodes): `MetricCard.tsx`
+- **Thin community `Community 1171`** (1 nodes): `MetricCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1171`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 1172`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1172`** (1 nodes): `CommandApprovalDialog.test.tsx`
+- **Thin community `Community 1173`** (1 nodes): `CommandApprovalDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1173`** (1 nodes): `OperationReviewWorkspace.tsx`
+- **Thin community `Community 1174`** (1 nodes): `OperationReviewWorkspace.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1174`** (1 nodes): `OperationsQueueView.auth.test.tsx`
+- **Thin community `Community 1175`** (1 nodes): `OperationsQueueView.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1175`** (1 nodes): `useApprovedCommand.test.tsx`
+- **Thin community `Community 1176`** (1 nodes): `useApprovedCommand.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1176`** (1 nodes): `OrderStatus.test.tsx`
+- **Thin community `Community 1177`** (1 nodes): `OrderStatus.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1177`** (1 nodes): `OrderStatus.tsx`
+- **Thin community `Community 1178`** (1 nodes): `OrderStatus.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1178`** (1 nodes): `OrderSummary.tsx`
+- **Thin community `Community 1179`** (1 nodes): `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1179`** (1 nodes): `Orders.tsx`
+- **Thin community `Community 1180`** (1 nodes): `Orders.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1180`** (1 nodes): `RefundsView.test.tsx`
+- **Thin community `Community 1181`** (1 nodes): `RefundsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1181`** (1 nodes): `ReturnExchangeView.test.tsx`
+- **Thin community `Community 1182`** (1 nodes): `ReturnExchangeView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1182`** (1 nodes): `constants.ts`
+- **Thin community `Community 1183`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1183`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1184`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1184`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1185`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1185`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1186`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1186`** (1 nodes): `data.ts`
+- **Thin community `Community 1187`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1187`** (1 nodes): `refundUtils.test.ts`
+- **Thin community `Community 1188`** (1 nodes): `refundUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1188`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1189`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1189`** (1 nodes): `constants.ts`
+- **Thin community `Community 1190`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1190`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1191`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1191`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1192`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1192`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1193`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1193`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1194`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1194`** (1 nodes): `data.ts`
+- **Thin community `Community 1195`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1195`** (1 nodes): `inviteColumns.tsx`
+- **Thin community `Community 1196`** (1 nodes): `inviteColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1196`** (1 nodes): `constants.ts`
+- **Thin community `Community 1197`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1197`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1198`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1198`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1199`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1199`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1200`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1200`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1201`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1201`** (1 nodes): `data.ts`
+- **Thin community `Community 1202`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1202`** (1 nodes): `membersColumns.tsx`
+- **Thin community `Community 1203`** (1 nodes): `membersColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1203`** (1 nodes): `organization-switcher.test.tsx`
+- **Thin community `Community 1204`** (1 nodes): `organization-switcher.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1204`** (1 nodes): `CashierAuthDialog.test.tsx`
+- **Thin community `Community 1205`** (1 nodes): `CashierAuthDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1205`** (1 nodes): `CashierView.tsx`
+- **Thin community `Community 1206`** (1 nodes): `CashierView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1206`** (1 nodes): `POSRegisterView.tsx`
+- **Thin community `Community 1207`** (1 nodes): `POSRegisterView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1207`** (1 nodes): `PaymentView.test.tsx`
+- **Thin community `Community 1208`** (1 nodes): `PaymentView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1208`** (1 nodes): `PointOfSaleView.test.tsx`
+- **Thin community `Community 1209`** (1 nodes): `PointOfSaleView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1209`** (1 nodes): `PointOfSaleView.tsx`
+- **Thin community `Community 1210`** (1 nodes): `PointOfSaleView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1210`** (1 nodes): `ProductLookup.tsx`
+- **Thin community `Community 1211`** (1 nodes): `ProductLookup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1211`** (1 nodes): `RegisterActions.tsx`
+- **Thin community `Community 1212`** (1 nodes): `RegisterActions.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1212`** (1 nodes): `SessionManager.test.tsx`
+- **Thin community `Community 1213`** (1 nodes): `SessionManager.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1213`** (1 nodes): `SessionManager.tsx`
+- **Thin community `Community 1214`** (1 nodes): `SessionManager.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1214`** (1 nodes): `TotalsDisplay.test.tsx`
+- **Thin community `Community 1215`** (1 nodes): `TotalsDisplay.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1215`** (1 nodes): `TotalsDisplay.tsx`
+- **Thin community `Community 1216`** (1 nodes): `TotalsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1216`** (1 nodes): `ExpenseReportView.tsx`
+- **Thin community `Community 1217`** (1 nodes): `ExpenseReportView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1217`** (1 nodes): `ExpenseReportsView.test.ts`
+- **Thin community `Community 1218`** (1 nodes): `ExpenseReportsView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1218`** (1 nodes): `ExpenseReportsView.test.tsx`
+- **Thin community `Community 1219`** (1 nodes): `ExpenseReportsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1219`** (1 nodes): `expenseReportColumns.tsx`
+- **Thin community `Community 1220`** (1 nodes): `expenseReportColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1220`** (1 nodes): `PosReceiptShareControl.test.tsx`
+- **Thin community `Community 1221`** (1 nodes): `PosReceiptShareControl.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1221`** (1 nodes): `POSRegisterOpeningGuard.test.tsx`
+- **Thin community `Community 1222`** (1 nodes): `POSRegisterOpeningGuard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1222`** (1 nodes): `POSRegisterView.test.tsx`
+- **Thin community `Community 1223`** (1 nodes): `POSRegisterView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1223`** (1 nodes): `RegisterActionBar.test.tsx`
+- **Thin community `Community 1224`** (1 nodes): `RegisterActionBar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1224`** (1 nodes): `RegisterActionBar.tsx`
+- **Thin community `Community 1225`** (1 nodes): `RegisterActionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1225`** (1 nodes): `RegisterCheckoutPanel.tsx`
+- **Thin community `Community 1226`** (1 nodes): `RegisterCheckoutPanel.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1226`** (1 nodes): `HeldSessionsList.test.tsx`
+- **Thin community `Community 1227`** (1 nodes): `HeldSessionsList.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1227`** (1 nodes): `POSSessionsView.test.tsx`
+- **Thin community `Community 1228`** (1 nodes): `POSSessionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1228`** (1 nodes): `posSessionColumns.tsx`
+- **Thin community `Community 1229`** (1 nodes): `posSessionColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1229`** (1 nodes): `TransactionsView.test.tsx`
+- **Thin community `Community 1230`** (1 nodes): `TransactionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1230`** (1 nodes): `types.ts`
+- **Thin community `Community 1231`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1231`** (1 nodes): `ReceivingView.test.tsx`
+- **Thin community `Community 1232`** (1 nodes): `ReceivingView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1232`** (1 nodes): `AnalyticsInsights.tsx`
+- **Thin community `Community 1233`** (1 nodes): `AnalyticsInsights.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1233`** (1 nodes): `AttributesView.tsx`
+- **Thin community `Community 1234`** (1 nodes): `AttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1234`** (1 nodes): `DetailsView.tsx`
+- **Thin community `Community 1235`** (1 nodes): `DetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1235`** (1 nodes): `ProductDetailView.tsx`
+- **Thin community `Community 1236`** (1 nodes): `ProductDetailView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1236`** (1 nodes): `ArchivedProducts.tsx`
+- **Thin community `Community 1237`** (1 nodes): `ArchivedProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1237`** (1 nodes): `CategoryListView.tsx`
+- **Thin community `Community 1238`** (1 nodes): `CategoryListView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1238`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
+- **Thin community `Community 1239`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1239`** (1 nodes): `Products.tsx`
+- **Thin community `Community 1240`** (1 nodes): `Products.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1240`** (1 nodes): `StoreProducts.tsx`
+- **Thin community `Community 1241`** (1 nodes): `StoreProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1241`** (1 nodes): `UnresolvedProducts.tsx`
+- **Thin community `Community 1242`** (1 nodes): `UnresolvedProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1242`** (1 nodes): `ComplimentaryProducts.tsx`
+- **Thin community `Community 1243`** (1 nodes): `ComplimentaryProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1243`** (1 nodes): `complimentaryProductsColumn.tsx`
+- **Thin community `Community 1244`** (1 nodes): `complimentaryProductsColumn.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1244`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1245`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1245`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1246`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1246`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1247`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1247`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1248`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1248`** (1 nodes): `data.ts`
+- **Thin community `Community 1249`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1249`** (1 nodes): `productColumns.tsx`
+- **Thin community `Community 1250`** (1 nodes): `productColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1250`** (1 nodes): `PromoCodeHeader.test.tsx`
+- **Thin community `Community 1251`** (1 nodes): `PromoCodeHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1251`** (1 nodes): `PromoCodes.tsx`
+- **Thin community `Community 1252`** (1 nodes): `PromoCodes.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1252`** (1 nodes): `PromoCodeAnalytics.tsx`
+- **Thin community `Community 1253`** (1 nodes): `PromoCodeAnalytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1253`** (1 nodes): `captured-emails-columns.tsx`
+- **Thin community `Community 1254`** (1 nodes): `captured-emails-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1254`** (1 nodes): `promoCodeMoney.test.ts`
+- **Thin community `Community 1255`** (1 nodes): `promoCodeMoney.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1255`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1256`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1256`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1257`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1257`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1258`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1258`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1259`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1259`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1260`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1260`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1261`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1261`** (1 nodes): `constants.ts`
+- **Thin community `Community 1262`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1262`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1263`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1263`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1264`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1264`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1265`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1265`** (1 nodes): `data.ts`
+- **Thin community `Community 1266`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1266`** (1 nodes): `types.ts`
+- **Thin community `Community 1267`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1267`** (1 nodes): `welcome-offer-card.tsx`
+- **Thin community `Community 1268`** (1 nodes): `welcome-offer-card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1268`** (1 nodes): `RatingStars.tsx`
+- **Thin community `Community 1269`** (1 nodes): `RatingStars.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1269`** (1 nodes): `ReviewCard.tsx`
+- **Thin community `Community 1270`** (1 nodes): `ReviewCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1270`** (1 nodes): `ReviewMetadata.tsx`
+- **Thin community `Community 1271`** (1 nodes): `ReviewMetadata.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1271`** (1 nodes): `ServicesWorkspaceView.test.tsx`
+- **Thin community `Community 1272`** (1 nodes): `ServicesWorkspaceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1272`** (1 nodes): `index.tsx`
+- **Thin community `Community 1273`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1273`** (1 nodes): `StaffAuthenticationDialog.test.tsx`
+- **Thin community `Community 1274`** (1 nodes): `StaffAuthenticationDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1274`** (1 nodes): `FeesView.test.ts`
+- **Thin community `Community 1275`** (1 nodes): `FeesView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1275`** (1 nodes): `FulfillmentView.test.tsx`
+- **Thin community `Community 1276`** (1 nodes): `FulfillmentView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1276`** (1 nodes): `MaintenanceView.test.tsx`
+- **Thin community `Community 1277`** (1 nodes): `MaintenanceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1277`** (1 nodes): `MtnMomoView.test.tsx`
+- **Thin community `Community 1278`** (1 nodes): `MtnMomoView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1278`** (1 nodes): `useStoreConfigUpdate.test.tsx`
+- **Thin community `Community 1279`** (1 nodes): `useStoreConfigUpdate.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1279`** (1 nodes): `index.tsx`
+- **Thin community `Community 1280`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1280`** (1 nodes): `WorkflowTraceView.test.tsx`
+- **Thin community `Community 1281`** (1 nodes): `WorkflowTraceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1281`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 1282`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1282`** (1 nodes): `button.test.tsx`
+- **Thin community `Community 1283`** (1 nodes): `button.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1283`** (1 nodes): `button.tsx`
+- **Thin community `Community 1284`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1284`** (1 nodes): `calendar.test.tsx`
+- **Thin community `Community 1285`** (1 nodes): `calendar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1285`** (1 nodes): `card.tsx`
+- **Thin community `Community 1286`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1286`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 1287`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1287`** (1 nodes): `collapsible.tsx`
+- **Thin community `Community 1288`** (1 nodes): `collapsible.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1288`** (1 nodes): `command.tsx`
+- **Thin community `Community 1289`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1289`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 1290`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1290`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 1291`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1291`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 1292`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1292`** (1 nodes): `form.tsx`
+- **Thin community `Community 1293`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1293`** (1 nodes): `icons.tsx`
+- **Thin community `Community 1294`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1294`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 1295`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1295`** (1 nodes): `input.tsx`
+- **Thin community `Community 1296`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1296`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 1297`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1297`** (1 nodes): `panel-header.tsx`
+- **Thin community `Community 1298`** (1 nodes): `panel-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1298`** (1 nodes): `popover.tsx`
+- **Thin community `Community 1299`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1299`** (1 nodes): `primitives.test.tsx`
+- **Thin community `Community 1300`** (1 nodes): `primitives.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1300`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 1301`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1301`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 1302`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1302`** (1 nodes): `select.tsx`
+- **Thin community `Community 1303`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1303`** (1 nodes): `separator.tsx`
+- **Thin community `Community 1304`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1304`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 1305`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1305`** (1 nodes): `switch.tsx`
+- **Thin community `Community 1306`** (1 nodes): `switch.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1306`** (1 nodes): `table.tsx`
+- **Thin community `Community 1307`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1307`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 1308`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1308`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 1309`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1309`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 1310`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1310`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 1311`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1311`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 1312`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1312`** (1 nodes): `upload-button.tsx`
+- **Thin community `Community 1313`** (1 nodes): `upload-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1313`** (1 nodes): `BagView.tsx`
+- **Thin community `Community 1314`** (1 nodes): `BagView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1314`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1315`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1315`** (1 nodes): `constants.ts`
+- **Thin community `Community 1316`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1316`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1317`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1317`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1318`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1318`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1319`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1319`** (1 nodes): `data.ts`
+- **Thin community `Community 1320`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1320`** (1 nodes): `bag-columns.tsx`
+- **Thin community `Community 1321`** (1 nodes): `bag-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1321`** (1 nodes): `bags-table.tsx`
+- **Thin community `Community 1322`** (1 nodes): `bags-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1322`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1323`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1323`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1324`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1324`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1325`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1325`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1326`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1326`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1327`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1327`** (1 nodes): `LinkedAccounts.tsx`
+- **Thin community `Community 1328`** (1 nodes): `LinkedAccounts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1328`** (1 nodes): `TimelineEventCard.test.tsx`
+- **Thin community `Community 1329`** (1 nodes): `TimelineEventCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1329`** (1 nodes): `UserCheckoutSession.tsx`
+- **Thin community `Community 1330`** (1 nodes): `UserCheckoutSession.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1330`** (1 nodes): `UserInsightsSection.tsx`
+- **Thin community `Community 1331`** (1 nodes): `UserInsightsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1331`** (1 nodes): `UserBehaviorInsights.tsx`
+- **Thin community `Community 1332`** (1 nodes): `UserBehaviorInsights.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1332`** (1 nodes): `index.ts`
+- **Thin community `Community 1333`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1333`** (1 nodes): `config.test.ts`
+- **Thin community `Community 1334`** (1 nodes): `config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1334`** (1 nodes): `ThemeContext.tsx`
+- **Thin community `Community 1335`** (1 nodes): `ThemeContext.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1335`** (1 nodes): `design-system-build-config.test.ts`
+- **Thin community `Community 1336`** (1 nodes): `design-system-build-config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1336`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 1337`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1337`** (1 nodes): `useAuth.test.tsx`
+- **Thin community `Community 1338`** (1 nodes): `useAuth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1338`** (1 nodes): `useExpenseSessions.test.ts`
+- **Thin community `Community 1339`** (1 nodes): `useExpenseSessions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1339`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 1340`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1340`** (1 nodes): `aws.ts`
+- **Thin community `Community 1341`** (1 nodes): `aws.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1341`** (1 nodes): `constants.ts`
+- **Thin community `Community 1342`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1342`** (1 nodes): `countries.ts`
+- **Thin community `Community 1343`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1343`** (1 nodes): `operatorMessages.test.ts`
+- **Thin community `Community 1344`** (1 nodes): `operatorMessages.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1344`** (1 nodes): `presentCommandToast.test.ts`
+- **Thin community `Community 1345`** (1 nodes): `presentCommandToast.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1345`** (1 nodes): `presentUnexpectedErrorToast.test.ts`
+- **Thin community `Community 1346`** (1 nodes): `presentUnexpectedErrorToast.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1346`** (1 nodes): `runCommand.test.ts`
+- **Thin community `Community 1347`** (1 nodes): `runCommand.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1347`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1348`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1348`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 1349`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1349`** (1 nodes): `dto.ts`
+- **Thin community `Community 1350`** (1 nodes): `dto.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1350`** (1 nodes): `ports.ts`
+- **Thin community `Community 1351`** (1 nodes): `ports.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1351`** (1 nodes): `constants.ts`
+- **Thin community `Community 1352`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1352`** (1 nodes): `displayAmounts.test.ts`
+- **Thin community `Community 1353`** (1 nodes): `displayAmounts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1353`** (1 nodes): `cart.test.ts`
+- **Thin community `Community 1354`** (1 nodes): `cart.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1354`** (1 nodes): `index.ts`
+- **Thin community `Community 1355`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1355`** (1 nodes): `session.test.ts`
+- **Thin community `Community 1356`** (1 nodes): `session.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1356`** (1 nodes): `types.ts`
+- **Thin community `Community 1357`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1357`** (1 nodes): `registerGateway.test.ts`
+- **Thin community `Community 1358`** (1 nodes): `registerGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1358`** (1 nodes): `sessionGateway.test.ts`
+- **Thin community `Community 1359`** (1 nodes): `sessionGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1359`** (1 nodes): `loggerGateway.ts`
+- **Thin community `Community 1360`** (1 nodes): `loggerGateway.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1360`** (1 nodes): `catalogSearch.test.ts`
+- **Thin community `Community 1361`** (1 nodes): `catalogSearch.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1361`** (1 nodes): `registerUiState.ts`
+- **Thin community `Community 1362`** (1 nodes): `registerUiState.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1362`** (1 nodes): `productUtils.test.ts`
+- **Thin community `Community 1363`** (1 nodes): `productUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1363`** (1 nodes): `category.ts`
+- **Thin community `Community 1364`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1364`** (1 nodes): `product.ts`
+- **Thin community `Community 1365`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1365`** (1 nodes): `store.ts`
+- **Thin community `Community 1366`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1366`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1367`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1367`** (1 nodes): `user.ts`
+- **Thin community `Community 1368`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1368`** (1 nodes): `storeConfig.test.ts`
+- **Thin community `Community 1369`** (1 nodes): `storeConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1369`** (1 nodes): `createWorkflowTraceId.test.ts`
+- **Thin community `Community 1370`** (1 nodes): `createWorkflowTraceId.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1370`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1371`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1371`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 1372`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1372`** (1 nodes): `__root.tsx`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1373`** (1 nodes): `index.tsx`
+- **Thin community `Community 1373`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1374`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1375`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1376`** (1 nodes): `$storeUrlSlug.tsx`
+- **Thin community `Community 1376`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1377`** (1 nodes): `analytics.tsx`
+- **Thin community `Community 1377`** (1 nodes): `$storeUrlSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1378`** (1 nodes): `assets.index.tsx`
+- **Thin community `Community 1378`** (1 nodes): `analytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1379`** (1 nodes): `bags.$bagId.tsx`
+- **Thin community `Community 1379`** (1 nodes): `assets.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1380`** (1 nodes): `bags.index.tsx`
+- **Thin community `Community 1380`** (1 nodes): `bags.$bagId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1381`** (1 nodes): `index.tsx`
+- **Thin community `Community 1381`** (1 nodes): `bags.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1382`** (1 nodes): `checkout-sessions.index.tsx`
+- **Thin community `Community 1382`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1383`** (1 nodes): `configuration.index.tsx`
+- **Thin community `Community 1383`** (1 nodes): `checkout-sessions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1384`** (1 nodes): `dashboard.index.tsx`
+- **Thin community `Community 1384`** (1 nodes): `configuration.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1385`** (1 nodes): `home.tsx`
+- **Thin community `Community 1385`** (1 nodes): `dashboard.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1386`** (1 nodes): `logs.$logId.tsx`
+- **Thin community `Community 1386`** (1 nodes): `home.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1387`** (1 nodes): `logs.index.tsx`
+- **Thin community `Community 1387`** (1 nodes): `logs.$logId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1388`** (1 nodes): `members.index.tsx`
+- **Thin community `Community 1388`** (1 nodes): `logs.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1389`** (1 nodes): `index.tsx`
+- **Thin community `Community 1389`** (1 nodes): `members.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1390`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1391`** (1 nodes): `all.index.tsx`
+- **Thin community `Community 1391`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1392`** (1 nodes): `cancelled.index.tsx`
+- **Thin community `Community 1392`** (1 nodes): `all.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1393`** (1 nodes): `completed.index.tsx`
+- **Thin community `Community 1393`** (1 nodes): `cancelled.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1394`** (1 nodes): `index.tsx`
+- **Thin community `Community 1394`** (1 nodes): `completed.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1395`** (1 nodes): `open.index.tsx`
+- **Thin community `Community 1395`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1396`** (1 nodes): `out-for-delivery.index.tsx`
+- **Thin community `Community 1396`** (1 nodes): `open.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1397`** (1 nodes): `ready.index.tsx`
+- **Thin community `Community 1397`** (1 nodes): `out-for-delivery.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1398`** (1 nodes): `refunded.index.tsx`
+- **Thin community `Community 1398`** (1 nodes): `ready.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1399`** (1 nodes): `$reportId.tsx`
+- **Thin community `Community 1399`** (1 nodes): `refunded.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1400`** (1 nodes): `expense-reports.index.tsx`
+- **Thin community `Community 1400`** (1 nodes): `$reportId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1401`** (1 nodes): `index.tsx`
+- **Thin community `Community 1401`** (1 nodes): `expense-reports.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1402`** (1 nodes): `register.index.tsx`
+- **Thin community `Community 1402`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1403`** (1 nodes): `sessions.index.tsx`
+- **Thin community `Community 1403`** (1 nodes): `register.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1404`** (1 nodes): `settings.index.tsx`
+- **Thin community `Community 1404`** (1 nodes): `sessions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1405`** (1 nodes): `$transactionId.tsx`
+- **Thin community `Community 1405`** (1 nodes): `settings.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1406`** (1 nodes): `transactions.index.tsx`
+- **Thin community `Community 1406`** (1 nodes): `$transactionId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1407`** (1 nodes): `procurement.index.test.ts`
+- **Thin community `Community 1407`** (1 nodes): `transactions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1408`** (1 nodes): `edit.tsx`
+- **Thin community `Community 1408`** (1 nodes): `procurement.index.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1409`** (1 nodes): `index.tsx`
+- **Thin community `Community 1409`** (1 nodes): `edit.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1410`** (1 nodes): `archived.tsx`
+- **Thin community `Community 1410`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1411`** (1 nodes): `index.tsx`
+- **Thin community `Community 1411`** (1 nodes): `archived.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1412`** (1 nodes): `new.tsx`
+- **Thin community `Community 1412`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1413`** (1 nodes): `index.tsx`
+- **Thin community `Community 1413`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1414`** (1 nodes): `new.tsx`
+- **Thin community `Community 1414`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1415`** (1 nodes): `unresolved.tsx`
+- **Thin community `Community 1415`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1416`** (1 nodes): `$promoCodeSlug.tsx`
+- **Thin community `Community 1416`** (1 nodes): `unresolved.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1417`** (1 nodes): `index.tsx`
+- **Thin community `Community 1417`** (1 nodes): `$promoCodeSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1418`** (1 nodes): `new.tsx`
+- **Thin community `Community 1418`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1419`** (1 nodes): `index.tsx`
+- **Thin community `Community 1419`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1420`** (1 nodes): `new.index.tsx`
+- **Thin community `Community 1420`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1421`** (1 nodes): `active-cases.index.tsx`
+- **Thin community `Community 1421`** (1 nodes): `new.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1422`** (1 nodes): `appointments.index.tsx`
+- **Thin community `Community 1422`** (1 nodes): `active-cases.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1423`** (1 nodes): `catalog-management.index.tsx`
+- **Thin community `Community 1423`** (1 nodes): `appointments.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1424`** (1 nodes): `index.tsx`
+- **Thin community `Community 1424`** (1 nodes): `catalog-management.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1425`** (1 nodes): `intake.index.tsx`
+- **Thin community `Community 1425`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1426`** (1 nodes): `$traceId.test.tsx`
+- **Thin community `Community 1426`** (1 nodes): `intake.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1427`** (1 nodes): `users.$userId.tsx`
+- **Thin community `Community 1427`** (1 nodes): `$traceId.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1428`** (1 nodes): `index.tsx`
+- **Thin community `Community 1428`** (1 nodes): `users.$userId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1429`** (1 nodes): `_authed.test.tsx`
+- **Thin community `Community 1429`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1430`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 1430`** (1 nodes): `_authed.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1431`** (1 nodes): `join-team.index.tsx`
+- **Thin community `Community 1431`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1432`** (1 nodes): `_layout.index.test.tsx`
+- **Thin community `Community 1432`** (1 nodes): `join-team.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1433`** (1 nodes): `_layout.test.tsx`
+- **Thin community `Community 1433`** (1 nodes): `_layout.index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1434`** (1 nodes): `StoresSettingsAccordion.tsx`
+- **Thin community `Community 1434`** (1 nodes): `_layout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1435`** (1 nodes): `expenseStore.ts`
+- **Thin community `Community 1435`** (1 nodes): `StoresSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1436`** (1 nodes): `Overview.stories.tsx`
+- **Thin community `Community 1436`** (1 nodes): `expenseStore.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1437`** (1 nodes): `foundations-content.test.tsx`
+- **Thin community `Community 1437`** (1 nodes): `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1438`** (1 nodes): `Introduction.stories.tsx`
+- **Thin community `Community 1438`** (1 nodes): `foundations-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1439`** (1 nodes): `introduction-content.test.tsx`
+- **Thin community `Community 1439`** (1 nodes): `Introduction.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1440`** (1 nodes): `introduction-content.tsx`
+- **Thin community `Community 1440`** (1 nodes): `introduction-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1441`** (1 nodes): `AdminShell.stories.tsx`
+- **Thin community `Community 1441`** (1 nodes): `introduction-content.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1442`** (1 nodes): `View.stories.tsx`
+- **Thin community `Community 1442`** (1 nodes): `AdminShell.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1443`** (1 nodes): `admin-shell-patterns.test.tsx`
+- **Thin community `Community 1443`** (1 nodes): `View.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1444`** (1 nodes): `view-patterns.test.tsx`
+- **Thin community `Community 1444`** (1 nodes): `admin-shell-patterns.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1445`** (1 nodes): `Surfaces.stories.tsx`
+- **Thin community `Community 1445`** (1 nodes): `view-patterns.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1446`** (1 nodes): `DashboardWorkspace.stories.tsx`
+- **Thin community `Community 1446`** (1 nodes): `Surfaces.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1447`** (1 nodes): `DataWorkspace.stories.tsx`
+- **Thin community `Community 1447`** (1 nodes): `DashboardWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1448`** (1 nodes): `SettingsWorkspace.stories.tsx`
+- **Thin community `Community 1448`** (1 nodes): `DataWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1449`** (1 nodes): `reference-fixtures.test.tsx`
+- **Thin community `Community 1449`** (1 nodes): `SettingsWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1450`** (1 nodes): `storybook-config.test.ts`
+- **Thin community `Community 1450`** (1 nodes): `reference-fixtures.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1451`** (1 nodes): `storybook-theme-decorator.test.ts`
+- **Thin community `Community 1451`** (1 nodes): `storybook-config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1452`** (1 nodes): `setup.ts`
+- **Thin community `Community 1452`** (1 nodes): `storybook-theme-decorator.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1453`** (1 nodes): `usePrint.test.ts`
+- **Thin community `Community 1453`** (1 nodes): `setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1454`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 1454`** (1 nodes): `usePrint.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1455`** (1 nodes): `types.ts`
+- **Thin community `Community 1455`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1456`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 1456`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1457`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 1457`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1458`** (1 nodes): `global.d.ts`
+- **Thin community `Community 1458`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1459`** (1 nodes): `playwright.config.ts`
+- **Thin community `Community 1459`** (1 nodes): `global.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1460`** (1 nodes): `analytics.test.ts`
+- **Thin community `Community 1460`** (1 nodes): `playwright.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1461`** (1 nodes): `types.ts`
+- **Thin community `Community 1461`** (1 nodes): `analytics.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1462`** (1 nodes): `HeartIconFilled.tsx`
+- **Thin community `Community 1462`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1463`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 1463`** (1 nodes): `HeartIconFilled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1464`** (1 nodes): `HomePage.test.tsx`
+- **Thin community `Community 1464`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1465`** (1 nodes): `ProductCard.test.tsx`
+- **Thin community `Community 1465`** (1 nodes): `HomePage.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1466`** (1 nodes): `ProductCard.tsx`
+- **Thin community `Community 1466`** (1 nodes): `ProductCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1467`** (1 nodes): `Upsell.tsx`
+- **Thin community `Community 1467`** (1 nodes): `ProductCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1468`** (1 nodes): `Checkout.test.tsx`
+- **Thin community `Community 1468`** (1 nodes): `Upsell.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1469`** (1 nodes): `Checkout.tsx`
+- **Thin community `Community 1469`** (1 nodes): `Checkout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1470`** (1 nodes): `CustomerInfoSection.tsx`
+- **Thin community `Community 1470`** (1 nodes): `Checkout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1471`** (1 nodes): `schema.ts`
+- **Thin community `Community 1471`** (1 nodes): `CustomerInfoSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1472`** (1 nodes): `DeliveryDetailsSection.tsx`
+- **Thin community `Community 1472`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1473`** (1 nodes): `checkoutStorage.test.ts`
+- **Thin community `Community 1473`** (1 nodes): `DeliveryDetailsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1474`** (1 nodes): `deliveryFees.test.ts`
+- **Thin community `Community 1474`** (1 nodes): `checkoutStorage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1475`** (1 nodes): `deriveCheckoutState.test.ts`
+- **Thin community `Community 1475`** (1 nodes): `deliveryFees.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1476`** (1 nodes): `billingDetailsSchema.ts`
+- **Thin community `Community 1476`** (1 nodes): `deriveCheckoutState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1477`** (1 nodes): `checkoutFormSchema.ts`
+- **Thin community `Community 1477`** (1 nodes): `billingDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1478`** (1 nodes): `customerDetailsSchema.ts`
+- **Thin community `Community 1478`** (1 nodes): `checkoutFormSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1479`** (1 nodes): `deliveryDetailsSchema.ts`
+- **Thin community `Community 1479`** (1 nodes): `customerDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1480`** (1 nodes): `webOrderSchema.ts`
+- **Thin community `Community 1480`** (1 nodes): `deliveryDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1481`** (1 nodes): `types.ts`
+- **Thin community `Community 1481`** (1 nodes): `webOrderSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1482`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1482`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1483`** (1 nodes): `ProductFilterBar.tsx`
+- **Thin community `Community 1483`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1484`** (1 nodes): `BestSellersSection.test.tsx`
+- **Thin community `Community 1484`** (1 nodes): `ProductFilterBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1485`** (1 nodes): `HomeHero.tsx`
+- **Thin community `Community 1485`** (1 nodes): `BestSellersSection.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1486`** (1 nodes): `HomeHeroSection.tsx`
+- **Thin community `Community 1486`** (1 nodes): `HomeHero.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1487`** (1 nodes): `homePageContent.test.ts`
+- **Thin community `Community 1487`** (1 nodes): `HomeHeroSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1488`** (1 nodes): `MobileMenu.tsx`
+- **Thin community `Community 1488`** (1 nodes): `homePageContent.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1489`** (1 nodes): `constants.ts`
+- **Thin community `Community 1489`** (1 nodes): `MobileMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1490`** (1 nodes): `navBarConstants.ts`
+- **Thin community `Community 1490`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1491`** (1 nodes): `About.tsx`
+- **Thin community `Community 1491`** (1 nodes): `navBarConstants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1492`** (1 nodes): `AboutProduct.tsx`
+- **Thin community `Community 1492`** (1 nodes): `About.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1493`** (1 nodes): `ProductActions.test.tsx`
+- **Thin community `Community 1493`** (1 nodes): `AboutProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1494`** (1 nodes): `ProductInfo.tsx`
+- **Thin community `Community 1494`** (1 nodes): `ProductActions.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1495`** (1 nodes): `ProductReviews.tsx`
+- **Thin community `Community 1495`** (1 nodes): `ProductInfo.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1496`** (1 nodes): `ProductsNavigationBar.tsx`
+- **Thin community `Community 1496`** (1 nodes): `ProductReviews.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1497`** (1 nodes): `ErrorMessage.tsx`
+- **Thin community `Community 1497`** (1 nodes): `ProductsNavigationBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1498`** (1 nodes): `ExistingReviewMessage.tsx`
+- **Thin community `Community 1498`** (1 nodes): `ErrorMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1499`** (1 nodes): `OrderItem.test.tsx`
+- **Thin community `Community 1499`** (1 nodes): `ExistingReviewMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1500`** (1 nodes): `ReviewForm.tsx`
+- **Thin community `Community 1500`** (1 nodes): `OrderItem.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1501`** (1 nodes): `SuccessMessage.tsx`
+- **Thin community `Community 1501`** (1 nodes): `ReviewForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1502`** (1 nodes): `types.ts`
+- **Thin community `Community 1502`** (1 nodes): `SuccessMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1503`** (1 nodes): `SavedBag.tsx`
+- **Thin community `Community 1503`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1504`** (1 nodes): `SavedIcon.tsx`
+- **Thin community `Community 1504`** (1 nodes): `SavedBag.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1505`** (1 nodes): `CartIcon.tsx`
+- **Thin community `Community 1505`** (1 nodes): `SavedIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1506`** (1 nodes): `ShoppingBag.test.tsx`
+- **Thin community `Community 1506`** (1 nodes): `CartIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1507`** (1 nodes): `empty-state.tsx`
+- **Thin community `Community 1507`** (1 nodes): `ShoppingBag.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1508`** (1 nodes): `Maintenance.test.tsx`
+- **Thin community `Community 1508`** (1 nodes): `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1509`** (1 nodes): `Maintenance.tsx`
+- **Thin community `Community 1509`** (1 nodes): `Maintenance.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1510`** (1 nodes): `AnimatedCard.tsx`
+- **Thin community `Community 1510`** (1 nodes): `Maintenance.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1511`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 1511`** (1 nodes): `AnimatedCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1512`** (1 nodes): `alert.tsx`
+- **Thin community `Community 1512`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1513`** (1 nodes): `breadcrumb.tsx`
+- **Thin community `Community 1513`** (1 nodes): `alert.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1514`** (1 nodes): `button.tsx`
+- **Thin community `Community 1514`** (1 nodes): `breadcrumb.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1515`** (1 nodes): `card.tsx`
+- **Thin community `Community 1515`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1516`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 1516`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1517`** (1 nodes): `command.tsx`
+- **Thin community `Community 1517`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1518`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 1518`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1519`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 1519`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1520`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 1520`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1521`** (1 nodes): `form.tsx`
+- **Thin community `Community 1521`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1522`** (1 nodes): `icons.tsx`
+- **Thin community `Community 1522`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1523`** (1 nodes): `image-with-fallback.tsx`
+- **Thin community `Community 1523`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1524`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 1524`** (1 nodes): `image-with-fallback.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1525`** (1 nodes): `input-with-end-button.tsx`
+- **Thin community `Community 1525`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1526`** (1 nodes): `input.tsx`
+- **Thin community `Community 1526`** (1 nodes): `input-with-end-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1527`** (1 nodes): `label.tsx`
+- **Thin community `Community 1527`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1528`** (1 nodes): `LeaveAReviewModalForm.tsx`
+- **Thin community `Community 1528`** (1 nodes): `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1529`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 1529`** (1 nodes): `LeaveAReviewModalForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1530`** (1 nodes): `welcomeBackModalAnimations.ts`
+- **Thin community `Community 1530`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1531`** (1 nodes): `index.ts`
+- **Thin community `Community 1531`** (1 nodes): `welcomeBackModalAnimations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1532`** (1 nodes): `types.ts`
+- **Thin community `Community 1532`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1533`** (1 nodes): `navigation-menu.tsx`
+- **Thin community `Community 1533`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1534`** (1 nodes): `popover.tsx`
+- **Thin community `Community 1534`** (1 nodes): `navigation-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1535`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 1535`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1536`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 1536`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1537`** (1 nodes): `select.tsx`
+- **Thin community `Community 1537`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1538`** (1 nodes): `separator.tsx`
+- **Thin community `Community 1538`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1539`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 1539`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1540`** (1 nodes): `table.tsx`
+- **Thin community `Community 1540`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1541`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 1541`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1542`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 1542`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1543`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 1543`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1544`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 1544`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1545`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 1545`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1546`** (1 nodes): `config.ts`
+- **Thin community `Community 1546`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1547`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 1547`** (1 nodes): `config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1548`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 1548`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1549`** (1 nodes): `useQueryEnabled.test.ts`
+- **Thin community `Community 1549`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1550`** (1 nodes): `useStorefrontObservability.ts`
+- **Thin community `Community 1550`** (1 nodes): `useQueryEnabled.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1551`** (1 nodes): `constants.ts`
+- **Thin community `Community 1551`** (1 nodes): `useStorefrontObservability.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1552`** (1 nodes): `countries.ts`
+- **Thin community `Community 1552`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1553`** (1 nodes): `feeUtils.test.ts`
+- **Thin community `Community 1553`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1554`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1554`** (1 nodes): `feeUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1555`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 1555`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1556`** (1 nodes): `maintenanceUtils.test.ts`
+- **Thin community `Community 1556`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1557`** (1 nodes): `index.ts`
+- **Thin community `Community 1557`** (1 nodes): `maintenanceUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1558`** (1 nodes): `store.ts`
+- **Thin community `Community 1558`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1559`** (1 nodes): `bag.ts`
+- **Thin community `Community 1559`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1560`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1560`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1561`** (1 nodes): `category.ts`
+- **Thin community `Community 1561`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1562`** (1 nodes): `organization.ts`
+- **Thin community `Community 1562`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1563`** (1 nodes): `product.ts`
+- **Thin community `Community 1563`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1564`** (1 nodes): `store.ts`
+- **Thin community `Community 1564`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1565`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1565`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1566`** (1 nodes): `user.ts`
+- **Thin community `Community 1566`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1567`** (1 nodes): `states.ts`
+- **Thin community `Community 1567`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1568`** (1 nodes): `storefrontFailureObservability.test.ts`
+- **Thin community `Community 1568`** (1 nodes): `states.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1569`** (1 nodes): `storefrontJourneyEvents.test.ts`
+- **Thin community `Community 1569`** (1 nodes): `storefrontFailureObservability.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1570`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1570`** (1 nodes): `storefrontJourneyEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1571`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 1571`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1572`** (1 nodes): `-homePageLoader.test.ts`
+- **Thin community `Community 1572`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1573`** (1 nodes): `__root.tsx`
+- **Thin community `Community 1573`** (1 nodes): `-homePageLoader.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1574`** (1 nodes): `$orderItemId.review.tsx`
+- **Thin community `Community 1574`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1575`** (1 nodes): `index.tsx`
+- **Thin community `Community 1575`** (1 nodes): `$orderItemId.review.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1576`** (1 nodes): `$subcategorySlug.tsx`
+- **Thin community `Community 1576`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1577`** (1 nodes): `index.tsx`
+- **Thin community `Community 1577`** (1 nodes): `$subcategorySlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1578`** (1 nodes): `rewards.index.tsx`
+- **Thin community `Community 1578`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1579`** (1 nodes): `shop.saved.index.tsx`
+- **Thin community `Community 1579`** (1 nodes): `rewards.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1580`** (1 nodes): `bag.index.tsx`
+- **Thin community `Community 1580`** (1 nodes): `shop.saved.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1581`** (1 nodes): `complete.tsx`
+- **Thin community `Community 1581`** (1 nodes): `bag.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1582`** (1 nodes): `incomplete.tsx`
+- **Thin community `Community 1582`** (1 nodes): `complete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1583`** (1 nodes): `index.tsx`
+- **Thin community `Community 1583`** (1 nodes): `incomplete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1584`** (1 nodes): `pending.tsx`
+- **Thin community `Community 1584`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1585`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 1585`** (1 nodes): `pending.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1586`** (1 nodes): `storefront-boot.e2e.ts`
+- **Thin community `Community 1586`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1587`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 1587`** (1 nodes): `storefront-boot.e2e.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1588`** (1 nodes): `vitest.setup.ts`
+- **Thin community `Community 1588`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1589`** (1 nodes): `index.js`
+- **Thin community `Community 1589`** (1 nodes): `vitest.setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1590`** (1 nodes): `harness-app-registry.test.ts`
+- **Thin community `Community 1590`** (1 nodes): `index.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1591`** (1 nodes): `athena-runtime-app.test.ts`
+- **Thin community `Community 1591`** (1 nodes): `harness-app-registry.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1592`** (1 nodes): `storefront-runtime-api.test.ts`
+- **Thin community `Community 1592`** (1 nodes): `athena-runtime-app.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1593`** (1 nodes): `valkey-runtime-app.test.ts`
+- **Thin community `Community 1593`** (1 nodes): `storefront-runtime-api.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1594`** (1 nodes): `harness-behavior-scenarios.test.ts`
+- **Thin community `Community 1594`** (1 nodes): `valkey-runtime-app.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1595`** (1 nodes): `harness-repo-validation.test.ts`
+- **Thin community `Community 1595`** (1 nodes): `harness-behavior-scenarios.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1596`** (1 nodes): `harness-repo-validation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -31325,26 +31325,26 @@
     },
     {
       "_src": "packages_athena_webapp_src_components_organization_members_index_tsx",
-      "_tgt": "index_header",
-      "confidence": "EXTRACTED",
-      "confidence_score": 1,
-      "relation": "contains",
-      "source": "index_header",
-      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
-      "source_location": "L43",
-      "target": "packages_athena_webapp_src_components_organization_members_index_tsx",
-      "weight": 1
-    },
-    {
-      "_src": "packages_athena_webapp_src_components_organization_members_index_tsx",
       "_tgt": "index_onsubmit",
       "confidence": "EXTRACTED",
       "confidence_score": 1,
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_organization_members_index_tsx",
       "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
-      "source_location": "L106",
+      "source_location": "L119",
       "target": "index_onsubmit",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_components_organization_members_index_tsx",
+      "_tgt": "index_sectionheader",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_components_organization_members_index_tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
+      "source_location": "L45",
+      "target": "index_sectionheader",
       "weight": 1
     },
     {
@@ -61827,6 +61827,15 @@
     {
       "community": 1000,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_inventory_redeemedpromocode_ts",
+      "label": "redeemedPromoCode.ts",
+      "norm_label": "redeemedpromocode.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/inventory/redeemedPromoCode.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1001,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_store_ts",
       "label": "store.ts",
       "norm_label": "store.ts",
@@ -61834,7 +61843,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1001,
+      "community": 1002,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_subcategory_ts",
       "label": "subcategory.ts",
@@ -61843,7 +61852,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1002,
+      "community": 1003,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_observability_index_ts",
       "label": "index.ts",
@@ -61852,7 +61861,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1003,
+      "community": 1004,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_observability_workflowtrace_ts",
       "label": "workflowTrace.ts",
@@ -61861,7 +61870,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1004,
+      "community": 1005,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_observability_workflowtraceevent_ts",
       "label": "workflowTraceEvent.ts",
@@ -61870,7 +61879,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1005,
+      "community": 1006,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_observability_workflowtracelookup_ts",
       "label": "workflowTraceLookup.ts",
@@ -61879,7 +61888,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1006,
+      "community": 1007,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_approvalrequest_ts",
       "label": "approvalRequest.ts",
@@ -61888,7 +61897,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1007,
+      "community": 1008,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_customerprofile_ts",
       "label": "customerProfile.ts",
@@ -61897,21 +61906,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1008,
+      "community": 1009,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_dailyclose_ts",
       "label": "dailyClose.ts",
       "norm_label": "dailyclose.ts",
       "source_file": "packages/athena-webapp/convex/schemas/operations/dailyClose.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1009,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_operations_dailyopening_ts",
-      "label": "dailyOpening.ts",
-      "norm_label": "dailyopening.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/operations/dailyOpening.ts",
       "source_location": "L1"
     },
     {
@@ -61989,6 +61989,15 @@
     {
       "community": 1010,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_operations_dailyopening_ts",
+      "label": "dailyOpening.ts",
+      "norm_label": "dailyopening.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/operations/dailyOpening.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1011,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_index_ts",
       "label": "index.ts",
       "norm_label": "index.ts",
@@ -61996,7 +62005,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1011,
+      "community": 1012,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_inventorymovement_ts",
       "label": "inventoryMovement.ts",
@@ -62005,7 +62014,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1012,
+      "community": 1013,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_operationalevent_ts",
       "label": "operationalEvent.ts",
@@ -62014,7 +62023,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1013,
+      "community": 1014,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_operationalworkitem_ts",
       "label": "operationalWorkItem.ts",
@@ -62023,7 +62032,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1014,
+      "community": 1015,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_paymentallocation_ts",
       "label": "paymentAllocation.ts",
@@ -62032,7 +62041,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1015,
+      "community": 1016,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_registersession_ts",
       "label": "registerSession.ts",
@@ -62041,7 +62050,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1016,
+      "community": 1017,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_staffcredential_ts",
       "label": "staffCredential.ts",
@@ -62050,7 +62059,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1017,
+      "community": 1018,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_staffprofile_ts",
       "label": "staffProfile.ts",
@@ -62059,21 +62068,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1018,
+      "community": 1019,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_staffroleassignment_ts",
       "label": "staffRoleAssignment.ts",
       "norm_label": "staffroleassignment.ts",
       "source_file": "packages/athena-webapp/convex/schemas/operations/staffRoleAssignment.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1019,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_payments_mtncollections_ts",
-      "label": "mtnCollections.ts",
-      "norm_label": "mtncollections.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/payments/mtnCollections.ts",
       "source_location": "L1"
     },
     {
@@ -62151,6 +62151,15 @@
     {
       "community": 1020,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_payments_mtncollections_ts",
+      "label": "mtnCollections.ts",
+      "norm_label": "mtncollections.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/payments/mtnCollections.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1021,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_customer_ts",
       "label": "customer.ts",
       "norm_label": "customer.ts",
@@ -62158,7 +62167,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1021,
+      "community": 1022,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_expensesession_ts",
       "label": "expenseSession.ts",
@@ -62167,7 +62176,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1022,
+      "community": 1023,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_expensesessionitem_ts",
       "label": "expenseSessionItem.ts",
@@ -62176,7 +62185,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1023,
+      "community": 1024,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_expensetransaction_ts",
       "label": "expenseTransaction.ts",
@@ -62185,7 +62194,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1024,
+      "community": 1025,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_expensetransactionitem_ts",
       "label": "expenseTransactionItem.ts",
@@ -62194,7 +62203,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1025,
+      "community": 1026,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_index_ts",
       "label": "index.ts",
@@ -62203,7 +62212,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1026,
+      "community": 1027,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_possession_ts",
       "label": "posSession.ts",
@@ -62212,7 +62221,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1027,
+      "community": 1028,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_possessionitem_ts",
       "label": "posSessionItem.ts",
@@ -62221,21 +62230,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1028,
+      "community": 1029,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_posterminal_ts",
       "label": "posTerminal.ts",
       "norm_label": "posterminal.ts",
       "source_file": "packages/athena-webapp/convex/schemas/pos/posTerminal.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1029,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_pos_postransaction_ts",
-      "label": "posTransaction.ts",
-      "norm_label": "postransaction.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/pos/posTransaction.ts",
       "source_location": "L1"
     },
     {
@@ -62313,6 +62313,15 @@
     {
       "community": 1030,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_pos_postransaction_ts",
+      "label": "posTransaction.ts",
+      "norm_label": "postransaction.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/pos/posTransaction.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1031,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_postransactionitem_ts",
       "label": "posTransactionItem.ts",
       "norm_label": "postransactionitem.ts",
@@ -62320,7 +62329,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1031,
+      "community": 1032,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_index_ts",
       "label": "index.ts",
@@ -62329,7 +62338,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1032,
+      "community": 1033,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_serviceappointment_ts",
       "label": "serviceAppointment.ts",
@@ -62338,7 +62347,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1033,
+      "community": 1034,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_servicecase_ts",
       "label": "serviceCase.ts",
@@ -62347,7 +62356,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1034,
+      "community": 1035,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_servicecaselineitem_ts",
       "label": "serviceCaseLineItem.ts",
@@ -62356,7 +62365,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1035,
+      "community": 1036,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_servicecatalog_ts",
       "label": "serviceCatalog.ts",
@@ -62365,7 +62374,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1036,
+      "community": 1037,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_serviceinventoryusage_ts",
       "label": "serviceInventoryUsage.ts",
@@ -62374,7 +62383,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1037,
+      "community": 1038,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_stockops_cyclecountdraft_ts",
       "label": "cycleCountDraft.ts",
@@ -62383,21 +62392,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1038,
+      "community": 1039,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_stockops_index_ts",
       "label": "index.ts",
       "norm_label": "index.ts",
       "source_file": "packages/athena-webapp/convex/schemas/stockOps/index.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1039,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_stockops_purchaseorder_ts",
-      "label": "purchaseOrder.ts",
-      "norm_label": "purchaseorder.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/stockOps/purchaseOrder.ts",
       "source_location": "L1"
     },
     {
@@ -62475,6 +62475,15 @@
     {
       "community": 1040,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_stockops_purchaseorder_ts",
+      "label": "purchaseOrder.ts",
+      "norm_label": "purchaseorder.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/stockOps/purchaseOrder.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1041,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_stockops_purchaseorderlineitem_ts",
       "label": "purchaseOrderLineItem.ts",
       "norm_label": "purchaseorderlineitem.ts",
@@ -62482,7 +62491,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1041,
+      "community": 1042,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_stockops_receivingbatch_ts",
       "label": "receivingBatch.ts",
@@ -62491,7 +62500,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1042,
+      "community": 1043,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_stockops_stockadjustmentbatch_ts",
       "label": "stockAdjustmentBatch.ts",
@@ -62500,7 +62509,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1043,
+      "community": 1044,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_stockops_vendor_ts",
       "label": "vendor.ts",
@@ -62509,7 +62518,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1044,
+      "community": 1045,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_analytics_ts",
       "label": "analytics.ts",
@@ -62518,7 +62527,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1045,
+      "community": 1046,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_bag_ts",
       "label": "bag.ts",
@@ -62527,7 +62536,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1046,
+      "community": 1047,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_bagitem_ts",
       "label": "bagItem.ts",
@@ -62536,7 +62545,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1047,
+      "community": 1048,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_checkoutsession_ts",
       "label": "checkoutSession.ts",
@@ -62545,21 +62554,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1048,
+      "community": 1049,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_checkoutsessionitem_ts",
       "label": "checkoutSessionItem.ts",
       "norm_label": "checkoutsessionitem.ts",
       "source_file": "packages/athena-webapp/convex/schemas/storeFront/checkoutSessionItem.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1049,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_storefront_guest_ts",
-      "label": "guest.ts",
-      "norm_label": "guest.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/storeFront/guest.ts",
       "source_location": "L1"
     },
     {
@@ -62637,6 +62637,15 @@
     {
       "community": 1050,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_storefront_guest_ts",
+      "label": "guest.ts",
+      "norm_label": "guest.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/storeFront/guest.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1051,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_index_ts",
       "label": "index.ts",
       "norm_label": "index.ts",
@@ -62644,7 +62653,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1051,
+      "community": 1052,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_offer_ts",
       "label": "offer.ts",
@@ -62653,7 +62662,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1052,
+      "community": 1053,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_onlineorder_onlineorder_ts",
       "label": "onlineOrder.ts",
@@ -62662,7 +62671,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1053,
+      "community": 1054,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_onlineorder_onlineorderitem_ts",
       "label": "onlineOrderItem.ts",
@@ -62671,7 +62680,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1054,
+      "community": 1055,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_review_ts",
       "label": "review.ts",
@@ -62680,7 +62689,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1055,
+      "community": 1056,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_rewards_ts",
       "label": "rewards.ts",
@@ -62689,7 +62698,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1056,
+      "community": 1057,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_savedbag_ts",
       "label": "savedBag.ts",
@@ -62698,7 +62707,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1057,
+      "community": 1058,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_savedbagitem_ts",
       "label": "savedBagItem.ts",
@@ -62707,21 +62716,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1058,
+      "community": 1059,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_storefrontsession_ts",
       "label": "storeFrontSession.ts",
       "norm_label": "storefrontsession.ts",
       "source_file": "packages/athena-webapp/convex/schemas/storeFront/storeFrontSession.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1059,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_storefront_storefrontuser_ts",
-      "label": "storeFrontUser.ts",
-      "norm_label": "storefrontuser.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/storeFront/storeFrontUser.ts",
       "source_location": "L1"
     },
     {
@@ -62799,6 +62799,15 @@
     {
       "community": 1060,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_storefront_storefrontuser_ts",
+      "label": "storeFrontUser.ts",
+      "norm_label": "storefrontuser.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/storeFront/storeFrontUser.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1061,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_storefrontverificationcode_ts",
       "label": "storeFrontVerificationCode.ts",
       "norm_label": "storefrontverificationcode.ts",
@@ -62806,7 +62815,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1061,
+      "community": 1062,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_supportticket_ts",
       "label": "supportTicket.ts",
@@ -62815,7 +62824,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1062,
+      "community": 1063,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_serviceops_catalogappointments_test_ts",
       "label": "catalogAppointments.test.ts",
@@ -62824,7 +62833,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1063,
+      "community": 1064,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_bag_ts",
       "label": "bag.ts",
@@ -62833,7 +62842,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1064,
+      "community": 1065,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_bagitem_ts",
       "label": "bagItem.ts",
@@ -62842,7 +62851,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1065,
+      "community": 1066,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_checkoutsession_test_ts",
       "label": "checkoutSession.test.ts",
@@ -62851,7 +62860,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1066,
+      "community": 1067,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_customer_ts",
       "label": "customer.ts",
@@ -62860,7 +62869,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1067,
+      "community": 1068,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_guest_ts",
       "label": "guest.ts",
@@ -62869,21 +62878,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1068,
+      "community": 1069,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_offers_test_ts",
       "label": "offers.test.ts",
       "norm_label": "offers.test.ts",
       "source_file": "packages/athena-webapp/convex/storeFront/offers.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1069,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_onlineorderutilfns_ts",
-      "label": "onlineOrderUtilFns.ts",
-      "norm_label": "onlineorderutilfns.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrderUtilFns.ts",
       "source_location": "L1"
     },
     {
@@ -62961,6 +62961,15 @@
     {
       "community": 1070,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_onlineorderutilfns_ts",
+      "label": "onlineOrderUtilFns.ts",
+      "norm_label": "onlineorderutilfns.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrderUtilFns.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1071,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_orderoperations_test_ts",
       "label": "orderOperations.test.ts",
       "norm_label": "orderoperations.test.ts",
@@ -62968,7 +62977,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1071,
+      "community": 1072,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_payment_test_ts",
       "label": "payment.test.ts",
@@ -62977,7 +62986,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1072,
+      "community": 1073,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_payment_ts",
       "label": "payment.ts",
@@ -62986,7 +62995,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1073,
+      "community": 1074,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_paystackactions_ts",
       "label": "paystackActions.ts",
@@ -62995,7 +63004,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1074,
+      "community": 1075,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_savedbagitem_ts",
       "label": "savedBagItem.ts",
@@ -63004,7 +63013,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1075,
+      "community": 1076,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_supportticket_ts",
       "label": "supportTicket.ts",
@@ -63013,7 +63022,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1076,
+      "community": 1077,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_users_ts",
       "label": "users.ts",
@@ -63022,7 +63031,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1077,
+      "community": 1078,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_types_payment_ts",
       "label": "payment.ts",
@@ -63031,21 +63040,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1078,
+      "community": 1079,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_adapters_possession_test_ts",
       "label": "posSession.test.ts",
       "norm_label": "possession.test.ts",
       "source_file": "packages/athena-webapp/convex/workflowTraces/adapters/posSession.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1079,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_workflowtraces_adapters_registersession_test_ts",
-      "label": "registerSession.test.ts",
-      "norm_label": "registersession.test.ts",
-      "source_file": "packages/athena-webapp/convex/workflowTraces/adapters/registerSession.test.ts",
       "source_location": "L1"
     },
     {
@@ -63123,6 +63123,15 @@
     {
       "community": 1080,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_workflowtraces_adapters_registersession_test_ts",
+      "label": "registerSession.test.ts",
+      "norm_label": "registersession.test.ts",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/adapters/registerSession.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1081,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_presentation_test_ts",
       "label": "presentation.test.ts",
       "norm_label": "presentation.test.ts",
@@ -63130,7 +63139,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1081,
+      "community": 1082,
       "file_type": "code",
       "id": "packages_athena_webapp_eslint_config_js",
       "label": "eslint.config.js",
@@ -63139,7 +63148,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1082,
+      "community": 1083,
       "file_type": "code",
       "id": "packages_athena_webapp_index_ts",
       "label": "index.ts",
@@ -63148,7 +63157,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1083,
+      "community": 1084,
       "file_type": "code",
       "id": "packages_athena_webapp_postcss_config_js",
       "label": "postcss.config.js",
@@ -63157,7 +63166,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1084,
+      "community": 1085,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_approvalpolicy_ts",
       "label": "approvalPolicy.ts",
@@ -63166,7 +63175,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1085,
+      "community": 1086,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_auth_ts",
       "label": "auth.ts",
@@ -63175,7 +63184,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1086,
+      "community": 1087,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_commandresult_test_ts",
       "label": "commandResult.test.ts",
@@ -63184,7 +63193,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1087,
+      "community": 1088,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_currencyformatter_test_ts",
       "label": "currencyFormatter.test.ts",
@@ -63193,21 +63202,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1088,
+      "community": 1089,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_registersessionstatus_test_ts",
       "label": "registerSessionStatus.test.ts",
       "norm_label": "registersessionstatus.test.ts",
       "source_file": "packages/athena-webapp/shared/registerSessionStatus.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1089,
-      "file_type": "code",
-      "id": "packages_athena_webapp_shared_staffdisplayname_test_ts",
-      "label": "staffDisplayName.test.ts",
-      "norm_label": "staffdisplayname.test.ts",
-      "source_file": "packages/athena-webapp/shared/staffDisplayName.test.ts",
       "source_location": "L1"
     },
     {
@@ -63285,6 +63285,15 @@
     {
       "community": 1090,
       "file_type": "code",
+      "id": "packages_athena_webapp_shared_staffdisplayname_test_ts",
+      "label": "staffDisplayName.test.ts",
+      "norm_label": "staffdisplayname.test.ts",
+      "source_file": "packages/athena-webapp/shared/staffDisplayName.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1091,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_genericcombobox_tsx",
       "label": "GenericComboBox.tsx",
       "norm_label": "genericcombobox.tsx",
@@ -63292,7 +63301,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1091,
+      "community": 1092,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storeaccordion_tsx",
       "label": "StoreAccordion.tsx",
@@ -63301,7 +63310,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1092,
+      "community": 1093,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storesaccordion_tsx",
       "label": "StoresAccordion.tsx",
@@ -63310,7 +63319,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1093,
+      "community": 1094,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_themetoggle_tsx",
       "label": "ThemeToggle.tsx",
@@ -63319,7 +63328,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1094,
+      "community": 1095,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_defaultattributestogglegroup_tsx",
       "label": "DefaultAttributesToggleGroup.tsx",
@@ -63328,7 +63337,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1095,
+      "community": 1096,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productattributesview_tsx",
       "label": "ProductAttributesView.tsx",
@@ -63337,7 +63346,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1096,
+      "community": 1097,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productstock_test_ts",
       "label": "ProductStock.test.ts",
@@ -63346,7 +63355,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1097,
+      "community": 1098,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productview_test_tsx",
       "label": "ProductView.test.tsx",
@@ -63355,21 +63364,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1098,
+      "community": 1099,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_constants_ts",
       "label": "constants.ts",
       "norm_label": "constants.ts",
       "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/constants.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1099,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_faceted_filter_tsx",
-      "label": "data-table-faceted-filter.tsx",
-      "norm_label": "data-table-faceted-filter.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table-faceted-filter.tsx",
       "source_location": "L1"
     },
     {
@@ -63726,6 +63726,15 @@
     {
       "community": 1100,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_faceted_filter_tsx",
+      "label": "data-table-faceted-filter.tsx",
+      "norm_label": "data-table-faceted-filter.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table-faceted-filter.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1101,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
       "norm_label": "data-table-pagination.tsx",
@@ -63733,7 +63742,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1101,
+      "community": 1102,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -63742,7 +63751,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1102,
+      "community": 1103,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_types_ts",
       "label": "types.ts",
@@ -63751,7 +63760,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1103,
+      "community": 1104,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_conversionfunnelchart_tsx",
       "label": "ConversionFunnelChart.tsx",
@@ -63760,7 +63769,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1104,
+      "community": 1105,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_revenuechart_tsx",
       "label": "RevenueChart.tsx",
@@ -63769,7 +63778,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1105,
+      "community": 1106,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_analytics_columns_tsx",
       "label": "analytics-columns.tsx",
@@ -63778,7 +63787,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1106,
+      "community": 1107,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -63787,7 +63796,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1107,
+      "community": 1108,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -63796,21 +63805,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1108,
+      "community": 1109,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
       "norm_label": "data-table-toolbar.tsx",
       "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/data-table-toolbar.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1109,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_tsx",
-      "label": "data-table.tsx",
-      "norm_label": "data-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/data-table.tsx",
       "source_location": "L1"
     },
     {
@@ -63888,6 +63888,15 @@
     {
       "community": 1110,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_tsx",
+      "label": "data-table.tsx",
+      "norm_label": "data-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/data-table.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1111,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_columns_tsx",
       "label": "columns.tsx",
       "norm_label": "columns.tsx",
@@ -63895,7 +63904,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1111,
+      "community": 1112,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -63904,7 +63913,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1112,
+      "community": 1113,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -63913,7 +63922,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1113,
+      "community": 1114,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -63922,7 +63931,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1114,
+      "community": 1115,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -63931,7 +63940,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1115,
+      "community": 1116,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_users_table_columns_tsx",
       "label": "columns.tsx",
@@ -63940,7 +63949,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1116,
+      "community": 1117,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_users_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -63949,7 +63958,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1117,
+      "community": 1118,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_users_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -63958,21 +63967,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1118,
+      "community": 1119,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_chart_tsx",
       "label": "chart.tsx",
       "norm_label": "chart.tsx",
       "source_file": "packages/athena-webapp/src/components/analytics/chart.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1119,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_combined_users_table_columns_tsx",
-      "label": "columns.tsx",
-      "norm_label": "columns.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/combined-users-table/columns.tsx",
       "source_location": "L1"
     },
     {
@@ -64050,6 +64050,15 @@
     {
       "community": 1120,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_combined_users_table_columns_tsx",
+      "label": "columns.tsx",
+      "norm_label": "columns.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/combined-users-table/columns.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1121,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_combined_users_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
       "norm_label": "data-table-pagination.tsx",
@@ -64057,7 +64066,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1121,
+      "community": 1122,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_combined_users_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -64066,7 +64075,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1122,
+      "community": 1123,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_columns_tsx",
       "label": "columns.tsx",
@@ -64075,7 +64084,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1123,
+      "community": 1124,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_constants_ts",
       "label": "constants.ts",
@@ -64084,7 +64093,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1124,
+      "community": 1125,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -64093,7 +64102,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1125,
+      "community": 1126,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -64102,7 +64111,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1126,
+      "community": 1127,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -64111,7 +64120,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1127,
+      "community": 1128,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_data_ts",
       "label": "data.ts",
@@ -64120,21 +64129,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1128,
+      "community": 1129,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_users_table_columns_tsx",
       "label": "columns.tsx",
       "norm_label": "columns.tsx",
       "source_file": "packages/athena-webapp/src/components/analytics/users-table/columns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1129,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_users_table_data_table_pagination_tsx",
-      "label": "data-table-pagination.tsx",
-      "norm_label": "data-table-pagination.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/users-table/data-table-pagination.tsx",
       "source_location": "L1"
     },
     {
@@ -64212,6 +64212,15 @@
     {
       "community": 1130,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_users_table_data_table_pagination_tsx",
+      "label": "data-table-pagination.tsx",
+      "norm_label": "data-table-pagination.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/users-table/data-table-pagination.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1131,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_users_table_data_table_tsx",
       "label": "data-table.tsx",
       "norm_label": "data-table.tsx",
@@ -64219,7 +64228,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1131,
+      "community": 1132,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_columns_tsx",
       "label": "columns.tsx",
@@ -64228,7 +64237,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1132,
+      "community": 1133,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -64237,7 +64246,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1133,
+      "community": 1134,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -64246,7 +64255,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1134,
+      "community": 1135,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -64255,7 +64264,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1135,
+      "community": 1136,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -64264,7 +64273,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1136,
+      "community": 1137,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_assetscolumns_tsx",
       "label": "assetsColumns.tsx",
@@ -64273,7 +64282,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1137,
+      "community": 1138,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_constants_ts",
       "label": "constants.ts",
@@ -64282,21 +64291,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1138,
+      "community": 1139,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
       "norm_label": "data-table-faceted-filter.tsx",
       "source_file": "packages/athena-webapp/src/components/assets/assets-table/data-table-faceted-filter.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1139,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_pagination_tsx",
-      "label": "data-table-pagination.tsx",
-      "norm_label": "data-table-pagination.tsx",
-      "source_file": "packages/athena-webapp/src/components/assets/assets-table/data-table-pagination.tsx",
       "source_location": "L1"
     },
     {
@@ -64374,6 +64374,15 @@
     {
       "community": 1140,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_pagination_tsx",
+      "label": "data-table-pagination.tsx",
+      "norm_label": "data-table-pagination.tsx",
+      "source_file": "packages/athena-webapp/src/components/assets/assets-table/data-table-pagination.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1141,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_tsx",
       "label": "data-table.tsx",
       "norm_label": "data-table.tsx",
@@ -64381,7 +64390,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1141,
+      "community": 1142,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_data_ts",
       "label": "data.ts",
@@ -64390,7 +64399,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1142,
+      "community": 1143,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_defaultcatchboundary_test_tsx",
       "label": "DefaultCatchBoundary.test.tsx",
@@ -64399,7 +64408,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1143,
+      "community": 1144,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_defaultcatchboundary_tsx",
       "label": "DefaultCatchBoundary.tsx",
@@ -64408,7 +64417,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1144,
+      "community": 1145,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_login_loginform_test_tsx",
       "label": "LoginForm.test.tsx",
@@ -64417,7 +64426,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1145,
+      "community": 1146,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_login_loginform_tsx",
       "label": "LoginForm.tsx",
@@ -64426,7 +64435,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1146,
+      "community": 1147,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_columns_tsx",
       "label": "columns.tsx",
@@ -64435,7 +64444,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1147,
+      "community": 1148,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -64444,21 +64453,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1148,
+      "community": 1149,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
       "norm_label": "data-table-pagination.tsx",
       "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/data-table-pagination.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1149,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_toolbar_tsx",
-      "label": "data-table-toolbar.tsx",
-      "norm_label": "data-table-toolbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/data-table-toolbar.tsx",
       "source_location": "L1"
     },
     {
@@ -64536,6 +64536,15 @@
     {
       "community": 1150,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_toolbar_tsx",
+      "label": "data-table-toolbar.tsx",
+      "norm_label": "data-table-toolbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/data-table-toolbar.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1151,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_tsx",
       "label": "data-table.tsx",
       "norm_label": "data-table.tsx",
@@ -64543,7 +64552,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1151,
+      "community": 1152,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_columns_tsx",
       "label": "columns.tsx",
@@ -64552,7 +64561,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1152,
+      "community": 1153,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_constants_ts",
       "label": "constants.ts",
@@ -64561,7 +64570,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1153,
+      "community": 1154,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -64570,7 +64579,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1154,
+      "community": 1155,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -64579,7 +64588,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1155,
+      "community": 1156,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -64588,7 +64597,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1156,
+      "community": 1157,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationspage_tsx",
       "label": "BulkOperationsPage.tsx",
@@ -64597,7 +64606,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1157,
+      "community": 1158,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_cashcontrolsdashboard_auth_test_tsx",
       "label": "CashControlsDashboard.auth.test.tsx",
@@ -64606,21 +64615,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1158,
+      "community": 1159,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_cashcontrolsdashboard_test_tsx",
       "label": "CashControlsDashboard.test.tsx",
       "norm_label": "cashcontrolsdashboard.test.tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1159,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_cash_controls_cashcontrolsworkspaceheader_tsx",
-      "label": "CashControlsWorkspaceHeader.tsx",
-      "norm_label": "cashcontrolsworkspaceheader.tsx",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsWorkspaceHeader.tsx",
       "source_location": "L1"
     },
     {
@@ -64698,6 +64698,15 @@
     {
       "community": 1160,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_cash_controls_cashcontrolsworkspaceheader_tsx",
+      "label": "CashControlsWorkspaceHeader.tsx",
+      "norm_label": "cashcontrolsworkspaceheader.tsx",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsWorkspaceHeader.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1161,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_registersessionview_auth_test_tsx",
       "label": "RegisterSessionView.auth.test.tsx",
       "norm_label": "registersessionview.auth.test.tsx",
@@ -64705,7 +64714,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1161,
+      "community": 1162,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_registersessionview_test_tsx",
       "label": "RegisterSessionView.test.tsx",
@@ -64714,7 +64723,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1162,
+      "community": 1163,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_registersessionsview_test_tsx",
       "label": "RegisterSessionsView.test.tsx",
@@ -64723,7 +64732,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1163,
+      "community": 1164,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_formatreviewreason_test_ts",
       "label": "formatReviewReason.test.ts",
@@ -64732,7 +64741,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1164,
+      "community": 1165,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkout_sessions_table_columns_tsx",
       "label": "columns.tsx",
@@ -64741,7 +64750,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1165,
+      "community": 1166,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkout_sessions_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -64750,7 +64759,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1166,
+      "community": 1167,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkout_sessions_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -64759,7 +64768,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1167,
+      "community": 1168,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_common_listpagination_tsx",
       "label": "ListPagination.tsx",
@@ -64768,21 +64777,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1168,
+      "community": 1169,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_common_pagelevelheader_test_tsx",
       "label": "PageLevelHeader.test.tsx",
       "norm_label": "pagelevelheader.test.tsx",
       "source_file": "packages/athena-webapp/src/components/common/PageLevelHeader.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1169,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_common_pagelevelheader_tsx",
-      "label": "PageLevelHeader.tsx",
-      "norm_label": "pagelevelheader.tsx",
-      "source_file": "packages/athena-webapp/src/components/common/PageLevelHeader.tsx",
       "source_location": "L1"
     },
     {
@@ -64860,6 +64860,15 @@
     {
       "community": 1170,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_common_pagelevelheader_tsx",
+      "label": "PageLevelHeader.tsx",
+      "norm_label": "pagelevelheader.tsx",
+      "source_file": "packages/athena-webapp/src/components/common/PageLevelHeader.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1171,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_dashboard_metriccard_tsx",
       "label": "MetricCard.tsx",
       "norm_label": "metriccard.tsx",
@@ -64867,7 +64876,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1171,
+      "community": 1172,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_join_team_index_test_tsx",
       "label": "index.test.tsx",
@@ -64876,7 +64885,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1172,
+      "community": 1173,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_commandapprovaldialog_test_tsx",
       "label": "CommandApprovalDialog.test.tsx",
@@ -64885,7 +64894,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1173,
+      "community": 1174,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_operationreviewworkspace_tsx",
       "label": "OperationReviewWorkspace.tsx",
@@ -64894,7 +64903,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1174,
+      "community": 1175,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_operationsqueueview_auth_test_tsx",
       "label": "OperationsQueueView.auth.test.tsx",
@@ -64903,7 +64912,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1175,
+      "community": 1176,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_useapprovedcommand_test_tsx",
       "label": "useApprovedCommand.test.tsx",
@@ -64912,7 +64921,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1176,
+      "community": 1177,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orderstatus_test_tsx",
       "label": "OrderStatus.test.tsx",
@@ -64921,7 +64930,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1177,
+      "community": 1178,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orderstatus_tsx",
       "label": "OrderStatus.tsx",
@@ -64930,21 +64939,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1178,
+      "community": 1179,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_ordersummary_tsx",
       "label": "OrderSummary.tsx",
       "norm_label": "ordersummary.tsx",
       "source_file": "packages/athena-webapp/src/components/orders/OrderSummary.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1179,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_orders_tsx",
-      "label": "Orders.tsx",
-      "norm_label": "orders.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/Orders.tsx",
       "source_location": "L1"
     },
     {
@@ -65022,6 +65022,15 @@
     {
       "community": 1180,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_orders_tsx",
+      "label": "Orders.tsx",
+      "norm_label": "orders.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/Orders.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1181,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_refundsview_test_tsx",
       "label": "RefundsView.test.tsx",
       "norm_label": "refundsview.test.tsx",
@@ -65029,7 +65038,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1181,
+      "community": 1182,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_returnexchangeview_test_tsx",
       "label": "ReturnExchangeView.test.tsx",
@@ -65038,7 +65047,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1182,
+      "community": 1183,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_constants_ts",
       "label": "constants.ts",
@@ -65047,7 +65056,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1183,
+      "community": 1184,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -65056,7 +65065,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1184,
+      "community": 1185,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -65065,7 +65074,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1185,
+      "community": 1186,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_tsx",
       "label": "data-table.tsx",
@@ -65074,7 +65083,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1186,
+      "community": 1187,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_ts",
       "label": "data.ts",
@@ -65083,7 +65092,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1187,
+      "community": 1188,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_refundutils_test_ts",
       "label": "refundUtils.test.ts",
@@ -65092,21 +65101,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1188,
+      "community": 1189,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_utils_test_ts",
       "label": "utils.test.ts",
       "norm_label": "utils.test.ts",
       "source_file": "packages/athena-webapp/src/components/orders/utils.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1189,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_constants_ts",
-      "label": "constants.ts",
-      "norm_label": "constants.ts",
-      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/constants.ts",
       "source_location": "L1"
     },
     {
@@ -65184,6 +65184,15 @@
     {
       "community": 1190,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_constants_ts",
+      "label": "constants.ts",
+      "norm_label": "constants.ts",
+      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/constants.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1191,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
       "norm_label": "data-table-faceted-filter.tsx",
@@ -65191,7 +65200,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1191,
+      "community": 1192,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -65200,7 +65209,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1192,
+      "community": 1193,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -65209,7 +65218,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1193,
+      "community": 1194,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_tsx",
       "label": "data-table.tsx",
@@ -65218,7 +65227,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1194,
+      "community": 1195,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_ts",
       "label": "data.ts",
@@ -65227,7 +65236,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1195,
+      "community": 1196,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_invitecolumns_tsx",
       "label": "inviteColumns.tsx",
@@ -65236,7 +65245,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1196,
+      "community": 1197,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_constants_ts",
       "label": "constants.ts",
@@ -65245,7 +65254,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1197,
+      "community": 1198,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -65254,21 +65263,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1198,
+      "community": 1199,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
       "norm_label": "data-table-pagination.tsx",
       "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data-table-pagination.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1199,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_toolbar_tsx",
-      "label": "data-table-toolbar.tsx",
-      "norm_label": "data-table-toolbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data-table-toolbar.tsx",
       "source_location": "L1"
     },
     {
@@ -65598,6 +65598,15 @@
     {
       "community": 1200,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_toolbar_tsx",
+      "label": "data-table-toolbar.tsx",
+      "norm_label": "data-table-toolbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data-table-toolbar.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1201,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_tsx",
       "label": "data-table.tsx",
       "norm_label": "data-table.tsx",
@@ -65605,7 +65614,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1201,
+      "community": 1202,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_ts",
       "label": "data.ts",
@@ -65614,7 +65623,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1202,
+      "community": 1203,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_memberscolumns_tsx",
       "label": "membersColumns.tsx",
@@ -65623,7 +65632,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1203,
+      "community": 1204,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_switcher_test_tsx",
       "label": "organization-switcher.test.tsx",
@@ -65632,7 +65641,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1204,
+      "community": 1205,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_cashierauthdialog_test_tsx",
       "label": "CashierAuthDialog.test.tsx",
@@ -65641,7 +65650,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1205,
+      "community": 1206,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_cashierview_tsx",
       "label": "CashierView.tsx",
@@ -65650,7 +65659,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1206,
+      "community": 1207,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_posregisterview_tsx",
       "label": "POSRegisterView.tsx",
@@ -65659,7 +65668,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1207,
+      "community": 1208,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_paymentview_test_tsx",
       "label": "PaymentView.test.tsx",
@@ -65668,21 +65677,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1208,
+      "community": 1209,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_pointofsaleview_test_tsx",
       "label": "PointOfSaleView.test.tsx",
       "norm_label": "pointofsaleview.test.tsx",
       "source_file": "packages/athena-webapp/src/components/pos/PointOfSaleView.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1209,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_pointofsaleview_tsx",
-      "label": "PointOfSaleView.tsx",
-      "norm_label": "pointofsaleview.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/PointOfSaleView.tsx",
       "source_location": "L1"
     },
     {
@@ -65760,6 +65760,15 @@
     {
       "community": 1210,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_pointofsaleview_tsx",
+      "label": "PointOfSaleView.tsx",
+      "norm_label": "pointofsaleview.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/PointOfSaleView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1211,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_productlookup_tsx",
       "label": "ProductLookup.tsx",
       "norm_label": "productlookup.tsx",
@@ -65767,7 +65776,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1211,
+      "community": 1212,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_registeractions_tsx",
       "label": "RegisterActions.tsx",
@@ -65776,7 +65785,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1212,
+      "community": 1213,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_sessionmanager_test_tsx",
       "label": "SessionManager.test.tsx",
@@ -65785,7 +65794,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1213,
+      "community": 1214,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_sessionmanager_tsx",
       "label": "SessionManager.tsx",
@@ -65794,7 +65803,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1214,
+      "community": 1215,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_totalsdisplay_test_tsx",
       "label": "TotalsDisplay.test.tsx",
@@ -65803,7 +65812,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1215,
+      "community": 1216,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_totalsdisplay_tsx",
       "label": "TotalsDisplay.tsx",
@@ -65812,7 +65821,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1216,
+      "community": 1217,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportview_tsx",
       "label": "ExpenseReportView.tsx",
@@ -65821,7 +65830,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1217,
+      "community": 1218,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportsview_test_ts",
       "label": "ExpenseReportsView.test.ts",
@@ -65830,21 +65839,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1218,
+      "community": 1219,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportsview_test_tsx",
       "label": "ExpenseReportsView.test.tsx",
       "norm_label": "expensereportsview.test.tsx",
       "source_file": "packages/athena-webapp/src/components/pos/expense-reports/ExpenseReportsView.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1219,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportcolumns_tsx",
-      "label": "expenseReportColumns.tsx",
-      "norm_label": "expensereportcolumns.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/expense-reports/expenseReportColumns.tsx",
       "source_location": "L1"
     },
     {
@@ -65913,6 +65913,15 @@
     {
       "community": 1220,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportcolumns_tsx",
+      "label": "expenseReportColumns.tsx",
+      "norm_label": "expensereportcolumns.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/expense-reports/expenseReportColumns.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1221,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_receipt_posreceiptsharecontrol_test_tsx",
       "label": "PosReceiptShareControl.test.tsx",
       "norm_label": "posreceiptsharecontrol.test.tsx",
@@ -65920,7 +65929,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1221,
+      "community": 1222,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_posregisteropeningguard_test_tsx",
       "label": "POSRegisterOpeningGuard.test.tsx",
@@ -65929,7 +65938,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1222,
+      "community": 1223,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_posregisterview_test_tsx",
       "label": "POSRegisterView.test.tsx",
@@ -65938,7 +65947,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1223,
+      "community": 1224,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_registeractionbar_test_tsx",
       "label": "RegisterActionBar.test.tsx",
@@ -65947,7 +65956,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1224,
+      "community": 1225,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_registeractionbar_tsx",
       "label": "RegisterActionBar.tsx",
@@ -65956,7 +65965,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1225,
+      "community": 1226,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_registercheckoutpanel_tsx",
       "label": "RegisterCheckoutPanel.tsx",
@@ -65965,7 +65974,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1226,
+      "community": 1227,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_session_heldsessionslist_test_tsx",
       "label": "HeldSessionsList.test.tsx",
@@ -65974,7 +65983,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1227,
+      "community": 1228,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_sessions_possessionsview_test_tsx",
       "label": "POSSessionsView.test.tsx",
@@ -65983,21 +65992,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1228,
+      "community": 1229,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_sessions_possessioncolumns_tsx",
       "label": "posSessionColumns.tsx",
       "norm_label": "possessioncolumns.tsx",
       "source_file": "packages/athena-webapp/src/components/pos/sessions/posSessionColumns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1229,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_transactions_transactionsview_test_tsx",
-      "label": "TransactionsView.test.tsx",
-      "norm_label": "transactionsview.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionsView.test.tsx",
       "source_location": "L1"
     },
     {
@@ -66066,6 +66066,15 @@
     {
       "community": 1230,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_transactions_transactionsview_test_tsx",
+      "label": "TransactionsView.test.tsx",
+      "norm_label": "transactionsview.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionsView.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1231,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_types_ts",
       "label": "types.ts",
       "norm_label": "types.ts",
@@ -66073,7 +66082,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1231,
+      "community": 1232,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_procurement_receivingview_test_tsx",
       "label": "ReceivingView.test.tsx",
@@ -66082,7 +66091,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1232,
+      "community": 1233,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_analyticsinsights_tsx",
       "label": "AnalyticsInsights.tsx",
@@ -66091,7 +66100,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1233,
+      "community": 1234,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_attributesview_tsx",
       "label": "AttributesView.tsx",
@@ -66100,7 +66109,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1234,
+      "community": 1235,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_detailsview_tsx",
       "label": "DetailsView.tsx",
@@ -66109,7 +66118,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1235,
+      "community": 1236,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_productdetailview_tsx",
       "label": "ProductDetailView.tsx",
@@ -66118,7 +66127,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1236,
+      "community": 1237,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_archivedproducts_tsx",
       "label": "ArchivedProducts.tsx",
@@ -66127,7 +66136,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1237,
+      "community": 1238,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_categorylistview_tsx",
       "label": "CategoryListView.tsx",
@@ -66136,21 +66145,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1238,
+      "community": 1239,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_productsubcategorytogglegroup_tsx",
       "label": "ProductSubcategoryToggleGroup.tsx",
       "norm_label": "productsubcategorytogglegroup.tsx",
       "source_file": "packages/athena-webapp/src/components/products/ProductSubcategoryToggleGroup.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1239,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_products_tsx",
-      "label": "Products.tsx",
-      "norm_label": "products.tsx",
-      "source_file": "packages/athena-webapp/src/components/products/Products.tsx",
       "source_location": "L1"
     },
     {
@@ -66219,6 +66219,15 @@
     {
       "community": 1240,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_products_products_tsx",
+      "label": "Products.tsx",
+      "norm_label": "products.tsx",
+      "source_file": "packages/athena-webapp/src/components/products/Products.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1241,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_storeproducts_tsx",
       "label": "StoreProducts.tsx",
       "norm_label": "storeproducts.tsx",
@@ -66226,7 +66235,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1241,
+      "community": 1242,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_unresolvedproducts_tsx",
       "label": "UnresolvedProducts.tsx",
@@ -66235,7 +66244,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1242,
+      "community": 1243,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_complimentary_complimentaryproducts_tsx",
       "label": "ComplimentaryProducts.tsx",
@@ -66244,7 +66253,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1243,
+      "community": 1244,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_complimentary_complimentaryproductscolumn_tsx",
       "label": "complimentaryProductsColumn.tsx",
@@ -66253,7 +66262,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1244,
+      "community": 1245,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -66262,7 +66271,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1245,
+      "community": 1246,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -66271,7 +66280,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1246,
+      "community": 1247,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -66280,7 +66289,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1247,
+      "community": 1248,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_tsx",
       "label": "data-table.tsx",
@@ -66289,21 +66298,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1248,
+      "community": 1249,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_ts",
       "label": "data.ts",
       "norm_label": "data.ts",
       "source_file": "packages/athena-webapp/src/components/products/products-table/components/data.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1249,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_products_table_components_productcolumns_tsx",
-      "label": "productColumns.tsx",
-      "norm_label": "productcolumns.tsx",
-      "source_file": "packages/athena-webapp/src/components/products/products-table/components/productColumns.tsx",
       "source_location": "L1"
     },
     {
@@ -66372,6 +66372,15 @@
     {
       "community": 1250,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_products_products_table_components_productcolumns_tsx",
+      "label": "productColumns.tsx",
+      "norm_label": "productcolumns.tsx",
+      "source_file": "packages/athena-webapp/src/components/products/products-table/components/productColumns.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1251,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodeheader_test_tsx",
       "label": "PromoCodeHeader.test.tsx",
       "norm_label": "promocodeheader.test.tsx",
@@ -66379,7 +66388,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1251,
+      "community": 1252,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodes_tsx",
       "label": "PromoCodes.tsx",
@@ -66388,7 +66397,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1252,
+      "community": 1253,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_analytics_promocodeanalytics_tsx",
       "label": "PromoCodeAnalytics.tsx",
@@ -66397,7 +66406,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1253,
+      "community": 1254,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_captured_captured_emails_columns_tsx",
       "label": "captured-emails-columns.tsx",
@@ -66406,7 +66415,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1254,
+      "community": 1255,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodemoney_test_ts",
       "label": "promoCodeMoney.test.ts",
@@ -66415,7 +66424,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1255,
+      "community": 1256,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_columns_tsx",
       "label": "columns.tsx",
@@ -66424,7 +66433,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1256,
+      "community": 1257,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -66433,7 +66442,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1257,
+      "community": 1258,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -66442,21 +66451,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1258,
+      "community": 1259,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
       "norm_label": "data-table-toolbar.tsx",
       "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/data-table-toolbar.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1259,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_tsx",
-      "label": "data-table.tsx",
-      "norm_label": "data-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/data-table.tsx",
       "source_location": "L1"
     },
     {
@@ -66525,6 +66525,15 @@
     {
       "community": 1260,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_tsx",
+      "label": "data-table.tsx",
+      "norm_label": "data-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/data-table.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1261,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_columns_tsx",
       "label": "columns.tsx",
       "norm_label": "columns.tsx",
@@ -66532,7 +66541,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1261,
+      "community": 1262,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_constants_ts",
       "label": "constants.ts",
@@ -66541,7 +66550,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1262,
+      "community": 1263,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -66550,7 +66559,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1263,
+      "community": 1264,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -66559,7 +66568,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1264,
+      "community": 1265,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -66568,7 +66577,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1265,
+      "community": 1266,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_data_ts",
       "label": "data.ts",
@@ -66577,7 +66586,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1266,
+      "community": 1267,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_types_ts",
       "label": "types.ts",
@@ -66586,7 +66595,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1267,
+      "community": 1268,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_welcome_offer_card_tsx",
       "label": "welcome-offer-card.tsx",
@@ -66595,21 +66604,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1268,
+      "community": 1269,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reviews_ratingstars_tsx",
       "label": "RatingStars.tsx",
       "norm_label": "ratingstars.tsx",
       "source_file": "packages/athena-webapp/src/components/reviews/RatingStars.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1269,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_reviews_reviewcard_tsx",
-      "label": "ReviewCard.tsx",
-      "norm_label": "reviewcard.tsx",
-      "source_file": "packages/athena-webapp/src/components/reviews/ReviewCard.tsx",
       "source_location": "L1"
     },
     {
@@ -66678,6 +66678,15 @@
     {
       "community": 1270,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_reviews_reviewcard_tsx",
+      "label": "ReviewCard.tsx",
+      "norm_label": "reviewcard.tsx",
+      "source_file": "packages/athena-webapp/src/components/reviews/ReviewCard.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1271,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_reviews_reviewmetadata_tsx",
       "label": "ReviewMetadata.tsx",
       "norm_label": "reviewmetadata.tsx",
@@ -66685,7 +66694,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1271,
+      "community": 1272,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_servicesworkspaceview_test_tsx",
       "label": "ServicesWorkspaceView.test.tsx",
@@ -66694,7 +66703,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1272,
+      "community": 1273,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_staff_index_tsx",
       "label": "index.tsx",
@@ -66703,7 +66712,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1273,
+      "community": 1274,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_staff_auth_staffauthenticationdialog_test_tsx",
       "label": "StaffAuthenticationDialog.test.tsx",
@@ -66712,7 +66721,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1274,
+      "community": 1275,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_feesview_test_ts",
       "label": "FeesView.test.ts",
@@ -66721,7 +66730,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1275,
+      "community": 1276,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_fulfillmentview_test_tsx",
       "label": "FulfillmentView.test.tsx",
@@ -66730,7 +66739,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1276,
+      "community": 1277,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_maintenanceview_test_tsx",
       "label": "MaintenanceView.test.tsx",
@@ -66739,7 +66748,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1277,
+      "community": 1278,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_mtnmomoview_test_tsx",
       "label": "MtnMomoView.test.tsx",
@@ -66748,21 +66757,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1278,
+      "community": 1279,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_hooks_usestoreconfigupdate_test_tsx",
       "label": "useStoreConfigUpdate.test.tsx",
       "norm_label": "usestoreconfigupdate.test.tsx",
       "source_file": "packages/athena-webapp/src/components/store-configuration/hooks/useStoreConfigUpdate.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1279,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_store_configuration_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/index.tsx",
       "source_location": "L1"
     },
     {
@@ -66831,6 +66831,15 @@
     {
       "community": 1280,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_store_configuration_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1281,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_traces_workflowtraceview_test_tsx",
       "label": "WorkflowTraceView.test.tsx",
       "norm_label": "workflowtraceview.test.tsx",
@@ -66838,7 +66847,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1281,
+      "community": 1282,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_accordion_tsx",
       "label": "accordion.tsx",
@@ -66847,7 +66856,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1282,
+      "community": 1283,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_button_test_tsx",
       "label": "button.test.tsx",
@@ -66856,7 +66865,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1283,
+      "community": 1284,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_button_tsx",
       "label": "button.tsx",
@@ -66865,7 +66874,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1284,
+      "community": 1285,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_calendar_test_tsx",
       "label": "calendar.test.tsx",
@@ -66874,7 +66883,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1285,
+      "community": 1286,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_card_tsx",
       "label": "card.tsx",
@@ -66883,7 +66892,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1286,
+      "community": 1287,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_checkbox_tsx",
       "label": "checkbox.tsx",
@@ -66892,7 +66901,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1287,
+      "community": 1288,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_collapsible_tsx",
       "label": "collapsible.tsx",
@@ -66901,21 +66910,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1288,
+      "community": 1289,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_command_tsx",
       "label": "command.tsx",
       "norm_label": "command.tsx",
       "source_file": "packages/athena-webapp/src/components/ui/command.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1289,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_context_menu_tsx",
-      "label": "context-menu.tsx",
-      "norm_label": "context-menu.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/context-menu.tsx",
       "source_location": "L1"
     },
     {
@@ -66984,6 +66984,15 @@
     {
       "community": 1290,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_context_menu_tsx",
+      "label": "context-menu.tsx",
+      "norm_label": "context-menu.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/context-menu.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1291,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_dialog_tsx",
       "label": "dialog.tsx",
       "norm_label": "dialog.tsx",
@@ -66991,7 +67000,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1291,
+      "community": 1292,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_dropdown_menu_tsx",
       "label": "dropdown-menu.tsx",
@@ -67000,7 +67009,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1292,
+      "community": 1293,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_form_tsx",
       "label": "form.tsx",
@@ -67009,7 +67018,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1293,
+      "community": 1294,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_icons_tsx",
       "label": "icons.tsx",
@@ -67018,7 +67027,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1294,
+      "community": 1295,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_input_otp_tsx",
       "label": "input-otp.tsx",
@@ -67027,7 +67036,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1295,
+      "community": 1296,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_input_tsx",
       "label": "input.tsx",
@@ -67036,7 +67045,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1296,
+      "community": 1297,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_action_modal_tsx",
       "label": "action-modal.tsx",
@@ -67045,7 +67054,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1297,
+      "community": 1298,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_panel_header_tsx",
       "label": "panel-header.tsx",
@@ -67054,21 +67063,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1298,
+      "community": 1299,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_popover_tsx",
       "label": "popover.tsx",
       "norm_label": "popover.tsx",
       "source_file": "packages/athena-webapp/src/components/ui/popover.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1299,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_primitives_test_tsx",
-      "label": "primitives.test.tsx",
-      "norm_label": "primitives.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/primitives.test.tsx",
       "source_location": "L1"
     },
     {
@@ -67389,6 +67389,15 @@
     {
       "community": 1300,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_primitives_test_tsx",
+      "label": "primitives.test.tsx",
+      "norm_label": "primitives.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/primitives.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1301,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_radio_group_tsx",
       "label": "radio-group.tsx",
       "norm_label": "radio-group.tsx",
@@ -67396,7 +67405,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1301,
+      "community": 1302,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_scroll_area_tsx",
       "label": "scroll-area.tsx",
@@ -67405,7 +67414,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1302,
+      "community": 1303,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_select_tsx",
       "label": "select.tsx",
@@ -67414,7 +67423,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1303,
+      "community": 1304,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_separator_tsx",
       "label": "separator.tsx",
@@ -67423,7 +67432,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1304,
+      "community": 1305,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_sheet_tsx",
       "label": "sheet.tsx",
@@ -67432,7 +67441,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1305,
+      "community": 1306,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_switch_tsx",
       "label": "switch.tsx",
@@ -67441,7 +67450,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1306,
+      "community": 1307,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_table_tsx",
       "label": "table.tsx",
@@ -67450,7 +67459,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1307,
+      "community": 1308,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_tabs_tsx",
       "label": "tabs.tsx",
@@ -67459,21 +67468,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1308,
+      "community": 1309,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_textarea_tsx",
       "label": "textarea.tsx",
       "norm_label": "textarea.tsx",
       "source_file": "packages/athena-webapp/src/components/ui/textarea.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1309,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_toggle_group_tsx",
-      "label": "toggle-group.tsx",
-      "norm_label": "toggle-group.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/toggle-group.tsx",
       "source_location": "L1"
     },
     {
@@ -67542,6 +67542,15 @@
     {
       "community": 1310,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_toggle_group_tsx",
+      "label": "toggle-group.tsx",
+      "norm_label": "toggle-group.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/toggle-group.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1311,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_toggle_tsx",
       "label": "toggle.tsx",
       "norm_label": "toggle.tsx",
@@ -67549,7 +67558,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1311,
+      "community": 1312,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_tooltip_tsx",
       "label": "tooltip.tsx",
@@ -67558,7 +67567,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1312,
+      "community": 1313,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_upload_button_tsx",
       "label": "upload-button.tsx",
@@ -67567,7 +67576,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1313,
+      "community": 1314,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_bagview_tsx",
       "label": "BagView.tsx",
@@ -67576,7 +67585,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1314,
+      "community": 1315,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_columns_tsx",
       "label": "columns.tsx",
@@ -67585,7 +67594,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1315,
+      "community": 1316,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_constants_ts",
       "label": "constants.ts",
@@ -67594,7 +67603,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1316,
+      "community": 1317,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -67603,7 +67612,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1317,
+      "community": 1318,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -67612,21 +67621,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1318,
+      "community": 1319,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_data_table_tsx",
       "label": "data-table.tsx",
       "norm_label": "data-table.tsx",
       "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1319,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_table_data_ts",
-      "label": "data.ts",
-      "norm_label": "data.ts",
-      "source_file": "packages/athena-webapp/src/components/user-bags/table/data.ts",
       "source_location": "L1"
     },
     {
@@ -67695,6 +67695,15 @@
     {
       "community": 1320,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_table_data_ts",
+      "label": "data.ts",
+      "norm_label": "data.ts",
+      "source_file": "packages/athena-webapp/src/components/user-bags/table/data.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1321,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_bag_columns_tsx",
       "label": "bag-columns.tsx",
       "norm_label": "bag-columns.tsx",
@@ -67702,7 +67711,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1321,
+      "community": 1322,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_bags_table_tsx",
       "label": "bags-table.tsx",
@@ -67711,7 +67720,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1322,
+      "community": 1323,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_columns_tsx",
       "label": "columns.tsx",
@@ -67720,7 +67729,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1323,
+      "community": 1324,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -67729,7 +67738,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1324,
+      "community": 1325,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -67738,7 +67747,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1325,
+      "community": 1326,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -67747,7 +67756,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1326,
+      "community": 1327,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -67756,7 +67765,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1327,
+      "community": 1328,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_linkedaccounts_tsx",
       "label": "LinkedAccounts.tsx",
@@ -67765,21 +67774,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1328,
+      "community": 1329,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_timelineeventcard_test_tsx",
       "label": "TimelineEventCard.test.tsx",
       "norm_label": "timelineeventcard.test.tsx",
       "source_file": "packages/athena-webapp/src/components/users/TimelineEventCard.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1329,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_users_usercheckoutsession_tsx",
-      "label": "UserCheckoutSession.tsx",
-      "norm_label": "usercheckoutsession.tsx",
-      "source_file": "packages/athena-webapp/src/components/users/UserCheckoutSession.tsx",
       "source_location": "L1"
     },
     {
@@ -67848,6 +67848,15 @@
     {
       "community": 1330,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_users_usercheckoutsession_tsx",
+      "label": "UserCheckoutSession.tsx",
+      "norm_label": "usercheckoutsession.tsx",
+      "source_file": "packages/athena-webapp/src/components/users/UserCheckoutSession.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1331,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_userinsightssection_tsx",
       "label": "UserInsightsSection.tsx",
       "norm_label": "userinsightssection.tsx",
@@ -67855,7 +67864,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1331,
+      "community": 1332,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_userbehaviorinsights_tsx",
       "label": "UserBehaviorInsights.tsx",
@@ -67864,7 +67873,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1332,
+      "community": 1333,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_index_ts",
       "label": "index.ts",
@@ -67873,7 +67882,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1333,
+      "community": 1334,
       "file_type": "code",
       "id": "packages_athena_webapp_src_config_test_ts",
       "label": "config.test.ts",
@@ -67882,7 +67891,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1334,
+      "community": 1335,
       "file_type": "code",
       "id": "packages_athena_webapp_src_contexts_themecontext_tsx",
       "label": "ThemeContext.tsx",
@@ -67891,7 +67900,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1335,
+      "community": 1336,
       "file_type": "code",
       "id": "packages_athena_webapp_src_design_system_build_config_test_ts",
       "label": "design-system-build-config.test.ts",
@@ -67900,7 +67909,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1336,
+      "community": 1337,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_store_modal_tsx",
       "label": "use-store-modal.tsx",
@@ -67909,7 +67918,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1337,
+      "community": 1338,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useauth_test_tsx",
       "label": "useAuth.test.tsx",
@@ -67918,21 +67927,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1338,
+      "community": 1339,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useexpensesessions_test_ts",
       "label": "useExpenseSessions.test.ts",
       "norm_label": "useexpensesessions.test.ts",
       "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1339,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_useorganizationmodal_tsx",
-      "label": "useOrganizationModal.tsx",
-      "norm_label": "useorganizationmodal.tsx",
-      "source_file": "packages/athena-webapp/src/hooks/useOrganizationModal.tsx",
       "source_location": "L1"
     },
     {
@@ -68001,6 +68001,15 @@
     {
       "community": 1340,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_useorganizationmodal_tsx",
+      "label": "useOrganizationModal.tsx",
+      "norm_label": "useorganizationmodal.tsx",
+      "source_file": "packages/athena-webapp/src/hooks/useOrganizationModal.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1341,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_lib_aws_ts",
       "label": "aws.ts",
       "norm_label": "aws.ts",
@@ -68008,7 +68017,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1341,
+      "community": 1342,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_constants_ts",
       "label": "constants.ts",
@@ -68017,7 +68026,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1342,
+      "community": 1343,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_countries_ts",
       "label": "countries.ts",
@@ -68026,7 +68035,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1343,
+      "community": 1344,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_operatormessages_test_ts",
       "label": "operatorMessages.test.ts",
@@ -68035,7 +68044,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1344,
+      "community": 1345,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_presentcommandtoast_test_ts",
       "label": "presentCommandToast.test.ts",
@@ -68044,7 +68053,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1345,
+      "community": 1346,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_presentunexpectederrortoast_test_ts",
       "label": "presentUnexpectedErrorToast.test.ts",
@@ -68053,7 +68062,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1346,
+      "community": 1347,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_runcommand_test_ts",
       "label": "runCommand.test.ts",
@@ -68062,7 +68071,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1347,
+      "community": 1348,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_ghana_ts",
       "label": "ghana.ts",
@@ -68071,21 +68080,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1348,
+      "community": 1349,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_ghanaregions_ts",
       "label": "ghanaRegions.ts",
       "norm_label": "ghanaregions.ts",
       "source_file": "packages/athena-webapp/src/lib/ghanaRegions.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1349,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_application_dto_ts",
-      "label": "dto.ts",
-      "norm_label": "dto.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/dto.ts",
       "source_location": "L1"
     },
     {
@@ -68154,6 +68154,15 @@
     {
       "community": 1350,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_application_dto_ts",
+      "label": "dto.ts",
+      "norm_label": "dto.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/dto.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1351,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_ports_ts",
       "label": "ports.ts",
       "norm_label": "ports.ts",
@@ -68161,7 +68170,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1351,
+      "community": 1352,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_constants_ts",
       "label": "constants.ts",
@@ -68170,7 +68179,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1352,
+      "community": 1353,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_displayamounts_test_ts",
       "label": "displayAmounts.test.ts",
@@ -68179,7 +68188,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1353,
+      "community": 1354,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_domain_cart_test_ts",
       "label": "cart.test.ts",
@@ -68188,7 +68197,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1354,
+      "community": 1355,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_domain_index_ts",
       "label": "index.ts",
@@ -68197,7 +68206,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1355,
+      "community": 1356,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_domain_session_test_ts",
       "label": "session.test.ts",
@@ -68206,7 +68215,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1356,
+      "community": 1357,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_domain_types_ts",
       "label": "types.ts",
@@ -68215,7 +68224,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1357,
+      "community": 1358,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_registergateway_test_ts",
       "label": "registerGateway.test.ts",
@@ -68224,21 +68233,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1358,
+      "community": 1359,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_sessiongateway_test_ts",
       "label": "sessionGateway.test.ts",
       "norm_label": "sessiongateway.test.ts",
       "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/sessionGateway.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1359,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_infrastructure_telemetry_loggergateway_ts",
-      "label": "loggerGateway.ts",
-      "norm_label": "loggergateway.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/loggerGateway.ts",
       "source_location": "L1"
     },
     {
@@ -68307,6 +68307,15 @@
     {
       "community": 1360,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_infrastructure_telemetry_loggergateway_ts",
+      "label": "loggerGateway.ts",
+      "norm_label": "loggergateway.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/loggerGateway.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1361,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_presentation_register_catalogsearch_test_ts",
       "label": "catalogSearch.test.ts",
       "norm_label": "catalogsearch.test.ts",
@@ -68314,7 +68323,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1361,
+      "community": 1362,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_presentation_register_registeruistate_ts",
       "label": "registerUiState.ts",
@@ -68323,7 +68332,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1362,
+      "community": 1363,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_productutils_test_ts",
       "label": "productUtils.test.ts",
@@ -68332,7 +68341,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1363,
+      "community": 1364,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_schemas_category_ts",
       "label": "category.ts",
@@ -68341,7 +68350,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1364,
+      "community": 1365,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_schemas_product_ts",
       "label": "product.ts",
@@ -68350,7 +68359,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1365,
+      "community": 1366,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_schemas_store_ts",
       "label": "store.ts",
@@ -68359,7 +68368,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1366,
+      "community": 1367,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_schemas_subcategory_ts",
       "label": "subcategory.ts",
@@ -68368,7 +68377,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1367,
+      "community": 1368,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_schemas_user_ts",
       "label": "user.ts",
@@ -68377,21 +68386,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1368,
+      "community": 1369,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_storeconfig_test_ts",
       "label": "storeConfig.test.ts",
       "norm_label": "storeconfig.test.ts",
       "source_file": "packages/athena-webapp/src/lib/storeConfig.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1369,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_traces_createworkflowtraceid_test_ts",
-      "label": "createWorkflowTraceId.test.ts",
-      "norm_label": "createworkflowtraceid.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/traces/createWorkflowTraceId.test.ts",
       "source_location": "L1"
     },
     {
@@ -68460,6 +68460,15 @@
     {
       "community": 1370,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_traces_createworkflowtraceid_test_ts",
+      "label": "createWorkflowTraceId.test.ts",
+      "norm_label": "createworkflowtraceid.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/traces/createWorkflowTraceId.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1371,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_lib_utils_test_ts",
       "label": "utils.test.ts",
       "norm_label": "utils.test.ts",
@@ -68467,7 +68476,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1371,
+      "community": 1372,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routetree_gen_ts",
       "label": "routeTree.gen.ts",
@@ -68476,7 +68485,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1372,
+      "community": 1373,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_root_tsx",
       "label": "__root.tsx",
@@ -68485,7 +68494,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1373,
+      "community": 1374,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_index_tsx",
       "label": "index.tsx",
@@ -68494,7 +68503,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1374,
+      "community": 1375,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_settings_index_tsx",
       "label": "index.tsx",
@@ -68503,7 +68512,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1375,
+      "community": 1376,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_settings_organization_index_tsx",
       "label": "index.tsx",
@@ -68512,7 +68521,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1376,
+      "community": 1377,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_settings_stores_storeurlslug_tsx",
       "label": "$storeUrlSlug.tsx",
@@ -68521,7 +68530,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1377,
+      "community": 1378,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_analytics_tsx",
       "label": "analytics.tsx",
@@ -68530,21 +68539,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1378,
+      "community": 1379,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_assets_index_tsx",
       "label": "assets.index.tsx",
       "norm_label": "assets.index.tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/assets.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1379,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_bags_bagid_tsx",
-      "label": "bags.$bagId.tsx",
-      "norm_label": "bags.$bagid.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/bags.$bagId.tsx",
       "source_location": "L1"
     },
     {
@@ -68613,6 +68613,15 @@
     {
       "community": 1380,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_bags_bagid_tsx",
+      "label": "bags.$bagId.tsx",
+      "norm_label": "bags.$bagid.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/bags.$bagId.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1381,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_bags_index_tsx",
       "label": "bags.index.tsx",
       "norm_label": "bags.index.tsx",
@@ -68620,7 +68629,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1381,
+      "community": 1382,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_bulk_operations_index_tsx",
       "label": "index.tsx",
@@ -68629,7 +68638,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1382,
+      "community": 1383,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_checkout_sessions_index_tsx",
       "label": "checkout-sessions.index.tsx",
@@ -68638,7 +68647,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1383,
+      "community": 1384,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_configuration_index_tsx",
       "label": "configuration.index.tsx",
@@ -68647,7 +68656,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1384,
+      "community": 1385,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_dashboard_index_tsx",
       "label": "dashboard.index.tsx",
@@ -68656,7 +68665,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1385,
+      "community": 1386,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_home_tsx",
       "label": "home.tsx",
@@ -68665,7 +68674,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1386,
+      "community": 1387,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_logs_logid_tsx",
       "label": "logs.$logId.tsx",
@@ -68674,7 +68683,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1387,
+      "community": 1388,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_logs_index_tsx",
       "label": "logs.index.tsx",
@@ -68683,21 +68692,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1388,
+      "community": 1389,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_members_index_tsx",
       "label": "members.index.tsx",
       "norm_label": "members.index.tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/members.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1389,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_operations_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/index.tsx",
       "source_location": "L1"
     },
     {
@@ -68766,6 +68766,15 @@
     {
       "community": 1390,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_operations_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1391,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_orderslug_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
@@ -68773,7 +68782,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1391,
+      "community": 1392,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_all_index_tsx",
       "label": "all.index.tsx",
@@ -68782,7 +68791,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1392,
+      "community": 1393,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_cancelled_index_tsx",
       "label": "cancelled.index.tsx",
@@ -68791,7 +68800,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1393,
+      "community": 1394,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_completed_index_tsx",
       "label": "completed.index.tsx",
@@ -68800,7 +68809,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1394,
+      "community": 1395,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_index_tsx",
       "label": "index.tsx",
@@ -68809,7 +68818,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1395,
+      "community": 1396,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_open_index_tsx",
       "label": "open.index.tsx",
@@ -68818,7 +68827,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1396,
+      "community": 1397,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_out_for_delivery_index_tsx",
       "label": "out-for-delivery.index.tsx",
@@ -68827,7 +68836,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1397,
+      "community": 1398,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_ready_index_tsx",
       "label": "ready.index.tsx",
@@ -68836,21 +68845,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1398,
+      "community": 1399,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_refunded_index_tsx",
       "label": "refunded.index.tsx",
       "norm_label": "refunded.index.tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/refunded.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1399,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_reports_reportid_tsx",
-      "label": "$reportId.tsx",
-      "norm_label": "$reportid.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/expense-reports/$reportId.tsx",
       "source_location": "L1"
     },
     {
@@ -69144,6 +69144,15 @@
     {
       "community": 1400,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_reports_reportid_tsx",
+      "label": "$reportId.tsx",
+      "norm_label": "$reportid.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/expense-reports/$reportId.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1401,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_reports_index_tsx",
       "label": "expense-reports.index.tsx",
       "norm_label": "expense-reports.index.tsx",
@@ -69151,7 +69160,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1401,
+      "community": 1402,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_index_tsx",
       "label": "index.tsx",
@@ -69160,7 +69169,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1402,
+      "community": 1403,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_register_index_tsx",
       "label": "register.index.tsx",
@@ -69169,7 +69178,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1403,
+      "community": 1404,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_sessions_index_tsx",
       "label": "sessions.index.tsx",
@@ -69178,7 +69187,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1404,
+      "community": 1405,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_settings_index_tsx",
       "label": "settings.index.tsx",
@@ -69187,7 +69196,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1405,
+      "community": 1406,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_transactions_transactionid_tsx",
       "label": "$transactionId.tsx",
@@ -69196,7 +69205,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1406,
+      "community": 1407,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_transactions_index_tsx",
       "label": "transactions.index.tsx",
@@ -69205,7 +69214,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1407,
+      "community": 1408,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_procurement_index_test_ts",
       "label": "procurement.index.test.ts",
@@ -69214,21 +69223,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1408,
+      "community": 1409,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_productslug_edit_tsx",
       "label": "edit.tsx",
       "norm_label": "edit.tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/$productSlug/edit.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1409,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_productslug_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/$productSlug/index.tsx",
       "source_location": "L1"
     },
     {
@@ -69297,6 +69297,15 @@
     {
       "community": 1410,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_productslug_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/$productSlug/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1411,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_archived_tsx",
       "label": "archived.tsx",
       "norm_label": "archived.tsx",
@@ -69304,7 +69313,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1411,
+      "community": 1412,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_complimentary_index_tsx",
       "label": "index.tsx",
@@ -69313,7 +69322,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1412,
+      "community": 1413,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_complimentary_new_tsx",
       "label": "new.tsx",
@@ -69322,7 +69331,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1413,
+      "community": 1414,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_index_tsx",
       "label": "index.tsx",
@@ -69331,7 +69340,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1414,
+      "community": 1415,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_new_tsx",
       "label": "new.tsx",
@@ -69340,7 +69349,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1415,
+      "community": 1416,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_unresolved_tsx",
       "label": "unresolved.tsx",
@@ -69349,7 +69358,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1416,
+      "community": 1417,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_promocodeslug_tsx",
       "label": "$promoCodeSlug.tsx",
@@ -69358,7 +69367,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1417,
+      "community": 1418,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_index_tsx",
       "label": "index.tsx",
@@ -69367,21 +69376,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1418,
+      "community": 1419,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_new_tsx",
       "label": "new.tsx",
       "norm_label": "new.tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/promo-codes/new.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1419,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reviews_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/reviews/index.tsx",
       "source_location": "L1"
     },
     {
@@ -69450,6 +69450,15 @@
     {
       "community": 1420,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reviews_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/reviews/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1421,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reviews_new_index_tsx",
       "label": "new.index.tsx",
       "norm_label": "new.index.tsx",
@@ -69457,7 +69466,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1421,
+      "community": 1422,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_active_cases_index_tsx",
       "label": "active-cases.index.tsx",
@@ -69466,7 +69475,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1422,
+      "community": 1423,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_appointments_index_tsx",
       "label": "appointments.index.tsx",
@@ -69475,7 +69484,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1423,
+      "community": 1424,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_catalog_management_index_tsx",
       "label": "catalog-management.index.tsx",
@@ -69484,7 +69493,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1424,
+      "community": 1425,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_index_tsx",
       "label": "index.tsx",
@@ -69493,7 +69502,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1425,
+      "community": 1426,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_intake_index_tsx",
       "label": "intake.index.tsx",
@@ -69502,7 +69511,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1426,
+      "community": 1427,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_traces_traceid_test_tsx",
       "label": "$traceId.test.tsx",
@@ -69511,7 +69520,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1427,
+      "community": 1428,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_users_userid_tsx",
       "label": "users.$userId.tsx",
@@ -69520,21 +69529,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1428,
+      "community": 1429,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1429,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_test_tsx",
-      "label": "_authed.test.tsx",
-      "norm_label": "_authed.test.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed.test.tsx",
       "source_location": "L1"
     },
     {
@@ -69603,6 +69603,15 @@
     {
       "community": 1430,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_test_tsx",
+      "label": "_authed.test.tsx",
+      "norm_label": "_authed.test.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1431,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_index_test_tsx",
       "label": "index.test.tsx",
       "norm_label": "index.test.tsx",
@@ -69610,7 +69619,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1431,
+      "community": 1432,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_join_team_index_tsx",
       "label": "join-team.index.tsx",
@@ -69619,7 +69628,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1432,
+      "community": 1433,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_login_layout_index_test_tsx",
       "label": "_layout.index.test.tsx",
@@ -69628,7 +69637,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1433,
+      "community": 1434,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_login_layout_test_tsx",
       "label": "_layout.test.tsx",
@@ -69637,7 +69646,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1434,
+      "community": 1435,
       "file_type": "code",
       "id": "packages_athena_webapp_src_settings_store_storessettingsaccordion_tsx",
       "label": "StoresSettingsAccordion.tsx",
@@ -69646,7 +69655,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1435,
+      "community": 1436,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stores_expensestore_ts",
       "label": "expenseStore.ts",
@@ -69655,7 +69664,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1436,
+      "community": 1437,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_foundations_overview_stories_tsx",
       "label": "Overview.stories.tsx",
@@ -69664,7 +69673,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1437,
+      "community": 1438,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_foundations_foundations_content_test_tsx",
       "label": "foundations-content.test.tsx",
@@ -69673,7 +69682,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1438,
+      "community": 1439,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_guidance_introduction_stories_tsx",
       "label": "Introduction.stories.tsx",
@@ -69682,322 +69691,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1439,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_guidance_introduction_content_test_tsx",
-      "label": "introduction-content.test.tsx",
-      "norm_label": "introduction-content.test.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Guidance/introduction-content.test.tsx",
-      "source_location": "L1"
-    },
-    {
       "community": 144,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_templates_reference_fixtures_tsx",
-      "label": "reference-fixtures.tsx",
-      "norm_label": "reference-fixtures.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 144,
-      "file_type": "code",
-      "id": "reference_fixtures_compacttable",
-      "label": "CompactTable()",
-      "norm_label": "compacttable()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L263"
-    },
-    {
-      "community": 144,
-      "file_type": "code",
-      "id": "reference_fixtures_framecard",
-      "label": "FrameCard()",
-      "norm_label": "framecard()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L163"
-    },
-    {
-      "community": 144,
-      "file_type": "code",
-      "id": "reference_fixtures_lanecard",
-      "label": "LaneCard()",
-      "norm_label": "lanecard()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L213"
-    },
-    {
-      "community": 144,
-      "file_type": "code",
-      "id": "reference_fixtures_metrictile",
-      "label": "MetricTile()",
-      "norm_label": "metrictile()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L194"
-    },
-    {
-      "community": 144,
-      "file_type": "code",
-      "id": "reference_fixtures_minitrendchart",
-      "label": "MiniTrendChart()",
-      "norm_label": "minitrendchart()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L240"
-    },
-    {
-      "community": 144,
-      "file_type": "code",
-      "id": "reference_fixtures_referencepageshell",
-      "label": "ReferencePageShell()",
-      "norm_label": "referencepageshell()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L145"
-    },
-    {
-      "community": 1440,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_guidance_introduction_content_tsx",
-      "label": "introduction-content.tsx",
-      "norm_label": "introduction-content.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Guidance/introduction-content.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1441,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_patterns_adminshell_stories_tsx",
-      "label": "AdminShell.stories.tsx",
-      "norm_label": "adminshell.stories.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Patterns/AdminShell.stories.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1442,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_patterns_view_stories_tsx",
-      "label": "View.stories.tsx",
-      "norm_label": "view.stories.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Patterns/View.stories.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1443,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_patterns_admin_shell_patterns_test_tsx",
-      "label": "admin-shell-patterns.test.tsx",
-      "norm_label": "admin-shell-patterns.test.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Patterns/admin-shell-patterns.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1444,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_patterns_view_patterns_test_tsx",
-      "label": "view-patterns.test.tsx",
-      "norm_label": "view-patterns.test.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Patterns/view-patterns.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1445,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_primitives_surfaces_stories_tsx",
-      "label": "Surfaces.stories.tsx",
-      "norm_label": "surfaces.stories.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Primitives/Surfaces.stories.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1446,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_templates_dashboardworkspace_stories_tsx",
-      "label": "DashboardWorkspace.stories.tsx",
-      "norm_label": "dashboardworkspace.stories.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Templates/DashboardWorkspace.stories.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1447,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_templates_dataworkspace_stories_tsx",
-      "label": "DataWorkspace.stories.tsx",
-      "norm_label": "dataworkspace.stories.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Templates/DataWorkspace.stories.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1448,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_templates_settingsworkspace_stories_tsx",
-      "label": "SettingsWorkspace.stories.tsx",
-      "norm_label": "settingsworkspace.stories.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Templates/SettingsWorkspace.stories.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1449,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_templates_reference_fixtures_test_tsx",
-      "label": "reference-fixtures.test.tsx",
-      "norm_label": "reference-fixtures.test.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 145,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_savedbag_ts",
-      "label": "savedBag.ts",
-      "norm_label": "savedbag.ts",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 145,
-      "file_type": "code",
-      "id": "savedbag_additemtosavedbag",
-      "label": "addItemToSavedBag()",
-      "norm_label": "additemtosavedbag()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L25"
-    },
-    {
-      "community": 145,
-      "file_type": "code",
-      "id": "savedbag_getactivesavedbag",
-      "label": "getActiveSavedBag()",
-      "norm_label": "getactivesavedbag()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L10"
-    },
-    {
-      "community": 145,
-      "file_type": "code",
-      "id": "savedbag_getbaseurl",
-      "label": "getBaseUrl()",
-      "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L8"
-    },
-    {
-      "community": 145,
-      "file_type": "code",
-      "id": "savedbag_removeitemfromsavedbag",
-      "label": "removeItemFromSavedBag()",
-      "norm_label": "removeitemfromsavedbag()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L91"
-    },
-    {
-      "community": 145,
-      "file_type": "code",
-      "id": "savedbag_updatesavedbagitem",
-      "label": "updateSavedBagItem()",
-      "norm_label": "updatesavedbagitem()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L61"
-    },
-    {
-      "community": 145,
-      "file_type": "code",
-      "id": "savedbag_updatesavedbagowner",
-      "label": "updateSavedBagOwner()",
-      "norm_label": "updatesavedbagowner()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L109"
-    },
-    {
-      "community": 1450,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_storybook_config_test_ts",
-      "label": "storybook-config.test.ts",
-      "norm_label": "storybook-config.test.ts",
-      "source_file": "packages/athena-webapp/src/stories/storybook-config.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1451,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_storybook_theme_decorator_test_ts",
-      "label": "storybook-theme-decorator.test.ts",
-      "norm_label": "storybook-theme-decorator.test.ts",
-      "source_file": "packages/athena-webapp/src/stories/storybook-theme-decorator.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1452,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_test_setup_ts",
-      "label": "setup.ts",
-      "norm_label": "setup.ts",
-      "source_file": "packages/athena-webapp/src/test/setup.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1453,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_tests_pos_useprint_test_ts",
-      "label": "usePrint.test.ts",
-      "norm_label": "useprint.test.ts",
-      "source_file": "packages/athena-webapp/src/tests/pos/usePrint.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1454,
-      "file_type": "code",
-      "id": "packages_athena_webapp_tailwind_config_js",
-      "label": "tailwind.config.js",
-      "norm_label": "tailwind.config.js",
-      "source_file": "packages/athena-webapp/tailwind.config.js",
-      "source_location": "L1"
-    },
-    {
-      "community": 1455,
-      "file_type": "code",
-      "id": "packages_athena_webapp_types_ts",
-      "label": "types.ts",
-      "norm_label": "types.ts",
-      "source_file": "packages/athena-webapp/types.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1456,
-      "file_type": "code",
-      "id": "packages_athena_webapp_vitest_config_ts",
-      "label": "vitest.config.ts",
-      "norm_label": "vitest.config.ts",
-      "source_file": "packages/athena-webapp/vitest.config.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1457,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_eslint_config_js",
-      "label": "eslint.config.js",
-      "norm_label": "eslint.config.js",
-      "source_file": "packages/storefront-webapp/eslint.config.js",
-      "source_location": "L1"
-    },
-    {
-      "community": 1458,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_global_d_ts",
-      "label": "global.d.ts",
-      "norm_label": "global.d.ts",
-      "source_file": "packages/storefront-webapp/global.d.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1459,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_playwright_config_ts",
-      "label": "playwright.config.ts",
-      "norm_label": "playwright.config.ts",
-      "source_file": "packages/storefront-webapp/playwright.config.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 146,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_productutils_ts",
       "label": "productUtils.ts",
@@ -70006,7 +69700,7 @@
       "source_location": "L1"
     },
     {
-      "community": 146,
+      "community": 144,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_productutils_ts",
       "label": "productUtils.ts",
@@ -70015,7 +69709,7 @@
       "source_location": "L1"
     },
     {
-      "community": 146,
+      "community": 144,
       "file_type": "code",
       "id": "productutils_getproductname",
       "label": "getProductName()",
@@ -70024,7 +69718,7 @@
       "source_location": "L18"
     },
     {
-      "community": 146,
+      "community": 144,
       "file_type": "code",
       "id": "productutils_haslowstock",
       "label": "hasLowStock()",
@@ -70033,7 +69727,7 @@
       "source_location": "L52"
     },
     {
-      "community": 146,
+      "community": 144,
       "file_type": "code",
       "id": "productutils_issoldout",
       "label": "isSoldOut()",
@@ -70042,7 +69736,7 @@
       "source_location": "L45"
     },
     {
-      "community": 146,
+      "community": 144,
       "file_type": "code",
       "id": "productutils_sortproduct",
       "label": "sortProduct()",
@@ -70051,7 +69745,7 @@
       "source_location": "L66"
     },
     {
-      "community": 146,
+      "community": 144,
       "file_type": "code",
       "id": "productutils_sortskusbylength",
       "label": "sortSkusByLength()",
@@ -70060,7 +69754,322 @@
       "source_location": "L62"
     },
     {
+      "community": 1440,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_guidance_introduction_content_test_tsx",
+      "label": "introduction-content.test.tsx",
+      "norm_label": "introduction-content.test.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Guidance/introduction-content.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1441,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_guidance_introduction_content_tsx",
+      "label": "introduction-content.tsx",
+      "norm_label": "introduction-content.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Guidance/introduction-content.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1442,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_patterns_adminshell_stories_tsx",
+      "label": "AdminShell.stories.tsx",
+      "norm_label": "adminshell.stories.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Patterns/AdminShell.stories.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1443,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_patterns_view_stories_tsx",
+      "label": "View.stories.tsx",
+      "norm_label": "view.stories.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Patterns/View.stories.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1444,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_patterns_admin_shell_patterns_test_tsx",
+      "label": "admin-shell-patterns.test.tsx",
+      "norm_label": "admin-shell-patterns.test.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Patterns/admin-shell-patterns.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1445,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_patterns_view_patterns_test_tsx",
+      "label": "view-patterns.test.tsx",
+      "norm_label": "view-patterns.test.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Patterns/view-patterns.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1446,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_primitives_surfaces_stories_tsx",
+      "label": "Surfaces.stories.tsx",
+      "norm_label": "surfaces.stories.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Primitives/Surfaces.stories.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1447,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_templates_dashboardworkspace_stories_tsx",
+      "label": "DashboardWorkspace.stories.tsx",
+      "norm_label": "dashboardworkspace.stories.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Templates/DashboardWorkspace.stories.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1448,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_templates_dataworkspace_stories_tsx",
+      "label": "DataWorkspace.stories.tsx",
+      "norm_label": "dataworkspace.stories.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Templates/DataWorkspace.stories.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1449,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_templates_settingsworkspace_stories_tsx",
+      "label": "SettingsWorkspace.stories.tsx",
+      "norm_label": "settingsworkspace.stories.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Templates/SettingsWorkspace.stories.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 145,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_templates_reference_fixtures_tsx",
+      "label": "reference-fixtures.tsx",
+      "norm_label": "reference-fixtures.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 145,
+      "file_type": "code",
+      "id": "reference_fixtures_compacttable",
+      "label": "CompactTable()",
+      "norm_label": "compacttable()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L263"
+    },
+    {
+      "community": 145,
+      "file_type": "code",
+      "id": "reference_fixtures_framecard",
+      "label": "FrameCard()",
+      "norm_label": "framecard()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L163"
+    },
+    {
+      "community": 145,
+      "file_type": "code",
+      "id": "reference_fixtures_lanecard",
+      "label": "LaneCard()",
+      "norm_label": "lanecard()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L213"
+    },
+    {
+      "community": 145,
+      "file_type": "code",
+      "id": "reference_fixtures_metrictile",
+      "label": "MetricTile()",
+      "norm_label": "metrictile()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L194"
+    },
+    {
+      "community": 145,
+      "file_type": "code",
+      "id": "reference_fixtures_minitrendchart",
+      "label": "MiniTrendChart()",
+      "norm_label": "minitrendchart()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L240"
+    },
+    {
+      "community": 145,
+      "file_type": "code",
+      "id": "reference_fixtures_referencepageshell",
+      "label": "ReferencePageShell()",
+      "norm_label": "referencepageshell()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L145"
+    },
+    {
+      "community": 1450,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_templates_reference_fixtures_test_tsx",
+      "label": "reference-fixtures.test.tsx",
+      "norm_label": "reference-fixtures.test.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1451,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_storybook_config_test_ts",
+      "label": "storybook-config.test.ts",
+      "norm_label": "storybook-config.test.ts",
+      "source_file": "packages/athena-webapp/src/stories/storybook-config.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1452,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_storybook_theme_decorator_test_ts",
+      "label": "storybook-theme-decorator.test.ts",
+      "norm_label": "storybook-theme-decorator.test.ts",
+      "source_file": "packages/athena-webapp/src/stories/storybook-theme-decorator.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1453,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_test_setup_ts",
+      "label": "setup.ts",
+      "norm_label": "setup.ts",
+      "source_file": "packages/athena-webapp/src/test/setup.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1454,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_tests_pos_useprint_test_ts",
+      "label": "usePrint.test.ts",
+      "norm_label": "useprint.test.ts",
+      "source_file": "packages/athena-webapp/src/tests/pos/usePrint.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1455,
+      "file_type": "code",
+      "id": "packages_athena_webapp_tailwind_config_js",
+      "label": "tailwind.config.js",
+      "norm_label": "tailwind.config.js",
+      "source_file": "packages/athena-webapp/tailwind.config.js",
+      "source_location": "L1"
+    },
+    {
+      "community": 1456,
+      "file_type": "code",
+      "id": "packages_athena_webapp_types_ts",
+      "label": "types.ts",
+      "norm_label": "types.ts",
+      "source_file": "packages/athena-webapp/types.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1457,
+      "file_type": "code",
+      "id": "packages_athena_webapp_vitest_config_ts",
+      "label": "vitest.config.ts",
+      "norm_label": "vitest.config.ts",
+      "source_file": "packages/athena-webapp/vitest.config.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1458,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_eslint_config_js",
+      "label": "eslint.config.js",
+      "norm_label": "eslint.config.js",
+      "source_file": "packages/storefront-webapp/eslint.config.js",
+      "source_location": "L1"
+    },
+    {
+      "community": 1459,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_global_d_ts",
+      "label": "global.d.ts",
+      "norm_label": "global.d.ts",
+      "source_file": "packages/storefront-webapp/global.d.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 146,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_api_savedbag_ts",
+      "label": "savedBag.ts",
+      "norm_label": "savedbag.ts",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 146,
+      "file_type": "code",
+      "id": "savedbag_additemtosavedbag",
+      "label": "addItemToSavedBag()",
+      "norm_label": "additemtosavedbag()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L25"
+    },
+    {
+      "community": 146,
+      "file_type": "code",
+      "id": "savedbag_getactivesavedbag",
+      "label": "getActiveSavedBag()",
+      "norm_label": "getactivesavedbag()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L10"
+    },
+    {
+      "community": 146,
+      "file_type": "code",
+      "id": "savedbag_getbaseurl",
+      "label": "getBaseUrl()",
+      "norm_label": "getbaseurl()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L8"
+    },
+    {
+      "community": 146,
+      "file_type": "code",
+      "id": "savedbag_removeitemfromsavedbag",
+      "label": "removeItemFromSavedBag()",
+      "norm_label": "removeitemfromsavedbag()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L91"
+    },
+    {
+      "community": 146,
+      "file_type": "code",
+      "id": "savedbag_updatesavedbagitem",
+      "label": "updateSavedBagItem()",
+      "norm_label": "updatesavedbagitem()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L61"
+    },
+    {
+      "community": 146,
+      "file_type": "code",
+      "id": "savedbag_updatesavedbagowner",
+      "label": "updateSavedBagOwner()",
+      "norm_label": "updatesavedbagowner()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L109"
+    },
+    {
       "community": 1460,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_playwright_config_ts",
+      "label": "playwright.config.ts",
+      "norm_label": "playwright.config.ts",
+      "source_file": "packages/storefront-webapp/playwright.config.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1461,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_analytics_test_ts",
       "label": "analytics.test.ts",
@@ -70069,7 +70078,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1461,
+      "community": 1462,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_types_ts",
       "label": "types.ts",
@@ -70078,7 +70087,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1462,
+      "community": 1463,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_assets_icons_hearticonfilled_tsx",
       "label": "HeartIconFilled.tsx",
@@ -70087,7 +70096,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1463,
+      "community": 1464,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_defaultcatchboundary_tsx",
       "label": "DefaultCatchBoundary.tsx",
@@ -70096,7 +70105,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1464,
+      "community": 1465,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_homepage_test_tsx",
       "label": "HomePage.test.tsx",
@@ -70105,7 +70114,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1465,
+      "community": 1466,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_productcard_test_tsx",
       "label": "ProductCard.test.tsx",
@@ -70114,7 +70123,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1466,
+      "community": 1467,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_productcard_tsx",
       "label": "ProductCard.tsx",
@@ -70123,7 +70132,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1467,
+      "community": 1468,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_upsell_tsx",
       "label": "Upsell.tsx",
@@ -70132,21 +70141,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1468,
+      "community": 1469,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkout_test_tsx",
       "label": "Checkout.test.tsx",
       "norm_label": "checkout.test.tsx",
       "source_file": "packages/storefront-webapp/src/components/checkout/Checkout.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1469,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_checkout_tsx",
-      "label": "Checkout.tsx",
-      "norm_label": "checkout.tsx",
-      "source_file": "packages/storefront-webapp/src/components/checkout/Checkout.tsx",
       "source_location": "L1"
     },
     {
@@ -70215,6 +70215,15 @@
     {
       "community": 1470,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_checkout_tsx",
+      "label": "Checkout.tsx",
+      "norm_label": "checkout.tsx",
+      "source_file": "packages/storefront-webapp/src/components/checkout/Checkout.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1471,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_customerinfosection_tsx",
       "label": "CustomerInfoSection.tsx",
       "norm_label": "customerinfosection.tsx",
@@ -70222,7 +70231,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1471,
+      "community": 1472,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_schema_ts",
       "label": "schema.ts",
@@ -70231,7 +70240,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1472,
+      "community": 1473,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliverydetailssection_tsx",
       "label": "DeliveryDetailsSection.tsx",
@@ -70240,7 +70249,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1473,
+      "community": 1474,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkoutstorage_test_ts",
       "label": "checkoutStorage.test.ts",
@@ -70249,7 +70258,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1474,
+      "community": 1475,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliveryfees_test_ts",
       "label": "deliveryFees.test.ts",
@@ -70258,7 +70267,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1475,
+      "community": 1476,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_derivecheckoutstate_test_ts",
       "label": "deriveCheckoutState.test.ts",
@@ -70267,7 +70276,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1476,
+      "community": 1477,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_billingdetailsschema_ts",
       "label": "billingDetailsSchema.ts",
@@ -70276,7 +70285,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1477,
+      "community": 1478,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_checkoutformschema_ts",
       "label": "checkoutFormSchema.ts",
@@ -70285,21 +70294,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1478,
+      "community": 1479,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_customerdetailsschema_ts",
       "label": "customerDetailsSchema.ts",
       "norm_label": "customerdetailsschema.ts",
       "source_file": "packages/storefront-webapp/src/components/checkout/schemas/customerDetailsSchema.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1479,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_schemas_deliverydetailsschema_ts",
-      "label": "deliveryDetailsSchema.ts",
-      "norm_label": "deliverydetailsschema.ts",
-      "source_file": "packages/storefront-webapp/src/components/checkout/schemas/deliveryDetailsSchema.ts",
       "source_location": "L1"
     },
     {
@@ -70368,6 +70368,15 @@
     {
       "community": 1480,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_schemas_deliverydetailsschema_ts",
+      "label": "deliveryDetailsSchema.ts",
+      "norm_label": "deliverydetailsschema.ts",
+      "source_file": "packages/storefront-webapp/src/components/checkout/schemas/deliveryDetailsSchema.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1481,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_weborderschema_ts",
       "label": "webOrderSchema.ts",
       "norm_label": "weborderschema.ts",
@@ -70375,7 +70384,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1481,
+      "community": 1482,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_types_ts",
       "label": "types.ts",
@@ -70384,7 +70393,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1482,
+      "community": 1483,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_utils_test_ts",
       "label": "utils.test.ts",
@@ -70393,7 +70402,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1483,
+      "community": 1484,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_filter_productfilterbar_tsx",
       "label": "ProductFilterBar.tsx",
@@ -70402,7 +70411,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1484,
+      "community": 1485,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_bestsellerssection_test_tsx",
       "label": "BestSellersSection.test.tsx",
@@ -70411,7 +70420,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1485,
+      "community": 1486,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_homehero_tsx",
       "label": "HomeHero.tsx",
@@ -70420,7 +70429,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1486,
+      "community": 1487,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_homeherosection_tsx",
       "label": "HomeHeroSection.tsx",
@@ -70429,7 +70438,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1487,
+      "community": 1488,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_homepagecontent_test_ts",
       "label": "homePageContent.test.ts",
@@ -70438,21 +70447,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1488,
+      "community": 1489,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_mobilemenu_tsx",
       "label": "MobileMenu.tsx",
       "norm_label": "mobilemenu.tsx",
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/MobileMenu.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1489,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_navigation_bar_constants_ts",
-      "label": "constants.ts",
-      "norm_label": "constants.ts",
-      "source_file": "packages/storefront-webapp/src/components/navigation-bar/constants.ts",
       "source_location": "L1"
     },
     {
@@ -70521,6 +70521,15 @@
     {
       "community": 1490,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_navigation_bar_constants_ts",
+      "label": "constants.ts",
+      "norm_label": "constants.ts",
+      "source_file": "packages/storefront-webapp/src/components/navigation-bar/constants.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1491,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_navbarconstants_ts",
       "label": "navBarConstants.ts",
       "norm_label": "navbarconstants.ts",
@@ -70528,7 +70537,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1491,
+      "community": 1492,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_about_tsx",
       "label": "About.tsx",
@@ -70537,7 +70546,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1492,
+      "community": 1493,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_aboutproduct_tsx",
       "label": "AboutProduct.tsx",
@@ -70546,7 +70555,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1493,
+      "community": 1494,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productactions_test_tsx",
       "label": "ProductActions.test.tsx",
@@ -70555,7 +70564,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1494,
+      "community": 1495,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productinfo_tsx",
       "label": "ProductInfo.tsx",
@@ -70564,7 +70573,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1495,
+      "community": 1496,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productreviews_tsx",
       "label": "ProductReviews.tsx",
@@ -70573,7 +70582,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1496,
+      "community": 1497,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productsnavigationbar_tsx",
       "label": "ProductsNavigationBar.tsx",
@@ -70582,7 +70591,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1497,
+      "community": 1498,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_errormessage_tsx",
       "label": "ErrorMessage.tsx",
@@ -70591,21 +70600,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1498,
+      "community": 1499,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_existingreviewmessage_tsx",
       "label": "ExistingReviewMessage.tsx",
       "norm_label": "existingreviewmessage.tsx",
       "source_file": "packages/storefront-webapp/src/components/product-reviews/ExistingReviewMessage.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1499,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_reviews_orderitem_test_tsx",
-      "label": "OrderItem.test.tsx",
-      "norm_label": "orderitem.test.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-reviews/OrderItem.test.tsx",
       "source_location": "L1"
     },
     {
@@ -70899,6 +70899,15 @@
     {
       "community": 1500,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_reviews_orderitem_test_tsx",
+      "label": "OrderItem.test.tsx",
+      "norm_label": "orderitem.test.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-reviews/OrderItem.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1501,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_reviewform_tsx",
       "label": "ReviewForm.tsx",
       "norm_label": "reviewform.tsx",
@@ -70906,7 +70915,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1501,
+      "community": 1502,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_successmessage_tsx",
       "label": "SuccessMessage.tsx",
@@ -70915,7 +70924,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1502,
+      "community": 1503,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_types_ts",
       "label": "types.ts",
@@ -70924,7 +70933,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1503,
+      "community": 1504,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_saved_items_savedbag_tsx",
       "label": "SavedBag.tsx",
@@ -70933,7 +70942,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1504,
+      "community": 1505,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_saved_items_savedicon_tsx",
       "label": "SavedIcon.tsx",
@@ -70942,7 +70951,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1505,
+      "community": 1506,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_shopping_bag_carticon_tsx",
       "label": "CartIcon.tsx",
@@ -70951,7 +70960,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1506,
+      "community": 1507,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_shopping_bag_shoppingbag_test_tsx",
       "label": "ShoppingBag.test.tsx",
@@ -70960,7 +70969,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1507,
+      "community": 1508,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_empty_empty_state_tsx",
       "label": "empty-state.tsx",
@@ -70969,21 +70978,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1508,
+      "community": 1509,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_maintenance_maintenance_test_tsx",
       "label": "Maintenance.test.tsx",
       "norm_label": "maintenance.test.tsx",
       "source_file": "packages/storefront-webapp/src/components/states/maintenance/Maintenance.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1509,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_states_maintenance_maintenance_tsx",
-      "label": "Maintenance.tsx",
-      "norm_label": "maintenance.tsx",
-      "source_file": "packages/storefront-webapp/src/components/states/maintenance/Maintenance.tsx",
       "source_location": "L1"
     },
     {
@@ -71043,6 +71043,15 @@
     {
       "community": 1510,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_states_maintenance_maintenance_tsx",
+      "label": "Maintenance.tsx",
+      "norm_label": "maintenance.tsx",
+      "source_file": "packages/storefront-webapp/src/components/states/maintenance/Maintenance.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1511,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_animatedcard_tsx",
       "label": "AnimatedCard.tsx",
       "norm_label": "animatedcard.tsx",
@@ -71050,7 +71059,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1511,
+      "community": 1512,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_accordion_tsx",
       "label": "accordion.tsx",
@@ -71059,7 +71068,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1512,
+      "community": 1513,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_alert_tsx",
       "label": "alert.tsx",
@@ -71068,7 +71077,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1513,
+      "community": 1514,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_breadcrumb_tsx",
       "label": "breadcrumb.tsx",
@@ -71077,7 +71086,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1514,
+      "community": 1515,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_button_tsx",
       "label": "button.tsx",
@@ -71086,7 +71095,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1515,
+      "community": 1516,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_card_tsx",
       "label": "card.tsx",
@@ -71095,7 +71104,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1516,
+      "community": 1517,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_checkbox_tsx",
       "label": "checkbox.tsx",
@@ -71104,7 +71113,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1517,
+      "community": 1518,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_command_tsx",
       "label": "command.tsx",
@@ -71113,21 +71122,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1518,
+      "community": 1519,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_context_menu_tsx",
       "label": "context-menu.tsx",
       "norm_label": "context-menu.tsx",
       "source_file": "packages/storefront-webapp/src/components/ui/context-menu.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1519,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_dialog_tsx",
-      "label": "dialog.tsx",
-      "norm_label": "dialog.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/dialog.tsx",
       "source_location": "L1"
     },
     {
@@ -71187,6 +71187,15 @@
     {
       "community": 1520,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_dialog_tsx",
+      "label": "dialog.tsx",
+      "norm_label": "dialog.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/dialog.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1521,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_dropdown_menu_tsx",
       "label": "dropdown-menu.tsx",
       "norm_label": "dropdown-menu.tsx",
@@ -71194,7 +71203,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1521,
+      "community": 1522,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_form_tsx",
       "label": "form.tsx",
@@ -71203,7 +71212,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1522,
+      "community": 1523,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_icons_tsx",
       "label": "icons.tsx",
@@ -71212,7 +71221,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1523,
+      "community": 1524,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_image_with_fallback_tsx",
       "label": "image-with-fallback.tsx",
@@ -71221,7 +71230,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1524,
+      "community": 1525,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_input_otp_tsx",
       "label": "input-otp.tsx",
@@ -71230,7 +71239,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1525,
+      "community": 1526,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_input_with_end_button_tsx",
       "label": "input-with-end-button.tsx",
@@ -71239,7 +71248,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1526,
+      "community": 1527,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_input_tsx",
       "label": "input.tsx",
@@ -71248,7 +71257,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1527,
+      "community": 1528,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_label_tsx",
       "label": "label.tsx",
@@ -71257,21 +71266,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1528,
+      "community": 1529,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_leaveareviewmodalform_tsx",
       "label": "LeaveAReviewModalForm.tsx",
       "norm_label": "leaveareviewmodalform.tsx",
       "source_file": "packages/storefront-webapp/src/components/ui/modals/LeaveAReviewModalForm.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1529,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_modals_action_modal_tsx",
-      "label": "action-modal.tsx",
-      "norm_label": "action-modal.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/action-modal.tsx",
       "source_location": "L1"
     },
     {
@@ -71331,6 +71331,15 @@
     {
       "community": 1530,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_modals_action_modal_tsx",
+      "label": "action-modal.tsx",
+      "norm_label": "action-modal.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/action-modal.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1531,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_animations_welcomebackmodalanimations_ts",
       "label": "welcomeBackModalAnimations.ts",
       "norm_label": "welcomebackmodalanimations.ts",
@@ -71338,7 +71347,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1531,
+      "community": 1532,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_index_ts",
       "label": "index.ts",
@@ -71347,7 +71356,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1532,
+      "community": 1533,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_types_ts",
       "label": "types.ts",
@@ -71356,7 +71365,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1533,
+      "community": 1534,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_navigation_menu_tsx",
       "label": "navigation-menu.tsx",
@@ -71365,7 +71374,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1534,
+      "community": 1535,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_popover_tsx",
       "label": "popover.tsx",
@@ -71374,7 +71383,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1535,
+      "community": 1536,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_radio_group_tsx",
       "label": "radio-group.tsx",
@@ -71383,7 +71392,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1536,
+      "community": 1537,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_scroll_area_tsx",
       "label": "scroll-area.tsx",
@@ -71392,7 +71401,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1537,
+      "community": 1538,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_select_tsx",
       "label": "select.tsx",
@@ -71401,21 +71410,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1538,
+      "community": 1539,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_separator_tsx",
       "label": "separator.tsx",
       "norm_label": "separator.tsx",
       "source_file": "packages/storefront-webapp/src/components/ui/separator.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1539,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_sheet_tsx",
-      "label": "sheet.tsx",
-      "norm_label": "sheet.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/sheet.tsx",
       "source_location": "L1"
     },
     {
@@ -71475,6 +71475,15 @@
     {
       "community": 1540,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_sheet_tsx",
+      "label": "sheet.tsx",
+      "norm_label": "sheet.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/sheet.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1541,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_table_tsx",
       "label": "table.tsx",
       "norm_label": "table.tsx",
@@ -71482,7 +71491,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1541,
+      "community": 1542,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_tabs_tsx",
       "label": "tabs.tsx",
@@ -71491,7 +71500,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1542,
+      "community": 1543,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_textarea_tsx",
       "label": "textarea.tsx",
@@ -71500,7 +71509,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1543,
+      "community": 1544,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_toggle_group_tsx",
       "label": "toggle-group.tsx",
@@ -71509,7 +71518,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1544,
+      "community": 1545,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_toggle_tsx",
       "label": "toggle.tsx",
@@ -71518,7 +71527,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1545,
+      "community": 1546,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_tooltip_tsx",
       "label": "tooltip.tsx",
@@ -71527,7 +71536,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1546,
+      "community": 1547,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_config_ts",
       "label": "config.ts",
@@ -71536,7 +71545,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1547,
+      "community": 1548,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_use_store_modal_tsx",
       "label": "use-store-modal.tsx",
@@ -71545,21 +71554,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1548,
+      "community": 1549,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useorganizationmodal_tsx",
       "label": "useOrganizationModal.tsx",
       "norm_label": "useorganizationmodal.tsx",
       "source_file": "packages/storefront-webapp/src/hooks/useOrganizationModal.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1549,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_usequeryenabled_test_ts",
-      "label": "useQueryEnabled.test.ts",
-      "norm_label": "usequeryenabled.test.ts",
-      "source_file": "packages/storefront-webapp/src/hooks/useQueryEnabled.test.ts",
       "source_location": "L1"
     },
     {
@@ -71619,6 +71619,15 @@
     {
       "community": 1550,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_usequeryenabled_test_ts",
+      "label": "useQueryEnabled.test.ts",
+      "norm_label": "usequeryenabled.test.ts",
+      "source_file": "packages/storefront-webapp/src/hooks/useQueryEnabled.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1551,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usestorefrontobservability_ts",
       "label": "useStorefrontObservability.ts",
       "norm_label": "usestorefrontobservability.ts",
@@ -71626,7 +71635,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1551,
+      "community": 1552,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_constants_ts",
       "label": "constants.ts",
@@ -71635,7 +71644,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1552,
+      "community": 1553,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_countries_ts",
       "label": "countries.ts",
@@ -71644,7 +71653,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1553,
+      "community": 1554,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_feeutils_test_ts",
       "label": "feeUtils.test.ts",
@@ -71653,7 +71662,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1554,
+      "community": 1555,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_ghana_ts",
       "label": "ghana.ts",
@@ -71662,7 +71671,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1555,
+      "community": 1556,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_ghanaregions_ts",
       "label": "ghanaRegions.ts",
@@ -71671,7 +71680,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1556,
+      "community": 1557,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_maintenanceutils_test_ts",
       "label": "maintenanceUtils.test.ts",
@@ -71680,7 +71689,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1557,
+      "community": 1558,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_mutations_ts_index_ts",
       "label": "index.ts",
@@ -71689,21 +71698,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1558,
+      "community": 1559,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_store_ts",
       "label": "store.ts",
       "norm_label": "store.ts",
       "source_file": "packages/storefront-webapp/src/lib/queries/store.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1559,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_schemas_bag_ts",
-      "label": "bag.ts",
-      "norm_label": "bag.ts",
-      "source_file": "packages/storefront-webapp/src/lib/schemas/bag.ts",
       "source_location": "L1"
     },
     {
@@ -71763,6 +71763,15 @@
     {
       "community": 1560,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_schemas_bag_ts",
+      "label": "bag.ts",
+      "norm_label": "bag.ts",
+      "source_file": "packages/storefront-webapp/src/lib/schemas/bag.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1561,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_bagitem_ts",
       "label": "bagItem.ts",
       "norm_label": "bagitem.ts",
@@ -71770,7 +71779,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1561,
+      "community": 1562,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_category_ts",
       "label": "category.ts",
@@ -71779,7 +71788,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1562,
+      "community": 1563,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_organization_ts",
       "label": "organization.ts",
@@ -71788,7 +71797,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1563,
+      "community": 1564,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_product_ts",
       "label": "product.ts",
@@ -71797,7 +71806,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1564,
+      "community": 1565,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_store_ts",
       "label": "store.ts",
@@ -71806,7 +71815,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1565,
+      "community": 1566,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_subcategory_ts",
       "label": "subcategory.ts",
@@ -71815,7 +71824,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1566,
+      "community": 1567,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_user_ts",
       "label": "user.ts",
@@ -71824,7 +71833,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1567,
+      "community": 1568,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_states_ts",
       "label": "states.ts",
@@ -71833,21 +71842,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1568,
+      "community": 1569,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_storefrontfailureobservability_test_ts",
       "label": "storefrontFailureObservability.test.ts",
       "norm_label": "storefrontfailureobservability.test.ts",
       "source_file": "packages/storefront-webapp/src/lib/storefrontFailureObservability.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1569,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_storefrontjourneyevents_test_ts",
-      "label": "storefrontJourneyEvents.test.ts",
-      "norm_label": "storefrontjourneyevents.test.ts",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.test.ts",
       "source_location": "L1"
     },
     {
@@ -71907,6 +71907,15 @@
     {
       "community": 1570,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_storefrontjourneyevents_test_ts",
+      "label": "storefrontJourneyEvents.test.ts",
+      "norm_label": "storefrontjourneyevents.test.ts",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1571,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_utils_test_ts",
       "label": "utils.test.ts",
       "norm_label": "utils.test.ts",
@@ -71914,7 +71923,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1571,
+      "community": 1572,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routetree_gen_ts",
       "label": "routeTree.gen.ts",
@@ -71923,7 +71932,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1572,
+      "community": 1573,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_homepageloader_test_ts",
       "label": "-homePageLoader.test.ts",
@@ -71932,7 +71941,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1573,
+      "community": 1574,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_root_tsx",
       "label": "__root.tsx",
@@ -71941,7 +71950,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1574,
+      "community": 1575,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_orderid_orderitemid_review_tsx",
       "label": "$orderItemId.review.tsx",
@@ -71950,7 +71959,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1575,
+      "community": 1576,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_index_tsx",
       "label": "index.tsx",
@@ -71959,7 +71968,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1576,
+      "community": 1577,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_shoplayout_shop_categoryslug_subcategoryslug_tsx",
       "label": "$subcategorySlug.tsx",
@@ -71968,7 +71977,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1577,
+      "community": 1578,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_shoplayout_shop_categoryslug_index_tsx",
       "label": "index.tsx",
@@ -71977,21 +71986,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1578,
+      "community": 1579,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_rewards_index_tsx",
       "label": "rewards.index.tsx",
       "norm_label": "rewards.index.tsx",
       "source_file": "packages/storefront-webapp/src/routes/_layout/rewards.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1579,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_layout_shop_saved_index_tsx",
-      "label": "shop.saved.index.tsx",
-      "norm_label": "shop.saved.index.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/shop.saved.index.tsx",
       "source_location": "L1"
     },
     {
@@ -72051,6 +72051,15 @@
     {
       "community": 1580,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_layout_shop_saved_index_tsx",
+      "label": "shop.saved.index.tsx",
+      "norm_label": "shop.saved.index.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/shop.saved.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1581,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_bag_index_tsx",
       "label": "bag.index.tsx",
       "norm_label": "bag.index.tsx",
@@ -72058,7 +72067,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1581,
+      "community": 1582,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_complete_tsx",
       "label": "complete.tsx",
@@ -72067,7 +72076,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1582,
+      "community": 1583,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_incomplete_tsx",
       "label": "incomplete.tsx",
@@ -72076,7 +72085,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1583,
+      "community": 1584,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_index_tsx",
       "label": "index.tsx",
@@ -72085,7 +72094,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1584,
+      "community": 1585,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_pending_tsx",
       "label": "pending.tsx",
@@ -72094,7 +72103,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1585,
+      "community": 1586,
       "file_type": "code",
       "id": "packages_storefront_webapp_tailwind_config_js",
       "label": "tailwind.config.js",
@@ -72103,7 +72112,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1586,
+      "community": 1587,
       "file_type": "code",
       "id": "packages_storefront_webapp_tests_e2e_storefront_boot_e2e_ts",
       "label": "storefront-boot.e2e.ts",
@@ -72112,7 +72121,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1587,
+      "community": 1588,
       "file_type": "code",
       "id": "packages_storefront_webapp_vitest_config_ts",
       "label": "vitest.config.ts",
@@ -72121,21 +72130,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1588,
+      "community": 1589,
       "file_type": "code",
       "id": "packages_storefront_webapp_vitest_setup_ts",
       "label": "vitest.setup.ts",
       "norm_label": "vitest.setup.ts",
       "source_file": "packages/storefront-webapp/vitest.setup.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1589,
-      "file_type": "code",
-      "id": "packages_valkey_proxy_server_index_js",
-      "label": "index.js",
-      "norm_label": "index.js",
-      "source_file": "packages/valkey-proxy-server/index.js",
       "source_location": "L1"
     },
     {
@@ -72195,6 +72195,15 @@
     {
       "community": 1590,
       "file_type": "code",
+      "id": "packages_valkey_proxy_server_index_js",
+      "label": "index.js",
+      "norm_label": "index.js",
+      "source_file": "packages/valkey-proxy-server/index.js",
+      "source_location": "L1"
+    },
+    {
+      "community": 1591,
+      "file_type": "code",
       "id": "scripts_harness_app_registry_test_ts",
       "label": "harness-app-registry.test.ts",
       "norm_label": "harness-app-registry.test.ts",
@@ -72202,7 +72211,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1591,
+      "community": 1592,
       "file_type": "code",
       "id": "scripts_harness_behavior_fixtures_athena_runtime_app_test_ts",
       "label": "athena-runtime-app.test.ts",
@@ -72211,7 +72220,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1592,
+      "community": 1593,
       "file_type": "code",
       "id": "scripts_harness_behavior_fixtures_storefront_runtime_api_test_ts",
       "label": "storefront-runtime-api.test.ts",
@@ -72220,7 +72229,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1593,
+      "community": 1594,
       "file_type": "code",
       "id": "scripts_harness_behavior_fixtures_valkey_runtime_app_test_ts",
       "label": "valkey-runtime-app.test.ts",
@@ -72229,7 +72238,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1594,
+      "community": 1595,
       "file_type": "code",
       "id": "scripts_harness_behavior_scenarios_test_ts",
       "label": "harness-behavior-scenarios.test.ts",
@@ -72238,7 +72247,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1595,
+      "community": 1596,
       "file_type": "code",
       "id": "scripts_harness_repo_validation_test_ts",
       "label": "harness-repo-validation.test.ts",
@@ -76236,46 +76245,46 @@
     {
       "community": 209,
       "file_type": "code",
-      "id": "index_header",
-      "label": "Header()",
-      "norm_label": "header()",
-      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
-      "source_location": "L43"
+      "id": "cashcontrolsdashboard_cn",
+      "label": "cn()",
+      "norm_label": "cn()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
+      "source_location": "L365"
     },
     {
       "community": 209,
       "file_type": "code",
-      "id": "index_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
-      "source_location": "L106"
+      "id": "cashcontrolsdashboard_if",
+      "label": "if()",
+      "norm_label": "if()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
+      "source_location": "L425"
     },
     {
       "community": 209,
       "file_type": "code",
-      "id": "index_storeassets",
-      "label": "StoreAssets()",
-      "norm_label": "storeassets()",
-      "source_file": "packages/athena-webapp/src/components/assets/index.tsx",
-      "source_location": "L23"
+      "id": "cashcontrolsdashboard_metriccardskeleton",
+      "label": "MetricCardSkeleton()",
+      "norm_label": "metriccardskeleton()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
+      "source_location": "L87"
     },
     {
       "community": 209,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_assets_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/components/assets/index.tsx",
-      "source_location": "L1"
+      "id": "cashcontrolsdashboard_switch",
+      "label": "switch()",
+      "norm_label": "switch()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
+      "source_location": "L258"
     },
     {
       "community": 209,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
+      "id": "packages_athena_webapp_src_components_cash_controls_cashcontrolsdashboard_tsx",
+      "label": "CashControlsDashboard.tsx",
+      "norm_label": "cashcontrolsdashboard.tsx",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
       "source_location": "L1"
     },
     {
@@ -76479,51 +76488,6 @@
     {
       "community": 210,
       "file_type": "code",
-      "id": "cashcontrolsdashboard_cn",
-      "label": "cn()",
-      "norm_label": "cn()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
-      "source_location": "L365"
-    },
-    {
-      "community": 210,
-      "file_type": "code",
-      "id": "cashcontrolsdashboard_if",
-      "label": "if()",
-      "norm_label": "if()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
-      "source_location": "L425"
-    },
-    {
-      "community": 210,
-      "file_type": "code",
-      "id": "cashcontrolsdashboard_metriccardskeleton",
-      "label": "MetricCardSkeleton()",
-      "norm_label": "metriccardskeleton()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
-      "source_location": "L87"
-    },
-    {
-      "community": 210,
-      "file_type": "code",
-      "id": "cashcontrolsdashboard_switch",
-      "label": "switch()",
-      "norm_label": "switch()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
-      "source_location": "L258"
-    },
-    {
-      "community": 210,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_cash_controls_cashcontrolsdashboard_tsx",
-      "label": "CashControlsDashboard.tsx",
-      "norm_label": "cashcontrolsdashboard.tsx",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 211,
-      "file_type": "code",
       "id": "packages_athena_webapp_src_components_common_pageheader_tsx",
       "label": "PageHeader.tsx",
       "norm_label": "pageheader.tsx",
@@ -76531,7 +76495,7 @@
       "source_location": "L1"
     },
     {
-      "community": 211,
+      "community": 210,
       "file_type": "code",
       "id": "pageheader_navigatebackbutton",
       "label": "NavigateBackButton()",
@@ -76540,7 +76504,7 @@
       "source_location": "L30"
     },
     {
-      "community": 211,
+      "community": 210,
       "file_type": "code",
       "id": "pageheader_pageheader",
       "label": "PageHeader()",
@@ -76549,7 +76513,7 @@
       "source_location": "L8"
     },
     {
-      "community": 211,
+      "community": 210,
       "file_type": "code",
       "id": "pageheader_simplepageheader",
       "label": "SimplePageHeader()",
@@ -76558,7 +76522,7 @@
       "source_location": "L50"
     },
     {
-      "community": 211,
+      "community": 210,
       "file_type": "code",
       "id": "pageheader_viewheader",
       "label": "ViewHeader()",
@@ -76567,7 +76531,7 @@
       "source_location": "L67"
     },
     {
-      "community": 212,
+      "community": 211,
       "file_type": "code",
       "id": "dashboard_getperiodrange",
       "label": "getPeriodRange()",
@@ -76576,7 +76540,7 @@
       "source_location": "L20"
     },
     {
-      "community": 212,
+      "community": 211,
       "file_type": "code",
       "id": "dashboard_loadingsection",
       "label": "LoadingSection()",
@@ -76585,7 +76549,7 @@
       "source_location": "L50"
     },
     {
-      "community": 212,
+      "community": 211,
       "file_type": "code",
       "id": "dashboard_renderproductssection",
       "label": "renderProductsSection()",
@@ -76594,7 +76558,7 @@
       "source_location": "L342"
     },
     {
-      "community": 212,
+      "community": 211,
       "file_type": "code",
       "id": "dashboard_rendersalessection",
       "label": "renderSalesSection()",
@@ -76603,7 +76567,7 @@
       "source_location": "L322"
     },
     {
-      "community": 212,
+      "community": 211,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_dashboard_dashboard_tsx",
       "label": "Dashboard.tsx",
@@ -76612,7 +76576,7 @@
       "source_location": "L1"
     },
     {
-      "community": 213,
+      "community": 212,
       "file_type": "code",
       "id": "herosectiontabs_handledisplaytypechange",
       "label": "handleDisplayTypeChange()",
@@ -76621,7 +76585,7 @@
       "source_location": "L61"
     },
     {
-      "community": 213,
+      "community": 212,
       "file_type": "code",
       "id": "herosectiontabs_handleimageupdate",
       "label": "handleImageUpdate()",
@@ -76630,7 +76594,7 @@
       "source_location": "L57"
     },
     {
-      "community": 213,
+      "community": 212,
       "file_type": "code",
       "id": "herosectiontabs_handleoverlaytoggle",
       "label": "handleOverlayToggle()",
@@ -76639,7 +76603,7 @@
       "source_location": "L98"
     },
     {
-      "community": 213,
+      "community": 212,
       "file_type": "code",
       "id": "herosectiontabs_handletexttoggle",
       "label": "handleTextToggle()",
@@ -76648,7 +76612,7 @@
       "source_location": "L134"
     },
     {
-      "community": 213,
+      "community": 212,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_herosectiontabs_tsx",
       "label": "HeroSectionTabs.tsx",
@@ -76657,7 +76621,7 @@
       "source_location": "L1"
     },
     {
-      "community": 214,
+      "community": 213,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_reeluploader_tsx",
       "label": "ReelUploader.tsx",
@@ -76666,7 +76630,7 @@
       "source_location": "L1"
     },
     {
-      "community": 214,
+      "community": 213,
       "file_type": "code",
       "id": "reeluploader_formatfilesize",
       "label": "formatFileSize()",
@@ -76675,7 +76639,7 @@
       "source_location": "L38"
     },
     {
-      "community": 214,
+      "community": 213,
       "file_type": "code",
       "id": "reeluploader_handlefileselect",
       "label": "handleFileSelect()",
@@ -76684,7 +76648,7 @@
       "source_location": "L64"
     },
     {
-      "community": 214,
+      "community": 213,
       "file_type": "code",
       "id": "reeluploader_handleupload",
       "label": "handleUpload()",
@@ -76693,7 +76657,7 @@
       "source_location": "L135"
     },
     {
-      "community": 214,
+      "community": 213,
       "file_type": "code",
       "id": "reeluploader_validatefile",
       "label": "validateFile()",
@@ -76702,7 +76666,7 @@
       "source_location": "L43"
     },
     {
-      "community": 215,
+      "community": 214,
       "file_type": "code",
       "id": "dailyoperationsview_test_formattestoperatingdate",
       "label": "formatTestOperatingDate()",
@@ -76711,7 +76675,7 @@
       "source_location": "L356"
     },
     {
-      "community": 215,
+      "community": 214,
       "file_type": "code",
       "id": "dailyoperationsview_test_getcurrentlocaloperatingdate",
       "label": "getCurrentLocalOperatingDate()",
@@ -76720,7 +76684,7 @@
       "source_location": "L323"
     },
     {
-      "community": 215,
+      "community": 214,
       "file_type": "code",
       "id": "dailyoperationsview_test_getcurrentsaturdayweekendoperatingdate",
       "label": "getCurrentSaturdayWeekEndOperatingDate()",
@@ -76729,7 +76693,7 @@
       "source_location": "L332"
     },
     {
-      "community": 215,
+      "community": 214,
       "file_type": "code",
       "id": "dailyoperationsview_test_shifttestoperatingdate",
       "label": "shiftTestOperatingDate()",
@@ -76738,7 +76702,7 @@
       "source_location": "L346"
     },
     {
-      "community": 215,
+      "community": 214,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_dailyoperationsview_test_tsx",
       "label": "DailyOperationsView.test.tsx",
@@ -76747,7 +76711,7 @@
       "source_location": "L1"
     },
     {
-      "community": 216,
+      "community": 215,
       "file_type": "code",
       "id": "activityview_iscreatedaction",
       "label": "isCreatedAction()",
@@ -76756,7 +76720,7 @@
       "source_location": "L58"
     },
     {
-      "community": 216,
+      "community": 215,
       "file_type": "code",
       "id": "activityview_isfeedbackrequestaction",
       "label": "isFeedbackRequestAction()",
@@ -76765,7 +76729,7 @@
       "source_location": "L63"
     },
     {
-      "community": 216,
+      "community": 215,
       "file_type": "code",
       "id": "activityview_isrefundaction",
       "label": "isRefundAction()",
@@ -76774,7 +76738,7 @@
       "source_location": "L50"
     },
     {
-      "community": 216,
+      "community": 215,
       "file_type": "code",
       "id": "activityview_istransitionaction",
       "label": "isTransitionAction()",
@@ -76783,7 +76747,7 @@
       "source_location": "L53"
     },
     {
-      "community": 216,
+      "community": 215,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_activityview_tsx",
       "label": "ActivityView.tsx",
@@ -76792,7 +76756,7 @@
       "source_location": "L1"
     },
     {
-      "community": 217,
+      "community": 216,
       "file_type": "code",
       "id": "orderdetailsview_fetchtransactions",
       "label": "fetchTransactions()",
@@ -76801,7 +76765,7 @@
       "source_location": "L140"
     },
     {
-      "community": 217,
+      "community": 216,
       "file_type": "code",
       "id": "orderdetailsview_handlemarkasverified",
       "label": "handleMarkAsVerified()",
@@ -76810,7 +76774,7 @@
       "source_location": "L177"
     },
     {
-      "community": 217,
+      "community": 216,
       "file_type": "code",
       "id": "orderdetailsview_handlemarkpaymentcollected",
       "label": "handleMarkPaymentCollected()",
@@ -76819,7 +76783,7 @@
       "source_location": "L195"
     },
     {
-      "community": 217,
+      "community": 216,
       "file_type": "code",
       "id": "orderdetailsview_verifiedbadge",
       "label": "VerifiedBadge()",
@@ -76828,7 +76792,7 @@
       "source_location": "L45"
     },
     {
-      "community": 217,
+      "community": 216,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orderdetailsview_tsx",
       "label": "OrderDetailsView.tsx",
@@ -76837,7 +76801,7 @@
       "source_location": "L1"
     },
     {
-      "community": 218,
+      "community": 217,
       "file_type": "code",
       "id": "orderitemsview_handlerequestfeedback",
       "label": "handleRequestFeedback()",
@@ -76846,7 +76810,7 @@
       "source_location": "L92"
     },
     {
-      "community": 218,
+      "community": 217,
       "file_type": "code",
       "id": "orderitemsview_handlerestockall",
       "label": "handleRestockAll()",
@@ -76855,7 +76819,7 @@
       "source_location": "L307"
     },
     {
-      "community": 218,
+      "community": 217,
       "file_type": "code",
       "id": "orderitemsview_handlereturnitemtostock",
       "label": "handleReturnItemToStock()",
@@ -76864,7 +76828,7 @@
       "source_location": "L70"
     },
     {
-      "community": 218,
+      "community": 217,
       "file_type": "code",
       "id": "orderitemsview_handleupdateorderitem",
       "label": "handleUpdateOrderItem()",
@@ -76873,7 +76837,7 @@
       "source_location": "L50"
     },
     {
-      "community": 218,
+      "community": 217,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orderitemsview_tsx",
       "label": "OrderItemsView.tsx",
@@ -76882,7 +76846,7 @@
       "source_location": "L1"
     },
     {
-      "community": 219,
+      "community": 218,
       "file_type": "code",
       "id": "ordersummary_test_getbalancedueamount",
       "label": "getBalanceDueAmount()",
@@ -76891,7 +76855,7 @@
       "source_location": "L40"
     },
     {
-      "community": 219,
+      "community": 218,
       "file_type": "code",
       "id": "ordersummary_test_getbalanceduelabel",
       "label": "getBalanceDueLabel()",
@@ -76900,7 +76864,7 @@
       "source_location": "L57"
     },
     {
-      "community": 219,
+      "community": 218,
       "file_type": "code",
       "id": "ordersummary_test_getbalanceduepanel",
       "label": "getBalanceDuePanel()",
@@ -76909,7 +76873,7 @@
       "source_location": "L66"
     },
     {
-      "community": 219,
+      "community": 218,
       "file_type": "code",
       "id": "ordersummary_test_stripwhitespace",
       "label": "stripWhitespace()",
@@ -76918,13 +76882,58 @@
       "source_location": "L36"
     },
     {
-      "community": 219,
+      "community": 218,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_ordersummary_test_tsx",
       "label": "OrderSummary.test.tsx",
       "norm_label": "ordersummary.test.tsx",
       "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.test.tsx",
       "source_location": "L1"
+    },
+    {
+      "community": 219,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_paymentsaddedlist_test_tsx",
+      "label": "PaymentsAddedList.test.tsx",
+      "norm_label": "paymentsaddedlist.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 219,
+      "file_type": "code",
+      "id": "paymentsaddedlist_test_getsummaryamount",
+      "label": "getSummaryAmount()",
+      "norm_label": "getsummaryamount()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.test.tsx",
+      "source_location": "L27"
+    },
+    {
+      "community": 219,
+      "file_type": "code",
+      "id": "paymentsaddedlist_test_getsummarylabel",
+      "label": "getSummaryLabel()",
+      "norm_label": "getsummarylabel()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.test.tsx",
+      "source_location": "L18"
+    },
+    {
+      "community": 219,
+      "file_type": "code",
+      "id": "paymentsaddedlist_test_getsummarypanel",
+      "label": "getSummaryPanel()",
+      "norm_label": "getsummarypanel()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.test.tsx",
+      "source_location": "L40"
+    },
+    {
+      "community": 219,
+      "file_type": "code",
+      "id": "paymentsaddedlist_test_stripwhitespace",
+      "label": "stripWhitespace()",
+      "norm_label": "stripwhitespace()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.test.tsx",
+      "source_location": "L14"
     },
     {
       "community": 22,
@@ -77127,51 +77136,6 @@
     {
       "community": 220,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_paymentsaddedlist_test_tsx",
-      "label": "PaymentsAddedList.test.tsx",
-      "norm_label": "paymentsaddedlist.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 220,
-      "file_type": "code",
-      "id": "paymentsaddedlist_test_getsummaryamount",
-      "label": "getSummaryAmount()",
-      "norm_label": "getsummaryamount()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.test.tsx",
-      "source_location": "L27"
-    },
-    {
-      "community": 220,
-      "file_type": "code",
-      "id": "paymentsaddedlist_test_getsummarylabel",
-      "label": "getSummaryLabel()",
-      "norm_label": "getsummarylabel()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.test.tsx",
-      "source_location": "L18"
-    },
-    {
-      "community": 220,
-      "file_type": "code",
-      "id": "paymentsaddedlist_test_getsummarypanel",
-      "label": "getSummaryPanel()",
-      "norm_label": "getsummarypanel()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.test.tsx",
-      "source_location": "L40"
-    },
-    {
-      "community": 220,
-      "file_type": "code",
-      "id": "paymentsaddedlist_test_stripwhitespace",
-      "label": "stripWhitespace()",
-      "norm_label": "stripwhitespace()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.test.tsx",
-      "source_location": "L14"
-    },
-    {
-      "community": 221,
-      "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_productentry_tsx",
       "label": "ProductEntry.tsx",
       "norm_label": "productentry.tsx",
@@ -77179,7 +77143,7 @@
       "source_location": "L1"
     },
     {
-      "community": 221,
+      "community": 220,
       "file_type": "code",
       "id": "productentry_handleclearsearch",
       "label": "handleClearSearch()",
@@ -77188,7 +77152,7 @@
       "source_location": "L234"
     },
     {
-      "community": 221,
+      "community": 220,
       "file_type": "code",
       "id": "productentry_handleopenquickadd",
       "label": "handleOpenQuickAdd()",
@@ -77197,7 +77161,7 @@
       "source_location": "L239"
     },
     {
-      "community": 221,
+      "community": 220,
       "file_type": "code",
       "id": "productentry_handlequickaddsubmit",
       "label": "handleQuickAddSubmit()",
@@ -77206,7 +77170,7 @@
       "source_location": "L272"
     },
     {
-      "community": 221,
+      "community": 220,
       "file_type": "code",
       "id": "productentry_resetquickaddform",
       "label": "resetQuickAddForm()",
@@ -77215,7 +77179,7 @@
       "source_location": "L263"
     },
     {
-      "community": 222,
+      "community": 221,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_registerdrawergate_tsx",
       "label": "RegisterDrawerGate.tsx",
@@ -77224,7 +77188,7 @@
       "source_location": "L1"
     },
     {
-      "community": 222,
+      "community": 221,
       "file_type": "code",
       "id": "registerdrawergate_handlecloseoutsubmit",
       "label": "handleCloseoutSubmit()",
@@ -77233,7 +77197,7 @@
       "source_location": "L80"
     },
     {
-      "community": 222,
+      "community": 221,
       "file_type": "code",
       "id": "registerdrawergate_handleopeningfloatcorrectionsubmit",
       "label": "handleOpeningFloatCorrectionSubmit()",
@@ -77242,7 +77206,7 @@
       "source_location": "L84"
     },
     {
-      "community": 222,
+      "community": 221,
       "file_type": "code",
       "id": "registerdrawergate_handlesubmit",
       "label": "handleSubmit()",
@@ -77251,7 +77215,7 @@
       "source_location": "L73"
     },
     {
-      "community": 222,
+      "community": 221,
       "file_type": "code",
       "id": "registerdrawergate_if",
       "label": "if()",
@@ -77260,7 +77224,7 @@
       "source_location": "L61"
     },
     {
-      "community": 223,
+      "community": 222,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodeview_tsx",
       "label": "PromoCodeView.tsx",
@@ -77269,7 +77233,7 @@
       "source_location": "L1"
     },
     {
-      "community": 223,
+      "community": 222,
       "file_type": "code",
       "id": "promocodeview_handleaddpromocode",
       "label": "handleAddPromoCode()",
@@ -77278,7 +77242,7 @@
       "source_location": "L158"
     },
     {
-      "community": 223,
+      "community": 222,
       "file_type": "code",
       "id": "promocodeview_handleupdatepromocode",
       "label": "handleUpdatePromoCode()",
@@ -77287,7 +77251,7 @@
       "source_location": "L231"
     },
     {
-      "community": 223,
+      "community": 222,
       "file_type": "code",
       "id": "promocodeview_updatehomepagediscountcode",
       "label": "updateHomepageDiscountCode()",
@@ -77296,7 +77260,7 @@
       "source_location": "L324"
     },
     {
-      "community": 223,
+      "community": 222,
       "file_type": "code",
       "id": "promocodeview_updateleaveareviewdiscountcode",
       "label": "updateLeaveAReviewDiscountCode()",
@@ -77305,7 +77269,7 @@
       "source_location": "L379"
     },
     {
-      "community": 224,
+      "community": 223,
       "file_type": "code",
       "id": "date_time_picker_handleclear",
       "label": "handleClear()",
@@ -77314,7 +77278,7 @@
       "source_location": "L99"
     },
     {
-      "community": 224,
+      "community": 223,
       "file_type": "code",
       "id": "date_time_picker_handledateselect",
       "label": "handleDateSelect()",
@@ -77323,7 +77287,7 @@
       "source_location": "L53"
     },
     {
-      "community": 224,
+      "community": 223,
       "file_type": "code",
       "id": "date_time_picker_handletimeblur",
       "label": "handleTimeBlur()",
@@ -77332,7 +77296,7 @@
       "source_location": "L75"
     },
     {
-      "community": 224,
+      "community": 223,
       "file_type": "code",
       "id": "date_time_picker_handletimechange",
       "label": "handleTimeChange()",
@@ -77341,7 +77305,7 @@
       "source_location": "L63"
     },
     {
-      "community": 224,
+      "community": 223,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_date_time_picker_tsx",
       "label": "date-time-picker.tsx",
@@ -77350,7 +77314,7 @@
       "source_location": "L1"
     },
     {
-      "community": 225,
+      "community": 224,
       "file_type": "code",
       "id": "custom_modal_example_basicmodalexample",
       "label": "BasicModalExample()",
@@ -77359,7 +77323,7 @@
       "source_location": "L7"
     },
     {
-      "community": 225,
+      "community": 224,
       "file_type": "code",
       "id": "custom_modal_example_customclosebuttonexample",
       "label": "CustomCloseButtonExample()",
@@ -77368,7 +77332,7 @@
       "source_location": "L69"
     },
     {
-      "community": 225,
+      "community": 224,
       "file_type": "code",
       "id": "custom_modal_example_custompositionmodalexample",
       "label": "CustomPositionModalExample()",
@@ -77377,7 +77341,7 @@
       "source_location": "L44"
     },
     {
-      "community": 225,
+      "community": 224,
       "file_type": "code",
       "id": "custom_modal_example_fullscreenmodalexample",
       "label": "FullScreenModalExample()",
@@ -77386,7 +77350,7 @@
       "source_location": "L103"
     },
     {
-      "community": 225,
+      "community": 224,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_custom_modal_example_tsx",
       "label": "custom-modal-example.tsx",
@@ -77395,7 +77359,7 @@
       "source_location": "L1"
     },
     {
-      "community": 226,
+      "community": 225,
       "file_type": "code",
       "id": "config_getruntimeorigin",
       "label": "getRuntimeOrigin()",
@@ -77404,7 +77368,7 @@
       "source_location": "L12"
     },
     {
-      "community": 226,
+      "community": 225,
       "file_type": "code",
       "id": "config_islocalhost",
       "label": "isLocalHost()",
@@ -77413,7 +77377,7 @@
       "source_location": "L20"
     },
     {
-      "community": 226,
+      "community": 225,
       "file_type": "code",
       "id": "config_resolvestorefronturl",
       "label": "resolveStoreFrontUrl()",
@@ -77422,7 +77386,7 @@
       "source_location": "L24"
     },
     {
-      "community": 226,
+      "community": 225,
       "file_type": "code",
       "id": "config_trimtrailingslash",
       "label": "trimTrailingSlash()",
@@ -77431,7 +77395,7 @@
       "source_location": "L8"
     },
     {
-      "community": 226,
+      "community": 225,
       "file_type": "code",
       "id": "packages_athena_webapp_src_config_ts",
       "label": "config.ts",
@@ -77440,7 +77404,7 @@
       "source_location": "L1"
     },
     {
-      "community": 227,
+      "community": 226,
       "file_type": "code",
       "id": "browserfingerprint_buffertohex",
       "label": "bufferToHex()",
@@ -77449,7 +77413,7 @@
       "source_location": "L18"
     },
     {
-      "community": 227,
+      "community": 226,
       "file_type": "code",
       "id": "browserfingerprint_collectbrowserinfo",
       "label": "collectBrowserInfo()",
@@ -77458,7 +77422,7 @@
       "source_location": "L23"
     },
     {
-      "community": 227,
+      "community": 226,
       "file_type": "code",
       "id": "browserfingerprint_generatebrowserfingerprint",
       "label": "generateBrowserFingerprint()",
@@ -77467,7 +77431,7 @@
       "source_location": "L65"
     },
     {
-      "community": 227,
+      "community": 226,
       "file_type": "code",
       "id": "browserfingerprint_hashfingerprintsource",
       "label": "hashFingerprintSource()",
@@ -77476,7 +77440,7 @@
       "source_location": "L45"
     },
     {
-      "community": 227,
+      "community": 226,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_browserfingerprint_ts",
       "label": "browserFingerprint.ts",
@@ -77485,7 +77449,7 @@
       "source_location": "L1"
     },
     {
-      "community": 228,
+      "community": 227,
       "file_type": "code",
       "id": "imageutils_test_arraybuffer",
       "label": "arrayBuffer()",
@@ -77494,7 +77458,7 @@
       "source_location": "L78"
     },
     {
-      "community": 228,
+      "community": 227,
       "file_type": "code",
       "id": "imageutils_test_constructor",
       "label": "constructor()",
@@ -77503,7 +77467,7 @@
       "source_location": "L74"
     },
     {
-      "community": 228,
+      "community": 227,
       "file_type": "code",
       "id": "imageutils_test_mockimage",
       "label": "MockImage",
@@ -77512,7 +77476,7 @@
       "source_location": "L103"
     },
     {
-      "community": 228,
+      "community": 227,
       "file_type": "code",
       "id": "imageutils_test_mockimage_src",
       "label": ".src()",
@@ -77521,7 +77485,7 @@
       "source_location": "L109"
     },
     {
-      "community": 228,
+      "community": 227,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_imageutils_test_ts",
       "label": "imageUtils.test.ts",
@@ -77530,7 +77494,7 @@
       "source_location": "L1"
     },
     {
-      "community": 229,
+      "community": 228,
       "file_type": "code",
       "id": "imageutils_convertimagestojpg",
       "label": "convertImagesToJpg()",
@@ -77539,7 +77503,7 @@
       "source_location": "L75"
     },
     {
-      "community": 229,
+      "community": 228,
       "file_type": "code",
       "id": "imageutils_convertimagestowebp",
       "label": "convertImagesToWebp()",
@@ -77548,7 +77512,7 @@
       "source_location": "L26"
     },
     {
-      "community": 229,
+      "community": 228,
       "file_type": "code",
       "id": "imageutils_converttojpg",
       "label": "convertToJpg()",
@@ -77557,7 +77521,7 @@
       "source_location": "L38"
     },
     {
-      "community": 229,
+      "community": 228,
       "file_type": "code",
       "id": "imageutils_getuploadimagesdata",
       "label": "getUploadImagesData()",
@@ -77566,12 +77530,57 @@
       "source_location": "L4"
     },
     {
-      "community": 229,
+      "community": 228,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_imageutils_ts",
       "label": "imageUtils.ts",
       "norm_label": "imageutils.ts",
       "source_file": "packages/athena-webapp/src/lib/imageUtils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 229,
+      "file_type": "code",
+      "id": "cart_calculateposcarttotals",
+      "label": "calculatePosCartTotals()",
+      "norm_label": "calculateposcarttotals()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/cart.ts",
+      "source_location": "L3"
+    },
+    {
+      "community": 229,
+      "file_type": "code",
+      "id": "cart_calculatepositemtotal",
+      "label": "calculatePosItemTotal()",
+      "norm_label": "calculatepositemtotal()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/cart.ts",
+      "source_location": "L29"
+    },
+    {
+      "community": 229,
+      "file_type": "code",
+      "id": "cart_getposeffectiveprice",
+      "label": "getPosEffectivePrice()",
+      "norm_label": "getposeffectiveprice()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/cart.ts",
+      "source_location": "L33"
+    },
+    {
+      "community": 229,
+      "file_type": "code",
+      "id": "cart_roundposamount",
+      "label": "roundPosAmount()",
+      "norm_label": "roundposamount()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/cart.ts",
+      "source_location": "L40"
+    },
+    {
+      "community": 229,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_domain_cart_ts",
+      "label": "cart.ts",
+      "norm_label": "cart.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/cart.ts",
       "source_location": "L1"
     },
     {
@@ -77766,51 +77775,6 @@
     {
       "community": 230,
       "file_type": "code",
-      "id": "cart_calculateposcarttotals",
-      "label": "calculatePosCartTotals()",
-      "norm_label": "calculateposcarttotals()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/cart.ts",
-      "source_location": "L3"
-    },
-    {
-      "community": 230,
-      "file_type": "code",
-      "id": "cart_calculatepositemtotal",
-      "label": "calculatePosItemTotal()",
-      "norm_label": "calculatepositemtotal()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/cart.ts",
-      "source_location": "L29"
-    },
-    {
-      "community": 230,
-      "file_type": "code",
-      "id": "cart_getposeffectiveprice",
-      "label": "getPosEffectivePrice()",
-      "norm_label": "getposeffectiveprice()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/cart.ts",
-      "source_location": "L33"
-    },
-    {
-      "community": 230,
-      "file_type": "code",
-      "id": "cart_roundposamount",
-      "label": "roundPosAmount()",
-      "norm_label": "roundposamount()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/cart.ts",
-      "source_location": "L40"
-    },
-    {
-      "community": 230,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_domain_cart_ts",
-      "label": "cart.ts",
-      "norm_label": "cart.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/cart.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 231,
-      "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_registergateway_ts",
       "label": "registerGateway.ts",
       "norm_label": "registergateway.ts",
@@ -77818,7 +77782,7 @@
       "source_location": "L1"
     },
     {
-      "community": 231,
+      "community": 230,
       "file_type": "code",
       "id": "registergateway_mapregisterstatedto",
       "label": "mapRegisterStateDto()",
@@ -77827,7 +77791,7 @@
       "source_location": "L12"
     },
     {
-      "community": 231,
+      "community": 230,
       "file_type": "code",
       "id": "registergateway_mapterminaldto",
       "label": "mapTerminalDto()",
@@ -77836,7 +77800,7 @@
       "source_location": "L30"
     },
     {
-      "community": 231,
+      "community": 230,
       "file_type": "code",
       "id": "registergateway_useconvexregisterstate",
       "label": "useConvexRegisterState()",
@@ -77845,7 +77809,7 @@
       "source_location": "L36"
     },
     {
-      "community": 231,
+      "community": 230,
       "file_type": "code",
       "id": "registergateway_useconvexterminalbyfingerprint",
       "label": "useConvexTerminalByFingerprint()",
@@ -77854,7 +77818,7 @@
       "source_location": "L58"
     },
     {
-      "community": 232,
+      "community": 231,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_transactionutils_ts",
       "label": "transactionUtils.ts",
@@ -77863,7 +77827,7 @@
       "source_location": "L1"
     },
     {
-      "community": 232,
+      "community": 231,
       "file_type": "code",
       "id": "transactionutils_calculatechange",
       "label": "calculateChange()",
@@ -77872,7 +77836,7 @@
       "source_location": "L42"
     },
     {
-      "community": 232,
+      "community": 231,
       "file_type": "code",
       "id": "transactionutils_formatcurrency",
       "label": "formatCurrency()",
@@ -77881,7 +77845,7 @@
       "source_location": "L29"
     },
     {
-      "community": 232,
+      "community": 231,
       "file_type": "code",
       "id": "transactionutils_formattimestamp",
       "label": "formatTimestamp()",
@@ -77890,7 +77854,7 @@
       "source_location": "L49"
     },
     {
-      "community": 232,
+      "community": 231,
       "file_type": "code",
       "id": "transactionutils_generatetransactionnumber",
       "label": "generateTransactionNumber()",
@@ -77899,7 +77863,7 @@
       "source_location": "L14"
     },
     {
-      "community": 233,
+      "community": 232,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_timelineutils_ts",
       "label": "timelineUtils.ts",
@@ -77908,7 +77872,7 @@
       "source_location": "L1"
     },
     {
-      "community": 233,
+      "community": 232,
       "file_type": "code",
       "id": "timelineutils_enrichtimelineevent",
       "label": "enrichTimelineEvent()",
@@ -77917,7 +77881,7 @@
       "source_location": "L184"
     },
     {
-      "community": 233,
+      "community": 232,
       "file_type": "code",
       "id": "timelineutils_enrichtimelineevents",
       "label": "enrichTimelineEvents()",
@@ -77926,7 +77890,7 @@
       "source_location": "L200"
     },
     {
-      "community": 233,
+      "community": 232,
       "file_type": "code",
       "id": "timelineutils_gettimerangelabel",
       "label": "getTimeRangeLabel()",
@@ -77935,7 +77899,7 @@
       "source_location": "L244"
     },
     {
-      "community": 233,
+      "community": 232,
       "file_type": "code",
       "id": "timelineutils_groupeventsbytimeframe",
       "label": "groupEventsByTimeframe()",
@@ -77944,7 +77908,7 @@
       "source_location": "L206"
     },
     {
-      "community": 234,
+      "community": 233,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_procurement_index_tsx",
       "label": "procurement.index.tsx",
@@ -77953,7 +77917,7 @@
       "source_location": "L1"
     },
     {
-      "community": 234,
+      "community": 233,
       "file_type": "code",
       "id": "procurement_index_getnextprocurementmodesearch",
       "label": "getNextProcurementModeSearch()",
@@ -77962,7 +77926,7 @@
       "source_location": "L16"
     },
     {
-      "community": 234,
+      "community": 233,
       "file_type": "code",
       "id": "procurement_index_getnextprocurementpagesearch",
       "label": "getNextProcurementPageSearch()",
@@ -77971,7 +77935,7 @@
       "source_location": "L34"
     },
     {
-      "community": 234,
+      "community": 233,
       "file_type": "code",
       "id": "procurement_index_getnextprocurementselectedskusearch",
       "label": "getNextProcurementSelectedSkuSearch()",
@@ -77980,7 +77944,7 @@
       "source_location": "L44"
     },
     {
-      "community": 234,
+      "community": 233,
       "file_type": "code",
       "id": "procurement_index_procurementroute",
       "label": "ProcurementRoute()",
@@ -77989,7 +77953,7 @@
       "source_location": "L70"
     },
     {
-      "community": 235,
+      "community": 234,
       "file_type": "code",
       "id": "authed_authedcomponent",
       "label": "AuthedComponent()",
@@ -77998,7 +77962,7 @@
       "source_location": "L29"
     },
     {
-      "community": 235,
+      "community": 234,
       "file_type": "code",
       "id": "authed_layout",
       "label": "Layout()",
@@ -78007,7 +77971,7 @@
       "source_location": "L99"
     },
     {
-      "community": 235,
+      "community": 234,
       "file_type": "code",
       "id": "authed_topbar",
       "label": "TopBar()",
@@ -78016,7 +77980,7 @@
       "source_location": "L74"
     },
     {
-      "community": 235,
+      "community": 234,
       "file_type": "code",
       "id": "authed_usermenu",
       "label": "UserMenu()",
@@ -78025,7 +77989,7 @@
       "source_location": "L39"
     },
     {
-      "community": 235,
+      "community": 234,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_tsx",
       "label": "_authed.tsx",
@@ -78034,7 +77998,7 @@
       "source_location": "L1"
     },
     {
-      "community": 236,
+      "community": 235,
       "file_type": "code",
       "id": "layout_completependingauthsync",
       "label": "completePendingAuthSync()",
@@ -78043,7 +78007,7 @@
       "source_location": "L114"
     },
     {
-      "community": 236,
+      "community": 235,
       "file_type": "code",
       "id": "layout_handlependingauthsync",
       "label": "handlePendingAuthSync()",
@@ -78052,7 +78016,7 @@
       "source_location": "L81"
     },
     {
-      "community": 236,
+      "community": 235,
       "file_type": "code",
       "id": "layout_sleep",
       "label": "sleep()",
@@ -78061,7 +78025,7 @@
       "source_location": "L23"
     },
     {
-      "community": 236,
+      "community": 235,
       "file_type": "code",
       "id": "layout_usedocumentscrolllock",
       "label": "useDocumentScrollLock()",
@@ -78070,7 +78034,7 @@
       "source_location": "L27"
     },
     {
-      "community": 236,
+      "community": 235,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_login_layout_tsx",
       "label": "_layout.tsx",
@@ -78079,7 +78043,7 @@
       "source_location": "L1"
     },
     {
-      "community": 237,
+      "community": 236,
       "file_type": "code",
       "id": "analytics_getproductviewcount",
       "label": "getProductViewCount()",
@@ -78088,7 +78052,7 @@
       "source_location": "L93"
     },
     {
-      "community": 237,
+      "community": 236,
       "file_type": "code",
       "id": "analytics_logout",
       "label": "logout()",
@@ -78097,7 +78061,7 @@
       "source_location": "L75"
     },
     {
-      "community": 237,
+      "community": 236,
       "file_type": "code",
       "id": "analytics_postanalytics",
       "label": "postAnalytics()",
@@ -78106,7 +78070,7 @@
       "source_location": "L4"
     },
     {
-      "community": 237,
+      "community": 236,
       "file_type": "code",
       "id": "analytics_updateanalyticsowner",
       "label": "updateAnalyticsOwner()",
@@ -78115,7 +78079,7 @@
       "source_location": "L47"
     },
     {
-      "community": 237,
+      "community": 236,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_analytics_ts",
       "label": "analytics.ts",
@@ -78124,7 +78088,7 @@
       "source_location": "L1"
     },
     {
-      "community": 238,
+      "community": 237,
       "file_type": "code",
       "id": "category_getallcategories",
       "label": "getAllCategories()",
@@ -78133,7 +78097,7 @@
       "source_location": "L11"
     },
     {
-      "community": 238,
+      "community": 237,
       "file_type": "code",
       "id": "category_getallcategorieswithsubcategories",
       "label": "getAllCategoriesWithSubcategories()",
@@ -78142,7 +78106,7 @@
       "source_location": "L25"
     },
     {
-      "community": 238,
+      "community": 237,
       "file_type": "code",
       "id": "category_getbaseurl",
       "label": "getBaseUrl()",
@@ -78151,7 +78115,7 @@
       "source_location": "L9"
     },
     {
-      "community": 238,
+      "community": 237,
       "file_type": "code",
       "id": "category_getcategory",
       "label": "getCategory()",
@@ -78160,7 +78124,7 @@
       "source_location": "L39"
     },
     {
-      "community": 238,
+      "community": 237,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_category_ts",
       "label": "category.ts",
@@ -78169,7 +78133,7 @@
       "source_location": "L1"
     },
     {
-      "community": 239,
+      "community": 238,
       "file_type": "code",
       "id": "onlineorder_getbaseurl",
       "label": "getBaseUrl()",
@@ -78178,7 +78142,7 @@
       "source_location": "L4"
     },
     {
-      "community": 239,
+      "community": 238,
       "file_type": "code",
       "id": "onlineorder_getorder",
       "label": "getOrder()",
@@ -78187,7 +78151,7 @@
       "source_location": "L24"
     },
     {
-      "community": 239,
+      "community": 238,
       "file_type": "code",
       "id": "onlineorder_getorders",
       "label": "getOrders()",
@@ -78196,7 +78160,7 @@
       "source_location": "L6"
     },
     {
-      "community": 239,
+      "community": 238,
       "file_type": "code",
       "id": "onlineorder_updateordersowner",
       "label": "updateOrdersOwner()",
@@ -78205,13 +78169,58 @@
       "source_location": "L42"
     },
     {
-      "community": 239,
+      "community": 238,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_onlineorder_ts",
       "label": "onlineOrder.ts",
       "norm_label": "onlineorder.ts",
       "source_file": "packages/storefront-webapp/src/api/onlineOrder.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 239,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_api_storefrontuser_ts",
+      "label": "storeFrontUser.ts",
+      "norm_label": "storefrontuser.ts",
+      "source_file": "packages/storefront-webapp/src/api/storeFrontUser.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 239,
+      "file_type": "code",
+      "id": "storefrontuser_getactiveuser",
+      "label": "getActiveUser()",
+      "norm_label": "getactiveuser()",
+      "source_file": "packages/storefront-webapp/src/api/storeFrontUser.ts",
+      "source_location": "L28"
+    },
+    {
+      "community": 239,
+      "file_type": "code",
+      "id": "storefrontuser_getbaseurl",
+      "label": "getBaseUrl()",
+      "norm_label": "getbaseurl()",
+      "source_file": "packages/storefront-webapp/src/api/storeFrontUser.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 239,
+      "file_type": "code",
+      "id": "storefrontuser_getguest",
+      "label": "getGuest()",
+      "norm_label": "getguest()",
+      "source_file": "packages/storefront-webapp/src/api/storeFrontUser.ts",
+      "source_location": "L7"
+    },
+    {
+      "community": 239,
+      "file_type": "code",
+      "id": "storefrontuser_updateuser",
+      "label": "updateUser()",
+      "norm_label": "updateuser()",
+      "source_file": "packages/storefront-webapp/src/api/storeFrontUser.ts",
+      "source_location": "L46"
     },
     {
       "community": 24,
@@ -78405,51 +78414,6 @@
     {
       "community": 240,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_storefrontuser_ts",
-      "label": "storeFrontUser.ts",
-      "norm_label": "storefrontuser.ts",
-      "source_file": "packages/storefront-webapp/src/api/storeFrontUser.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 240,
-      "file_type": "code",
-      "id": "storefrontuser_getactiveuser",
-      "label": "getActiveUser()",
-      "norm_label": "getactiveuser()",
-      "source_file": "packages/storefront-webapp/src/api/storeFrontUser.ts",
-      "source_location": "L28"
-    },
-    {
-      "community": 240,
-      "file_type": "code",
-      "id": "storefrontuser_getbaseurl",
-      "label": "getBaseUrl()",
-      "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/storeFrontUser.ts",
-      "source_location": "L5"
-    },
-    {
-      "community": 240,
-      "file_type": "code",
-      "id": "storefrontuser_getguest",
-      "label": "getGuest()",
-      "norm_label": "getguest()",
-      "source_file": "packages/storefront-webapp/src/api/storeFrontUser.ts",
-      "source_location": "L7"
-    },
-    {
-      "community": 240,
-      "file_type": "code",
-      "id": "storefrontuser_updateuser",
-      "label": "updateUser()",
-      "norm_label": "updateuser()",
-      "source_file": "packages/storefront-webapp/src/api/storeFrontUser.ts",
-      "source_location": "L46"
-    },
-    {
-      "community": 241,
-      "file_type": "code",
       "id": "homepage_enableprompts",
       "label": "enablePrompts()",
       "norm_label": "enableprompts()",
@@ -78457,7 +78421,7 @@
       "source_location": "L147"
     },
     {
-      "community": 241,
+      "community": 240,
       "file_type": "code",
       "id": "homepage_handleclickonleavereviewbutton",
       "label": "handleClickOnLeaveReviewButton()",
@@ -78466,7 +78430,7 @@
       "source_location": "L186"
     },
     {
-      "community": 241,
+      "community": 240,
       "file_type": "code",
       "id": "homepage_handlescroll",
       "label": "handleScroll()",
@@ -78475,7 +78439,7 @@
       "source_location": "L115"
     },
     {
-      "community": 241,
+      "community": 240,
       "file_type": "code",
       "id": "homepage_homepagereadyshell",
       "label": "HomePageReadyShell()",
@@ -78484,7 +78448,7 @@
       "source_location": "L31"
     },
     {
-      "community": 241,
+      "community": 240,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_homepage_tsx",
       "label": "HomePage.tsx",
@@ -78493,7 +78457,7 @@
       "source_location": "L1"
     },
     {
-      "community": 242,
+      "community": 241,
       "file_type": "code",
       "id": "inventorylevelbadge_lowstockbadge",
       "label": "LowStockBadge()",
@@ -78502,7 +78466,7 @@
       "source_location": "L14"
     },
     {
-      "community": 242,
+      "community": 241,
       "file_type": "code",
       "id": "inventorylevelbadge_sellingfastbadge",
       "label": "SellingFastBadge()",
@@ -78511,7 +78475,7 @@
       "source_location": "L22"
     },
     {
-      "community": 242,
+      "community": 241,
       "file_type": "code",
       "id": "inventorylevelbadge_sellingfastsignal",
       "label": "SellingFastSignal()",
@@ -78520,7 +78484,7 @@
       "source_location": "L30"
     },
     {
-      "community": 242,
+      "community": 241,
       "file_type": "code",
       "id": "inventorylevelbadge_soldoutbadge",
       "label": "SoldOutBadge()",
@@ -78529,7 +78493,7 @@
       "source_location": "L3"
     },
     {
-      "community": 242,
+      "community": 241,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_inventorylevelbadge_tsx",
       "label": "InventoryLevelBadge.tsx",
@@ -78538,7 +78502,7 @@
       "source_location": "L1"
     },
     {
-      "community": 243,
+      "community": 242,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_storefrontfailureobservability_ts",
       "label": "storefrontFailureObservability.ts",
@@ -78547,7 +78511,7 @@
       "source_location": "L1"
     },
     {
-      "community": 243,
+      "community": 242,
       "file_type": "code",
       "id": "storefrontfailureobservability_createstorefrontfailureevent",
       "label": "createStorefrontFailureEvent()",
@@ -78556,7 +78520,7 @@
       "source_location": "L136"
     },
     {
-      "community": 243,
+      "community": 242,
       "file_type": "code",
       "id": "storefrontfailureobservability_emitstorefrontfailure",
       "label": "emitStorefrontFailure()",
@@ -78565,7 +78529,7 @@
       "source_location": "L154"
     },
     {
-      "community": 243,
+      "community": 242,
       "file_type": "code",
       "id": "storefrontfailureobservability_inferstorefrontjourneyfromroute",
       "label": "inferStorefrontJourneyFromRoute()",
@@ -78574,7 +78538,7 @@
       "source_location": "L25"
     },
     {
-      "community": 243,
+      "community": 242,
       "file_type": "code",
       "id": "storefrontfailureobservability_normalizestorefronterror",
       "label": "normalizeStorefrontError()",
@@ -78583,7 +78547,7 @@
       "source_location": "L47"
     },
     {
-      "community": 244,
+      "community": 243,
       "file_type": "code",
       "id": "convex_node_env_test_resolveesbuildwithenv",
       "label": "resolveEsbuildWithEnv()",
@@ -78592,7 +78556,7 @@
       "source_location": "L48"
     },
     {
-      "community": 244,
+      "community": 243,
       "file_type": "code",
       "id": "convex_node_env_test_resolvewithenv",
       "label": "resolveWithEnv()",
@@ -78601,7 +78565,7 @@
       "source_location": "L26"
     },
     {
-      "community": 244,
+      "community": 243,
       "file_type": "code",
       "id": "convex_node_env_test_withtempdir",
       "label": "withTempDir()",
@@ -78610,7 +78574,7 @@
       "source_location": "L6"
     },
     {
-      "community": 244,
+      "community": 243,
       "file_type": "code",
       "id": "convex_node_env_test_writenodeshim",
       "label": "writeNodeShim()",
@@ -78619,7 +78583,7 @@
       "source_location": "L16"
     },
     {
-      "community": 244,
+      "community": 243,
       "file_type": "code",
       "id": "scripts_convex_node_env_test_ts",
       "label": "convex-node-env.test.ts",
@@ -78628,7 +78592,7 @@
       "source_location": "L1"
     },
     {
-      "community": 245,
+      "community": 244,
       "file_type": "code",
       "id": "harness_behavior_test_createbrowser",
       "label": "createBrowser()",
@@ -78637,7 +78601,7 @@
       "source_location": "L52"
     },
     {
-      "community": 245,
+      "community": 244,
       "file_type": "code",
       "id": "harness_behavior_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -78646,7 +78610,7 @@
       "source_location": "L22"
     },
     {
-      "community": 245,
+      "community": 244,
       "file_type": "code",
       "id": "harness_behavior_test_createplaywrightmodule",
       "label": "createPlaywrightModule()",
@@ -78655,7 +78619,7 @@
       "source_location": "L44"
     },
     {
-      "community": 245,
+      "community": 244,
       "file_type": "code",
       "id": "harness_behavior_test_write",
       "label": "write()",
@@ -78664,7 +78628,7 @@
       "source_location": "L16"
     },
     {
-      "community": 245,
+      "community": 244,
       "file_type": "code",
       "id": "scripts_harness_behavior_test_ts",
       "label": "harness-behavior.test.ts",
@@ -78673,7 +78637,7 @@
       "source_location": "L1"
     },
     {
-      "community": 246,
+      "community": 245,
       "file_type": "code",
       "id": "harness_repo_validation_collectharnessrepovalidationselection",
       "label": "collectHarnessRepoValidationSelection()",
@@ -78682,7 +78646,7 @@
       "source_location": "L47"
     },
     {
-      "community": 246,
+      "community": 245,
       "file_type": "code",
       "id": "harness_repo_validation_matchesharnessrepovalidationpath",
       "label": "matchesHarnessRepoValidationPath()",
@@ -78691,7 +78655,7 @@
       "source_location": "L39"
     },
     {
-      "community": 246,
+      "community": 245,
       "file_type": "code",
       "id": "harness_repo_validation_normalizerepopath",
       "label": "normalizeRepoPath()",
@@ -78700,7 +78664,7 @@
       "source_location": "L29"
     },
     {
-      "community": 246,
+      "community": 245,
       "file_type": "code",
       "id": "harness_repo_validation_sortuniquepaths",
       "label": "sortUniquePaths()",
@@ -78709,7 +78673,7 @@
       "source_location": "L33"
     },
     {
-      "community": 246,
+      "community": 245,
       "file_type": "code",
       "id": "scripts_harness_repo_validation_ts",
       "label": "harness-repo-validation.ts",
@@ -78718,7 +78682,7 @@
       "source_location": "L1"
     },
     {
-      "community": 247,
+      "community": 246,
       "file_type": "code",
       "id": "pre_commit_generated_artifacts_test_log",
       "label": "log()",
@@ -78727,7 +78691,7 @@
       "source_location": "L73"
     },
     {
-      "community": 247,
+      "community": 246,
       "file_type": "code",
       "id": "pre_commit_generated_artifacts_test_spawn",
       "label": "spawn()",
@@ -78736,7 +78700,7 @@
       "source_location": "L65"
     },
     {
-      "community": 247,
+      "community": 246,
       "file_type": "code",
       "id": "pre_commit_generated_artifacts_test_withtemprepo",
       "label": "withTempRepo()",
@@ -78745,7 +78709,7 @@
       "source_location": "L14"
     },
     {
-      "community": 247,
+      "community": 246,
       "file_type": "code",
       "id": "pre_commit_generated_artifacts_test_writeconvexapifixture",
       "label": "writeConvexApiFixture()",
@@ -78754,7 +78718,7 @@
       "source_location": "L24"
     },
     {
-      "community": 247,
+      "community": 246,
       "file_type": "code",
       "id": "scripts_pre_commit_generated_artifacts_test_ts",
       "label": "pre-commit-generated-artifacts.test.ts",
@@ -78763,7 +78727,7 @@
       "source_location": "L1"
     },
     {
-      "community": 248,
+      "community": 247,
       "file_type": "code",
       "id": "scripts_worktree_manager_test_ts",
       "label": "worktree-manager.test.ts",
@@ -78772,7 +78736,7 @@
       "source_location": "L1"
     },
     {
-      "community": 248,
+      "community": 247,
       "file_type": "code",
       "id": "worktree_manager_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -78781,7 +78745,7 @@
       "source_location": "L17"
     },
     {
-      "community": 248,
+      "community": 247,
       "file_type": "code",
       "id": "worktree_manager_test_fixtureenv",
       "label": "fixtureEnv()",
@@ -78790,7 +78754,7 @@
       "source_location": "L72"
     },
     {
-      "community": 248,
+      "community": 247,
       "file_type": "code",
       "id": "worktree_manager_test_rungit",
       "label": "runGit()",
@@ -78799,7 +78763,7 @@
       "source_location": "L45"
     },
     {
-      "community": 248,
+      "community": 247,
       "file_type": "code",
       "id": "worktree_manager_test_runworktreemanager",
       "label": "runWorktreeManager()",
@@ -78808,7 +78772,7 @@
       "source_location": "L59"
     },
     {
-      "community": 249,
+      "community": 248,
       "file_type": "code",
       "id": "convexpaginationantipatterncheck_test_createtemproot",
       "label": "createTempRoot()",
@@ -78817,7 +78781,7 @@
       "source_location": "L12"
     },
     {
-      "community": 249,
+      "community": 248,
       "file_type": "code",
       "id": "convexpaginationantipatterncheck_test_runpaginationcheck",
       "label": "runPaginationCheck()",
@@ -78826,7 +78790,7 @@
       "source_location": "L26"
     },
     {
-      "community": 249,
+      "community": 248,
       "file_type": "code",
       "id": "convexpaginationantipatterncheck_test_writeconvexfile",
       "label": "writeConvexFile()",
@@ -78835,12 +78799,48 @@
       "source_location": "L20"
     },
     {
-      "community": 249,
+      "community": 248,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_convexpaginationantipatterncheck_test_ts",
       "label": "convexPaginationAntiPatternCheck.test.ts",
       "norm_label": "convexpaginationantipatterncheck.test.ts",
       "source_file": "packages/athena-webapp/convex/convexPaginationAntiPatternCheck.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 249,
+      "file_type": "code",
+      "id": "domain_maskreceiptphone",
+      "label": "maskReceiptPhone()",
+      "norm_label": "maskreceiptphone()",
+      "source_file": "packages/athena-webapp/convex/customerMessaging/domain.ts",
+      "source_location": "L67"
+    },
+    {
+      "community": 249,
+      "file_type": "code",
+      "id": "domain_normalizereceiptphone",
+      "label": "normalizeReceiptPhone()",
+      "norm_label": "normalizereceiptphone()",
+      "source_file": "packages/athena-webapp/convex/customerMessaging/domain.ts",
+      "source_location": "L52"
+    },
+    {
+      "community": 249,
+      "file_type": "code",
+      "id": "domain_statusisretryable",
+      "label": "statusIsRetryable()",
+      "norm_label": "statusisretryable()",
+      "source_file": "packages/athena-webapp/convex/customerMessaging/domain.ts",
+      "source_location": "L79"
+    },
+    {
+      "community": 249,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_customermessaging_domain_ts",
+      "label": "domain.ts",
+      "norm_label": "domain.ts",
+      "source_file": "packages/athena-webapp/convex/customerMessaging/domain.ts",
       "source_location": "L1"
     },
     {
@@ -79035,42 +79035,6 @@
     {
       "community": 250,
       "file_type": "code",
-      "id": "domain_maskreceiptphone",
-      "label": "maskReceiptPhone()",
-      "norm_label": "maskreceiptphone()",
-      "source_file": "packages/athena-webapp/convex/customerMessaging/domain.ts",
-      "source_location": "L67"
-    },
-    {
-      "community": 250,
-      "file_type": "code",
-      "id": "domain_normalizereceiptphone",
-      "label": "normalizeReceiptPhone()",
-      "norm_label": "normalizereceiptphone()",
-      "source_file": "packages/athena-webapp/convex/customerMessaging/domain.ts",
-      "source_location": "L52"
-    },
-    {
-      "community": 250,
-      "file_type": "code",
-      "id": "domain_statusisretryable",
-      "label": "statusIsRetryable()",
-      "norm_label": "statusisretryable()",
-      "source_file": "packages/athena-webapp/convex/customerMessaging/domain.ts",
-      "source_location": "L79"
-    },
-    {
-      "community": 250,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_customermessaging_domain_ts",
-      "label": "domain.ts",
-      "norm_label": "domain.ts",
-      "source_file": "packages/athena-webapp/convex/customerMessaging/domain.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 251,
-      "file_type": "code",
       "id": "packages_athena_webapp_convex_customermessaging_token_ts",
       "label": "token.ts",
       "norm_label": "token.ts",
@@ -79078,7 +79042,7 @@
       "source_location": "L1"
     },
     {
-      "community": 251,
+      "community": 250,
       "file_type": "code",
       "id": "token_createreceiptsharetoken",
       "label": "createReceiptShareToken()",
@@ -79087,7 +79051,7 @@
       "source_location": "L9"
     },
     {
-      "community": 251,
+      "community": 250,
       "file_type": "code",
       "id": "token_hashreceiptsharetoken",
       "label": "hashReceiptShareToken()",
@@ -79096,7 +79060,7 @@
       "source_location": "L15"
     },
     {
-      "community": 251,
+      "community": 250,
       "file_type": "code",
       "id": "token_tohex",
       "label": "toHex()",
@@ -79105,7 +79069,7 @@
       "source_location": "L3"
     },
     {
-      "community": 252,
+      "community": 251,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_customermessaging_webhooksecurity_ts",
       "label": "webhookSecurity.ts",
@@ -79114,7 +79078,7 @@
       "source_location": "L1"
     },
     {
-      "community": 252,
+      "community": 251,
       "file_type": "code",
       "id": "webhooksecurity_timingsafeequal",
       "label": "timingSafeEqual()",
@@ -79123,7 +79087,7 @@
       "source_location": "L9"
     },
     {
-      "community": 252,
+      "community": 251,
       "file_type": "code",
       "id": "webhooksecurity_tohex",
       "label": "toHex()",
@@ -79132,7 +79096,7 @@
       "source_location": "L3"
     },
     {
-      "community": 252,
+      "community": 251,
       "file_type": "code",
       "id": "webhooksecurity_verifymetawebhooksignature",
       "label": "verifyMetaWebhookSignature()",
@@ -79141,7 +79105,7 @@
       "source_location": "L22"
     },
     {
-      "community": 253,
+      "community": 252,
       "file_type": "code",
       "id": "checkout_hasallvisibilesessionitems",
       "label": "hasAllVisibileSessionItems()",
@@ -79150,7 +79114,7 @@
       "source_location": "L109"
     },
     {
-      "community": 253,
+      "community": 252,
       "file_type": "code",
       "id": "checkout_hasvalidcanonicalbagitem",
       "label": "hasValidCanonicalBagItem()",
@@ -79159,7 +79123,7 @@
       "source_location": "L84"
     },
     {
-      "community": 253,
+      "community": 252,
       "file_type": "code",
       "id": "checkout_hasvalidsessionitems",
       "label": "hasValidSessionItems()",
@@ -79168,7 +79132,7 @@
       "source_location": "L95"
     },
     {
-      "community": 253,
+      "community": 252,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_checkout_ts",
       "label": "checkout.ts",
@@ -79177,7 +79141,7 @@
       "source_location": "L1"
     },
     {
-      "community": 254,
+      "community": 253,
       "file_type": "code",
       "id": "expensesessions_test_buildsession",
       "label": "buildSession()",
@@ -79186,7 +79150,7 @@
       "source_location": "L235"
     },
     {
-      "community": 254,
+      "community": 253,
       "file_type": "code",
       "id": "expensesessions_test_createmutationctx",
       "label": "createMutationCtx()",
@@ -79195,7 +79159,7 @@
       "source_location": "L53"
     },
     {
-      "community": 254,
+      "community": 253,
       "file_type": "code",
       "id": "expensesessions_test_gethandler",
       "label": "getHandler()",
@@ -79204,7 +79168,7 @@
       "source_location": "L250"
     },
     {
-      "community": 254,
+      "community": 253,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_expensesessions_test_ts",
       "label": "expenseSessions.test.ts",
@@ -79213,7 +79177,7 @@
       "source_location": "L1"
     },
     {
-      "community": 255,
+      "community": 254,
       "file_type": "code",
       "id": "expensetransactions_createexpensetransactionfromsessionhandler",
       "label": "createExpenseTransactionFromSessionHandler()",
@@ -79222,7 +79186,7 @@
       "source_location": "L50"
     },
     {
-      "community": 255,
+      "community": 254,
       "file_type": "code",
       "id": "expensetransactions_expensetransactionerror",
       "label": "expenseTransactionError()",
@@ -79231,7 +79195,7 @@
       "source_location": "L23"
     },
     {
-      "community": 255,
+      "community": 254,
       "file_type": "code",
       "id": "expensetransactions_formatexpensestaffprofilename",
       "label": "formatExpenseStaffProfileName()",
@@ -79240,7 +79204,7 @@
       "source_location": "L37"
     },
     {
-      "community": 255,
+      "community": 254,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_expensetransactions_ts",
       "label": "expenseTransactions.ts",
@@ -79249,7 +79213,7 @@
       "source_location": "L1"
     },
     {
-      "community": 256,
+      "community": 255,
       "file_type": "code",
       "id": "expensesessionexpiration_calculateexpensesessionexpiration",
       "label": "calculateExpenseSessionExpiration()",
@@ -79258,7 +79222,7 @@
       "source_location": "L21"
     },
     {
-      "community": 256,
+      "community": 255,
       "file_type": "code",
       "id": "expensesessionexpiration_getexpensesessionexpiryduration",
       "label": "getExpenseSessionExpiryDuration()",
@@ -79267,7 +79231,7 @@
       "source_location": "L35"
     },
     {
-      "community": 256,
+      "community": 255,
       "file_type": "code",
       "id": "expensesessionexpiration_getexpensesessionexpirydurationminutes",
       "label": "getExpenseSessionExpiryDurationMinutes()",
@@ -79276,7 +79240,7 @@
       "source_location": "L45"
     },
     {
-      "community": 256,
+      "community": 255,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_helpers_expensesessionexpiration_ts",
       "label": "expenseSessionExpiration.ts",
@@ -79285,7 +79249,7 @@
       "source_location": "L1"
     },
     {
-      "community": 257,
+      "community": 256,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_helpers_sessionexpiration_ts",
       "label": "sessionExpiration.ts",
@@ -79294,7 +79258,7 @@
       "source_location": "L1"
     },
     {
-      "community": 257,
+      "community": 256,
       "file_type": "code",
       "id": "sessionexpiration_calculatesessionexpiration",
       "label": "calculateSessionExpiration()",
@@ -79303,7 +79267,7 @@
       "source_location": "L21"
     },
     {
-      "community": 257,
+      "community": 256,
       "file_type": "code",
       "id": "sessionexpiration_getsessionexpiryduration",
       "label": "getSessionExpiryDuration()",
@@ -79312,7 +79276,7 @@
       "source_location": "L35"
     },
     {
-      "community": 257,
+      "community": 256,
       "file_type": "code",
       "id": "sessionexpiration_getsessionexpirydurationminutes",
       "label": "getSessionExpiryDurationMinutes()",
@@ -79321,7 +79285,7 @@
       "source_location": "L45"
     },
     {
-      "community": 258,
+      "community": 257,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_possessions_trace_test_ts",
       "label": "posSessions.trace.test.ts",
@@ -79330,7 +79294,7 @@
       "source_location": "L1"
     },
     {
-      "community": 258,
+      "community": 257,
       "file_type": "code",
       "id": "possessions_trace_test_buildsession",
       "label": "buildSession()",
@@ -79339,7 +79303,7 @@
       "source_location": "L407"
     },
     {
-      "community": 258,
+      "community": 257,
       "file_type": "code",
       "id": "possessions_trace_test_createmutationctx",
       "label": "createMutationCtx()",
@@ -79348,7 +79312,7 @@
       "source_location": "L161"
     },
     {
-      "community": 258,
+      "community": 257,
       "file_type": "code",
       "id": "possessions_trace_test_gethandler",
       "label": "getHandler()",
@@ -79357,7 +79321,7 @@
       "source_location": "L424"
     },
     {
-      "community": 259,
+      "community": 258,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_products_sku_test_ts",
       "label": "products.sku.test.ts",
@@ -79366,7 +79330,7 @@
       "source_location": "L1"
     },
     {
-      "community": 259,
+      "community": 258,
       "file_type": "code",
       "id": "products_sku_test_createproductsqueryctx",
       "label": "createProductsQueryCtx()",
@@ -79375,7 +79339,7 @@
       "source_location": "L146"
     },
     {
-      "community": 259,
+      "community": 258,
       "file_type": "code",
       "id": "products_sku_test_createskumutationctx",
       "label": "createSkuMutationCtx()",
@@ -79384,13 +79348,49 @@
       "source_location": "L39"
     },
     {
-      "community": 259,
+      "community": 258,
       "file_type": "code",
       "id": "products_sku_test_gethandler",
       "label": "getHandler()",
       "norm_label": "gethandler()",
       "source_file": "packages/athena-webapp/convex/inventory/products.sku.test.ts",
       "source_location": "L35"
+    },
+    {
+      "community": 259,
+      "file_type": "code",
+      "id": "collections_getcachedtokenrecord",
+      "label": "getCachedTokenRecord()",
+      "norm_label": "getcachedtokenrecord()",
+      "source_file": "packages/athena-webapp/convex/mtn/collections.ts",
+      "source_location": "L26"
+    },
+    {
+      "community": 259,
+      "file_type": "code",
+      "id": "collections_resolveaccesstokenforstore",
+      "label": "resolveAccessTokenForStore()",
+      "norm_label": "resolveaccesstokenforstore()",
+      "source_file": "packages/athena-webapp/convex/mtn/collections.ts",
+      "source_location": "L79"
+    },
+    {
+      "community": 259,
+      "file_type": "code",
+      "id": "collections_resolveconfigforstore",
+      "label": "resolveConfigForStore()",
+      "norm_label": "resolveconfigforstore()",
+      "source_file": "packages/athena-webapp/convex/mtn/collections.ts",
+      "source_location": "L33"
+    },
+    {
+      "community": 259,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_mtn_collections_ts",
+      "label": "collections.ts",
+      "norm_label": "collections.ts",
+      "source_file": "packages/athena-webapp/convex/mtn/collections.ts",
+      "source_location": "L1"
     },
     {
       "community": 26,
@@ -79584,42 +79584,6 @@
     {
       "community": 260,
       "file_type": "code",
-      "id": "collections_getcachedtokenrecord",
-      "label": "getCachedTokenRecord()",
-      "norm_label": "getcachedtokenrecord()",
-      "source_file": "packages/athena-webapp/convex/mtn/collections.ts",
-      "source_location": "L26"
-    },
-    {
-      "community": 260,
-      "file_type": "code",
-      "id": "collections_resolveaccesstokenforstore",
-      "label": "resolveAccessTokenForStore()",
-      "norm_label": "resolveaccesstokenforstore()",
-      "source_file": "packages/athena-webapp/convex/mtn/collections.ts",
-      "source_location": "L79"
-    },
-    {
-      "community": 260,
-      "file_type": "code",
-      "id": "collections_resolveconfigforstore",
-      "label": "resolveConfigForStore()",
-      "norm_label": "resolveconfigforstore()",
-      "source_file": "packages/athena-webapp/convex/mtn/collections.ts",
-      "source_location": "L33"
-    },
-    {
-      "community": 260,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_mtn_collections_ts",
-      "label": "collections.ts",
-      "norm_label": "collections.ts",
-      "source_file": "packages/athena-webapp/convex/mtn/collections.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 261,
-      "file_type": "code",
       "id": "normalize_maskmtnpartyid",
       "label": "maskMtnPartyId()",
       "norm_label": "maskmtnpartyid()",
@@ -79627,7 +79591,7 @@
       "source_location": "L10"
     },
     {
-      "community": 261,
+      "community": 260,
       "file_type": "code",
       "id": "normalize_normalizecollectionstransaction",
       "label": "normalizeCollectionsTransaction()",
@@ -79636,7 +79600,7 @@
       "source_location": "L18"
     },
     {
-      "community": 261,
+      "community": 260,
       "file_type": "code",
       "id": "normalize_parsecollectionsnotificationrequest",
       "label": "parseCollectionsNotificationRequest()",
@@ -79645,7 +79609,7 @@
       "source_location": "L52"
     },
     {
-      "community": 261,
+      "community": 260,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_normalize_ts",
       "label": "normalize.ts",
@@ -79654,7 +79618,7 @@
       "source_location": "L1"
     },
     {
-      "community": 262,
+      "community": 261,
       "file_type": "code",
       "id": "approvalproofs_consumeapprovalproofwithctx",
       "label": "consumeApprovalProofWithCtx()",
@@ -79663,7 +79627,7 @@
       "source_location": "L98"
     },
     {
-      "community": 262,
+      "community": 261,
       "file_type": "code",
       "id": "approvalproofs_createapprovalproofwithctx",
       "label": "createApprovalProofWithCtx()",
@@ -79672,7 +79636,7 @@
       "source_location": "L56"
     },
     {
-      "community": 262,
+      "community": 261,
       "file_type": "code",
       "id": "approvalproofs_invalidapprovalproofresult",
       "label": "invalidApprovalProofResult()",
@@ -79681,7 +79645,7 @@
       "source_location": "L49"
     },
     {
-      "community": 262,
+      "community": 261,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_approvalproofs_ts",
       "label": "approvalProofs.ts",
@@ -79690,7 +79654,7 @@
       "source_location": "L1"
     },
     {
-      "community": 263,
+      "community": 262,
       "file_type": "code",
       "id": "dailyclose_test_createdb",
       "label": "createDb()",
@@ -79699,7 +79663,7 @@
       "source_location": "L30"
     },
     {
-      "community": 263,
+      "community": 262,
       "file_type": "code",
       "id": "dailyclose_test_dailycloseapprovalproof",
       "label": "dailyCloseApprovalProof()",
@@ -79708,7 +79672,7 @@
       "source_location": "L240"
     },
     {
-      "community": 263,
+      "community": 262,
       "file_type": "code",
       "id": "dailyclose_test_dailyclosesummary",
       "label": "dailyCloseSummary()",
@@ -79717,7 +79681,7 @@
       "source_location": "L215"
     },
     {
-      "community": 263,
+      "community": 262,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_dailyclose_test_ts",
       "label": "dailyClose.test.ts",
@@ -79726,7 +79690,7 @@
       "source_location": "L1"
     },
     {
-      "community": 264,
+      "community": 263,
       "file_type": "code",
       "id": "operationalevents_buildoperationalevent",
       "label": "buildOperationalEvent()",
@@ -79735,7 +79699,7 @@
       "source_location": "L28"
     },
     {
-      "community": 264,
+      "community": 263,
       "file_type": "code",
       "id": "operationalevents_matchesexistingevent",
       "label": "matchesExistingEvent()",
@@ -79744,7 +79708,7 @@
       "source_location": "L42"
     },
     {
-      "community": 264,
+      "community": 263,
       "file_type": "code",
       "id": "operationalevents_recordoperationaleventwithctx",
       "label": "recordOperationalEventWithCtx()",
@@ -79753,7 +79717,7 @@
       "source_location": "L73"
     },
     {
-      "community": 264,
+      "community": 263,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_operationalevents_ts",
       "label": "operationalEvents.ts",
@@ -79762,7 +79726,7 @@
       "source_location": "L1"
     },
     {
-      "community": 265,
+      "community": 264,
       "file_type": "code",
       "id": "operationalworkitems_buildoperationalworkitem",
       "label": "buildOperationalWorkItem()",
@@ -79771,7 +79735,7 @@
       "source_location": "L13"
     },
     {
-      "community": 265,
+      "community": 264,
       "file_type": "code",
       "id": "operationalworkitems_createoperationalworkitemwithctx",
       "label": "createOperationalWorkItemWithCtx()",
@@ -79780,7 +79744,7 @@
       "source_location": "L37"
     },
     {
-      "community": 265,
+      "community": 264,
       "file_type": "code",
       "id": "operationalworkitems_updateoperationalworkitemstatuswithctx",
       "label": "updateOperationalWorkItemStatusWithCtx()",
@@ -79789,7 +79753,7 @@
       "source_location": "L69"
     },
     {
-      "community": 265,
+      "community": 264,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_operationalworkitems_ts",
       "label": "operationalWorkItems.ts",
@@ -79798,7 +79762,7 @@
       "source_location": "L1"
     },
     {
-      "community": 266,
+      "community": 265,
       "file_type": "code",
       "id": "operationsqueryindexes_test_expectindex",
       "label": "expectIndex()",
@@ -79807,7 +79771,7 @@
       "source_location": "L18"
     },
     {
-      "community": 266,
+      "community": 265,
       "file_type": "code",
       "id": "operationsqueryindexes_test_getsource",
       "label": "getSource()",
@@ -79816,7 +79780,7 @@
       "source_location": "L25"
     },
     {
-      "community": 266,
+      "community": 265,
       "file_type": "code",
       "id": "operationsqueryindexes_test_gettableindexes",
       "label": "getTableIndexes()",
@@ -79825,7 +79789,7 @@
       "source_location": "L11"
     },
     {
-      "community": 266,
+      "community": 265,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_operationsqueryindexes_test_ts",
       "label": "operationsQueryIndexes.test.ts",
@@ -79834,7 +79798,7 @@
       "source_location": "L1"
     },
     {
-      "community": 267,
+      "community": 266,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_registersessiontracing_test_ts",
       "label": "registerSessionTracing.test.ts",
@@ -79843,7 +79807,7 @@
       "source_location": "L1"
     },
     {
-      "community": 267,
+      "community": 266,
       "file_type": "code",
       "id": "registersessiontracing_test_buildctx",
       "label": "buildCtx()",
@@ -79852,7 +79816,7 @@
       "source_location": "L33"
     },
     {
-      "community": 267,
+      "community": 266,
       "file_type": "code",
       "id": "registersessiontracing_test_buildsession",
       "label": "buildSession()",
@@ -79861,7 +79825,7 @@
       "source_location": "L19"
     },
     {
-      "community": 267,
+      "community": 266,
       "file_type": "code",
       "id": "registersessiontracing_test_formatstoredtraceamount",
       "label": "formatStoredTraceAmount()",
@@ -79870,7 +79834,7 @@
       "source_location": "L42"
     },
     {
-      "community": 268,
+      "community": 267,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_registersessions_trace_test_ts",
       "label": "registerSessions.trace.test.ts",
@@ -79879,7 +79843,7 @@
       "source_location": "L1"
     },
     {
-      "community": 268,
+      "community": 267,
       "file_type": "code",
       "id": "registersessions_trace_test_buildregistersession",
       "label": "buildRegisterSession()",
@@ -79888,7 +79852,7 @@
       "source_location": "L33"
     },
     {
-      "community": 268,
+      "community": 267,
       "file_type": "code",
       "id": "registersessions_trace_test_createmutationctx",
       "label": "createMutationCtx()",
@@ -79897,7 +79861,7 @@
       "source_location": "L50"
     },
     {
-      "community": 268,
+      "community": 267,
       "file_type": "code",
       "id": "registersessions_trace_test_gethandler",
       "label": "getHandler()",
@@ -79906,7 +79870,7 @@
       "source_location": "L133"
     },
     {
-      "community": 269,
+      "community": 268,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_serviceintake_ts",
       "label": "serviceIntake.ts",
@@ -79915,7 +79879,7 @@
       "source_location": "L1"
     },
     {
-      "community": 269,
+      "community": 268,
       "file_type": "code",
       "id": "serviceintake_resolveserviceintakecustomerprofile",
       "label": "resolveServiceIntakeCustomerProfile()",
@@ -79924,7 +79888,7 @@
       "source_location": "L37"
     },
     {
-      "community": 269,
+      "community": 268,
       "file_type": "code",
       "id": "serviceintake_splitfullname",
       "label": "splitFullName()",
@@ -79933,13 +79897,49 @@
       "source_location": "L24"
     },
     {
-      "community": 269,
+      "community": 268,
       "file_type": "code",
       "id": "serviceintake_trimoptional",
       "label": "trimOptional()",
       "norm_label": "trimoptional()",
       "source_file": "packages/athena-webapp/convex/operations/serviceIntake.ts",
       "source_location": "L19"
+    },
+    {
+      "community": 269,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_commands_register_ts",
+      "label": "register.ts",
+      "norm_label": "register.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/register.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 269,
+      "file_type": "code",
+      "id": "register_mapopendrawerusererror",
+      "label": "mapOpenDrawerUserError()",
+      "norm_label": "mapopendrawerusererror()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/register.ts",
+      "source_location": "L31"
+    },
+    {
+      "community": 269,
+      "file_type": "code",
+      "id": "register_normalizeregisternumber",
+      "label": "normalizeRegisterNumber()",
+      "norm_label": "normalizeregisternumber()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/register.ts",
+      "source_location": "L26"
+    },
+    {
+      "community": 269,
+      "file_type": "code",
+      "id": "register_opendrawer",
+      "label": "openDrawer()",
+      "norm_label": "opendrawer()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/register.ts",
+      "source_location": "L53"
     },
     {
       "community": 27,
@@ -80124,42 +80124,6 @@
     {
       "community": 270,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_commands_register_ts",
-      "label": "register.ts",
-      "norm_label": "register.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/register.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 270,
-      "file_type": "code",
-      "id": "register_mapopendrawerusererror",
-      "label": "mapOpenDrawerUserError()",
-      "norm_label": "mapopendrawerusererror()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/register.ts",
-      "source_location": "L31"
-    },
-    {
-      "community": 270,
-      "file_type": "code",
-      "id": "register_normalizeregisternumber",
-      "label": "normalizeRegisterNumber()",
-      "norm_label": "normalizeregisternumber()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/register.ts",
-      "source_location": "L26"
-    },
-    {
-      "community": 270,
-      "file_type": "code",
-      "id": "register_opendrawer",
-      "label": "openDrawer()",
-      "norm_label": "opendrawer()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/register.ts",
-      "source_location": "L53"
-    },
-    {
-      "community": 271,
-      "file_type": "code",
       "id": "opendrawer_test_createdbgetmock",
       "label": "createDbGetMock()",
       "norm_label": "createdbgetmock()",
@@ -80167,7 +80131,7 @@
       "source_location": "L36"
     },
     {
-      "community": 271,
+      "community": 270,
       "file_type": "code",
       "id": "opendrawer_test_createdbmock",
       "label": "createDbMock()",
@@ -80176,7 +80140,7 @@
       "source_location": "L96"
     },
     {
-      "community": 271,
+      "community": 270,
       "file_type": "code",
       "id": "opendrawer_test_createdbquerymock",
       "label": "createDbQueryMock()",
@@ -80185,7 +80149,7 @@
       "source_location": "L71"
     },
     {
-      "community": 271,
+      "community": 270,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_opendrawer_test_ts",
       "label": "openDrawer.test.ts",
@@ -80194,7 +80158,7 @@
       "source_location": "L1"
     },
     {
-      "community": 272,
+      "community": 271,
       "file_type": "code",
       "id": "getregisterstate_buildregisterstate",
       "label": "buildRegisterState()",
@@ -80203,7 +80167,7 @@
       "source_location": "L21"
     },
     {
-      "community": 272,
+      "community": 271,
       "file_type": "code",
       "id": "getregisterstate_getactivesessionconflictforregisterstate",
       "label": "getActiveSessionConflictForRegisterState()",
@@ -80212,7 +80176,7 @@
       "source_location": "L42"
     },
     {
-      "community": 272,
+      "community": 271,
       "file_type": "code",
       "id": "getregisterstate_getregisterstate",
       "label": "getRegisterState()",
@@ -80221,7 +80185,7 @@
       "source_location": "L80"
     },
     {
-      "community": 272,
+      "community": 271,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_queries_getregisterstate_ts",
       "label": "getRegisterState.ts",
@@ -80230,7 +80194,7 @@
       "source_location": "L1"
     },
     {
-      "community": 273,
+      "community": 272,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_queries_searchcatalog_ts",
       "label": "searchCatalog.ts",
@@ -80239,7 +80203,7 @@
       "source_location": "L1"
     },
     {
-      "community": 273,
+      "community": 272,
       "file_type": "code",
       "id": "searchcatalog_lookupbybarcode",
       "label": "lookupByBarcode()",
@@ -80248,7 +80212,7 @@
       "source_location": "L126"
     },
     {
-      "community": 273,
+      "community": 272,
       "file_type": "code",
       "id": "searchcatalog_mapskutocatalogresult",
       "label": "mapSkuToCatalogResult()",
@@ -80257,7 +80221,7 @@
       "source_location": "L34"
     },
     {
-      "community": 273,
+      "community": 272,
       "file_type": "code",
       "id": "searchcatalog_searchproducts",
       "label": "searchProducts()",
@@ -80266,7 +80230,7 @@
       "source_location": "L76"
     },
     {
-      "community": 274,
+      "community": 273,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_sessioncommandrepository_ts",
       "label": "sessionCommandRepository.ts",
@@ -80275,7 +80239,7 @@
       "source_location": "L1"
     },
     {
-      "community": 274,
+      "community": 273,
       "file_type": "code",
       "id": "sessioncommandrepository_collectsessionitemsfrompages",
       "label": "collectSessionItemsFromPages()",
@@ -80284,7 +80248,7 @@
       "source_location": "L159"
     },
     {
-      "community": 274,
+      "community": 273,
       "file_type": "code",
       "id": "sessioncommandrepository_createsessioncommandrepository",
       "label": "createSessionCommandRepository()",
@@ -80293,7 +80257,7 @@
       "source_location": "L56"
     },
     {
-      "community": 274,
+      "community": 273,
       "file_type": "code",
       "id": "sessioncommandrepository_scansessionitembyskuinpages",
       "label": "scanSessionItemBySkuInPages()",
@@ -80302,7 +80266,7 @@
       "source_location": "L177"
     },
     {
-      "community": 275,
+      "community": 274,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_transactions_test_ts",
       "label": "transactions.test.ts",
@@ -80311,7 +80275,7 @@
       "source_location": "L1"
     },
     {
-      "community": 275,
+      "community": 274,
       "file_type": "code",
       "id": "transactions_test_exportreturns",
       "label": "exportReturns()",
@@ -80320,7 +80284,7 @@
       "source_location": "L30"
     },
     {
-      "community": 275,
+      "community": 274,
       "file_type": "code",
       "id": "transactions_test_gethandler",
       "label": "getHandler()",
@@ -80329,7 +80293,7 @@
       "source_location": "L38"
     },
     {
-      "community": 275,
+      "community": 274,
       "file_type": "code",
       "id": "transactions_test_parsevalidator",
       "label": "parseValidator()",
@@ -80338,7 +80302,7 @@
       "source_location": "L34"
     },
     {
-      "community": 276,
+      "community": 275,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_replenishment_test_ts",
       "label": "replenishment.test.ts",
@@ -80347,7 +80311,7 @@
       "source_location": "L1"
     },
     {
-      "community": 276,
+      "community": 275,
       "file_type": "code",
       "id": "replenishment_test_createreplenishmentqueryctx",
       "label": "createReplenishmentQueryCtx()",
@@ -80356,7 +80320,7 @@
       "source_location": "L21"
     },
     {
-      "community": 276,
+      "community": 275,
       "file_type": "code",
       "id": "replenishment_test_getsource",
       "label": "getSource()",
@@ -80365,7 +80329,7 @@
       "source_location": "L7"
     },
     {
-      "community": 276,
+      "community": 275,
       "file_type": "code",
       "id": "replenishment_test_toasynciterable",
       "label": "toAsyncIterable()",
@@ -80374,7 +80338,7 @@
       "source_location": "L11"
     },
     {
-      "community": 277,
+      "community": 276,
       "file_type": "code",
       "id": "commercequeryindexes_test_expectindex",
       "label": "expectIndex()",
@@ -80383,7 +80347,7 @@
       "source_location": "L19"
     },
     {
-      "community": 277,
+      "community": 276,
       "file_type": "code",
       "id": "commercequeryindexes_test_getsource",
       "label": "getSource()",
@@ -80392,7 +80356,7 @@
       "source_location": "L26"
     },
     {
-      "community": 277,
+      "community": 276,
       "file_type": "code",
       "id": "commercequeryindexes_test_gettableindexes",
       "label": "getTableIndexes()",
@@ -80401,7 +80365,7 @@
       "source_location": "L12"
     },
     {
-      "community": 277,
+      "community": 276,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_commercequeryindexes_test_ts",
       "label": "commerceQueryIndexes.test.ts",
@@ -80410,7 +80374,7 @@
       "source_location": "L1"
     },
     {
-      "community": 278,
+      "community": 277,
       "file_type": "code",
       "id": "customerengagementevents_findexistingcustomerprofileid",
       "label": "findExistingCustomerProfileId()",
@@ -80419,7 +80383,7 @@
       "source_location": "L21"
     },
     {
-      "community": 278,
+      "community": 277,
       "file_type": "code",
       "id": "customerengagementevents_getstoreorganizationid",
       "label": "getStoreOrganizationId()",
@@ -80428,7 +80392,7 @@
       "source_location": "L63"
     },
     {
-      "community": 278,
+      "community": 277,
       "file_type": "code",
       "id": "customerengagementevents_recordstorefrontcustomermilestone",
       "label": "recordStoreFrontCustomerMilestone()",
@@ -80437,7 +80401,7 @@
       "source_location": "L71"
     },
     {
-      "community": 278,
+      "community": 277,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_helpers_customerengagementevents_ts",
       "label": "customerEngagementEvents.ts",
@@ -80446,7 +80410,7 @@
       "source_location": "L1"
     },
     {
-      "community": 279,
+      "community": 278,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_returnexchangeoperations_test_ts",
       "label": "returnExchangeOperations.test.ts",
@@ -80455,7 +80419,7 @@
       "source_location": "L1"
     },
     {
-      "community": 279,
+      "community": 278,
       "file_type": "code",
       "id": "returnexchangeoperations_test_createorderitem",
       "label": "createOrderItem()",
@@ -80464,7 +80428,7 @@
       "source_location": "L13"
     },
     {
-      "community": 279,
+      "community": 278,
       "file_type": "code",
       "id": "returnexchangeoperations_test_createreplacement",
       "label": "createReplacement()",
@@ -80473,13 +80437,49 @@
       "source_location": "L31"
     },
     {
-      "community": 279,
+      "community": 278,
       "file_type": "code",
       "id": "returnexchangeoperations_test_getsource",
       "label": "getSource()",
       "norm_label": "getsource()",
       "source_file": "packages/athena-webapp/convex/storeFront/returnExchangeOperations.test.ts",
       "source_location": "L9"
+    },
+    {
+      "community": 279,
+      "file_type": "code",
+      "id": "packages_athena_webapp_shared_staffdisplayname_ts",
+      "label": "staffDisplayName.ts",
+      "norm_label": "staffdisplayname.ts",
+      "source_file": "packages/athena-webapp/shared/staffDisplayName.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 279,
+      "file_type": "code",
+      "id": "staffdisplayname_formatstaffdisplayname",
+      "label": "formatStaffDisplayName()",
+      "norm_label": "formatstaffdisplayname()",
+      "source_file": "packages/athena-webapp/shared/staffDisplayName.ts",
+      "source_location": "L12"
+    },
+    {
+      "community": 279,
+      "file_type": "code",
+      "id": "staffdisplayname_formatstaffdisplaynameorfallback",
+      "label": "formatStaffDisplayNameOrFallback()",
+      "norm_label": "formatstaffdisplaynameorfallback()",
+      "source_file": "packages/athena-webapp/shared/staffDisplayName.ts",
+      "source_location": "L46"
+    },
+    {
+      "community": 279,
+      "file_type": "code",
+      "id": "staffdisplayname_normalizenamepart",
+      "label": "normalizeNamePart()",
+      "norm_label": "normalizenamepart()",
+      "source_file": "packages/athena-webapp/shared/staffDisplayName.ts",
+      "source_location": "L7"
     },
     {
       "community": 28,
@@ -80664,42 +80664,6 @@
     {
       "community": 280,
       "file_type": "code",
-      "id": "packages_athena_webapp_shared_staffdisplayname_ts",
-      "label": "staffDisplayName.ts",
-      "norm_label": "staffdisplayname.ts",
-      "source_file": "packages/athena-webapp/shared/staffDisplayName.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 280,
-      "file_type": "code",
-      "id": "staffdisplayname_formatstaffdisplayname",
-      "label": "formatStaffDisplayName()",
-      "norm_label": "formatstaffdisplayname()",
-      "source_file": "packages/athena-webapp/shared/staffDisplayName.ts",
-      "source_location": "L12"
-    },
-    {
-      "community": 280,
-      "file_type": "code",
-      "id": "staffdisplayname_formatstaffdisplaynameorfallback",
-      "label": "formatStaffDisplayNameOrFallback()",
-      "norm_label": "formatstaffdisplaynameorfallback()",
-      "source_file": "packages/athena-webapp/shared/staffDisplayName.ts",
-      "source_location": "L46"
-    },
-    {
-      "community": 280,
-      "file_type": "code",
-      "id": "staffdisplayname_normalizenamepart",
-      "label": "normalizeNamePart()",
-      "norm_label": "normalizenamepart()",
-      "source_file": "packages/athena-webapp/shared/staffDisplayName.ts",
-      "source_location": "L7"
-    },
-    {
-      "community": 281,
-      "file_type": "code",
       "id": "attributesmanager_attributesmanager",
       "label": "AttributesManager()",
       "norm_label": "attributesmanager()",
@@ -80707,7 +80671,7 @@
       "source_location": "L227"
     },
     {
-      "community": 281,
+      "community": 280,
       "file_type": "code",
       "id": "attributesmanager_colormanager",
       "label": "ColorManager()",
@@ -80716,7 +80680,7 @@
       "source_location": "L46"
     },
     {
-      "community": 281,
+      "community": 280,
       "file_type": "code",
       "id": "attributesmanager_sidebar",
       "label": "Sidebar()",
@@ -80725,7 +80689,7 @@
       "source_location": "L27"
     },
     {
-      "community": 281,
+      "community": 280,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_attributesmanager_tsx",
       "label": "AttributesManager.tsx",
@@ -80734,7 +80698,7 @@
       "source_location": "L1"
     },
     {
-      "community": 282,
+      "community": 281,
       "file_type": "code",
       "id": "attributestable_getproductattribute",
       "label": "getProductAttribute()",
@@ -80743,7 +80707,7 @@
       "source_location": "L55"
     },
     {
-      "community": 282,
+      "community": 281,
       "file_type": "code",
       "id": "attributestable_handlechange",
       "label": "handleChange()",
@@ -80752,7 +80716,7 @@
       "source_location": "L32"
     },
     {
-      "community": 282,
+      "community": 281,
       "file_type": "code",
       "id": "attributestable_onsubmit",
       "label": "onSubmit()",
@@ -80761,7 +80725,7 @@
       "source_location": "L211"
     },
     {
-      "community": 282,
+      "community": 281,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_attributestable_tsx",
       "label": "AttributesTable.tsx",
@@ -80770,7 +80734,7 @@
       "source_location": "L1"
     },
     {
-      "community": 283,
+      "community": 282,
       "file_type": "code",
       "id": "categorysubcategorymanager_categorymanager",
       "label": "CategoryManager()",
@@ -80779,7 +80743,7 @@
       "source_location": "L52"
     },
     {
-      "community": 283,
+      "community": 282,
       "file_type": "code",
       "id": "categorysubcategorymanager_sidebar",
       "label": "Sidebar()",
@@ -80788,7 +80752,7 @@
       "source_location": "L27"
     },
     {
-      "community": 283,
+      "community": 282,
       "file_type": "code",
       "id": "categorysubcategorymanager_subcategorymanager",
       "label": "SubcategoryManager()",
@@ -80797,7 +80761,7 @@
       "source_location": "L288"
     },
     {
-      "community": 283,
+      "community": 282,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_categorysubcategorymanager_tsx",
       "label": "CategorySubcategoryManager.tsx",
@@ -80806,7 +80770,7 @@
       "source_location": "L1"
     },
     {
-      "community": 284,
+      "community": 283,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_storefrontobservabilitypanel_tsx",
       "label": "StorefrontObservabilityPanel.tsx",
@@ -80815,7 +80779,7 @@
       "source_location": "L1"
     },
     {
-      "community": 284,
+      "community": 283,
       "file_type": "code",
       "id": "storefrontobservabilitypanel_formatlabel",
       "label": "formatLabel()",
@@ -80824,7 +80788,7 @@
       "source_location": "L15"
     },
     {
-      "community": 284,
+      "community": 283,
       "file_type": "code",
       "id": "storefrontobservabilitypanel_gettrafficsourcebadge",
       "label": "getTrafficSourceBadge()",
@@ -80833,7 +80797,7 @@
       "source_location": "L32"
     },
     {
-      "community": 284,
+      "community": 283,
       "file_type": "code",
       "id": "storefrontobservabilitypanel_summarycard",
       "label": "SummaryCard()",
@@ -80842,7 +80806,7 @@
       "source_location": "L19"
     },
     {
-      "community": 285,
+      "community": 284,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_utils_ts",
       "label": "utils.ts",
@@ -80851,7 +80815,7 @@
       "source_location": "L1"
     },
     {
-      "community": 285,
+      "community": 284,
       "file_type": "code",
       "id": "utils_countgroupedanalytics",
       "label": "countGroupedAnalytics()",
@@ -80860,7 +80824,7 @@
       "source_location": "L52"
     },
     {
-      "community": 285,
+      "community": 284,
       "file_type": "code",
       "id": "utils_groupanalytics",
       "label": "groupAnalytics()",
@@ -80869,7 +80833,7 @@
       "source_location": "L3"
     },
     {
-      "community": 285,
+      "community": 284,
       "file_type": "code",
       "id": "utils_groupproductviewsbyday",
       "label": "groupProductViewsByDay()",
@@ -80878,7 +80842,7 @@
       "source_location": "L90"
     },
     {
-      "community": 286,
+      "community": 285,
       "file_type": "code",
       "id": "maintenancemessageeditor_getcountdownstatus",
       "label": "getCountdownStatus()",
@@ -80887,7 +80851,7 @@
       "source_location": "L86"
     },
     {
-      "community": 286,
+      "community": 285,
       "file_type": "code",
       "id": "maintenancemessageeditor_handlecountdownchange",
       "label": "handleCountdownChange()",
@@ -80896,7 +80860,7 @@
       "source_location": "L76"
     },
     {
-      "community": 286,
+      "community": 285,
       "file_type": "code",
       "id": "maintenancemessageeditor_handlesave",
       "label": "handleSave()",
@@ -80905,7 +80869,7 @@
       "source_location": "L52"
     },
     {
-      "community": 286,
+      "community": 285,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_maintenancemessageeditor_tsx",
       "label": "MaintenanceMessageEditor.tsx",
@@ -80914,7 +80878,7 @@
       "source_location": "L1"
     },
     {
-      "community": 287,
+      "community": 286,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_shoplook_tsx",
       "label": "ShopLook.tsx",
@@ -80923,7 +80887,7 @@
       "source_location": "L1"
     },
     {
-      "community": 287,
+      "community": 286,
       "file_type": "code",
       "id": "shoplook_handlehighlighteditem",
       "label": "handleHighlightedItem()",
@@ -80932,7 +80896,7 @@
       "source_location": "L67"
     },
     {
-      "community": 287,
+      "community": 286,
       "file_type": "code",
       "id": "shoplook_handleimageupdate",
       "label": "handleImageUpdate()",
@@ -80941,7 +80905,7 @@
       "source_location": "L90"
     },
     {
-      "community": 287,
+      "community": 286,
       "file_type": "code",
       "id": "shoplook_ondragend",
       "label": "onDragEnd()",
@@ -80950,7 +80914,7 @@
       "source_location": "L73"
     },
     {
-      "community": 288,
+      "community": 287,
       "file_type": "code",
       "id": "commandapprovaldialog_getasyncresolution",
       "label": "getAsyncResolution()",
@@ -80959,7 +80923,7 @@
       "source_location": "L78"
     },
     {
-      "community": 288,
+      "community": 287,
       "file_type": "code",
       "id": "commandapprovaldialog_getinlinemanagerresolution",
       "label": "getInlineManagerResolution()",
@@ -80968,7 +80932,7 @@
       "source_location": "L67"
     },
     {
-      "community": 288,
+      "community": 287,
       "file_type": "code",
       "id": "commandapprovaldialog_tostaffauthenticationresult",
       "label": "toStaffAuthenticationResult()",
@@ -80977,7 +80941,7 @@
       "source_location": "L85"
     },
     {
-      "community": 288,
+      "community": 287,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_commandapprovaldialog_tsx",
       "label": "CommandApprovalDialog.tsx",
@@ -80986,7 +80950,7 @@
       "source_location": "L1"
     },
     {
-      "community": 289,
+      "community": 288,
       "file_type": "code",
       "id": "dailycloseview_test_disconnect",
       "label": "disconnect()",
@@ -80995,7 +80959,7 @@
       "source_location": "L312"
     },
     {
-      "community": 289,
+      "community": 288,
       "file_type": "code",
       "id": "dailycloseview_test_observe",
       "label": "observe()",
@@ -81004,7 +80968,7 @@
       "source_location": "L313"
     },
     {
-      "community": 289,
+      "community": 288,
       "file_type": "code",
       "id": "dailycloseview_test_unobserve",
       "label": "unobserve()",
@@ -81013,12 +80977,48 @@
       "source_location": "L314"
     },
     {
-      "community": 289,
+      "community": 288,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_dailycloseview_test_tsx",
       "label": "DailyCloseView.test.tsx",
       "norm_label": "dailycloseview.test.tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 289,
+      "file_type": "code",
+      "id": "operationsqueueview_test_disconnect",
+      "label": "disconnect()",
+      "norm_label": "disconnect()",
+      "source_file": "packages/athena-webapp/src/components/operations/OperationsQueueView.test.tsx",
+      "source_location": "L225"
+    },
+    {
+      "community": 289,
+      "file_type": "code",
+      "id": "operationsqueueview_test_observe",
+      "label": "observe()",
+      "norm_label": "observe()",
+      "source_file": "packages/athena-webapp/src/components/operations/OperationsQueueView.test.tsx",
+      "source_location": "L226"
+    },
+    {
+      "community": 289,
+      "file_type": "code",
+      "id": "operationsqueueview_test_unobserve",
+      "label": "unobserve()",
+      "norm_label": "unobserve()",
+      "source_file": "packages/athena-webapp/src/components/operations/OperationsQueueView.test.tsx",
+      "source_location": "L227"
+    },
+    {
+      "community": 289,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_operations_operationsqueueview_test_tsx",
+      "label": "OperationsQueueView.test.tsx",
+      "norm_label": "operationsqueueview.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/operations/OperationsQueueView.test.tsx",
       "source_location": "L1"
     },
     {
@@ -81204,42 +81204,6 @@
     {
       "community": 290,
       "file_type": "code",
-      "id": "operationsqueueview_test_disconnect",
-      "label": "disconnect()",
-      "norm_label": "disconnect()",
-      "source_file": "packages/athena-webapp/src/components/operations/OperationsQueueView.test.tsx",
-      "source_location": "L225"
-    },
-    {
-      "community": 290,
-      "file_type": "code",
-      "id": "operationsqueueview_test_observe",
-      "label": "observe()",
-      "norm_label": "observe()",
-      "source_file": "packages/athena-webapp/src/components/operations/OperationsQueueView.test.tsx",
-      "source_location": "L226"
-    },
-    {
-      "community": 290,
-      "file_type": "code",
-      "id": "operationsqueueview_test_unobserve",
-      "label": "unobserve()",
-      "norm_label": "unobserve()",
-      "source_file": "packages/athena-webapp/src/components/operations/OperationsQueueView.test.tsx",
-      "source_location": "L227"
-    },
-    {
-      "community": 290,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_operations_operationsqueueview_test_tsx",
-      "label": "OperationsQueueView.test.tsx",
-      "norm_label": "operationsqueueview.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/operations/OperationsQueueView.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 291,
-      "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_returnexchangeview_tsx",
       "label": "ReturnExchangeView.tsx",
       "norm_label": "returnexchangeview.tsx",
@@ -81247,7 +81211,7 @@
       "source_location": "L1"
     },
     {
-      "community": 291,
+      "community": 290,
       "file_type": "code",
       "id": "returnexchangeview_handlesubmit",
       "label": "handleSubmit()",
@@ -81256,7 +81220,7 @@
       "source_location": "L125"
     },
     {
-      "community": 291,
+      "community": 290,
       "file_type": "code",
       "id": "returnexchangeview_resetreplacementfields",
       "label": "resetReplacementFields()",
@@ -81265,7 +81229,7 @@
       "source_location": "L117"
     },
     {
-      "community": 291,
+      "community": 290,
       "file_type": "code",
       "id": "returnexchangeview_toggleitem",
       "label": "toggleItem()",
@@ -81274,7 +81238,7 @@
       "source_location": "L103"
     },
     {
-      "community": 292,
+      "community": 291,
       "file_type": "code",
       "id": "newtransactionview_handlequickstart",
       "label": "handleQuickStart()",
@@ -81283,7 +81247,7 @@
       "source_location": "L91"
     },
     {
-      "community": 292,
+      "community": 291,
       "file_type": "code",
       "id": "newtransactionview_handlestarttransaction",
       "label": "handleStartTransaction()",
@@ -81292,7 +81256,7 @@
       "source_location": "L68"
     },
     {
-      "community": 292,
+      "community": 291,
       "file_type": "code",
       "id": "newtransactionview_navigation",
       "label": "Navigation()",
@@ -81301,7 +81265,7 @@
       "source_location": "L22"
     },
     {
-      "community": 292,
+      "community": 291,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_newtransactionview_tsx",
       "label": "NewTransactionView.tsx",
@@ -81310,7 +81274,7 @@
       "source_location": "L1"
     },
     {
-      "community": 293,
+      "community": 292,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_transactions_transactionview_test_tsx",
       "label": "TransactionView.test.tsx",
@@ -81319,7 +81283,7 @@
       "source_location": "L1"
     },
     {
-      "community": 293,
+      "community": 292,
       "file_type": "code",
       "id": "transactionview_test_async",
       "label": "async()",
@@ -81328,7 +81292,7 @@
       "source_location": "L164"
     },
     {
-      "community": 293,
+      "community": 292,
       "file_type": "code",
       "id": "transactionview_test_mocktransactionmutations",
       "label": "mockTransactionMutations()",
@@ -81337,7 +81301,7 @@
       "source_location": "L388"
     },
     {
-      "community": 293,
+      "community": 292,
       "file_type": "code",
       "id": "transactionview_test_paymentapprovalrequirement",
       "label": "paymentApprovalRequirement()",
@@ -81346,7 +81310,7 @@
       "source_location": "L347"
     },
     {
-      "community": 294,
+      "community": 293,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_procurement_procurementview_test_tsx",
       "label": "ProcurementView.test.tsx",
@@ -81355,7 +81319,7 @@
       "source_location": "L1"
     },
     {
-      "community": 294,
+      "community": 293,
       "file_type": "code",
       "id": "procurementview_test_choosedraftvendor",
       "label": "chooseDraftVendor()",
@@ -81364,7 +81328,7 @@
       "source_location": "L324"
     },
     {
-      "community": 294,
+      "community": 293,
       "file_type": "code",
       "id": "procurementview_test_installmutationmocks",
       "label": "installMutationMocks()",
@@ -81373,7 +81337,7 @@
       "source_location": "L290"
     },
     {
-      "community": 294,
+      "community": 293,
       "file_type": "code",
       "id": "procurementview_test_makerecommendation",
       "label": "makeRecommendation()",
@@ -81382,7 +81346,7 @@
       "source_location": "L279"
     },
     {
-      "community": 295,
+      "community": 294,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_productstock_tsx",
       "label": "ProductStock.tsx",
@@ -81391,7 +81355,7 @@
       "source_location": "L1"
     },
     {
-      "community": 295,
+      "community": 294,
       "file_type": "code",
       "id": "productstock_lowstockstatus",
       "label": "LowStockStatus()",
@@ -81400,7 +81364,7 @@
       "source_location": "L63"
     },
     {
-      "community": 295,
+      "community": 294,
       "file_type": "code",
       "id": "productstock_outofstockstatus",
       "label": "OutOfStockStatus()",
@@ -81409,7 +81373,7 @@
       "source_location": "L54"
     },
     {
-      "community": 295,
+      "community": 294,
       "file_type": "code",
       "id": "productstock_productstockstatus",
       "label": "ProductStockStatus()",
@@ -81418,7 +81382,7 @@
       "source_location": "L11"
     },
     {
-      "community": 296,
+      "community": 295,
       "file_type": "code",
       "id": "complimentaryproductsview_body",
       "label": "Body()",
@@ -81427,7 +81391,7 @@
       "source_location": "L16"
     },
     {
-      "community": 296,
+      "community": 295,
       "file_type": "code",
       "id": "complimentaryproductsview_complimentaryproductsview",
       "label": "ComplimentaryProductsView()",
@@ -81436,7 +81400,7 @@
       "source_location": "L35"
     },
     {
-      "community": 296,
+      "community": 295,
       "file_type": "code",
       "id": "complimentaryproductsview_navigation",
       "label": "Navigation()",
@@ -81445,7 +81409,7 @@
       "source_location": "L6"
     },
     {
-      "community": 296,
+      "community": 295,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_complimentary_complimentaryproductsview_tsx",
       "label": "ComplimentaryProductsView.tsx",
@@ -81454,7 +81418,7 @@
       "source_location": "L1"
     },
     {
-      "community": 297,
+      "community": 296,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodemoney_ts",
       "label": "promoCodeMoney.ts",
@@ -81463,7 +81427,7 @@
       "source_location": "L1"
     },
     {
-      "community": 297,
+      "community": 296,
       "file_type": "code",
       "id": "promocodemoney_parsepromodiscountinput",
       "label": "parsePromoDiscountInput()",
@@ -81472,7 +81436,7 @@
       "source_location": "L5"
     },
     {
-      "community": 297,
+      "community": 296,
       "file_type": "code",
       "id": "promocodemoney_promodiscountdisplaytext",
       "label": "promoDiscountDisplayText()",
@@ -81481,7 +81445,7 @@
       "source_location": "L30"
     },
     {
-      "community": 297,
+      "community": 296,
       "file_type": "code",
       "id": "promocodemoney_promodiscountinputvalue",
       "label": "promoDiscountInputValue()",
@@ -81490,7 +81454,7 @@
       "source_location": "L21"
     },
     {
-      "community": 298,
+      "community": 297,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_servicecasesview_tsx",
       "label": "ServiceCasesView.tsx",
@@ -81499,7 +81463,7 @@
       "source_location": "L1"
     },
     {
-      "community": 298,
+      "community": 297,
       "file_type": "code",
       "id": "servicecasesview_applycommandresult",
       "label": "applyCommandResult()",
@@ -81508,7 +81472,7 @@
       "source_location": "L194"
     },
     {
-      "community": 298,
+      "community": 297,
       "file_type": "code",
       "id": "servicecasesview_handlecreatecase",
       "label": "handleCreateCase()",
@@ -81517,7 +81481,7 @@
       "source_location": "L215"
     },
     {
-      "community": 298,
+      "community": 297,
       "file_type": "code",
       "id": "servicecasesview_withsavestate",
       "label": "withSaveState()",
@@ -81526,7 +81490,7 @@
       "source_location": "L910"
     },
     {
-      "community": 299,
+      "community": 298,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_traces_workflowtraceview_tsx",
       "label": "WorkflowTraceView.tsx",
@@ -81535,7 +81499,7 @@
       "source_location": "L1"
     },
     {
-      "community": 299,
+      "community": 298,
       "file_type": "code",
       "id": "workflowtraceview_formattracelabel",
       "label": "formatTraceLabel()",
@@ -81544,7 +81508,7 @@
       "source_location": "L41"
     },
     {
-      "community": 299,
+      "community": 298,
       "file_type": "code",
       "id": "workflowtraceview_getstatustone",
       "label": "getStatusTone()",
@@ -81553,13 +81517,49 @@
       "source_location": "L45"
     },
     {
-      "community": 299,
+      "community": 298,
       "file_type": "code",
       "id": "workflowtraceview_workflowtraceheader",
       "label": "WorkflowTraceHeader()",
       "norm_label": "workflowtraceheader()",
       "source_file": "packages/athena-webapp/src/components/traces/WorkflowTraceView.tsx",
       "source_location": "L65"
+    },
+    {
+      "community": 299,
+      "file_type": "code",
+      "id": "engagementmetrics_formatlastactivity",
+      "label": "formatLastActivity()",
+      "norm_label": "formatlastactivity()",
+      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/EngagementMetrics.tsx",
+      "source_location": "L75"
+    },
+    {
+      "community": 299,
+      "file_type": "code",
+      "id": "engagementmetrics_getdeviceicon",
+      "label": "getDeviceIcon()",
+      "norm_label": "getdeviceicon()",
+      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/EngagementMetrics.tsx",
+      "source_location": "L82"
+    },
+    {
+      "community": 299,
+      "file_type": "code",
+      "id": "engagementmetrics_getdevicelabel",
+      "label": "getDeviceLabel()",
+      "norm_label": "getdevicelabel()",
+      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/EngagementMetrics.tsx",
+      "source_location": "L93"
+    },
+    {
+      "community": 299,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_users_behavioral_insights_engagementmetrics_tsx",
+      "label": "EngagementMetrics.tsx",
+      "norm_label": "engagementmetrics.tsx",
+      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/EngagementMetrics.tsx",
+      "source_location": "L1"
     },
     {
       "community": 3,
@@ -82149,42 +82149,6 @@
     {
       "community": 300,
       "file_type": "code",
-      "id": "engagementmetrics_formatlastactivity",
-      "label": "formatLastActivity()",
-      "norm_label": "formatlastactivity()",
-      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/EngagementMetrics.tsx",
-      "source_location": "L75"
-    },
-    {
-      "community": 300,
-      "file_type": "code",
-      "id": "engagementmetrics_getdeviceicon",
-      "label": "getDeviceIcon()",
-      "norm_label": "getdeviceicon()",
-      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/EngagementMetrics.tsx",
-      "source_location": "L82"
-    },
-    {
-      "community": 300,
-      "file_type": "code",
-      "id": "engagementmetrics_getdevicelabel",
-      "label": "getDeviceLabel()",
-      "norm_label": "getdevicelabel()",
-      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/EngagementMetrics.tsx",
-      "source_location": "L93"
-    },
-    {
-      "community": 300,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_users_behavioral_insights_engagementmetrics_tsx",
-      "label": "EngagementMetrics.tsx",
-      "norm_label": "engagementmetrics.tsx",
-      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/EngagementMetrics.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 301,
-      "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_riskindicators_tsx",
       "label": "RiskIndicators.tsx",
       "norm_label": "riskindicators.tsx",
@@ -82192,7 +82156,7 @@
       "source_location": "L1"
     },
     {
-      "community": 301,
+      "community": 300,
       "file_type": "code",
       "id": "riskindicators_getriskicon",
       "label": "getRiskIcon()",
@@ -82201,7 +82165,7 @@
       "source_location": "L15"
     },
     {
-      "community": 301,
+      "community": 300,
       "file_type": "code",
       "id": "riskindicators_getriskstyles",
       "label": "getRiskStyles()",
@@ -82210,7 +82174,7 @@
       "source_location": "L28"
     },
     {
-      "community": 301,
+      "community": 300,
       "file_type": "code",
       "id": "riskindicators_riskindicators",
       "label": "RiskIndicators()",
@@ -82219,7 +82183,7 @@
       "source_location": "L54"
     },
     {
-      "community": 302,
+      "community": 301,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useexpenseoperations_ts",
       "label": "useExpenseOperations.ts",
@@ -82228,7 +82192,7 @@
       "source_location": "L1"
     },
     {
-      "community": 302,
+      "community": 301,
       "file_type": "code",
       "id": "useexpenseoperations_clonecartitems",
       "label": "cloneCartItems()",
@@ -82237,7 +82201,7 @@
       "source_location": "L19"
     },
     {
-      "community": 302,
+      "community": 301,
       "file_type": "code",
       "id": "useexpenseoperations_mapproducttoexpensecartitem",
       "label": "mapProductToExpenseCartItem()",
@@ -82246,7 +82210,7 @@
       "source_location": "L23"
     },
     {
-      "community": 302,
+      "community": 301,
       "file_type": "code",
       "id": "useexpenseoperations_useexpenseoperations",
       "label": "useExpenseOperations()",
@@ -82255,7 +82219,7 @@
       "source_location": "L50"
     },
     {
-      "community": 303,
+      "community": 302,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetproducts_ts",
       "label": "useGetProducts.ts",
@@ -82264,7 +82228,7 @@
       "source_location": "L1"
     },
     {
-      "community": 303,
+      "community": 302,
       "file_type": "code",
       "id": "usegetproducts_usegetarchivedproducts",
       "label": "useGetArchivedProducts()",
@@ -82273,7 +82237,7 @@
       "source_location": "L36"
     },
     {
-      "community": 303,
+      "community": 302,
       "file_type": "code",
       "id": "usegetproducts_usegetproducts",
       "label": "useGetProducts()",
@@ -82282,7 +82246,7 @@
       "source_location": "L7"
     },
     {
-      "community": 303,
+      "community": 302,
       "file_type": "code",
       "id": "usegetproducts_usegetunresolvedproducts",
       "label": "useGetUnresolvedProducts()",
@@ -82291,7 +82255,7 @@
       "source_location": "L40"
     },
     {
-      "community": 304,
+      "community": 303,
       "file_type": "code",
       "id": "customerobservabilitytimeline_formatobservabilitylabel",
       "label": "formatObservabilityLabel()",
@@ -82300,7 +82264,7 @@
       "source_location": "L66"
     },
     {
-      "community": 304,
+      "community": 303,
       "file_type": "code",
       "id": "customerobservabilitytimeline_getdeviceicon",
       "label": "getDeviceIcon()",
@@ -82309,7 +82273,7 @@
       "source_location": "L121"
     },
     {
-      "community": 304,
+      "community": 303,
       "file_type": "code",
       "id": "customerobservabilitytimeline_getobservabilitystatusstyles",
       "label": "getObservabilityStatusStyles()",
@@ -82318,7 +82282,7 @@
       "source_location": "L74"
     },
     {
-      "community": 304,
+      "community": 303,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_customerobservabilitytimeline_ts",
       "label": "customerObservabilityTimeline.ts",
@@ -82327,7 +82291,7 @@
       "source_location": "L1"
     },
     {
-      "community": 305,
+      "community": 304,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_runcommand_ts",
       "label": "runCommand.ts",
@@ -82336,7 +82300,7 @@
       "source_location": "L1"
     },
     {
-      "community": 305,
+      "community": 304,
       "file_type": "code",
       "id": "runcommand_extracttraceid",
       "label": "extractTraceId()",
@@ -82345,7 +82309,7 @@
       "source_location": "L34"
     },
     {
-      "community": 305,
+      "community": 304,
       "file_type": "code",
       "id": "runcommand_isapprovalrequiredresult",
       "label": "isApprovalRequiredResult()",
@@ -82354,7 +82318,7 @@
       "source_location": "L28"
     },
     {
-      "community": 305,
+      "community": 304,
       "file_type": "code",
       "id": "runcommand_runcommand",
       "label": "runCommand()",
@@ -82363,7 +82327,7 @@
       "source_location": "L48"
     },
     {
-      "community": 306,
+      "community": 305,
       "file_type": "code",
       "id": "barcodeutils_extractbarcodefrominput",
       "label": "extractBarcodeFromInput()",
@@ -82372,7 +82336,7 @@
       "source_location": "L51"
     },
     {
-      "community": 306,
+      "community": 305,
       "file_type": "code",
       "id": "barcodeutils_isurlorbarcode",
       "label": "isUrlOrBarcode()",
@@ -82381,7 +82345,7 @@
       "source_location": "L92"
     },
     {
-      "community": 306,
+      "community": 305,
       "file_type": "code",
       "id": "barcodeutils_isvalidconvexid",
       "label": "isValidConvexId()",
@@ -82390,7 +82354,7 @@
       "source_location": "L16"
     },
     {
-      "community": 306,
+      "community": 305,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_barcodeutils_ts",
       "label": "barcodeUtils.ts",
@@ -82399,7 +82363,7 @@
       "source_location": "L1"
     },
     {
-      "community": 307,
+      "community": 306,
       "file_type": "code",
       "id": "displayamounts_formatstoredamount",
       "label": "formatStoredAmount()",
@@ -82408,7 +82372,7 @@
       "source_location": "L8"
     },
     {
-      "community": 307,
+      "community": 306,
       "file_type": "code",
       "id": "displayamounts_formatstoredcurrencyamount",
       "label": "formatStoredCurrencyAmount()",
@@ -82417,7 +82381,7 @@
       "source_location": "L15"
     },
     {
-      "community": 307,
+      "community": 306,
       "file_type": "code",
       "id": "displayamounts_parsedisplayamountinput",
       "label": "parseDisplayAmountInput()",
@@ -82426,7 +82390,7 @@
       "source_location": "L32"
     },
     {
-      "community": 307,
+      "community": 306,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_displayamounts_ts",
       "label": "displayAmounts.ts",
@@ -82435,7 +82399,7 @@
       "source_location": "L1"
     },
     {
-      "community": 308,
+      "community": 307,
       "file_type": "code",
       "id": "customergateway_useconvexposcustomercreate",
       "label": "useConvexPosCustomerCreate()",
@@ -82444,7 +82408,7 @@
       "source_location": "L22"
     },
     {
-      "community": 308,
+      "community": 307,
       "file_type": "code",
       "id": "customergateway_useconvexposcustomersearch",
       "label": "useConvexPosCustomerSearch()",
@@ -82453,7 +82417,7 @@
       "source_location": "L10"
     },
     {
-      "community": 308,
+      "community": 307,
       "file_type": "code",
       "id": "customergateway_useconvexposcustomerupdate",
       "label": "useConvexPosCustomerUpdate()",
@@ -82462,7 +82426,7 @@
       "source_location": "L57"
     },
     {
-      "community": 308,
+      "community": 307,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_customergateway_ts",
       "label": "customerGateway.ts",
@@ -82471,7 +82435,7 @@
       "source_location": "L1"
     },
     {
-      "community": 309,
+      "community": 308,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_sessiongateway_mapper_ts",
       "label": "sessionGateway.mapper.ts",
@@ -82480,7 +82444,7 @@
       "source_location": "L1"
     },
     {
-      "community": 309,
+      "community": 308,
       "file_type": "code",
       "id": "sessiongateway_mapper_mapactivesessiondto",
       "label": "mapActiveSessionDto()",
@@ -82489,7 +82453,7 @@
       "source_location": "L83"
     },
     {
-      "community": 309,
+      "community": 308,
       "file_type": "code",
       "id": "sessiongateway_mapper_mapheldsessionsdto",
       "label": "mapHeldSessionsDto()",
@@ -82498,13 +82462,49 @@
       "source_location": "L100"
     },
     {
-      "community": 309,
+      "community": 308,
       "file_type": "code",
       "id": "sessiongateway_mapper_normalizecartitems",
       "label": "normalizeCartItems()",
       "norm_label": "normalizecartitems()",
       "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/sessionGateway.mapper.ts",
       "source_location": "L79"
+    },
+    {
+      "community": 309,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_sessiongateway_ts",
+      "label": "sessionGateway.ts",
+      "norm_label": "sessiongateway.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/sessionGateway.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 309,
+      "file_type": "code",
+      "id": "sessiongateway_useconvexactivesession",
+      "label": "useConvexActiveSession()",
+      "norm_label": "useconvexactivesession()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/sessionGateway.ts",
+      "source_location": "L38"
+    },
+    {
+      "community": 309,
+      "file_type": "code",
+      "id": "sessiongateway_useconvexheldsessions",
+      "label": "useConvexHeldSessions()",
+      "norm_label": "useconvexheldsessions()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/sessionGateway.ts",
+      "source_location": "L65"
+    },
+    {
+      "community": 309,
+      "file_type": "code",
+      "id": "sessiongateway_useconvexsessionactions",
+      "label": "useConvexSessionActions()",
+      "norm_label": "useconvexsessionactions()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/sessionGateway.ts",
+      "source_location": "L91"
     },
     {
       "community": 31,
@@ -82680,42 +82680,6 @@
     {
       "community": 310,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_sessiongateway_ts",
-      "label": "sessionGateway.ts",
-      "norm_label": "sessiongateway.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/sessionGateway.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 310,
-      "file_type": "code",
-      "id": "sessiongateway_useconvexactivesession",
-      "label": "useConvexActiveSession()",
-      "norm_label": "useconvexactivesession()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/sessionGateway.ts",
-      "source_location": "L38"
-    },
-    {
-      "community": 310,
-      "file_type": "code",
-      "id": "sessiongateway_useconvexheldsessions",
-      "label": "useConvexHeldSessions()",
-      "norm_label": "useconvexheldsessions()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/sessionGateway.ts",
-      "source_location": "L65"
-    },
-    {
-      "community": 310,
-      "file_type": "code",
-      "id": "sessiongateway_useconvexsessionactions",
-      "label": "useConvexSessionActions()",
-      "norm_label": "useconvexsessionactions()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/sessionGateway.ts",
-      "source_location": "L91"
-    },
-    {
-      "community": 311,
-      "file_type": "code",
       "id": "fingerprint_isbrowserfingerprintresult",
       "label": "isBrowserFingerprintResult()",
       "norm_label": "isbrowserfingerprintresult()",
@@ -82723,7 +82687,7 @@
       "source_location": "L4"
     },
     {
-      "community": 311,
+      "community": 310,
       "file_type": "code",
       "id": "fingerprint_readstoredterminalfingerprint",
       "label": "readStoredTerminalFingerprint()",
@@ -82732,7 +82696,7 @@
       "source_location": "L20"
     },
     {
-      "community": 311,
+      "community": 310,
       "file_type": "code",
       "id": "fingerprint_readstoredterminalfingerprinthash",
       "label": "readStoredTerminalFingerprintHash()",
@@ -82741,7 +82705,7 @@
       "source_location": "L42"
     },
     {
-      "community": 311,
+      "community": 310,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_terminal_fingerprint_ts",
       "label": "fingerprint.ts",
@@ -82750,7 +82714,7 @@
       "source_location": "L1"
     },
     {
-      "community": 312,
+      "community": 311,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_presentation_expense_useexpenseregisterviewmodel_ts",
       "label": "useExpenseRegisterViewModel.ts",
@@ -82759,7 +82723,7 @@
       "source_location": "L1"
     },
     {
-      "community": 312,
+      "community": 311,
       "file_type": "code",
       "id": "useexpenseregisterviewmodel_getcashierdisplayname",
       "label": "getCashierDisplayName()",
@@ -82768,7 +82732,7 @@
       "source_location": "L37"
     },
     {
-      "community": 312,
+      "community": 311,
       "file_type": "code",
       "id": "useexpenseregisterviewmodel_getexpensesessionloadkey",
       "label": "getExpenseSessionLoadKey()",
@@ -82777,7 +82741,7 @@
       "source_location": "L49"
     },
     {
-      "community": 312,
+      "community": 311,
       "file_type": "code",
       "id": "useexpenseregisterviewmodel_useexpenseregisterviewmodel",
       "label": "useExpenseRegisterViewModel()",
@@ -82786,7 +82750,7 @@
       "source_location": "L68"
     },
     {
-      "community": 313,
+      "community": 312,
       "file_type": "code",
       "id": "offers_getbaseurl",
       "label": "getBaseUrl()",
@@ -82795,7 +82759,7 @@
       "source_location": "L13"
     },
     {
-      "community": 313,
+      "community": 312,
       "file_type": "code",
       "id": "offers_getuserredeemedoffers",
       "label": "getUserRedeemedOffers()",
@@ -82804,7 +82768,7 @@
       "source_location": "L46"
     },
     {
-      "community": 313,
+      "community": 312,
       "file_type": "code",
       "id": "offers_submitoffer",
       "label": "submitOffer()",
@@ -82813,7 +82777,7 @@
       "source_location": "L21"
     },
     {
-      "community": 313,
+      "community": 312,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_offers_ts",
       "label": "offers.ts",
@@ -82822,7 +82786,7 @@
       "source_location": "L1"
     },
     {
-      "community": 314,
+      "community": 313,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_stores_ts",
       "label": "stores.ts",
@@ -82831,7 +82795,7 @@
       "source_location": "L1"
     },
     {
-      "community": 314,
+      "community": 313,
       "file_type": "code",
       "id": "stores_getallstores",
       "label": "getAllStores()",
@@ -82840,7 +82804,7 @@
       "source_location": "L8"
     },
     {
-      "community": 314,
+      "community": 313,
       "file_type": "code",
       "id": "stores_getbaseurl",
       "label": "getBaseUrl()",
@@ -82849,7 +82813,7 @@
       "source_location": "L5"
     },
     {
-      "community": 314,
+      "community": 313,
       "file_type": "code",
       "id": "stores_getstore",
       "label": "getStore()",
@@ -82858,7 +82822,7 @@
       "source_location": "L20"
     },
     {
-      "community": 315,
+      "community": 314,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_subcategory_ts",
       "label": "subcategory.ts",
@@ -82867,7 +82831,7 @@
       "source_location": "L1"
     },
     {
-      "community": 315,
+      "community": 314,
       "file_type": "code",
       "id": "subcategory_getallsubcategories",
       "label": "getAllSubcategories()",
@@ -82876,7 +82840,7 @@
       "source_location": "L11"
     },
     {
-      "community": 315,
+      "community": 314,
       "file_type": "code",
       "id": "subcategory_getbaseurl",
       "label": "getBaseUrl()",
@@ -82885,7 +82849,7 @@
       "source_location": "L9"
     },
     {
-      "community": 315,
+      "community": 314,
       "file_type": "code",
       "id": "subcategory_getsubategory",
       "label": "getSubategory()",
@@ -82894,7 +82858,7 @@
       "source_location": "L25"
     },
     {
-      "community": 316,
+      "community": 315,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_productactionbar_tsx",
       "label": "ProductActionBar.tsx",
@@ -82903,7 +82867,7 @@
       "source_location": "L1"
     },
     {
-      "community": 316,
+      "community": 315,
       "file_type": "code",
       "id": "productactionbar_checkscroll",
       "label": "checkScroll()",
@@ -82912,7 +82876,7 @@
       "source_location": "L50"
     },
     {
-      "community": 316,
+      "community": 315,
       "file_type": "code",
       "id": "productactionbar_handleaction",
       "label": "handleAction()",
@@ -82921,7 +82885,7 @@
       "source_location": "L92"
     },
     {
-      "community": 316,
+      "community": 315,
       "file_type": "code",
       "id": "productactionbar_handledismiss",
       "label": "handleDismiss()",
@@ -82930,7 +82894,7 @@
       "source_location": "L74"
     },
     {
-      "community": 317,
+      "community": 316,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_productreminderbar_tsx",
       "label": "ProductReminderBar.tsx",
@@ -82939,7 +82903,7 @@
       "source_location": "L1"
     },
     {
-      "community": 317,
+      "community": 316,
       "file_type": "code",
       "id": "productreminderbar_checkscroll",
       "label": "checkScroll()",
@@ -82948,7 +82912,7 @@
       "source_location": "L62"
     },
     {
-      "community": 317,
+      "community": 316,
       "file_type": "code",
       "id": "productreminderbar_handleaddtobag",
       "label": "handleAddToBag()",
@@ -82957,7 +82921,7 @@
       "source_location": "L109"
     },
     {
-      "community": 317,
+      "community": 316,
       "file_type": "code",
       "id": "productreminderbar_handledismiss",
       "label": "handleDismiss()",
@@ -82966,7 +82930,7 @@
       "source_location": "L177"
     },
     {
-      "community": 318,
+      "community": 317,
       "file_type": "code",
       "id": "billingdetailssection_clearform",
       "label": "clearForm()",
@@ -82975,7 +82939,7 @@
       "source_location": "L18"
     },
     {
-      "community": 318,
+      "community": 317,
       "file_type": "code",
       "id": "billingdetailssection_handleusebillingaddressonfile",
       "label": "handleUseBillingAddressOnFile()",
@@ -82984,7 +82948,7 @@
       "source_location": "L52"
     },
     {
-      "community": 318,
+      "community": 317,
       "file_type": "code",
       "id": "billingdetailssection_togglesameasdelivery",
       "label": "toggleSameAsDelivery()",
@@ -82993,7 +82957,7 @@
       "source_location": "L68"
     },
     {
-      "community": 318,
+      "community": 317,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_billingdetailssection_tsx",
       "label": "BillingDetailsSection.tsx",
@@ -83002,7 +82966,7 @@
       "source_location": "L1"
     },
     {
-      "community": 319,
+      "community": 318,
       "file_type": "code",
       "id": "hooks_usegetshopsearchparams",
       "label": "useGetShopSearchParams()",
@@ -83011,7 +82975,7 @@
       "source_location": "L68"
     },
     {
-      "community": 319,
+      "community": 318,
       "file_type": "code",
       "id": "hooks_usegetstorecategories",
       "label": "useGetStoreCategories()",
@@ -83020,7 +82984,7 @@
       "source_location": "L26"
     },
     {
-      "community": 319,
+      "community": 318,
       "file_type": "code",
       "id": "hooks_usegetstoresubcategories",
       "label": "useGetStoreSubcategories()",
@@ -83029,13 +82993,49 @@
       "source_location": "L7"
     },
     {
-      "community": 319,
+      "community": 318,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_hooks_ts",
       "label": "hooks.ts",
       "norm_label": "hooks.ts",
       "source_file": "packages/storefront-webapp/src/components/navigation/hooks.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 319,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_page_productattribute_tsx",
+      "label": "ProductAttribute.tsx",
+      "norm_label": "productattribute.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-page/ProductAttribute.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 319,
+      "file_type": "code",
+      "id": "productattribute_findsize",
+      "label": "findSize()",
+      "norm_label": "findsize()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/ProductAttribute.tsx",
+      "source_location": "L81"
+    },
+    {
+      "community": 319,
+      "file_type": "code",
+      "id": "productattribute_handleclick",
+      "label": "handleClick()",
+      "norm_label": "handleclick()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/ProductAttribute.tsx",
+      "source_location": "L85"
+    },
+    {
+      "community": 319,
+      "file_type": "code",
+      "id": "productattribute_optionclassname",
+      "label": "optionClassName()",
+      "norm_label": "optionclassname()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/ProductAttribute.tsx",
+      "source_location": "L27"
     },
     {
       "community": 32,
@@ -83211,42 +83211,6 @@
     {
       "community": 320,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_page_productattribute_tsx",
-      "label": "ProductAttribute.tsx",
-      "norm_label": "productattribute.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-page/ProductAttribute.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 320,
-      "file_type": "code",
-      "id": "productattribute_findsize",
-      "label": "findSize()",
-      "norm_label": "findsize()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/ProductAttribute.tsx",
-      "source_location": "L81"
-    },
-    {
-      "community": 320,
-      "file_type": "code",
-      "id": "productattribute_handleclick",
-      "label": "handleClick()",
-      "norm_label": "handleclick()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/ProductAttribute.tsx",
-      "source_location": "L85"
-    },
-    {
-      "community": 320,
-      "file_type": "code",
-      "id": "productattribute_optionclassname",
-      "label": "optionClassName()",
-      "norm_label": "optionclassname()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/ProductAttribute.tsx",
-      "source_location": "L27"
-    },
-    {
-      "community": 321,
-      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productdetails_tsx",
       "label": "ProductDetails.tsx",
       "norm_label": "productdetails.tsx",
@@ -83254,7 +83218,7 @@
       "source_location": "L1"
     },
     {
-      "community": 321,
+      "community": 320,
       "file_type": "code",
       "id": "productdetails_bagproduct",
       "label": "BagProduct()",
@@ -83263,7 +83227,7 @@
       "source_location": "L43"
     },
     {
-      "community": 321,
+      "community": 320,
       "file_type": "code",
       "id": "productdetails_pickupdetails",
       "label": "PickupDetails()",
@@ -83272,7 +83236,7 @@
       "source_location": "L13"
     },
     {
-      "community": 321,
+      "community": 320,
       "file_type": "code",
       "id": "productdetails_shippingpolicy",
       "label": "ShippingPolicy()",
@@ -83281,7 +83245,7 @@
       "source_location": "L88"
     },
     {
-      "community": 322,
+      "community": 321,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_upsellmodal_tsx",
       "label": "UpsellModal.tsx",
@@ -83290,7 +83254,7 @@
       "source_location": "L1"
     },
     {
-      "community": 322,
+      "community": 321,
       "file_type": "code",
       "id": "upsellmodal_handleclose",
       "label": "handleClose()",
@@ -83299,7 +83263,7 @@
       "source_location": "L111"
     },
     {
-      "community": 322,
+      "community": 321,
       "file_type": "code",
       "id": "upsellmodal_handlescroll",
       "label": "handleScroll()",
@@ -83308,7 +83272,7 @@
       "source_location": "L66"
     },
     {
-      "community": 322,
+      "community": 321,
       "file_type": "code",
       "id": "upsellmodal_handlesuccess",
       "label": "handleSuccess()",
@@ -83317,7 +83281,7 @@
       "source_location": "L127"
     },
     {
-      "community": 323,
+      "community": 322,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_upsellmodalform_tsx",
       "label": "UpsellModalForm.tsx",
@@ -83326,7 +83290,7 @@
       "source_location": "L1"
     },
     {
-      "community": 323,
+      "community": 322,
       "file_type": "code",
       "id": "upsellmodalform_formatstoredamount",
       "label": "formatStoredAmount()",
@@ -83335,7 +83299,7 @@
       "source_location": "L92"
     },
     {
-      "community": 323,
+      "community": 322,
       "file_type": "code",
       "id": "upsellmodalform_handleinputchange",
       "label": "handleInputChange()",
@@ -83344,7 +83308,7 @@
       "source_location": "L64"
     },
     {
-      "community": 323,
+      "community": 322,
       "file_type": "code",
       "id": "upsellmodalform_handlesubmit",
       "label": "handleSubmit()",
@@ -83353,7 +83317,7 @@
       "source_location": "L49"
     },
     {
-      "community": 324,
+      "community": 323,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_contexts_storecontext_tsx",
       "label": "StoreContext.tsx",
@@ -83362,7 +83326,7 @@
       "source_location": "L1"
     },
     {
-      "community": 324,
+      "community": 323,
       "file_type": "code",
       "id": "storecontext_storeprovider",
       "label": "StoreProvider()",
@@ -83371,7 +83335,7 @@
       "source_location": "L25"
     },
     {
-      "community": 324,
+      "community": 323,
       "file_type": "code",
       "id": "storecontext_useoptionalstorecontext",
       "label": "useOptionalStoreContext()",
@@ -83380,7 +83344,7 @@
       "source_location": "L90"
     },
     {
-      "community": 324,
+      "community": 323,
       "file_type": "code",
       "id": "storecontext_usestorecontext",
       "label": "useStoreContext()",
@@ -83389,7 +83353,7 @@
       "source_location": "L82"
     },
     {
-      "community": 325,
+      "community": 324,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_shoplayout_tsx",
       "label": "_shopLayout.tsx",
@@ -83398,7 +83362,7 @@
       "source_location": "L1"
     },
     {
-      "community": 325,
+      "community": 324,
       "file_type": "code",
       "id": "shoplayout_clearfilters",
       "label": "clearFilters()",
@@ -83407,7 +83371,7 @@
       "source_location": "L115"
     },
     {
-      "community": 325,
+      "community": 324,
       "file_type": "code",
       "id": "shoplayout_onclickonmobilefilters",
       "label": "onClickOnMobileFilters()",
@@ -83416,7 +83380,7 @@
       "source_location": "L105"
     },
     {
-      "community": 325,
+      "community": 324,
       "file_type": "code",
       "id": "shoplayout_onmobilefilterscloseclick",
       "label": "onMobileFiltersCloseClick()",
@@ -83425,7 +83389,7 @@
       "source_location": "L110"
     },
     {
-      "community": 326,
+      "community": 325,
       "file_type": "code",
       "id": "index_cancelorder",
       "label": "cancelOrder()",
@@ -83434,7 +83398,7 @@
       "source_location": "L121"
     },
     {
-      "community": 326,
+      "community": 325,
       "file_type": "code",
       "id": "index_geterrormessage",
       "label": "getErrorMessage()",
@@ -83443,7 +83407,7 @@
       "source_location": "L26"
     },
     {
-      "community": 326,
+      "community": 325,
       "file_type": "code",
       "id": "index_placeorder",
       "label": "placeOrder()",
@@ -83452,7 +83416,7 @@
       "source_location": "L71"
     },
     {
-      "community": 326,
+      "community": 325,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_index_tsx",
       "label": "index.tsx",
@@ -83461,7 +83425,7 @@
       "source_location": "L1"
     },
     {
-      "community": 327,
+      "community": 326,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_receipt_posreceiptpage_tsx",
       "label": "-PosReceiptPage.tsx",
@@ -83470,7 +83434,7 @@
       "source_location": "L1"
     },
     {
-      "community": 327,
+      "community": 326,
       "file_type": "code",
       "id": "posreceiptpage_money",
       "label": "money()",
@@ -83479,7 +83443,7 @@
       "source_location": "L51"
     },
     {
-      "community": 327,
+      "community": 326,
       "file_type": "code",
       "id": "posreceiptpage_paymentlabel",
       "label": "paymentLabel()",
@@ -83488,7 +83452,7 @@
       "source_location": "L13"
     },
     {
-      "community": 327,
+      "community": 326,
       "file_type": "code",
       "id": "posreceiptpage_shouldretryreceiptlookup",
       "label": "shouldRetryReceiptLookup()",
@@ -83497,7 +83461,7 @@
       "source_location": "L21"
     },
     {
-      "community": 328,
+      "community": 327,
       "file_type": "code",
       "id": "bootstrap_bootstrapcheckout",
       "label": "bootstrapCheckout()",
@@ -83506,7 +83470,7 @@
       "source_location": "L46"
     },
     {
-      "community": 328,
+      "community": 327,
       "file_type": "code",
       "id": "bootstrap_createbootstraptoken",
       "label": "createBootstrapToken()",
@@ -83515,7 +83479,7 @@
       "source_location": "L24"
     },
     {
-      "community": 328,
+      "community": 327,
       "file_type": "code",
       "id": "bootstrap_createmarker",
       "label": "createMarker()",
@@ -83524,7 +83488,7 @@
       "source_location": "L20"
     },
     {
-      "community": 328,
+      "community": 327,
       "file_type": "code",
       "id": "packages_storefront_webapp_tests_e2e_helpers_bootstrap_ts",
       "label": "bootstrap.ts",
@@ -83533,7 +83497,7 @@
       "source_location": "L1"
     },
     {
-      "community": 329,
+      "community": 328,
       "file_type": "code",
       "id": "graphify_check_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -83542,7 +83506,7 @@
       "source_location": "L17"
     },
     {
-      "community": 329,
+      "community": 328,
       "file_type": "code",
       "id": "graphify_check_test_write",
       "label": "write()",
@@ -83551,7 +83515,7 @@
       "source_location": "L11"
     },
     {
-      "community": 329,
+      "community": 328,
       "file_type": "code",
       "id": "graphify_check_test_writegraphifywikiartifacts",
       "label": "writeGraphifyWikiArtifacts()",
@@ -83560,12 +83524,48 @@
       "source_location": "L24"
     },
     {
-      "community": 329,
+      "community": 328,
       "file_type": "code",
       "id": "scripts_graphify_check_test_ts",
       "label": "graphify-check.test.ts",
       "norm_label": "graphify-check.test.ts",
       "source_file": "scripts/graphify-check.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 329,
+      "file_type": "code",
+      "id": "graphify_rebuild_test_createfixtureroot",
+      "label": "createFixtureRoot()",
+      "norm_label": "createfixtureroot()",
+      "source_file": "scripts/graphify-rebuild.test.ts",
+      "source_location": "L20"
+    },
+    {
+      "community": 329,
+      "file_type": "code",
+      "id": "graphify_rebuild_test_spawn",
+      "label": "spawn()",
+      "norm_label": "spawn()",
+      "source_file": "scripts/graphify-rebuild.test.ts",
+      "source_location": "L65"
+    },
+    {
+      "community": 329,
+      "file_type": "code",
+      "id": "graphify_rebuild_test_write",
+      "label": "write()",
+      "norm_label": "write()",
+      "source_file": "scripts/graphify-rebuild.test.ts",
+      "source_location": "L14"
+    },
+    {
+      "community": 329,
+      "file_type": "code",
+      "id": "scripts_graphify_rebuild_test_ts",
+      "label": "graphify-rebuild.test.ts",
+      "norm_label": "graphify-rebuild.test.ts",
+      "source_file": "scripts/graphify-rebuild.test.ts",
       "source_location": "L1"
     },
     {
@@ -83742,42 +83742,6 @@
     {
       "community": 330,
       "file_type": "code",
-      "id": "graphify_rebuild_test_createfixtureroot",
-      "label": "createFixtureRoot()",
-      "norm_label": "createfixtureroot()",
-      "source_file": "scripts/graphify-rebuild.test.ts",
-      "source_location": "L20"
-    },
-    {
-      "community": 330,
-      "file_type": "code",
-      "id": "graphify_rebuild_test_spawn",
-      "label": "spawn()",
-      "norm_label": "spawn()",
-      "source_file": "scripts/graphify-rebuild.test.ts",
-      "source_location": "L65"
-    },
-    {
-      "community": 330,
-      "file_type": "code",
-      "id": "graphify_rebuild_test_write",
-      "label": "write()",
-      "norm_label": "write()",
-      "source_file": "scripts/graphify-rebuild.test.ts",
-      "source_location": "L14"
-    },
-    {
-      "community": 330,
-      "file_type": "code",
-      "id": "scripts_graphify_rebuild_test_ts",
-      "label": "graphify-rebuild.test.ts",
-      "norm_label": "graphify-rebuild.test.ts",
-      "source_file": "scripts/graphify-rebuild.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 331,
-      "file_type": "code",
       "id": "harness_app_registry_buildharnessdocpaths",
       "label": "buildHarnessDocPaths()",
       "norm_label": "buildharnessdocpaths()",
@@ -83785,7 +83749,7 @@
       "source_location": "L129"
     },
     {
-      "community": 331,
+      "community": 330,
       "file_type": "code",
       "id": "harness_app_registry_buildharnessdocpathsforarchetype",
       "label": "buildHarnessDocPathsForArchetype()",
@@ -83794,7 +83758,7 @@
       "source_location": "L133"
     },
     {
-      "community": 331,
+      "community": 330,
       "file_type": "code",
       "id": "harness_app_registry_getharnesspackageregistration",
       "label": "getHarnessPackageRegistration()",
@@ -83803,7 +83767,7 @@
       "source_location": "L974"
     },
     {
-      "community": 331,
+      "community": 330,
       "file_type": "code",
       "id": "scripts_harness_app_registry_ts",
       "label": "harness-app-registry.ts",
@@ -83812,7 +83776,7 @@
       "source_location": "L1"
     },
     {
-      "community": 332,
+      "community": 331,
       "file_type": "code",
       "id": "scripts_harness_behavior_fixtures_valkey_runtime_app_ts",
       "label": "valkey-runtime-app.ts",
@@ -83821,7 +83785,7 @@
       "source_location": "L1"
     },
     {
-      "community": 332,
+      "community": 331,
       "file_type": "code",
       "id": "valkey_runtime_app_createvalkeyruntimeserver",
       "label": "createValkeyRuntimeServer()",
@@ -83830,7 +83794,7 @@
       "source_location": "L8"
     },
     {
-      "community": 332,
+      "community": 331,
       "file_type": "code",
       "id": "valkey_runtime_app_shutdown",
       "label": "shutdown()",
@@ -83839,7 +83803,7 @@
       "source_location": "L79"
     },
     {
-      "community": 332,
+      "community": 331,
       "file_type": "code",
       "id": "valkey_runtime_app_stopvalkeyruntimeserver",
       "label": "stopValkeyRuntimeServer()",
@@ -83848,7 +83812,7 @@
       "source_location": "L61"
     },
     {
-      "community": 333,
+      "community": 332,
       "file_type": "code",
       "id": "harness_scorecard_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -83857,7 +83821,7 @@
       "source_location": "L49"
     },
     {
-      "community": 333,
+      "community": 332,
       "file_type": "code",
       "id": "harness_scorecard_test_createinferentialartifact",
       "label": "createInferentialArtifact()",
@@ -83866,7 +83830,7 @@
       "source_location": "L17"
     },
     {
-      "community": 333,
+      "community": 332,
       "file_type": "code",
       "id": "harness_scorecard_test_write",
       "label": "write()",
@@ -83875,7 +83839,7 @@
       "source_location": "L11"
     },
     {
-      "community": 333,
+      "community": 332,
       "file_type": "code",
       "id": "scripts_harness_scorecard_test_ts",
       "label": "harness-scorecard.test.ts",
@@ -83884,7 +83848,7 @@
       "source_location": "L1"
     },
     {
-      "community": 334,
+      "community": 333,
       "file_type": "code",
       "id": "harness_test_collectharnesstesttargets",
       "label": "collectHarnessTestTargets()",
@@ -83893,7 +83857,7 @@
       "source_location": "L26"
     },
     {
-      "community": 334,
+      "community": 333,
       "file_type": "code",
       "id": "harness_test_parseharnesstestcliargs",
       "label": "parseHarnessTestCliArgs()",
@@ -83902,7 +83866,7 @@
       "source_location": "L72"
     },
     {
-      "community": 334,
+      "community": 333,
       "file_type": "code",
       "id": "harness_test_runharnesstest",
       "label": "runHarnessTest()",
@@ -83911,7 +83875,7 @@
       "source_location": "L36"
     },
     {
-      "community": 334,
+      "community": 333,
       "file_type": "code",
       "id": "scripts_harness_test_ts",
       "label": "harness-test.ts",
@@ -83920,7 +83884,7 @@
       "source_location": "L1"
     },
     {
-      "community": 335,
+      "community": 334,
       "file_type": "code",
       "id": "pre_push_review_test_error",
       "label": "error()",
@@ -83929,7 +83893,7 @@
       "source_location": "L96"
     },
     {
-      "community": 335,
+      "community": 334,
       "file_type": "code",
       "id": "pre_push_review_test_log",
       "label": "log()",
@@ -83938,7 +83902,7 @@
       "source_location": "L94"
     },
     {
-      "community": 335,
+      "community": 334,
       "file_type": "code",
       "id": "pre_push_review_test_warn",
       "label": "warn()",
@@ -83947,7 +83911,7 @@
       "source_location": "L95"
     },
     {
-      "community": 335,
+      "community": 334,
       "file_type": "code",
       "id": "scripts_pre_push_review_test_ts",
       "label": "pre-push-review.test.ts",
@@ -83956,7 +83920,7 @@
       "source_location": "L1"
     },
     {
-      "community": 336,
+      "community": 335,
       "file_type": "code",
       "id": "preview_worktree_test_makedir",
       "label": "makeDir()",
@@ -83965,7 +83929,7 @@
       "source_location": "L17"
     },
     {
-      "community": 336,
+      "community": 335,
       "file_type": "code",
       "id": "preview_worktree_test_previewoptions",
       "label": "previewOptions()",
@@ -83974,7 +83938,7 @@
       "source_location": "L23"
     },
     {
-      "community": 336,
+      "community": 335,
       "file_type": "code",
       "id": "preview_worktree_test_real",
       "label": "real()",
@@ -83983,7 +83947,7 @@
       "source_location": "L40"
     },
     {
-      "community": 336,
+      "community": 335,
       "file_type": "code",
       "id": "scripts_preview_worktree_test_ts",
       "label": "preview-worktree.test.ts",
@@ -83992,7 +83956,7 @@
       "source_location": "L1"
     },
     {
-      "community": 337,
+      "community": 336,
       "file_type": "code",
       "id": "closeouts_test_gethandler",
       "label": "getHandler()",
@@ -84001,7 +83965,7 @@
       "source_location": "L16"
     },
     {
-      "community": 337,
+      "community": 336,
       "file_type": "code",
       "id": "closeouts_test_getsource",
       "label": "getSource()",
@@ -84010,7 +83974,7 @@
       "source_location": "L12"
     },
     {
-      "community": 337,
+      "community": 336,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cashcontrols_closeouts_test_ts",
       "label": "closeouts.test.ts",
@@ -84019,7 +83983,7 @@
       "source_location": "L1"
     },
     {
-      "community": 338,
+      "community": 337,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_customermessaging_public_ts",
       "label": "public.ts",
@@ -84028,7 +83992,7 @@
       "source_location": "L1"
     },
     {
-      "community": 338,
+      "community": 337,
       "file_type": "code",
       "id": "public_resolverecipient",
       "label": "resolveRecipient()",
@@ -84037,7 +84001,7 @@
       "source_location": "L57"
     },
     {
-      "community": 338,
+      "community": 337,
       "file_type": "code",
       "id": "public_topublicreceipttransaction",
       "label": "toPublicReceiptTransaction()",
@@ -84046,7 +84010,7 @@
       "source_location": "L29"
     },
     {
-      "community": 339,
+      "community": 338,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_customermessaging_whatsappclient_ts",
       "label": "whatsappClient.ts",
@@ -84055,7 +84019,7 @@
       "source_location": "L1"
     },
     {
-      "community": 339,
+      "community": 338,
       "file_type": "code",
       "id": "whatsappclient_providererrorcategory",
       "label": "providerErrorCategory()",
@@ -84064,13 +84028,40 @@
       "source_location": "L20"
     },
     {
-      "community": 339,
+      "community": 338,
       "file_type": "code",
       "id": "whatsappclient_sendwhatsappreceipttemplate",
       "label": "sendWhatsAppReceiptTemplate()",
       "norm_label": "sendwhatsappreceipttemplate()",
       "source_file": "packages/athena-webapp/convex/customerMessaging/whatsappClient.ts",
       "source_location": "L27"
+    },
+    {
+      "community": 339,
+      "file_type": "code",
+      "id": "discountcode_chunkproducts",
+      "label": "chunkProducts()",
+      "norm_label": "chunkproducts()",
+      "source_file": "packages/athena-webapp/convex/emails/DiscountCode.tsx",
+      "source_location": "L98"
+    },
+    {
+      "community": 339,
+      "file_type": "code",
+      "id": "discountcode_productcard",
+      "label": "ProductCard()",
+      "norm_label": "productcard()",
+      "source_file": "packages/athena-webapp/convex/emails/DiscountCode.tsx",
+      "source_location": "L33"
+    },
+    {
+      "community": 339,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_emails_discountcode_tsx",
+      "label": "DiscountCode.tsx",
+      "norm_label": "discountcode.tsx",
+      "source_file": "packages/athena-webapp/convex/emails/DiscountCode.tsx",
+      "source_location": "L1"
     },
     {
       "community": 34,
@@ -84237,33 +84228,6 @@
     {
       "community": 340,
       "file_type": "code",
-      "id": "discountcode_chunkproducts",
-      "label": "chunkProducts()",
-      "norm_label": "chunkproducts()",
-      "source_file": "packages/athena-webapp/convex/emails/DiscountCode.tsx",
-      "source_location": "L98"
-    },
-    {
-      "community": 340,
-      "file_type": "code",
-      "id": "discountcode_productcard",
-      "label": "ProductCard()",
-      "norm_label": "productcard()",
-      "source_file": "packages/athena-webapp/convex/emails/DiscountCode.tsx",
-      "source_location": "L33"
-    },
-    {
-      "community": 340,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_emails_discountcode_tsx",
-      "label": "DiscountCode.tsx",
-      "norm_label": "discountcode.tsx",
-      "source_file": "packages/athena-webapp/convex/emails/DiscountCode.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 341,
-      "file_type": "code",
       "id": "discountreminder_chunkproducts",
       "label": "chunkProducts()",
       "norm_label": "chunkproducts()",
@@ -84271,7 +84235,7 @@
       "source_location": "L85"
     },
     {
-      "community": 341,
+      "community": 340,
       "file_type": "code",
       "id": "discountreminder_productcard",
       "label": "ProductCard()",
@@ -84280,7 +84244,7 @@
       "source_location": "L31"
     },
     {
-      "community": 341,
+      "community": 340,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_discountreminder_tsx",
       "label": "DiscountReminder.tsx",
@@ -84289,7 +84253,7 @@
       "source_location": "L1"
     },
     {
-      "community": 342,
+      "community": 341,
       "file_type": "code",
       "id": "categories_removestorefronthiddencategories",
       "label": "removeStorefrontHiddenCategories()",
@@ -84298,7 +84262,7 @@
       "source_location": "L12"
     },
     {
-      "community": 342,
+      "community": 341,
       "file_type": "code",
       "id": "categories_removestorefronthiddensubcategories",
       "label": "removeStorefrontHiddenSubcategories()",
@@ -84307,7 +84271,7 @@
       "source_location": "L21"
     },
     {
-      "community": 342,
+      "community": 341,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_core_routes_categories_ts",
       "label": "categories.ts",
@@ -84316,7 +84280,7 @@
       "source_location": "L1"
     },
     {
-      "community": 343,
+      "community": 342,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_utils_ts",
       "label": "utils.ts",
@@ -84325,7 +84289,7 @@
       "source_location": "L1"
     },
     {
-      "community": 343,
+      "community": 342,
       "file_type": "code",
       "id": "utils_getstoredatafromrequest",
       "label": "getStoreDataFromRequest()",
@@ -84334,7 +84298,7 @@
       "source_location": "L5"
     },
     {
-      "community": 343,
+      "community": 342,
       "file_type": "code",
       "id": "utils_getstorefrontuserfromrequest",
       "label": "getStorefrontUserFromRequest()",
@@ -84343,7 +84307,7 @@
       "source_location": "L12"
     },
     {
-      "community": 344,
+      "community": 343,
       "file_type": "code",
       "id": "inventoryholds_test_buildhold",
       "label": "buildHold()",
@@ -84352,7 +84316,7 @@
       "source_location": "L566"
     },
     {
-      "community": 344,
+      "community": 343,
       "file_type": "code",
       "id": "inventoryholds_test_createdb",
       "label": "createDb()",
@@ -84361,7 +84325,7 @@
       "source_location": "L40"
     },
     {
-      "community": 344,
+      "community": 343,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_helpers_inventoryholds_test_ts",
       "label": "inventoryHolds.test.ts",
@@ -84370,7 +84334,7 @@
       "source_location": "L1"
     },
     {
-      "community": 345,
+      "community": 344,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_sessionqueryindexes_test_ts",
       "label": "sessionQueryIndexes.test.ts",
@@ -84379,7 +84343,7 @@
       "source_location": "L1"
     },
     {
-      "community": 345,
+      "community": 344,
       "file_type": "code",
       "id": "sessionqueryindexes_test_readprojectfile",
       "label": "readProjectFile()",
@@ -84388,7 +84352,7 @@
       "source_location": "L6"
     },
     {
-      "community": 345,
+      "community": 344,
       "file_type": "code",
       "id": "sessionqueryindexes_test_readsourceslice",
       "label": "readSourceSlice()",
@@ -84397,7 +84361,7 @@
       "source_location": "L9"
     },
     {
-      "community": 346,
+      "community": 345,
       "file_type": "code",
       "id": "analyticsutils_calculateactivitytrend",
       "label": "calculateActivityTrend()",
@@ -84406,7 +84370,7 @@
       "source_location": "L43"
     },
     {
-      "community": 346,
+      "community": 345,
       "file_type": "code",
       "id": "analyticsutils_calculatedevicedistribution",
       "label": "calculateDeviceDistribution()",
@@ -84415,7 +84379,7 @@
       "source_location": "L11"
     },
     {
-      "community": 346,
+      "community": 345,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_utils_analyticsutils_ts",
       "label": "analyticsUtils.ts",
@@ -84424,7 +84388,7 @@
       "source_location": "L1"
     },
     {
-      "community": 347,
+      "community": 346,
       "file_type": "code",
       "id": "dailyopening_test_completeddailyclose",
       "label": "completedDailyClose()",
@@ -84433,7 +84397,7 @@
       "source_location": "L168"
     },
     {
-      "community": 347,
+      "community": 346,
       "file_type": "code",
       "id": "dailyopening_test_createdb",
       "label": "createDb()",
@@ -84442,7 +84406,7 @@
       "source_location": "L21"
     },
     {
-      "community": 347,
+      "community": 346,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_dailyopening_test_ts",
       "label": "dailyOpening.test.ts",
@@ -84451,7 +84415,7 @@
       "source_location": "L1"
     },
     {
-      "community": 348,
+      "community": 347,
       "file_type": "code",
       "id": "dailyoperations_test_buildctx",
       "label": "buildCtx()",
@@ -84460,7 +84424,7 @@
       "source_location": "L211"
     },
     {
-      "community": 348,
+      "community": 347,
       "file_type": "code",
       "id": "dailyoperations_test_createdb",
       "label": "createDb()",
@@ -84469,7 +84433,7 @@
       "source_location": "L23"
     },
     {
-      "community": 348,
+      "community": 347,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_dailyoperations_test_ts",
       "label": "dailyOperations.test.ts",
@@ -84478,7 +84442,7 @@
       "source_location": "L1"
     },
     {
-      "community": 349,
+      "community": 348,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_staffcredentials_test_ts",
       "label": "staffCredentials.test.ts",
@@ -84487,7 +84451,7 @@
       "source_location": "L1"
     },
     {
-      "community": 349,
+      "community": 348,
       "file_type": "code",
       "id": "staffcredentials_test_createstaffcredentialsmutationctx",
       "label": "createStaffCredentialsMutationCtx()",
@@ -84496,13 +84460,40 @@
       "source_location": "L26"
     },
     {
-      "community": 349,
+      "community": 348,
       "file_type": "code",
       "id": "staffcredentials_test_gethandler",
       "label": "getHandler()",
       "norm_label": "gethandler()",
       "source_file": "packages/athena-webapp/convex/operations/staffCredentials.test.ts",
       "source_location": "L118"
+    },
+    {
+      "community": 349,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_staffprofiles_test_ts",
+      "label": "staffProfiles.test.ts",
+      "norm_label": "staffprofiles.test.ts",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 349,
+      "file_type": "code",
+      "id": "staffprofiles_test_createstaffprofilesmutationctx",
+      "label": "createStaffProfilesMutationCtx()",
+      "norm_label": "createstaffprofilesmutationctx()",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.test.ts",
+      "source_location": "L16"
+    },
+    {
+      "community": 349,
+      "file_type": "code",
+      "id": "staffprofiles_test_gethandler",
+      "label": "getHandler()",
+      "norm_label": "gethandler()",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.test.ts",
+      "source_location": "L92"
     },
     {
       "community": 35,
@@ -84669,33 +84660,6 @@
     {
       "community": 350,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_staffprofiles_test_ts",
-      "label": "staffProfiles.test.ts",
-      "norm_label": "staffprofiles.test.ts",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 350,
-      "file_type": "code",
-      "id": "staffprofiles_test_createstaffprofilesmutationctx",
-      "label": "createStaffProfilesMutationCtx()",
-      "norm_label": "createstaffprofilesmutationctx()",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.test.ts",
-      "source_location": "L16"
-    },
-    {
-      "community": 350,
-      "file_type": "code",
-      "id": "staffprofiles_test_gethandler",
-      "label": "getHandler()",
-      "norm_label": "gethandler()",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.test.ts",
-      "source_location": "L92"
-    },
-    {
-      "community": 351,
-      "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_staffroles_ts",
       "label": "staffRoles.ts",
       "norm_label": "staffroles.ts",
@@ -84703,7 +84667,7 @@
       "source_location": "L1"
     },
     {
-      "community": 351,
+      "community": 350,
       "file_type": "code",
       "id": "staffroles_derivedefaultoperationalroles",
       "label": "deriveDefaultOperationalRoles()",
@@ -84712,7 +84676,7 @@
       "source_location": "L21"
     },
     {
-      "community": 351,
+      "community": 350,
       "file_type": "code",
       "id": "staffroles_uniqueoperationalroles",
       "label": "uniqueOperationalRoles()",
@@ -84721,7 +84685,7 @@
       "source_location": "L31"
     },
     {
-      "community": 352,
+      "community": 351,
       "file_type": "code",
       "id": "index_listtransactions",
       "label": "listTransactions()",
@@ -84730,7 +84694,7 @@
       "source_location": "L7"
     },
     {
-      "community": 352,
+      "community": 351,
       "file_type": "code",
       "id": "index_verifytransaction",
       "label": "verifyTransaction()",
@@ -84739,7 +84703,7 @@
       "source_location": "L109"
     },
     {
-      "community": 352,
+      "community": 351,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_paystack_index_ts",
       "label": "index.ts",
@@ -84748,7 +84712,7 @@
       "source_location": "L1"
     },
     {
-      "community": 353,
+      "community": 352,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_queries_terminals_ts",
       "label": "terminals.ts",
@@ -84757,7 +84721,7 @@
       "source_location": "L1"
     },
     {
-      "community": 353,
+      "community": 352,
       "file_type": "code",
       "id": "terminals_getterminalbyfingerprint",
       "label": "getTerminalByFingerprint()",
@@ -84766,7 +84730,7 @@
       "source_location": "L18"
     },
     {
-      "community": 353,
+      "community": 352,
       "file_type": "code",
       "id": "terminals_listterminals",
       "label": "listTerminals()",
@@ -84775,7 +84739,7 @@
       "source_location": "L9"
     },
     {
-      "community": 354,
+      "community": 353,
       "file_type": "code",
       "id": "errors_posservererror",
       "label": "PosServerError",
@@ -84784,7 +84748,7 @@
       "source_location": "L8"
     },
     {
-      "community": 354,
+      "community": 353,
       "file_type": "code",
       "id": "errors_posservererror_constructor",
       "label": ".constructor()",
@@ -84793,7 +84757,7 @@
       "source_location": "L9"
     },
     {
-      "community": 354,
+      "community": 353,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_domain_errors_ts",
       "label": "errors.ts",
@@ -84802,7 +84766,7 @@
       "source_location": "L1"
     },
     {
-      "community": 355,
+      "community": 354,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_domain_sessionrules_ts",
       "label": "sessionRules.ts",
@@ -84811,7 +84775,7 @@
       "source_location": "L1"
     },
     {
-      "community": 355,
+      "community": 354,
       "file_type": "code",
       "id": "sessionrules_deriveregisterphase",
       "label": "deriveRegisterPhase()",
@@ -84820,7 +84784,7 @@
       "source_location": "L7"
     },
     {
-      "community": 355,
+      "community": 354,
       "file_type": "code",
       "id": "sessionrules_selectresumablesession",
       "label": "selectResumableSession()",
@@ -84829,7 +84793,7 @@
       "source_location": "L29"
     },
     {
-      "community": 356,
+      "community": 355,
       "file_type": "code",
       "id": "inventoryholdgateway_test_createctx",
       "label": "createCtx()",
@@ -84838,7 +84802,7 @@
       "source_location": "L16"
     },
     {
-      "community": 356,
+      "community": 355,
       "file_type": "code",
       "id": "inventoryholdgateway_test_createlegacypatchctx",
       "label": "createLegacyPatchCtx()",
@@ -84847,7 +84811,7 @@
       "source_location": "L22"
     },
     {
-      "community": 356,
+      "community": 355,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_integrations_inventoryholdgateway_test_ts",
       "label": "inventoryHoldGateway.test.ts",
@@ -84856,7 +84820,7 @@
       "source_location": "L1"
     },
     {
-      "community": 357,
+      "community": 356,
       "file_type": "code",
       "id": "inventoryholdgateway_assertobjectshapedholdargs",
       "label": "assertObjectShapedHoldArgs()",
@@ -84865,7 +84829,7 @@
       "source_location": "L43"
     },
     {
-      "community": 357,
+      "community": 356,
       "file_type": "code",
       "id": "inventoryholdgateway_createinventoryholdgateway",
       "label": "createInventoryHoldGateway()",
@@ -84874,7 +84838,7 @@
       "source_location": "L24"
     },
     {
-      "community": 357,
+      "community": 356,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_integrations_inventoryholdgateway_ts",
       "label": "inventoryHoldGateway.ts",
@@ -84883,7 +84847,7 @@
       "source_location": "L1"
     },
     {
-      "community": 358,
+      "community": 357,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_integrations_paymentallocationservice_ts",
       "label": "paymentAllocationService.ts",
@@ -84892,7 +84856,7 @@
       "source_location": "L1"
     },
     {
-      "community": 358,
+      "community": 357,
       "file_type": "code",
       "id": "paymentallocationservice_recordretailsalepaymentallocations",
       "label": "recordRetailSalePaymentAllocations()",
@@ -84901,7 +84865,7 @@
       "source_location": "L13"
     },
     {
-      "community": 358,
+      "community": 357,
       "file_type": "code",
       "id": "paymentallocationservice_recordretailvoidpaymentallocations",
       "label": "recordRetailVoidPaymentAllocations()",
@@ -84910,7 +84874,7 @@
       "source_location": "L45"
     },
     {
-      "community": 359,
+      "community": 358,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_registersessionrepository_ts",
       "label": "registerSessionRepository.ts",
@@ -84919,7 +84883,7 @@
       "source_location": "L1"
     },
     {
-      "community": 359,
+      "community": 358,
       "file_type": "code",
       "id": "registersessionrepository_getactiveregistersessionforregisterstate",
       "label": "getActiveRegisterSessionForRegisterState()",
@@ -84928,13 +84892,40 @@
       "source_location": "L36"
     },
     {
-      "community": 359,
+      "community": 358,
       "file_type": "code",
       "id": "registersessionrepository_mapregistersessiontocashdrawersummary",
       "label": "mapRegisterSessionToCashDrawerSummary()",
       "norm_label": "mapregistersessiontocashdrawersummary()",
       "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/registerSessionRepository.ts",
       "source_location": "L13"
+    },
+    {
+      "community": 359,
+      "file_type": "code",
+      "id": "appointments_buildserviceappointment",
+      "label": "buildServiceAppointment()",
+      "norm_label": "buildserviceappointment()",
+      "source_file": "packages/athena-webapp/convex/serviceOps/appointments.ts",
+      "source_location": "L17"
+    },
+    {
+      "community": 359,
+      "file_type": "code",
+      "id": "appointments_findoverlappingappointment",
+      "label": "findOverlappingAppointment()",
+      "norm_label": "findoverlappingappointment()",
+      "source_file": "packages/athena-webapp/convex/serviceOps/appointments.ts",
+      "source_location": "L61"
+    },
+    {
+      "community": 359,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_serviceops_appointments_ts",
+      "label": "appointments.ts",
+      "norm_label": "appointments.ts",
+      "source_file": "packages/athena-webapp/convex/serviceOps/appointments.ts",
+      "source_location": "L1"
     },
     {
       "community": 36,
@@ -85101,33 +85092,6 @@
     {
       "community": 360,
       "file_type": "code",
-      "id": "appointments_buildserviceappointment",
-      "label": "buildServiceAppointment()",
-      "norm_label": "buildserviceappointment()",
-      "source_file": "packages/athena-webapp/convex/serviceOps/appointments.ts",
-      "source_location": "L17"
-    },
-    {
-      "community": 360,
-      "file_type": "code",
-      "id": "appointments_findoverlappingappointment",
-      "label": "findOverlappingAppointment()",
-      "norm_label": "findoverlappingappointment()",
-      "source_file": "packages/athena-webapp/convex/serviceOps/appointments.ts",
-      "source_location": "L61"
-    },
-    {
-      "community": 360,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_serviceops_appointments_ts",
-      "label": "appointments.ts",
-      "norm_label": "appointments.ts",
-      "source_file": "packages/athena-webapp/convex/serviceOps/appointments.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 361,
-      "file_type": "code",
       "id": "catalog_buildservicecatalogitem",
       "label": "buildServiceCatalogItem()",
       "norm_label": "buildservicecatalogitem()",
@@ -85135,7 +85099,7 @@
       "source_location": "L13"
     },
     {
-      "community": 361,
+      "community": 360,
       "file_type": "code",
       "id": "catalog_normalizeservicecatalognamekey",
       "label": "normalizeServiceCatalogNameKey()",
@@ -85144,7 +85108,7 @@
       "source_location": "L9"
     },
     {
-      "community": 361,
+      "community": 360,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_serviceops_catalog_ts",
       "label": "catalog.ts",
@@ -85153,7 +85117,7 @@
       "source_location": "L1"
     },
     {
-      "community": 362,
+      "community": 361,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_serviceops_servicecases_test_ts",
       "label": "serviceCases.test.ts",
@@ -85162,7 +85126,7 @@
       "source_location": "L1"
     },
     {
-      "community": 362,
+      "community": 361,
       "file_type": "code",
       "id": "servicecases_test_expectindex",
       "label": "expectIndex()",
@@ -85171,7 +85135,7 @@
       "source_location": "L23"
     },
     {
-      "community": 362,
+      "community": 361,
       "file_type": "code",
       "id": "servicecases_test_gettableindexes",
       "label": "getTableIndexes()",
@@ -85180,7 +85144,7 @@
       "source_location": "L16"
     },
     {
-      "community": 363,
+      "community": 362,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_purchaseorders_test_ts",
       "label": "purchaseOrders.test.ts",
@@ -85189,7 +85153,7 @@
       "source_location": "L1"
     },
     {
-      "community": 363,
+      "community": 362,
       "file_type": "code",
       "id": "purchaseorders_test_createpurchaseordermutationctx",
       "label": "createPurchaseOrderMutationCtx()",
@@ -85198,7 +85162,7 @@
       "source_location": "L26"
     },
     {
-      "community": 363,
+      "community": 362,
       "file_type": "code",
       "id": "purchaseorders_test_getsource",
       "label": "getSource()",
@@ -85207,7 +85171,7 @@
       "source_location": "L22"
     },
     {
-      "community": 364,
+      "community": 363,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_receiving_test_ts",
       "label": "receiving.test.ts",
@@ -85216,7 +85180,7 @@
       "source_location": "L1"
     },
     {
-      "community": 364,
+      "community": 363,
       "file_type": "code",
       "id": "receiving_test_createreceivingmutationctx",
       "label": "createReceivingMutationCtx()",
@@ -85225,7 +85189,7 @@
       "source_location": "L28"
     },
     {
-      "community": 364,
+      "community": 363,
       "file_type": "code",
       "id": "receiving_test_getsource",
       "label": "getSource()",
@@ -85234,7 +85198,7 @@
       "source_location": "L24"
     },
     {
-      "community": 365,
+      "community": 364,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_vendors_test_ts",
       "label": "vendors.test.ts",
@@ -85243,7 +85207,7 @@
       "source_location": "L1"
     },
     {
-      "community": 365,
+      "community": 364,
       "file_type": "code",
       "id": "vendors_test_createvendormutationctx",
       "label": "createVendorMutationCtx()",
@@ -85252,7 +85216,7 @@
       "source_location": "L24"
     },
     {
-      "community": 365,
+      "community": 364,
       "file_type": "code",
       "id": "vendors_test_getsource",
       "label": "getSource()",
@@ -85261,7 +85225,7 @@
       "source_location": "L20"
     },
     {
-      "community": 366,
+      "community": 365,
       "file_type": "code",
       "id": "errorfoundation_test_gethandler",
       "label": "getHandler()",
@@ -85270,7 +85234,7 @@
       "source_location": "L25"
     },
     {
-      "community": 366,
+      "community": 365,
       "file_type": "code",
       "id": "errorfoundation_test_getsource",
       "label": "getSource()",
@@ -85279,7 +85243,7 @@
       "source_location": "L21"
     },
     {
-      "community": 366,
+      "community": 365,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_errorfoundation_test_ts",
       "label": "errorFoundation.test.ts",
@@ -85288,7 +85252,7 @@
       "source_location": "L1"
     },
     {
-      "community": 367,
+      "community": 366,
       "file_type": "code",
       "id": "bag_listbagitems",
       "label": "listBagItems()",
@@ -85297,7 +85261,7 @@
       "source_location": "L7"
     },
     {
-      "community": 367,
+      "community": 366,
       "file_type": "code",
       "id": "bag_loadbagwithitems",
       "label": "loadBagWithItems()",
@@ -85306,7 +85270,7 @@
       "source_location": "L14"
     },
     {
-      "community": 367,
+      "community": 366,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_helpers_bag_ts",
       "label": "bag.ts",
@@ -85315,7 +85279,7 @@
       "source_location": "L1"
     },
     {
-      "community": 368,
+      "community": 367,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_adapters_registersession_ts",
       "label": "registerSession.ts",
@@ -85324,7 +85288,7 @@
       "source_location": "L1"
     },
     {
-      "community": 368,
+      "community": 367,
       "file_type": "code",
       "id": "registersession_buildregistersessiontraceseed",
       "label": "buildRegisterSessionTraceSeed()",
@@ -85333,7 +85297,7 @@
       "source_location": "L45"
     },
     {
-      "community": 368,
+      "community": 367,
       "file_type": "code",
       "id": "registersession_formatregistersessionlabel",
       "label": "formatRegisterSessionLabel()",
@@ -85342,7 +85306,7 @@
       "source_location": "L37"
     },
     {
-      "community": 369,
+      "community": 368,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_public_ts",
       "label": "public.ts",
@@ -85351,7 +85315,7 @@
       "source_location": "L1"
     },
     {
-      "community": 369,
+      "community": 368,
       "file_type": "code",
       "id": "public_getworkflowtraceviewbyidwithctx",
       "label": "getWorkflowTraceViewByIdWithCtx()",
@@ -85360,13 +85324,40 @@
       "source_location": "L10"
     },
     {
-      "community": 369,
+      "community": 368,
       "file_type": "code",
       "id": "public_getworkflowtraceviewbylookupwithctx",
       "label": "getWorkflowTraceViewByLookupWithCtx()",
       "norm_label": "getworkflowtraceviewbylookupwithctx()",
       "source_file": "packages/athena-webapp/convex/workflowTraces/public.ts",
       "source_location": "L44"
+    },
+    {
+      "community": 369,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_workflowtraces_queryusage_test_ts",
+      "label": "queryUsage.test.ts",
+      "norm_label": "queryusage.test.ts",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/queryUsage.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 369,
+      "file_type": "code",
+      "id": "queryusage_test_comparebyfields",
+      "label": "compareByFields()",
+      "norm_label": "comparebyfields()",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/queryUsage.test.ts",
+      "source_location": "L84"
+    },
+    {
+      "community": 369,
+      "file_type": "code",
+      "id": "queryusage_test_createtestctx",
+      "label": "createTestCtx()",
+      "norm_label": "createtestctx()",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/queryUsage.test.ts",
+      "source_location": "L100"
     },
     {
       "community": 37,
@@ -85533,33 +85524,6 @@
     {
       "community": 370,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_workflowtraces_queryusage_test_ts",
-      "label": "queryUsage.test.ts",
-      "norm_label": "queryusage.test.ts",
-      "source_file": "packages/athena-webapp/convex/workflowTraces/queryUsage.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 370,
-      "file_type": "code",
-      "id": "queryusage_test_comparebyfields",
-      "label": "compareByFields()",
-      "norm_label": "comparebyfields()",
-      "source_file": "packages/athena-webapp/convex/workflowTraces/queryUsage.test.ts",
-      "source_location": "L84"
-    },
-    {
-      "community": 370,
-      "file_type": "code",
-      "id": "queryusage_test_createtestctx",
-      "label": "createTestCtx()",
-      "norm_label": "createtestctx()",
-      "source_file": "packages/athena-webapp/convex/workflowTraces/queryUsage.test.ts",
-      "source_location": "L100"
-    },
-    {
-      "community": 371,
-      "file_type": "code",
       "id": "currencyformatter_currencydisplaysymbol",
       "label": "currencyDisplaySymbol()",
       "norm_label": "currencydisplaysymbol()",
@@ -85567,7 +85531,7 @@
       "source_location": "L10"
     },
     {
-      "community": 371,
+      "community": 370,
       "file_type": "code",
       "id": "currencyformatter_currencyformatter",
       "label": "currencyFormatter()",
@@ -85576,7 +85540,7 @@
       "source_location": "L30"
     },
     {
-      "community": 371,
+      "community": 370,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_currencyformatter_ts",
       "label": "currencyFormatter.ts",
@@ -85585,7 +85549,7 @@
       "source_location": "L1"
     },
     {
-      "community": 372,
+      "community": 371,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_workflowtrace_ts",
       "label": "workflowTrace.ts",
@@ -85594,7 +85558,7 @@
       "source_location": "L1"
     },
     {
-      "community": 372,
+      "community": 371,
       "file_type": "code",
       "id": "workflowtrace_createworkflowtraceid",
       "label": "createWorkflowTraceId()",
@@ -85603,7 +85567,7 @@
       "source_location": "L35"
     },
     {
-      "community": 372,
+      "community": 371,
       "file_type": "code",
       "id": "workflowtrace_normalizeworkflowtracelookupvalue",
       "label": "normalizeWorkflowTraceLookupValue()",
@@ -85612,7 +85576,7 @@
       "source_location": "L25"
     },
     {
-      "community": 373,
+      "community": 372,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_view_tsx",
       "label": "View.tsx",
@@ -85621,7 +85585,7 @@
       "source_location": "L1"
     },
     {
-      "community": 373,
+      "community": 372,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_view_tsx",
       "label": "View.tsx",
@@ -85630,7 +85594,7 @@
       "source_location": "L1"
     },
     {
-      "community": 373,
+      "community": 372,
       "file_type": "code",
       "id": "view_view",
       "label": "View()",
@@ -85639,7 +85603,7 @@
       "source_location": "L4"
     },
     {
-      "community": 374,
+      "community": 373,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productavailability_tsx",
       "label": "ProductAvailability.tsx",
@@ -85648,7 +85612,7 @@
       "source_location": "L1"
     },
     {
-      "community": 374,
+      "community": 373,
       "file_type": "code",
       "id": "productavailability_productavailability",
       "label": "ProductAvailability()",
@@ -85657,7 +85621,7 @@
       "source_location": "L19"
     },
     {
-      "community": 374,
+      "community": 373,
       "file_type": "code",
       "id": "productavailability_productavailabilityview",
       "label": "ProductAvailabilityView()",
@@ -85666,7 +85630,7 @@
       "source_location": "L5"
     },
     {
-      "community": 375,
+      "community": 374,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_sheetprovider_tsx",
       "label": "SheetProvider.tsx",
@@ -85675,7 +85639,7 @@
       "source_location": "L1"
     },
     {
-      "community": 375,
+      "community": 374,
       "file_type": "code",
       "id": "sheetprovider_sheetprovider",
       "label": "SheetProvider()",
@@ -85684,7 +85648,7 @@
       "source_location": "L19"
     },
     {
-      "community": 375,
+      "community": 374,
       "file_type": "code",
       "id": "sheetprovider_usesheet",
       "label": "useSheet()",
@@ -85693,7 +85657,7 @@
       "source_location": "L11"
     },
     {
-      "community": 376,
+      "community": 375,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_wigtype_tsx",
       "label": "WigType.tsx",
@@ -85702,7 +85666,7 @@
       "source_location": "L1"
     },
     {
-      "community": 376,
+      "community": 375,
       "file_type": "code",
       "id": "wigtype_wigtype",
       "label": "WigType()",
@@ -85711,7 +85675,7 @@
       "source_location": "L22"
     },
     {
-      "community": 376,
+      "community": 375,
       "file_type": "code",
       "id": "wigtype_wigtypeview",
       "label": "WigTypeView()",
@@ -85720,7 +85684,7 @@
       "source_location": "L8"
     },
     {
-      "community": 377,
+      "community": 376,
       "file_type": "code",
       "id": "copyimagesprovider_copyimagesprovider",
       "label": "CopyImagesProvider()",
@@ -85729,7 +85693,7 @@
       "source_location": "L21"
     },
     {
-      "community": 377,
+      "community": 376,
       "file_type": "code",
       "id": "copyimagesprovider_usecopyimages",
       "label": "useCopyImages()",
@@ -85738,7 +85702,7 @@
       "source_location": "L13"
     },
     {
-      "community": 377,
+      "community": 376,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_copyimagesprovider_tsx",
       "label": "CopyImagesProvider.tsx",
@@ -85747,7 +85711,7 @@
       "source_location": "L1"
     },
     {
-      "community": 378,
+      "community": 377,
       "file_type": "code",
       "id": "analyticstopusers_analyticstopusers",
       "label": "AnalyticsTopUsers()",
@@ -85756,7 +85720,7 @@
       "source_location": "L100"
     },
     {
-      "community": 378,
+      "community": 377,
       "file_type": "code",
       "id": "analyticstopusers_processanalyticstousers",
       "label": "processAnalyticsToUsers()",
@@ -85765,7 +85729,7 @@
       "source_location": "L10"
     },
     {
-      "community": 378,
+      "community": 377,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticstopusers_tsx",
       "label": "AnalyticsTopUsers.tsx",
@@ -85774,7 +85738,7 @@
       "source_location": "L1"
     },
     {
-      "community": 379,
+      "community": 378,
       "file_type": "code",
       "id": "log_items_provider_logitemsprovider",
       "label": "LogItemsProvider()",
@@ -85783,7 +85747,7 @@
       "source_location": "L15"
     },
     {
-      "community": 379,
+      "community": 378,
       "file_type": "code",
       "id": "log_items_provider_uselogitems",
       "label": "useLogItems()",
@@ -85792,12 +85756,39 @@
       "source_location": "L39"
     },
     {
-      "community": 379,
+      "community": 378,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_log_items_provider_tsx",
       "label": "log-items-provider.tsx",
       "norm_label": "log-items-provider.tsx",
       "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/log-items-provider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 379,
+      "file_type": "code",
+      "id": "index_header",
+      "label": "Header()",
+      "norm_label": "header()",
+      "source_file": "packages/athena-webapp/src/components/assets/index.tsx",
+      "source_location": "L15"
+    },
+    {
+      "community": 379,
+      "file_type": "code",
+      "id": "index_storeassets",
+      "label": "StoreAssets()",
+      "norm_label": "storeassets()",
+      "source_file": "packages/athena-webapp/src/components/assets/index.tsx",
+      "source_location": "L23"
+    },
+    {
+      "community": 379,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_assets_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/components/assets/index.tsx",
       "source_location": "L1"
     },
     {
@@ -86127,6 +86118,33 @@
     {
       "community": 386,
       "file_type": "code",
+      "id": "index_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
+      "source_location": "L119"
+    },
+    {
+      "community": 386,
+      "file_type": "code",
+      "id": "index_sectionheader",
+      "label": "SectionHeader()",
+      "norm_label": "sectionheader()",
+      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
+      "source_location": "L45"
+    },
+    {
+      "community": 386,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_organization_members_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 387,
+      "file_type": "code",
       "id": "cashierauthdialog_cashierauthdialog",
       "label": "CashierAuthDialog()",
       "norm_label": "cashierauthdialog()",
@@ -86134,7 +86152,7 @@
       "source_location": "L33"
     },
     {
-      "community": 386,
+      "community": 387,
       "file_type": "code",
       "id": "cashierauthdialog_getstaffdisplayname",
       "label": "getStaffDisplayName()",
@@ -86143,7 +86161,7 @@
       "source_location": "L24"
     },
     {
-      "community": 386,
+      "community": 387,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_cashierauthdialog_tsx",
       "label": "CashierAuthDialog.tsx",
@@ -86152,7 +86170,7 @@
       "source_location": "L1"
     },
     {
-      "community": 387,
+      "community": 388,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_searchresultssection_tsx",
       "label": "SearchResultsSection.tsx",
@@ -86161,7 +86179,7 @@
       "source_location": "L1"
     },
     {
-      "community": 387,
+      "community": 388,
       "file_type": "code",
       "id": "searchresultssection_handlequickaddproductshortcut",
       "label": "handleQuickAddProductShortcut()",
@@ -86170,7 +86188,7 @@
       "source_location": "L117"
     },
     {
-      "community": 387,
+      "community": 388,
       "file_type": "code",
       "id": "searchresultssection_handlequickaddvariantshortcut",
       "label": "handleQuickAddVariantShortcut()",
@@ -86179,7 +86197,7 @@
       "source_location": "L84"
     },
     {
-      "community": 388,
+      "community": 389,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_posregisteropeningguard_tsx",
       "label": "POSRegisterOpeningGuard.tsx",
@@ -86188,7 +86206,7 @@
       "source_location": "L1"
     },
     {
-      "community": 388,
+      "community": 389,
       "file_type": "code",
       "id": "posregisteropeningguard_getlocaloperatingdate",
       "label": "getLocalOperatingDate()",
@@ -86197,40 +86215,13 @@
       "source_location": "L17"
     },
     {
-      "community": 388,
+      "community": 389,
       "file_type": "code",
       "id": "posregisteropeningguard_getlocaloperatingdaterange",
       "label": "getLocalOperatingDateRange()",
       "norm_label": "getlocaloperatingdaterange()",
       "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterOpeningGuard.tsx",
       "source_location": "L25"
-    },
-    {
-      "community": 389,
-      "file_type": "code",
-      "id": "heldsessionslist_getsessioncartitemscount",
-      "label": "getSessionCartItemsCount()",
-      "norm_label": "getsessioncartitemscount()",
-      "source_file": "packages/athena-webapp/src/components/pos/session/HeldSessionsList.tsx",
-      "source_location": "L36"
-    },
-    {
-      "community": 389,
-      "file_type": "code",
-      "id": "heldsessionslist_hasexpired",
-      "label": "hasExpired()",
-      "norm_label": "hasexpired()",
-      "source_file": "packages/athena-webapp/src/components/pos/session/HeldSessionsList.tsx",
-      "source_location": "L32"
-    },
-    {
-      "community": 389,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_session_heldsessionslist_tsx",
-      "label": "HeldSessionsList.tsx",
-      "norm_label": "heldsessionslist.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/session/HeldSessionsList.tsx",
-      "source_location": "L1"
     },
     {
       "community": 39,
@@ -86388,6 +86379,33 @@
     {
       "community": 390,
       "file_type": "code",
+      "id": "heldsessionslist_getsessioncartitemscount",
+      "label": "getSessionCartItemsCount()",
+      "norm_label": "getsessioncartitemscount()",
+      "source_file": "packages/athena-webapp/src/components/pos/session/HeldSessionsList.tsx",
+      "source_location": "L36"
+    },
+    {
+      "community": 390,
+      "file_type": "code",
+      "id": "heldsessionslist_hasexpired",
+      "label": "hasExpired()",
+      "norm_label": "hasexpired()",
+      "source_file": "packages/athena-webapp/src/components/pos/session/HeldSessionsList.tsx",
+      "source_location": "L32"
+    },
+    {
+      "community": 390,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_session_heldsessionslist_tsx",
+      "label": "HeldSessionsList.tsx",
+      "norm_label": "heldsessionslist.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/session/HeldSessionsList.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 391,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_settings_possettingsview_tsx",
       "label": "POSSettingsView.tsx",
       "norm_label": "possettingsview.tsx",
@@ -86395,7 +86413,7 @@
       "source_location": "L1"
     },
     {
-      "community": 390,
+      "community": 391,
       "file_type": "code",
       "id": "possettingsview_fingerprintregistrationcard",
       "label": "FingerprintRegistrationCard()",
@@ -86404,7 +86422,7 @@
       "source_location": "L57"
     },
     {
-      "community": 390,
+      "community": 391,
       "file_type": "code",
       "id": "possettingsview_possettingsview",
       "label": "POSSettingsView()",
@@ -86413,7 +86431,7 @@
       "source_location": "L184"
     },
     {
-      "community": 391,
+      "community": 392,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_productstatus_test_tsx",
       "label": "ProductStatus.test.tsx",
@@ -86422,7 +86440,7 @@
       "source_location": "L1"
     },
     {
-      "community": 391,
+      "community": 392,
       "file_type": "code",
       "id": "productstatus_test_makeproduct",
       "label": "makeProduct()",
@@ -86431,7 +86449,7 @@
       "source_location": "L8"
     },
     {
-      "community": 391,
+      "community": 392,
       "file_type": "code",
       "id": "productstatus_test_makevariant",
       "label": "makeVariant()",
@@ -86440,7 +86458,7 @@
       "source_location": "L18"
     },
     {
-      "community": 392,
+      "community": 393,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_productslistview_tsx",
       "label": "ProductsListView.tsx",
@@ -86449,7 +86467,7 @@
       "source_location": "L1"
     },
     {
-      "community": 392,
+      "community": 393,
       "file_type": "code",
       "id": "productslistview_handleclearcache",
       "label": "handleClearCache()",
@@ -86458,7 +86476,7 @@
       "source_location": "L65"
     },
     {
-      "community": 392,
+      "community": 393,
       "file_type": "code",
       "id": "productslistview_productactionstogglegroup",
       "label": "ProductActionsToggleGroup()",
@@ -86467,7 +86485,7 @@
       "source_location": "L20"
     },
     {
-      "community": 393,
+      "community": 394,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_productstablecontext_tsx",
       "label": "ProductsTableContext.tsx",
@@ -86476,7 +86494,7 @@
       "source_location": "L1"
     },
     {
-      "community": 393,
+      "community": 394,
       "file_type": "code",
       "id": "productstablecontext_productstableprovider",
       "label": "ProductsTableProvider()",
@@ -86485,7 +86503,7 @@
       "source_location": "L16"
     },
     {
-      "community": 393,
+      "community": 394,
       "file_type": "code",
       "id": "productstablecontext_useproductstablestate",
       "label": "useProductsTableState()",
@@ -86494,7 +86512,7 @@
       "source_location": "L60"
     },
     {
-      "community": 394,
+      "community": 395,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_storeproductsview_tsx",
       "label": "StoreProductsView.tsx",
@@ -86503,7 +86521,7 @@
       "source_location": "L1"
     },
     {
-      "community": 394,
+      "community": 395,
       "file_type": "code",
       "id": "storeproductsview_navigation",
       "label": "Navigation()",
@@ -86512,7 +86530,7 @@
       "source_location": "L45"
     },
     {
-      "community": 394,
+      "community": 395,
       "file_type": "code",
       "id": "storeproductsview_productactionstogglegroup",
       "label": "ProductActionsToggleGroup()",
@@ -86521,7 +86539,7 @@
       "source_location": "L19"
     },
     {
-      "community": 395,
+      "community": 396,
       "file_type": "code",
       "id": "addcomplimentaryproduct_addcomplimentaryproduct",
       "label": "AddComplimentaryProduct()",
@@ -86530,7 +86548,7 @@
       "source_location": "L128"
     },
     {
-      "community": 395,
+      "community": 396,
       "file_type": "code",
       "id": "addcomplimentaryproduct_handleaddcomplimentaryproducts",
       "label": "handleAddComplimentaryProducts()",
@@ -86539,7 +86557,7 @@
       "source_location": "L40"
     },
     {
-      "community": 395,
+      "community": 396,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_complimentary_addcomplimentaryproduct_tsx",
       "label": "AddComplimentaryProduct.tsx",
@@ -86548,7 +86566,7 @@
       "source_location": "L1"
     },
     {
-      "community": 396,
+      "community": 397,
       "file_type": "code",
       "id": "color_picker_handleblur",
       "label": "handleBlur()",
@@ -86557,7 +86575,7 @@
       "source_location": "L24"
     },
     {
-      "community": 396,
+      "community": 397,
       "file_type": "code",
       "id": "color_picker_handleinputchange",
       "label": "handleInputChange()",
@@ -86566,7 +86584,7 @@
       "source_location": "L20"
     },
     {
-      "community": 396,
+      "community": 397,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_modals_color_picker_tsx",
       "label": "color-picker.tsx",
@@ -86575,7 +86593,7 @@
       "source_location": "L1"
     },
     {
-      "community": 397,
+      "community": 398,
       "file_type": "code",
       "id": "currency_provider_currencyprovider",
       "label": "CurrencyProvider()",
@@ -86584,7 +86602,7 @@
       "source_location": "L25"
     },
     {
-      "community": 397,
+      "community": 398,
       "file_type": "code",
       "id": "currency_provider_usestorecurrency",
       "label": "useStoreCurrency()",
@@ -86593,7 +86611,7 @@
       "source_location": "L17"
     },
     {
-      "community": 397,
+      "community": 398,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_providers_currency_provider_tsx",
       "label": "currency-provider.tsx",
@@ -86602,7 +86620,7 @@
       "source_location": "L1"
     },
     {
-      "community": 398,
+      "community": 399,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_serviceappointmentsview_test_tsx",
       "label": "ServiceAppointmentsView.test.tsx",
@@ -86611,7 +86629,7 @@
       "source_location": "L1"
     },
     {
-      "community": 398,
+      "community": 399,
       "file_type": "code",
       "id": "serviceappointmentsview_test_choosedatetime",
       "label": "chooseDateTime()",
@@ -86620,40 +86638,13 @@
       "source_location": "L59"
     },
     {
-      "community": 398,
+      "community": 399,
       "file_type": "code",
       "id": "serviceappointmentsview_test_chooseselectoption",
       "label": "chooseSelectOption()",
       "norm_label": "chooseselectoption()",
       "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.test.tsx",
       "source_location": "L50"
-    },
-    {
-      "community": 399,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_services_serviceintakeview_tsx",
-      "label": "ServiceIntakeView.tsx",
-      "norm_label": "serviceintakeview.tsx",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceIntakeView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 399,
-      "file_type": "code",
-      "id": "serviceintakeview_serviceintakeview",
-      "label": "ServiceIntakeView()",
-      "norm_label": "serviceintakeview()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceIntakeView.tsx",
-      "source_location": "L216"
-    },
-    {
-      "community": 399,
-      "file_type": "code",
-      "id": "serviceintakeview_serviceintakeviewcontent",
-      "label": "ServiceIntakeViewContent()",
-      "norm_label": "serviceintakeviewcontent()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceIntakeView.tsx",
-      "source_location": "L84"
     },
     {
       "community": 4,
@@ -87171,6 +87162,33 @@
     {
       "community": 400,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_services_serviceintakeview_tsx",
+      "label": "ServiceIntakeView.tsx",
+      "norm_label": "serviceintakeview.tsx",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceIntakeView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 400,
+      "file_type": "code",
+      "id": "serviceintakeview_serviceintakeview",
+      "label": "ServiceIntakeView()",
+      "norm_label": "serviceintakeview()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceIntakeView.tsx",
+      "source_location": "L216"
+    },
+    {
+      "community": 400,
+      "file_type": "code",
+      "id": "serviceintakeview_serviceintakeviewcontent",
+      "label": "ServiceIntakeViewContent()",
+      "norm_label": "serviceintakeviewcontent()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceIntakeView.tsx",
+      "source_location": "L84"
+    },
+    {
+      "community": 401,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_staff_staffmanagement_test_tsx",
       "label": "StaffManagement.test.tsx",
       "norm_label": "staffmanagement.test.tsx",
@@ -87178,7 +87196,7 @@
       "source_location": "L1"
     },
     {
-      "community": 400,
+      "community": 401,
       "file_type": "code",
       "id": "staffmanagement_test_chooserole",
       "label": "chooseRole()",
@@ -87187,7 +87205,7 @@
       "source_location": "L163"
     },
     {
-      "community": 400,
+      "community": 401,
       "file_type": "code",
       "id": "staffmanagement_test_mockconvex",
       "label": "mockConvex()",
@@ -87196,7 +87214,7 @@
       "source_location": "L107"
     },
     {
-      "community": 401,
+      "community": 402,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_staff_auth_staffauthenticationdialog_tsx",
       "label": "StaffAuthenticationDialog.tsx",
@@ -87205,7 +87223,7 @@
       "source_location": "L1"
     },
     {
-      "community": 401,
+      "community": 402,
       "file_type": "code",
       "id": "staffauthenticationdialog_handlekeydown",
       "label": "handleKeyDown()",
@@ -87214,7 +87232,7 @@
       "source_location": "L168"
     },
     {
-      "community": 401,
+      "community": 402,
       "file_type": "code",
       "id": "staffauthenticationdialog_handlesubmit",
       "label": "handleSubmit()",
@@ -87223,7 +87241,7 @@
       "source_location": "L110"
     },
     {
-      "community": 402,
+      "community": 403,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_error_singlelineerror_tsx",
       "label": "SingleLineError.tsx",
@@ -87232,7 +87250,7 @@
       "source_location": "L1"
     },
     {
-      "community": 402,
+      "community": 403,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_error_singlelineerror_tsx",
       "label": "SingleLineError.tsx",
@@ -87241,7 +87259,7 @@
       "source_location": "L1"
     },
     {
-      "community": 402,
+      "community": 403,
       "file_type": "code",
       "id": "singlelineerror_singlelineerror",
       "label": "SingleLineError()",
@@ -87250,7 +87268,7 @@
       "source_location": "L3"
     },
     {
-      "community": 403,
+      "community": 404,
       "file_type": "code",
       "id": "index_errorpage",
       "label": "ErrorPage()",
@@ -87259,7 +87277,7 @@
       "source_location": "L9"
     },
     {
-      "community": 403,
+      "community": 404,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_error_index_tsx",
       "label": "index.tsx",
@@ -87268,7 +87286,7 @@
       "source_location": "L1"
     },
     {
-      "community": 403,
+      "community": 404,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_error_index_tsx",
       "label": "index.tsx",
@@ -87277,7 +87295,7 @@
       "source_location": "L1"
     },
     {
-      "community": 404,
+      "community": 405,
       "file_type": "code",
       "id": "app_skeleton_appskeleton",
       "label": "AppSkeleton()",
@@ -87286,7 +87304,7 @@
       "source_location": "L3"
     },
     {
-      "community": 404,
+      "community": 405,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_loading_app_skeleton_tsx",
       "label": "app-skeleton.tsx",
@@ -87295,7 +87313,7 @@
       "source_location": "L1"
     },
     {
-      "community": 404,
+      "community": 405,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_loading_app_skeleton_tsx",
       "label": "app-skeleton.tsx",
@@ -87304,7 +87322,7 @@
       "source_location": "L1"
     },
     {
-      "community": 405,
+      "community": 406,
       "file_type": "code",
       "id": "dashboard_skeleton_dashboardskeleton",
       "label": "DashboardSkeleton()",
@@ -87313,7 +87331,7 @@
       "source_location": "L3"
     },
     {
-      "community": 405,
+      "community": 406,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_loading_dashboard_skeleton_tsx",
       "label": "dashboard-skeleton.tsx",
@@ -87322,7 +87340,7 @@
       "source_location": "L1"
     },
     {
-      "community": 405,
+      "community": 406,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_loading_dashboard_skeleton_tsx",
       "label": "dashboard-skeleton.tsx",
@@ -87331,7 +87349,7 @@
       "source_location": "L1"
     },
     {
-      "community": 406,
+      "community": 407,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_loading_table_skeleton_tsx",
       "label": "table-skeleton.tsx",
@@ -87340,7 +87358,7 @@
       "source_location": "L1"
     },
     {
-      "community": 406,
+      "community": 407,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_loading_table_skeleton_tsx",
       "label": "table-skeleton.tsx",
@@ -87349,7 +87367,7 @@
       "source_location": "L1"
     },
     {
-      "community": 406,
+      "community": 407,
       "file_type": "code",
       "id": "table_skeleton_tableskeleton",
       "label": "TableSkeleton()",
@@ -87358,7 +87376,7 @@
       "source_location": "L3"
     },
     {
-      "community": 407,
+      "community": 408,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_loading_transactions_skeleton_tsx",
       "label": "transactions-skeleton.tsx",
@@ -87367,7 +87385,7 @@
       "source_location": "L1"
     },
     {
-      "community": 407,
+      "community": 408,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_loading_transactions_skeleton_tsx",
       "label": "transactions-skeleton.tsx",
@@ -87376,7 +87394,7 @@
       "source_location": "L1"
     },
     {
-      "community": 407,
+      "community": 408,
       "file_type": "code",
       "id": "transactions_skeleton_transactionsskeleton",
       "label": "TransactionsSkeleton()",
@@ -87385,7 +87403,7 @@
       "source_location": "L3"
     },
     {
-      "community": 408,
+      "community": 409,
       "file_type": "code",
       "id": "notfound_notfound",
       "label": "NotFound()",
@@ -87394,7 +87412,7 @@
       "source_location": "L4"
     },
     {
-      "community": 408,
+      "community": 409,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_not_found_notfound_tsx",
       "label": "NotFound.tsx",
@@ -87403,40 +87421,13 @@
       "source_location": "L1"
     },
     {
-      "community": 408,
+      "community": 409,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_not_found_notfound_tsx",
       "label": "NotFound.tsx",
       "norm_label": "notfound.tsx",
       "source_file": "packages/storefront-webapp/src/components/states/not-found/NotFound.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 409,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_traces_workflowtraceroutelink_tsx",
-      "label": "WorkflowTraceRouteLink.tsx",
-      "norm_label": "workflowtraceroutelink.tsx",
-      "source_file": "packages/athena-webapp/src/components/traces/WorkflowTraceRouteLink.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 409,
-      "file_type": "code",
-      "id": "workflowtraceroutelink_getworkflowtraceroutetarget",
-      "label": "getWorkflowTraceRouteTarget()",
-      "norm_label": "getworkflowtraceroutetarget()",
-      "source_file": "packages/athena-webapp/src/components/traces/WorkflowTraceRouteLink.tsx",
-      "source_location": "L23"
-    },
-    {
-      "community": 409,
-      "file_type": "code",
-      "id": "workflowtraceroutelink_workflowtraceroutelink",
-      "label": "WorkflowTraceRouteLink()",
-      "norm_label": "workflowtraceroutelink()",
-      "source_file": "packages/athena-webapp/src/components/traces/WorkflowTraceRouteLink.tsx",
-      "source_location": "L41"
     },
     {
       "community": 41,
@@ -87594,6 +87585,33 @@
     {
       "community": 410,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_traces_workflowtraceroutelink_tsx",
+      "label": "WorkflowTraceRouteLink.tsx",
+      "norm_label": "workflowtraceroutelink.tsx",
+      "source_file": "packages/athena-webapp/src/components/traces/WorkflowTraceRouteLink.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 410,
+      "file_type": "code",
+      "id": "workflowtraceroutelink_getworkflowtraceroutetarget",
+      "label": "getWorkflowTraceRouteTarget()",
+      "norm_label": "getworkflowtraceroutetarget()",
+      "source_file": "packages/athena-webapp/src/components/traces/WorkflowTraceRouteLink.tsx",
+      "source_location": "L23"
+    },
+    {
+      "community": 410,
+      "file_type": "code",
+      "id": "workflowtraceroutelink_workflowtraceroutelink",
+      "label": "WorkflowTraceRouteLink()",
+      "norm_label": "workflowtraceroutelink()",
+      "source_file": "packages/athena-webapp/src/components/traces/WorkflowTraceRouteLink.tsx",
+      "source_location": "L41"
+    },
+    {
+      "community": 411,
+      "file_type": "code",
       "id": "app_context_menu_appcontextmenu",
       "label": "AppContextMenu()",
       "norm_label": "appcontextmenu()",
@@ -87601,7 +87619,7 @@
       "source_location": "L20"
     },
     {
-      "community": 410,
+      "community": 411,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_app_context_menu_tsx",
       "label": "app-context-menu.tsx",
@@ -87610,7 +87628,7 @@
       "source_location": "L1"
     },
     {
-      "community": 410,
+      "community": 411,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_app_context_menu_tsx",
       "label": "app-context-menu.tsx",
@@ -87619,7 +87637,7 @@
       "source_location": "L1"
     },
     {
-      "community": 411,
+      "community": 412,
       "file_type": "code",
       "id": "badge_badge",
       "label": "Badge()",
@@ -87628,7 +87646,7 @@
       "source_location": "L30"
     },
     {
-      "community": 411,
+      "community": 412,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_badge_tsx",
       "label": "badge.tsx",
@@ -87637,7 +87655,7 @@
       "source_location": "L1"
     },
     {
-      "community": 411,
+      "community": 412,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_badge_tsx",
       "label": "badge.tsx",
@@ -87646,7 +87664,7 @@
       "source_location": "L1"
     },
     {
-      "community": 412,
+      "community": 413,
       "file_type": "code",
       "id": "calendar_calendar",
       "label": "Calendar()",
@@ -87655,7 +87673,7 @@
       "source_location": "L12"
     },
     {
-      "community": 412,
+      "community": 413,
       "file_type": "code",
       "id": "calendar_cn",
       "label": "cn()",
@@ -87664,7 +87682,7 @@
       "source_location": "L201"
     },
     {
-      "community": 412,
+      "community": 413,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_calendar_tsx",
       "label": "calendar.tsx",
@@ -87673,7 +87691,7 @@
       "source_location": "L1"
     },
     {
-      "community": 413,
+      "community": 414,
       "file_type": "code",
       "id": "loading_button_loadingbutton",
       "label": "LoadingButton()",
@@ -87682,7 +87700,7 @@
       "source_location": "L9"
     },
     {
-      "community": 413,
+      "community": 414,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_loading_button_tsx",
       "label": "loading-button.tsx",
@@ -87691,7 +87709,7 @@
       "source_location": "L1"
     },
     {
-      "community": 413,
+      "community": 414,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_loading_button_tsx",
       "label": "loading-button.tsx",
@@ -87700,7 +87718,7 @@
       "source_location": "L1"
     },
     {
-      "community": 414,
+      "community": 415,
       "file_type": "code",
       "id": "modal_onchange",
       "label": "onChange()",
@@ -87709,7 +87727,7 @@
       "source_location": "L38"
     },
     {
-      "community": 414,
+      "community": 415,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modal_tsx",
       "label": "modal.tsx",
@@ -87718,7 +87736,7 @@
       "source_location": "L1"
     },
     {
-      "community": 414,
+      "community": 415,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modal_tsx",
       "label": "modal.tsx",
@@ -87727,7 +87745,7 @@
       "source_location": "L1"
     },
     {
-      "community": 415,
+      "community": 416,
       "file_type": "code",
       "id": "alert_modal_alertmodal",
       "label": "AlertModal()",
@@ -87736,7 +87754,7 @@
       "source_location": "L20"
     },
     {
-      "community": 415,
+      "community": 416,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_alert_modal_tsx",
       "label": "alert-modal.tsx",
@@ -87745,7 +87763,7 @@
       "source_location": "L1"
     },
     {
-      "community": 415,
+      "community": 416,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_alert_modal_tsx",
       "label": "alert-modal.tsx",
@@ -87754,7 +87772,7 @@
       "source_location": "L1"
     },
     {
-      "community": 416,
+      "community": 417,
       "file_type": "code",
       "id": "overlay_modal_overlaymodal",
       "label": "OverlayModal()",
@@ -87763,7 +87781,7 @@
       "source_location": "L12"
     },
     {
-      "community": 416,
+      "community": 417,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_overlay_modal_tsx",
       "label": "overlay-modal.tsx",
@@ -87772,7 +87790,7 @@
       "source_location": "L1"
     },
     {
-      "community": 416,
+      "community": 417,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_overlay_modal_tsx",
       "label": "overlay-modal.tsx",
@@ -87781,7 +87799,7 @@
       "source_location": "L1"
     },
     {
-      "community": 417,
+      "community": 418,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_skeleton_tsx",
       "label": "skeleton.tsx",
@@ -87790,7 +87808,7 @@
       "source_location": "L1"
     },
     {
-      "community": 417,
+      "community": 418,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_skeleton_tsx",
       "label": "skeleton.tsx",
@@ -87799,7 +87817,7 @@
       "source_location": "L1"
     },
     {
-      "community": 417,
+      "community": 418,
       "file_type": "code",
       "id": "skeleton_skeleton",
       "label": "Skeleton()",
@@ -87808,7 +87826,7 @@
       "source_location": "L3"
     },
     {
-      "community": 418,
+      "community": 419,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_sonner_tsx",
       "label": "sonner.tsx",
@@ -87817,7 +87835,7 @@
       "source_location": "L1"
     },
     {
-      "community": 418,
+      "community": 419,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_sonner_tsx",
       "label": "sonner.tsx",
@@ -87826,40 +87844,13 @@
       "source_location": "L1"
     },
     {
-      "community": 418,
+      "community": 419,
       "file_type": "code",
       "id": "sonner_toaster",
       "label": "Toaster()",
       "norm_label": "toaster()",
       "source_file": "packages/storefront-webapp/src/components/ui/sonner.tsx",
       "source_location": "L6"
-    },
-    {
-      "community": 419,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_spinner_tsx",
-      "label": "spinner.tsx",
-      "norm_label": "spinner.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/spinner.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 419,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_spinner_tsx",
-      "label": "spinner.tsx",
-      "norm_label": "spinner.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/spinner.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 419,
-      "file_type": "code",
-      "id": "spinner_spinner",
-      "label": "Spinner()",
-      "norm_label": "spinner()",
-      "source_file": "packages/storefront-webapp/src/components/ui/spinner.tsx",
-      "source_location": "L3"
     },
     {
       "community": 42,
@@ -88017,6 +88008,33 @@
     {
       "community": 420,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_spinner_tsx",
+      "label": "spinner.tsx",
+      "norm_label": "spinner.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/spinner.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 420,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_spinner_tsx",
+      "label": "spinner.tsx",
+      "norm_label": "spinner.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/spinner.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 420,
+      "file_type": "code",
+      "id": "spinner_spinner",
+      "label": "Spinner()",
+      "norm_label": "spinner()",
+      "source_file": "packages/storefront-webapp/src/components/ui/spinner.tsx",
+      "source_location": "L3"
+    },
+    {
+      "community": 421,
+      "file_type": "code",
       "id": "activitysummarycards_activitysummarycards",
       "label": "ActivitySummaryCards()",
       "norm_label": "activitysummarycards()",
@@ -88024,7 +88042,7 @@
       "source_location": "L44"
     },
     {
-      "community": 420,
+      "community": 421,
       "file_type": "code",
       "id": "activitysummarycards_summarycard",
       "label": "SummaryCard()",
@@ -88033,7 +88051,7 @@
       "source_location": "L19"
     },
     {
-      "community": 420,
+      "community": 421,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_activitysummarycards_tsx",
       "label": "ActivitySummaryCards.tsx",
@@ -88042,7 +88060,7 @@
       "source_location": "L1"
     },
     {
-      "community": 421,
+      "community": 422,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_timelineeventcard_tsx",
       "label": "TimelineEventCard.tsx",
@@ -88051,7 +88069,7 @@
       "source_location": "L1"
     },
     {
-      "community": 421,
+      "community": 422,
       "file_type": "code",
       "id": "timelineeventcard_formatobservabilitylabel",
       "label": "formatObservabilityLabel()",
@@ -88060,7 +88078,7 @@
       "source_location": "L162"
     },
     {
-      "community": 421,
+      "community": 422,
       "file_type": "code",
       "id": "timelineeventcard_loadmore",
       "label": "loadMore()",
@@ -88069,7 +88087,7 @@
       "source_location": "L198"
     },
     {
-      "community": 422,
+      "community": 423,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_useractivity_tsx",
       "label": "UserActivity.tsx",
@@ -88078,7 +88096,7 @@
       "source_location": "L1"
     },
     {
-      "community": 422,
+      "community": 423,
       "file_type": "code",
       "id": "useractivity_activityheader",
       "label": "ActivityHeader()",
@@ -88087,7 +88105,7 @@
       "source_location": "L22"
     },
     {
-      "community": 422,
+      "community": 423,
       "file_type": "code",
       "id": "useractivity_useractivity",
       "label": "UserActivity()",
@@ -88096,7 +88114,7 @@
       "source_location": "L45"
     },
     {
-      "community": 423,
+      "community": 424,
       "file_type": "code",
       "id": "onlineordercontext_onlineorderprovider",
       "label": "OnlineOrderProvider()",
@@ -88105,7 +88123,7 @@
       "source_location": "L24"
     },
     {
-      "community": 423,
+      "community": 424,
       "file_type": "code",
       "id": "onlineordercontext_useonlineorder",
       "label": "useOnlineOrder()",
@@ -88114,7 +88132,7 @@
       "source_location": "L38"
     },
     {
-      "community": 423,
+      "community": 424,
       "file_type": "code",
       "id": "packages_athena_webapp_src_contexts_onlineordercontext_tsx",
       "label": "OnlineOrderContext.tsx",
@@ -88123,7 +88141,7 @@
       "source_location": "L1"
     },
     {
-      "community": 424,
+      "community": 425,
       "file_type": "code",
       "id": "packages_athena_webapp_src_contexts_permissionscontext_tsx",
       "label": "PermissionsContext.tsx",
@@ -88132,7 +88150,7 @@
       "source_location": "L1"
     },
     {
-      "community": 424,
+      "community": 425,
       "file_type": "code",
       "id": "permissionscontext_permissionsprovider",
       "label": "PermissionsProvider()",
@@ -88141,7 +88159,7 @@
       "source_location": "L23"
     },
     {
-      "community": 424,
+      "community": 425,
       "file_type": "code",
       "id": "permissionscontext_usepermissionscontext",
       "label": "usePermissionsContext()",
@@ -88150,7 +88168,7 @@
       "source_location": "L51"
     },
     {
-      "community": 425,
+      "community": 426,
       "file_type": "code",
       "id": "packages_athena_webapp_src_contexts_productcontext_tsx",
       "label": "ProductContext.tsx",
@@ -88159,7 +88177,7 @@
       "source_location": "L1"
     },
     {
-      "community": 425,
+      "community": 426,
       "file_type": "code",
       "id": "productcontext_productprovider",
       "label": "ProductProvider()",
@@ -88168,7 +88186,7 @@
       "source_location": "L54"
     },
     {
-      "community": 425,
+      "community": 426,
       "file_type": "code",
       "id": "productcontext_useproduct",
       "label": "useProduct()",
@@ -88177,7 +88195,7 @@
       "source_location": "L282"
     },
     {
-      "community": 426,
+      "community": 427,
       "file_type": "code",
       "id": "packages_athena_webapp_src_contexts_usercontext_tsx",
       "label": "UserContext.tsx",
@@ -88186,7 +88204,7 @@
       "source_location": "L1"
     },
     {
-      "community": 426,
+      "community": 427,
       "file_type": "code",
       "id": "usercontext_userprovider",
       "label": "UserProvider()",
@@ -88195,7 +88213,7 @@
       "source_location": "L12"
     },
     {
-      "community": 426,
+      "community": 427,
       "file_type": "code",
       "id": "usercontext_useusercontext",
       "label": "useUserContext()",
@@ -88204,7 +88222,7 @@
       "source_location": "L37"
     },
     {
-      "community": 427,
+      "community": 428,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useauth_ts",
       "label": "useAuth.ts",
@@ -88213,7 +88231,7 @@
       "source_location": "L1"
     },
     {
-      "community": 427,
+      "community": 428,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useauth_ts",
       "label": "useAuth.ts",
@@ -88222,7 +88240,7 @@
       "source_location": "L1"
     },
     {
-      "community": 427,
+      "community": 428,
       "file_type": "code",
       "id": "useauth_useauth",
       "label": "useAuth()",
@@ -88231,7 +88249,7 @@
       "source_location": "L4"
     },
     {
-      "community": 428,
+      "community": 429,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetactivestore_ts",
       "label": "useGetActiveStore.ts",
@@ -88240,7 +88258,7 @@
       "source_location": "L1"
     },
     {
-      "community": 428,
+      "community": 429,
       "file_type": "code",
       "id": "usegetactivestore_usegetactivestore",
       "label": "useGetActiveStore()",
@@ -88249,40 +88267,13 @@
       "source_location": "L9"
     },
     {
-      "community": 428,
+      "community": 429,
       "file_type": "code",
       "id": "usegetactivestore_usegetstores",
       "label": "useGetStores()",
       "norm_label": "usegetstores()",
       "source_file": "packages/athena-webapp/src/hooks/useGetActiveStore.ts",
       "source_location": "L50"
-    },
-    {
-      "community": 429,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_usegetorganizations_ts",
-      "label": "useGetOrganizations.ts",
-      "norm_label": "usegetorganizations.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useGetOrganizations.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 429,
-      "file_type": "code",
-      "id": "usegetorganizations_usegetactiveorganization",
-      "label": "useGetActiveOrganization()",
-      "norm_label": "usegetactiveorganization()",
-      "source_file": "packages/athena-webapp/src/hooks/useGetOrganizations.ts",
-      "source_location": "L6"
-    },
-    {
-      "community": 429,
-      "file_type": "code",
-      "id": "usegetorganizations_usegetorganizations",
-      "label": "useGetOrganizations()",
-      "norm_label": "usegetorganizations()",
-      "source_file": "packages/athena-webapp/src/hooks/useGetOrganizations.ts",
-      "source_location": "L31"
     },
     {
       "community": 43,
@@ -88431,6 +88422,33 @@
     {
       "community": 430,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_usegetorganizations_ts",
+      "label": "useGetOrganizations.ts",
+      "norm_label": "usegetorganizations.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useGetOrganizations.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 430,
+      "file_type": "code",
+      "id": "usegetorganizations_usegetactiveorganization",
+      "label": "useGetActiveOrganization()",
+      "norm_label": "usegetactiveorganization()",
+      "source_file": "packages/athena-webapp/src/hooks/useGetOrganizations.ts",
+      "source_location": "L6"
+    },
+    {
+      "community": 430,
+      "file_type": "code",
+      "id": "usegetorganizations_usegetorganizations",
+      "label": "useGetOrganizations()",
+      "norm_label": "usegetorganizations()",
+      "source_file": "packages/athena-webapp/src/hooks/useGetOrganizations.ts",
+      "source_location": "L31"
+    },
+    {
+      "community": 431,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usesessionmanagementexpense_ts",
       "label": "useSessionManagementExpense.ts",
       "norm_label": "usesessionmanagementexpense.ts",
@@ -88438,7 +88456,7 @@
       "source_location": "L1"
     },
     {
-      "community": 430,
+      "community": 431,
       "file_type": "code",
       "id": "usesessionmanagementexpense_getcommanderrormessage",
       "label": "getCommandErrorMessage()",
@@ -88447,7 +88465,7 @@
       "source_location": "L19"
     },
     {
-      "community": 430,
+      "community": 431,
       "file_type": "code",
       "id": "usesessionmanagementexpense_usesessionmanagementexpense",
       "label": "useSessionManagementExpense()",
@@ -88456,7 +88474,7 @@
       "source_location": "L33"
     },
     {
-      "community": 431,
+      "community": 432,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_presentcommandtoast_ts",
       "label": "presentCommandToast.ts",
@@ -88465,7 +88483,7 @@
       "source_location": "L1"
     },
     {
-      "community": 431,
+      "community": 432,
       "file_type": "code",
       "id": "presentcommandtoast_getapprovalguidance",
       "label": "getApprovalGuidance()",
@@ -88474,7 +88492,7 @@
       "source_location": "L9"
     },
     {
-      "community": 431,
+      "community": 432,
       "file_type": "code",
       "id": "presentcommandtoast_presentcommandtoast",
       "label": "presentCommandToast()",
@@ -88483,7 +88501,7 @@
       "source_location": "L16"
     },
     {
-      "community": 432,
+      "community": 433,
       "file_type": "code",
       "id": "maintenanceutils_isinmaintenancemode",
       "label": "isInMaintenanceMode()",
@@ -88492,7 +88510,7 @@
       "source_location": "L7"
     },
     {
-      "community": 432,
+      "community": 433,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_maintenanceutils_ts",
       "label": "maintenanceUtils.ts",
@@ -88501,7 +88519,7 @@
       "source_location": "L1"
     },
     {
-      "community": 432,
+      "community": 433,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_maintenanceutils_ts",
       "label": "maintenanceUtils.ts",
@@ -88510,7 +88528,7 @@
       "source_location": "L1"
     },
     {
-      "community": 433,
+      "community": 434,
       "file_type": "code",
       "id": "bootstrapregister_test_drawer",
       "label": "drawer()",
@@ -88519,7 +88537,7 @@
       "source_location": "L9"
     },
     {
-      "community": 433,
+      "community": 434,
       "file_type": "code",
       "id": "bootstrapregister_test_state",
       "label": "state()",
@@ -88528,7 +88546,7 @@
       "source_location": "L23"
     },
     {
-      "community": 433,
+      "community": 434,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_bootstrapregister_test_ts",
       "label": "bootstrapRegister.test.ts",
@@ -88537,7 +88555,7 @@
       "source_location": "L1"
     },
     {
-      "community": 434,
+      "community": 435,
       "file_type": "code",
       "id": "commandgateway_useconvexcommandgateway",
       "label": "useConvexCommandGateway()",
@@ -88546,7 +88564,7 @@
       "source_location": "L18"
     },
     {
-      "community": 434,
+      "community": 435,
       "file_type": "code",
       "id": "commandgateway_useconvexdirecttransactionmutation",
       "label": "useConvexDirectTransactionMutation()",
@@ -88555,7 +88573,7 @@
       "source_location": "L60"
     },
     {
-      "community": 434,
+      "community": 435,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_commandgateway_ts",
       "label": "commandGateway.ts",
@@ -88564,7 +88582,7 @@
       "source_location": "L1"
     },
     {
-      "community": 435,
+      "community": 436,
       "file_type": "code",
       "id": "catalogsearchpresentation_mapcatalogrowtoproduct",
       "label": "mapCatalogRowToProduct()",
@@ -88573,7 +88591,7 @@
       "source_location": "L10"
     },
     {
-      "community": 435,
+      "community": 436,
       "file_type": "code",
       "id": "catalogsearchpresentation_normalizeexactinput",
       "label": "normalizeExactInput()",
@@ -88582,7 +88600,7 @@
       "source_location": "L39"
     },
     {
-      "community": 435,
+      "community": 436,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_presentation_register_catalogsearchpresentation_ts",
       "label": "catalogSearchPresentation.ts",
@@ -88591,7 +88609,7 @@
       "source_location": "L1"
     },
     {
-      "community": 436,
+      "community": 437,
       "file_type": "code",
       "id": "main_app",
       "label": "App()",
@@ -88600,7 +88618,7 @@
       "source_location": "L31"
     },
     {
-      "community": 436,
+      "community": 437,
       "file_type": "code",
       "id": "packages_athena_webapp_src_main_tsx",
       "label": "main.tsx",
@@ -88609,7 +88627,7 @@
       "source_location": "L1"
     },
     {
-      "community": 436,
+      "community": 437,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_main_tsx",
       "label": "main.tsx",
@@ -88618,7 +88636,7 @@
       "source_location": "L1"
     },
     {
-      "community": 437,
+      "community": 438,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routetree_browser_boundary_test_ts",
       "label": "routeTree.browser-boundary.test.ts",
@@ -88627,7 +88645,7 @@
       "source_location": "L1"
     },
     {
-      "community": 437,
+      "community": 438,
       "file_type": "code",
       "id": "routetree_browser_boundary_test_collectsourcefiles",
       "label": "collectSourceFiles()",
@@ -88636,7 +88654,7 @@
       "source_location": "L28"
     },
     {
-      "community": 437,
+      "community": 438,
       "file_type": "code",
       "id": "routetree_browser_boundary_test_findillegalconveximports",
       "label": "findIllegalConvexImports()",
@@ -88645,7 +88663,7 @@
       "source_location": "L46"
     },
     {
-      "community": 438,
+      "community": 439,
       "file_type": "code",
       "id": "actioncolorreview_stories_swatch",
       "label": "Swatch()",
@@ -88654,7 +88672,7 @@
       "source_location": "L179"
     },
     {
-      "community": 438,
+      "community": 439,
       "file_type": "code",
       "id": "actioncolorreview_stories_tokenscope",
       "label": "TokenScope()",
@@ -88663,39 +88681,12 @@
       "source_location": "L168"
     },
     {
-      "community": 438,
+      "community": 439,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_foundations_actioncolorreview_stories_tsx",
       "label": "ActionColorReview.stories.tsx",
       "norm_label": "actioncolorreview.stories.tsx",
       "source_file": "packages/athena-webapp/src/stories/Foundations/ActionColorReview.stories.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 439,
-      "file_type": "code",
-      "id": "admin_shell_patterns_patterncard",
-      "label": "PatternCard()",
-      "norm_label": "patterncard()",
-      "source_file": "packages/athena-webapp/src/stories/Patterns/admin-shell-patterns.tsx",
-      "source_location": "L127"
-    },
-    {
-      "community": 439,
-      "file_type": "code",
-      "id": "admin_shell_patterns_patternshell",
-      "label": "PatternShell()",
-      "norm_label": "patternshell()",
-      "source_file": "packages/athena-webapp/src/stories/Patterns/admin-shell-patterns.tsx",
-      "source_location": "L106"
-    },
-    {
-      "community": 439,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_patterns_admin_shell_patterns_tsx",
-      "label": "admin-shell-patterns.tsx",
-      "norm_label": "admin-shell-patterns.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Patterns/admin-shell-patterns.tsx",
       "source_location": "L1"
     },
     {
@@ -88845,6 +88836,33 @@
     {
       "community": 440,
       "file_type": "code",
+      "id": "admin_shell_patterns_patterncard",
+      "label": "PatternCard()",
+      "norm_label": "patterncard()",
+      "source_file": "packages/athena-webapp/src/stories/Patterns/admin-shell-patterns.tsx",
+      "source_location": "L127"
+    },
+    {
+      "community": 440,
+      "file_type": "code",
+      "id": "admin_shell_patterns_patternshell",
+      "label": "PatternShell()",
+      "norm_label": "patternshell()",
+      "source_file": "packages/athena-webapp/src/stories/Patterns/admin-shell-patterns.tsx",
+      "source_location": "L106"
+    },
+    {
+      "community": 440,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_patterns_admin_shell_patterns_tsx",
+      "label": "admin-shell-patterns.tsx",
+      "norm_label": "admin-shell-patterns.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Patterns/admin-shell-patterns.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 441,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_stories_storybook_theme_decorator_tsx",
       "label": "storybook-theme-decorator.tsx",
       "norm_label": "storybook-theme-decorator.tsx",
@@ -88852,7 +88870,7 @@
       "source_location": "L1"
     },
     {
-      "community": 440,
+      "community": 441,
       "file_type": "code",
       "id": "storybook_theme_decorator_getathenadesigntokenstyle",
       "label": "getAthenaDesignTokenStyle()",
@@ -88861,7 +88879,7 @@
       "source_location": "L49"
     },
     {
-      "community": 440,
+      "community": 441,
       "file_type": "code",
       "id": "storybook_theme_decorator_withathenatheme",
       "label": "withAthenaTheme()",
@@ -88870,7 +88888,7 @@
       "source_location": "L62"
     },
     {
-      "community": 441,
+      "community": 442,
       "file_type": "code",
       "id": "inventoryvalidationlogic_test_mockgetsku",
       "label": "mockGetSku()",
@@ -88879,7 +88897,7 @@
       "source_location": "L66"
     },
     {
-      "community": 441,
+      "community": 442,
       "file_type": "code",
       "id": "inventoryvalidationlogic_test_validateinventoryfortransaction",
       "label": "validateInventoryForTransaction()",
@@ -88888,7 +88906,7 @@
       "source_location": "L20"
     },
     {
-      "community": 441,
+      "community": 442,
       "file_type": "code",
       "id": "packages_athena_webapp_src_tests_pos_inventoryvalidationlogic_test_ts",
       "label": "inventoryValidationLogic.test.ts",
@@ -88897,7 +88915,7 @@
       "source_location": "L1"
     },
     {
-      "community": 442,
+      "community": 443,
       "file_type": "code",
       "id": "index_hashpassword",
       "label": "hashPassword()",
@@ -88906,7 +88924,7 @@
       "source_location": "L1"
     },
     {
-      "community": 442,
+      "community": 443,
       "file_type": "code",
       "id": "packages_athena_webapp_src_utils_index_ts",
       "label": "index.ts",
@@ -88915,7 +88933,7 @@
       "source_location": "L1"
     },
     {
-      "community": 442,
+      "community": 443,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_utils_index_ts",
       "label": "index.ts",
@@ -88924,7 +88942,7 @@
       "source_location": "L1"
     },
     {
-      "community": 443,
+      "community": 444,
       "file_type": "code",
       "id": "packages_athena_webapp_src_utils_versionchecker_ts",
       "label": "versionChecker.ts",
@@ -88933,7 +88951,7 @@
       "source_location": "L1"
     },
     {
-      "community": 443,
+      "community": 444,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_utils_versionchecker_ts",
       "label": "versionChecker.ts",
@@ -88942,7 +88960,7 @@
       "source_location": "L1"
     },
     {
-      "community": 443,
+      "community": 444,
       "file_type": "code",
       "id": "versionchecker_createversionchecker",
       "label": "createVersionChecker()",
@@ -88951,7 +88969,7 @@
       "source_location": "L16"
     },
     {
-      "community": 444,
+      "community": 445,
       "file_type": "code",
       "id": "packages_athena_webapp_vite_config_ts",
       "label": "vite.config.ts",
@@ -88960,7 +88978,7 @@
       "source_location": "L1"
     },
     {
-      "community": 444,
+      "community": 445,
       "file_type": "code",
       "id": "packages_storefront_webapp_vite_config_ts",
       "label": "vite.config.ts",
@@ -88969,7 +88987,7 @@
       "source_location": "L1"
     },
     {
-      "community": 444,
+      "community": 445,
       "file_type": "code",
       "id": "vite_config_manualchunks",
       "label": "manualChunks()",
@@ -88978,7 +88996,7 @@
       "source_location": "L26"
     },
     {
-      "community": 445,
+      "community": 446,
       "file_type": "code",
       "id": "packages_athena_webapp_vitest_setup_ts",
       "label": "vitest.setup.ts",
@@ -88987,7 +89005,7 @@
       "source_location": "L1"
     },
     {
-      "community": 445,
+      "community": 446,
       "file_type": "code",
       "id": "vitest_setup_pointercapturestub",
       "label": "pointerCaptureStub()",
@@ -88996,7 +89014,7 @@
       "source_location": "L23"
     },
     {
-      "community": 445,
+      "community": 446,
       "file_type": "code",
       "id": "vitest_setup_pointerreleasestub",
       "label": "pointerReleaseStub()",
@@ -89005,7 +89023,7 @@
       "source_location": "L24"
     },
     {
-      "community": 446,
+      "community": 447,
       "file_type": "code",
       "id": "auth_logout",
       "label": "logout()",
@@ -89014,7 +89032,7 @@
       "source_location": "L32"
     },
     {
-      "community": 446,
+      "community": 447,
       "file_type": "code",
       "id": "auth_verifyuseraccount",
       "label": "verifyUserAccount()",
@@ -89023,7 +89041,7 @@
       "source_location": "L3"
     },
     {
-      "community": 446,
+      "community": 447,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_auth_ts",
       "label": "auth.ts",
@@ -89032,7 +89050,7 @@
       "source_location": "L1"
     },
     {
-      "community": 447,
+      "community": 448,
       "file_type": "code",
       "id": "color_getallcolors",
       "label": "getAllColors()",
@@ -89041,7 +89059,7 @@
       "source_location": "L7"
     },
     {
-      "community": 447,
+      "community": 448,
       "file_type": "code",
       "id": "color_getbaseurl",
       "label": "getBaseUrl()",
@@ -89050,7 +89068,7 @@
       "source_location": "L5"
     },
     {
-      "community": 447,
+      "community": 448,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_color_ts",
       "label": "color.ts",
@@ -89059,7 +89077,7 @@
       "source_location": "L1"
     },
     {
-      "community": 448,
+      "community": 449,
       "file_type": "code",
       "id": "organization_getallorganizations",
       "label": "getAllOrganizations()",
@@ -89068,7 +89086,7 @@
       "source_location": "L6"
     },
     {
-      "community": 448,
+      "community": 449,
       "file_type": "code",
       "id": "organization_getorganization",
       "label": "getOrganization()",
@@ -89077,40 +89095,13 @@
       "source_location": "L18"
     },
     {
-      "community": 448,
+      "community": 449,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_organization_ts",
       "label": "organization.ts",
       "norm_label": "organization.ts",
       "source_file": "packages/storefront-webapp/src/api/organization.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 449,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_upsells_ts",
-      "label": "upsells.ts",
-      "norm_label": "upsells.ts",
-      "source_file": "packages/storefront-webapp/src/api/upsells.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 449,
-      "file_type": "code",
-      "id": "upsells_getbaseurl",
-      "label": "getBaseUrl()",
-      "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/upsells.ts",
-      "source_location": "L3"
-    },
-    {
-      "community": 449,
-      "file_type": "code",
-      "id": "upsells_getlastviewedproduct",
-      "label": "getLastViewedProduct()",
-      "norm_label": "getlastviewedproduct()",
-      "source_file": "packages/storefront-webapp/src/api/upsells.ts",
-      "source_location": "L5"
     },
     {
       "community": 45,
@@ -89259,6 +89250,33 @@
     {
       "community": 450,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_api_upsells_ts",
+      "label": "upsells.ts",
+      "norm_label": "upsells.ts",
+      "source_file": "packages/storefront-webapp/src/api/upsells.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 450,
+      "file_type": "code",
+      "id": "upsells_getbaseurl",
+      "label": "getBaseUrl()",
+      "norm_label": "getbaseurl()",
+      "source_file": "packages/storefront-webapp/src/api/upsells.ts",
+      "source_location": "L3"
+    },
+    {
+      "community": 450,
+      "file_type": "code",
+      "id": "upsells_getlastviewedproduct",
+      "label": "getLastViewedProduct()",
+      "norm_label": "getlastviewedproduct()",
+      "source_file": "packages/storefront-webapp/src/api/upsells.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 451,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_api_useroffers_ts",
       "label": "userOffers.ts",
       "norm_label": "useroffers.ts",
@@ -89266,7 +89284,7 @@
       "source_location": "L1"
     },
     {
-      "community": 450,
+      "community": 451,
       "file_type": "code",
       "id": "useroffers_getbaseurl",
       "label": "getBaseUrl()",
@@ -89275,7 +89293,7 @@
       "source_location": "L18"
     },
     {
-      "community": 450,
+      "community": 451,
       "file_type": "code",
       "id": "useroffers_getuserofferseligibility",
       "label": "getUserOffersEligibility()",
@@ -89284,7 +89302,7 @@
       "source_location": "L23"
     },
     {
-      "community": 451,
+      "community": 452,
       "file_type": "code",
       "id": "customerdetails_enteredcustomerdetails",
       "label": "EnteredCustomerDetails()",
@@ -89293,7 +89311,7 @@
       "source_location": "L22"
     },
     {
-      "community": 451,
+      "community": 452,
       "file_type": "code",
       "id": "customerdetails_onsubmit",
       "label": "onSubmit()",
@@ -89302,7 +89320,7 @@
       "source_location": "L55"
     },
     {
-      "community": 451,
+      "community": 452,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_customerdetails_tsx",
       "label": "CustomerDetails.tsx",
@@ -89311,7 +89329,7 @@
       "source_location": "L1"
     },
     {
-      "community": 452,
+      "community": 453,
       "file_type": "code",
       "id": "deliveryoptionsselector_handlechange",
       "label": "handleChange()",
@@ -89320,7 +89338,7 @@
       "source_location": "L77"
     },
     {
-      "community": 452,
+      "community": 453,
       "file_type": "code",
       "id": "deliveryoptionsselector_storeselector",
       "label": "StoreSelector()",
@@ -89329,7 +89347,7 @@
       "source_location": "L11"
     },
     {
-      "community": 452,
+      "community": 453,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_deliveryoptionsselector_tsx",
       "label": "DeliveryOptionsSelector.tsx",
@@ -89338,7 +89356,7 @@
       "source_location": "L1"
     },
     {
-      "community": 453,
+      "community": 454,
       "file_type": "code",
       "id": "deliverysection_deliverydetails",
       "label": "DeliveryDetails()",
@@ -89347,7 +89365,7 @@
       "source_location": "L11"
     },
     {
-      "community": 453,
+      "community": 454,
       "file_type": "code",
       "id": "deliverysection_deliveryoptions",
       "label": "DeliveryOptions()",
@@ -89356,7 +89374,7 @@
       "source_location": "L22"
     },
     {
-      "community": 453,
+      "community": 454,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_deliverysection_tsx",
       "label": "DeliverySection.tsx",
@@ -89365,7 +89383,7 @@
       "source_location": "L1"
     },
     {
-      "community": 454,
+      "community": 455,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_pickupoptions_tsx",
       "label": "PickupOptions.tsx",
@@ -89374,7 +89392,7 @@
       "source_location": "L1"
     },
     {
-      "community": 454,
+      "community": 455,
       "file_type": "code",
       "id": "pickupoptions_formatstoredamount",
       "label": "formatStoredAmount()",
@@ -89383,7 +89401,7 @@
       "source_location": "L165"
     },
     {
-      "community": 454,
+      "community": 455,
       "file_type": "code",
       "id": "pickupoptions_iswithinrestrictiontime",
       "label": "isWithinRestrictionTime()",
@@ -89392,7 +89410,7 @@
       "source_location": "L12"
     },
     {
-      "community": 455,
+      "community": 456,
       "file_type": "code",
       "id": "mobilebagsummary_handlekeydown",
       "label": "handleKeyDown()",
@@ -89401,7 +89419,7 @@
       "source_location": "L110"
     },
     {
-      "community": 455,
+      "community": 456,
       "file_type": "code",
       "id": "mobilebagsummary_handleredeempromocode",
       "label": "handleRedeemPromoCode()",
@@ -89410,7 +89428,7 @@
       "source_location": "L89"
     },
     {
-      "community": 455,
+      "community": 456,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_mobilebagsummary_tsx",
       "label": "MobileBagSummary.tsx",
@@ -89419,7 +89437,7 @@
       "source_location": "L1"
     },
     {
-      "community": 456,
+      "community": 457,
       "file_type": "code",
       "id": "checkoutstorage_loadcheckoutstate",
       "label": "loadCheckoutState()",
@@ -89428,7 +89446,7 @@
       "source_location": "L4"
     },
     {
-      "community": 456,
+      "community": 457,
       "file_type": "code",
       "id": "checkoutstorage_savecheckoutstate",
       "label": "saveCheckoutState()",
@@ -89437,7 +89455,7 @@
       "source_location": "L24"
     },
     {
-      "community": 456,
+      "community": 457,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkoutstorage_ts",
       "label": "checkoutStorage.ts",
@@ -89446,7 +89464,7 @@
       "source_location": "L1"
     },
     {
-      "community": 457,
+      "community": 458,
       "file_type": "code",
       "id": "footer_enablecategories",
       "label": "enableCategories()",
@@ -89455,7 +89473,7 @@
       "source_location": "L131"
     },
     {
-      "community": 457,
+      "community": 458,
       "file_type": "code",
       "id": "footer_linkgroup",
       "label": "LinkGroup()",
@@ -89464,7 +89482,7 @@
       "source_location": "L12"
     },
     {
-      "community": 457,
+      "community": 458,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_footer_footer_tsx",
       "label": "Footer.tsx",
@@ -89473,7 +89491,7 @@
       "source_location": "L1"
     },
     {
-      "community": 458,
+      "community": 459,
       "file_type": "code",
       "id": "featuredproductssection_featuredproductssection",
       "label": "FeaturedProductsSection()",
@@ -89482,7 +89500,7 @@
       "source_location": "L20"
     },
     {
-      "community": 458,
+      "community": 459,
       "file_type": "code",
       "id": "featuredproductssection_featuredsection",
       "label": "FeaturedSection()",
@@ -89491,40 +89509,13 @@
       "source_location": "L46"
     },
     {
-      "community": 458,
+      "community": 459,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_featuredproductssection_tsx",
       "label": "FeaturedProductsSection.tsx",
       "norm_label": "featuredproductssection.tsx",
       "source_file": "packages/storefront-webapp/src/components/home/FeaturedProductsSection.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 459,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_home_promoalert_tsx",
-      "label": "PromoAlert.tsx",
-      "norm_label": "promoalert.tsx",
-      "source_file": "packages/storefront-webapp/src/components/home/PromoAlert.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 459,
-      "file_type": "code",
-      "id": "promoalert_getpromoalertcopy",
-      "label": "getPromoAlertCopy()",
-      "norm_label": "getpromoalertcopy()",
-      "source_file": "packages/storefront-webapp/src/components/home/PromoAlert.tsx",
-      "source_location": "L20"
-    },
-    {
-      "community": 459,
-      "file_type": "code",
-      "id": "promoalert_promoalert",
-      "label": "PromoAlert()",
-      "norm_label": "promoalert()",
-      "source_file": "packages/storefront-webapp/src/components/home/PromoAlert.tsx",
-      "source_location": "L59"
     },
     {
       "community": 46,
@@ -89673,6 +89664,33 @@
     {
       "community": 460,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_home_promoalert_tsx",
+      "label": "PromoAlert.tsx",
+      "norm_label": "promoalert.tsx",
+      "source_file": "packages/storefront-webapp/src/components/home/PromoAlert.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 460,
+      "file_type": "code",
+      "id": "promoalert_getpromoalertcopy",
+      "label": "getPromoAlertCopy()",
+      "norm_label": "getpromoalertcopy()",
+      "source_file": "packages/storefront-webapp/src/components/home/PromoAlert.tsx",
+      "source_location": "L20"
+    },
+    {
+      "community": 460,
+      "file_type": "code",
+      "id": "promoalert_promoalert",
+      "label": "PromoAlert()",
+      "norm_label": "promoalert()",
+      "source_file": "packages/storefront-webapp/src/components/home/PromoAlert.tsx",
+      "source_location": "L59"
+    },
+    {
+      "community": 461,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_rewardsalert_tsx",
       "label": "RewardsAlert.tsx",
       "norm_label": "rewardsalert.tsx",
@@ -89680,7 +89698,7 @@
       "source_location": "L1"
     },
     {
-      "community": 460,
+      "community": 461,
       "file_type": "code",
       "id": "rewardsalert_handleshopnow",
       "label": "handleShopNow()",
@@ -89689,7 +89707,7 @@
       "source_location": "L25"
     },
     {
-      "community": 460,
+      "community": 461,
       "file_type": "code",
       "id": "rewardsalert_onrewardsalertclose",
       "label": "onRewardsAlertClose()",
@@ -89698,7 +89716,7 @@
       "source_location": "L20"
     },
     {
-      "community": 461,
+      "community": 462,
       "file_type": "code",
       "id": "navigationbar_navigationbar",
       "label": "NavigationBar()",
@@ -89707,7 +89725,7 @@
       "source_location": "L30"
     },
     {
-      "community": 461,
+      "community": 462,
       "file_type": "code",
       "id": "navigationbar_storecategoriessubmenu",
       "label": "StoreCategoriesSubmenu()",
@@ -89716,7 +89734,7 @@
       "source_location": "L95"
     },
     {
-      "community": 461,
+      "community": 462,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_navigationbar_tsx",
       "label": "NavigationBar.tsx",
@@ -89725,7 +89743,7 @@
       "source_location": "L1"
     },
     {
-      "community": 462,
+      "community": 463,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_revieweditor_tsx",
       "label": "ReviewEditor.tsx",
@@ -89734,7 +89752,7 @@
       "source_location": "L1"
     },
     {
-      "community": 462,
+      "community": 463,
       "file_type": "code",
       "id": "revieweditor_handleformdatachange",
       "label": "handleFormDataChange()",
@@ -89743,7 +89761,7 @@
       "source_location": "L150"
     },
     {
-      "community": 462,
+      "community": 463,
       "file_type": "code",
       "id": "revieweditor_handlesubmit",
       "label": "handleSubmit()",
@@ -89752,7 +89770,7 @@
       "source_location": "L157"
     },
     {
-      "community": 463,
+      "community": 464,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_welcomebackmodal_tsx",
       "label": "WelcomeBackModal.tsx",
@@ -89761,7 +89779,7 @@
       "source_location": "L1"
     },
     {
-      "community": 463,
+      "community": 464,
       "file_type": "code",
       "id": "welcomebackmodal_handleclose",
       "label": "handleClose()",
@@ -89770,7 +89788,7 @@
       "source_location": "L63"
     },
     {
-      "community": 463,
+      "community": 464,
       "file_type": "code",
       "id": "welcomebackmodal_handlesuccess",
       "label": "handleSuccess()",
@@ -89779,7 +89797,7 @@
       "source_location": "L76"
     },
     {
-      "community": 464,
+      "community": 465,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_welcomebackmodalform_tsx",
       "label": "WelcomeBackModalForm.tsx",
@@ -89788,7 +89806,7 @@
       "source_location": "L1"
     },
     {
-      "community": 464,
+      "community": 465,
       "file_type": "code",
       "id": "welcomebackmodalform_handleinputchange",
       "label": "handleInputChange()",
@@ -89797,7 +89815,7 @@
       "source_location": "L51"
     },
     {
-      "community": 464,
+      "community": 465,
       "file_type": "code",
       "id": "welcomebackmodalform_handlesubmit",
       "label": "handleSubmit()",
@@ -89806,7 +89824,7 @@
       "source_location": "L36"
     },
     {
-      "community": 465,
+      "community": 466,
       "file_type": "code",
       "id": "navigationbarprovider_navigationbarprovider",
       "label": "NavigationBarProvider()",
@@ -89815,7 +89833,7 @@
       "source_location": "L16"
     },
     {
-      "community": 465,
+      "community": 466,
       "file_type": "code",
       "id": "navigationbarprovider_usenavigationbarcontext",
       "label": "useNavigationBarContext()",
@@ -89824,7 +89842,7 @@
       "source_location": "L39"
     },
     {
-      "community": 465,
+      "community": 466,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_contexts_navigationbarprovider_tsx",
       "label": "NavigationBarProvider.tsx",
@@ -89833,7 +89851,7 @@
       "source_location": "L1"
     },
     {
-      "community": 466,
+      "community": 467,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_contexts_storefrontobservabilityprovider_tsx",
       "label": "StorefrontObservabilityProvider.tsx",
@@ -89842,7 +89860,7 @@
       "source_location": "L1"
     },
     {
-      "community": 466,
+      "community": 467,
       "file_type": "code",
       "id": "storefrontobservabilityprovider_storefrontobservabilityprovider",
       "label": "StorefrontObservabilityProvider()",
@@ -89851,7 +89869,7 @@
       "source_location": "L20"
     },
     {
-      "community": 466,
+      "community": 467,
       "file_type": "code",
       "id": "storefrontobservabilityprovider_usestorefrontobservability",
       "label": "useStorefrontObservability()",
@@ -89860,7 +89878,7 @@
       "source_location": "L55"
     },
     {
-      "community": 467,
+      "community": 468,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useproductdiscount_ts",
       "label": "useProductDiscount.ts",
@@ -89869,7 +89887,7 @@
       "source_location": "L1"
     },
     {
-      "community": 467,
+      "community": 468,
       "file_type": "code",
       "id": "useproductdiscount_useproductdiscount",
       "label": "useProductDiscount()",
@@ -89878,7 +89896,7 @@
       "source_location": "L107"
     },
     {
-      "community": 467,
+      "community": 468,
       "file_type": "code",
       "id": "useproductdiscount_useproductdiscounts",
       "label": "useProductDiscounts()",
@@ -89887,7 +89905,7 @@
       "source_location": "L25"
     },
     {
-      "community": 468,
+      "community": 469,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useshoppingbag_ts",
       "label": "useShoppingBag.ts",
@@ -89896,7 +89914,7 @@
       "source_location": "L1"
     },
     {
-      "community": 468,
+      "community": 469,
       "file_type": "code",
       "id": "useshoppingbag_isunavailableproductlist",
       "label": "isUnavailableProductList()",
@@ -89905,40 +89923,13 @@
       "source_location": "L556"
     },
     {
-      "community": 468,
+      "community": 469,
       "file_type": "code",
       "id": "useshoppingbag_useshoppingbag",
       "label": "useShoppingBag()",
       "norm_label": "useshoppingbag()",
       "source_file": "packages/storefront-webapp/src/hooks/useShoppingBag.ts",
       "source_location": "L52"
-    },
-    {
-      "community": 469,
-      "file_type": "code",
-      "id": "index_getordermessage",
-      "label": "getOrderMessage()",
-      "norm_label": "getordermessage()",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/index.tsx",
-      "source_location": "L431"
-    },
-    {
-      "community": 469,
-      "file_type": "code",
-      "id": "index_getpaymenttext",
-      "label": "getPaymentText()",
-      "norm_label": "getpaymenttext()",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/index.tsx",
-      "source_location": "L102"
-    },
-    {
-      "community": 469,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_orderid_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/index.tsx",
-      "source_location": "L1"
     },
     {
       "community": 47,
@@ -90087,6 +90078,33 @@
     {
       "community": 470,
       "file_type": "code",
+      "id": "index_getordermessage",
+      "label": "getOrderMessage()",
+      "norm_label": "getordermessage()",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/index.tsx",
+      "source_location": "L431"
+    },
+    {
+      "community": 470,
+      "file_type": "code",
+      "id": "index_getpaymenttext",
+      "label": "getPaymentText()",
+      "norm_label": "getpaymenttext()",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/index.tsx",
+      "source_location": "L102"
+    },
+    {
+      "community": 470,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_orderid_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 471,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_orderid_review_tsx",
       "label": "review.tsx",
       "norm_label": "review.tsx",
@@ -90094,7 +90112,7 @@
       "source_location": "L1"
     },
     {
-      "community": 470,
+      "community": 471,
       "file_type": "code",
       "id": "review_getordermessage",
       "label": "getOrderMessage()",
@@ -90103,7 +90121,7 @@
       "source_location": "L257"
     },
     {
-      "community": 470,
+      "community": 471,
       "file_type": "code",
       "id": "review_ordernavigation",
       "label": "OrderNavigation()",
@@ -90112,7 +90130,7 @@
       "source_location": "L47"
     },
     {
-      "community": 471,
+      "community": 472,
       "file_type": "code",
       "id": "account_accountbeforeload",
       "label": "accountBeforeLoad()",
@@ -90121,7 +90139,7 @@
       "source_location": "L17"
     },
     {
-      "community": 471,
+      "community": 472,
       "file_type": "code",
       "id": "account_handleonsubmitform",
       "label": "handleOnSubmitForm()",
@@ -90130,7 +90148,7 @@
       "source_location": "L63"
     },
     {
-      "community": 471,
+      "community": 472,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_account_tsx",
       "label": "account.tsx",
@@ -90139,7 +90157,7 @@
       "source_location": "L1"
     },
     {
-      "community": 472,
+      "community": 473,
       "file_type": "code",
       "id": "login_loginbeforeload",
       "label": "loginBeforeLoad()",
@@ -90148,7 +90166,7 @@
       "source_location": "L47"
     },
     {
-      "community": 472,
+      "community": 473,
       "file_type": "code",
       "id": "login_onsubmit",
       "label": "onSubmit()",
@@ -90157,7 +90175,7 @@
       "source_location": "L141"
     },
     {
-      "community": 472,
+      "community": 473,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_login_tsx",
       "label": "login.tsx",
@@ -90166,7 +90184,7 @@
       "source_location": "L1"
     },
     {
-      "community": 473,
+      "community": 474,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_verify_index_tsx",
       "label": "verify.index.tsx",
@@ -90175,7 +90193,7 @@
       "source_location": "L1"
     },
     {
-      "community": 473,
+      "community": 474,
       "file_type": "code",
       "id": "verify_index_verify",
       "label": "Verify()",
@@ -90184,7 +90202,7 @@
       "source_location": "L21"
     },
     {
-      "community": 473,
+      "community": 474,
       "file_type": "code",
       "id": "verify_index_verifycheckoutsessionpayment",
       "label": "VerifyCheckoutSessionPayment()",
@@ -90193,7 +90211,7 @@
       "source_location": "L107"
     },
     {
-      "community": 474,
+      "community": 475,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_signup_tsx",
       "label": "signup.tsx",
@@ -90202,7 +90220,7 @@
       "source_location": "L1"
     },
     {
-      "community": 474,
+      "community": 475,
       "file_type": "code",
       "id": "signup_onsubmit",
       "label": "onSubmit()",
@@ -90211,7 +90229,7 @@
       "source_location": "L161"
     },
     {
-      "community": 474,
+      "community": 475,
       "file_type": "code",
       "id": "signup_signupbeforeload",
       "label": "signupBeforeLoad()",
@@ -90220,7 +90238,7 @@
       "source_location": "L66"
     },
     {
-      "community": 475,
+      "community": 476,
       "file_type": "code",
       "id": "env_optionalnumberenv",
       "label": "optionalNumberEnv()",
@@ -90229,7 +90247,7 @@
       "source_location": "L11"
     },
     {
-      "community": 475,
+      "community": 476,
       "file_type": "code",
       "id": "env_requireenv",
       "label": "requireEnv()",
@@ -90238,7 +90256,7 @@
       "source_location": "L1"
     },
     {
-      "community": 475,
+      "community": 476,
       "file_type": "code",
       "id": "packages_storefront_webapp_tests_e2e_helpers_env_ts",
       "label": "env.ts",
@@ -90247,7 +90265,7 @@
       "source_location": "L1"
     },
     {
-      "community": 476,
+      "community": 477,
       "file_type": "code",
       "id": "graphify_wiki_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -90256,7 +90274,7 @@
       "source_location": "L16"
     },
     {
-      "community": 476,
+      "community": 477,
       "file_type": "code",
       "id": "graphify_wiki_test_write",
       "label": "write()",
@@ -90265,7 +90283,7 @@
       "source_location": "L10"
     },
     {
-      "community": 476,
+      "community": 477,
       "file_type": "code",
       "id": "scripts_graphify_wiki_test_ts",
       "label": "graphify-wiki.test.ts",
@@ -90274,7 +90292,7 @@
       "source_location": "L1"
     },
     {
-      "community": 477,
+      "community": 478,
       "file_type": "code",
       "id": "harness_audit_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -90283,7 +90301,7 @@
       "source_location": "L17"
     },
     {
-      "community": 477,
+      "community": 478,
       "file_type": "code",
       "id": "harness_audit_test_write",
       "label": "write()",
@@ -90292,7 +90310,7 @@
       "source_location": "L11"
     },
     {
-      "community": 477,
+      "community": 478,
       "file_type": "code",
       "id": "scripts_harness_audit_test_ts",
       "label": "harness-audit.test.ts",
@@ -90301,7 +90319,7 @@
       "source_location": "L1"
     },
     {
-      "community": 478,
+      "community": 479,
       "file_type": "code",
       "id": "harness_check_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -90310,7 +90328,7 @@
       "source_location": "L48"
     },
     {
-      "community": 478,
+      "community": 479,
       "file_type": "code",
       "id": "harness_check_test_write",
       "label": "write()",
@@ -90319,39 +90337,12 @@
       "source_location": "L42"
     },
     {
-      "community": 478,
+      "community": 479,
       "file_type": "code",
       "id": "scripts_harness_check_test_ts",
       "label": "harness-check.test.ts",
       "norm_label": "harness-check.test.ts",
       "source_file": "scripts/harness-check.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 479,
-      "file_type": "code",
-      "id": "harness_generate_test_createfixturerepo",
-      "label": "createFixtureRepo()",
-      "norm_label": "createfixturerepo()",
-      "source_file": "scripts/harness-generate.test.ts",
-      "source_location": "L16"
-    },
-    {
-      "community": 479,
-      "file_type": "code",
-      "id": "harness_generate_test_write",
-      "label": "write()",
-      "norm_label": "write()",
-      "source_file": "scripts/harness-generate.test.ts",
-      "source_location": "L10"
-    },
-    {
-      "community": 479,
-      "file_type": "code",
-      "id": "scripts_harness_generate_test_ts",
-      "label": "harness-generate.test.ts",
-      "norm_label": "harness-generate.test.ts",
-      "source_file": "scripts/harness-generate.test.ts",
       "source_location": "L1"
     },
     {
@@ -90501,6 +90492,33 @@
     {
       "community": 480,
       "file_type": "code",
+      "id": "harness_generate_test_createfixturerepo",
+      "label": "createFixtureRepo()",
+      "norm_label": "createfixturerepo()",
+      "source_file": "scripts/harness-generate.test.ts",
+      "source_location": "L16"
+    },
+    {
+      "community": 480,
+      "file_type": "code",
+      "id": "harness_generate_test_write",
+      "label": "write()",
+      "norm_label": "write()",
+      "source_file": "scripts/harness-generate.test.ts",
+      "source_location": "L10"
+    },
+    {
+      "community": 480,
+      "file_type": "code",
+      "id": "scripts_harness_generate_test_ts",
+      "label": "harness-generate.test.ts",
+      "norm_label": "harness-generate.test.ts",
+      "source_file": "scripts/harness-generate.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 481,
+      "file_type": "code",
       "id": "harness_inferential_review_test_createfixturerepo",
       "label": "createFixtureRepo()",
       "norm_label": "createfixturerepo()",
@@ -90508,7 +90526,7 @@
       "source_location": "L19"
     },
     {
-      "community": 480,
+      "community": 481,
       "file_type": "code",
       "id": "harness_inferential_review_test_write",
       "label": "write()",
@@ -90517,7 +90535,7 @@
       "source_location": "L13"
     },
     {
-      "community": 480,
+      "community": 481,
       "file_type": "code",
       "id": "scripts_harness_inferential_review_test_ts",
       "label": "harness-inferential-review.test.ts",
@@ -90526,7 +90544,7 @@
       "source_location": "L1"
     },
     {
-      "community": 481,
+      "community": 482,
       "file_type": "code",
       "id": "harness_self_review_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -90535,7 +90553,7 @@
       "source_location": "L16"
     },
     {
-      "community": 481,
+      "community": 482,
       "file_type": "code",
       "id": "harness_self_review_test_write",
       "label": "write()",
@@ -90544,7 +90562,7 @@
       "source_location": "L10"
     },
     {
-      "community": 481,
+      "community": 482,
       "file_type": "code",
       "id": "scripts_harness_self_review_test_ts",
       "label": "harness-self-review.test.ts",
@@ -90553,7 +90571,7 @@
       "source_location": "L1"
     },
     {
-      "community": 482,
+      "community": 483,
       "file_type": "code",
       "id": "harness_test_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -90562,7 +90580,7 @@
       "source_location": "L20"
     },
     {
-      "community": 482,
+      "community": 483,
       "file_type": "code",
       "id": "harness_test_test_write",
       "label": "write()",
@@ -90571,7 +90589,7 @@
       "source_location": "L14"
     },
     {
-      "community": 482,
+      "community": 483,
       "file_type": "code",
       "id": "scripts_harness_test_test_ts",
       "label": "harness-test.test.ts",
@@ -90580,7 +90598,7 @@
       "source_location": "L1"
     },
     {
-      "community": 483,
+      "community": 484,
       "file_type": "code",
       "id": "root_scripts_coverage_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -90589,7 +90607,7 @@
       "source_location": "L10"
     },
     {
-      "community": 483,
+      "community": 484,
       "file_type": "code",
       "id": "root_scripts_coverage_test_write",
       "label": "write()",
@@ -90598,7 +90616,7 @@
       "source_location": "L16"
     },
     {
-      "community": 483,
+      "community": 484,
       "file_type": "code",
       "id": "scripts_root_scripts_coverage_test_ts",
       "label": "root-scripts-coverage.test.ts",
@@ -90607,7 +90625,7 @@
       "source_location": "L1"
     },
     {
-      "community": 484,
+      "community": 485,
       "file_type": "code",
       "id": "root_scripts_coverage_collectrootscripttestfiles",
       "label": "collectRootScriptTestFiles()",
@@ -90616,7 +90634,7 @@
       "source_location": "L4"
     },
     {
-      "community": 484,
+      "community": 485,
       "file_type": "code",
       "id": "root_scripts_coverage_runrootscriptscoverage",
       "label": "runRootScriptsCoverage()",
@@ -90625,7 +90643,7 @@
       "source_location": "L13"
     },
     {
-      "community": 484,
+      "community": 485,
       "file_type": "code",
       "id": "scripts_root_scripts_coverage_ts",
       "label": "root-scripts-coverage.ts",
@@ -90634,7 +90652,7 @@
       "source_location": "L1"
     },
     {
-      "community": 485,
+      "community": 486,
       "file_type": "code",
       "id": "deposits_test_getsource",
       "label": "getSource()",
@@ -90643,7 +90661,7 @@
       "source_location": "L9"
     },
     {
-      "community": 485,
+      "community": 486,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cashcontrols_deposits_test_ts",
       "label": "deposits.test.ts",
@@ -90652,7 +90670,7 @@
       "source_location": "L1"
     },
     {
-      "community": 486,
+      "community": 487,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cashcontrols_paymentallocationattribution_test_ts",
       "label": "paymentAllocationAttribution.test.ts",
@@ -90661,7 +90679,7 @@
       "source_location": "L1"
     },
     {
-      "community": 486,
+      "community": 487,
       "file_type": "code",
       "id": "paymentallocationattribution_test_readprojectfile",
       "label": "readProjectFile()",
@@ -90670,7 +90688,7 @@
       "source_location": "L12"
     },
     {
-      "community": 487,
+      "community": 488,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cloudflare_stream_ts",
       "label": "stream.ts",
@@ -90679,7 +90697,7 @@
       "source_location": "L1"
     },
     {
-      "community": 487,
+      "community": 488,
       "file_type": "code",
       "id": "stream_getcloudflareconfig",
       "label": "getCloudflareConfig()",
@@ -90688,7 +90706,7 @@
       "source_location": "L8"
     },
     {
-      "community": 488,
+      "community": 489,
       "file_type": "code",
       "id": "convexauditscript_test_createcommandshimbin",
       "label": "createCommandShimBin()",
@@ -90697,31 +90715,13 @@
       "source_location": "L10"
     },
     {
-      "community": 488,
+      "community": 489,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_convexauditscript_test_ts",
       "label": "convexAuditScript.test.ts",
       "norm_label": "convexauditscript.test.ts",
       "source_file": "packages/athena-webapp/convex/convexAuditScript.test.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 489,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_customermessaging_policy_ts",
-      "label": "policy.ts",
-      "norm_label": "policy.ts",
-      "source_file": "packages/athena-webapp/convex/customerMessaging/policy.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 489,
-      "file_type": "code",
-      "id": "policy_assertsupportedcustomermessagepolicy",
-      "label": "assertSupportedCustomerMessagePolicy()",
-      "norm_label": "assertsupportedcustomermessagepolicy()",
-      "source_file": "packages/athena-webapp/convex/customerMessaging/policy.ts",
-      "source_location": "L8"
     },
     {
       "community": 49,
@@ -90861,6 +90861,24 @@
     {
       "community": 490,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_customermessaging_policy_ts",
+      "label": "policy.ts",
+      "norm_label": "policy.ts",
+      "source_file": "packages/athena-webapp/convex/customerMessaging/policy.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 490,
+      "file_type": "code",
+      "id": "policy_assertsupportedcustomermessagepolicy",
+      "label": "assertSupportedCustomerMessagePolicy()",
+      "norm_label": "assertsupportedcustomermessagepolicy()",
+      "source_file": "packages/athena-webapp/convex/customerMessaging/policy.ts",
+      "source_location": "L8"
+    },
+    {
+      "community": 491,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_customermessaging_repository_test_ts",
       "label": "repository.test.ts",
       "norm_label": "repository.test.ts",
@@ -90868,7 +90886,7 @@
       "source_location": "L1"
     },
     {
-      "community": 490,
+      "community": 491,
       "file_type": "code",
       "id": "repository_test_queryresult",
       "label": "queryResult()",
@@ -90877,7 +90895,7 @@
       "source_location": "L12"
     },
     {
-      "community": 491,
+      "community": 492,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_customermessaging_webhooksecurity_test_ts",
       "label": "webhookSecurity.test.ts",
@@ -90886,7 +90904,7 @@
       "source_location": "L1"
     },
     {
-      "community": 491,
+      "community": 492,
       "file_type": "code",
       "id": "webhooksecurity_test_sign",
       "label": "sign()",
@@ -90895,7 +90913,7 @@
       "source_location": "L5"
     },
     {
-      "community": 492,
+      "community": 493,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_verificationcode_tsx",
       "label": "VerificationCode.tsx",
@@ -90904,7 +90922,7 @@
       "source_location": "L1"
     },
     {
-      "community": 492,
+      "community": 493,
       "file_type": "code",
       "id": "verificationcode_verificationcode",
       "label": "VerificationCode()",
@@ -90913,7 +90931,7 @@
       "source_location": "L18"
     },
     {
-      "community": 493,
+      "community": 494,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_core_routes_subcategories_ts",
       "label": "subcategories.ts",
@@ -90922,7 +90940,7 @@
       "source_location": "L1"
     },
     {
-      "community": 493,
+      "community": 494,
       "file_type": "code",
       "id": "subcategories_removestorefronthiddensubcategorylist",
       "label": "removeStorefrontHiddenSubcategoryList()",
@@ -90931,7 +90949,7 @@
       "source_location": "L10"
     },
     {
-      "community": 494,
+      "community": 495,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_storefrontcors_test_ts",
       "label": "storefrontCors.test.ts",
@@ -90940,7 +90958,7 @@
       "source_location": "L1"
     },
     {
-      "community": 494,
+      "community": 495,
       "file_type": "code",
       "id": "storefrontcors_test_readroutefile",
       "label": "readRouteFile()",
@@ -90949,7 +90967,7 @@
       "source_location": "L6"
     },
     {
-      "community": 495,
+      "community": 496,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customermessaging_routes_whatsapp_ts",
       "label": "whatsapp.ts",
@@ -90958,7 +90976,7 @@
       "source_location": "L1"
     },
     {
-      "community": 495,
+      "community": 496,
       "file_type": "code",
       "id": "whatsapp_mapwebhookstatus",
       "label": "mapWebhookStatus()",
@@ -90967,7 +90985,7 @@
       "source_location": "L15"
     },
     {
-      "community": 496,
+      "community": 497,
       "file_type": "code",
       "id": "mtnmomo_handlecollectionnotification",
       "label": "handleCollectionNotification()",
@@ -90976,7 +90994,7 @@
       "source_location": "L10"
     },
     {
-      "community": 496,
+      "community": 497,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_moneymovement_routes_mtnmomo_ts",
       "label": "mtnMomo.ts",
@@ -90985,7 +91003,7 @@
       "source_location": "L1"
     },
     {
-      "community": 497,
+      "community": 498,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_routercomposition_test_ts",
       "label": "routerComposition.test.ts",
@@ -90994,7 +91012,7 @@
       "source_location": "L1"
     },
     {
-      "community": 497,
+      "community": 498,
       "file_type": "code",
       "id": "routercomposition_test_readprojectfile",
       "label": "readProjectFile()",
@@ -91003,7 +91021,7 @@
       "source_location": "L6"
     },
     {
-      "community": 498,
+      "community": 499,
       "file_type": "code",
       "id": "auth_mapathenaauthsyncerror",
       "label": "mapAthenaAuthSyncError()",
@@ -91012,30 +91030,12 @@
       "source_location": "L110"
     },
     {
-      "community": 498,
+      "community": 499,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_auth_ts",
       "label": "auth.ts",
       "norm_label": "auth.ts",
       "source_file": "packages/athena-webapp/convex/inventory/auth.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 499,
-      "file_type": "code",
-      "id": "bestseller_test_gethandler",
-      "label": "getHandler()",
-      "norm_label": "gethandler()",
-      "source_file": "packages/athena-webapp/convex/inventory/bestSeller.test.ts",
-      "source_location": "L6"
-    },
-    {
-      "community": 499,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_bestseller_test_ts",
-      "label": "bestSeller.test.ts",
-      "norm_label": "bestseller.test.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/bestSeller.test.ts",
       "source_location": "L1"
     },
     {
@@ -91500,6 +91500,24 @@
     {
       "community": 500,
       "file_type": "code",
+      "id": "bestseller_test_gethandler",
+      "label": "getHandler()",
+      "norm_label": "gethandler()",
+      "source_file": "packages/athena-webapp/convex/inventory/bestSeller.test.ts",
+      "source_location": "L6"
+    },
+    {
+      "community": 500,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_bestseller_test_ts",
+      "label": "bestSeller.test.ts",
+      "norm_label": "bestseller.test.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/bestSeller.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 501,
+      "file_type": "code",
       "id": "expensesessionitems_usererrorfromexpenseitemcommandfailure",
       "label": "userErrorFromExpenseItemCommandFailure()",
       "norm_label": "usererrorfromexpenseitemcommandfailure()",
@@ -91507,7 +91525,7 @@
       "source_location": "L14"
     },
     {
-      "community": 500,
+      "community": 501,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_expensesessionitems_ts",
       "label": "expenseSessionItems.ts",
@@ -91516,7 +91534,7 @@
       "source_location": "L1"
     },
     {
-      "community": 501,
+      "community": 502,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_posquerycleanup_test_ts",
       "label": "posQueryCleanup.test.ts",
@@ -91525,7 +91543,7 @@
       "source_location": "L1"
     },
     {
-      "community": 501,
+      "community": 502,
       "file_type": "code",
       "id": "posquerycleanup_test_readprojectfile",
       "label": "readProjectFile()",
@@ -91534,7 +91552,7 @@
       "source_location": "L8"
     },
     {
-      "community": 502,
+      "community": 503,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_possessionitems_ts",
       "label": "posSessionItems.ts",
@@ -91543,7 +91561,7 @@
       "source_location": "L1"
     },
     {
-      "community": 502,
+      "community": 503,
       "file_type": "code",
       "id": "possessionitems_usererrorfromsessionitemfailure",
       "label": "userErrorFromSessionItemFailure()",
@@ -91552,7 +91570,7 @@
       "source_location": "L22"
     },
     {
-      "community": 503,
+      "community": 504,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_productutil_ts",
       "label": "productUtil.ts",
@@ -91561,7 +91579,7 @@
       "source_location": "L1"
     },
     {
-      "community": 503,
+      "community": 504,
       "file_type": "code",
       "id": "productutil_buildallproductscachekey",
       "label": "buildAllProductsCacheKey()",
@@ -91570,7 +91588,7 @@
       "source_location": "L8"
     },
     {
-      "community": 504,
+      "community": 505,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_promocode_ts",
       "label": "promoCode.ts",
@@ -91579,7 +91597,7 @@
       "source_location": "L1"
     },
     {
-      "community": 504,
+      "community": 505,
       "file_type": "code",
       "id": "promocode_calculateselectedproductpromodiscount",
       "label": "calculateSelectedProductPromoDiscount()",
@@ -91588,7 +91606,7 @@
       "source_location": "L14"
     },
     {
-      "community": 505,
+      "community": 506,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_stores_ts",
       "label": "stores.ts",
@@ -91597,7 +91615,7 @@
       "source_location": "L1"
     },
     {
-      "community": 505,
+      "community": 506,
       "file_type": "code",
       "id": "stores_tov2onlyconfig",
       "label": "toV2OnlyConfig()",
@@ -91606,7 +91624,7 @@
       "source_location": "L29"
     },
     {
-      "community": 506,
+      "community": 507,
       "file_type": "code",
       "id": "commandresultvalidators_commandresultvalidator",
       "label": "commandResultValidator()",
@@ -91615,7 +91633,7 @@
       "source_location": "L73"
     },
     {
-      "community": 506,
+      "community": 507,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_lib_commandresultvalidators_ts",
       "label": "commandResultValidators.ts",
@@ -91624,7 +91642,7 @@
       "source_location": "L1"
     },
     {
-      "community": 507,
+      "community": 508,
       "file_type": "code",
       "id": "callllmprovider_callllmprovider",
       "label": "callLlmProvider()",
@@ -91633,7 +91651,7 @@
       "source_location": "L4"
     },
     {
-      "community": 507,
+      "community": 508,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_callllmprovider_ts",
       "label": "callLlmProvider.ts",
@@ -91642,7 +91660,7 @@
       "source_location": "L1"
     },
     {
-      "community": 508,
+      "community": 509,
       "file_type": "code",
       "id": "anthropic_callanthropic",
       "label": "callAnthropic()",
@@ -91651,30 +91669,12 @@
       "source_location": "L3"
     },
     {
-      "community": 508,
+      "community": 509,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_providers_anthropic_ts",
       "label": "anthropic.ts",
       "norm_label": "anthropic.ts",
       "source_file": "packages/athena-webapp/convex/llm/providers/anthropic.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 509,
-      "file_type": "code",
-      "id": "openai_callopenai",
-      "label": "callOpenAi()",
-      "norm_label": "callopenai()",
-      "source_file": "packages/athena-webapp/convex/llm/providers/openai.ts",
-      "source_location": "L3"
-    },
-    {
-      "community": 509,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_llm_providers_openai_ts",
-      "label": "openai.ts",
-      "norm_label": "openai.ts",
-      "source_file": "packages/athena-webapp/convex/llm/providers/openai.ts",
       "source_location": "L1"
     },
     {
@@ -91815,6 +91815,24 @@
     {
       "community": 510,
       "file_type": "code",
+      "id": "openai_callopenai",
+      "label": "callOpenAi()",
+      "norm_label": "callopenai()",
+      "source_file": "packages/athena-webapp/convex/llm/providers/openai.ts",
+      "source_location": "L3"
+    },
+    {
+      "community": 510,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_llm_providers_openai_ts",
+      "label": "openai.ts",
+      "norm_label": "openai.ts",
+      "source_file": "packages/athena-webapp/convex/llm/providers/openai.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 511,
+      "file_type": "code",
       "id": "foundation_test_readprojectfile",
       "label": "readProjectFile()",
       "norm_label": "readprojectfile()",
@@ -91822,7 +91840,7 @@
       "source_location": "L6"
     },
     {
-      "community": 510,
+      "community": 511,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_foundation_test_ts",
       "label": "foundation.test.ts",
@@ -91831,7 +91849,7 @@
       "source_location": "L1"
     },
     {
-      "community": 511,
+      "community": 512,
       "file_type": "code",
       "id": "approvalactions_consumecommandapprovalproofwithctx",
       "label": "consumeCommandApprovalProofWithCtx()",
@@ -91840,7 +91858,7 @@
       "source_location": "L46"
     },
     {
-      "community": 511,
+      "community": 512,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_approvalactions_ts",
       "label": "approvalActions.ts",
@@ -91849,7 +91867,7 @@
       "source_location": "L1"
     },
     {
-      "community": 512,
+      "community": 513,
       "file_type": "code",
       "id": "approvalauditevents_test_createoperationaleventctx",
       "label": "createOperationalEventCtx()",
@@ -91858,7 +91876,7 @@
       "source_location": "L11"
     },
     {
-      "community": 512,
+      "community": 513,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_approvalauditevents_test_ts",
       "label": "approvalAuditEvents.test.ts",
@@ -91867,7 +91885,7 @@
       "source_location": "L1"
     },
     {
-      "community": 513,
+      "community": 514,
       "file_type": "code",
       "id": "approvalproofs_test_createapprovalproofmutationctx",
       "label": "createApprovalProofMutationCtx()",
@@ -91876,7 +91894,7 @@
       "source_location": "L11"
     },
     {
-      "community": 513,
+      "community": 514,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_approvalproofs_test_ts",
       "label": "approvalProofs.test.ts",
@@ -91885,7 +91903,7 @@
       "source_location": "L1"
     },
     {
-      "community": 514,
+      "community": 515,
       "file_type": "code",
       "id": "approvalrequesthelpers_buildapprovalrequest",
       "label": "buildApprovalRequest()",
@@ -91894,7 +91912,7 @@
       "source_location": "L3"
     },
     {
-      "community": 514,
+      "community": 515,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_approvalrequesthelpers_ts",
       "label": "approvalRequestHelpers.ts",
@@ -91903,7 +91921,7 @@
       "source_location": "L1"
     },
     {
-      "community": 515,
+      "community": 516,
       "file_type": "code",
       "id": "approvalrequests_test_createapprovalrequestmutationctx",
       "label": "createApprovalRequestMutationCtx()",
@@ -91912,7 +91930,7 @@
       "source_location": "L19"
     },
     {
-      "community": 515,
+      "community": 516,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_approvalrequests_test_ts",
       "label": "approvalRequests.test.ts",
@@ -91921,7 +91939,7 @@
       "source_location": "L1"
     },
     {
-      "community": 516,
+      "community": 517,
       "file_type": "code",
       "id": "eventbuilders_buildoperationaleventmessage",
       "label": "buildOperationalEventMessage()",
@@ -91930,7 +91948,7 @@
       "source_location": "L1"
     },
     {
-      "community": 516,
+      "community": 517,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_helpers_eventbuilders_ts",
       "label": "eventBuilders.ts",
@@ -91939,7 +91957,7 @@
       "source_location": "L1"
     },
     {
-      "community": 517,
+      "community": 518,
       "file_type": "code",
       "id": "emailotp_formatvalidtime",
       "label": "formatValidTime()",
@@ -91948,7 +91966,7 @@
       "source_location": "L9"
     },
     {
-      "community": 517,
+      "community": 518,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_otp_emailotp_ts",
       "label": "EmailOTP.ts",
@@ -91957,7 +91975,7 @@
       "source_location": "L1"
     },
     {
-      "community": 518,
+      "community": 519,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_commands_quickaddcatalogitem_test_ts",
       "label": "quickAddCatalogItem.test.ts",
@@ -91966,31 +91984,13 @@
       "source_location": "L1"
     },
     {
-      "community": 518,
+      "community": 519,
       "file_type": "code",
       "id": "quickaddcatalogitem_test_createquickaddctx",
       "label": "createQuickAddCtx()",
       "norm_label": "createquickaddctx()",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.test.ts",
       "source_location": "L17"
-    },
-    {
-      "community": 519,
-      "file_type": "code",
-      "id": "completetransaction_test_expectnocompletionsideeffects",
-      "label": "expectNoCompletionSideEffects()",
-      "norm_label": "expectnocompletionsideeffects()",
-      "source_file": "packages/athena-webapp/convex/pos/application/completeTransaction.test.ts",
-      "source_location": "L82"
-    },
-    {
-      "community": 519,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_completetransaction_test_ts",
-      "label": "completeTransaction.test.ts",
-      "norm_label": "completetransaction.test.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/completeTransaction.test.ts",
-      "source_location": "L1"
     },
     {
       "community": 52,
@@ -92130,6 +92130,24 @@
     {
       "community": 520,
       "file_type": "code",
+      "id": "completetransaction_test_expectnocompletionsideeffects",
+      "label": "expectNoCompletionSideEffects()",
+      "norm_label": "expectnocompletionsideeffects()",
+      "source_file": "packages/athena-webapp/convex/pos/application/completeTransaction.test.ts",
+      "source_location": "L82"
+    },
+    {
+      "community": 520,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_completetransaction_test_ts",
+      "label": "completeTransaction.test.ts",
+      "norm_label": "completetransaction.test.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/completeTransaction.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 521,
+      "file_type": "code",
       "id": "correcttransactionpaymentmethod_test_createmutationctx",
       "label": "createMutationCtx()",
       "norm_label": "createmutationctx()",
@@ -92137,7 +92155,7 @@
       "source_location": "L44"
     },
     {
-      "community": 520,
+      "community": 521,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_correcttransactionpaymentmethod_test_ts",
       "label": "correctTransactionPaymentMethod.test.ts",
@@ -92146,7 +92164,7 @@
       "source_location": "L1"
     },
     {
-      "community": 521,
+      "community": 522,
       "file_type": "code",
       "id": "correctionevents_buildcorrectionoperationalevent",
       "label": "buildCorrectionOperationalEvent()",
@@ -92155,7 +92173,7 @@
       "source_location": "L35"
     },
     {
-      "community": 521,
+      "community": 522,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_corrections_correctionevents_ts",
       "label": "correctionEvents.ts",
@@ -92164,7 +92182,7 @@
       "source_location": "L1"
     },
     {
-      "community": 522,
+      "community": 523,
       "file_type": "code",
       "id": "gettransactions_test_mockcorrectionhistorydb",
       "label": "mockCorrectionHistoryDb()",
@@ -92173,7 +92191,7 @@
       "source_location": "L33"
     },
     {
-      "community": 522,
+      "community": 523,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_gettransactions_test_ts",
       "label": "getTransactions.test.ts",
@@ -92182,7 +92200,7 @@
       "source_location": "L1"
     },
     {
-      "community": 523,
+      "community": 524,
       "file_type": "code",
       "id": "listregistercatalog_test_createregistercatalogctx",
       "label": "createRegisterCatalogCtx()",
@@ -92191,7 +92209,7 @@
       "source_location": "L22"
     },
     {
-      "community": 523,
+      "community": 524,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_queries_listregistercatalog_test_ts",
       "label": "listRegisterCatalog.test.ts",
@@ -92200,7 +92218,7 @@
       "source_location": "L1"
     },
     {
-      "community": 524,
+      "community": 525,
       "file_type": "code",
       "id": "cashierrepository_getcashierforregisterstate",
       "label": "getCashierForRegisterState()",
@@ -92209,7 +92227,7 @@
       "source_location": "L7"
     },
     {
-      "community": 524,
+      "community": 525,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_cashierrepository_ts",
       "label": "cashierRepository.ts",
@@ -92218,7 +92236,7 @@
       "source_location": "L1"
     },
     {
-      "community": 525,
+      "community": 526,
       "file_type": "code",
       "id": "expensesessioncommandrepository_createexpensesessioncommandrepository",
       "label": "createExpenseSessionCommandRepository()",
@@ -92227,7 +92245,7 @@
       "source_location": "L60"
     },
     {
-      "community": 525,
+      "community": 526,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_expensesessioncommandrepository_ts",
       "label": "expenseSessionCommandRepository.ts",
@@ -92236,7 +92254,7 @@
       "source_location": "L1"
     },
     {
-      "community": 526,
+      "community": 527,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_sessioncommandrepository_test_ts",
       "label": "sessionCommandRepository.test.ts",
@@ -92245,7 +92263,7 @@
       "source_location": "L1"
     },
     {
-      "community": 526,
+      "community": 527,
       "file_type": "code",
       "id": "sessioncommandrepository_test_readprojectfile",
       "label": "readProjectFile()",
@@ -92254,7 +92272,7 @@
       "source_location": "L9"
     },
     {
-      "community": 527,
+      "community": 528,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_sessionrepository_test_ts",
       "label": "sessionRepository.test.ts",
@@ -92263,7 +92281,7 @@
       "source_location": "L1"
     },
     {
-      "community": 527,
+      "community": 528,
       "file_type": "code",
       "id": "sessionrepository_test_buildsession",
       "label": "buildSession()",
@@ -92272,7 +92290,7 @@
       "source_location": "L88"
     },
     {
-      "community": 528,
+      "community": 529,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_transactions_ts",
       "label": "transactions.ts",
@@ -92281,31 +92299,13 @@
       "source_location": "L1"
     },
     {
-      "community": 528,
+      "community": 529,
       "file_type": "code",
       "id": "transactions_mapcorrectionerror",
       "label": "mapCorrectionError()",
       "norm_label": "mapcorrectionerror()",
       "source_file": "packages/athena-webapp/convex/pos/public/transactions.ts",
       "source_location": "L60"
-    },
-    {
-      "community": 529,
-      "file_type": "code",
-      "id": "modulewiring_test_getsource",
-      "label": "getSource()",
-      "norm_label": "getsource()",
-      "source_file": "packages/athena-webapp/convex/serviceOps/moduleWiring.test.ts",
-      "source_location": "L4"
-    },
-    {
-      "community": 529,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_serviceops_modulewiring_test_ts",
-      "label": "moduleWiring.test.ts",
-      "norm_label": "modulewiring.test.ts",
-      "source_file": "packages/athena-webapp/convex/serviceOps/moduleWiring.test.ts",
-      "source_location": "L1"
     },
     {
       "community": 53,
@@ -92445,6 +92445,24 @@
     {
       "community": 530,
       "file_type": "code",
+      "id": "modulewiring_test_getsource",
+      "label": "getSource()",
+      "norm_label": "getsource()",
+      "source_file": "packages/athena-webapp/convex/serviceOps/moduleWiring.test.ts",
+      "source_location": "L4"
+    },
+    {
+      "community": 530,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_serviceops_modulewiring_test_ts",
+      "label": "moduleWiring.test.ts",
+      "norm_label": "modulewiring.test.ts",
+      "source_file": "packages/athena-webapp/convex/serviceOps/moduleWiring.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 531,
+      "file_type": "code",
       "id": "access_test_createstockopsaccessqueryctx",
       "label": "createStockOpsAccessQueryCtx()",
       "norm_label": "createstockopsaccessqueryctx()",
@@ -92452,7 +92470,7 @@
       "source_location": "L15"
     },
     {
-      "community": 530,
+      "community": 531,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_access_test_ts",
       "label": "access.test.ts",
@@ -92461,7 +92479,7 @@
       "source_location": "L1"
     },
     {
-      "community": 531,
+      "community": 532,
       "file_type": "code",
       "id": "access_requirestorefulladminaccess",
       "label": "requireStoreFullAdminAccess()",
@@ -92470,7 +92488,7 @@
       "source_location": "L7"
     },
     {
-      "community": 531,
+      "community": 532,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_access_ts",
       "label": "access.ts",
@@ -92479,7 +92497,7 @@
       "source_location": "L1"
     },
     {
-      "community": 532,
+      "community": 533,
       "file_type": "code",
       "id": "cyclecountdrafts_test_createcyclecountdraftctx",
       "label": "createCycleCountDraftCtx()",
@@ -92488,7 +92506,7 @@
       "source_location": "L22"
     },
     {
-      "community": 532,
+      "community": 533,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_cyclecountdrafts_test_ts",
       "label": "cycleCountDrafts.test.ts",
@@ -92497,7 +92515,7 @@
       "source_location": "L1"
     },
     {
-      "community": 533,
+      "community": 534,
       "file_type": "code",
       "id": "auth_getstorefrontactorbyid",
       "label": "getStoreFrontActorById()",
@@ -92506,7 +92524,7 @@
       "source_location": "L15"
     },
     {
-      "community": 533,
+      "community": 534,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_auth_ts",
       "label": "auth.ts",
@@ -92515,7 +92533,7 @@
       "source_location": "L1"
     },
     {
-      "community": 534,
+      "community": 535,
       "file_type": "code",
       "id": "customerbehaviortimeline_test_createqueryctx",
       "label": "createQueryCtx()",
@@ -92524,7 +92542,7 @@
       "source_location": "L8"
     },
     {
-      "community": 534,
+      "community": 535,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_customerbehaviortimeline_test_ts",
       "label": "customerBehaviorTimeline.test.ts",
@@ -92533,7 +92551,7 @@
       "source_location": "L1"
     },
     {
-      "community": 535,
+      "community": 536,
       "file_type": "code",
       "id": "customerobservabilitytimeline_test_createanalyticsevent",
       "label": "createAnalyticsEvent()",
@@ -92542,7 +92560,7 @@
       "source_location": "L17"
     },
     {
-      "community": 535,
+      "community": 536,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_customerobservabilitytimeline_test_ts",
       "label": "customerObservabilityTimeline.test.ts",
@@ -92551,7 +92569,7 @@
       "source_location": "L1"
     },
     {
-      "community": 536,
+      "community": 537,
       "file_type": "code",
       "id": "helperorchestration_test_readprojectfile",
       "label": "readProjectFile()",
@@ -92560,7 +92578,7 @@
       "source_location": "L6"
     },
     {
-      "community": 536,
+      "community": 537,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_helperorchestration_test_ts",
       "label": "helperOrchestration.test.ts",
@@ -92569,7 +92587,7 @@
       "source_location": "L1"
     },
     {
-      "community": 537,
+      "community": 538,
       "file_type": "code",
       "id": "customerengagementevents_test_createmutationctx",
       "label": "createMutationCtx()",
@@ -92578,7 +92596,7 @@
       "source_location": "L5"
     },
     {
-      "community": 537,
+      "community": 538,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_helpers_customerengagementevents_test_ts",
       "label": "customerEngagementEvents.test.ts",
@@ -92587,7 +92605,7 @@
       "source_location": "L1"
     },
     {
-      "community": 538,
+      "community": 539,
       "file_type": "code",
       "id": "onlineorder_test_getsource",
       "label": "getSource()",
@@ -92596,30 +92614,12 @@
       "source_location": "L4"
     },
     {
-      "community": 538,
+      "community": 539,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_onlineorder_test_ts",
       "label": "onlineOrder.test.ts",
       "norm_label": "onlineorder.test.ts",
       "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 539,
-      "file_type": "code",
-      "id": "onlineorderitem_updateonlineorderitem",
-      "label": "updateOnlineOrderItem()",
-      "norm_label": "updateonlineorderitem()",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrderItem.ts",
-      "source_location": "L25"
-    },
-    {
-      "community": 539,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_onlineorderitem_ts",
-      "label": "onlineOrderItem.ts",
-      "norm_label": "onlineorderitem.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrderItem.ts",
       "source_location": "L1"
     },
     {
@@ -92751,6 +92751,24 @@
     {
       "community": 540,
       "file_type": "code",
+      "id": "onlineorderitem_updateonlineorderitem",
+      "label": "updateOnlineOrderItem()",
+      "norm_label": "updateonlineorderitem()",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrderItem.ts",
+      "source_location": "L25"
+    },
+    {
+      "community": 540,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_onlineorderitem_ts",
+      "label": "onlineOrderItem.ts",
+      "norm_label": "onlineorderitem.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrderItem.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 541,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_reviews_ts",
       "label": "reviews.ts",
       "norm_label": "reviews.ts",
@@ -92758,7 +92776,7 @@
       "source_location": "L1"
     },
     {
-      "community": 540,
+      "community": 541,
       "file_type": "code",
       "id": "reviews_getstorefrontactorbyid",
       "label": "getStoreFrontActorById()",
@@ -92767,7 +92785,7 @@
       "source_location": "L19"
     },
     {
-      "community": 541,
+      "community": 542,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_rewards_ts",
       "label": "rewards.ts",
@@ -92776,7 +92794,7 @@
       "source_location": "L1"
     },
     {
-      "community": 541,
+      "community": 542,
       "file_type": "code",
       "id": "rewards_formatpointslabel",
       "label": "formatPointsLabel()",
@@ -92785,7 +92803,7 @@
       "source_location": "L7"
     },
     {
-      "community": 542,
+      "community": 543,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_savedbag_ts",
       "label": "savedBag.ts",
@@ -92794,7 +92812,7 @@
       "source_location": "L1"
     },
     {
-      "community": 542,
+      "community": 543,
       "file_type": "code",
       "id": "savedbag_listsavedbagitems",
       "label": "listSavedBagItems()",
@@ -92803,7 +92821,7 @@
       "source_location": "L14"
     },
     {
-      "community": 543,
+      "community": 544,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_storefrontobservabilityreport_test_ts",
       "label": "storefrontObservabilityReport.test.ts",
@@ -92812,7 +92830,7 @@
       "source_location": "L1"
     },
     {
-      "community": 543,
+      "community": 544,
       "file_type": "code",
       "id": "storefrontobservabilityreport_test_createanalyticsevent",
       "label": "createAnalyticsEvent()",
@@ -92821,7 +92839,7 @@
       "source_location": "L8"
     },
     {
-      "community": 544,
+      "community": 545,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_syntheticmonitor_ts",
       "label": "syntheticMonitor.ts",
@@ -92830,7 +92848,7 @@
       "source_location": "L1"
     },
     {
-      "community": 544,
+      "community": 545,
       "file_type": "code",
       "id": "syntheticmonitor_issyntheticmonitororigin",
       "label": "isSyntheticMonitorOrigin()",
@@ -92839,7 +92857,7 @@
       "source_location": "L3"
     },
     {
-      "community": 545,
+      "community": 546,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_timequeryrefactors_test_ts",
       "label": "timeQueryRefactors.test.ts",
@@ -92848,7 +92866,7 @@
       "source_location": "L1"
     },
     {
-      "community": 545,
+      "community": 546,
       "file_type": "code",
       "id": "timequeryrefactors_test_readsource",
       "label": "readSource()",
@@ -92857,7 +92875,7 @@
       "source_location": "L5"
     },
     {
-      "community": 546,
+      "community": 547,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_user_ts",
       "label": "user.ts",
@@ -92866,7 +92884,7 @@
       "source_location": "L1"
     },
     {
-      "community": 546,
+      "community": 547,
       "file_type": "code",
       "id": "user_getstorefrontactorbyid",
       "label": "getStoreFrontActorById()",
@@ -92875,7 +92893,7 @@
       "source_location": "L16"
     },
     {
-      "community": 547,
+      "community": 548,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_useroffers_ts",
       "label": "userOffers.ts",
@@ -92884,7 +92902,7 @@
       "source_location": "L1"
     },
     {
-      "community": 547,
+      "community": 548,
       "file_type": "code",
       "id": "useroffers_determineoffereligibility",
       "label": "determineOfferEligibility()",
@@ -92893,7 +92911,7 @@
       "source_location": "L30"
     },
     {
-      "community": 548,
+      "community": 549,
       "file_type": "code",
       "id": "expensesession_buildexpensesessiontraceseed",
       "label": "buildExpenseSessionTraceSeed()",
@@ -92902,31 +92920,13 @@
       "source_location": "L42"
     },
     {
-      "community": 548,
+      "community": 549,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_adapters_expensesession_ts",
       "label": "expenseSession.ts",
       "norm_label": "expensesession.ts",
       "source_file": "packages/athena-webapp/convex/workflowTraces/adapters/expenseSession.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 549,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_workflowtraces_adapters_possession_ts",
-      "label": "posSession.ts",
-      "norm_label": "possession.ts",
-      "source_file": "packages/athena-webapp/convex/workflowTraces/adapters/posSession.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 549,
-      "file_type": "code",
-      "id": "possession_buildpossessiontraceseed",
-      "label": "buildPosSessionTraceSeed()",
-      "norm_label": "buildpossessiontraceseed()",
-      "source_file": "packages/athena-webapp/convex/workflowTraces/adapters/posSession.ts",
-      "source_location": "L42"
     },
     {
       "community": 55,
@@ -93057,6 +93057,24 @@
     {
       "community": 550,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_workflowtraces_adapters_possession_ts",
+      "label": "posSession.ts",
+      "norm_label": "possession.ts",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/adapters/posSession.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 550,
+      "file_type": "code",
+      "id": "possession_buildpossessiontraceseed",
+      "label": "buildPosSessionTraceSeed()",
+      "norm_label": "buildpossessiontraceseed()",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/adapters/posSession.ts",
+      "source_location": "L42"
+    },
+    {
+      "community": 551,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_presentation_ts",
       "label": "presentation.ts",
       "norm_label": "presentation.ts",
@@ -93064,7 +93082,7 @@
       "source_location": "L1"
     },
     {
-      "community": 550,
+      "community": 551,
       "file_type": "code",
       "id": "presentation_buildworkflowtraceviewmodel",
       "label": "buildWorkflowTraceViewModel()",
@@ -93073,7 +93091,7 @@
       "source_location": "L31"
     },
     {
-      "community": 551,
+      "community": 552,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_schemaindexes_test_ts",
       "label": "schemaIndexes.test.ts",
@@ -93082,7 +93100,7 @@
       "source_location": "L1"
     },
     {
-      "community": 551,
+      "community": 552,
       "file_type": "code",
       "id": "schemaindexes_test_gettableindexes",
       "label": "getTableIndexes()",
@@ -93091,7 +93109,7 @@
       "source_location": "L5"
     },
     {
-      "community": 552,
+      "community": 553,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_serviceintake_ts",
       "label": "serviceIntake.ts",
@@ -93100,7 +93118,7 @@
       "source_location": "L1"
     },
     {
-      "community": 552,
+      "community": 553,
       "file_type": "code",
       "id": "serviceintake_validateserviceintakeinput",
       "label": "validateServiceIntakeInput()",
@@ -93109,7 +93127,7 @@
       "source_location": "L1"
     },
     {
-      "community": 553,
+      "community": 554,
       "file_type": "code",
       "id": "organizationview_navigation",
       "label": "Navigation()",
@@ -93118,7 +93136,7 @@
       "source_location": "L7"
     },
     {
-      "community": 553,
+      "community": 554,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organizationview_tsx",
       "label": "OrganizationView.tsx",
@@ -93127,7 +93145,7 @@
       "source_location": "L1"
     },
     {
-      "community": 554,
+      "community": 555,
       "file_type": "code",
       "id": "organizationsview_navigation",
       "label": "Navigation()",
@@ -93136,7 +93154,7 @@
       "source_location": "L12"
     },
     {
-      "community": 554,
+      "community": 555,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organizationsview_tsx",
       "label": "OrganizationsView.tsx",
@@ -93145,7 +93163,7 @@
       "source_location": "L1"
     },
     {
-      "community": 555,
+      "community": 556,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_permissiongate_tsx",
       "label": "PermissionGate.tsx",
@@ -93154,7 +93172,7 @@
       "source_location": "L1"
     },
     {
-      "community": 555,
+      "community": 556,
       "file_type": "code",
       "id": "permissiongate_permissiongate",
       "label": "PermissionGate()",
@@ -93163,7 +93181,7 @@
       "source_location": "L11"
     },
     {
-      "community": 556,
+      "community": 557,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_protectedroute_tsx",
       "label": "ProtectedRoute.tsx",
@@ -93172,7 +93190,7 @@
       "source_location": "L1"
     },
     {
-      "community": 556,
+      "community": 557,
       "file_type": "code",
       "id": "protectedroute_protectedroute",
       "label": "ProtectedRoute()",
@@ -93181,7 +93199,7 @@
       "source_location": "L11"
     },
     {
-      "community": 557,
+      "community": 558,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_settingsview_tsx",
       "label": "SettingsView.tsx",
@@ -93190,7 +93208,7 @@
       "source_location": "L1"
     },
     {
-      "community": 557,
+      "community": 558,
       "file_type": "code",
       "id": "settingsview_settingsview",
       "label": "SettingsView()",
@@ -93199,7 +93217,7 @@
       "source_location": "L3"
     },
     {
-      "community": 558,
+      "community": 559,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storeactions_tsx",
       "label": "StoreActions.tsx",
@@ -93208,31 +93226,13 @@
       "source_location": "L1"
     },
     {
-      "community": 558,
+      "community": 559,
       "file_type": "code",
       "id": "storeactions_storeactions",
       "label": "StoreActions()",
       "norm_label": "storeactions()",
       "source_file": "packages/athena-webapp/src/components/StoreActions.tsx",
       "source_location": "L12"
-    },
-    {
-      "community": 559,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_storedropdown_tsx",
-      "label": "StoreDropdown.tsx",
-      "norm_label": "storedropdown.tsx",
-      "source_file": "packages/athena-webapp/src/components/StoreDropdown.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 559,
-      "file_type": "code",
-      "id": "storedropdown_storedropdown",
-      "label": "StoreDropdown()",
-      "norm_label": "storedropdown()",
-      "source_file": "packages/athena-webapp/src/components/StoreDropdown.tsx",
-      "source_location": "L42"
     },
     {
       "community": 56,
@@ -93363,6 +93363,24 @@
     {
       "community": 560,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_storedropdown_tsx",
+      "label": "StoreDropdown.tsx",
+      "norm_label": "storedropdown.tsx",
+      "source_file": "packages/athena-webapp/src/components/StoreDropdown.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 560,
+      "file_type": "code",
+      "id": "storedropdown_storedropdown",
+      "label": "StoreDropdown()",
+      "norm_label": "storedropdown()",
+      "source_file": "packages/athena-webapp/src/components/StoreDropdown.tsx",
+      "source_location": "L42"
+    },
+    {
+      "community": 561,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_storeview_tsx",
       "label": "StoreView.tsx",
       "norm_label": "storeview.tsx",
@@ -93370,7 +93388,7 @@
       "source_location": "L1"
     },
     {
-      "community": 560,
+      "community": 561,
       "file_type": "code",
       "id": "storeview_navigation",
       "label": "Navigation()",
@@ -93379,7 +93397,7 @@
       "source_location": "L13"
     },
     {
-      "community": 561,
+      "community": 562,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storesdropdown_tsx",
       "label": "StoresDropdown.tsx",
@@ -93388,7 +93406,7 @@
       "source_location": "L1"
     },
     {
-      "community": 561,
+      "community": 562,
       "file_type": "code",
       "id": "storesdropdown_storesdropdown",
       "label": "StoresDropdown()",
@@ -93397,7 +93415,7 @@
       "source_location": "L42"
     },
     {
-      "community": 562,
+      "community": 563,
       "file_type": "code",
       "id": "barcodeqrviewer_handleprint",
       "label": "handlePrint()",
@@ -93406,7 +93424,7 @@
       "source_location": "L31"
     },
     {
-      "community": 562,
+      "community": 563,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_barcodeqrviewer_tsx",
       "label": "BarcodeQRViewer.tsx",
@@ -93415,7 +93433,7 @@
       "source_location": "L1"
     },
     {
-      "community": 563,
+      "community": 564,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_processingfees_tsx",
       "label": "ProcessingFees.tsx",
@@ -93424,7 +93442,7 @@
       "source_location": "L1"
     },
     {
-      "community": 563,
+      "community": 564,
       "file_type": "code",
       "id": "processingfees_processingfeesview",
       "label": "ProcessingFeesView()",
@@ -93433,7 +93451,7 @@
       "source_location": "L10"
     },
     {
-      "community": 564,
+      "community": 565,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productattributes_tsx",
       "label": "ProductAttributes.tsx",
@@ -93442,7 +93460,7 @@
       "source_location": "L1"
     },
     {
-      "community": 564,
+      "community": 565,
       "file_type": "code",
       "id": "productattributes_isallowedattribute",
       "label": "isAllowedAttribute()",
@@ -93451,7 +93469,7 @@
       "source_location": "L14"
     },
     {
-      "community": 565,
+      "community": 566,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productavailabilitytogglegroup_tsx",
       "label": "ProductAvailabilityToggleGroup.tsx",
@@ -93460,7 +93478,7 @@
       "source_location": "L1"
     },
     {
-      "community": 565,
+      "community": 566,
       "file_type": "code",
       "id": "productavailabilitytogglegroup_productavailabilitytogglegroup",
       "label": "ProductAvailabilityToggleGroup()",
@@ -93469,7 +93487,7 @@
       "source_location": "L5"
     },
     {
-      "community": 566,
+      "community": 567,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productdetails_tsx",
       "label": "ProductDetails.tsx",
@@ -93478,7 +93496,7 @@
       "source_location": "L1"
     },
     {
-      "community": 566,
+      "community": 567,
       "file_type": "code",
       "id": "productdetails_handlenamechange",
       "label": "handleNameChange()",
@@ -93487,7 +93505,7 @@
       "source_location": "L10"
     },
     {
-      "community": 567,
+      "community": 568,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productimages_tsx",
       "label": "ProductImages.tsx",
@@ -93496,7 +93514,7 @@
       "source_location": "L1"
     },
     {
-      "community": 567,
+      "community": 568,
       "file_type": "code",
       "id": "productimages_header",
       "label": "Header()",
@@ -93505,7 +93523,7 @@
       "source_location": "L15"
     },
     {
-      "community": 568,
+      "community": 569,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productpage_tsx",
       "label": "ProductPage.tsx",
@@ -93514,31 +93532,13 @@
       "source_location": "L1"
     },
     {
-      "community": 568,
+      "community": 569,
       "file_type": "code",
       "id": "productpage_productpage",
       "label": "ProductPage()",
       "norm_label": "productpage()",
       "source_file": "packages/athena-webapp/src/components/add-product/ProductPage.tsx",
       "source_location": "L13"
-    },
-    {
-      "community": 569,
-      "file_type": "code",
-      "id": "copyimagesview_setisupdatingsku",
-      "label": "setIsUpdatingSku()",
-      "norm_label": "setisupdatingsku()",
-      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/CopyImagesView.tsx",
-      "source_location": "L118"
-    },
-    {
-      "community": 569,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_copy_images_copyimagesview_tsx",
-      "label": "CopyImagesView.tsx",
-      "norm_label": "copyimagesview.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/CopyImagesView.tsx",
-      "source_location": "L1"
     },
     {
       "community": 57,
@@ -93669,6 +93669,24 @@
     {
       "community": 570,
       "file_type": "code",
+      "id": "copyimagesview_setisupdatingsku",
+      "label": "setIsUpdatingSku()",
+      "norm_label": "setisupdatingsku()",
+      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/CopyImagesView.tsx",
+      "source_location": "L118"
+    },
+    {
+      "community": 570,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_copy_images_copyimagesview_tsx",
+      "label": "CopyImagesView.tsx",
+      "norm_label": "copyimagesview.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/CopyImagesView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 571,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_product_variant_columns_tsx",
       "label": "product-variant-columns.tsx",
       "norm_label": "product-variant-columns.tsx",
@@ -93676,7 +93694,7 @@
       "source_location": "L1"
     },
     {
-      "community": 570,
+      "community": 571,
       "file_type": "code",
       "id": "product_variant_columns_setsourcevariant",
       "label": "setSourceVariant()",
@@ -93685,7 +93703,7 @@
       "source_location": "L47"
     },
     {
-      "community": 571,
+      "community": 572,
       "file_type": "code",
       "id": "activitytimeline_capitalizefirstletter",
       "label": "capitalizeFirstLetter()",
@@ -93694,7 +93712,7 @@
       "source_location": "L152"
     },
     {
-      "community": 571,
+      "community": 572,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_activitytimeline_tsx",
       "label": "ActivityTimeline.tsx",
@@ -93703,7 +93721,7 @@
       "source_location": "L1"
     },
     {
-      "community": 572,
+      "community": 573,
       "file_type": "code",
       "id": "analyticscombinedusers_analyticscombinedusers",
       "label": "AnalyticsCombinedUsers()",
@@ -93712,7 +93730,7 @@
       "source_location": "L5"
     },
     {
-      "community": 572,
+      "community": 573,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticscombinedusers_tsx",
       "label": "AnalyticsCombinedUsers.tsx",
@@ -93721,7 +93739,7 @@
       "source_location": "L1"
     },
     {
-      "community": 573,
+      "community": 574,
       "file_type": "code",
       "id": "analyticsitems_analyticsitems",
       "label": "AnalyticsItems()",
@@ -93730,7 +93748,7 @@
       "source_location": "L6"
     },
     {
-      "community": 573,
+      "community": 574,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticsitems_tsx",
       "label": "AnalyticsItems.tsx",
@@ -93739,7 +93757,7 @@
       "source_location": "L1"
     },
     {
-      "community": 574,
+      "community": 575,
       "file_type": "code",
       "id": "analyticsproducts_analyticsproducts",
       "label": "AnalyticsProducts()",
@@ -93748,7 +93766,7 @@
       "source_location": "L13"
     },
     {
-      "community": 574,
+      "community": 575,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticsproducts_tsx",
       "label": "AnalyticsProducts.tsx",
@@ -93757,7 +93775,7 @@
       "source_location": "L1"
     },
     {
-      "community": 575,
+      "community": 576,
       "file_type": "code",
       "id": "analyticsusers_analyticsusers",
       "label": "AnalyticsUsers()",
@@ -93766,7 +93784,7 @@
       "source_location": "L7"
     },
     {
-      "community": 575,
+      "community": 576,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticsusers_tsx",
       "label": "AnalyticsUsers.tsx",
@@ -93775,7 +93793,7 @@
       "source_location": "L1"
     },
     {
-      "community": 576,
+      "community": 577,
       "file_type": "code",
       "id": "analyticsview_formatmetric",
       "label": "formatMetric()",
@@ -93784,7 +93802,7 @@
       "source_location": "L27"
     },
     {
-      "community": 576,
+      "community": 577,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticsview_tsx",
       "label": "AnalyticsView.tsx",
@@ -93793,7 +93811,7 @@
       "source_location": "L1"
     },
     {
-      "community": 577,
+      "community": 578,
       "file_type": "code",
       "id": "enhancedanalyticsview_getdaterangemilliseconds",
       "label": "getDateRangeMilliseconds()",
@@ -93802,7 +93820,7 @@
       "source_location": "L42"
     },
     {
-      "community": 577,
+      "community": 578,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_enhancedanalyticsview_tsx",
       "label": "EnhancedAnalyticsView.tsx",
@@ -93811,7 +93829,7 @@
       "source_location": "L1"
     },
     {
-      "community": 578,
+      "community": 579,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_storeinsights_tsx",
       "label": "StoreInsights.tsx",
@@ -93820,31 +93838,13 @@
       "source_location": "L1"
     },
     {
-      "community": 578,
+      "community": 579,
       "file_type": "code",
       "id": "storeinsights_gettrendicon",
       "label": "getTrendIcon()",
       "norm_label": "gettrendicon()",
       "source_file": "packages/athena-webapp/src/components/analytics/StoreInsights.tsx",
       "source_location": "L66"
-    },
-    {
-      "community": 579,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_visitorchart_tsx",
-      "label": "VisitorChart.tsx",
-      "norm_label": "visitorchart.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/VisitorChart.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 579,
-      "file_type": "code",
-      "id": "visitorchart_formathour",
-      "label": "formatHour()",
-      "norm_label": "formathour()",
-      "source_file": "packages/athena-webapp/src/components/analytics/VisitorChart.tsx",
-      "source_location": "L18"
     },
     {
       "community": 58,
@@ -93975,6 +93975,24 @@
     {
       "community": 580,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_visitorchart_tsx",
+      "label": "VisitorChart.tsx",
+      "norm_label": "visitorchart.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/VisitorChart.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 580,
+      "file_type": "code",
+      "id": "visitorchart_formathour",
+      "label": "formatHour()",
+      "norm_label": "formathour()",
+      "source_file": "packages/athena-webapp/src/components/analytics/VisitorChart.tsx",
+      "source_location": "L18"
+    },
+    {
+      "community": 581,
+      "file_type": "code",
       "id": "analyticsworkspaceefficiency_test_readsource",
       "label": "readSource()",
       "norm_label": "readsource()",
@@ -93982,7 +94000,7 @@
       "source_location": "L5"
     },
     {
-      "community": 580,
+      "community": 581,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticsworkspaceefficiency_test_ts",
       "label": "analyticsWorkspaceEfficiency.test.ts",
@@ -93991,7 +94009,7 @@
       "source_location": "L1"
     },
     {
-      "community": 581,
+      "community": 582,
       "file_type": "code",
       "id": "logitems_logitems",
       "label": "LogItems()",
@@ -94000,7 +94018,7 @@
       "source_location": "L6"
     },
     {
-      "community": 581,
+      "community": 582,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_logitems_tsx",
       "label": "LogItems.tsx",
@@ -94009,7 +94027,7 @@
       "source_location": "L1"
     },
     {
-      "community": 582,
+      "community": 583,
       "file_type": "code",
       "id": "logview_header",
       "label": "Header()",
@@ -94018,7 +94036,7 @@
       "source_location": "L10"
     },
     {
-      "community": 582,
+      "community": 583,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_logview_tsx",
       "label": "LogView.tsx",
@@ -94027,7 +94045,7 @@
       "source_location": "L1"
     },
     {
-      "community": 583,
+      "community": 584,
       "file_type": "code",
       "id": "logsview_navigation",
       "label": "Navigation()",
@@ -94036,7 +94054,7 @@
       "source_location": "L27"
     },
     {
-      "community": 583,
+      "community": 584,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_logsview_tsx",
       "label": "LogsView.tsx",
@@ -94045,7 +94063,7 @@
       "source_location": "L1"
     },
     {
-      "community": 584,
+      "community": 585,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_hooks_useloadlogitems_ts",
       "label": "useLoadLogItems.ts",
@@ -94054,7 +94072,7 @@
       "source_location": "L1"
     },
     {
-      "community": 584,
+      "community": 585,
       "file_type": "code",
       "id": "useloadlogitems_useloadlogitems",
       "label": "useLoadLogItems()",
@@ -94063,7 +94081,7 @@
       "source_location": "L12"
     },
     {
-      "community": 585,
+      "community": 586,
       "file_type": "code",
       "id": "app_sidebar_sidebarmenucollapsible",
       "label": "SidebarMenuCollapsible()",
@@ -94072,7 +94090,7 @@
       "source_location": "L59"
     },
     {
-      "community": 585,
+      "community": 586,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_sidebar_tsx",
       "label": "app-sidebar.tsx",
@@ -94081,7 +94099,7 @@
       "source_location": "L1"
     },
     {
-      "community": 586,
+      "community": 587,
       "file_type": "code",
       "id": "auth_auth",
       "label": "Auth()",
@@ -94090,7 +94108,7 @@
       "source_location": "L3"
     },
     {
-      "community": 586,
+      "community": 587,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_auth_tsx",
       "label": "Auth.tsx",
@@ -94099,7 +94117,7 @@
       "source_location": "L1"
     },
     {
-      "community": 587,
+      "community": 588,
       "file_type": "code",
       "id": "inputotp_test_resolvesignin",
       "label": "resolveSignIn()",
@@ -94108,7 +94126,7 @@
       "source_location": "L102"
     },
     {
-      "community": 587,
+      "community": 588,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_login_inputotp_test_tsx",
       "label": "InputOTP.test.tsx",
@@ -94117,7 +94135,7 @@
       "source_location": "L1"
     },
     {
-      "community": 588,
+      "community": 589,
       "file_type": "code",
       "id": "index_login",
       "label": "Login()",
@@ -94126,30 +94144,12 @@
       "source_location": "L5"
     },
     {
-      "community": 588,
+      "community": 589,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_login_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
       "source_file": "packages/athena-webapp/src/components/auth/Login/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 589,
-      "file_type": "code",
-      "id": "data_table_column_header_datatablecolumnheader",
-      "label": "DataTableColumnHeader()",
-      "norm_label": "datatablecolumnheader()",
-      "source_file": "packages/athena-webapp/src/components/base/table/data-table-column-header.tsx",
-      "source_location": "L25"
-    },
-    {
-      "community": 589,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_base_table_data_table_column_header_tsx",
-      "label": "data-table-column-header.tsx",
-      "norm_label": "data-table-column-header.tsx",
-      "source_file": "packages/athena-webapp/src/components/base/table/data-table-column-header.tsx",
       "source_location": "L1"
     },
     {
@@ -94281,6 +94281,24 @@
     {
       "community": 590,
       "file_type": "code",
+      "id": "data_table_column_header_datatablecolumnheader",
+      "label": "DataTableColumnHeader()",
+      "norm_label": "datatablecolumnheader()",
+      "source_file": "packages/athena-webapp/src/components/base/table/data-table-column-header.tsx",
+      "source_location": "L25"
+    },
+    {
+      "community": 590,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_base_table_data_table_column_header_tsx",
+      "label": "data-table-column-header.tsx",
+      "norm_label": "data-table-column-header.tsx",
+      "source_file": "packages/athena-webapp/src/components/base/table/data-table-column-header.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 591,
+      "file_type": "code",
       "id": "bulkoperationsfilters_handleloadproducts",
       "label": "handleLoadProducts()",
       "norm_label": "handleloadproducts()",
@@ -94288,7 +94306,7 @@
       "source_location": "L49"
     },
     {
-      "community": 590,
+      "community": 591,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationsfilters_tsx",
       "label": "BulkOperationsFilters.tsx",
@@ -94297,7 +94315,7 @@
       "source_location": "L1"
     },
     {
-      "community": 591,
+      "community": 592,
       "file_type": "code",
       "id": "bulkoperationspreview_test_makerow",
       "label": "makeRow()",
@@ -94306,7 +94324,7 @@
       "source_location": "L23"
     },
     {
-      "community": 591,
+      "community": 592,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationspreview_test_tsx",
       "label": "BulkOperationsPreview.test.tsx",
@@ -94315,7 +94333,7 @@
       "source_location": "L1"
     },
     {
-      "community": 592,
+      "community": 593,
       "file_type": "code",
       "id": "bulkoperationspreview_formatprice",
       "label": "formatPrice()",
@@ -94324,7 +94342,7 @@
       "source_location": "L50"
     },
     {
-      "community": 592,
+      "community": 593,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationspreview_tsx",
       "label": "BulkOperationsPreview.tsx",
@@ -94333,7 +94351,7 @@
       "source_location": "L1"
     },
     {
-      "community": 593,
+      "community": 594,
       "file_type": "code",
       "id": "formatreviewreason_formatreviewreason",
       "label": "formatReviewReason()",
@@ -94342,7 +94360,7 @@
       "source_location": "L3"
     },
     {
-      "community": 593,
+      "community": 594,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_formatreviewreason_ts",
       "label": "formatReviewReason.ts",
@@ -94351,7 +94369,7 @@
       "source_location": "L1"
     },
     {
-      "community": 594,
+      "community": 595,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_registersessioncolumns_tsx",
       "label": "registerSessionColumns.tsx",
@@ -94360,7 +94378,7 @@
       "source_location": "L1"
     },
     {
-      "community": 594,
+      "community": 595,
       "file_type": "code",
       "id": "registersessioncolumns_registersessionlink",
       "label": "RegisterSessionLink()",
@@ -94369,7 +94387,7 @@
       "source_location": "L33"
     },
     {
-      "community": 595,
+      "community": 596,
       "file_type": "code",
       "id": "checkoutsessionstable_checkoutsessionstable",
       "label": "CheckoutSessionsTable()",
@@ -94378,7 +94396,7 @@
       "source_location": "L13"
     },
     {
-      "community": 595,
+      "community": 596,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkoutsessionstable_tsx",
       "label": "CheckoutSessionsTable.tsx",
@@ -94387,7 +94405,7 @@
       "source_location": "L1"
     },
     {
-      "community": 596,
+      "community": 597,
       "file_type": "code",
       "id": "checkoutsesssionsview_navigation",
       "label": "Navigation()",
@@ -94396,7 +94414,7 @@
       "source_location": "L11"
     },
     {
-      "community": 596,
+      "community": 597,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkoutsesssionsview_tsx",
       "label": "CheckoutSesssionsView.tsx",
@@ -94405,7 +94423,7 @@
       "source_location": "L1"
     },
     {
-      "community": 597,
+      "community": 598,
       "file_type": "code",
       "id": "expensecompletion_expensecompletion",
       "label": "ExpenseCompletion()",
@@ -94414,7 +94432,7 @@
       "source_location": "L24"
     },
     {
-      "community": 597,
+      "community": 598,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_expense_expensecompletion_tsx",
       "label": "ExpenseCompletion.tsx",
@@ -94423,7 +94441,7 @@
       "source_location": "L1"
     },
     {
-      "community": 598,
+      "community": 599,
       "file_type": "code",
       "id": "expenseview_expenseview",
       "label": "ExpenseView()",
@@ -94432,30 +94450,12 @@
       "source_location": "L4"
     },
     {
-      "community": 598,
+      "community": 599,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_expense_expenseview_tsx",
       "label": "ExpenseView.tsx",
       "norm_label": "expenseview.tsx",
       "source_file": "packages/athena-webapp/src/components/expense/ExpenseView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 599,
-      "file_type": "code",
-      "id": "bestsellersdialog_handleaddbestseller",
-      "label": "handleAddBestSeller()",
-      "norm_label": "handleaddbestseller()",
-      "source_file": "packages/athena-webapp/src/components/homepage/BestSellersDialog.tsx",
-      "source_location": "L29"
-    },
-    {
-      "community": 599,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_homepage_bestsellersdialog_tsx",
-      "label": "BestSellersDialog.tsx",
-      "norm_label": "bestsellersdialog.tsx",
-      "source_file": "packages/athena-webapp/src/components/homepage/BestSellersDialog.tsx",
       "source_location": "L1"
     },
     {
@@ -94884,6 +94884,24 @@
     {
       "community": 600,
       "file_type": "code",
+      "id": "bestsellersdialog_handleaddbestseller",
+      "label": "handleAddBestSeller()",
+      "norm_label": "handleaddbestseller()",
+      "source_file": "packages/athena-webapp/src/components/homepage/BestSellersDialog.tsx",
+      "source_location": "L29"
+    },
+    {
+      "community": 600,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_homepage_bestsellersdialog_tsx",
+      "label": "BestSellersDialog.tsx",
+      "norm_label": "bestsellersdialog.tsx",
+      "source_file": "packages/athena-webapp/src/components/homepage/BestSellersDialog.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 601,
+      "file_type": "code",
       "id": "featuredsectiondialog_handleaddfeatureditem",
       "label": "handleAddFeaturedItem()",
       "norm_label": "handleaddfeatureditem()",
@@ -94891,7 +94909,7 @@
       "source_location": "L37"
     },
     {
-      "community": 600,
+      "community": 601,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_featuredsectiondialog_tsx",
       "label": "FeaturedSectionDialog.tsx",
@@ -94900,7 +94918,7 @@
       "source_location": "L1"
     },
     {
-      "community": 601,
+      "community": 602,
       "file_type": "code",
       "id": "home_navigation",
       "label": "Navigation()",
@@ -94909,7 +94927,7 @@
       "source_location": "L25"
     },
     {
-      "community": 601,
+      "community": 602,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_home_tsx",
       "label": "Home.tsx",
@@ -94918,7 +94936,7 @@
       "source_location": "L1"
     },
     {
-      "community": 602,
+      "community": 603,
       "file_type": "code",
       "id": "landingpagereelversion_handleupdateconfig",
       "label": "handleUpdateConfig()",
@@ -94927,7 +94945,7 @@
       "source_location": "L83"
     },
     {
-      "community": 602,
+      "community": 603,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_landingpagereelversion_tsx",
       "label": "LandingPageReelVersion.tsx",
@@ -94936,7 +94954,7 @@
       "source_location": "L1"
     },
     {
-      "community": 603,
+      "community": 604,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_shoplookdialog_tsx",
       "label": "ShopLookDialog.tsx",
@@ -94945,7 +94963,7 @@
       "source_location": "L1"
     },
     {
-      "community": 603,
+      "community": 604,
       "file_type": "code",
       "id": "shoplookdialog_handleaddfeatureditem",
       "label": "handleAddFeaturedItem()",
@@ -94954,7 +94972,7 @@
       "source_location": "L35"
     },
     {
-      "community": 604,
+      "community": 605,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_shoplookimageuploader_tsx",
       "label": "ShopLookImageUploader.tsx",
@@ -94963,7 +94981,7 @@
       "source_location": "L1"
     },
     {
-      "community": 604,
+      "community": 605,
       "file_type": "code",
       "id": "shoplookimageuploader_shoplookimageuploader",
       "label": "ShopLookImageUploader()",
@@ -94972,7 +94990,7 @@
       "source_location": "L28"
     },
     {
-      "community": 605,
+      "community": 606,
       "file_type": "code",
       "id": "index_jointeam",
       "label": "JoinTeam()",
@@ -94981,7 +94999,7 @@
       "source_location": "L12"
     },
     {
-      "community": 605,
+      "community": 606,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_join_team_index_tsx",
       "label": "index.tsx",
@@ -94990,7 +95008,7 @@
       "source_location": "L1"
     },
     {
-      "community": 606,
+      "community": 607,
       "file_type": "code",
       "id": "operationreviewitemcard_cn",
       "label": "cn()",
@@ -94999,7 +95017,7 @@
       "source_location": "L82"
     },
     {
-      "community": 606,
+      "community": 607,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_operationreviewitemcard_tsx",
       "label": "OperationReviewItemCard.tsx",
@@ -95008,7 +95026,7 @@
       "source_location": "L1"
     },
     {
-      "community": 607,
+      "community": 608,
       "file_type": "code",
       "id": "operationssummarymetric_buildparams",
       "label": "buildParams()",
@@ -95017,7 +95035,7 @@
       "source_location": "L15"
     },
     {
-      "community": 607,
+      "community": 608,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_operationssummarymetric_tsx",
       "label": "OperationsSummaryMetric.tsx",
@@ -95026,7 +95044,7 @@
       "source_location": "L1"
     },
     {
-      "community": 608,
+      "community": 609,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_test_tsx",
       "label": "StockAdjustmentWorkspace.test.tsx",
@@ -95035,31 +95053,13 @@
       "source_location": "L1"
     },
     {
-      "community": 608,
+      "community": 609,
       "file_type": "code",
       "id": "stockadjustmentworkspace_test_renderstockadjustmentworkspace",
       "label": "renderStockAdjustmentWorkspace()",
       "norm_label": "renderstockadjustmentworkspace()",
       "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.test.tsx",
       "source_location": "L88"
-    },
-    {
-      "community": 609,
-      "file_type": "code",
-      "id": "customerdetailsview_customerdetailsview",
-      "label": "CustomerDetailsView()",
-      "norm_label": "customerdetailsview()",
-      "source_file": "packages/athena-webapp/src/components/orders/CustomerDetailsView.tsx",
-      "source_location": "L13"
-    },
-    {
-      "community": 609,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_customerdetailsview_tsx",
-      "label": "CustomerDetailsView.tsx",
-      "norm_label": "customerdetailsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/CustomerDetailsView.tsx",
-      "source_location": "L1"
     },
     {
       "community": 61,
@@ -95181,6 +95181,24 @@
     {
       "community": 610,
       "file_type": "code",
+      "id": "customerdetailsview_customerdetailsview",
+      "label": "CustomerDetailsView()",
+      "norm_label": "customerdetailsview()",
+      "source_file": "packages/athena-webapp/src/components/orders/CustomerDetailsView.tsx",
+      "source_location": "L13"
+    },
+    {
+      "community": 610,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_customerdetailsview_tsx",
+      "label": "CustomerDetailsView.tsx",
+      "norm_label": "customerdetailsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/CustomerDetailsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 611,
+      "file_type": "code",
       "id": "emailstatusview_handlesendorderemail",
       "label": "handleSendOrderEmail()",
       "norm_label": "handlesendorderemail()",
@@ -95188,7 +95206,7 @@
       "source_location": "L43"
     },
     {
-      "community": 610,
+      "community": 611,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_emailstatusview_tsx",
       "label": "EmailStatusView.tsx",
@@ -95197,7 +95215,7 @@
       "source_location": "L1"
     },
     {
-      "community": 611,
+      "community": 612,
       "file_type": "code",
       "id": "ordermetricspanel_handletimerangechange",
       "label": "handleTimeRangeChange()",
@@ -95206,7 +95224,7 @@
       "source_location": "L33"
     },
     {
-      "community": 611,
+      "community": 612,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_ordermetricspanel_tsx",
       "label": "OrderMetricsPanel.tsx",
@@ -95215,7 +95233,7 @@
       "source_location": "L1"
     },
     {
-      "community": 612,
+      "community": 613,
       "file_type": "code",
       "id": "ordersview_gettimefilter",
       "label": "getTimeFilter()",
@@ -95224,7 +95242,7 @@
       "source_location": "L35"
     },
     {
-      "community": 612,
+      "community": 613,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_ordersview_tsx",
       "label": "OrdersView.tsx",
@@ -95233,7 +95251,7 @@
       "source_location": "L1"
     },
     {
-      "community": 613,
+      "community": 614,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_refundsview_tsx",
       "label": "RefundsView.tsx",
@@ -95242,7 +95260,7 @@
       "source_location": "L1"
     },
     {
-      "community": 613,
+      "community": 614,
       "file_type": "code",
       "id": "refundsview_handlerefundorder",
       "label": "handleRefundOrder()",
@@ -95251,7 +95269,7 @@
       "source_location": "L83"
     },
     {
-      "community": 614,
+      "community": 615,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_hooks_usegetactiveonlineorder_ts",
       "label": "useGetActiveOnlineOrder.ts",
@@ -95260,7 +95278,7 @@
       "source_location": "L1"
     },
     {
-      "community": 614,
+      "community": 615,
       "file_type": "code",
       "id": "usegetactiveonlineorder_usegetactiveonlineorder",
       "label": "useGetActiveOnlineOrder()",
@@ -95269,7 +95287,7 @@
       "source_location": "L6"
     },
     {
-      "community": 615,
+      "community": 616,
       "file_type": "code",
       "id": "data_table_toolbar_handleclearfilters",
       "label": "handleClearFilters()",
@@ -95278,7 +95296,7 @@
       "source_location": "L34"
     },
     {
-      "community": 615,
+      "community": 616,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -95287,7 +95305,7 @@
       "source_location": "L1"
     },
     {
-      "community": 616,
+      "community": 617,
       "file_type": "code",
       "id": "ordercolumns_if",
       "label": "if()",
@@ -95296,7 +95314,7 @@
       "source_location": "L89"
     },
     {
-      "community": 616,
+      "community": 617,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_ordercolumns_tsx",
       "label": "orderColumns.tsx",
@@ -95305,7 +95323,7 @@
       "source_location": "L1"
     },
     {
-      "community": 617,
+      "community": 618,
       "file_type": "code",
       "id": "organization_switcher_organizationswitcher",
       "label": "OrganizationSwitcher()",
@@ -95314,7 +95332,7 @@
       "source_location": "L37"
     },
     {
-      "community": 617,
+      "community": 618,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_switcher_tsx",
       "label": "organization-switcher.tsx",
@@ -95323,7 +95341,7 @@
       "source_location": "L1"
     },
     {
-      "community": 618,
+      "community": 619,
       "file_type": "code",
       "id": "cartitems_cn",
       "label": "cn()",
@@ -95332,30 +95350,12 @@
       "source_location": "L215"
     },
     {
-      "community": 618,
+      "community": 619,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_cartitems_tsx",
       "label": "CartItems.tsx",
       "norm_label": "cartitems.tsx",
       "source_file": "packages/athena-webapp/src/components/pos/CartItems.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 619,
-      "file_type": "code",
-      "id": "debugproducts_debugproducts",
-      "label": "DebugProducts()",
-      "norm_label": "debugproducts()",
-      "source_file": "packages/athena-webapp/src/components/pos/DebugProducts.tsx",
-      "source_location": "L5"
-    },
-    {
-      "community": 619,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_debugproducts_tsx",
-      "label": "DebugProducts.tsx",
-      "norm_label": "debugproducts.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/DebugProducts.tsx",
       "source_location": "L1"
     },
     {
@@ -95478,6 +95478,24 @@
     {
       "community": 620,
       "file_type": "code",
+      "id": "debugproducts_debugproducts",
+      "label": "DebugProducts()",
+      "norm_label": "debugproducts()",
+      "source_file": "packages/athena-webapp/src/components/pos/DebugProducts.tsx",
+      "source_location": "L5"
+    },
+    {
+      "community": 620,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_debugproducts_tsx",
+      "label": "DebugProducts.tsx",
+      "norm_label": "debugproducts.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/DebugProducts.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 621,
+      "file_type": "code",
       "id": "noresultsmessage_noresultsmessage",
       "label": "NoResultsMessage()",
       "norm_label": "noresultsmessage()",
@@ -95485,7 +95503,7 @@
       "source_location": "L7"
     },
     {
-      "community": 620,
+      "community": 621,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_noresultsmessage_tsx",
       "label": "NoResultsMessage.tsx",
@@ -95494,7 +95512,7 @@
       "source_location": "L1"
     },
     {
-      "community": 621,
+      "community": 622,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_pininput_tsx",
       "label": "PinInput.tsx",
@@ -95503,7 +95521,7 @@
       "source_location": "L1"
     },
     {
-      "community": 621,
+      "community": 622,
       "file_type": "code",
       "id": "pininput_pininput",
       "label": "PinInput()",
@@ -95512,7 +95530,7 @@
       "source_location": "L13"
     },
     {
-      "community": 622,
+      "community": 623,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_printinstructions_tsx",
       "label": "PrintInstructions.tsx",
@@ -95521,7 +95539,7 @@
       "source_location": "L1"
     },
     {
-      "community": 622,
+      "community": 623,
       "file_type": "code",
       "id": "printinstructions_printinstructions",
       "label": "PrintInstructions()",
@@ -95530,7 +95548,7 @@
       "source_location": "L3"
     },
     {
-      "community": 623,
+      "community": 624,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_productcard_tsx",
       "label": "ProductCard.tsx",
@@ -95539,7 +95557,7 @@
       "source_location": "L1"
     },
     {
-      "community": 623,
+      "community": 624,
       "file_type": "code",
       "id": "productcard_productcard",
       "label": "ProductCard()",
@@ -95548,7 +95566,7 @@
       "source_location": "L14"
     },
     {
-      "community": 624,
+      "community": 625,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_searchresultssection_test_tsx",
       "label": "SearchResultsSection.test.tsx",
@@ -95557,7 +95575,7 @@
       "source_location": "L1"
     },
     {
-      "community": 624,
+      "community": 625,
       "file_type": "code",
       "id": "searchresultssection_test_buildproduct",
       "label": "buildProduct()",
@@ -95566,7 +95584,7 @@
       "source_location": "L12"
     },
     {
-      "community": 625,
+      "community": 626,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_sessiondemo_tsx",
       "label": "SessionDemo.tsx",
@@ -95575,7 +95593,7 @@
       "source_location": "L1"
     },
     {
-      "community": 625,
+      "community": 626,
       "file_type": "code",
       "id": "sessiondemo_sessiondemo",
       "label": "SessionDemo()",
@@ -95584,7 +95602,7 @@
       "source_location": "L15"
     },
     {
-      "community": 626,
+      "community": 627,
       "file_type": "code",
       "id": "expensereportsview_istoday",
       "label": "isToday()",
@@ -95593,7 +95611,7 @@
       "source_location": "L21"
     },
     {
-      "community": 626,
+      "community": 627,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportsview_tsx",
       "label": "ExpenseReportsView.tsx",
@@ -95602,7 +95620,7 @@
       "source_location": "L1"
     },
     {
-      "community": 627,
+      "community": 628,
       "file_type": "code",
       "id": "expensereportrows_toexpensereportrows",
       "label": "toExpenseReportRows()",
@@ -95611,7 +95629,7 @@
       "source_location": "L15"
     },
     {
-      "community": 627,
+      "community": 628,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportrows_ts",
       "label": "expenseReportRows.ts",
@@ -95620,7 +95638,7 @@
       "source_location": "L1"
     },
     {
-      "community": 628,
+      "community": 629,
       "file_type": "code",
       "id": "expensecompletionpanel_expensecompletionpanel",
       "label": "ExpenseCompletionPanel()",
@@ -95629,31 +95647,13 @@
       "source_location": "L9"
     },
     {
-      "community": 628,
+      "community": 629,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_expensecompletionpanel_tsx",
       "label": "ExpenseCompletionPanel.tsx",
       "norm_label": "expensecompletionpanel.tsx",
       "source_file": "packages/athena-webapp/src/components/pos/register/ExpenseCompletionPanel.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 629,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_register_registercustomerattribution_test_tsx",
-      "label": "RegisterCustomerAttribution.test.tsx",
-      "norm_label": "registercustomerattribution.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 629,
-      "file_type": "code",
-      "id": "registercustomerattribution_test_makecustomer",
-      "label": "makeCustomer()",
-      "norm_label": "makecustomer()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.test.tsx",
-      "source_location": "L28"
     },
     {
       "community": 63,
@@ -95775,6 +95775,24 @@
     {
       "community": 630,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_register_registercustomerattribution_test_tsx",
+      "label": "RegisterCustomerAttribution.test.tsx",
+      "norm_label": "registercustomerattribution.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 630,
+      "file_type": "code",
+      "id": "registercustomerattribution_test_makecustomer",
+      "label": "makeCustomer()",
+      "norm_label": "makecustomer()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.test.tsx",
+      "source_location": "L28"
+    },
+    {
+      "community": 631,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_registercustomerpanel_tsx",
       "label": "RegisterCustomerPanel.tsx",
       "norm_label": "registercustomerpanel.tsx",
@@ -95782,7 +95800,7 @@
       "source_location": "L1"
     },
     {
-      "community": 630,
+      "community": 631,
       "file_type": "code",
       "id": "registercustomerpanel_registercustomerpanel",
       "label": "RegisterCustomerPanel()",
@@ -95791,7 +95809,7 @@
       "source_location": "L9"
     },
     {
-      "community": 631,
+      "community": 632,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_registerdrawergate_test_tsx",
       "label": "RegisterDrawerGate.test.tsx",
@@ -95800,7 +95818,7 @@
       "source_location": "L1"
     },
     {
-      "community": 631,
+      "community": 632,
       "file_type": "code",
       "id": "registerdrawergate_test_rendergate",
       "label": "renderGate()",
@@ -95809,7 +95827,7 @@
       "source_location": "L23"
     },
     {
-      "community": 632,
+      "community": 633,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_registersessionpanel_tsx",
       "label": "RegisterSessionPanel.tsx",
@@ -95818,7 +95836,7 @@
       "source_location": "L1"
     },
     {
-      "community": 632,
+      "community": 633,
       "file_type": "code",
       "id": "registersessionpanel_registersessionpanel",
       "label": "RegisterSessionPanel()",
@@ -95827,7 +95845,7 @@
       "source_location": "L9"
     },
     {
-      "community": 633,
+      "community": 634,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_transactions_transactioncolumns_test_tsx",
       "label": "transactionColumns.test.tsx",
@@ -95836,7 +95854,7 @@
       "source_location": "L1"
     },
     {
-      "community": 633,
+      "community": 634,
       "file_type": "code",
       "id": "transactioncolumns_test_rendertransactioncell",
       "label": "renderTransactionCell()",
@@ -95845,7 +95863,7 @@
       "source_location": "L34"
     },
     {
-      "community": 634,
+      "community": 635,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_transactions_transactioncolumns_tsx",
       "label": "transactionColumns.tsx",
@@ -95854,7 +95872,7 @@
       "source_location": "L1"
     },
     {
-      "community": 634,
+      "community": 635,
       "file_type": "code",
       "id": "transactioncolumns_getpaymentmethodicon",
       "label": "getPaymentMethodIcon()",
@@ -95863,7 +95881,7 @@
       "source_location": "L27"
     },
     {
-      "community": 635,
+      "community": 636,
       "file_type": "code",
       "id": "barcodeview_barcodeview",
       "label": "BarcodeView()",
@@ -95872,7 +95890,7 @@
       "source_location": "L14"
     },
     {
-      "community": 635,
+      "community": 636,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_barcodeview_tsx",
       "label": "BarcodeView.tsx",
@@ -95881,7 +95899,7 @@
       "source_location": "L1"
     },
     {
-      "community": 636,
+      "community": 637,
       "file_type": "code",
       "id": "categorizationview_categorizationview",
       "label": "CategorizationView()",
@@ -95890,7 +95908,7 @@
       "source_location": "L6"
     },
     {
-      "community": 636,
+      "community": 637,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_categorizationview_tsx",
       "label": "CategorizationView.tsx",
@@ -95899,7 +95917,7 @@
       "source_location": "L1"
     },
     {
-      "community": 637,
+      "community": 638,
       "file_type": "code",
       "id": "imagesview_handlekeydown",
       "label": "handleKeyDown()",
@@ -95908,7 +95926,7 @@
       "source_location": "L37"
     },
     {
-      "community": 637,
+      "community": 638,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_imagesview_tsx",
       "label": "ImagesView.tsx",
@@ -95917,7 +95935,7 @@
       "source_location": "L1"
     },
     {
-      "community": 638,
+      "community": 639,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_productstatus_tsx",
       "label": "ProductStatus.tsx",
@@ -95926,31 +95944,13 @@
       "source_location": "L1"
     },
     {
-      "community": 638,
+      "community": 639,
       "file_type": "code",
       "id": "productstatus_productstatus",
       "label": "ProductStatus()",
       "norm_label": "productstatus()",
       "source_file": "packages/athena-webapp/src/components/product/ProductStatus.tsx",
       "source_location": "L11"
-    },
-    {
-      "community": 639,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_product_skuselector_tsx",
-      "label": "SKUSelector.tsx",
-      "norm_label": "skuselector.tsx",
-      "source_file": "packages/athena-webapp/src/components/product/SKUSelector.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 639,
-      "file_type": "code",
-      "id": "skuselector_skuselector",
-      "label": "SKUSelector()",
-      "norm_label": "skuselector()",
-      "source_file": "packages/athena-webapp/src/components/product/SKUSelector.tsx",
-      "source_location": "L10"
     },
     {
       "community": 64,
@@ -96072,6 +96072,24 @@
     {
       "community": 640,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_product_skuselector_tsx",
+      "label": "SKUSelector.tsx",
+      "norm_label": "skuselector.tsx",
+      "source_file": "packages/athena-webapp/src/components/product/SKUSelector.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 640,
+      "file_type": "code",
+      "id": "skuselector_skuselector",
+      "label": "SKUSelector()",
+      "norm_label": "skuselector()",
+      "source_file": "packages/athena-webapp/src/components/product/SKUSelector.tsx",
+      "source_location": "L10"
+    },
+    {
+      "community": 641,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_actions_tsx",
       "label": "product-actions.tsx",
       "norm_label": "product-actions.tsx",
@@ -96079,7 +96097,7 @@
       "source_location": "L1"
     },
     {
-      "community": 640,
+      "community": 641,
       "file_type": "code",
       "id": "product_actions_usearchiveproduct",
       "label": "useArchiveProduct()",
@@ -96088,7 +96106,7 @@
       "source_location": "L6"
     },
     {
-      "community": 641,
+      "community": 642,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_productsview_tsx",
       "label": "ProductsView.tsx",
@@ -96097,7 +96115,7 @@
       "source_location": "L1"
     },
     {
-      "community": 641,
+      "community": 642,
       "file_type": "code",
       "id": "productsview_productsview",
       "label": "ProductsView()",
@@ -96106,7 +96124,7 @@
       "source_location": "L5"
     },
     {
-      "community": 642,
+      "community": 643,
       "file_type": "code",
       "id": "add_product_command_addproductcommand",
       "label": "AddProductCommand()",
@@ -96115,7 +96133,7 @@
       "source_location": "L17"
     },
     {
-      "community": 642,
+      "community": 643,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_add_product_command_tsx",
       "label": "add-product-command.tsx",
@@ -96124,7 +96142,7 @@
       "source_location": "L1"
     },
     {
-      "community": 643,
+      "community": 644,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_products_tsx",
       "label": "Products.tsx",
@@ -96133,7 +96151,7 @@
       "source_location": "L1"
     },
     {
-      "community": 643,
+      "community": 644,
       "file_type": "code",
       "id": "products_products",
       "label": "Products()",
@@ -96142,7 +96160,7 @@
       "source_location": "L4"
     },
     {
-      "community": 644,
+      "community": 645,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodeform_tsx",
       "label": "PromoCodeForm.tsx",
@@ -96151,7 +96169,7 @@
       "source_location": "L1"
     },
     {
-      "community": 644,
+      "community": 645,
       "file_type": "code",
       "id": "promocodeform_togglediscounttype",
       "label": "toggleDiscountType()",
@@ -96160,7 +96178,7 @@
       "source_location": "L82"
     },
     {
-      "community": 645,
+      "community": 646,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodeheader_tsx",
       "label": "PromoCodeHeader.tsx",
@@ -96169,7 +96187,7 @@
       "source_location": "L1"
     },
     {
-      "community": 645,
+      "community": 646,
       "file_type": "code",
       "id": "promocodeheader_handledeletepromocode",
       "label": "handleDeletePromoCode()",
@@ -96178,7 +96196,7 @@
       "source_location": "L23"
     },
     {
-      "community": 646,
+      "community": 647,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodepreview_tsx",
       "label": "PromoCodePreview.tsx",
@@ -96187,7 +96205,7 @@
       "source_location": "L1"
     },
     {
-      "community": 646,
+      "community": 647,
       "file_type": "code",
       "id": "promocodepreview_discount",
       "label": "Discount()",
@@ -96196,7 +96214,7 @@
       "source_location": "L37"
     },
     {
-      "community": 647,
+      "community": 648,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodesview_test_tsx",
       "label": "PromoCodesView.test.tsx",
@@ -96205,7 +96223,7 @@
       "source_location": "L1"
     },
     {
-      "community": 647,
+      "community": 648,
       "file_type": "code",
       "id": "promocodesview_test_readsource",
       "label": "readSource()",
@@ -96214,7 +96232,7 @@
       "source_location": "L5"
     },
     {
-      "community": 648,
+      "community": 649,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodesview_tsx",
       "label": "PromoCodesView.tsx",
@@ -96223,31 +96241,13 @@
       "source_location": "L1"
     },
     {
-      "community": 648,
+      "community": 649,
       "file_type": "code",
       "id": "promocodesview_promocodesview",
       "label": "PromoCodesView()",
       "norm_label": "promocodesview()",
       "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodesView.tsx",
       "source_location": "L10"
-    },
-    {
-      "community": 649,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_selectablecategories_tsx",
-      "label": "SelectableCategories.tsx",
-      "norm_label": "selectablecategories.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/SelectableCategories.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 649,
-      "file_type": "code",
-      "id": "selectablecategories_toggle",
-      "label": "toggle()",
-      "norm_label": "toggle()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/SelectableCategories.tsx",
-      "source_location": "L23"
     },
     {
       "community": 65,
@@ -96369,6 +96369,24 @@
     {
       "community": 650,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_selectablecategories_tsx",
+      "label": "SelectableCategories.tsx",
+      "norm_label": "selectablecategories.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/SelectableCategories.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 650,
+      "file_type": "code",
+      "id": "selectablecategories_toggle",
+      "label": "toggle()",
+      "norm_label": "toggle()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/SelectableCategories.tsx",
+      "source_location": "L23"
+    },
+    {
+      "community": 651,
+      "file_type": "code",
       "id": "discounttypetogglegroup_discounttypetogglegroup",
       "label": "DiscountTypeToggleGroup()",
       "norm_label": "discounttypetogglegroup()",
@@ -96376,7 +96394,7 @@
       "source_location": "L5"
     },
     {
-      "community": 650,
+      "community": 651,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_add_promo_code_discounttypetogglegroup_tsx",
       "label": "DiscountTypeToggleGroup.tsx",
@@ -96385,7 +96403,7 @@
       "source_location": "L1"
     },
     {
-      "community": 651,
+      "community": 652,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_add_promo_code_promocodespantogglegroup_tsx",
       "label": "PromoCodeSpanToggleGroup.tsx",
@@ -96394,7 +96412,7 @@
       "source_location": "L1"
     },
     {
-      "community": 651,
+      "community": 652,
       "file_type": "code",
       "id": "promocodespantogglegroup_promocodespantogglegroup",
       "label": "PromoCodeSpanToggleGroup()",
@@ -96403,7 +96421,7 @@
       "source_location": "L4"
     },
     {
-      "community": 652,
+      "community": 653,
       "file_type": "code",
       "id": "capturedemails_capturedemails",
       "label": "CapturedEmails()",
@@ -96412,7 +96430,7 @@
       "source_location": "L13"
     },
     {
-      "community": 652,
+      "community": 653,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_captured_capturedemails_tsx",
       "label": "CapturedEmails.tsx",
@@ -96421,7 +96439,7 @@
       "source_location": "L1"
     },
     {
-      "community": 653,
+      "community": 654,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_modals_promo_code_modal_tsx",
       "label": "promo-code-modal.tsx",
@@ -96430,7 +96448,7 @@
       "source_location": "L1"
     },
     {
-      "community": 653,
+      "community": 654,
       "file_type": "code",
       "id": "promo_code_modal_promocodemodal",
       "label": "PromoCodeModal()",
@@ -96439,7 +96457,7 @@
       "source_location": "L29"
     },
     {
-      "community": 654,
+      "community": 655,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reviews_reviewactions_tsx",
       "label": "ReviewActions.tsx",
@@ -96448,7 +96466,7 @@
       "source_location": "L1"
     },
     {
-      "community": 654,
+      "community": 655,
       "file_type": "code",
       "id": "reviewactions_reviewactions",
       "label": "ReviewActions()",
@@ -96457,7 +96475,7 @@
       "source_location": "L20"
     },
     {
-      "community": 655,
+      "community": 656,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_servicecasesview_test_tsx",
       "label": "ServiceCasesView.test.tsx",
@@ -96466,7 +96484,7 @@
       "source_location": "L1"
     },
     {
-      "community": 655,
+      "community": 656,
       "file_type": "code",
       "id": "servicecasesview_test_chooseselectoption",
       "label": "chooseSelectOption()",
@@ -96475,7 +96493,7 @@
       "source_location": "L63"
     },
     {
-      "community": 656,
+      "community": 657,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_servicecatalogview_test_tsx",
       "label": "ServiceCatalogView.test.tsx",
@@ -96484,7 +96502,7 @@
       "source_location": "L1"
     },
     {
-      "community": 656,
+      "community": 657,
       "file_type": "code",
       "id": "servicecatalogview_test_chooseselectoption",
       "label": "chooseSelectOption()",
@@ -96493,7 +96511,7 @@
       "source_location": "L60"
     },
     {
-      "community": 657,
+      "community": 658,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_serviceintakeform_tsx",
       "label": "ServiceIntakeForm.tsx",
@@ -96502,7 +96520,7 @@
       "source_location": "L1"
     },
     {
-      "community": 657,
+      "community": 658,
       "file_type": "code",
       "id": "serviceintakeform_serviceintakeform",
       "label": "ServiceIntakeForm()",
@@ -96511,7 +96529,7 @@
       "source_location": "L59"
     },
     {
-      "community": 658,
+      "community": 659,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_serviceintakeview_auth_test_tsx",
       "label": "ServiceIntakeView.auth.test.tsx",
@@ -96520,31 +96538,13 @@
       "source_location": "L1"
     },
     {
-      "community": 658,
+      "community": 659,
       "file_type": "code",
       "id": "serviceintakeview_auth_test_chooseselectoption",
       "label": "chooseSelectOption()",
       "norm_label": "chooseselectoption()",
       "source_file": "packages/athena-webapp/src/components/services/ServiceIntakeView.auth.test.tsx",
       "source_location": "L45"
-    },
-    {
-      "community": 659,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_services_serviceintakeview_test_tsx",
-      "label": "ServiceIntakeView.test.tsx",
-      "norm_label": "serviceintakeview.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceIntakeView.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 659,
-      "file_type": "code",
-      "id": "serviceintakeview_test_chooseselectoption",
-      "label": "chooseSelectOption()",
-      "norm_label": "chooseselectoption()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceIntakeView.test.tsx",
-      "source_location": "L47"
     },
     {
       "community": 66,
@@ -96666,6 +96666,24 @@
     {
       "community": 660,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_services_serviceintakeview_test_tsx",
+      "label": "ServiceIntakeView.test.tsx",
+      "norm_label": "serviceintakeview.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceIntakeView.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 660,
+      "file_type": "code",
+      "id": "serviceintakeview_test_chooseselectoption",
+      "label": "chooseSelectOption()",
+      "norm_label": "chooseselectoption()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceIntakeView.test.tsx",
+      "source_location": "L47"
+    },
+    {
+      "community": 661,
+      "file_type": "code",
       "id": "empty_state_onclick",
       "label": "onClick()",
       "norm_label": "onclick()",
@@ -96673,7 +96691,7 @@
       "source_location": "L29"
     },
     {
-      "community": 660,
+      "community": 661,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_empty_empty_state_tsx",
       "label": "empty-state.tsx",
@@ -96682,7 +96700,7 @@
       "source_location": "L1"
     },
     {
-      "community": 661,
+      "community": 662,
       "file_type": "code",
       "id": "nopermission_nopermission",
       "label": "NoPermission()",
@@ -96691,7 +96709,7 @@
       "source_location": "L3"
     },
     {
-      "community": 661,
+      "community": 662,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_no_permission_nopermission_tsx",
       "label": "NoPermission.tsx",
@@ -96700,7 +96718,7 @@
       "source_location": "L1"
     },
     {
-      "community": 662,
+      "community": 663,
       "file_type": "code",
       "id": "nopermissionview_nopermissionview",
       "label": "NoPermissionView()",
@@ -96709,7 +96727,7 @@
       "source_location": "L4"
     },
     {
-      "community": 662,
+      "community": 663,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_no_permission_nopermissionview_tsx",
       "label": "NoPermissionView.tsx",
@@ -96718,7 +96736,7 @@
       "source_location": "L1"
     },
     {
-      "community": 663,
+      "community": 664,
       "file_type": "code",
       "id": "notfoundview_notfoundview",
       "label": "NotFoundView()",
@@ -96727,7 +96745,7 @@
       "source_location": "L4"
     },
     {
-      "community": 663,
+      "community": 664,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_not_found_notfoundview_tsx",
       "label": "NotFoundView.tsx",
@@ -96736,7 +96754,7 @@
       "source_location": "L1"
     },
     {
-      "community": 664,
+      "community": 665,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_signed_out_protectedadminsigninview_tsx",
       "label": "ProtectedAdminSignInView.tsx",
@@ -96745,7 +96763,7 @@
       "source_location": "L1"
     },
     {
-      "community": 664,
+      "community": 665,
       "file_type": "code",
       "id": "protectedadminsigninview_protectedadminsigninview",
       "label": "ProtectedAdminSignInView()",
@@ -96754,7 +96772,7 @@
       "source_location": "L9"
     },
     {
-      "community": 665,
+      "community": 666,
       "file_type": "code",
       "id": "contactview_contactview",
       "label": "ContactView()",
@@ -96763,7 +96781,7 @@
       "source_location": "L9"
     },
     {
-      "community": 665,
+      "community": 666,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_contactview_tsx",
       "label": "ContactView.tsx",
@@ -96772,7 +96790,7 @@
       "source_location": "L1"
     },
     {
-      "community": 666,
+      "community": 667,
       "file_type": "code",
       "id": "header_header",
       "label": "Header()",
@@ -96781,7 +96799,7 @@
       "source_location": "L1"
     },
     {
-      "community": 666,
+      "community": 667,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_header_tsx",
       "label": "Header.tsx",
@@ -96790,7 +96808,7 @@
       "source_location": "L1"
     },
     {
-      "community": 667,
+      "community": 668,
       "file_type": "code",
       "id": "maintenanceview_maintenanceview",
       "label": "MaintenanceView()",
@@ -96799,7 +96817,7 @@
       "source_location": "L11"
     },
     {
-      "community": 667,
+      "community": 668,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_maintenanceview_tsx",
       "label": "MaintenanceView.tsx",
@@ -96808,7 +96826,7 @@
       "source_location": "L1"
     },
     {
-      "community": 668,
+      "community": 669,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_taxview_tsx",
       "label": "TaxView.tsx",
@@ -96817,31 +96835,13 @@
       "source_location": "L1"
     },
     {
-      "community": 668,
+      "community": 669,
       "file_type": "code",
       "id": "taxview_handleupdatetaxsettings",
       "label": "handleUpdateTaxSettings()",
       "norm_label": "handleupdatetaxsettings()",
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/TaxView.tsx",
       "source_location": "L25"
-    },
-    {
-      "community": 669,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_store_configuration_hooks_usestoreconfigupdate_ts",
-      "label": "useStoreConfigUpdate.ts",
-      "norm_label": "usestoreconfigupdate.ts",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/hooks/useStoreConfigUpdate.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 669,
-      "file_type": "code",
-      "id": "usestoreconfigupdate_usestoreconfigupdate",
-      "label": "useStoreConfigUpdate()",
-      "norm_label": "usestoreconfigupdate()",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/hooks/useStoreConfigUpdate.ts",
-      "source_location": "L21"
     },
     {
       "community": 67,
@@ -96954,6 +96954,24 @@
     {
       "community": 670,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_store_configuration_hooks_usestoreconfigupdate_ts",
+      "label": "useStoreConfigUpdate.ts",
+      "norm_label": "usestoreconfigupdate.ts",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/hooks/useStoreConfigUpdate.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 670,
+      "file_type": "code",
+      "id": "usestoreconfigupdate_usestoreconfigupdate",
+      "label": "useStoreConfigUpdate()",
+      "norm_label": "usestoreconfigupdate()",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/hooks/useStoreConfigUpdate.ts",
+      "source_location": "L21"
+    },
+    {
+      "community": 671,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_switcher_tsx",
       "label": "store-switcher.tsx",
       "norm_label": "store-switcher.tsx",
@@ -96961,7 +96979,7 @@
       "source_location": "L1"
     },
     {
-      "community": 670,
+      "community": 671,
       "file_type": "code",
       "id": "store_switcher_onstoreselect",
       "label": "onStoreSelect()",
@@ -96970,7 +96988,7 @@
       "source_location": "L63"
     },
     {
-      "community": 671,
+      "community": 672,
       "file_type": "code",
       "id": "chart_usechart",
       "label": "useChart()",
@@ -96979,7 +96997,7 @@
       "source_location": "L25"
     },
     {
-      "community": 671,
+      "community": 672,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_chart_tsx",
       "label": "chart.tsx",
@@ -96988,7 +97006,7 @@
       "source_location": "L1"
     },
     {
-      "community": 672,
+      "community": 673,
       "file_type": "code",
       "id": "copy_button_handlecopy",
       "label": "handleCopy()",
@@ -96997,7 +97015,7 @@
       "source_location": "L15"
     },
     {
-      "community": 672,
+      "community": 673,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_copy_button_tsx",
       "label": "copy-button.tsx",
@@ -97006,7 +97024,7 @@
       "source_location": "L1"
     },
     {
-      "community": 673,
+      "community": 674,
       "file_type": "code",
       "id": "copy_wrapper_handlecopy",
       "label": "handleCopy()",
@@ -97015,7 +97033,7 @@
       "source_location": "L21"
     },
     {
-      "community": 673,
+      "community": 674,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_copy_wrapper_tsx",
       "label": "copy-wrapper.tsx",
@@ -97024,7 +97042,7 @@
       "source_location": "L1"
     },
     {
-      "community": 674,
+      "community": 675,
       "file_type": "code",
       "id": "label_label",
       "label": "Label()",
@@ -97033,7 +97051,7 @@
       "source_location": "L6"
     },
     {
-      "community": 674,
+      "community": 675,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_label_tsx",
       "label": "label.tsx",
@@ -97042,7 +97060,7 @@
       "source_location": "L1"
     },
     {
-      "community": 675,
+      "community": 676,
       "file_type": "code",
       "id": "custom_modal_custommodal",
       "label": "CustomModal()",
@@ -97051,7 +97069,7 @@
       "source_location": "L25"
     },
     {
-      "community": 675,
+      "community": 676,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_custom_modal_tsx",
       "label": "custom-modal.tsx",
@@ -97060,7 +97078,7 @@
       "source_location": "L1"
     },
     {
-      "community": 676,
+      "community": 677,
       "file_type": "code",
       "id": "organization_modal_onsubmit",
       "label": "onSubmit()",
@@ -97069,7 +97087,7 @@
       "source_location": "L49"
     },
     {
-      "community": 676,
+      "community": 677,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_organization_modal_tsx",
       "label": "organization-modal.tsx",
@@ -97078,7 +97096,7 @@
       "source_location": "L1"
     },
     {
-      "community": 677,
+      "community": 678,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_store_modal_tsx",
       "label": "store-modal.tsx",
@@ -97087,7 +97105,7 @@
       "source_location": "L1"
     },
     {
-      "community": 677,
+      "community": 678,
       "file_type": "code",
       "id": "store_modal_onsubmit",
       "label": "onSubmit()",
@@ -97096,7 +97114,7 @@
       "source_location": "L63"
     },
     {
-      "community": 678,
+      "community": 679,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_welcome_back_modal_example_tsx",
       "label": "welcome-back-modal-example.tsx",
@@ -97105,31 +97123,13 @@
       "source_location": "L1"
     },
     {
-      "community": 678,
+      "community": 679,
       "file_type": "code",
       "id": "welcome_back_modal_example_welcomebackmodalexample",
       "label": "WelcomeBackModalExample()",
       "norm_label": "welcomebackmodalexample()",
       "source_file": "packages/athena-webapp/src/components/ui/modals/welcome-back-modal-example.tsx",
       "source_location": "L5"
-    },
-    {
-      "community": 679,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_modals_welcome_back_modal_tsx",
-      "label": "welcome-back-modal.tsx",
-      "norm_label": "welcome-back-modal.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/modals/welcome-back-modal.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 679,
-      "file_type": "code",
-      "id": "welcome_back_modal_welcomebackmodal",
-      "label": "WelcomeBackModal()",
-      "norm_label": "welcomebackmodal()",
-      "source_file": "packages/athena-webapp/src/components/ui/modals/welcome-back-modal.tsx",
-      "source_location": "L12"
     },
     {
       "community": 68,
@@ -97242,6 +97242,24 @@
     {
       "community": 680,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_modals_welcome_back_modal_tsx",
+      "label": "welcome-back-modal.tsx",
+      "norm_label": "welcome-back-modal.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/modals/welcome-back-modal.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 680,
+      "file_type": "code",
+      "id": "welcome_back_modal_welcomebackmodal",
+      "label": "WelcomeBackModal()",
+      "norm_label": "welcomebackmodal()",
+      "source_file": "packages/athena-webapp/src/components/ui/modals/welcome-back-modal.tsx",
+      "source_location": "L12"
+    },
+    {
+      "community": 681,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_select_native_tsx",
       "label": "select-native.tsx",
       "norm_label": "select-native.tsx",
@@ -97249,7 +97267,7 @@
       "source_location": "L1"
     },
     {
-      "community": 680,
+      "community": 681,
       "file_type": "code",
       "id": "select_native_cn",
       "label": "cn()",
@@ -97258,7 +97276,7 @@
       "source_location": "L15"
     },
     {
-      "community": 681,
+      "community": 682,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_timeline_item_tsx",
       "label": "timeline-item.tsx",
@@ -97267,7 +97285,7 @@
       "source_location": "L1"
     },
     {
-      "community": 681,
+      "community": 682,
       "file_type": "code",
       "id": "timeline_item_timelineitem",
       "label": "TimelineItem()",
@@ -97276,7 +97294,7 @@
       "source_location": "L3"
     },
     {
-      "community": 682,
+      "community": 683,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_webp_image_tsx",
       "label": "webp-image.tsx",
@@ -97285,7 +97303,7 @@
       "source_location": "L1"
     },
     {
-      "community": 682,
+      "community": 683,
       "file_type": "code",
       "id": "webp_image_webpimage",
       "label": "WebpImage()",
@@ -97294,7 +97312,7 @@
       "source_location": "L1"
     },
     {
-      "community": 683,
+      "community": 684,
       "file_type": "code",
       "id": "bagitems_bagitems",
       "label": "BagItems()",
@@ -97303,7 +97321,7 @@
       "source_location": "L5"
     },
     {
-      "community": 683,
+      "community": 684,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_bagitems_tsx",
       "label": "BagItems.tsx",
@@ -97312,7 +97330,7 @@
       "source_location": "L1"
     },
     {
-      "community": 684,
+      "community": 685,
       "file_type": "code",
       "id": "bagitemsview_bagitemsview",
       "label": "BagItemsView()",
@@ -97321,7 +97339,7 @@
       "source_location": "L11"
     },
     {
-      "community": 684,
+      "community": 685,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_bagitemsview_tsx",
       "label": "BagItemsView.tsx",
@@ -97330,7 +97348,7 @@
       "source_location": "L1"
     },
     {
-      "community": 685,
+      "community": 686,
       "file_type": "code",
       "id": "bags_bags",
       "label": "Bags()",
@@ -97339,7 +97357,7 @@
       "source_location": "L4"
     },
     {
-      "community": 685,
+      "community": 686,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_bags_tsx",
       "label": "Bags.tsx",
@@ -97348,7 +97366,7 @@
       "source_location": "L1"
     },
     {
-      "community": 686,
+      "community": 687,
       "file_type": "code",
       "id": "customerbehaviortimeline_string",
       "label": "String()",
@@ -97357,7 +97375,7 @@
       "source_location": "L102"
     },
     {
-      "community": 686,
+      "community": 687,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_customerbehaviortimeline_tsx",
       "label": "CustomerBehaviorTimeline.tsx",
@@ -97366,7 +97384,7 @@
       "source_location": "L1"
     },
     {
-      "community": 687,
+      "community": 688,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_useranalyticsname_tsx",
       "label": "UserAnalyticsName.tsx",
@@ -97375,7 +97393,7 @@
       "source_location": "L1"
     },
     {
-      "community": 687,
+      "community": 688,
       "file_type": "code",
       "id": "useranalyticsname_useranalyticsname",
       "label": "UserAnalyticsName()",
@@ -97384,7 +97402,7 @@
       "source_location": "L13"
     },
     {
-      "community": 688,
+      "community": 689,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_userbag_tsx",
       "label": "UserBag.tsx",
@@ -97393,31 +97411,13 @@
       "source_location": "L1"
     },
     {
-      "community": 688,
+      "community": 689,
       "file_type": "code",
       "id": "userbag_userbag",
       "label": "UserBag()",
       "norm_label": "userbag()",
       "source_file": "packages/athena-webapp/src/components/users/UserBag.tsx",
       "source_location": "L7"
-    },
-    {
-      "community": 689,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_users_useronlineorders_tsx",
-      "label": "UserOnlineOrders.tsx",
-      "norm_label": "useronlineorders.tsx",
-      "source_file": "packages/athena-webapp/src/components/users/UserOnlineOrders.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 689,
-      "file_type": "code",
-      "id": "useronlineorders_useronlineorders",
-      "label": "UserOnlineOrders()",
-      "norm_label": "useronlineorders()",
-      "source_file": "packages/athena-webapp/src/components/users/UserOnlineOrders.tsx",
-      "source_location": "L11"
     },
     {
       "community": 69,
@@ -97530,6 +97530,24 @@
     {
       "community": 690,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_users_useronlineorders_tsx",
+      "label": "UserOnlineOrders.tsx",
+      "norm_label": "useronlineorders.tsx",
+      "source_file": "packages/athena-webapp/src/components/users/UserOnlineOrders.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 690,
+      "file_type": "code",
+      "id": "useronlineorders_useronlineorders",
+      "label": "UserOnlineOrders()",
+      "norm_label": "useronlineorders()",
+      "source_file": "packages/athena-webapp/src/components/users/UserOnlineOrders.tsx",
+      "source_location": "L11"
+    },
+    {
+      "community": 691,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_userstatus_tsx",
       "label": "UserStatus.tsx",
       "norm_label": "userstatus.tsx",
@@ -97537,7 +97555,7 @@
       "source_location": "L1"
     },
     {
-      "community": 690,
+      "community": 691,
       "file_type": "code",
       "id": "userstatus_userstatus",
       "label": "UserStatus()",
@@ -97546,7 +97564,7 @@
       "source_location": "L7"
     },
     {
-      "community": 691,
+      "community": 692,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_userview_tsx",
       "label": "UserView.tsx",
@@ -97555,7 +97573,7 @@
       "source_location": "L1"
     },
     {
-      "community": 691,
+      "community": 692,
       "file_type": "code",
       "id": "userview_useractions",
       "label": "UserActions()",
@@ -97564,7 +97582,7 @@
       "source_location": "L45"
     },
     {
-      "community": 692,
+      "community": 693,
       "file_type": "code",
       "id": "customerjourneystage_customerjourneystagecard",
       "label": "CustomerJourneyStageCard()",
@@ -97573,7 +97591,7 @@
       "source_location": "L13"
     },
     {
-      "community": 692,
+      "community": 693,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_customerjourneystage_tsx",
       "label": "CustomerJourneyStage.tsx",
@@ -97582,7 +97600,7 @@
       "source_location": "L1"
     },
     {
-      "community": 693,
+      "community": 694,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_image_upload_ts",
       "label": "use-image-upload.ts",
@@ -97591,7 +97609,7 @@
       "source_location": "L1"
     },
     {
-      "community": 693,
+      "community": 694,
       "file_type": "code",
       "id": "use_image_upload_useimageupload",
       "label": "useImageUpload()",
@@ -97600,7 +97618,7 @@
       "source_location": "L7"
     },
     {
-      "community": 694,
+      "community": 695,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_mobile_tsx",
       "label": "use-mobile.tsx",
@@ -97609,7 +97627,7 @@
       "source_location": "L1"
     },
     {
-      "community": 694,
+      "community": 695,
       "file_type": "code",
       "id": "use_mobile_useismobile",
       "label": "useIsMobile()",
@@ -97618,7 +97636,7 @@
       "source_location": "L5"
     },
     {
-      "community": 695,
+      "community": 696,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_navigate_back_ts",
       "label": "use-navigate-back.ts",
@@ -97627,7 +97645,7 @@
       "source_location": "L1"
     },
     {
-      "community": 695,
+      "community": 696,
       "file_type": "code",
       "id": "use_navigate_back_usenavigateback",
       "label": "useNavigateBack()",
@@ -97636,7 +97654,7 @@
       "source_location": "L5"
     },
     {
-      "community": 696,
+      "community": 697,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_navigation_keyboard_shortcuts_ts",
       "label": "use-navigation-keyboard-shortcuts.ts",
@@ -97645,7 +97663,7 @@
       "source_location": "L1"
     },
     {
-      "community": 696,
+      "community": 697,
       "file_type": "code",
       "id": "use_navigation_keyboard_shortcuts_usenavigationkeyboardshortcuts",
       "label": "useNavigationKeyboardShortcuts()",
@@ -97654,7 +97672,7 @@
       "source_location": "L7"
     },
     {
-      "community": 697,
+      "community": 698,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_pagination_persistence_ts",
       "label": "use-pagination-persistence.ts",
@@ -97663,7 +97681,7 @@
       "source_location": "L1"
     },
     {
-      "community": 697,
+      "community": 698,
       "file_type": "code",
       "id": "use_pagination_persistence_usepaginationpersistence",
       "label": "usePaginationPersistence()",
@@ -97672,7 +97690,7 @@
       "source_location": "L11"
     },
     {
-      "community": 698,
+      "community": 699,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_table_keyboard_pagination_ts",
       "label": "use-table-keyboard-pagination.ts",
@@ -97681,31 +97699,13 @@
       "source_location": "L1"
     },
     {
-      "community": 698,
+      "community": 699,
       "file_type": "code",
       "id": "use_table_keyboard_pagination_usetablekeyboardpagination",
       "label": "useTableKeyboardPagination()",
       "norm_label": "usetablekeyboardpagination()",
       "source_file": "packages/athena-webapp/src/hooks/use-table-keyboard-pagination.ts",
       "source_location": "L6"
-    },
-    {
-      "community": 699,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_usebulkoperations_test_ts",
-      "label": "useBulkOperations.test.ts",
-      "norm_label": "usebulkoperations.test.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 699,
-      "file_type": "code",
-      "id": "usebulkoperations_test_makesku",
-      "label": "makeSku()",
-      "norm_label": "makesku()",
-      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.test.ts",
-      "source_location": "L189"
     },
     {
       "community": 7,
@@ -98106,6 +98106,24 @@
     {
       "community": 700,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_usebulkoperations_test_ts",
+      "label": "useBulkOperations.test.ts",
+      "norm_label": "usebulkoperations.test.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 700,
+      "file_type": "code",
+      "id": "usebulkoperations_test_makesku",
+      "label": "makeSku()",
+      "norm_label": "makesku()",
+      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.test.ts",
+      "source_location": "L189"
+    },
+    {
+      "community": 701,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useconvexauthidentity_ts",
       "label": "useConvexAuthIdentity.ts",
       "norm_label": "useconvexauthidentity.ts",
@@ -98113,7 +98131,7 @@
       "source_location": "L1"
     },
     {
-      "community": 700,
+      "community": 701,
       "file_type": "code",
       "id": "useconvexauthidentity_useconvexauthidentity",
       "label": "useConvexAuthIdentity()",
@@ -98122,7 +98140,7 @@
       "source_location": "L5"
     },
     {
-      "community": 701,
+      "community": 702,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usecopytext_ts",
       "label": "useCopyText.ts",
@@ -98131,7 +98149,7 @@
       "source_location": "L1"
     },
     {
-      "community": 701,
+      "community": 702,
       "file_type": "code",
       "id": "usecopytext_usecopytext",
       "label": "useCopyText()",
@@ -98140,7 +98158,7 @@
       "source_location": "L1"
     },
     {
-      "community": 702,
+      "community": 703,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usecreatecomplimentaryproduct_ts",
       "label": "useCreateComplimentaryProduct.ts",
@@ -98149,7 +98167,7 @@
       "source_location": "L1"
     },
     {
-      "community": 702,
+      "community": 703,
       "file_type": "code",
       "id": "usecreatecomplimentaryproduct_usecreatecomplimentaryproduct",
       "label": "useCreateComplimentaryProduct()",
@@ -98158,7 +98176,7 @@
       "source_location": "L6"
     },
     {
-      "community": 703,
+      "community": 704,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usedebounce_ts",
       "label": "useDebounce.ts",
@@ -98167,7 +98185,7 @@
       "source_location": "L1"
     },
     {
-      "community": 703,
+      "community": 704,
       "file_type": "code",
       "id": "usedebounce_usedebounce",
       "label": "useDebounce()",
@@ -98176,7 +98194,7 @@
       "source_location": "L12"
     },
     {
-      "community": 704,
+      "community": 705,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetactiveproduct_ts",
       "label": "useGetActiveProduct.ts",
@@ -98185,7 +98203,7 @@
       "source_location": "L1"
     },
     {
-      "community": 704,
+      "community": 705,
       "file_type": "code",
       "id": "usegetactiveproduct_usegetactiveproduct",
       "label": "useGetActiveProduct()",
@@ -98194,7 +98212,7 @@
       "source_location": "L6"
     },
     {
-      "community": 705,
+      "community": 706,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetautheduser_ts",
       "label": "useGetAuthedUser.ts",
@@ -98203,7 +98221,7 @@
       "source_location": "L1"
     },
     {
-      "community": 705,
+      "community": 706,
       "file_type": "code",
       "id": "usegetautheduser_usegetautheduser",
       "label": "useGetAuthedUser()",
@@ -98212,7 +98230,7 @@
       "source_location": "L4"
     },
     {
-      "community": 706,
+      "community": 707,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetcategories_ts",
       "label": "useGetCategories.ts",
@@ -98221,7 +98239,7 @@
       "source_location": "L1"
     },
     {
-      "community": 706,
+      "community": 707,
       "file_type": "code",
       "id": "usegetcategories_usegetcategories",
       "label": "useGetCategories()",
@@ -98230,7 +98248,7 @@
       "source_location": "L5"
     },
     {
-      "community": 707,
+      "community": 708,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetcomplimentaryproducts_ts",
       "label": "useGetComplimentaryProducts.ts",
@@ -98239,7 +98257,7 @@
       "source_location": "L1"
     },
     {
-      "community": 707,
+      "community": 708,
       "file_type": "code",
       "id": "usegetcomplimentaryproducts_usegetcomplimentaryproducts",
       "label": "useGetComplimentaryProducts()",
@@ -98248,7 +98266,7 @@
       "source_location": "L5"
     },
     {
-      "community": 708,
+      "community": 709,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetcurrencyformatter_ts",
       "label": "useGetCurrencyFormatter.ts",
@@ -98257,31 +98275,13 @@
       "source_location": "L1"
     },
     {
-      "community": 708,
+      "community": 709,
       "file_type": "code",
       "id": "usegetcurrencyformatter_usegetcurrencyformatter",
       "label": "useGetCurrencyFormatter()",
       "norm_label": "usegetcurrencyformatter()",
       "source_file": "packages/athena-webapp/src/hooks/useGetCurrencyFormatter.ts",
       "source_location": "L4"
-    },
-    {
-      "community": 709,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_usegetsubcategories_ts",
-      "label": "useGetSubcategories.ts",
-      "norm_label": "usegetsubcategories.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useGetSubcategories.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 709,
-      "file_type": "code",
-      "id": "usegetsubcategories_usegetsubcategories",
-      "label": "useGetSubcategories()",
-      "norm_label": "usegetsubcategories()",
-      "source_file": "packages/athena-webapp/src/hooks/useGetSubcategories.ts",
-      "source_location": "L5"
     },
     {
       "community": 71,
@@ -98385,6 +98385,24 @@
     {
       "community": 710,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_usegetsubcategories_ts",
+      "label": "useGetSubcategories.ts",
+      "norm_label": "usegetsubcategories.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useGetSubcategories.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 710,
+      "file_type": "code",
+      "id": "usegetsubcategories_usegetsubcategories",
+      "label": "useGetSubcategories()",
+      "norm_label": "usegetsubcategories()",
+      "source_file": "packages/athena-webapp/src/hooks/useGetSubcategories.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 711,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetterminal_ts",
       "label": "useGetTerminal.ts",
       "norm_label": "usegetterminal.ts",
@@ -98392,7 +98410,7 @@
       "source_location": "L1"
     },
     {
-      "community": 710,
+      "community": 711,
       "file_type": "code",
       "id": "usegetterminal_usegetterminal",
       "label": "useGetTerminal()",
@@ -98401,7 +98419,7 @@
       "source_location": "L5"
     },
     {
-      "community": 711,
+      "community": 712,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usenewordernotification_ts",
       "label": "useNewOrderNotification.ts",
@@ -98410,7 +98428,7 @@
       "source_location": "L1"
     },
     {
-      "community": 711,
+      "community": 712,
       "file_type": "code",
       "id": "usenewordernotification_usenewordernotification",
       "label": "useNewOrderNotification()",
@@ -98419,7 +98437,7 @@
       "source_location": "L8"
     },
     {
-      "community": 712,
+      "community": 713,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usepermissions_ts",
       "label": "usePermissions.ts",
@@ -98428,7 +98446,7 @@
       "source_location": "L1"
     },
     {
-      "community": 712,
+      "community": 713,
       "file_type": "code",
       "id": "usepermissions_usepermissions",
       "label": "usePermissions()",
@@ -98437,7 +98455,7 @@
       "source_location": "L13"
     },
     {
-      "community": 713,
+      "community": 714,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useprint_ts",
       "label": "usePrint.ts",
@@ -98446,7 +98464,7 @@
       "source_location": "L1"
     },
     {
-      "community": 713,
+      "community": 714,
       "file_type": "code",
       "id": "useprint_useprint",
       "label": "usePrint()",
@@ -98455,7 +98473,7 @@
       "source_location": "L3"
     },
     {
-      "community": 714,
+      "community": 715,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useproductsearchresults_ts",
       "label": "useProductSearchResults.ts",
@@ -98464,7 +98482,7 @@
       "source_location": "L1"
     },
     {
-      "community": 714,
+      "community": 715,
       "file_type": "code",
       "id": "useproductsearchresults_useproductsearchresults",
       "label": "useProductSearchResults()",
@@ -98473,7 +98491,7 @@
       "source_location": "L27"
     },
     {
-      "community": 715,
+      "community": 716,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useproductwithnoimagesnotification_tsx",
       "label": "useProductWithNoImagesNotification.tsx",
@@ -98482,7 +98500,7 @@
       "source_location": "L1"
     },
     {
-      "community": 715,
+      "community": 716,
       "file_type": "code",
       "id": "useproductwithnoimagesnotification_useproductwithnoimagesnotification",
       "label": "useProductWithNoImagesNotification()",
@@ -98491,7 +98509,7 @@
       "source_location": "L7"
     },
     {
-      "community": 716,
+      "community": 717,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useprotectedadminpagestate_ts",
       "label": "useProtectedAdminPageState.ts",
@@ -98500,7 +98518,7 @@
       "source_location": "L1"
     },
     {
-      "community": 716,
+      "community": 717,
       "file_type": "code",
       "id": "useprotectedadminpagestate_useprotectedadminpagestate",
       "label": "useProtectedAdminPageState()",
@@ -98509,7 +98527,7 @@
       "source_location": "L5"
     },
     {
-      "community": 717,
+      "community": 718,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useskusreservedincheckout_ts",
       "label": "useSkusReservedInCheckout.ts",
@@ -98518,7 +98536,7 @@
       "source_location": "L1"
     },
     {
-      "community": 717,
+      "community": 718,
       "file_type": "code",
       "id": "useskusreservedincheckout_useskusreservedincheckout",
       "label": "useSkusReservedInCheckout()",
@@ -98527,7 +98545,7 @@
       "source_location": "L12"
     },
     {
-      "community": 718,
+      "community": 719,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useskusreservedinpossession_ts",
       "label": "useSkusReservedInPosSession.ts",
@@ -98536,31 +98554,13 @@
       "source_location": "L1"
     },
     {
-      "community": 718,
+      "community": 719,
       "file_type": "code",
       "id": "useskusreservedinpossession_useskusreservedinpossession",
       "label": "useSkusReservedInPosSession()",
       "norm_label": "useskusreservedinpossession()",
       "source_file": "packages/athena-webapp/src/hooks/useSkusReservedInPosSession.ts",
       "source_location": "L12"
-    },
-    {
-      "community": 719,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_usetogglecomplimentaryproductactive_ts",
-      "label": "useToggleComplimentaryProductActive.ts",
-      "norm_label": "usetogglecomplimentaryproductactive.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useToggleComplimentaryProductActive.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 719,
-      "file_type": "code",
-      "id": "usetogglecomplimentaryproductactive_usetogglecomplimentaryproductactive",
-      "label": "useToggleComplimentaryProductActive()",
-      "norm_label": "usetogglecomplimentaryproductactive()",
-      "source_file": "packages/athena-webapp/src/hooks/useToggleComplimentaryProductActive.ts",
-      "source_location": "L5"
     },
     {
       "community": 72,
@@ -98664,6 +98664,24 @@
     {
       "community": 720,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_usetogglecomplimentaryproductactive_ts",
+      "label": "useToggleComplimentaryProductActive.ts",
+      "norm_label": "usetogglecomplimentaryproductactive.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useToggleComplimentaryProductActive.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 720,
+      "file_type": "code",
+      "id": "usetogglecomplimentaryproductactive_usetogglecomplimentaryproductactive",
+      "label": "useToggleComplimentaryProductActive()",
+      "norm_label": "usetogglecomplimentaryproductactive()",
+      "source_file": "packages/athena-webapp/src/hooks/useToggleComplimentaryProductActive.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 721,
+      "file_type": "code",
       "id": "operatormessages_tooperatormessage",
       "label": "toOperatorMessage()",
       "norm_label": "tooperatormessage()",
@@ -98671,7 +98689,7 @@
       "source_location": "L48"
     },
     {
-      "community": 720,
+      "community": 721,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_operatormessages_ts",
       "label": "operatorMessages.ts",
@@ -98680,7 +98698,7 @@
       "source_location": "L1"
     },
     {
-      "community": 721,
+      "community": 722,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_presentunexpectederrortoast_ts",
       "label": "presentUnexpectedErrorToast.ts",
@@ -98689,7 +98707,7 @@
       "source_location": "L1"
     },
     {
-      "community": 721,
+      "community": 722,
       "file_type": "code",
       "id": "presentunexpectederrortoast_presentunexpectederrortoast",
       "label": "presentUnexpectedErrorToast()",
@@ -98698,7 +98716,7 @@
       "source_location": "L7"
     },
     {
-      "community": 722,
+      "community": 723,
       "file_type": "code",
       "id": "navigationutils_getorigin",
       "label": "getOrigin()",
@@ -98707,7 +98725,7 @@
       "source_location": "L1"
     },
     {
-      "community": 722,
+      "community": 723,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_navigationutils_ts",
       "label": "navigationUtils.ts",
@@ -98716,7 +98734,7 @@
       "source_location": "L1"
     },
     {
-      "community": 723,
+      "community": 724,
       "file_type": "code",
       "id": "additem_additem",
       "label": "addItem()",
@@ -98725,7 +98743,7 @@
       "source_location": "L5"
     },
     {
-      "community": 723,
+      "community": 724,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_usecases_additem_ts",
       "label": "addItem.ts",
@@ -98734,7 +98752,7 @@
       "source_location": "L1"
     },
     {
-      "community": 724,
+      "community": 725,
       "file_type": "code",
       "id": "bootstrapregister_bootstrapregister",
       "label": "bootstrapRegister()",
@@ -98743,7 +98761,7 @@
       "source_location": "L6"
     },
     {
-      "community": 724,
+      "community": 725,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_usecases_bootstrapregister_ts",
       "label": "bootstrapRegister.ts",
@@ -98752,7 +98770,7 @@
       "source_location": "L1"
     },
     {
-      "community": 725,
+      "community": 726,
       "file_type": "code",
       "id": "holdsession_holdsession",
       "label": "holdSession()",
@@ -98761,7 +98779,7 @@
       "source_location": "L5"
     },
     {
-      "community": 725,
+      "community": 726,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_usecases_holdsession_ts",
       "label": "holdSession.ts",
@@ -98770,7 +98788,7 @@
       "source_location": "L1"
     },
     {
-      "community": 726,
+      "community": 727,
       "file_type": "code",
       "id": "opendrawer_opendrawer",
       "label": "openDrawer()",
@@ -98779,7 +98797,7 @@
       "source_location": "L5"
     },
     {
-      "community": 726,
+      "community": 727,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_usecases_opendrawer_ts",
       "label": "openDrawer.ts",
@@ -98788,7 +98806,7 @@
       "source_location": "L1"
     },
     {
-      "community": 727,
+      "community": 728,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_usecases_startsession_ts",
       "label": "startSession.ts",
@@ -98797,7 +98815,7 @@
       "source_location": "L1"
     },
     {
-      "community": 727,
+      "community": 728,
       "file_type": "code",
       "id": "startsession_startsession",
       "label": "startSession()",
@@ -98806,7 +98824,7 @@
       "source_location": "L5"
     },
     {
-      "community": 728,
+      "community": 729,
       "file_type": "code",
       "id": "calculations_calculatecarttotals",
       "label": "calculateCartTotals()",
@@ -98815,31 +98833,13 @@
       "source_location": "L10"
     },
     {
-      "community": 728,
+      "community": 729,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_calculations_ts",
       "label": "calculations.ts",
       "norm_label": "calculations.ts",
       "source_file": "packages/athena-webapp/src/lib/pos/calculations.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 729,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_presentation_register_useregistercatalogindex_ts",
-      "label": "useRegisterCatalogIndex.ts",
-      "norm_label": "useregistercatalogindex.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterCatalogIndex.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 729,
-      "file_type": "code",
-      "id": "useregistercatalogindex_useregistercatalogindex",
-      "label": "useRegisterCatalogIndex()",
-      "norm_label": "useregistercatalogindex()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterCatalogIndex.ts",
-      "source_location": "L8"
     },
     {
       "community": 73,
@@ -98943,6 +98943,24 @@
     {
       "community": 730,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_presentation_register_useregistercatalogindex_ts",
+      "label": "useRegisterCatalogIndex.ts",
+      "norm_label": "useregistercatalogindex.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterCatalogIndex.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 730,
+      "file_type": "code",
+      "id": "useregistercatalogindex_useregistercatalogindex",
+      "label": "useRegisterCatalogIndex()",
+      "norm_label": "useregistercatalogindex()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterCatalogIndex.ts",
+      "source_location": "L8"
+    },
+    {
+      "community": 731,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_lib_security_pinhash_ts",
       "label": "pinHash.ts",
       "norm_label": "pinhash.ts",
@@ -98950,7 +98968,7 @@
       "source_location": "L1"
     },
     {
-      "community": 730,
+      "community": 731,
       "file_type": "code",
       "id": "pinhash_hashpin",
       "label": "hashPin()",
@@ -98959,7 +98977,7 @@
       "source_location": "L12"
     },
     {
-      "community": 731,
+      "community": 732,
       "file_type": "code",
       "id": "index_hasorgnotfoundpayload",
       "label": "hasOrgNotFoundPayload()",
@@ -98968,7 +98986,7 @@
       "source_location": "L6"
     },
     {
-      "community": 731,
+      "community": 732,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_cash_controls_index_tsx",
       "label": "index.tsx",
@@ -98977,7 +98995,7 @@
       "source_location": "L1"
     },
     {
-      "community": 732,
+      "community": 733,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_cash_controls_registers_sessionid_tsx",
       "label": "$sessionId.tsx",
@@ -98986,7 +99004,7 @@
       "source_location": "L1"
     },
     {
-      "community": 732,
+      "community": 733,
       "file_type": "code",
       "id": "sessionid_hasorgnotfoundpayload",
       "label": "hasOrgNotFoundPayload()",
@@ -98995,7 +99013,7 @@
       "source_location": "L6"
     },
     {
-      "community": 733,
+      "community": 734,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_cash_controls_registers_index_tsx",
       "label": "registers.index.tsx",
@@ -99004,7 +99022,7 @@
       "source_location": "L1"
     },
     {
-      "community": 733,
+      "community": 734,
       "file_type": "code",
       "id": "registers_index_hasorgnotfoundpayload",
       "label": "hasOrgNotFoundPayload()",
@@ -99013,7 +99031,7 @@
       "source_location": "L6"
     },
     {
-      "community": 734,
+      "community": 735,
       "file_type": "code",
       "id": "index_storerootredirect",
       "label": "StoreRootRedirect()",
@@ -99022,7 +99040,7 @@
       "source_location": "L7"
     },
     {
-      "community": 734,
+      "community": 735,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_index_tsx",
       "label": "index.tsx",
@@ -99031,7 +99049,7 @@
       "source_location": "L1"
     },
     {
-      "community": 735,
+      "community": 736,
       "file_type": "code",
       "id": "approvals_approvalsroute",
       "label": "ApprovalsRoute()",
@@ -99040,7 +99058,7 @@
       "source_location": "L11"
     },
     {
-      "community": 735,
+      "community": 736,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_operations_approvals_tsx",
       "label": "approvals.tsx",
@@ -99049,7 +99067,7 @@
       "source_location": "L1"
     },
     {
-      "community": 736,
+      "community": 737,
       "file_type": "code",
       "id": "daily_close_history_dailyclosehistoryroute",
       "label": "DailyCloseHistoryRoute()",
@@ -99058,7 +99076,7 @@
       "source_location": "L11"
     },
     {
-      "community": 736,
+      "community": 737,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_operations_daily_close_history_tsx",
       "label": "daily-close-history.tsx",
@@ -99067,7 +99085,7 @@
       "source_location": "L1"
     },
     {
-      "community": 737,
+      "community": 738,
       "file_type": "code",
       "id": "daily_close_dailycloseroute",
       "label": "DailyCloseRoute()",
@@ -99076,7 +99094,7 @@
       "source_location": "L19"
     },
     {
-      "community": 737,
+      "community": 738,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_operations_daily_close_tsx",
       "label": "daily-close.tsx",
@@ -99085,7 +99103,7 @@
       "source_location": "L1"
     },
     {
-      "community": 738,
+      "community": 739,
       "file_type": "code",
       "id": "open_work_openworkroute",
       "label": "OpenWorkRoute()",
@@ -99094,30 +99112,12 @@
       "source_location": "L11"
     },
     {
-      "community": 738,
+      "community": 739,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_operations_open_work_tsx",
       "label": "open-work.tsx",
       "norm_label": "open-work.tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/open-work.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 739,
-      "file_type": "code",
-      "id": "opening_dailyopeningroute",
-      "label": "DailyOpeningRoute()",
-      "norm_label": "dailyopeningroute()",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/opening.tsx",
-      "source_location": "L11"
-    },
-    {
-      "community": 739,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_operations_opening_tsx",
-      "label": "opening.tsx",
-      "norm_label": "opening.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/opening.tsx",
       "source_location": "L1"
     },
     {
@@ -99222,6 +99222,24 @@
     {
       "community": 740,
       "file_type": "code",
+      "id": "opening_dailyopeningroute",
+      "label": "DailyOpeningRoute()",
+      "norm_label": "dailyopeningroute()",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/opening.tsx",
+      "source_location": "L11"
+    },
+    {
+      "community": 740,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_operations_opening_tsx",
+      "label": "opening.tsx",
+      "norm_label": "opening.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/opening.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 741,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_operations_stock_adjustments_tsx",
       "label": "stock-adjustments.tsx",
       "norm_label": "stock-adjustments.tsx",
@@ -99229,7 +99247,7 @@
       "source_location": "L1"
     },
     {
-      "community": 740,
+      "community": 741,
       "file_type": "code",
       "id": "stock_adjustments_stockadjustmentsroute",
       "label": "StockAdjustmentsRoute()",
@@ -99238,7 +99256,7 @@
       "source_location": "L25"
     },
     {
-      "community": 741,
+      "community": 742,
       "file_type": "code",
       "id": "expense_index_expenseroutecomponent",
       "label": "ExpenseRouteComponent()",
@@ -99247,7 +99265,7 @@
       "source_location": "L6"
     },
     {
-      "community": 741,
+      "community": 742,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_index_tsx",
       "label": "expense.index.tsx",
@@ -99256,7 +99274,7 @@
       "source_location": "L1"
     },
     {
-      "community": 742,
+      "community": 743,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reviews_published_index_tsx",
       "label": "published.index.tsx",
@@ -99265,7 +99283,7 @@
       "source_location": "L1"
     },
     {
-      "community": 742,
+      "community": 743,
       "file_type": "code",
       "id": "published_index_routecomponent",
       "label": "RouteComponent()",
@@ -99274,7 +99292,7 @@
       "source_location": "L9"
     },
     {
-      "community": 743,
+      "community": 744,
       "file_type": "code",
       "id": "index_index",
       "label": "Index()",
@@ -99283,7 +99301,7 @@
       "source_location": "L13"
     },
     {
-      "community": 743,
+      "community": 744,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_index_tsx",
       "label": "index.tsx",
@@ -99292,7 +99310,7 @@
       "source_location": "L1"
     },
     {
-      "community": 744,
+      "community": 745,
       "file_type": "code",
       "id": "layout_index_athenaloginreadyview",
       "label": "AthenaLoginReadyView()",
@@ -99301,7 +99319,7 @@
       "source_location": "L4"
     },
     {
-      "community": 744,
+      "community": 745,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_login_layout_index_tsx",
       "label": "_layout.index.tsx",
@@ -99310,7 +99328,7 @@
       "source_location": "L1"
     },
     {
-      "community": 745,
+      "community": 746,
       "file_type": "code",
       "id": "organizationssettingsaccordion_organizationsettingsaccordion",
       "label": "OrganizationSettingsAccordion()",
@@ -99319,7 +99337,7 @@
       "source_location": "L13"
     },
     {
-      "community": 745,
+      "community": 746,
       "file_type": "code",
       "id": "packages_athena_webapp_src_settings_organization_components_organizationssettingsaccordion_tsx",
       "label": "OrganizationsSettingsAccordion.tsx",
@@ -99328,7 +99346,7 @@
       "source_location": "L1"
     },
     {
-      "community": 746,
+      "community": 747,
       "file_type": "code",
       "id": "overview_stories_patternsoverview",
       "label": "PatternsOverview()",
@@ -99337,7 +99355,7 @@
       "source_location": "L5"
     },
     {
-      "community": 746,
+      "community": 747,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_patterns_overview_stories_tsx",
       "label": "Overview.stories.tsx",
@@ -99346,7 +99364,7 @@
       "source_location": "L1"
     },
     {
-      "community": 747,
+      "community": 748,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_patterns_view_patterns_tsx",
       "label": "view-patterns.tsx",
@@ -99355,7 +99373,7 @@
       "source_location": "L1"
     },
     {
-      "community": 747,
+      "community": 748,
       "file_type": "code",
       "id": "view_patterns_cn",
       "label": "cn()",
@@ -99364,7 +99382,7 @@
       "source_location": "L142"
     },
     {
-      "community": 748,
+      "community": 749,
       "file_type": "code",
       "id": "controls_stories_controlsshowcase",
       "label": "ControlsShowcase()",
@@ -99373,30 +99391,12 @@
       "source_location": "L17"
     },
     {
-      "community": 748,
+      "community": 749,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_controls_stories_tsx",
       "label": "Controls.stories.tsx",
       "norm_label": "controls.stories.tsx",
       "source_file": "packages/athena-webapp/src/stories/Primitives/Controls.stories.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 749,
-      "file_type": "code",
-      "id": "dialog_stories_dialogshowcase",
-      "label": "DialogShowcase()",
-      "norm_label": "dialogshowcase()",
-      "source_file": "packages/athena-webapp/src/stories/Primitives/Dialog.stories.tsx",
-      "source_location": "L15"
-    },
-    {
-      "community": 749,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_primitives_dialog_stories_tsx",
-      "label": "Dialog.stories.tsx",
-      "norm_label": "dialog.stories.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Primitives/Dialog.stories.tsx",
       "source_location": "L1"
     },
     {
@@ -99501,6 +99501,24 @@
     {
       "community": 750,
       "file_type": "code",
+      "id": "dialog_stories_dialogshowcase",
+      "label": "DialogShowcase()",
+      "norm_label": "dialogshowcase()",
+      "source_file": "packages/athena-webapp/src/stories/Primitives/Dialog.stories.tsx",
+      "source_location": "L15"
+    },
+    {
+      "community": 750,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_primitives_dialog_stories_tsx",
+      "label": "Dialog.stories.tsx",
+      "norm_label": "dialog.stories.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Primitives/Dialog.stories.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 751,
+      "file_type": "code",
       "id": "feedback_stories_feedbackshowcase",
       "label": "FeedbackShowcase()",
       "norm_label": "feedbackshowcase()",
@@ -99508,7 +99526,7 @@
       "source_location": "L12"
     },
     {
-      "community": 750,
+      "community": 751,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_feedback_stories_tsx",
       "label": "Feedback.stories.tsx",
@@ -99517,7 +99535,7 @@
       "source_location": "L1"
     },
     {
-      "community": 751,
+      "community": 752,
       "file_type": "code",
       "id": "overview_stories_primitivesoverview",
       "label": "PrimitivesOverview()",
@@ -99526,7 +99544,7 @@
       "source_location": "L5"
     },
     {
-      "community": 751,
+      "community": 752,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_overview_stories_tsx",
       "label": "Overview.stories.tsx",
@@ -99535,7 +99553,7 @@
       "source_location": "L1"
     },
     {
-      "community": 752,
+      "community": 753,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_popover_stories_tsx",
       "label": "Popover.stories.tsx",
@@ -99544,7 +99562,7 @@
       "source_location": "L1"
     },
     {
-      "community": 752,
+      "community": 753,
       "file_type": "code",
       "id": "popover_stories_popovershowcase",
       "label": "PopoverShowcase()",
@@ -99553,7 +99571,7 @@
       "source_location": "L13"
     },
     {
-      "community": 753,
+      "community": 754,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_sheet_stories_tsx",
       "label": "Sheet.stories.tsx",
@@ -99562,7 +99580,7 @@
       "source_location": "L1"
     },
     {
-      "community": 753,
+      "community": 754,
       "file_type": "code",
       "id": "sheet_stories_sheetshowcase",
       "label": "SheetShowcase()",
@@ -99571,7 +99589,7 @@
       "source_location": "L14"
     },
     {
-      "community": 754,
+      "community": 755,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_tooltip_stories_tsx",
       "label": "Tooltip.stories.tsx",
@@ -99580,7 +99598,7 @@
       "source_location": "L1"
     },
     {
-      "community": 754,
+      "community": 755,
       "file_type": "code",
       "id": "tooltip_stories_tooltipshowcase",
       "label": "TooltipShowcase()",
@@ -99589,7 +99607,7 @@
       "source_location": "L13"
     },
     {
-      "community": 755,
+      "community": 756,
       "file_type": "code",
       "id": "overview_stories_templatesoverview",
       "label": "TemplatesOverview()",
@@ -99598,7 +99616,7 @@
       "source_location": "L5"
     },
     {
-      "community": 755,
+      "community": 756,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_templates_overview_stories_tsx",
       "label": "Overview.stories.tsx",
@@ -99607,7 +99625,7 @@
       "source_location": "L1"
     },
     {
-      "community": 756,
+      "community": 757,
       "file_type": "code",
       "id": "formatnumber_formatnumber",
       "label": "formatNumber()",
@@ -99616,7 +99634,7 @@
       "source_location": "L1"
     },
     {
-      "community": 756,
+      "community": 757,
       "file_type": "code",
       "id": "packages_athena_webapp_src_utils_formatnumber_ts",
       "label": "formatNumber.ts",
@@ -99625,7 +99643,7 @@
       "source_location": "L1"
     },
     {
-      "community": 757,
+      "community": 758,
       "file_type": "code",
       "id": "bannermessage_getbannermessage",
       "label": "getBannerMessage()",
@@ -99634,7 +99652,7 @@
       "source_location": "L4"
     },
     {
-      "community": 757,
+      "community": 758,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_bannermessage_ts",
       "label": "bannerMessage.ts",
@@ -99643,7 +99661,7 @@
       "source_location": "L1"
     },
     {
-      "community": 758,
+      "community": 759,
       "file_type": "code",
       "id": "checkoutsession_test_jsonresponse",
       "label": "jsonResponse()",
@@ -99652,30 +99670,12 @@
       "source_location": "L27"
     },
     {
-      "community": 758,
+      "community": 759,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_checkoutsession_test_ts",
       "label": "checkoutSession.test.ts",
       "norm_label": "checkoutsession.test.ts",
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 759,
-      "file_type": "code",
-      "id": "guest_updateguest",
-      "label": "updateGuest()",
-      "norm_label": "updateguest()",
-      "source_file": "packages/storefront-webapp/src/api/guest.ts",
-      "source_location": "L4"
-    },
-    {
-      "community": 759,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_guest_ts",
-      "label": "guest.ts",
-      "norm_label": "guest.ts",
-      "source_file": "packages/storefront-webapp/src/api/guest.ts",
       "source_location": "L1"
     },
     {
@@ -99780,6 +99780,24 @@
     {
       "community": 760,
       "file_type": "code",
+      "id": "guest_updateguest",
+      "label": "updateGuest()",
+      "norm_label": "updateguest()",
+      "source_file": "packages/storefront-webapp/src/api/guest.ts",
+      "source_location": "L4"
+    },
+    {
+      "community": 760,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_api_guest_ts",
+      "label": "guest.ts",
+      "norm_label": "guest.ts",
+      "source_file": "packages/storefront-webapp/src/api/guest.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 761,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_api_postransaction_test_ts",
       "label": "posTransaction.test.ts",
       "norm_label": "postransaction.test.ts",
@@ -99787,7 +99805,7 @@
       "source_location": "L1"
     },
     {
-      "community": 760,
+      "community": 761,
       "file_type": "code",
       "id": "postransaction_test_jsonresponse",
       "label": "jsonResponse()",
@@ -99796,7 +99814,7 @@
       "source_location": "L10"
     },
     {
-      "community": 761,
+      "community": 762,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_storefront_ts",
       "label": "storefront.ts",
@@ -99805,7 +99823,7 @@
       "source_location": "L1"
     },
     {
-      "community": 761,
+      "community": 762,
       "file_type": "code",
       "id": "storefront_getstore",
       "label": "getStore()",
@@ -99814,7 +99832,7 @@
       "source_location": "L5"
     },
     {
-      "community": 762,
+      "community": 763,
       "file_type": "code",
       "id": "entitypage_entitypage",
       "label": "EntityPage()",
@@ -99823,7 +99841,7 @@
       "source_location": "L10"
     },
     {
-      "community": 762,
+      "community": 763,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_entitypage_tsx",
       "label": "EntityPage.tsx",
@@ -99832,7 +99850,7 @@
       "source_location": "L1"
     },
     {
-      "community": 763,
+      "community": 764,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_productspage_tsx",
       "label": "ProductsPage.tsx",
@@ -99841,7 +99859,7 @@
       "source_location": "L1"
     },
     {
-      "community": 763,
+      "community": 764,
       "file_type": "code",
       "id": "productspage_productcardloadingskeleton",
       "label": "ProductCardLoadingSkeleton()",
@@ -99850,7 +99868,7 @@
       "source_location": "L10"
     },
     {
-      "community": 764,
+      "community": 765,
       "file_type": "code",
       "id": "auth_authcomponent",
       "label": "AuthComponent()",
@@ -99859,7 +99877,7 @@
       "source_location": "L4"
     },
     {
-      "community": 764,
+      "community": 765,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_auth_auth_tsx",
       "label": "Auth.tsx",
@@ -99868,7 +99886,7 @@
       "source_location": "L1"
     },
     {
-      "community": 765,
+      "community": 766,
       "file_type": "code",
       "id": "bagsummary_tobagsummaryitems",
       "label": "toBagSummaryItems()",
@@ -99877,7 +99895,7 @@
       "source_location": "L39"
     },
     {
-      "community": 765,
+      "community": 766,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_bagsummary_tsx",
       "label": "BagSummary.tsx",
@@ -99886,7 +99904,7 @@
       "source_location": "L1"
     },
     {
-      "community": 766,
+      "community": 767,
       "file_type": "code",
       "id": "checkoutform_checkoutform",
       "label": "CheckoutForm()",
@@ -99895,7 +99913,7 @@
       "source_location": "L18"
     },
     {
-      "community": 766,
+      "community": 767,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkoutform_tsx",
       "label": "CheckoutForm.tsx",
@@ -99904,7 +99922,7 @@
       "source_location": "L1"
     },
     {
-      "community": 767,
+      "community": 768,
       "file_type": "code",
       "id": "checkoutprovider_checkoutprovider",
       "label": "CheckoutProvider()",
@@ -99913,7 +99931,7 @@
       "source_location": "L71"
     },
     {
-      "community": 767,
+      "community": 768,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkoutprovider_tsx",
       "label": "CheckoutProvider.tsx",
@@ -99922,7 +99940,7 @@
       "source_location": "L1"
     },
     {
-      "community": 768,
+      "community": 769,
       "file_type": "code",
       "id": "enteredbillingaddressdetails_enteredbillingaddressdetails",
       "label": "EnteredBillingAddressDetails()",
@@ -99931,30 +99949,12 @@
       "source_location": "L6"
     },
     {
-      "community": 768,
+      "community": 769,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_enteredbillingaddressdetails_tsx",
       "label": "EnteredBillingAddressDetails.tsx",
       "norm_label": "enteredbillingaddressdetails.tsx",
       "source_file": "packages/storefront-webapp/src/components/checkout/EnteredBillingAddressDetails.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 769,
-      "file_type": "code",
-      "id": "ordersummary_ordersummary",
-      "label": "OrderSummary()",
-      "norm_label": "ordersummary()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/OrderDetails/OrderSummary.tsx",
-      "source_location": "L18"
-    },
-    {
-      "community": 769,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_orderdetails_ordersummary_tsx",
-      "label": "OrderSummary.tsx",
-      "norm_label": "ordersummary.tsx",
-      "source_file": "packages/storefront-webapp/src/components/checkout/OrderDetails/OrderSummary.tsx",
       "source_location": "L1"
     },
     {
@@ -100050,6 +100050,24 @@
     {
       "community": 770,
       "file_type": "code",
+      "id": "ordersummary_ordersummary",
+      "label": "OrderSummary()",
+      "norm_label": "ordersummary()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/OrderDetails/OrderSummary.tsx",
+      "source_location": "L18"
+    },
+    {
+      "community": 770,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_orderdetails_ordersummary_tsx",
+      "label": "OrderSummary.tsx",
+      "norm_label": "ordersummary.tsx",
+      "source_file": "packages/storefront-webapp/src/components/checkout/OrderDetails/OrderSummary.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 771,
+      "file_type": "code",
       "id": "index_pickupdetails",
       "label": "PickupDetails()",
       "norm_label": "pickupdetails()",
@@ -100057,7 +100075,7 @@
       "source_location": "L11"
     },
     {
-      "community": 770,
+      "community": 771,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_orderdetails_index_tsx",
       "label": "index.tsx",
@@ -100066,7 +100084,7 @@
       "source_location": "L1"
     },
     {
-      "community": 771,
+      "community": 772,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_paymentmethodsection_tsx",
       "label": "PaymentMethodSection.tsx",
@@ -100075,7 +100093,7 @@
       "source_location": "L1"
     },
     {
-      "community": 771,
+      "community": 772,
       "file_type": "code",
       "id": "paymentmethodsection_paymentmethodsection",
       "label": "PaymentMethodSection()",
@@ -100084,7 +100102,7 @@
       "source_location": "L8"
     },
     {
-      "community": 772,
+      "community": 773,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_paymentsection_tsx",
       "label": "PaymentSection.tsx",
@@ -100093,7 +100111,7 @@
       "source_location": "L1"
     },
     {
-      "community": 772,
+      "community": 773,
       "file_type": "code",
       "id": "paymentsection_paymentsection",
       "label": "PaymentSection()",
@@ -100102,7 +100120,7 @@
       "source_location": "L27"
     },
     {
-      "community": 773,
+      "community": 774,
       "file_type": "code",
       "id": "deliveryfees_calculatedeliveryfee",
       "label": "calculateDeliveryFee()",
@@ -100111,7 +100129,7 @@
       "source_location": "L40"
     },
     {
-      "community": 773,
+      "community": 774,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliveryfees_ts",
       "label": "deliveryFees.ts",
@@ -100120,7 +100138,7 @@
       "source_location": "L1"
     },
     {
-      "community": 774,
+      "community": 775,
       "file_type": "code",
       "id": "derivecheckoutstate_derivecheckoutstate",
       "label": "deriveCheckoutState()",
@@ -100129,7 +100147,7 @@
       "source_location": "L3"
     },
     {
-      "community": 774,
+      "community": 775,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_derivecheckoutstate_ts",
       "label": "deriveCheckoutState.ts",
@@ -100138,7 +100156,7 @@
       "source_location": "L1"
     },
     {
-      "community": 775,
+      "community": 776,
       "file_type": "code",
       "id": "checkoutschemas_test_getissuemap",
       "label": "getIssueMap()",
@@ -100147,7 +100165,7 @@
       "source_location": "L8"
     },
     {
-      "community": 775,
+      "community": 776,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_checkoutschemas_test_ts",
       "label": "checkoutSchemas.test.ts",
@@ -100156,7 +100174,7 @@
       "source_location": "L1"
     },
     {
-      "community": 776,
+      "community": 777,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_weborderschema_test_ts",
       "label": "webOrderSchema.test.ts",
@@ -100165,7 +100183,7 @@
       "source_location": "L1"
     },
     {
-      "community": 776,
+      "community": 777,
       "file_type": "code",
       "id": "weborderschema_test_getissuemap",
       "label": "getIssueMap()",
@@ -100174,7 +100192,7 @@
       "source_location": "L12"
     },
     {
-      "community": 777,
+      "community": 778,
       "file_type": "code",
       "id": "customerdetailsform_onsubmit",
       "label": "onSubmit()",
@@ -100183,7 +100201,7 @@
       "source_location": "L77"
     },
     {
-      "community": 777,
+      "community": 778,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_common_forms_customerdetailsform_tsx",
       "label": "CustomerDetailsForm.tsx",
@@ -100192,7 +100210,7 @@
       "source_location": "L1"
     },
     {
-      "community": 778,
+      "community": 779,
       "file_type": "code",
       "id": "deliverydetailsform_onsubmit",
       "label": "onSubmit()",
@@ -100201,30 +100219,12 @@
       "source_location": "L161"
     },
     {
-      "community": 778,
+      "community": 779,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_common_forms_deliverydetailsform_tsx",
       "label": "DeliveryDetailsForm.tsx",
       "norm_label": "deliverydetailsform.tsx",
       "source_file": "packages/storefront-webapp/src/components/common/forms/DeliveryDetailsForm.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 779,
-      "file_type": "code",
-      "id": "hooks_usecountdown",
-      "label": "useCountdown()",
-      "norm_label": "usecountdown()",
-      "source_file": "packages/storefront-webapp/src/components/common/hooks.ts",
-      "source_location": "L3"
-    },
-    {
-      "community": 779,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_common_hooks_ts",
-      "label": "hooks.ts",
-      "norm_label": "hooks.ts",
-      "source_file": "packages/storefront-webapp/src/components/common/hooks.ts",
       "source_location": "L1"
     },
     {
@@ -100320,6 +100320,24 @@
     {
       "community": 780,
       "file_type": "code",
+      "id": "hooks_usecountdown",
+      "label": "useCountdown()",
+      "norm_label": "usecountdown()",
+      "source_file": "packages/storefront-webapp/src/components/common/hooks.ts",
+      "source_location": "L3"
+    },
+    {
+      "community": 780,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_common_hooks_ts",
+      "label": "hooks.ts",
+      "norm_label": "hooks.ts",
+      "source_file": "packages/storefront-webapp/src/components/common/hooks.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 781,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_communication_trustsignals_tsx",
       "label": "TrustSignals.tsx",
       "norm_label": "trustsignals.tsx",
@@ -100327,7 +100345,7 @@
       "source_location": "L1"
     },
     {
-      "community": 780,
+      "community": 781,
       "file_type": "code",
       "id": "trustsignals_trustsignals",
       "label": "TrustSignals()",
@@ -100336,7 +100354,7 @@
       "source_location": "L4"
     },
     {
-      "community": 781,
+      "community": 782,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_filter_productfilter_tsx",
       "label": "ProductFilter.tsx",
@@ -100345,7 +100363,7 @@
       "source_location": "L1"
     },
     {
-      "community": 781,
+      "community": 782,
       "file_type": "code",
       "id": "productfilter_productfilter",
       "label": "ProductFilter()",
@@ -100354,7 +100372,7 @@
       "source_location": "L14"
     },
     {
-      "community": 782,
+      "community": 783,
       "file_type": "code",
       "id": "filter_handlecheckboxchange",
       "label": "handleCheckboxChange()",
@@ -100363,7 +100381,7 @@
       "source_location": "L27"
     },
     {
-      "community": 782,
+      "community": 783,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_footer_filter_tsx",
       "label": "Filter.tsx",
@@ -100372,7 +100390,7 @@
       "source_location": "L1"
     },
     {
-      "community": 783,
+      "community": 784,
       "file_type": "code",
       "id": "bestsellerssection_bestsellerssection",
       "label": "BestSellersSection()",
@@ -100381,7 +100399,7 @@
       "source_location": "L17"
     },
     {
-      "community": 783,
+      "community": 784,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_bestsellerssection_tsx",
       "label": "BestSellersSection.tsx",
@@ -100390,7 +100408,7 @@
       "source_location": "L1"
     },
     {
-      "community": 784,
+      "community": 785,
       "file_type": "code",
       "id": "homepagecontent_resolvehomepagecontent",
       "label": "resolveHomepageContent()",
@@ -100399,7 +100417,7 @@
       "source_location": "L13"
     },
     {
-      "community": 784,
+      "community": 785,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_homepagecontent_ts",
       "label": "homePageContent.ts",
@@ -100408,7 +100426,7 @@
       "source_location": "L1"
     },
     {
-      "community": 785,
+      "community": 786,
       "file_type": "code",
       "id": "bagmenu_handleonlinkclick",
       "label": "handleOnLinkClick()",
@@ -100417,7 +100435,7 @@
       "source_location": "L47"
     },
     {
-      "community": 785,
+      "community": 786,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_bagmenu_tsx",
       "label": "BagMenu.tsx",
@@ -100426,7 +100444,7 @@
       "source_location": "L1"
     },
     {
-      "community": 786,
+      "community": 787,
       "file_type": "code",
       "id": "mobilebagmenu_mobilebagmenu",
       "label": "MobileBagMenu()",
@@ -100435,7 +100453,7 @@
       "source_location": "L7"
     },
     {
-      "community": 786,
+      "community": 787,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_mobilebagmenu_tsx",
       "label": "MobileBagMenu.tsx",
@@ -100444,7 +100462,7 @@
       "source_location": "L1"
     },
     {
-      "community": 787,
+      "community": 788,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_sitebanner_tsx",
       "label": "SiteBanner.tsx",
@@ -100453,7 +100471,7 @@
       "source_location": "L1"
     },
     {
-      "community": 787,
+      "community": 788,
       "file_type": "code",
       "id": "sitebanner_sitebanner",
       "label": "SiteBanner()",
@@ -100462,7 +100480,7 @@
       "source_location": "L18"
     },
     {
-      "community": 788,
+      "community": 789,
       "file_type": "code",
       "id": "notificationpill_notificationpill",
       "label": "NotificationPill()",
@@ -100471,30 +100489,12 @@
       "source_location": "L1"
     },
     {
-      "community": 788,
+      "community": 789,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_notification_notificationpill_tsx",
       "label": "NotificationPill.tsx",
       "norm_label": "notificationpill.tsx",
       "source_file": "packages/storefront-webapp/src/components/notification/NotificationPill.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 789,
-      "file_type": "code",
-      "id": "dimensionbar_mapvaluetolabelindex",
-      "label": "mapValueToLabelIndex()",
-      "norm_label": "mapvaluetolabelindex()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/DimensionBar.tsx",
-      "source_location": "L12"
-    },
-    {
-      "community": 789,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_page_dimensionbar_tsx",
-      "label": "DimensionBar.tsx",
-      "norm_label": "dimensionbar.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-page/DimensionBar.tsx",
       "source_location": "L1"
     },
     {
@@ -100590,6 +100590,24 @@
     {
       "community": 790,
       "file_type": "code",
+      "id": "dimensionbar_mapvaluetolabelindex",
+      "label": "mapValueToLabelIndex()",
+      "norm_label": "mapvaluetolabelindex()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/DimensionBar.tsx",
+      "source_location": "L12"
+    },
+    {
+      "community": 790,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_page_dimensionbar_tsx",
+      "label": "DimensionBar.tsx",
+      "norm_label": "dimensionbar.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-page/DimensionBar.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 791,
+      "file_type": "code",
       "id": "discountbadge_discountbadge",
       "label": "DiscountBadge()",
       "norm_label": "discountbadge()",
@@ -100597,7 +100615,7 @@
       "source_location": "L8"
     },
     {
-      "community": 790,
+      "community": 791,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_discountbadge_tsx",
       "label": "DiscountBadge.tsx",
@@ -100606,7 +100624,7 @@
       "source_location": "L1"
     },
     {
-      "community": 791,
+      "community": 792,
       "file_type": "code",
       "id": "galleryviewer_handleclickonpreview",
       "label": "handleClickOnPreview()",
@@ -100615,7 +100633,7 @@
       "source_location": "L45"
     },
     {
-      "community": 791,
+      "community": 792,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_galleryviewer_tsx",
       "label": "GalleryViewer.tsx",
@@ -100624,7 +100642,7 @@
       "source_location": "L1"
     },
     {
-      "community": 792,
+      "community": 793,
       "file_type": "code",
       "id": "onsaleproduct_onsaleproduct",
       "label": "OnsaleProduct()",
@@ -100633,7 +100651,7 @@
       "source_location": "L5"
     },
     {
-      "community": 792,
+      "community": 793,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_onsaleproduct_tsx",
       "label": "OnSaleProduct.tsx",
@@ -100642,7 +100660,7 @@
       "source_location": "L1"
     },
     {
-      "community": 793,
+      "community": 794,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productactions_tsx",
       "label": "ProductActions.tsx",
@@ -100651,7 +100669,7 @@
       "source_location": "L1"
     },
     {
-      "community": 793,
+      "community": 794,
       "file_type": "code",
       "id": "productactions_productactions",
       "label": "ProductActions()",
@@ -100660,7 +100678,7 @@
       "source_location": "L17"
     },
     {
-      "community": 794,
+      "community": 795,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productattributes_tsx",
       "label": "ProductAttributes.tsx",
@@ -100669,7 +100687,7 @@
       "source_location": "L1"
     },
     {
-      "community": 794,
+      "community": 795,
       "file_type": "code",
       "id": "productattributes_productattributes",
       "label": "ProductAttributes()",
@@ -100678,7 +100696,7 @@
       "source_location": "L3"
     },
     {
-      "community": 795,
+      "community": 796,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productpage_test_tsx",
       "label": "ProductPage.test.tsx",
@@ -100687,7 +100705,7 @@
       "source_location": "L1"
     },
     {
-      "community": 795,
+      "community": 796,
       "file_type": "code",
       "id": "productpage_test_makepagestate",
       "label": "makePageState()",
@@ -100696,7 +100714,7 @@
       "source_location": "L37"
     },
     {
-      "community": 796,
+      "community": 797,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productpage_tsx",
       "label": "ProductPage.tsx",
@@ -100705,7 +100723,7 @@
       "source_location": "L1"
     },
     {
-      "community": 796,
+      "community": 797,
       "file_type": "code",
       "id": "productpage_showshippingpolicy",
       "label": "showShippingPolicy()",
@@ -100714,7 +100732,7 @@
       "source_location": "L79"
     },
     {
-      "community": 797,
+      "community": 798,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productreview_tsx",
       "label": "ProductReview.tsx",
@@ -100723,7 +100741,7 @@
       "source_location": "L1"
     },
     {
-      "community": 797,
+      "community": 798,
       "file_type": "code",
       "id": "productreview_handlehelpful",
       "label": "handleHelpful()",
@@ -100732,7 +100750,7 @@
       "source_location": "L87"
     },
     {
-      "community": 798,
+      "community": 799,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_reviewsummary_tsx",
       "label": "ReviewSummary.tsx",
@@ -100741,31 +100759,13 @@
       "source_location": "L1"
     },
     {
-      "community": 798,
+      "community": 799,
       "file_type": "code",
       "id": "reviewsummary_reviewsummary",
       "label": "ReviewSummary()",
       "norm_label": "reviewsummary()",
       "source_file": "packages/storefront-webapp/src/components/product-page/ReviewSummary.tsx",
       "source_location": "L8"
-    },
-    {
-      "community": 799,
-      "file_type": "code",
-      "id": "orderitem_orderitem",
-      "label": "OrderItem()",
-      "norm_label": "orderitem()",
-      "source_file": "packages/storefront-webapp/src/components/product-reviews/OrderItem.tsx",
-      "source_location": "L13"
-    },
-    {
-      "community": 799,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_reviews_orderitem_tsx",
-      "label": "OrderItem.tsx",
-      "norm_label": "orderitem.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-reviews/OrderItem.tsx",
-      "source_location": "L1"
     },
     {
       "community": 8,
@@ -101148,6 +101148,24 @@
     {
       "community": 800,
       "file_type": "code",
+      "id": "orderitem_orderitem",
+      "label": "OrderItem()",
+      "norm_label": "orderitem()",
+      "source_file": "packages/storefront-webapp/src/components/product-reviews/OrderItem.tsx",
+      "source_location": "L13"
+    },
+    {
+      "community": 800,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_reviews_orderitem_tsx",
+      "label": "OrderItem.tsx",
+      "norm_label": "orderitem.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-reviews/OrderItem.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 801,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_ratingselector_tsx",
       "label": "RatingSelector.tsx",
       "norm_label": "ratingselector.tsx",
@@ -101155,7 +101173,7 @@
       "source_location": "L1"
     },
     {
-      "community": 800,
+      "community": 801,
       "file_type": "code",
       "id": "ratingselector_ratingselector",
       "label": "RatingSelector()",
@@ -101164,7 +101182,7 @@
       "source_location": "L18"
     },
     {
-      "community": 801,
+      "community": 802,
       "file_type": "code",
       "id": "guestrewardsprompt_guestrewardsprompt",
       "label": "GuestRewardsPrompt()",
@@ -101173,7 +101191,7 @@
       "source_location": "L10"
     },
     {
-      "community": 801,
+      "community": 802,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_rewards_guestrewardsprompt_tsx",
       "label": "GuestRewardsPrompt.tsx",
@@ -101182,7 +101200,7 @@
       "source_location": "L1"
     },
     {
-      "community": 802,
+      "community": 803,
       "file_type": "code",
       "id": "orderpointsdisplay_orderpointsdisplay",
       "label": "OrderPointsDisplay()",
@@ -101191,7 +101209,7 @@
       "source_location": "L11"
     },
     {
-      "community": 802,
+      "community": 803,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_rewards_orderpointsdisplay_tsx",
       "label": "OrderPointsDisplay.tsx",
@@ -101200,7 +101218,7 @@
       "source_location": "L1"
     },
     {
-      "community": 803,
+      "community": 804,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_rewards_pastordersrewards_tsx",
       "label": "PastOrdersRewards.tsx",
@@ -101209,7 +101227,7 @@
       "source_location": "L1"
     },
     {
-      "community": 803,
+      "community": 804,
       "file_type": "code",
       "id": "pastordersrewards_handleclaimpoints",
       "label": "handleClaimPoints()",
@@ -101218,7 +101236,7 @@
       "source_location": "L60"
     },
     {
-      "community": 804,
+      "community": 805,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_rewards_rewardspanel_tsx",
       "label": "RewardsPanel.tsx",
@@ -101227,7 +101245,7 @@
       "source_location": "L1"
     },
     {
-      "community": 804,
+      "community": 805,
       "file_type": "code",
       "id": "rewardspanel_handleredeemreward",
       "label": "handleRedeemReward()",
@@ -101236,7 +101254,7 @@
       "source_location": "L33"
     },
     {
-      "community": 805,
+      "community": 806,
       "file_type": "code",
       "id": "bagitem_bagitem",
       "label": "BagItem()",
@@ -101245,7 +101263,7 @@
       "source_location": "L20"
     },
     {
-      "community": 805,
+      "community": 806,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_shopping_bag_bagitem_tsx",
       "label": "BagItem.tsx",
@@ -101254,7 +101272,7 @@
       "source_location": "L1"
     },
     {
-      "community": 806,
+      "community": 807,
       "file_type": "code",
       "id": "checkoutunavailable_checkoutunavailable",
       "label": "CheckoutUnavailable()",
@@ -101263,7 +101281,7 @@
       "source_location": "L4"
     },
     {
-      "community": 806,
+      "community": 807,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_checkout_unavailable_checkoutunavailable_tsx",
       "label": "CheckoutUnavailable.tsx",
@@ -101272,7 +101290,7 @@
       "source_location": "L1"
     },
     {
-      "community": 807,
+      "community": 808,
       "file_type": "code",
       "id": "errorboundary_errorboundary",
       "label": "ErrorBoundary()",
@@ -101281,7 +101299,7 @@
       "source_location": "L22"
     },
     {
-      "community": 807,
+      "community": 808,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_error_errorboundary_tsx",
       "label": "ErrorBoundary.tsx",
@@ -101290,7 +101308,7 @@
       "source_location": "L1"
     },
     {
-      "community": 808,
+      "community": 809,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_scrolldownbutton_tsx",
       "label": "ScrollDownButton.tsx",
@@ -101299,31 +101317,13 @@
       "source_location": "L1"
     },
     {
-      "community": 808,
+      "community": 809,
       "file_type": "code",
       "id": "scrolldownbutton_scrolldownbutton",
       "label": "ScrollDownButton()",
       "norm_label": "scrolldownbutton()",
       "source_file": "packages/storefront-webapp/src/components/ui/ScrollDownButton.tsx",
       "source_location": "L11"
-    },
-    {
-      "community": 809,
-      "file_type": "code",
-      "id": "country_select_countryselect",
-      "label": "CountrySelect()",
-      "norm_label": "countryselect()",
-      "source_file": "packages/storefront-webapp/src/components/ui/country-select.tsx",
-      "source_location": "L3"
-    },
-    {
-      "community": 809,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_country_select_tsx",
-      "label": "country-select.tsx",
-      "norm_label": "country-select.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/country-select.tsx",
-      "source_location": "L1"
     },
     {
       "community": 81,
@@ -101418,6 +101418,24 @@
     {
       "community": 810,
       "file_type": "code",
+      "id": "country_select_countryselect",
+      "label": "CountrySelect()",
+      "norm_label": "countryselect()",
+      "source_file": "packages/storefront-webapp/src/components/ui/country-select.tsx",
+      "source_location": "L3"
+    },
+    {
+      "community": 810,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_country_select_tsx",
+      "label": "country-select.tsx",
+      "norm_label": "country-select.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/country-select.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 811,
+      "file_type": "code",
       "id": "ghana_region_select_ghanaregionselect",
       "label": "GhanaRegionSelect()",
       "norm_label": "ghanaregionselect()",
@@ -101425,7 +101443,7 @@
       "source_location": "L3"
     },
     {
-      "community": 810,
+      "community": 811,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_ghana_region_select_tsx",
       "label": "ghana-region-select.tsx",
@@ -101434,7 +101452,7 @@
       "source_location": "L1"
     },
     {
-      "community": 811,
+      "community": 812,
       "file_type": "code",
       "id": "ghost_button_ghostbutton",
       "label": "GhostButton()",
@@ -101443,7 +101461,7 @@
       "source_location": "L9"
     },
     {
-      "community": 811,
+      "community": 812,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_ghost_button_tsx",
       "label": "ghost-button.tsx",
@@ -101452,7 +101470,7 @@
       "source_location": "L1"
     },
     {
-      "community": 812,
+      "community": 813,
       "file_type": "code",
       "id": "leaveareviewmodal_handleclose",
       "label": "handleClose()",
@@ -101461,7 +101479,7 @@
       "source_location": "L66"
     },
     {
-      "community": 812,
+      "community": 813,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_leaveareviewmodal_tsx",
       "label": "LeaveAReviewModal.tsx",
@@ -101470,7 +101488,7 @@
       "source_location": "L1"
     },
     {
-      "community": 813,
+      "community": 814,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_upsellmodalsuccess_tsx",
       "label": "UpsellModalSuccess.tsx",
@@ -101479,7 +101497,7 @@
       "source_location": "L1"
     },
     {
-      "community": 813,
+      "community": 814,
       "file_type": "code",
       "id": "upsellmodalsuccess_upsellmodalsuccess",
       "label": "UpsellModalSuccess()",
@@ -101488,7 +101506,7 @@
       "source_location": "L19"
     },
     {
-      "community": 814,
+      "community": 815,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_welcomebackmodalsuccess_tsx",
       "label": "WelcomeBackModalSuccess.tsx",
@@ -101497,7 +101515,7 @@
       "source_location": "L1"
     },
     {
-      "community": 814,
+      "community": 815,
       "file_type": "code",
       "id": "welcomebackmodalsuccess_welcomebackmodalsuccess",
       "label": "WelcomeBackModalSuccess()",
@@ -101506,7 +101524,7 @@
       "source_location": "L13"
     },
     {
-      "community": 815,
+      "community": 816,
       "file_type": "code",
       "id": "leavereviewmodalconfig_getmodalconfig",
       "label": "getModalConfig()",
@@ -101515,7 +101533,7 @@
       "source_location": "L46"
     },
     {
-      "community": 815,
+      "community": 816,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_config_leavereviewmodalconfig_tsx",
       "label": "leaveReviewModalConfig.tsx",
@@ -101524,7 +101542,7 @@
       "source_location": "L1"
     },
     {
-      "community": 816,
+      "community": 817,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_config_welcomebackmodalconfig_tsx",
       "label": "welcomeBackModalConfig.tsx",
@@ -101533,7 +101551,7 @@
       "source_location": "L1"
     },
     {
-      "community": 816,
+      "community": 817,
       "file_type": "code",
       "id": "welcomebackmodalconfig_getmodalconfig",
       "label": "getModalConfig()",
@@ -101542,7 +101560,7 @@
       "source_location": "L46"
     },
     {
-      "community": 817,
+      "community": 818,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_webp_jpg_tsx",
       "label": "webp-jpg.tsx",
@@ -101551,7 +101569,7 @@
       "source_location": "L1"
     },
     {
-      "community": 817,
+      "community": 818,
       "file_type": "code",
       "id": "webp_jpg_webpimage",
       "label": "WebpImage()",
@@ -101560,7 +101578,7 @@
       "source_location": "L1"
     },
     {
-      "community": 818,
+      "community": 819,
       "file_type": "code",
       "id": "formsubmissionprovider_useformsubmission",
       "label": "useFormSubmission()",
@@ -101569,31 +101587,13 @@
       "source_location": "L15"
     },
     {
-      "community": 818,
+      "community": 819,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_contexts_formsubmissionprovider_tsx",
       "label": "FormSubmissionProvider.tsx",
       "norm_label": "formsubmissionprovider.tsx",
       "source_file": "packages/storefront-webapp/src/contexts/FormSubmissionProvider.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 819,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_usecheckout_ts",
-      "label": "useCheckout.ts",
-      "norm_label": "usecheckout.ts",
-      "source_file": "packages/storefront-webapp/src/hooks/useCheckout.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 819,
-      "file_type": "code",
-      "id": "usecheckout_usecheckout",
-      "label": "useCheckout()",
-      "norm_label": "usecheckout()",
-      "source_file": "packages/storefront-webapp/src/hooks/useCheckout.ts",
-      "source_location": "L5"
     },
     {
       "community": 82,
@@ -101688,6 +101688,24 @@
     {
       "community": 820,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_usecheckout_ts",
+      "label": "useCheckout.ts",
+      "norm_label": "usecheckout.ts",
+      "source_file": "packages/storefront-webapp/src/hooks/useCheckout.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 820,
+      "file_type": "code",
+      "id": "usecheckout_usecheckout",
+      "label": "useCheckout()",
+      "norm_label": "usecheckout()",
+      "source_file": "packages/storefront-webapp/src/hooks/useCheckout.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 821,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usediscountcodealert_tsx",
       "label": "useDiscountCodeAlert.tsx",
       "norm_label": "usediscountcodealert.tsx",
@@ -101695,7 +101713,7 @@
       "source_location": "L1"
     },
     {
-      "community": 820,
+      "community": 821,
       "file_type": "code",
       "id": "usediscountcodealert_usediscountcodealert",
       "label": "useDiscountCodeAlert()",
@@ -101704,7 +101722,7 @@
       "source_location": "L14"
     },
     {
-      "community": 821,
+      "community": 822,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useenhancedtracking_ts",
       "label": "useEnhancedTracking.ts",
@@ -101713,7 +101731,7 @@
       "source_location": "L1"
     },
     {
-      "community": 821,
+      "community": 822,
       "file_type": "code",
       "id": "useenhancedtracking_useenhancedtracking",
       "label": "useEnhancedTracking()",
@@ -101722,7 +101740,7 @@
       "source_location": "L29"
     },
     {
-      "community": 822,
+      "community": 823,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usegetactivecheckoutsession_tsx",
       "label": "useGetActiveCheckoutSession.tsx",
@@ -101731,7 +101749,7 @@
       "source_location": "L1"
     },
     {
-      "community": 822,
+      "community": 823,
       "file_type": "code",
       "id": "usegetactivecheckoutsession_usegetactivecheckoutsession",
       "label": "useGetActiveCheckoutSession()",
@@ -101740,7 +101758,7 @@
       "source_location": "L5"
     },
     {
-      "community": 823,
+      "community": 824,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usegetproduct_tsx",
       "label": "useGetProduct.tsx",
@@ -101749,7 +101767,7 @@
       "source_location": "L1"
     },
     {
-      "community": 823,
+      "community": 824,
       "file_type": "code",
       "id": "usegetproduct_usegetproductquery",
       "label": "useGetProductQuery()",
@@ -101758,7 +101776,7 @@
       "source_location": "L5"
     },
     {
-      "community": 824,
+      "community": 825,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usegetproductfilters_ts",
       "label": "useGetProductFilters.ts",
@@ -101767,7 +101785,7 @@
       "source_location": "L1"
     },
     {
-      "community": 824,
+      "community": 825,
       "file_type": "code",
       "id": "usegetproductfilters_usegetproductfilters",
       "label": "useGetProductFilters()",
@@ -101776,7 +101794,7 @@
       "source_location": "L3"
     },
     {
-      "community": 825,
+      "community": 826,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usegetproductreviews_ts",
       "label": "useGetProductReviews.ts",
@@ -101785,7 +101803,7 @@
       "source_location": "L1"
     },
     {
-      "community": 825,
+      "community": 826,
       "file_type": "code",
       "id": "usegetproductreviews_usegetproductreviewsquery",
       "label": "useGetProductReviewsQuery()",
@@ -101794,7 +101812,7 @@
       "source_location": "L4"
     },
     {
-      "community": 826,
+      "community": 827,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usegetstore_ts",
       "label": "useGetStore.ts",
@@ -101803,7 +101821,7 @@
       "source_location": "L1"
     },
     {
-      "community": 826,
+      "community": 827,
       "file_type": "code",
       "id": "usegetstore_usegetstore",
       "label": "useGetStore()",
@@ -101812,7 +101830,7 @@
       "source_location": "L4"
     },
     {
-      "community": 827,
+      "community": 828,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useinventorystatus_ts",
       "label": "useInventoryStatus.ts",
@@ -101821,7 +101839,7 @@
       "source_location": "L1"
     },
     {
-      "community": 827,
+      "community": 828,
       "file_type": "code",
       "id": "useinventorystatus_useinventorystatus",
       "label": "useInventoryStatus()",
@@ -101830,7 +101848,7 @@
       "source_location": "L9"
     },
     {
-      "community": 828,
+      "community": 829,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useleaveareviewmodal_tsx",
       "label": "useLeaveAReviewModal.tsx",
@@ -101839,31 +101857,13 @@
       "source_location": "L1"
     },
     {
-      "community": 828,
+      "community": 829,
       "file_type": "code",
       "id": "useleaveareviewmodal_useleaveareviewmodal",
       "label": "useLeaveAReviewModal()",
       "norm_label": "useleaveareviewmodal()",
       "source_file": "packages/storefront-webapp/src/hooks/useLeaveAReviewModal.tsx",
       "source_location": "L17"
-    },
-    {
-      "community": 829,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_uselogout_ts",
-      "label": "useLogout.ts",
-      "norm_label": "uselogout.ts",
-      "source_file": "packages/storefront-webapp/src/hooks/useLogout.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 829,
-      "file_type": "code",
-      "id": "uselogout_uselogout",
-      "label": "useLogout()",
-      "norm_label": "uselogout()",
-      "source_file": "packages/storefront-webapp/src/hooks/useLogout.ts",
-      "source_location": "L5"
     },
     {
       "community": 83,
@@ -101958,6 +101958,24 @@
     {
       "community": 830,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_uselogout_ts",
+      "label": "useLogout.ts",
+      "norm_label": "uselogout.ts",
+      "source_file": "packages/storefront-webapp/src/hooks/useLogout.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 830,
+      "file_type": "code",
+      "id": "uselogout_uselogout",
+      "label": "useLogout()",
+      "norm_label": "uselogout()",
+      "source_file": "packages/storefront-webapp/src/hooks/useLogout.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 831,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usemodalstate_tsx",
       "label": "useModalState.tsx",
       "norm_label": "usemodalstate.tsx",
@@ -101965,7 +101983,7 @@
       "source_location": "L1"
     },
     {
-      "community": 830,
+      "community": 831,
       "file_type": "code",
       "id": "usemodalstate_usemodalstate",
       "label": "useModalState()",
@@ -101974,7 +101992,7 @@
       "source_location": "L15"
     },
     {
-      "community": 831,
+      "community": 832,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useproductpagelogic_ts",
       "label": "useProductPageLogic.ts",
@@ -101983,7 +102001,7 @@
       "source_location": "L1"
     },
     {
-      "community": 831,
+      "community": 832,
       "file_type": "code",
       "id": "useproductpagelogic_useproductpagelogic",
       "label": "useProductPageLogic()",
@@ -101992,7 +102010,7 @@
       "source_location": "L18"
     },
     {
-      "community": 832,
+      "community": 833,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useproductreminder_tsx",
       "label": "useProductReminder.tsx",
@@ -102001,7 +102019,7 @@
       "source_location": "L1"
     },
     {
-      "community": 832,
+      "community": 833,
       "file_type": "code",
       "id": "useproductreminder_useproductreminder",
       "label": "useProductReminder()",
@@ -102010,7 +102028,7 @@
       "source_location": "L9"
     },
     {
-      "community": 833,
+      "community": 834,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usepromoalert_tsx",
       "label": "usePromoAlert.tsx",
@@ -102019,7 +102037,7 @@
       "source_location": "L1"
     },
     {
-      "community": 833,
+      "community": 834,
       "file_type": "code",
       "id": "usepromoalert_usepromoalert",
       "label": "usePromoAlert()",
@@ -102028,7 +102046,7 @@
       "source_location": "L16"
     },
     {
-      "community": 834,
+      "community": 835,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usequeryenabled_ts",
       "label": "useQueryEnabled.ts",
@@ -102037,7 +102055,7 @@
       "source_location": "L1"
     },
     {
-      "community": 834,
+      "community": 835,
       "file_type": "code",
       "id": "usequeryenabled_usequeryenabled",
       "label": "useQueryEnabled()",
@@ -102046,7 +102064,7 @@
       "source_location": "L3"
     },
     {
-      "community": 835,
+      "community": 836,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_userewardsalert_tsx",
       "label": "useRewardsAlert.tsx",
@@ -102055,7 +102073,7 @@
       "source_location": "L1"
     },
     {
-      "community": 835,
+      "community": 836,
       "file_type": "code",
       "id": "userewardsalert_userewardsalert",
       "label": "useRewardsAlert()",
@@ -102064,7 +102082,7 @@
       "source_location": "L11"
     },
     {
-      "community": 836,
+      "community": 837,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usescrolltotop_ts",
       "label": "useScrollToTop.ts",
@@ -102073,7 +102091,7 @@
       "source_location": "L1"
     },
     {
-      "community": 836,
+      "community": 837,
       "file_type": "code",
       "id": "usescrolltotop_usescrolltotop",
       "label": "useScrollToTop()",
@@ -102082,7 +102100,7 @@
       "source_location": "L3"
     },
     {
-      "community": 837,
+      "community": 838,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usetrackaction_ts",
       "label": "useTrackAction.ts",
@@ -102091,7 +102109,7 @@
       "source_location": "L1"
     },
     {
-      "community": 837,
+      "community": 838,
       "file_type": "code",
       "id": "usetrackaction_usetrackaction",
       "label": "useTrackAction()",
@@ -102100,7 +102118,7 @@
       "source_location": "L7"
     },
     {
-      "community": 838,
+      "community": 839,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usetrackevent_ts",
       "label": "useTrackEvent.ts",
@@ -102109,31 +102127,13 @@
       "source_location": "L1"
     },
     {
-      "community": 838,
+      "community": 839,
       "file_type": "code",
       "id": "usetrackevent_usetrackevent",
       "label": "useTrackEvent()",
       "norm_label": "usetrackevent()",
       "source_file": "packages/storefront-webapp/src/hooks/useTrackEvent.ts",
       "source_location": "L4"
-    },
-    {
-      "community": 839,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_useupsellmodal_tsx",
-      "label": "useUpsellModal.tsx",
-      "norm_label": "useupsellmodal.tsx",
-      "source_file": "packages/storefront-webapp/src/hooks/useUpsellModal.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 839,
-      "file_type": "code",
-      "id": "useupsellmodal_useupsellmodal",
-      "label": "useUpsellModal()",
-      "norm_label": "useupsellmodal()",
-      "source_file": "packages/storefront-webapp/src/hooks/useUpsellModal.tsx",
-      "source_location": "L14"
     },
     {
       "community": 84,
@@ -102228,6 +102228,24 @@
     {
       "community": 840,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_useupsellmodal_tsx",
+      "label": "useUpsellModal.tsx",
+      "norm_label": "useupsellmodal.tsx",
+      "source_file": "packages/storefront-webapp/src/hooks/useUpsellModal.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 840,
+      "file_type": "code",
+      "id": "useupsellmodal_useupsellmodal",
+      "label": "useUpsellModal()",
+      "norm_label": "useupsellmodal()",
+      "source_file": "packages/storefront-webapp/src/hooks/useUpsellModal.tsx",
+      "source_location": "L14"
+    },
+    {
+      "community": 841,
+      "file_type": "code",
       "id": "analytics_usepostanalytics",
       "label": "usePostAnalytics()",
       "norm_label": "usepostanalytics()",
@@ -102235,7 +102253,7 @@
       "source_location": "L4"
     },
     {
-      "community": 840,
+      "community": 841,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_mutations_ts_analytics_ts",
       "label": "analytics.ts",
@@ -102244,7 +102262,7 @@
       "source_location": "L1"
     },
     {
-      "community": 841,
+      "community": 842,
       "file_type": "code",
       "id": "bag_usebagqueries",
       "label": "useBagQueries()",
@@ -102253,7 +102271,7 @@
       "source_location": "L7"
     },
     {
-      "community": 841,
+      "community": 842,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_bag_ts",
       "label": "bag.ts",
@@ -102262,7 +102280,7 @@
       "source_location": "L1"
     },
     {
-      "community": 842,
+      "community": 843,
       "file_type": "code",
       "id": "bannermessage_usebannermessagequeries",
       "label": "useBannerMessageQueries()",
@@ -102271,7 +102289,7 @@
       "source_location": "L6"
     },
     {
-      "community": 842,
+      "community": 843,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_bannermessage_ts",
       "label": "bannerMessage.ts",
@@ -102280,7 +102298,7 @@
       "source_location": "L1"
     },
     {
-      "community": 843,
+      "community": 844,
       "file_type": "code",
       "id": "checkout_usecheckoutsessionqueries",
       "label": "useCheckoutSessionQueries()",
@@ -102289,7 +102307,7 @@
       "source_location": "L10"
     },
     {
-      "community": 843,
+      "community": 844,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_checkout_ts",
       "label": "checkout.ts",
@@ -102298,7 +102316,7 @@
       "source_location": "L1"
     },
     {
-      "community": 844,
+      "community": 845,
       "file_type": "code",
       "id": "inventory_useinventoryqueries",
       "label": "useInventoryQueries()",
@@ -102307,7 +102325,7 @@
       "source_location": "L6"
     },
     {
-      "community": 844,
+      "community": 845,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_inventory_ts",
       "label": "inventory.ts",
@@ -102316,7 +102334,7 @@
       "source_location": "L1"
     },
     {
-      "community": 845,
+      "community": 846,
       "file_type": "code",
       "id": "onlineorder_useonlineorderqueries",
       "label": "useOnlineOrderQueries()",
@@ -102325,7 +102343,7 @@
       "source_location": "L5"
     },
     {
-      "community": 845,
+      "community": 846,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_onlineorder_ts",
       "label": "onlineOrder.ts",
@@ -102334,7 +102352,7 @@
       "source_location": "L1"
     },
     {
-      "community": 846,
+      "community": 847,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_postransaction_ts",
       "label": "posTransaction.ts",
@@ -102343,7 +102361,7 @@
       "source_location": "L1"
     },
     {
-      "community": 846,
+      "community": 847,
       "file_type": "code",
       "id": "postransaction_usepostransactionqueries",
       "label": "usePosTransactionQueries()",
@@ -102352,7 +102370,7 @@
       "source_location": "L5"
     },
     {
-      "community": 847,
+      "community": 848,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_product_ts",
       "label": "product.ts",
@@ -102361,7 +102379,7 @@
       "source_location": "L1"
     },
     {
-      "community": 847,
+      "community": 848,
       "file_type": "code",
       "id": "product_useproductqueries",
       "label": "useProductQueries()",
@@ -102370,7 +102388,7 @@
       "source_location": "L14"
     },
     {
-      "community": 848,
+      "community": 849,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_promocode_ts",
       "label": "promoCode.ts",
@@ -102379,31 +102397,13 @@
       "source_location": "L1"
     },
     {
-      "community": 848,
+      "community": 849,
       "file_type": "code",
       "id": "promocode_usepromocodesqueries",
       "label": "usePromoCodesQueries()",
       "norm_label": "usepromocodesqueries()",
       "source_file": "packages/storefront-webapp/src/lib/queries/promoCode.ts",
       "source_location": "L9"
-    },
-    {
-      "community": 849,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_queries_reviews_ts",
-      "label": "reviews.ts",
-      "norm_label": "reviews.ts",
-      "source_file": "packages/storefront-webapp/src/lib/queries/reviews.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 849,
-      "file_type": "code",
-      "id": "reviews_usereviewqueries",
-      "label": "useReviewQueries()",
-      "norm_label": "usereviewqueries()",
-      "source_file": "packages/storefront-webapp/src/lib/queries/reviews.ts",
-      "source_location": "L10"
     },
     {
       "community": 85,
@@ -102498,6 +102498,24 @@
     {
       "community": 850,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_queries_reviews_ts",
+      "label": "reviews.ts",
+      "norm_label": "reviews.ts",
+      "source_file": "packages/storefront-webapp/src/lib/queries/reviews.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 850,
+      "file_type": "code",
+      "id": "reviews_usereviewqueries",
+      "label": "useReviewQueries()",
+      "norm_label": "usereviewqueries()",
+      "source_file": "packages/storefront-webapp/src/lib/queries/reviews.ts",
+      "source_location": "L10"
+    },
+    {
+      "community": 851,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_rewards_ts",
       "label": "rewards.ts",
       "norm_label": "rewards.ts",
@@ -102505,7 +102523,7 @@
       "source_location": "L1"
     },
     {
-      "community": 850,
+      "community": 851,
       "file_type": "code",
       "id": "rewards_userewardsqueries",
       "label": "useRewardsQueries()",
@@ -102514,7 +102532,7 @@
       "source_location": "L11"
     },
     {
-      "community": 851,
+      "community": 852,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_upsells_ts",
       "label": "upsells.ts",
@@ -102523,7 +102541,7 @@
       "source_location": "L1"
     },
     {
-      "community": 851,
+      "community": 852,
       "file_type": "code",
       "id": "upsells_useupsellsqueries",
       "label": "useUpsellsQueries()",
@@ -102532,7 +102550,7 @@
       "source_location": "L6"
     },
     {
-      "community": 852,
+      "community": 853,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_user_ts",
       "label": "user.ts",
@@ -102541,7 +102559,7 @@
       "source_location": "L1"
     },
     {
-      "community": 852,
+      "community": 853,
       "file_type": "code",
       "id": "user_useuserqueries",
       "label": "useUserQueries()",
@@ -102550,7 +102568,7 @@
       "source_location": "L5"
     },
     {
-      "community": 853,
+      "community": 854,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_useroffers_ts",
       "label": "userOffers.ts",
@@ -102559,7 +102577,7 @@
       "source_location": "L1"
     },
     {
-      "community": 853,
+      "community": 854,
       "file_type": "code",
       "id": "useroffers_useuseroffersqueries",
       "label": "useUserOffersQueries()",
@@ -102568,7 +102586,7 @@
       "source_location": "L6"
     },
     {
-      "community": 854,
+      "community": 855,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_storeconfig_test_ts",
       "label": "storeConfig.test.ts",
@@ -102577,7 +102595,7 @@
       "source_location": "L1"
     },
     {
-      "community": 854,
+      "community": 855,
       "file_type": "code",
       "id": "storeconfig_test_buildv2config",
       "label": "buildV2Config()",
@@ -102586,7 +102604,7 @@
       "source_location": "L10"
     },
     {
-      "community": 855,
+      "community": 856,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_storefrontobservability_test_ts",
       "label": "storefrontObservability.test.ts",
@@ -102595,7 +102613,7 @@
       "source_location": "L1"
     },
     {
-      "community": 855,
+      "community": 856,
       "file_type": "code",
       "id": "storefrontobservability_test_creatememorystorage",
       "label": "createMemoryStorage()",
@@ -102604,7 +102622,7 @@
       "source_location": "L15"
     },
     {
-      "community": 856,
+      "community": 857,
       "file_type": "code",
       "id": "email_validateemail",
       "label": "validateEmail()",
@@ -102613,7 +102631,7 @@
       "source_location": "L14"
     },
     {
-      "community": 856,
+      "community": 857,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_validations_email_ts",
       "label": "email.ts",
@@ -102622,7 +102640,7 @@
       "source_location": "L1"
     },
     {
-      "community": 857,
+      "community": 858,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_router_tsx",
       "label": "router.tsx",
@@ -102631,7 +102649,7 @@
       "source_location": "L1"
     },
     {
-      "community": 857,
+      "community": 858,
       "file_type": "code",
       "id": "router_createrouter",
       "label": "createRouter()",
@@ -102640,7 +102658,7 @@
       "source_location": "L6"
     },
     {
-      "community": 858,
+      "community": 859,
       "file_type": "code",
       "id": "homepageloader_loadhomepagedata",
       "label": "loadHomePageData()",
@@ -102649,30 +102667,12 @@
       "source_location": "L14"
     },
     {
-      "community": 858,
+      "community": 859,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_homepageloader_ts",
       "label": "-homePageLoader.ts",
       "norm_label": "-homepageloader.ts",
       "source_file": "packages/storefront-webapp/src/routes/-homePageLoader.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 859,
-      "file_type": "code",
-      "id": "orderslayout_layoutcomponent",
-      "label": "LayoutComponent()",
-      "norm_label": "layoutcomponent()",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout.tsx",
-      "source_location": "L8"
-    },
-    {
-      "community": 859,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_layout_orderslayout_tsx",
-      "label": "_ordersLayout.tsx",
-      "norm_label": "_orderslayout.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout.tsx",
       "source_location": "L1"
     },
     {
@@ -102768,6 +102768,24 @@
     {
       "community": 860,
       "file_type": "code",
+      "id": "orderslayout_layoutcomponent",
+      "label": "LayoutComponent()",
+      "norm_label": "layoutcomponent()",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout.tsx",
+      "source_location": "L8"
+    },
+    {
+      "community": 860,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_layout_orderslayout_tsx",
+      "label": "_ordersLayout.tsx",
+      "norm_label": "_orderslayout.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 861,
+      "file_type": "code",
       "id": "contact_us_contactus",
       "label": "ContactUs()",
       "norm_label": "contactus()",
@@ -102775,7 +102793,7 @@
       "source_location": "L14"
     },
     {
-      "community": 860,
+      "community": 861,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_contact_us_tsx",
       "label": "contact-us.tsx",
@@ -102784,7 +102802,7 @@
       "source_location": "L1"
     },
     {
-      "community": 861,
+      "community": 862,
       "file_type": "code",
       "id": "delivery_returns_exchanges_index_onlineorderpolicy",
       "label": "OnlineOrderPolicy()",
@@ -102793,7 +102811,7 @@
       "source_location": "L13"
     },
     {
-      "community": 861,
+      "community": 862,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_policies_delivery_returns_exchanges_index_tsx",
       "label": "delivery-returns-exchanges.index.tsx",
@@ -102802,7 +102820,7 @@
       "source_location": "L1"
     },
     {
-      "community": 862,
+      "community": 863,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_policies_privacy_index_tsx",
       "label": "privacy.index.tsx",
@@ -102811,7 +102829,7 @@
       "source_location": "L1"
     },
     {
-      "community": 862,
+      "community": 863,
       "file_type": "code",
       "id": "privacy_index_privacypolicy",
       "label": "PrivacyPolicy()",
@@ -102820,7 +102838,7 @@
       "source_location": "L9"
     },
     {
-      "community": 863,
+      "community": 864,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_policies_tos_index_tsx",
       "label": "tos.index.tsx",
@@ -102829,7 +102847,7 @@
       "source_location": "L1"
     },
     {
-      "community": 863,
+      "community": 864,
       "file_type": "code",
       "id": "tos_index_tossection",
       "label": "TosSection()",
@@ -102838,7 +102856,7 @@
       "source_location": "L15"
     },
     {
-      "community": 864,
+      "community": 865,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_shop_product_productslug_tsx",
       "label": "shop.product.$productSlug.tsx",
@@ -102847,7 +102865,7 @@
       "source_location": "L1"
     },
     {
-      "community": 864,
+      "community": 865,
       "file_type": "code",
       "id": "shop_product_productslug_component",
       "label": "Component()",
@@ -102856,7 +102874,7 @@
       "source_location": "L16"
     },
     {
-      "community": 865,
+      "community": 866,
       "file_type": "code",
       "id": "layout_layoutcomponent",
       "label": "LayoutComponent()",
@@ -102865,7 +102883,7 @@
       "source_location": "L6"
     },
     {
-      "community": 865,
+      "community": 866,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_tsx",
       "label": "_layout.tsx",
@@ -102874,7 +102892,7 @@
       "source_location": "L1"
     },
     {
-      "community": 866,
+      "community": 867,
       "file_type": "code",
       "id": "index_homeroute",
       "label": "HomeRoute()",
@@ -102883,7 +102901,7 @@
       "source_location": "L10"
     },
     {
-      "community": 866,
+      "community": 867,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_index_tsx",
       "label": "index.tsx",
@@ -102892,7 +102910,7 @@
       "source_location": "L1"
     },
     {
-      "community": 867,
+      "community": 868,
       "file_type": "code",
       "id": "canceled_checkoutcanceledview",
       "label": "CheckoutCanceledView()",
@@ -102901,7 +102919,7 @@
       "source_location": "L21"
     },
     {
-      "community": 867,
+      "community": 868,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_canceled_tsx",
       "label": "canceled.tsx",
@@ -102910,7 +102928,7 @@
       "source_location": "L1"
     },
     {
-      "community": 868,
+      "community": 869,
       "file_type": "code",
       "id": "complete_index_checkoutcomplete",
       "label": "CheckoutComplete()",
@@ -102919,31 +102937,13 @@
       "source_location": "L33"
     },
     {
-      "community": 868,
+      "community": 869,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_complete_index_tsx",
       "label": "complete.index.tsx",
       "norm_label": "complete.index.tsx",
       "source_file": "packages/storefront-webapp/src/routes/shop/checkout/complete.index.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 869,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_shop_checkout_pod_confirmation_tsx",
-      "label": "pod-confirmation.tsx",
-      "norm_label": "pod-confirmation.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/pod-confirmation.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 869,
-      "file_type": "code",
-      "id": "pod_confirmation_completepodcheckoutsession",
-      "label": "completePODCheckoutSession()",
-      "norm_label": "completepodcheckoutsession()",
-      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/pod-confirmation.tsx",
-      "source_location": "L196"
     },
     {
       "community": 87,
@@ -103038,6 +103038,24 @@
     {
       "community": 870,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_shop_checkout_pod_confirmation_tsx",
+      "label": "pod-confirmation.tsx",
+      "norm_label": "pod-confirmation.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/pod-confirmation.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 870,
+      "file_type": "code",
+      "id": "pod_confirmation_completepodcheckoutsession",
+      "label": "completePODCheckoutSession()",
+      "norm_label": "completepodcheckoutsession()",
+      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/pod-confirmation.tsx",
+      "source_location": "L196"
+    },
+    {
+      "community": 871,
+      "file_type": "code",
       "id": "index_receiptshareroute",
       "label": "ReceiptShareRoute()",
       "norm_label": "receiptshareroute()",
@@ -103045,7 +103063,7 @@
       "source_location": "L9"
     },
     {
-      "community": 870,
+      "community": 871,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_receipt_s_token_index_tsx",
       "label": "index.tsx",
@@ -103054,7 +103072,7 @@
       "source_location": "L1"
     },
     {
-      "community": 871,
+      "community": 872,
       "file_type": "code",
       "id": "packages_valkey_proxy_server_test_connection_js",
       "label": "test-connection.js",
@@ -103063,7 +103081,7 @@
       "source_location": "L1"
     },
     {
-      "community": 871,
+      "community": 872,
       "file_type": "code",
       "id": "test_connection_main",
       "label": "main()",
@@ -103072,7 +103090,7 @@
       "source_location": "L7"
     },
     {
-      "community": 872,
+      "community": 873,
       "file_type": "code",
       "id": "architecture_boundaries_test_createsnippetlinter",
       "label": "createSnippetLinter()",
@@ -103081,7 +103099,7 @@
       "source_location": "L10"
     },
     {
-      "community": 872,
+      "community": 873,
       "file_type": "code",
       "id": "scripts_architecture_boundaries_test_ts",
       "label": "architecture-boundaries.test.ts",
@@ -103090,7 +103108,7 @@
       "source_location": "L1"
     },
     {
-      "community": 873,
+      "community": 874,
       "file_type": "code",
       "id": "architecture_boundary_check_run",
       "label": "run()",
@@ -103099,7 +103117,7 @@
       "source_location": "L32"
     },
     {
-      "community": 873,
+      "community": 874,
       "file_type": "code",
       "id": "scripts_architecture_boundary_check_ts",
       "label": "architecture-boundary-check.ts",
@@ -103108,7 +103126,7 @@
       "source_location": "L1"
     },
     {
-      "community": 874,
+      "community": 875,
       "file_type": "code",
       "id": "deploy_qa_vps_test_readrepofile",
       "label": "readRepoFile()",
@@ -103117,7 +103135,7 @@
       "source_location": "L7"
     },
     {
-      "community": 874,
+      "community": 875,
       "file_type": "code",
       "id": "scripts_deploy_qa_vps_test_ts",
       "label": "deploy-qa-vps.test.ts",
@@ -103126,7 +103144,7 @@
       "source_location": "L1"
     },
     {
-      "community": 875,
+      "community": 876,
       "file_type": "code",
       "id": "github_pr_merge_test_runcommand",
       "label": "runCommand()",
@@ -103135,7 +103153,7 @@
       "source_location": "L16"
     },
     {
-      "community": 875,
+      "community": 876,
       "file_type": "code",
       "id": "scripts_github_pr_merge_test_ts",
       "label": "github-pr-merge.test.ts",
@@ -103144,7 +103162,7 @@
       "source_location": "L1"
     },
     {
-      "community": 876,
+      "community": 877,
       "file_type": "code",
       "id": "athena_runtime_app_shutdown",
       "label": "shutdown()",
@@ -103153,7 +103171,7 @@
       "source_location": "L211"
     },
     {
-      "community": 876,
+      "community": 877,
       "file_type": "code",
       "id": "scripts_harness_behavior_fixtures_athena_runtime_app_ts",
       "label": "athena-runtime-app.ts",
@@ -103162,7 +103180,7 @@
       "source_location": "L1"
     },
     {
-      "community": 877,
+      "community": 878,
       "file_type": "code",
       "id": "sample_app_shutdown",
       "label": "shutdown()",
@@ -103171,7 +103189,7 @@
       "source_location": "L85"
     },
     {
-      "community": 877,
+      "community": 878,
       "file_type": "code",
       "id": "scripts_harness_behavior_fixtures_sample_app_ts",
       "label": "sample-app.ts",
@@ -103180,7 +103198,7 @@
       "source_location": "L1"
     },
     {
-      "community": 878,
+      "community": 879,
       "file_type": "code",
       "id": "harness_runtime_trends_test_buildreportline",
       "label": "buildReportLine()",
@@ -103189,21 +103207,12 @@
       "source_location": "L15"
     },
     {
-      "community": 878,
+      "community": 879,
       "file_type": "code",
       "id": "scripts_harness_runtime_trends_test_ts",
       "label": "harness-runtime-trends.test.ts",
       "norm_label": "harness-runtime-trends.test.ts",
       "source_file": "scripts/harness-runtime-trends.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 879,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_generated_api_d_ts",
-      "label": "api.d.ts",
-      "norm_label": "api.d.ts",
-      "source_file": "packages/athena-webapp/convex/_generated/api.d.ts",
       "source_location": "L1"
     },
     {
@@ -103290,6 +103299,15 @@
     {
       "community": 880,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_generated_api_d_ts",
+      "label": "api.d.ts",
+      "norm_label": "api.d.ts",
+      "source_file": "packages/athena-webapp/convex/_generated/api.d.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 881,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_generated_api_js",
       "label": "api.js",
       "norm_label": "api.js",
@@ -103297,7 +103315,7 @@
       "source_location": "L1"
     },
     {
-      "community": 881,
+      "community": 882,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_generated_datamodel_d_ts",
       "label": "dataModel.d.ts",
@@ -103306,7 +103324,7 @@
       "source_location": "L1"
     },
     {
-      "community": 882,
+      "community": 883,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_generated_server_d_ts",
       "label": "server.d.ts",
@@ -103315,7 +103333,7 @@
       "source_location": "L1"
     },
     {
-      "community": 883,
+      "community": 884,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_generated_server_js",
       "label": "server.js",
@@ -103324,7 +103342,7 @@
       "source_location": "L1"
     },
     {
-      "community": 884,
+      "community": 885,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_app_ts",
       "label": "app.ts",
@@ -103333,7 +103351,7 @@
       "source_location": "L1"
     },
     {
-      "community": 885,
+      "community": 886,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_auth_config_js",
       "label": "auth.config.js",
@@ -103342,7 +103360,7 @@
       "source_location": "L1"
     },
     {
-      "community": 886,
+      "community": 887,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_auth_ts",
       "label": "auth.ts",
@@ -103351,7 +103369,7 @@
       "source_location": "L1"
     },
     {
-      "community": 887,
+      "community": 888,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cashcontrols_registersessions_test_ts",
       "label": "registerSessions.test.ts",
@@ -103360,21 +103378,12 @@
       "source_location": "L1"
     },
     {
-      "community": 888,
+      "community": 889,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cloudflare_r2_test_ts",
       "label": "r2.test.ts",
       "norm_label": "r2.test.ts",
       "source_file": "packages/athena-webapp/convex/cloudflare/r2.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 889,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_constants_countries_ts",
-      "label": "countries.ts",
-      "norm_label": "countries.ts",
-      "source_file": "packages/athena-webapp/convex/constants/countries.ts",
       "source_location": "L1"
     },
     {
@@ -103461,6 +103470,15 @@
     {
       "community": 890,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_constants_countries_ts",
+      "label": "countries.ts",
+      "norm_label": "countries.ts",
+      "source_file": "packages/athena-webapp/convex/constants/countries.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 891,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_constants_email_ts",
       "label": "email.ts",
       "norm_label": "email.ts",
@@ -103468,7 +103486,7 @@
       "source_location": "L1"
     },
     {
-      "community": 891,
+      "community": 892,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_constants_ghana_ts",
       "label": "ghana.ts",
@@ -103477,7 +103495,7 @@
       "source_location": "L1"
     },
     {
-      "community": 892,
+      "community": 893,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_constants_payment_ts",
       "label": "payment.ts",
@@ -103486,7 +103504,7 @@
       "source_location": "L1"
     },
     {
-      "community": 893,
+      "community": 894,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_crons_ts",
       "label": "crons.ts",
@@ -103495,7 +103513,7 @@
       "source_location": "L1"
     },
     {
-      "community": 894,
+      "community": 895,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_customermessaging_domain_test_ts",
       "label": "domain.test.ts",
@@ -103504,7 +103522,7 @@
       "source_location": "L1"
     },
     {
-      "community": 895,
+      "community": 896,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_customermessaging_internal_ts",
       "label": "internal.ts",
@@ -103513,7 +103531,7 @@
       "source_location": "L1"
     },
     {
-      "community": 896,
+      "community": 897,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_customermessaging_public_test_ts",
       "label": "public.test.ts",
@@ -103522,7 +103540,7 @@
       "source_location": "L1"
     },
     {
-      "community": 897,
+      "community": 898,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_customermessaging_token_test_ts",
       "label": "token.test.ts",
@@ -103531,21 +103549,12 @@
       "source_location": "L1"
     },
     {
-      "community": 898,
+      "community": 899,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_customermessaging_whatsappclient_test_ts",
       "label": "whatsappClient.test.ts",
       "norm_label": "whatsappclient.test.ts",
       "source_file": "packages/athena-webapp/convex/customerMessaging/whatsappClient.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 899,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_customermessaging_whatsappconfig_test_ts",
-      "label": "whatsappConfig.test.ts",
-      "norm_label": "whatsappconfig.test.ts",
-      "source_file": "packages/athena-webapp/convex/customerMessaging/whatsappConfig.test.ts",
       "source_location": "L1"
     },
     {
@@ -103920,6 +103929,15 @@
     {
       "community": 900,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_customermessaging_whatsappconfig_test_ts",
+      "label": "whatsappConfig.test.ts",
+      "norm_label": "whatsappconfig.test.ts",
+      "source_file": "packages/athena-webapp/convex/customerMessaging/whatsappConfig.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 901,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_devpatchbadtransaction_ts",
       "label": "devPatchBadTransaction.ts",
       "norm_label": "devpatchbadtransaction.ts",
@@ -103927,7 +103945,7 @@
       "source_location": "L1"
     },
     {
-      "community": 901,
+      "community": 902,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_feedbackrequest_tsx",
       "label": "FeedbackRequest.tsx",
@@ -103936,7 +103954,7 @@
       "source_location": "L1"
     },
     {
-      "community": 902,
+      "community": 903,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_neworderadmin_tsx",
       "label": "NewOrderAdmin.tsx",
@@ -103945,7 +103963,7 @@
       "source_location": "L1"
     },
     {
-      "community": 903,
+      "community": 904,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_orderemail_tsx",
       "label": "OrderEmail.tsx",
@@ -103954,7 +103972,7 @@
       "source_location": "L1"
     },
     {
-      "community": 904,
+      "community": 905,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_posreceiptemail_tsx",
       "label": "PosReceiptEmail.tsx",
@@ -103963,7 +103981,7 @@
       "source_location": "L1"
     },
     {
-      "community": 905,
+      "community": 906,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_env_ts",
       "label": "env.ts",
@@ -103972,7 +103990,7 @@
       "source_location": "L1"
     },
     {
-      "community": 906,
+      "community": 907,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_core_routes_analytics_ts",
       "label": "analytics.ts",
@@ -103981,7 +103999,7 @@
       "source_location": "L1"
     },
     {
-      "community": 907,
+      "community": 908,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_core_routes_auth_ts",
       "label": "auth.ts",
@@ -103990,21 +104008,12 @@
       "source_location": "L1"
     },
     {
-      "community": 908,
+      "community": 909,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_core_routes_bannermessage_ts",
       "label": "bannerMessage.ts",
       "norm_label": "bannermessage.ts",
       "source_file": "packages/athena-webapp/convex/http/domains/core/routes/bannerMessage.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 909,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_core_routes_colors_ts",
-      "label": "colors.ts",
-      "norm_label": "colors.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/core/routes/colors.ts",
       "source_location": "L1"
     },
     {
@@ -104091,6 +104100,15 @@
     {
       "community": 910,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_core_routes_colors_ts",
+      "label": "colors.ts",
+      "norm_label": "colors.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/core/routes/colors.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 911,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_core_routes_index_ts",
       "label": "index.ts",
       "norm_label": "index.ts",
@@ -104098,7 +104116,7 @@
       "source_location": "L1"
     },
     {
-      "community": 911,
+      "community": 912,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_core_routes_organizations_ts",
       "label": "organizations.ts",
@@ -104107,7 +104125,7 @@
       "source_location": "L1"
     },
     {
-      "community": 912,
+      "community": 913,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_core_routes_products_ts",
       "label": "products.ts",
@@ -104116,7 +104134,7 @@
       "source_location": "L1"
     },
     {
-      "community": 913,
+      "community": 914,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_core_routes_storefronthidden_test_ts",
       "label": "storefrontHidden.test.ts",
@@ -104125,7 +104143,7 @@
       "source_location": "L1"
     },
     {
-      "community": 914,
+      "community": 915,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_core_routes_stores_ts",
       "label": "stores.ts",
@@ -104134,7 +104152,7 @@
       "source_location": "L1"
     },
     {
-      "community": 915,
+      "community": 916,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_bag_ts",
       "label": "bag.ts",
@@ -104143,7 +104161,7 @@
       "source_location": "L1"
     },
     {
-      "community": 916,
+      "community": 917,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_guest_ts",
       "label": "guest.ts",
@@ -104152,7 +104170,7 @@
       "source_location": "L1"
     },
     {
-      "community": 917,
+      "community": 918,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_index_ts",
       "label": "index.ts",
@@ -104161,21 +104179,12 @@
       "source_location": "L1"
     },
     {
-      "community": 918,
+      "community": 919,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_me_ts",
       "label": "me.ts",
       "norm_label": "me.ts",
       "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/me.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 919,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_offers_ts",
-      "label": "offers.ts",
-      "norm_label": "offers.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/offers.ts",
       "source_location": "L1"
     },
     {
@@ -104262,6 +104271,15 @@
     {
       "community": 920,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_offers_ts",
+      "label": "offers.ts",
+      "norm_label": "offers.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/offers.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 921,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_onlineorder_ts",
       "label": "onlineOrder.ts",
       "norm_label": "onlineorder.ts",
@@ -104269,7 +104287,7 @@
       "source_location": "L1"
     },
     {
-      "community": 921,
+      "community": 922,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_paystack_ts",
       "label": "paystack.ts",
@@ -104278,7 +104296,7 @@
       "source_location": "L1"
     },
     {
-      "community": 922,
+      "community": 923,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_postransaction_ts",
       "label": "posTransaction.ts",
@@ -104287,7 +104305,7 @@
       "source_location": "L1"
     },
     {
-      "community": 923,
+      "community": 924,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_reviews_ts",
       "label": "reviews.ts",
@@ -104296,7 +104314,7 @@
       "source_location": "L1"
     },
     {
-      "community": 924,
+      "community": 925,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_rewards_ts",
       "label": "rewards.ts",
@@ -104305,7 +104323,7 @@
       "source_location": "L1"
     },
     {
-      "community": 925,
+      "community": 926,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_savedbag_ts",
       "label": "savedBag.ts",
@@ -104314,7 +104332,7 @@
       "source_location": "L1"
     },
     {
-      "community": 926,
+      "community": 927,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_security_test_ts",
       "label": "security.test.ts",
@@ -104323,7 +104341,7 @@
       "source_location": "L1"
     },
     {
-      "community": 927,
+      "community": 928,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_storefront_ts",
       "label": "storefront.ts",
@@ -104332,21 +104350,12 @@
       "source_location": "L1"
     },
     {
-      "community": 928,
+      "community": 929,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_upsells_ts",
       "label": "upsells.ts",
       "norm_label": "upsells.ts",
       "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/upsells.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 929,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_user_ts",
-      "label": "user.ts",
-      "norm_label": "user.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/user.ts",
       "source_location": "L1"
     },
     {
@@ -104433,6 +104442,15 @@
     {
       "community": 930,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_user_ts",
+      "label": "user.ts",
+      "norm_label": "user.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/user.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 931,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_useroffers_ts",
       "label": "userOffers.ts",
       "norm_label": "useroffers.ts",
@@ -104440,7 +104458,7 @@
       "source_location": "L1"
     },
     {
-      "community": 931,
+      "community": 932,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_moneymovement_routes_index_ts",
       "label": "index.ts",
@@ -104449,7 +104467,7 @@
       "source_location": "L1"
     },
     {
-      "community": 932,
+      "community": 933,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_health_test_ts",
       "label": "health.test.ts",
@@ -104458,7 +104476,7 @@
       "source_location": "L1"
     },
     {
-      "community": 933,
+      "community": 934,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_ts",
       "label": "http.ts",
@@ -104467,7 +104485,7 @@
       "source_location": "L1"
     },
     {
-      "community": 934,
+      "community": 935,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_athenauser_ts",
       "label": "athenaUser.ts",
@@ -104476,7 +104494,7 @@
       "source_location": "L1"
     },
     {
-      "community": 935,
+      "community": 936,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_bannermessage_ts",
       "label": "bannerMessage.ts",
@@ -104485,7 +104503,7 @@
       "source_location": "L1"
     },
     {
-      "community": 936,
+      "community": 937,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_bestseller_ts",
       "label": "bestSeller.ts",
@@ -104494,7 +104512,7 @@
       "source_location": "L1"
     },
     {
-      "community": 937,
+      "community": 938,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_categories_ts",
       "label": "categories.ts",
@@ -104503,21 +104521,12 @@
       "source_location": "L1"
     },
     {
-      "community": 938,
+      "community": 939,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_colors_ts",
       "label": "colors.ts",
       "norm_label": "colors.ts",
       "source_file": "packages/athena-webapp/convex/inventory/colors.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 939,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_complimentaryproduct_ts",
-      "label": "complimentaryProduct.ts",
-      "norm_label": "complimentaryproduct.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/complimentaryProduct.ts",
       "source_location": "L1"
     },
     {
@@ -104604,6 +104613,15 @@
     {
       "community": 940,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_complimentaryproduct_ts",
+      "label": "complimentaryProduct.ts",
+      "norm_label": "complimentaryproduct.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/complimentaryProduct.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 941,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_expensetransactions_test_ts",
       "label": "expenseTransactions.test.ts",
       "norm_label": "expensetransactions.test.ts",
@@ -104611,7 +104629,7 @@
       "source_location": "L1"
     },
     {
-      "community": 941,
+      "community": 942,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_featureditem_ts",
       "label": "featuredItem.ts",
@@ -104620,7 +104638,7 @@
       "source_location": "L1"
     },
     {
-      "community": 942,
+      "community": 943,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_invitecode_ts",
       "label": "inviteCode.ts",
@@ -104629,7 +104647,7 @@
       "source_location": "L1"
     },
     {
-      "community": 943,
+      "community": 944,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_organizationmembers_ts",
       "label": "organizationMembers.ts",
@@ -104638,7 +104656,7 @@
       "source_location": "L1"
     },
     {
-      "community": 944,
+      "community": 945,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_organizations_ts",
       "label": "organizations.ts",
@@ -104647,7 +104665,7 @@
       "source_location": "L1"
     },
     {
-      "community": 945,
+      "community": 946,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_pos_ts",
       "label": "pos.ts",
@@ -104656,7 +104674,7 @@
       "source_location": "L1"
     },
     {
-      "community": 946,
+      "community": 947,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_poscustomers_ts",
       "label": "posCustomers.ts",
@@ -104665,7 +104683,7 @@
       "source_location": "L1"
     },
     {
-      "community": 947,
+      "community": 948,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_posterminal_ts",
       "label": "posTerminal.ts",
@@ -104674,21 +104692,12 @@
       "source_location": "L1"
     },
     {
-      "community": 948,
+      "community": 949,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_productsku_ts",
       "label": "productSku.ts",
       "norm_label": "productsku.ts",
       "source_file": "packages/athena-webapp/convex/inventory/productSku.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 949,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_productutil_test_ts",
-      "label": "productUtil.test.ts",
-      "norm_label": "productutil.test.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/productUtil.test.ts",
       "source_location": "L1"
     },
     {
@@ -104775,6 +104784,15 @@
     {
       "community": 950,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_productutil_test_ts",
+      "label": "productUtil.test.ts",
+      "norm_label": "productutil.test.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/productUtil.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 951,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_promocode_test_ts",
       "label": "promoCode.test.ts",
       "norm_label": "promocode.test.ts",
@@ -104782,7 +104800,7 @@
       "source_location": "L1"
     },
     {
-      "community": 951,
+      "community": 952,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_stockvalidation_ts",
       "label": "stockValidation.ts",
@@ -104791,7 +104809,7 @@
       "source_location": "L1"
     },
     {
-      "community": 952,
+      "community": 953,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_storeconfigv2_test_ts",
       "label": "storeConfigV2.test.ts",
@@ -104800,7 +104818,7 @@
       "source_location": "L1"
     },
     {
-      "community": 953,
+      "community": 954,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_subcategories_ts",
       "label": "subcategories.ts",
@@ -104809,7 +104827,7 @@
       "source_location": "L1"
     },
     {
-      "community": 954,
+      "community": 955,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_lib_commandresultvalidators_test_ts",
       "label": "commandResultValidators.test.ts",
@@ -104818,7 +104836,7 @@
       "source_location": "L1"
     },
     {
-      "community": 955,
+      "community": 956,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_lib_currency_test_ts",
       "label": "currency.test.ts",
@@ -104827,7 +104845,7 @@
       "source_location": "L1"
     },
     {
-      "community": 956,
+      "community": 957,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_storeinsights_ts",
       "label": "storeInsights.ts",
@@ -104836,7 +104854,7 @@
       "source_location": "L1"
     },
     {
-      "community": 957,
+      "community": 958,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_userinsights_ts",
       "label": "userInsights.ts",
@@ -104845,21 +104863,12 @@
       "source_location": "L1"
     },
     {
-      "community": 958,
+      "community": 959,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_migrations_migrateamountstopesewas_ts",
       "label": "migrateAmountsToPesewas.ts",
       "norm_label": "migrateamountstopesewas.ts",
       "source_file": "packages/athena-webapp/convex/migrations/migrateAmountsToPesewas.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 959,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_mtn_client_test_ts",
-      "label": "client.test.ts",
-      "norm_label": "client.test.ts",
-      "source_file": "packages/athena-webapp/convex/mtn/client.test.ts",
       "source_location": "L1"
     },
     {
@@ -104937,6 +104946,15 @@
     {
       "community": 960,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_mtn_client_test_ts",
+      "label": "client.test.ts",
+      "norm_label": "client.test.ts",
+      "source_file": "packages/athena-webapp/convex/mtn/client.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 961,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_config_test_ts",
       "label": "config.test.ts",
       "norm_label": "config.test.ts",
@@ -104944,7 +104962,7 @@
       "source_location": "L1"
     },
     {
-      "community": 961,
+      "community": 962,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_normalize_test_ts",
       "label": "normalize.test.ts",
@@ -104953,7 +104971,7 @@
       "source_location": "L1"
     },
     {
-      "community": 962,
+      "community": 963,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_types_ts",
       "label": "types.ts",
@@ -104962,7 +104980,7 @@
       "source_location": "L1"
     },
     {
-      "community": 963,
+      "community": 964,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_customerprofiles_test_ts",
       "label": "customerProfiles.test.ts",
@@ -104971,7 +104989,7 @@
       "source_location": "L1"
     },
     {
-      "community": 964,
+      "community": 965,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_inventorymovements_test_ts",
       "label": "inventoryMovements.test.ts",
@@ -104980,7 +104998,7 @@
       "source_location": "L1"
     },
     {
-      "community": 965,
+      "community": 966,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_paymentallocations_test_ts",
       "label": "paymentAllocations.test.ts",
@@ -104989,7 +105007,7 @@
       "source_location": "L1"
     },
     {
-      "community": 966,
+      "community": 967,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_otp_emailotp_test_ts",
       "label": "EmailOTP.test.ts",
@@ -104998,7 +105016,7 @@
       "source_location": "L1"
     },
     {
-      "community": 967,
+      "community": 968,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_correcttransactioncustomer_test_ts",
       "label": "correctTransactionCustomer.test.ts",
@@ -105007,21 +105025,12 @@
       "source_location": "L1"
     },
     {
-      "community": 968,
+      "community": 969,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_corrections_correctionevents_test_ts",
       "label": "correctionEvents.test.ts",
       "norm_label": "correctionevents.test.ts",
       "source_file": "packages/athena-webapp/convex/pos/application/corrections/correctionEvents.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 969,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_corrections_correctionpolicy_test_ts",
-      "label": "correctionPolicy.test.ts",
-      "norm_label": "correctionpolicy.test.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/corrections/correctionPolicy.test.ts",
       "source_location": "L1"
     },
     {
@@ -105099,6 +105108,15 @@
     {
       "community": 970,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_corrections_correctionpolicy_test_ts",
+      "label": "correctionPolicy.test.ts",
+      "norm_label": "correctionpolicy.test.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/corrections/correctionPolicy.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 971,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_dto_ts",
       "label": "dto.ts",
       "norm_label": "dto.ts",
@@ -105106,7 +105124,7 @@
       "source_location": "L1"
     },
     {
-      "community": 971,
+      "community": 972,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_getregisterstate_test_ts",
       "label": "getRegisterState.test.ts",
@@ -105115,7 +105133,7 @@
       "source_location": "L1"
     },
     {
-      "community": 972,
+      "community": 973,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_possessiontracing_test_ts",
       "label": "posSessionTracing.test.ts",
@@ -105124,7 +105142,7 @@
       "source_location": "L1"
     },
     {
-      "community": 973,
+      "community": 974,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_terminals_test_ts",
       "label": "terminals.test.ts",
@@ -105133,7 +105151,7 @@
       "source_location": "L1"
     },
     {
-      "community": 974,
+      "community": 975,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_domain_types_ts",
       "label": "types.ts",
@@ -105142,7 +105160,7 @@
       "source_location": "L1"
     },
     {
-      "community": 975,
+      "community": 976,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_registersessionrepository_test_ts",
       "label": "registerSessionRepository.test.ts",
@@ -105151,7 +105169,7 @@
       "source_location": "L1"
     },
     {
-      "community": 976,
+      "community": 977,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_catalog_ts",
       "label": "catalog.ts",
@@ -105160,7 +105178,7 @@
       "source_location": "L1"
     },
     {
-      "community": 977,
+      "community": 978,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_customers_ts",
       "label": "customers.ts",
@@ -105169,21 +105187,12 @@
       "source_location": "L1"
     },
     {
-      "community": 978,
+      "community": 979,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_register_ts",
       "label": "register.ts",
       "norm_label": "register.ts",
       "source_file": "packages/athena-webapp/convex/pos/public/register.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 979,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_public_terminals_ts",
-      "label": "terminals.ts",
-      "norm_label": "terminals.ts",
-      "source_file": "packages/athena-webapp/convex/pos/public/terminals.ts",
       "source_location": "L1"
     },
     {
@@ -105261,6 +105270,15 @@
     {
       "community": 980,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_public_terminals_ts",
+      "label": "terminals.ts",
+      "norm_label": "terminals.ts",
+      "source_file": "packages/athena-webapp/convex/pos/public/terminals.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 981,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schema_ts",
       "label": "schema.ts",
       "norm_label": "schema.ts",
@@ -105268,7 +105286,7 @@
       "source_location": "L1"
     },
     {
-      "community": 981,
+      "community": 982,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_customermessaging_customermessagedelivery_ts",
       "label": "customerMessageDelivery.ts",
@@ -105277,7 +105295,7 @@
       "source_location": "L1"
     },
     {
-      "community": 982,
+      "community": 983,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_customermessaging_index_ts",
       "label": "index.ts",
@@ -105286,7 +105304,7 @@
       "source_location": "L1"
     },
     {
-      "community": 983,
+      "community": 984,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_customermessaging_receiptsharetoken_ts",
       "label": "receiptShareToken.ts",
@@ -105295,7 +105313,7 @@
       "source_location": "L1"
     },
     {
-      "community": 984,
+      "community": 985,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_appverificationcode_ts",
       "label": "appVerificationCode.ts",
@@ -105304,7 +105322,7 @@
       "source_location": "L1"
     },
     {
-      "community": 985,
+      "community": 986,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_athenauser_ts",
       "label": "athenaUser.ts",
@@ -105313,7 +105331,7 @@
       "source_location": "L1"
     },
     {
-      "community": 986,
+      "community": 987,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_bannermessage_ts",
       "label": "bannerMessage.ts",
@@ -105322,7 +105340,7 @@
       "source_location": "L1"
     },
     {
-      "community": 987,
+      "community": 988,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_bestseller_ts",
       "label": "bestSeller.ts",
@@ -105331,21 +105349,12 @@
       "source_location": "L1"
     },
     {
-      "community": 988,
+      "community": 989,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_category_ts",
       "label": "category.ts",
       "norm_label": "category.ts",
       "source_file": "packages/athena-webapp/convex/schemas/inventory/category.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 989,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_inventory_color_ts",
-      "label": "color.ts",
-      "norm_label": "color.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/inventory/color.ts",
       "source_location": "L1"
     },
     {
@@ -105423,6 +105432,15 @@
     {
       "community": 990,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_inventory_color_ts",
+      "label": "color.ts",
+      "norm_label": "color.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/inventory/color.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 991,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_complimentaryproduct_ts",
       "label": "complimentaryProduct.ts",
       "norm_label": "complimentaryproduct.ts",
@@ -105430,7 +105448,7 @@
       "source_location": "L1"
     },
     {
-      "community": 991,
+      "community": 992,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_featureditem_ts",
       "label": "featuredItem.ts",
@@ -105439,7 +105457,7 @@
       "source_location": "L1"
     },
     {
-      "community": 992,
+      "community": 993,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_index_ts",
       "label": "index.ts",
@@ -105448,7 +105466,7 @@
       "source_location": "L1"
     },
     {
-      "community": 993,
+      "community": 994,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_inventoryhold_ts",
       "label": "inventoryHold.ts",
@@ -105457,7 +105475,7 @@
       "source_location": "L1"
     },
     {
-      "community": 994,
+      "community": 995,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_invitecode_ts",
       "label": "inviteCode.ts",
@@ -105466,7 +105484,7 @@
       "source_location": "L1"
     },
     {
-      "community": 995,
+      "community": 996,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_organization_ts",
       "label": "organization.ts",
@@ -105475,7 +105493,7 @@
       "source_location": "L1"
     },
     {
-      "community": 996,
+      "community": 997,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_organizationmember_ts",
       "label": "organizationMember.ts",
@@ -105484,7 +105502,7 @@
       "source_location": "L1"
     },
     {
-      "community": 997,
+      "community": 998,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_product_ts",
       "label": "product.ts",
@@ -105493,21 +105511,12 @@
       "source_location": "L1"
     },
     {
-      "community": 998,
+      "community": 999,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_promocode_ts",
       "label": "promoCode.ts",
       "norm_label": "promocode.ts",
       "source_file": "packages/athena-webapp/convex/schemas/inventory/promoCode.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 999,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_inventory_redeemedpromocode_ts",
-      "label": "redeemedPromoCode.ts",
-      "norm_label": "redeemedpromocode.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/inventory/redeemedPromoCode.ts",
       "source_location": "L1"
     }
   ]

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,9 +8,9 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 1668
-- Graph nodes: 5020
+- Graph nodes: 5021
 - Graph edges: 5027
-- Communities: 1596
+- Communities: 1597
 
 ## Graph Hotspots
 - `DailyCloseView.tsx` (71 edges, Community 0) - [`packages/athena-webapp/src/components/operations/DailyCloseView.tsx`](../../packages/athena-webapp/src/components/operations/DailyCloseView.tsx)

--- a/packages/athena-webapp/src/components/organization-members/index.tsx
+++ b/packages/athena-webapp/src/components/organization-members/index.tsx
@@ -1,4 +1,6 @@
 import View from "../View";
+import { FadeIn } from "../common/FadeIn";
+import { PageLevelHeader, PageWorkspace } from "../common/PageLevelHeader";
 import { z } from "zod";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
@@ -40,10 +42,21 @@ const organizationMemberSchema = z.object({
   role: z.enum(["full_admin", "pos_only"]),
 });
 
-const Header = () => {
+const SectionHeader = ({
+  description,
+  title,
+}: {
+  description: string;
+  title: string;
+}) => {
   return (
-    <div className="container mx-auto flex gap-2 h-[40px] items-center justify-between">
-      <p className="text-xl font-medium">Organization Members</p>
+    <div className="space-y-1.5 border-b border-border/70 pb-layout-md">
+      <h2 className="text-xl font-semibold tracking-tight text-foreground">
+        {title}
+      </h2>
+      <p className="max-w-3xl text-sm leading-6 text-muted-foreground">
+        {description}
+      </p>
     </div>
   );
 };
@@ -104,13 +117,18 @@ const MemberForm = ({ onCancelClick }: { onCancelClick: () => void }) => {
   const { activeOrganization } = useGetActiveOrganization();
 
   const onSubmit = async (data: z.infer<typeof organizationMemberSchema>) => {
+    if (!activeOrganization?._id || !user?._id) {
+      toast.error("Member invite requires an active organization and user");
+      return;
+    }
+
     setIsAddingMember(true);
     try {
       const res = await createInviteCode({
-        organizationId: activeOrganization?._id!,
+        organizationId: activeOrganization._id,
         recipientEmail: data.email,
         role: data.role,
-        createdByUserId: user?._id!,
+        createdByUserId: user._id,
       });
 
       if (res.success) {
@@ -120,7 +138,7 @@ const MemberForm = ({ onCancelClick }: { onCancelClick: () => void }) => {
       }
 
       onCancelClick();
-    } catch (e) {
+    } catch {
       presentUnexpectedErrorToast("Failed to add member");
     } finally {
       setIsAddingMember(false);
@@ -214,36 +232,61 @@ export const OrganizationMembersView = () => {
   const { activeStore } = useGetActiveStore();
 
   return (
-    <View hideBorder hideHeaderBottomBorder header={<Header />}>
-      <div className="container mx-auto h-full w-full py-8 space-y-12">
-        <div className="grid grid-cols-2 gap-40">
-          <div className="space-y-8">
-            <Members />
-            {showMemberForm && (
-              <div>
-                <MemberForm onCancelClick={() => setShowMemberForm(false)} />
-              </div>
-            )}
-            {!showMemberForm && (
-              <Button variant={"ghost"} onClick={() => setShowMemberForm(true)}>
-                <Plus className="w-4 h-4 mr-2" />
-                Add Member
-              </Button>
-            )}
-          </div>
+    <View hideBorder hideHeaderBottomBorder scrollMode="page">
+      <FadeIn className="container mx-auto py-layout-xl">
+        <PageWorkspace>
+          <PageLevelHeader
+            eyebrow="Team access"
+            showBackButton
+            title="Members"
+            description="Review organization members, pending invites, and store staff profiles before assigning operational access."
+          />
 
-          <Invites />
-        </div>
-
-        {activeStore && activeOrganization && (
-          <div className="border-t pt-12">
-            <StaffManagement
-              storeId={activeStore._id}
-              organizationId={activeOrganization._id}
+          <section className="space-y-layout-lg rounded-lg border border-border bg-surface p-layout-lg shadow-surface">
+            <SectionHeader
+              title="Organization members"
+              description="Manage admin access and pending invites for the organization."
             />
-          </div>
-        )}
-      </div>
+
+            <div className="grid gap-layout-2xl xl:grid-cols-[minmax(0,1fr)_minmax(280px,360px)]">
+              <div className="space-y-layout-xl">
+                <Members />
+                {showMemberForm && (
+                  <div>
+                    <MemberForm
+                      onCancelClick={() => setShowMemberForm(false)}
+                    />
+                  </div>
+                )}
+                {!showMemberForm && (
+                  <Button
+                    variant={"ghost"}
+                    onClick={() => setShowMemberForm(true)}
+                  >
+                    <Plus className="w-4 h-4 mr-2" />
+                    Add Member
+                  </Button>
+                )}
+              </div>
+
+              <Invites />
+            </div>
+          </section>
+
+          {activeStore && activeOrganization && (
+            <section className="space-y-layout-lg rounded-lg border border-border bg-surface p-layout-lg shadow-surface">
+              <SectionHeader
+                title="Staff"
+                description="Manage store staff profiles and the credentials used in POS, services, and cash controls."
+              />
+              <StaffManagement
+                storeId={activeStore._id}
+                organizationId={activeOrganization._id}
+              />
+            </section>
+          )}
+        </PageWorkspace>
+      </FadeIn>
     </View>
   );
 };


### PR DESCRIPTION
## Summary
- Replaces the legacy members page compact header with the themed page-level header used by the services workspace
- Splits the members page into Organization members and Staff sections using themed surface headers
- Tightens member invite submission guards while updating the touched component

## Validation
- bun run --filter '@athena/webapp' lint:frontend:changed
- bun run --filter '@athena/webapp' test -- src/components/staff/StaffManagement.test.tsx
- bun run --filter '@athena/webapp' typecheck
- bun run pr:athena

Browser note: local protected members route redirects to /login without an authenticated org/store session.