### PR TITLE
[V26-540] Add manager elevation surface helper tests

### DIFF
--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,11 +1,11 @@
 # Graph Report - .
 
 ## Corpus Check
-- 1676 files · ~0 words
+- 1677 files · ~0 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 5045 nodes · 5048 edges · 1605 communities detected
+- 5047 nodes · 5052 edges · 1606 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -1615,6 +1615,7 @@
 - [[_COMMUNITY_Community 1602|Community 1602]]
 - [[_COMMUNITY_Community 1603|Community 1603]]
 - [[_COMMUNITY_Community 1604|Community 1604]]
+- [[_COMMUNITY_Community 1605|Community 1605]]
 
 ## God Nodes (most connected - your core abstractions)
 1. `createJourneyEvent()` - 40 edges
@@ -2859,56 +2860,56 @@ Cohesion: 0.67
 Nodes (2): useGetArchivedProducts(), useGetProducts()
 
 ### Community 304 - "Community 304"
+Cohesion: 1.0
+Nodes (3): canAccessFullAdminSurface(), canAccessStoreDaySurface(), getSurfaceAccess()
+
+### Community 305 - "Community 305"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 305 - "Community 305"
+### Community 306 - "Community 306"
 Cohesion: 0.67
 Nodes (2): extractTraceId(), runCommand()
 
-### Community 306 - "Community 306"
+### Community 307 - "Community 307"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 307 - "Community 307"
+### Community 308 - "Community 308"
 Cohesion: 0.67
 Nodes (2): formatStoredAmount(), formatStoredCurrencyAmount()
 
-### Community 308 - "Community 308"
+### Community 309 - "Community 309"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 309 - "Community 309"
+### Community 310 - "Community 310"
 Cohesion: 0.67
 Nodes (2): mapActiveSessionDto(), normalizeCartItems()
 
-### Community 310 - "Community 310"
+### Community 311 - "Community 311"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 311 - "Community 311"
+### Community 312 - "Community 312"
 Cohesion: 0.83
 Nodes (3): isBrowserFingerprintResult(), readStoredTerminalFingerprint(), readStoredTerminalFingerprintHash()
 
-### Community 312 - "Community 312"
+### Community 313 - "Community 313"
 Cohesion: 0.67
 Nodes (2): getCashierDisplayName(), useExpenseRegisterViewModel()
 
-### Community 313 - "Community 313"
+### Community 314 - "Community 314"
 Cohesion: 0.83
 Nodes (3): getBaseUrl(), getUserRedeemedOffers(), submitOffer()
 
-### Community 314 - "Community 314"
+### Community 315 - "Community 315"
 Cohesion: 0.83
 Nodes (3): getAllStores(), getBaseUrl(), getStore()
 
-### Community 315 - "Community 315"
+### Community 316 - "Community 316"
 Cohesion: 0.83
 Nodes (3): getAllSubcategories(), getBaseUrl(), getSubategory()
-
-### Community 316 - "Community 316"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 317 - "Community 317"
 Cohesion: 0.5
@@ -2939,59 +2940,59 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 324 - "Community 324"
-Cohesion: 0.67
-Nodes (2): useOptionalStoreContext(), useStoreContext()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 325 - "Community 325"
 Cohesion: 0.67
-Nodes (2): clearFilters(), onMobileFiltersCloseClick()
+Nodes (2): useOptionalStoreContext(), useStoreContext()
 
 ### Community 326 - "Community 326"
+Cohesion: 0.67
+Nodes (2): clearFilters(), onMobileFiltersCloseClick()
+
+### Community 327 - "Community 327"
 Cohesion: 0.83
 Nodes (3): cancelOrder(), getErrorMessage(), placeOrder()
 
-### Community 327 - "Community 327"
+### Community 328 - "Community 328"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 328 - "Community 328"
-Cohesion: 0.83
-Nodes (3): bootstrapCheckout(), createBootstrapToken(), createMarker()
 
 ### Community 329 - "Community 329"
 Cohesion: 0.83
-Nodes (3): createFixtureRoot(), write(), writeGraphifyWikiArtifacts()
+Nodes (3): bootstrapCheckout(), createBootstrapToken(), createMarker()
 
 ### Community 330 - "Community 330"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): createFixtureRoot(), write(), writeGraphifyWikiArtifacts()
 
 ### Community 331 - "Community 331"
-Cohesion: 0.67
-Nodes (2): buildHarnessDocPaths(), buildHarnessDocPathsForArchetype()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 332 - "Community 332"
 Cohesion: 0.67
-Nodes (2): shutdown(), stopValkeyRuntimeServer()
+Nodes (2): buildHarnessDocPaths(), buildHarnessDocPathsForArchetype()
 
 ### Community 333 - "Community 333"
+Cohesion: 0.67
+Nodes (2): shutdown(), stopValkeyRuntimeServer()
+
+### Community 334 - "Community 334"
 Cohesion: 0.83
 Nodes (3): createFixtureRepo(), createInferentialArtifact(), write()
 
-### Community 334 - "Community 334"
+### Community 335 - "Community 335"
 Cohesion: 0.67
 Nodes (2): collectHarnessTestTargets(), runHarnessTest()
-
-### Community 335 - "Community 335"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 336 - "Community 336"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 337 - "Community 337"
-Cohesion: 0.67
+Cohesion: 0.5
 Nodes (0):
 
 ### Community 338 - "Community 338"
@@ -2999,12 +3000,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 339 - "Community 339"
-Cohesion: 1.0
-Nodes (2): providerErrorCategory(), sendWhatsAppReceiptTemplate()
-
-### Community 340 - "Community 340"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 340 - "Community 340"
+Cohesion: 1.0
+Nodes (2): providerErrorCategory(), sendWhatsAppReceiptTemplate()
 
 ### Community 341 - "Community 341"
 Cohesion: 0.67
@@ -3035,12 +3036,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 348 - "Community 348"
-Cohesion: 1.0
-Nodes (2): buildCtx(), createDb()
-
-### Community 349 - "Community 349"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 349 - "Community 349"
+Cohesion: 1.0
+Nodes (2): buildCtx(), createDb()
 
 ### Community 350 - "Community 350"
 Cohesion: 0.67
@@ -3064,11 +3065,11 @@ Nodes (0):
 
 ### Community 355 - "Community 355"
 Cohesion: 0.67
-Nodes (1): PosServerError
+Nodes (0):
 
 ### Community 356 - "Community 356"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): PosServerError
 
 ### Community 357 - "Community 357"
 Cohesion: 0.67
@@ -3083,24 +3084,24 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 360 - "Community 360"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 361 - "Community 361"
 Cohesion: 1.0
 Nodes (2): getActiveRegisterSessionForRegisterState(), mapRegisterSessionToCashDrawerSummary()
 
-### Community 361 - "Community 361"
+### Community 362 - "Community 362"
 Cohesion: 0.67
 Nodes (0):
-
-### Community 362 - "Community 362"
-Cohesion: 1.0
-Nodes (2): buildServiceCatalogItem(), normalizeServiceCatalogNameKey()
 
 ### Community 363 - "Community 363"
 Cohesion: 1.0
-Nodes (2): expectIndex(), getTableIndexes()
+Nodes (2): buildServiceCatalogItem(), normalizeServiceCatalogNameKey()
 
 ### Community 364 - "Community 364"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): expectIndex(), getTableIndexes()
 
 ### Community 365 - "Community 365"
 Cohesion: 0.67
@@ -3115,36 +3116,36 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 368 - "Community 368"
-Cohesion: 1.0
-Nodes (2): listBagItems(), loadBagWithItems()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 369 - "Community 369"
 Cohesion: 1.0
-Nodes (2): buildRegisterSessionTraceSeed(), formatRegisterSessionLabel()
+Nodes (2): listBagItems(), loadBagWithItems()
 
 ### Community 370 - "Community 370"
 Cohesion: 1.0
-Nodes (2): getWorkflowTraceViewByIdWithCtx(), getWorkflowTraceViewByLookupWithCtx()
+Nodes (2): buildRegisterSessionTraceSeed(), formatRegisterSessionLabel()
 
 ### Community 371 - "Community 371"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getWorkflowTraceViewByIdWithCtx(), getWorkflowTraceViewByLookupWithCtx()
 
 ### Community 372 - "Community 372"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 373 - "Community 373"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 374 - "Community 374"
 Cohesion: 1.0
 Nodes (2): createWorkflowTraceId(), normalizeWorkflowTraceLookupValue()
 
-### Community 374 - "Community 374"
-Cohesion: 0.67
-Nodes (1): View()
-
 ### Community 375 - "Community 375"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): View()
 
 ### Community 376 - "Community 376"
 Cohesion: 0.67
@@ -3159,12 +3160,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 379 - "Community 379"
-Cohesion: 1.0
-Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
-
-### Community 380 - "Community 380"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 380 - "Community 380"
+Cohesion: 1.0
+Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
 
 ### Community 381 - "Community 381"
 Cohesion: 0.67
@@ -3172,11 +3173,11 @@ Nodes (0):
 
 ### Community 382 - "Community 382"
 Cohesion: 0.67
-Nodes (1): FadeIn()
+Nodes (0):
 
 ### Community 383 - "Community 383"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): FadeIn()
 
 ### Community 384 - "Community 384"
 Cohesion: 0.67
@@ -3184,35 +3185,35 @@ Nodes (0):
 
 ### Community 385 - "Community 385"
 Cohesion: 0.67
-Nodes (1): VideoPlayer()
+Nodes (0):
 
 ### Community 386 - "Community 386"
-Cohesion: 1.0
-Nodes (2): handleRefundOrder(), toast()
+Cohesion: 0.67
+Nodes (1): VideoPlayer()
 
 ### Community 387 - "Community 387"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): handleRefundOrder(), toast()
 
 ### Community 388 - "Community 388"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 389 - "Community 389"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 390 - "Community 390"
 Cohesion: 1.0
 Nodes (2): CashierAuthDialog(), getStaffDisplayName()
 
-### Community 390 - "Community 390"
+### Community 391 - "Community 391"
 Cohesion: 0.67
 Nodes (0):
-
-### Community 391 - "Community 391"
-Cohesion: 1.0
-Nodes (2): getLocalOperatingDate(), getLocalOperatingDateRange()
 
 ### Community 392 - "Community 392"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getLocalOperatingDate(), getLocalOperatingDateRange()
 
 ### Community 393 - "Community 393"
 Cohesion: 0.67
@@ -3259,84 +3260,84 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 404 - "Community 404"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 405 - "Community 405"
 Cohesion: 1.0
 Nodes (2): handleKeyDown(), handleSubmit()
 
-### Community 405 - "Community 405"
+### Community 406 - "Community 406"
 Cohesion: 0.67
 Nodes (1): SingleLineError()
 
-### Community 406 - "Community 406"
+### Community 407 - "Community 407"
 Cohesion: 0.67
 Nodes (1): ErrorPage()
 
-### Community 407 - "Community 407"
+### Community 408 - "Community 408"
 Cohesion: 0.67
 Nodes (1): AppSkeleton()
 
-### Community 408 - "Community 408"
+### Community 409 - "Community 409"
 Cohesion: 0.67
 Nodes (1): DashboardSkeleton()
 
-### Community 409 - "Community 409"
+### Community 410 - "Community 410"
 Cohesion: 0.67
 Nodes (1): TableSkeleton()
 
-### Community 410 - "Community 410"
+### Community 411 - "Community 411"
 Cohesion: 0.67
 Nodes (1): TransactionsSkeleton()
 
-### Community 411 - "Community 411"
+### Community 412 - "Community 412"
 Cohesion: 0.67
 Nodes (1): NotFound()
 
-### Community 412 - "Community 412"
+### Community 413 - "Community 413"
 Cohesion: 1.0
 Nodes (2): getWorkflowTraceRouteTarget(), WorkflowTraceRouteLink()
 
-### Community 413 - "Community 413"
+### Community 414 - "Community 414"
 Cohesion: 0.67
 Nodes (1): AppContextMenu()
 
-### Community 414 - "Community 414"
+### Community 415 - "Community 415"
 Cohesion: 0.67
 Nodes (1): Badge()
 
-### Community 415 - "Community 415"
-Cohesion: 0.67
-Nodes (0):
-
 ### Community 416 - "Community 416"
 Cohesion: 0.67
-Nodes (1): LoadingButton()
+Nodes (0):
 
 ### Community 417 - "Community 417"
 Cohesion: 0.67
-Nodes (1): onChange()
+Nodes (1): LoadingButton()
 
 ### Community 418 - "Community 418"
 Cohesion: 0.67
-Nodes (1): AlertModal()
+Nodes (1): onChange()
 
 ### Community 419 - "Community 419"
 Cohesion: 0.67
-Nodes (1): OverlayModal()
+Nodes (1): AlertModal()
 
 ### Community 420 - "Community 420"
 Cohesion: 0.67
-Nodes (1): Skeleton()
+Nodes (1): OverlayModal()
 
 ### Community 421 - "Community 421"
 Cohesion: 0.67
-Nodes (1): Toaster()
+Nodes (1): Skeleton()
 
 ### Community 422 - "Community 422"
 Cohesion: 0.67
-Nodes (1): Spinner()
+Nodes (1): Toaster()
 
 ### Community 423 - "Community 423"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): Spinner()
 
 ### Community 424 - "Community 424"
 Cohesion: 0.67
@@ -3364,11 +3365,11 @@ Nodes (0):
 
 ### Community 430 - "Community 430"
 Cohesion: 0.67
-Nodes (1): useAuth()
+Nodes (0):
 
 ### Community 431 - "Community 431"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): useAuth()
 
 ### Community 432 - "Community 432"
 Cohesion: 0.67
@@ -8062,6 +8063,10 @@ Nodes (0):
 Cohesion: 1.0
 Nodes (0):
 
+### Community 1605 - "Community 1605"
+Cohesion: 1.0
+Nodes (0):
+
 ## Knowledge Gaps
 - **1 isolated node(s):** `HelpRequested`
   These have ≤1 connection - possible missing edges or undocumented components.
@@ -9783,517 +9788,519 @@ Nodes (0):
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1348`** (1 nodes): `useProtectedAdminPageState.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1349`** (1 nodes): `aws.ts`
+- **Thin community `Community 1349`** (1 nodes): `capabilities.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1350`** (1 nodes): `constants.ts`
+- **Thin community `Community 1350`** (1 nodes): `aws.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1351`** (1 nodes): `countries.ts`
+- **Thin community `Community 1351`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1352`** (1 nodes): `operatorMessages.test.ts`
+- **Thin community `Community 1352`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1353`** (1 nodes): `presentCommandToast.test.ts`
+- **Thin community `Community 1353`** (1 nodes): `operatorMessages.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1354`** (1 nodes): `presentUnexpectedErrorToast.test.ts`
+- **Thin community `Community 1354`** (1 nodes): `presentCommandToast.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1355`** (1 nodes): `runCommand.test.ts`
+- **Thin community `Community 1355`** (1 nodes): `presentUnexpectedErrorToast.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1356`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1356`** (1 nodes): `runCommand.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1357`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 1357`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1358`** (1 nodes): `dto.ts`
+- **Thin community `Community 1358`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1359`** (1 nodes): `ports.ts`
+- **Thin community `Community 1359`** (1 nodes): `dto.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1360`** (1 nodes): `constants.ts`
+- **Thin community `Community 1360`** (1 nodes): `ports.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1361`** (1 nodes): `displayAmounts.test.ts`
+- **Thin community `Community 1361`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1362`** (1 nodes): `cart.test.ts`
+- **Thin community `Community 1362`** (1 nodes): `displayAmounts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1363`** (1 nodes): `index.ts`
+- **Thin community `Community 1363`** (1 nodes): `cart.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1364`** (1 nodes): `session.test.ts`
+- **Thin community `Community 1364`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1365`** (1 nodes): `types.ts`
+- **Thin community `Community 1365`** (1 nodes): `session.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1366`** (1 nodes): `registerGateway.test.ts`
+- **Thin community `Community 1366`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1367`** (1 nodes): `sessionGateway.test.ts`
+- **Thin community `Community 1367`** (1 nodes): `registerGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1368`** (1 nodes): `loggerGateway.ts`
+- **Thin community `Community 1368`** (1 nodes): `sessionGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1369`** (1 nodes): `catalogSearch.test.ts`
+- **Thin community `Community 1369`** (1 nodes): `loggerGateway.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1370`** (1 nodes): `registerUiState.ts`
+- **Thin community `Community 1370`** (1 nodes): `catalogSearch.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1371`** (1 nodes): `productUtils.test.ts`
+- **Thin community `Community 1371`** (1 nodes): `registerUiState.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1372`** (1 nodes): `category.ts`
+- **Thin community `Community 1372`** (1 nodes): `productUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1373`** (1 nodes): `product.ts`
+- **Thin community `Community 1373`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1374`** (1 nodes): `store.ts`
+- **Thin community `Community 1374`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1375`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1375`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1376`** (1 nodes): `user.ts`
+- **Thin community `Community 1376`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1377`** (1 nodes): `storeConfig.test.ts`
+- **Thin community `Community 1377`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1378`** (1 nodes): `createWorkflowTraceId.test.ts`
+- **Thin community `Community 1378`** (1 nodes): `storeConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1379`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1379`** (1 nodes): `createWorkflowTraceId.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1380`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 1380`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1381`** (1 nodes): `__root.tsx`
+- **Thin community `Community 1381`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1382`** (1 nodes): `index.tsx`
+- **Thin community `Community 1382`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1383`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1384`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1385`** (1 nodes): `$storeUrlSlug.tsx`
+- **Thin community `Community 1385`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1386`** (1 nodes): `analytics.tsx`
+- **Thin community `Community 1386`** (1 nodes): `$storeUrlSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1387`** (1 nodes): `assets.index.tsx`
+- **Thin community `Community 1387`** (1 nodes): `analytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1388`** (1 nodes): `bags.$bagId.tsx`
+- **Thin community `Community 1388`** (1 nodes): `assets.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1389`** (1 nodes): `bags.index.tsx`
+- **Thin community `Community 1389`** (1 nodes): `bags.$bagId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1390`** (1 nodes): `index.tsx`
+- **Thin community `Community 1390`** (1 nodes): `bags.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1391`** (1 nodes): `checkout-sessions.index.tsx`
+- **Thin community `Community 1391`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1392`** (1 nodes): `configuration.index.tsx`
+- **Thin community `Community 1392`** (1 nodes): `checkout-sessions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1393`** (1 nodes): `dashboard.index.tsx`
+- **Thin community `Community 1393`** (1 nodes): `configuration.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1394`** (1 nodes): `home.tsx`
+- **Thin community `Community 1394`** (1 nodes): `dashboard.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1395`** (1 nodes): `logs.$logId.tsx`
+- **Thin community `Community 1395`** (1 nodes): `home.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1396`** (1 nodes): `logs.index.tsx`
+- **Thin community `Community 1396`** (1 nodes): `logs.$logId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1397`** (1 nodes): `members.index.tsx`
+- **Thin community `Community 1397`** (1 nodes): `logs.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1398`** (1 nodes): `index.tsx`
+- **Thin community `Community 1398`** (1 nodes): `members.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1399`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1400`** (1 nodes): `all.index.tsx`
+- **Thin community `Community 1400`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1401`** (1 nodes): `cancelled.index.tsx`
+- **Thin community `Community 1401`** (1 nodes): `all.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1402`** (1 nodes): `completed.index.tsx`
+- **Thin community `Community 1402`** (1 nodes): `cancelled.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1403`** (1 nodes): `index.tsx`
+- **Thin community `Community 1403`** (1 nodes): `completed.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1404`** (1 nodes): `open.index.tsx`
+- **Thin community `Community 1404`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1405`** (1 nodes): `out-for-delivery.index.tsx`
+- **Thin community `Community 1405`** (1 nodes): `open.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1406`** (1 nodes): `ready.index.tsx`
+- **Thin community `Community 1406`** (1 nodes): `out-for-delivery.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1407`** (1 nodes): `refunded.index.tsx`
+- **Thin community `Community 1407`** (1 nodes): `ready.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1408`** (1 nodes): `$reportId.tsx`
+- **Thin community `Community 1408`** (1 nodes): `refunded.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1409`** (1 nodes): `expense-reports.index.tsx`
+- **Thin community `Community 1409`** (1 nodes): `$reportId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1410`** (1 nodes): `index.tsx`
+- **Thin community `Community 1410`** (1 nodes): `expense-reports.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1411`** (1 nodes): `register.index.tsx`
+- **Thin community `Community 1411`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1412`** (1 nodes): `sessions.index.tsx`
+- **Thin community `Community 1412`** (1 nodes): `register.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1413`** (1 nodes): `settings.index.tsx`
+- **Thin community `Community 1413`** (1 nodes): `sessions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1414`** (1 nodes): `$transactionId.tsx`
+- **Thin community `Community 1414`** (1 nodes): `settings.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1415`** (1 nodes): `transactions.index.tsx`
+- **Thin community `Community 1415`** (1 nodes): `$transactionId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1416`** (1 nodes): `procurement.index.test.ts`
+- **Thin community `Community 1416`** (1 nodes): `transactions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1417`** (1 nodes): `edit.tsx`
+- **Thin community `Community 1417`** (1 nodes): `procurement.index.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1418`** (1 nodes): `index.tsx`
+- **Thin community `Community 1418`** (1 nodes): `edit.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1419`** (1 nodes): `archived.tsx`
+- **Thin community `Community 1419`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1420`** (1 nodes): `index.tsx`
+- **Thin community `Community 1420`** (1 nodes): `archived.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1421`** (1 nodes): `new.tsx`
+- **Thin community `Community 1421`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1422`** (1 nodes): `index.tsx`
+- **Thin community `Community 1422`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1423`** (1 nodes): `new.tsx`
+- **Thin community `Community 1423`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1424`** (1 nodes): `unresolved.tsx`
+- **Thin community `Community 1424`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1425`** (1 nodes): `$promoCodeSlug.tsx`
+- **Thin community `Community 1425`** (1 nodes): `unresolved.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1426`** (1 nodes): `index.tsx`
+- **Thin community `Community 1426`** (1 nodes): `$promoCodeSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1427`** (1 nodes): `new.tsx`
+- **Thin community `Community 1427`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1428`** (1 nodes): `index.tsx`
+- **Thin community `Community 1428`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1429`** (1 nodes): `new.index.tsx`
+- **Thin community `Community 1429`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1430`** (1 nodes): `active-cases.index.tsx`
+- **Thin community `Community 1430`** (1 nodes): `new.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1431`** (1 nodes): `appointments.index.tsx`
+- **Thin community `Community 1431`** (1 nodes): `active-cases.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1432`** (1 nodes): `catalog-management.index.tsx`
+- **Thin community `Community 1432`** (1 nodes): `appointments.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1433`** (1 nodes): `index.tsx`
+- **Thin community `Community 1433`** (1 nodes): `catalog-management.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1434`** (1 nodes): `intake.index.tsx`
+- **Thin community `Community 1434`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1435`** (1 nodes): `$traceId.test.tsx`
+- **Thin community `Community 1435`** (1 nodes): `intake.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1436`** (1 nodes): `users.$userId.tsx`
+- **Thin community `Community 1436`** (1 nodes): `$traceId.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1437`** (1 nodes): `index.tsx`
+- **Thin community `Community 1437`** (1 nodes): `users.$userId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1438`** (1 nodes): `_authed.test.tsx`
+- **Thin community `Community 1438`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1439`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 1439`** (1 nodes): `_authed.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1440`** (1 nodes): `join-team.index.tsx`
+- **Thin community `Community 1440`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1441`** (1 nodes): `_layout.index.test.tsx`
+- **Thin community `Community 1441`** (1 nodes): `join-team.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1442`** (1 nodes): `_layout.test.tsx`
+- **Thin community `Community 1442`** (1 nodes): `_layout.index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1443`** (1 nodes): `StoresSettingsAccordion.tsx`
+- **Thin community `Community 1443`** (1 nodes): `_layout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1444`** (1 nodes): `expenseStore.ts`
+- **Thin community `Community 1444`** (1 nodes): `StoresSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1445`** (1 nodes): `Overview.stories.tsx`
+- **Thin community `Community 1445`** (1 nodes): `expenseStore.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1446`** (1 nodes): `foundations-content.test.tsx`
+- **Thin community `Community 1446`** (1 nodes): `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1447`** (1 nodes): `Introduction.stories.tsx`
+- **Thin community `Community 1447`** (1 nodes): `foundations-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1448`** (1 nodes): `introduction-content.test.tsx`
+- **Thin community `Community 1448`** (1 nodes): `Introduction.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1449`** (1 nodes): `introduction-content.tsx`
+- **Thin community `Community 1449`** (1 nodes): `introduction-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1450`** (1 nodes): `AdminShell.stories.tsx`
+- **Thin community `Community 1450`** (1 nodes): `introduction-content.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1451`** (1 nodes): `View.stories.tsx`
+- **Thin community `Community 1451`** (1 nodes): `AdminShell.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1452`** (1 nodes): `admin-shell-patterns.test.tsx`
+- **Thin community `Community 1452`** (1 nodes): `View.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1453`** (1 nodes): `view-patterns.test.tsx`
+- **Thin community `Community 1453`** (1 nodes): `admin-shell-patterns.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1454`** (1 nodes): `Surfaces.stories.tsx`
+- **Thin community `Community 1454`** (1 nodes): `view-patterns.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1455`** (1 nodes): `DashboardWorkspace.stories.tsx`
+- **Thin community `Community 1455`** (1 nodes): `Surfaces.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1456`** (1 nodes): `DataWorkspace.stories.tsx`
+- **Thin community `Community 1456`** (1 nodes): `DashboardWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1457`** (1 nodes): `SettingsWorkspace.stories.tsx`
+- **Thin community `Community 1457`** (1 nodes): `DataWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1458`** (1 nodes): `reference-fixtures.test.tsx`
+- **Thin community `Community 1458`** (1 nodes): `SettingsWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1459`** (1 nodes): `storybook-config.test.ts`
+- **Thin community `Community 1459`** (1 nodes): `reference-fixtures.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1460`** (1 nodes): `storybook-theme-decorator.test.ts`
+- **Thin community `Community 1460`** (1 nodes): `storybook-config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1461`** (1 nodes): `setup.ts`
+- **Thin community `Community 1461`** (1 nodes): `storybook-theme-decorator.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1462`** (1 nodes): `usePrint.test.ts`
+- **Thin community `Community 1462`** (1 nodes): `setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1463`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 1463`** (1 nodes): `usePrint.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1464`** (1 nodes): `types.ts`
+- **Thin community `Community 1464`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1465`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 1465`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1466`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 1466`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1467`** (1 nodes): `global.d.ts`
+- **Thin community `Community 1467`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1468`** (1 nodes): `playwright.config.ts`
+- **Thin community `Community 1468`** (1 nodes): `global.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1469`** (1 nodes): `analytics.test.ts`
+- **Thin community `Community 1469`** (1 nodes): `playwright.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1470`** (1 nodes): `types.ts`
+- **Thin community `Community 1470`** (1 nodes): `analytics.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1471`** (1 nodes): `HeartIconFilled.tsx`
+- **Thin community `Community 1471`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1472`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 1472`** (1 nodes): `HeartIconFilled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1473`** (1 nodes): `HomePage.test.tsx`
+- **Thin community `Community 1473`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1474`** (1 nodes): `ProductCard.test.tsx`
+- **Thin community `Community 1474`** (1 nodes): `HomePage.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1475`** (1 nodes): `ProductCard.tsx`
+- **Thin community `Community 1475`** (1 nodes): `ProductCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1476`** (1 nodes): `Upsell.tsx`
+- **Thin community `Community 1476`** (1 nodes): `ProductCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1477`** (1 nodes): `Checkout.test.tsx`
+- **Thin community `Community 1477`** (1 nodes): `Upsell.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1478`** (1 nodes): `Checkout.tsx`
+- **Thin community `Community 1478`** (1 nodes): `Checkout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1479`** (1 nodes): `CustomerInfoSection.tsx`
+- **Thin community `Community 1479`** (1 nodes): `Checkout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1480`** (1 nodes): `schema.ts`
+- **Thin community `Community 1480`** (1 nodes): `CustomerInfoSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1481`** (1 nodes): `DeliveryDetailsSection.tsx`
+- **Thin community `Community 1481`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1482`** (1 nodes): `checkoutStorage.test.ts`
+- **Thin community `Community 1482`** (1 nodes): `DeliveryDetailsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1483`** (1 nodes): `deliveryFees.test.ts`
+- **Thin community `Community 1483`** (1 nodes): `checkoutStorage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1484`** (1 nodes): `deriveCheckoutState.test.ts`
+- **Thin community `Community 1484`** (1 nodes): `deliveryFees.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1485`** (1 nodes): `billingDetailsSchema.ts`
+- **Thin community `Community 1485`** (1 nodes): `deriveCheckoutState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1486`** (1 nodes): `checkoutFormSchema.ts`
+- **Thin community `Community 1486`** (1 nodes): `billingDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1487`** (1 nodes): `customerDetailsSchema.ts`
+- **Thin community `Community 1487`** (1 nodes): `checkoutFormSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1488`** (1 nodes): `deliveryDetailsSchema.ts`
+- **Thin community `Community 1488`** (1 nodes): `customerDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1489`** (1 nodes): `webOrderSchema.ts`
+- **Thin community `Community 1489`** (1 nodes): `deliveryDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1490`** (1 nodes): `types.ts`
+- **Thin community `Community 1490`** (1 nodes): `webOrderSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1491`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1491`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1492`** (1 nodes): `ProductFilterBar.tsx`
+- **Thin community `Community 1492`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1493`** (1 nodes): `BestSellersSection.test.tsx`
+- **Thin community `Community 1493`** (1 nodes): `ProductFilterBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1494`** (1 nodes): `HomeHero.tsx`
+- **Thin community `Community 1494`** (1 nodes): `BestSellersSection.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1495`** (1 nodes): `HomeHeroSection.tsx`
+- **Thin community `Community 1495`** (1 nodes): `HomeHero.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1496`** (1 nodes): `homePageContent.test.ts`
+- **Thin community `Community 1496`** (1 nodes): `HomeHeroSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1497`** (1 nodes): `MobileMenu.tsx`
+- **Thin community `Community 1497`** (1 nodes): `homePageContent.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1498`** (1 nodes): `constants.ts`
+- **Thin community `Community 1498`** (1 nodes): `MobileMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1499`** (1 nodes): `navBarConstants.ts`
+- **Thin community `Community 1499`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1500`** (1 nodes): `About.tsx`
+- **Thin community `Community 1500`** (1 nodes): `navBarConstants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1501`** (1 nodes): `AboutProduct.tsx`
+- **Thin community `Community 1501`** (1 nodes): `About.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1502`** (1 nodes): `ProductActions.test.tsx`
+- **Thin community `Community 1502`** (1 nodes): `AboutProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1503`** (1 nodes): `ProductInfo.tsx`
+- **Thin community `Community 1503`** (1 nodes): `ProductActions.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1504`** (1 nodes): `ProductReviews.tsx`
+- **Thin community `Community 1504`** (1 nodes): `ProductInfo.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1505`** (1 nodes): `ProductsNavigationBar.tsx`
+- **Thin community `Community 1505`** (1 nodes): `ProductReviews.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1506`** (1 nodes): `ErrorMessage.tsx`
+- **Thin community `Community 1506`** (1 nodes): `ProductsNavigationBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1507`** (1 nodes): `ExistingReviewMessage.tsx`
+- **Thin community `Community 1507`** (1 nodes): `ErrorMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1508`** (1 nodes): `OrderItem.test.tsx`
+- **Thin community `Community 1508`** (1 nodes): `ExistingReviewMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1509`** (1 nodes): `ReviewForm.tsx`
+- **Thin community `Community 1509`** (1 nodes): `OrderItem.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1510`** (1 nodes): `SuccessMessage.tsx`
+- **Thin community `Community 1510`** (1 nodes): `ReviewForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1511`** (1 nodes): `types.ts`
+- **Thin community `Community 1511`** (1 nodes): `SuccessMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1512`** (1 nodes): `SavedBag.tsx`
+- **Thin community `Community 1512`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1513`** (1 nodes): `SavedIcon.tsx`
+- **Thin community `Community 1513`** (1 nodes): `SavedBag.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1514`** (1 nodes): `CartIcon.tsx`
+- **Thin community `Community 1514`** (1 nodes): `SavedIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1515`** (1 nodes): `ShoppingBag.test.tsx`
+- **Thin community `Community 1515`** (1 nodes): `CartIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1516`** (1 nodes): `empty-state.tsx`
+- **Thin community `Community 1516`** (1 nodes): `ShoppingBag.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1517`** (1 nodes): `Maintenance.test.tsx`
+- **Thin community `Community 1517`** (1 nodes): `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1518`** (1 nodes): `Maintenance.tsx`
+- **Thin community `Community 1518`** (1 nodes): `Maintenance.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1519`** (1 nodes): `AnimatedCard.tsx`
+- **Thin community `Community 1519`** (1 nodes): `Maintenance.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1520`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 1520`** (1 nodes): `AnimatedCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1521`** (1 nodes): `alert.tsx`
+- **Thin community `Community 1521`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1522`** (1 nodes): `breadcrumb.tsx`
+- **Thin community `Community 1522`** (1 nodes): `alert.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1523`** (1 nodes): `button.tsx`
+- **Thin community `Community 1523`** (1 nodes): `breadcrumb.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1524`** (1 nodes): `card.tsx`
+- **Thin community `Community 1524`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1525`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 1525`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1526`** (1 nodes): `command.tsx`
+- **Thin community `Community 1526`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1527`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 1527`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1528`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 1528`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1529`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 1529`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1530`** (1 nodes): `form.tsx`
+- **Thin community `Community 1530`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1531`** (1 nodes): `icons.tsx`
+- **Thin community `Community 1531`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1532`** (1 nodes): `image-with-fallback.tsx`
+- **Thin community `Community 1532`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1533`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 1533`** (1 nodes): `image-with-fallback.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1534`** (1 nodes): `input-with-end-button.tsx`
+- **Thin community `Community 1534`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1535`** (1 nodes): `input.tsx`
+- **Thin community `Community 1535`** (1 nodes): `input-with-end-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1536`** (1 nodes): `label.tsx`
+- **Thin community `Community 1536`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1537`** (1 nodes): `LeaveAReviewModalForm.tsx`
+- **Thin community `Community 1537`** (1 nodes): `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1538`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 1538`** (1 nodes): `LeaveAReviewModalForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1539`** (1 nodes): `welcomeBackModalAnimations.ts`
+- **Thin community `Community 1539`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1540`** (1 nodes): `index.ts`
+- **Thin community `Community 1540`** (1 nodes): `welcomeBackModalAnimations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1541`** (1 nodes): `types.ts`
+- **Thin community `Community 1541`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1542`** (1 nodes): `navigation-menu.tsx`
+- **Thin community `Community 1542`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1543`** (1 nodes): `popover.tsx`
+- **Thin community `Community 1543`** (1 nodes): `navigation-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1544`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 1544`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1545`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 1545`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1546`** (1 nodes): `select.tsx`
+- **Thin community `Community 1546`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1547`** (1 nodes): `separator.tsx`
+- **Thin community `Community 1547`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1548`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 1548`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1549`** (1 nodes): `table.tsx`
+- **Thin community `Community 1549`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1550`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 1550`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1551`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 1551`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1552`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 1552`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1553`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 1553`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1554`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 1554`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1555`** (1 nodes): `config.ts`
+- **Thin community `Community 1555`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1556`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 1556`** (1 nodes): `config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1557`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 1557`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1558`** (1 nodes): `useQueryEnabled.test.ts`
+- **Thin community `Community 1558`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1559`** (1 nodes): `useStorefrontObservability.ts`
+- **Thin community `Community 1559`** (1 nodes): `useQueryEnabled.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1560`** (1 nodes): `constants.ts`
+- **Thin community `Community 1560`** (1 nodes): `useStorefrontObservability.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1561`** (1 nodes): `countries.ts`
+- **Thin community `Community 1561`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1562`** (1 nodes): `feeUtils.test.ts`
+- **Thin community `Community 1562`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1563`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1563`** (1 nodes): `feeUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1564`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 1564`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1565`** (1 nodes): `maintenanceUtils.test.ts`
+- **Thin community `Community 1565`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1566`** (1 nodes): `index.ts`
+- **Thin community `Community 1566`** (1 nodes): `maintenanceUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1567`** (1 nodes): `store.ts`
+- **Thin community `Community 1567`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1568`** (1 nodes): `bag.ts`
+- **Thin community `Community 1568`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1569`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1569`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1570`** (1 nodes): `category.ts`
+- **Thin community `Community 1570`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1571`** (1 nodes): `organization.ts`
+- **Thin community `Community 1571`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1572`** (1 nodes): `product.ts`
+- **Thin community `Community 1572`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1573`** (1 nodes): `store.ts`
+- **Thin community `Community 1573`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1574`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1574`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1575`** (1 nodes): `user.ts`
+- **Thin community `Community 1575`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1576`** (1 nodes): `states.ts`
+- **Thin community `Community 1576`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1577`** (1 nodes): `storefrontFailureObservability.test.ts`
+- **Thin community `Community 1577`** (1 nodes): `states.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1578`** (1 nodes): `storefrontJourneyEvents.test.ts`
+- **Thin community `Community 1578`** (1 nodes): `storefrontFailureObservability.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1579`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1579`** (1 nodes): `storefrontJourneyEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1580`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 1580`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1581`** (1 nodes): `-homePageLoader.test.ts`
+- **Thin community `Community 1581`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1582`** (1 nodes): `__root.tsx`
+- **Thin community `Community 1582`** (1 nodes): `-homePageLoader.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1583`** (1 nodes): `$orderItemId.review.tsx`
+- **Thin community `Community 1583`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1584`** (1 nodes): `index.tsx`
+- **Thin community `Community 1584`** (1 nodes): `$orderItemId.review.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1585`** (1 nodes): `$subcategorySlug.tsx`
+- **Thin community `Community 1585`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1586`** (1 nodes): `index.tsx`
+- **Thin community `Community 1586`** (1 nodes): `$subcategorySlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1587`** (1 nodes): `rewards.index.tsx`
+- **Thin community `Community 1587`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1588`** (1 nodes): `shop.saved.index.tsx`
+- **Thin community `Community 1588`** (1 nodes): `rewards.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1589`** (1 nodes): `bag.index.tsx`
+- **Thin community `Community 1589`** (1 nodes): `shop.saved.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1590`** (1 nodes): `complete.tsx`
+- **Thin community `Community 1590`** (1 nodes): `bag.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1591`** (1 nodes): `incomplete.tsx`
+- **Thin community `Community 1591`** (1 nodes): `complete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1592`** (1 nodes): `index.tsx`
+- **Thin community `Community 1592`** (1 nodes): `incomplete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1593`** (1 nodes): `pending.tsx`
+- **Thin community `Community 1593`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1594`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 1594`** (1 nodes): `pending.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1595`** (1 nodes): `storefront-boot.e2e.ts`
+- **Thin community `Community 1595`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1596`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 1596`** (1 nodes): `storefront-boot.e2e.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1597`** (1 nodes): `vitest.setup.ts`
+- **Thin community `Community 1597`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1598`** (1 nodes): `index.js`
+- **Thin community `Community 1598`** (1 nodes): `vitest.setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1599`** (1 nodes): `harness-app-registry.test.ts`
+- **Thin community `Community 1599`** (1 nodes): `index.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1600`** (1 nodes): `athena-runtime-app.test.ts`
+- **Thin community `Community 1600`** (1 nodes): `harness-app-registry.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1601`** (1 nodes): `storefront-runtime-api.test.ts`
+- **Thin community `Community 1601`** (1 nodes): `athena-runtime-app.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1602`** (1 nodes): `valkey-runtime-app.test.ts`
+- **Thin community `Community 1602`** (1 nodes): `storefront-runtime-api.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1603`** (1 nodes): `harness-behavior-scenarios.test.ts`
+- **Thin community `Community 1603`** (1 nodes): `valkey-runtime-app.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1604`** (1 nodes): `harness-repo-validation.test.ts`
+- **Thin community `Community 1604`** (1 nodes): `harness-behavior-scenarios.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1605`** (1 nodes): `harness-repo-validation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -844,6 +844,42 @@
       "weight": 1
     },
     {
+      "_src": "capabilities_canaccessstoredaysurface",
+      "_tgt": "capabilities_canaccessfulladminsurface",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "capabilities_canaccessfulladminsurface",
+      "source_file": "packages/athena-webapp/src/lib/access/capabilities.ts",
+      "source_location": "L52",
+      "target": "capabilities_canaccessstoredaysurface",
+      "weight": 1
+    },
+    {
+      "_src": "capabilities_getsurfaceaccess",
+      "_tgt": "capabilities_canaccessfulladminsurface",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "capabilities_canaccessfulladminsurface",
+      "source_file": "packages/athena-webapp/src/lib/access/capabilities.ts",
+      "source_location": "L63",
+      "target": "capabilities_getsurfaceaccess",
+      "weight": 1
+    },
+    {
+      "_src": "capabilities_getsurfaceaccess",
+      "_tgt": "capabilities_canaccessstoredaysurface",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "capabilities_canaccessstoredaysurface",
+      "source_file": "packages/athena-webapp/src/lib/access/capabilities.ts",
+      "source_location": "L60",
+      "target": "capabilities_getsurfaceaccess",
+      "weight": 1
+    },
+    {
       "_src": "cart_calculateposcarttotals",
       "_tgt": "cart_roundposamount",
       "confidence": "EXTRACTED",
@@ -37667,7 +37703,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_lib_access_capabilities_ts",
       "source_file": "packages/athena-webapp/src/lib/access/capabilities.ts",
-      "source_location": "L4",
+      "source_location": "L42",
       "target": "capabilities_canaccessfulladminsurface",
       "weight": 1
     },
@@ -37679,8 +37715,20 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_lib_access_capabilities_ts",
       "source_file": "packages/athena-webapp/src/lib/access/capabilities.ts",
-      "source_location": "L8",
+      "source_location": "L48",
       "target": "capabilities_canaccessstoredaysurface",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_lib_access_capabilities_ts",
+      "_tgt": "capabilities_getsurfaceaccess",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_lib_access_capabilities_ts",
+      "source_file": "packages/athena-webapp/src/lib/access/capabilities.ts",
+      "source_location": "L55",
+      "target": "capabilities_getsurfaceaccess",
       "weight": 1
     },
     {
@@ -68343,10 +68391,10 @@
     {
       "community": 1349,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_aws_ts",
-      "label": "aws.ts",
-      "norm_label": "aws.ts",
-      "source_file": "packages/athena-webapp/src/lib/aws.ts",
+      "id": "packages_athena_webapp_src_lib_access_capabilities_test_ts",
+      "label": "capabilities.test.ts",
+      "norm_label": "capabilities.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/access/capabilities.test.ts",
       "source_location": "L1"
     },
     {
@@ -68415,6 +68463,15 @@
     {
       "community": 1350,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_aws_ts",
+      "label": "aws.ts",
+      "norm_label": "aws.ts",
+      "source_file": "packages/athena-webapp/src/lib/aws.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1351,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_lib_constants_ts",
       "label": "constants.ts",
       "norm_label": "constants.ts",
@@ -68422,7 +68479,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1351,
+      "community": 1352,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_countries_ts",
       "label": "countries.ts",
@@ -68431,7 +68488,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1352,
+      "community": 1353,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_operatormessages_test_ts",
       "label": "operatorMessages.test.ts",
@@ -68440,7 +68497,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1353,
+      "community": 1354,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_presentcommandtoast_test_ts",
       "label": "presentCommandToast.test.ts",
@@ -68449,7 +68506,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1354,
+      "community": 1355,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_presentunexpectederrortoast_test_ts",
       "label": "presentUnexpectedErrorToast.test.ts",
@@ -68458,7 +68515,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1355,
+      "community": 1356,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_runcommand_test_ts",
       "label": "runCommand.test.ts",
@@ -68467,7 +68524,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1356,
+      "community": 1357,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_ghana_ts",
       "label": "ghana.ts",
@@ -68476,7 +68533,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1357,
+      "community": 1358,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_ghanaregions_ts",
       "label": "ghanaRegions.ts",
@@ -68485,21 +68542,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1358,
+      "community": 1359,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_dto_ts",
       "label": "dto.ts",
       "norm_label": "dto.ts",
       "source_file": "packages/athena-webapp/src/lib/pos/application/dto.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1359,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_application_ports_ts",
-      "label": "ports.ts",
-      "norm_label": "ports.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/ports.ts",
       "source_location": "L1"
     },
     {
@@ -68568,6 +68616,15 @@
     {
       "community": 1360,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_application_ports_ts",
+      "label": "ports.ts",
+      "norm_label": "ports.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/ports.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1361,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_constants_ts",
       "label": "constants.ts",
       "norm_label": "constants.ts",
@@ -68575,7 +68632,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1361,
+      "community": 1362,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_displayamounts_test_ts",
       "label": "displayAmounts.test.ts",
@@ -68584,7 +68641,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1362,
+      "community": 1363,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_domain_cart_test_ts",
       "label": "cart.test.ts",
@@ -68593,7 +68650,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1363,
+      "community": 1364,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_domain_index_ts",
       "label": "index.ts",
@@ -68602,7 +68659,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1364,
+      "community": 1365,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_domain_session_test_ts",
       "label": "session.test.ts",
@@ -68611,7 +68668,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1365,
+      "community": 1366,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_domain_types_ts",
       "label": "types.ts",
@@ -68620,7 +68677,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1366,
+      "community": 1367,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_registergateway_test_ts",
       "label": "registerGateway.test.ts",
@@ -68629,7 +68686,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1367,
+      "community": 1368,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_sessiongateway_test_ts",
       "label": "sessionGateway.test.ts",
@@ -68638,21 +68695,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1368,
+      "community": 1369,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_telemetry_loggergateway_ts",
       "label": "loggerGateway.ts",
       "norm_label": "loggergateway.ts",
       "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/loggerGateway.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1369,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_presentation_register_catalogsearch_test_ts",
-      "label": "catalogSearch.test.ts",
-      "norm_label": "catalogsearch.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/catalogSearch.test.ts",
       "source_location": "L1"
     },
     {
@@ -68721,6 +68769,15 @@
     {
       "community": 1370,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_presentation_register_catalogsearch_test_ts",
+      "label": "catalogSearch.test.ts",
+      "norm_label": "catalogsearch.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/catalogSearch.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1371,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_presentation_register_registeruistate_ts",
       "label": "registerUiState.ts",
       "norm_label": "registeruistate.ts",
@@ -68728,7 +68785,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1371,
+      "community": 1372,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_productutils_test_ts",
       "label": "productUtils.test.ts",
@@ -68737,7 +68794,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1372,
+      "community": 1373,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_schemas_category_ts",
       "label": "category.ts",
@@ -68746,7 +68803,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1373,
+      "community": 1374,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_schemas_product_ts",
       "label": "product.ts",
@@ -68755,7 +68812,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1374,
+      "community": 1375,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_schemas_store_ts",
       "label": "store.ts",
@@ -68764,7 +68821,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1375,
+      "community": 1376,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_schemas_subcategory_ts",
       "label": "subcategory.ts",
@@ -68773,7 +68830,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1376,
+      "community": 1377,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_schemas_user_ts",
       "label": "user.ts",
@@ -68782,7 +68839,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1377,
+      "community": 1378,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_storeconfig_test_ts",
       "label": "storeConfig.test.ts",
@@ -68791,21 +68848,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1378,
+      "community": 1379,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_traces_createworkflowtraceid_test_ts",
       "label": "createWorkflowTraceId.test.ts",
       "norm_label": "createworkflowtraceid.test.ts",
       "source_file": "packages/athena-webapp/src/lib/traces/createWorkflowTraceId.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1379,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_utils_test_ts",
-      "label": "utils.test.ts",
-      "norm_label": "utils.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/utils.test.ts",
       "source_location": "L1"
     },
     {
@@ -68874,6 +68922,15 @@
     {
       "community": 1380,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_utils_test_ts",
+      "label": "utils.test.ts",
+      "norm_label": "utils.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/utils.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1381,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routetree_gen_ts",
       "label": "routeTree.gen.ts",
       "norm_label": "routetree.gen.ts",
@@ -68881,7 +68938,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1381,
+      "community": 1382,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_root_tsx",
       "label": "__root.tsx",
@@ -68890,7 +68947,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1382,
+      "community": 1383,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_index_tsx",
       "label": "index.tsx",
@@ -68899,7 +68956,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1383,
+      "community": 1384,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_settings_index_tsx",
       "label": "index.tsx",
@@ -68908,7 +68965,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1384,
+      "community": 1385,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_settings_organization_index_tsx",
       "label": "index.tsx",
@@ -68917,7 +68974,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1385,
+      "community": 1386,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_settings_stores_storeurlslug_tsx",
       "label": "$storeUrlSlug.tsx",
@@ -68926,7 +68983,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1386,
+      "community": 1387,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_analytics_tsx",
       "label": "analytics.tsx",
@@ -68935,7 +68992,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1387,
+      "community": 1388,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_assets_index_tsx",
       "label": "assets.index.tsx",
@@ -68944,21 +69001,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1388,
+      "community": 1389,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_bags_bagid_tsx",
       "label": "bags.$bagId.tsx",
       "norm_label": "bags.$bagid.tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/bags.$bagId.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1389,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_bags_index_tsx",
-      "label": "bags.index.tsx",
-      "norm_label": "bags.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/bags.index.tsx",
       "source_location": "L1"
     },
     {
@@ -69027,6 +69075,15 @@
     {
       "community": 1390,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_bags_index_tsx",
+      "label": "bags.index.tsx",
+      "norm_label": "bags.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/bags.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1391,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_bulk_operations_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
@@ -69034,7 +69091,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1391,
+      "community": 1392,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_checkout_sessions_index_tsx",
       "label": "checkout-sessions.index.tsx",
@@ -69043,7 +69100,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1392,
+      "community": 1393,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_configuration_index_tsx",
       "label": "configuration.index.tsx",
@@ -69052,7 +69109,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1393,
+      "community": 1394,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_dashboard_index_tsx",
       "label": "dashboard.index.tsx",
@@ -69061,7 +69118,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1394,
+      "community": 1395,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_home_tsx",
       "label": "home.tsx",
@@ -69070,7 +69127,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1395,
+      "community": 1396,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_logs_logid_tsx",
       "label": "logs.$logId.tsx",
@@ -69079,7 +69136,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1396,
+      "community": 1397,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_logs_index_tsx",
       "label": "logs.index.tsx",
@@ -69088,7 +69145,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1397,
+      "community": 1398,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_members_index_tsx",
       "label": "members.index.tsx",
@@ -69097,21 +69154,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1398,
+      "community": 1399,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_operations_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1399,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_orderslug_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/$orderSlug/index.tsx",
       "source_location": "L1"
     },
     {
@@ -69405,6 +69453,15 @@
     {
       "community": 1400,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_orderslug_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/$orderSlug/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1401,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_all_index_tsx",
       "label": "all.index.tsx",
       "norm_label": "all.index.tsx",
@@ -69412,7 +69469,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1401,
+      "community": 1402,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_cancelled_index_tsx",
       "label": "cancelled.index.tsx",
@@ -69421,7 +69478,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1402,
+      "community": 1403,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_completed_index_tsx",
       "label": "completed.index.tsx",
@@ -69430,7 +69487,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1403,
+      "community": 1404,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_index_tsx",
       "label": "index.tsx",
@@ -69439,7 +69496,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1404,
+      "community": 1405,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_open_index_tsx",
       "label": "open.index.tsx",
@@ -69448,7 +69505,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1405,
+      "community": 1406,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_out_for_delivery_index_tsx",
       "label": "out-for-delivery.index.tsx",
@@ -69457,7 +69514,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1406,
+      "community": 1407,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_ready_index_tsx",
       "label": "ready.index.tsx",
@@ -69466,7 +69523,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1407,
+      "community": 1408,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_refunded_index_tsx",
       "label": "refunded.index.tsx",
@@ -69475,21 +69532,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1408,
+      "community": 1409,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_reports_reportid_tsx",
       "label": "$reportId.tsx",
       "norm_label": "$reportid.tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/expense-reports/$reportId.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1409,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_reports_index_tsx",
-      "label": "expense-reports.index.tsx",
-      "norm_label": "expense-reports.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/expense-reports.index.tsx",
       "source_location": "L1"
     },
     {
@@ -69558,6 +69606,15 @@
     {
       "community": 1410,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_reports_index_tsx",
+      "label": "expense-reports.index.tsx",
+      "norm_label": "expense-reports.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/expense-reports.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1411,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
@@ -69565,7 +69622,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1411,
+      "community": 1412,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_register_index_tsx",
       "label": "register.index.tsx",
@@ -69574,7 +69631,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1412,
+      "community": 1413,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_sessions_index_tsx",
       "label": "sessions.index.tsx",
@@ -69583,7 +69640,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1413,
+      "community": 1414,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_settings_index_tsx",
       "label": "settings.index.tsx",
@@ -69592,7 +69649,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1414,
+      "community": 1415,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_transactions_transactionid_tsx",
       "label": "$transactionId.tsx",
@@ -69601,7 +69658,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1415,
+      "community": 1416,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_transactions_index_tsx",
       "label": "transactions.index.tsx",
@@ -69610,7 +69667,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1416,
+      "community": 1417,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_procurement_index_test_ts",
       "label": "procurement.index.test.ts",
@@ -69619,7 +69676,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1417,
+      "community": 1418,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_productslug_edit_tsx",
       "label": "edit.tsx",
@@ -69628,21 +69685,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1418,
+      "community": 1419,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_productslug_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/$productSlug/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1419,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_archived_tsx",
-      "label": "archived.tsx",
-      "norm_label": "archived.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/archived.tsx",
       "source_location": "L1"
     },
     {
@@ -69711,6 +69759,15 @@
     {
       "community": 1420,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_archived_tsx",
+      "label": "archived.tsx",
+      "norm_label": "archived.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/archived.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1421,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_complimentary_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
@@ -69718,7 +69775,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1421,
+      "community": 1422,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_complimentary_new_tsx",
       "label": "new.tsx",
@@ -69727,7 +69784,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1422,
+      "community": 1423,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_index_tsx",
       "label": "index.tsx",
@@ -69736,7 +69793,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1423,
+      "community": 1424,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_new_tsx",
       "label": "new.tsx",
@@ -69745,7 +69802,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1424,
+      "community": 1425,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_unresolved_tsx",
       "label": "unresolved.tsx",
@@ -69754,7 +69811,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1425,
+      "community": 1426,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_promocodeslug_tsx",
       "label": "$promoCodeSlug.tsx",
@@ -69763,7 +69820,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1426,
+      "community": 1427,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_index_tsx",
       "label": "index.tsx",
@@ -69772,7 +69829,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1427,
+      "community": 1428,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_new_tsx",
       "label": "new.tsx",
@@ -69781,21 +69838,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1428,
+      "community": 1429,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reviews_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/reviews/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1429,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reviews_new_index_tsx",
-      "label": "new.index.tsx",
-      "norm_label": "new.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/reviews/new.index.tsx",
       "source_location": "L1"
     },
     {
@@ -69864,6 +69912,15 @@
     {
       "community": 1430,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reviews_new_index_tsx",
+      "label": "new.index.tsx",
+      "norm_label": "new.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/reviews/new.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1431,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_active_cases_index_tsx",
       "label": "active-cases.index.tsx",
       "norm_label": "active-cases.index.tsx",
@@ -69871,7 +69928,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1431,
+      "community": 1432,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_appointments_index_tsx",
       "label": "appointments.index.tsx",
@@ -69880,7 +69937,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1432,
+      "community": 1433,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_catalog_management_index_tsx",
       "label": "catalog-management.index.tsx",
@@ -69889,7 +69946,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1433,
+      "community": 1434,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_index_tsx",
       "label": "index.tsx",
@@ -69898,7 +69955,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1434,
+      "community": 1435,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_intake_index_tsx",
       "label": "intake.index.tsx",
@@ -69907,7 +69964,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1435,
+      "community": 1436,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_traces_traceid_test_tsx",
       "label": "$traceId.test.tsx",
@@ -69916,7 +69973,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1436,
+      "community": 1437,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_users_userid_tsx",
       "label": "users.$userId.tsx",
@@ -69925,7 +69982,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1437,
+      "community": 1438,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_index_tsx",
       "label": "index.tsx",
@@ -69934,21 +69991,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1438,
+      "community": 1439,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_test_tsx",
       "label": "_authed.test.tsx",
       "norm_label": "_authed.test.tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1439,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_index_test_tsx",
-      "label": "index.test.tsx",
-      "norm_label": "index.test.tsx",
-      "source_file": "packages/athena-webapp/src/routes/index.test.tsx",
       "source_location": "L1"
     },
     {
@@ -70017,6 +70065,15 @@
     {
       "community": 1440,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_index_test_tsx",
+      "label": "index.test.tsx",
+      "norm_label": "index.test.tsx",
+      "source_file": "packages/athena-webapp/src/routes/index.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1441,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_join_team_index_tsx",
       "label": "join-team.index.tsx",
       "norm_label": "join-team.index.tsx",
@@ -70024,7 +70081,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1441,
+      "community": 1442,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_login_layout_index_test_tsx",
       "label": "_layout.index.test.tsx",
@@ -70033,7 +70090,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1442,
+      "community": 1443,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_login_layout_test_tsx",
       "label": "_layout.test.tsx",
@@ -70042,7 +70099,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1443,
+      "community": 1444,
       "file_type": "code",
       "id": "packages_athena_webapp_src_settings_store_storessettingsaccordion_tsx",
       "label": "StoresSettingsAccordion.tsx",
@@ -70051,7 +70108,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1444,
+      "community": 1445,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stores_expensestore_ts",
       "label": "expenseStore.ts",
@@ -70060,7 +70117,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1445,
+      "community": 1446,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_foundations_overview_stories_tsx",
       "label": "Overview.stories.tsx",
@@ -70069,7 +70126,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1446,
+      "community": 1447,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_foundations_foundations_content_test_tsx",
       "label": "foundations-content.test.tsx",
@@ -70078,7 +70135,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1447,
+      "community": 1448,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_guidance_introduction_stories_tsx",
       "label": "Introduction.stories.tsx",
@@ -70087,21 +70144,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1448,
+      "community": 1449,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_guidance_introduction_content_test_tsx",
       "label": "introduction-content.test.tsx",
       "norm_label": "introduction-content.test.tsx",
       "source_file": "packages/athena-webapp/src/stories/Guidance/introduction-content.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1449,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_guidance_introduction_content_tsx",
-      "label": "introduction-content.tsx",
-      "norm_label": "introduction-content.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Guidance/introduction-content.tsx",
       "source_location": "L1"
     },
     {
@@ -70170,6 +70218,15 @@
     {
       "community": 1450,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_guidance_introduction_content_tsx",
+      "label": "introduction-content.tsx",
+      "norm_label": "introduction-content.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Guidance/introduction-content.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1451,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_stories_patterns_adminshell_stories_tsx",
       "label": "AdminShell.stories.tsx",
       "norm_label": "adminshell.stories.tsx",
@@ -70177,7 +70234,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1451,
+      "community": 1452,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_patterns_view_stories_tsx",
       "label": "View.stories.tsx",
@@ -70186,7 +70243,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1452,
+      "community": 1453,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_patterns_admin_shell_patterns_test_tsx",
       "label": "admin-shell-patterns.test.tsx",
@@ -70195,7 +70252,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1453,
+      "community": 1454,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_patterns_view_patterns_test_tsx",
       "label": "view-patterns.test.tsx",
@@ -70204,7 +70261,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1454,
+      "community": 1455,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_surfaces_stories_tsx",
       "label": "Surfaces.stories.tsx",
@@ -70213,7 +70270,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1455,
+      "community": 1456,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_templates_dashboardworkspace_stories_tsx",
       "label": "DashboardWorkspace.stories.tsx",
@@ -70222,7 +70279,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1456,
+      "community": 1457,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_templates_dataworkspace_stories_tsx",
       "label": "DataWorkspace.stories.tsx",
@@ -70231,7 +70288,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1457,
+      "community": 1458,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_templates_settingsworkspace_stories_tsx",
       "label": "SettingsWorkspace.stories.tsx",
@@ -70240,21 +70297,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1458,
+      "community": 1459,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_templates_reference_fixtures_test_tsx",
       "label": "reference-fixtures.test.tsx",
       "norm_label": "reference-fixtures.test.tsx",
       "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1459,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_storybook_config_test_ts",
-      "label": "storybook-config.test.ts",
-      "norm_label": "storybook-config.test.ts",
-      "source_file": "packages/athena-webapp/src/stories/storybook-config.test.ts",
       "source_location": "L1"
     },
     {
@@ -70323,6 +70371,15 @@
     {
       "community": 1460,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_storybook_config_test_ts",
+      "label": "storybook-config.test.ts",
+      "norm_label": "storybook-config.test.ts",
+      "source_file": "packages/athena-webapp/src/stories/storybook-config.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1461,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_stories_storybook_theme_decorator_test_ts",
       "label": "storybook-theme-decorator.test.ts",
       "norm_label": "storybook-theme-decorator.test.ts",
@@ -70330,7 +70387,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1461,
+      "community": 1462,
       "file_type": "code",
       "id": "packages_athena_webapp_src_test_setup_ts",
       "label": "setup.ts",
@@ -70339,7 +70396,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1462,
+      "community": 1463,
       "file_type": "code",
       "id": "packages_athena_webapp_src_tests_pos_useprint_test_ts",
       "label": "usePrint.test.ts",
@@ -70348,7 +70405,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1463,
+      "community": 1464,
       "file_type": "code",
       "id": "packages_athena_webapp_tailwind_config_js",
       "label": "tailwind.config.js",
@@ -70357,7 +70414,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1464,
+      "community": 1465,
       "file_type": "code",
       "id": "packages_athena_webapp_types_ts",
       "label": "types.ts",
@@ -70366,7 +70423,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1465,
+      "community": 1466,
       "file_type": "code",
       "id": "packages_athena_webapp_vitest_config_ts",
       "label": "vitest.config.ts",
@@ -70375,7 +70432,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1466,
+      "community": 1467,
       "file_type": "code",
       "id": "packages_storefront_webapp_eslint_config_js",
       "label": "eslint.config.js",
@@ -70384,7 +70441,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1467,
+      "community": 1468,
       "file_type": "code",
       "id": "packages_storefront_webapp_global_d_ts",
       "label": "global.d.ts",
@@ -70393,21 +70450,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1468,
+      "community": 1469,
       "file_type": "code",
       "id": "packages_storefront_webapp_playwright_config_ts",
       "label": "playwright.config.ts",
       "norm_label": "playwright.config.ts",
       "source_file": "packages/storefront-webapp/playwright.config.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1469,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_analytics_test_ts",
-      "label": "analytics.test.ts",
-      "norm_label": "analytics.test.ts",
-      "source_file": "packages/storefront-webapp/src/api/analytics.test.ts",
       "source_location": "L1"
     },
     {
@@ -70476,6 +70524,15 @@
     {
       "community": 1470,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_api_analytics_test_ts",
+      "label": "analytics.test.ts",
+      "norm_label": "analytics.test.ts",
+      "source_file": "packages/storefront-webapp/src/api/analytics.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1471,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_api_types_ts",
       "label": "types.ts",
       "norm_label": "types.ts",
@@ -70483,7 +70540,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1471,
+      "community": 1472,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_assets_icons_hearticonfilled_tsx",
       "label": "HeartIconFilled.tsx",
@@ -70492,7 +70549,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1472,
+      "community": 1473,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_defaultcatchboundary_tsx",
       "label": "DefaultCatchBoundary.tsx",
@@ -70501,7 +70558,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1473,
+      "community": 1474,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_homepage_test_tsx",
       "label": "HomePage.test.tsx",
@@ -70510,7 +70567,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1474,
+      "community": 1475,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_productcard_test_tsx",
       "label": "ProductCard.test.tsx",
@@ -70519,7 +70576,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1475,
+      "community": 1476,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_productcard_tsx",
       "label": "ProductCard.tsx",
@@ -70528,7 +70585,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1476,
+      "community": 1477,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_upsell_tsx",
       "label": "Upsell.tsx",
@@ -70537,7 +70594,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1477,
+      "community": 1478,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkout_test_tsx",
       "label": "Checkout.test.tsx",
@@ -70546,21 +70603,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1478,
+      "community": 1479,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkout_tsx",
       "label": "Checkout.tsx",
       "norm_label": "checkout.tsx",
       "source_file": "packages/storefront-webapp/src/components/checkout/Checkout.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1479,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_customerinfosection_tsx",
-      "label": "CustomerInfoSection.tsx",
-      "norm_label": "customerinfosection.tsx",
-      "source_file": "packages/storefront-webapp/src/components/checkout/CustomerInfoSection.tsx",
       "source_location": "L1"
     },
     {
@@ -70629,6 +70677,15 @@
     {
       "community": 1480,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_customerinfosection_tsx",
+      "label": "CustomerInfoSection.tsx",
+      "norm_label": "customerinfosection.tsx",
+      "source_file": "packages/storefront-webapp/src/components/checkout/CustomerInfoSection.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1481,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_schema_ts",
       "label": "schema.ts",
       "norm_label": "schema.ts",
@@ -70636,7 +70693,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1481,
+      "community": 1482,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliverydetailssection_tsx",
       "label": "DeliveryDetailsSection.tsx",
@@ -70645,7 +70702,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1482,
+      "community": 1483,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkoutstorage_test_ts",
       "label": "checkoutStorage.test.ts",
@@ -70654,7 +70711,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1483,
+      "community": 1484,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliveryfees_test_ts",
       "label": "deliveryFees.test.ts",
@@ -70663,7 +70720,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1484,
+      "community": 1485,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_derivecheckoutstate_test_ts",
       "label": "deriveCheckoutState.test.ts",
@@ -70672,7 +70729,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1485,
+      "community": 1486,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_billingdetailsschema_ts",
       "label": "billingDetailsSchema.ts",
@@ -70681,7 +70738,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1486,
+      "community": 1487,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_checkoutformschema_ts",
       "label": "checkoutFormSchema.ts",
@@ -70690,7 +70747,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1487,
+      "community": 1488,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_customerdetailsschema_ts",
       "label": "customerDetailsSchema.ts",
@@ -70699,21 +70756,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1488,
+      "community": 1489,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_deliverydetailsschema_ts",
       "label": "deliveryDetailsSchema.ts",
       "norm_label": "deliverydetailsschema.ts",
       "source_file": "packages/storefront-webapp/src/components/checkout/schemas/deliveryDetailsSchema.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1489,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_schemas_weborderschema_ts",
-      "label": "webOrderSchema.ts",
-      "norm_label": "weborderschema.ts",
-      "source_file": "packages/storefront-webapp/src/components/checkout/schemas/webOrderSchema.ts",
       "source_location": "L1"
     },
     {
@@ -70782,6 +70830,15 @@
     {
       "community": 1490,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_schemas_weborderschema_ts",
+      "label": "webOrderSchema.ts",
+      "norm_label": "weborderschema.ts",
+      "source_file": "packages/storefront-webapp/src/components/checkout/schemas/webOrderSchema.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1491,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_types_ts",
       "label": "types.ts",
       "norm_label": "types.ts",
@@ -70789,7 +70846,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1491,
+      "community": 1492,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_utils_test_ts",
       "label": "utils.test.ts",
@@ -70798,7 +70855,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1492,
+      "community": 1493,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_filter_productfilterbar_tsx",
       "label": "ProductFilterBar.tsx",
@@ -70807,7 +70864,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1493,
+      "community": 1494,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_bestsellerssection_test_tsx",
       "label": "BestSellersSection.test.tsx",
@@ -70816,7 +70873,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1494,
+      "community": 1495,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_homehero_tsx",
       "label": "HomeHero.tsx",
@@ -70825,7 +70882,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1495,
+      "community": 1496,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_homeherosection_tsx",
       "label": "HomeHeroSection.tsx",
@@ -70834,7 +70891,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1496,
+      "community": 1497,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_homepagecontent_test_ts",
       "label": "homePageContent.test.ts",
@@ -70843,7 +70900,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1497,
+      "community": 1498,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_mobilemenu_tsx",
       "label": "MobileMenu.tsx",
@@ -70852,21 +70909,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1498,
+      "community": 1499,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_constants_ts",
       "label": "constants.ts",
       "norm_label": "constants.ts",
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/constants.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1499,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_navigation_bar_navbarconstants_ts",
-      "label": "navBarConstants.ts",
-      "norm_label": "navbarconstants.ts",
-      "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarConstants.ts",
       "source_location": "L1"
     },
     {
@@ -71160,6 +71208,15 @@
     {
       "community": 1500,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_navigation_bar_navbarconstants_ts",
+      "label": "navBarConstants.ts",
+      "norm_label": "navbarconstants.ts",
+      "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarConstants.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1501,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_about_tsx",
       "label": "About.tsx",
       "norm_label": "about.tsx",
@@ -71167,7 +71224,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1501,
+      "community": 1502,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_aboutproduct_tsx",
       "label": "AboutProduct.tsx",
@@ -71176,7 +71233,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1502,
+      "community": 1503,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productactions_test_tsx",
       "label": "ProductActions.test.tsx",
@@ -71185,7 +71242,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1503,
+      "community": 1504,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productinfo_tsx",
       "label": "ProductInfo.tsx",
@@ -71194,7 +71251,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1504,
+      "community": 1505,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productreviews_tsx",
       "label": "ProductReviews.tsx",
@@ -71203,7 +71260,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1505,
+      "community": 1506,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productsnavigationbar_tsx",
       "label": "ProductsNavigationBar.tsx",
@@ -71212,7 +71269,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1506,
+      "community": 1507,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_errormessage_tsx",
       "label": "ErrorMessage.tsx",
@@ -71221,7 +71278,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1507,
+      "community": 1508,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_existingreviewmessage_tsx",
       "label": "ExistingReviewMessage.tsx",
@@ -71230,21 +71287,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1508,
+      "community": 1509,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_orderitem_test_tsx",
       "label": "OrderItem.test.tsx",
       "norm_label": "orderitem.test.tsx",
       "source_file": "packages/storefront-webapp/src/components/product-reviews/OrderItem.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1509,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_reviews_reviewform_tsx",
-      "label": "ReviewForm.tsx",
-      "norm_label": "reviewform.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-reviews/ReviewForm.tsx",
       "source_location": "L1"
     },
     {
@@ -71313,6 +71361,15 @@
     {
       "community": 1510,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_reviews_reviewform_tsx",
+      "label": "ReviewForm.tsx",
+      "norm_label": "reviewform.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-reviews/ReviewForm.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1511,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_successmessage_tsx",
       "label": "SuccessMessage.tsx",
       "norm_label": "successmessage.tsx",
@@ -71320,7 +71377,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1511,
+      "community": 1512,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_types_ts",
       "label": "types.ts",
@@ -71329,7 +71386,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1512,
+      "community": 1513,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_saved_items_savedbag_tsx",
       "label": "SavedBag.tsx",
@@ -71338,7 +71395,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1513,
+      "community": 1514,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_saved_items_savedicon_tsx",
       "label": "SavedIcon.tsx",
@@ -71347,7 +71404,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1514,
+      "community": 1515,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_shopping_bag_carticon_tsx",
       "label": "CartIcon.tsx",
@@ -71356,7 +71413,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1515,
+      "community": 1516,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_shopping_bag_shoppingbag_test_tsx",
       "label": "ShoppingBag.test.tsx",
@@ -71365,7 +71422,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1516,
+      "community": 1517,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_empty_empty_state_tsx",
       "label": "empty-state.tsx",
@@ -71374,7 +71431,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1517,
+      "community": 1518,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_maintenance_maintenance_test_tsx",
       "label": "Maintenance.test.tsx",
@@ -71383,21 +71440,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1518,
+      "community": 1519,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_maintenance_maintenance_tsx",
       "label": "Maintenance.tsx",
       "norm_label": "maintenance.tsx",
       "source_file": "packages/storefront-webapp/src/components/states/maintenance/Maintenance.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1519,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_animatedcard_tsx",
-      "label": "AnimatedCard.tsx",
-      "norm_label": "animatedcard.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/AnimatedCard.tsx",
       "source_location": "L1"
     },
     {
@@ -71457,6 +71505,15 @@
     {
       "community": 1520,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_animatedcard_tsx",
+      "label": "AnimatedCard.tsx",
+      "norm_label": "animatedcard.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/AnimatedCard.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1521,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_accordion_tsx",
       "label": "accordion.tsx",
       "norm_label": "accordion.tsx",
@@ -71464,7 +71521,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1521,
+      "community": 1522,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_alert_tsx",
       "label": "alert.tsx",
@@ -71473,7 +71530,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1522,
+      "community": 1523,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_breadcrumb_tsx",
       "label": "breadcrumb.tsx",
@@ -71482,7 +71539,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1523,
+      "community": 1524,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_button_tsx",
       "label": "button.tsx",
@@ -71491,7 +71548,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1524,
+      "community": 1525,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_card_tsx",
       "label": "card.tsx",
@@ -71500,7 +71557,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1525,
+      "community": 1526,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_checkbox_tsx",
       "label": "checkbox.tsx",
@@ -71509,7 +71566,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1526,
+      "community": 1527,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_command_tsx",
       "label": "command.tsx",
@@ -71518,7 +71575,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1527,
+      "community": 1528,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_context_menu_tsx",
       "label": "context-menu.tsx",
@@ -71527,21 +71584,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1528,
+      "community": 1529,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_dialog_tsx",
       "label": "dialog.tsx",
       "norm_label": "dialog.tsx",
       "source_file": "packages/storefront-webapp/src/components/ui/dialog.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1529,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_dropdown_menu_tsx",
-      "label": "dropdown-menu.tsx",
-      "norm_label": "dropdown-menu.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/dropdown-menu.tsx",
       "source_location": "L1"
     },
     {
@@ -71601,6 +71649,15 @@
     {
       "community": 1530,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_dropdown_menu_tsx",
+      "label": "dropdown-menu.tsx",
+      "norm_label": "dropdown-menu.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/dropdown-menu.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1531,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_form_tsx",
       "label": "form.tsx",
       "norm_label": "form.tsx",
@@ -71608,7 +71665,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1531,
+      "community": 1532,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_icons_tsx",
       "label": "icons.tsx",
@@ -71617,7 +71674,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1532,
+      "community": 1533,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_image_with_fallback_tsx",
       "label": "image-with-fallback.tsx",
@@ -71626,7 +71683,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1533,
+      "community": 1534,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_input_otp_tsx",
       "label": "input-otp.tsx",
@@ -71635,7 +71692,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1534,
+      "community": 1535,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_input_with_end_button_tsx",
       "label": "input-with-end-button.tsx",
@@ -71644,7 +71701,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1535,
+      "community": 1536,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_input_tsx",
       "label": "input.tsx",
@@ -71653,7 +71710,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1536,
+      "community": 1537,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_label_tsx",
       "label": "label.tsx",
@@ -71662,7 +71719,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1537,
+      "community": 1538,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_leaveareviewmodalform_tsx",
       "label": "LeaveAReviewModalForm.tsx",
@@ -71671,21 +71728,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1538,
+      "community": 1539,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_action_modal_tsx",
       "label": "action-modal.tsx",
       "norm_label": "action-modal.tsx",
       "source_file": "packages/storefront-webapp/src/components/ui/modals/action-modal.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1539,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_modals_animations_welcomebackmodalanimations_ts",
-      "label": "welcomeBackModalAnimations.ts",
-      "norm_label": "welcomebackmodalanimations.ts",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/animations/welcomeBackModalAnimations.ts",
       "source_location": "L1"
     },
     {
@@ -71745,6 +71793,15 @@
     {
       "community": 1540,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_modals_animations_welcomebackmodalanimations_ts",
+      "label": "welcomeBackModalAnimations.ts",
+      "norm_label": "welcomebackmodalanimations.ts",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/animations/welcomeBackModalAnimations.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1541,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_index_ts",
       "label": "index.ts",
       "norm_label": "index.ts",
@@ -71752,7 +71809,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1541,
+      "community": 1542,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_types_ts",
       "label": "types.ts",
@@ -71761,7 +71818,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1542,
+      "community": 1543,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_navigation_menu_tsx",
       "label": "navigation-menu.tsx",
@@ -71770,7 +71827,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1543,
+      "community": 1544,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_popover_tsx",
       "label": "popover.tsx",
@@ -71779,7 +71836,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1544,
+      "community": 1545,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_radio_group_tsx",
       "label": "radio-group.tsx",
@@ -71788,7 +71845,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1545,
+      "community": 1546,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_scroll_area_tsx",
       "label": "scroll-area.tsx",
@@ -71797,7 +71854,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1546,
+      "community": 1547,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_select_tsx",
       "label": "select.tsx",
@@ -71806,7 +71863,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1547,
+      "community": 1548,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_separator_tsx",
       "label": "separator.tsx",
@@ -71815,21 +71872,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1548,
+      "community": 1549,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_sheet_tsx",
       "label": "sheet.tsx",
       "norm_label": "sheet.tsx",
       "source_file": "packages/storefront-webapp/src/components/ui/sheet.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1549,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_table_tsx",
-      "label": "table.tsx",
-      "norm_label": "table.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/table.tsx",
       "source_location": "L1"
     },
     {
@@ -71889,6 +71937,15 @@
     {
       "community": 1550,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_table_tsx",
+      "label": "table.tsx",
+      "norm_label": "table.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/table.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1551,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_tabs_tsx",
       "label": "tabs.tsx",
       "norm_label": "tabs.tsx",
@@ -71896,7 +71953,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1551,
+      "community": 1552,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_textarea_tsx",
       "label": "textarea.tsx",
@@ -71905,7 +71962,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1552,
+      "community": 1553,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_toggle_group_tsx",
       "label": "toggle-group.tsx",
@@ -71914,7 +71971,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1553,
+      "community": 1554,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_toggle_tsx",
       "label": "toggle.tsx",
@@ -71923,7 +71980,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1554,
+      "community": 1555,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_tooltip_tsx",
       "label": "tooltip.tsx",
@@ -71932,7 +71989,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1555,
+      "community": 1556,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_config_ts",
       "label": "config.ts",
@@ -71941,7 +71998,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1556,
+      "community": 1557,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_use_store_modal_tsx",
       "label": "use-store-modal.tsx",
@@ -71950,7 +72007,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1557,
+      "community": 1558,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useorganizationmodal_tsx",
       "label": "useOrganizationModal.tsx",
@@ -71959,21 +72016,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1558,
+      "community": 1559,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usequeryenabled_test_ts",
       "label": "useQueryEnabled.test.ts",
       "norm_label": "usequeryenabled.test.ts",
       "source_file": "packages/storefront-webapp/src/hooks/useQueryEnabled.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1559,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_usestorefrontobservability_ts",
-      "label": "useStorefrontObservability.ts",
-      "norm_label": "usestorefrontobservability.ts",
-      "source_file": "packages/storefront-webapp/src/hooks/useStorefrontObservability.ts",
       "source_location": "L1"
     },
     {
@@ -72033,6 +72081,15 @@
     {
       "community": 1560,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_usestorefrontobservability_ts",
+      "label": "useStorefrontObservability.ts",
+      "norm_label": "usestorefrontobservability.ts",
+      "source_file": "packages/storefront-webapp/src/hooks/useStorefrontObservability.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1561,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_constants_ts",
       "label": "constants.ts",
       "norm_label": "constants.ts",
@@ -72040,7 +72097,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1561,
+      "community": 1562,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_countries_ts",
       "label": "countries.ts",
@@ -72049,7 +72106,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1562,
+      "community": 1563,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_feeutils_test_ts",
       "label": "feeUtils.test.ts",
@@ -72058,7 +72115,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1563,
+      "community": 1564,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_ghana_ts",
       "label": "ghana.ts",
@@ -72067,7 +72124,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1564,
+      "community": 1565,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_ghanaregions_ts",
       "label": "ghanaRegions.ts",
@@ -72076,7 +72133,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1565,
+      "community": 1566,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_maintenanceutils_test_ts",
       "label": "maintenanceUtils.test.ts",
@@ -72085,7 +72142,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1566,
+      "community": 1567,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_mutations_ts_index_ts",
       "label": "index.ts",
@@ -72094,7 +72151,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1567,
+      "community": 1568,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_store_ts",
       "label": "store.ts",
@@ -72103,21 +72160,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1568,
+      "community": 1569,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_bag_ts",
       "label": "bag.ts",
       "norm_label": "bag.ts",
       "source_file": "packages/storefront-webapp/src/lib/schemas/bag.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1569,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_schemas_bagitem_ts",
-      "label": "bagItem.ts",
-      "norm_label": "bagitem.ts",
-      "source_file": "packages/storefront-webapp/src/lib/schemas/bagItem.ts",
       "source_location": "L1"
     },
     {
@@ -72177,6 +72225,15 @@
     {
       "community": 1570,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_schemas_bagitem_ts",
+      "label": "bagItem.ts",
+      "norm_label": "bagitem.ts",
+      "source_file": "packages/storefront-webapp/src/lib/schemas/bagItem.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1571,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_category_ts",
       "label": "category.ts",
       "norm_label": "category.ts",
@@ -72184,7 +72241,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1571,
+      "community": 1572,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_organization_ts",
       "label": "organization.ts",
@@ -72193,7 +72250,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1572,
+      "community": 1573,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_product_ts",
       "label": "product.ts",
@@ -72202,7 +72259,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1573,
+      "community": 1574,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_store_ts",
       "label": "store.ts",
@@ -72211,7 +72268,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1574,
+      "community": 1575,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_subcategory_ts",
       "label": "subcategory.ts",
@@ -72220,7 +72277,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1575,
+      "community": 1576,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_user_ts",
       "label": "user.ts",
@@ -72229,7 +72286,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1576,
+      "community": 1577,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_states_ts",
       "label": "states.ts",
@@ -72238,7 +72295,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1577,
+      "community": 1578,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_storefrontfailureobservability_test_ts",
       "label": "storefrontFailureObservability.test.ts",
@@ -72247,21 +72304,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1578,
+      "community": 1579,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_storefrontjourneyevents_test_ts",
       "label": "storefrontJourneyEvents.test.ts",
       "norm_label": "storefrontjourneyevents.test.ts",
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1579,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_utils_test_ts",
-      "label": "utils.test.ts",
-      "norm_label": "utils.test.ts",
-      "source_file": "packages/storefront-webapp/src/lib/utils.test.ts",
       "source_location": "L1"
     },
     {
@@ -72321,6 +72369,15 @@
     {
       "community": 1580,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_utils_test_ts",
+      "label": "utils.test.ts",
+      "norm_label": "utils.test.ts",
+      "source_file": "packages/storefront-webapp/src/lib/utils.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1581,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_routetree_gen_ts",
       "label": "routeTree.gen.ts",
       "norm_label": "routetree.gen.ts",
@@ -72328,7 +72385,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1581,
+      "community": 1582,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_homepageloader_test_ts",
       "label": "-homePageLoader.test.ts",
@@ -72337,7 +72394,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1582,
+      "community": 1583,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_root_tsx",
       "label": "__root.tsx",
@@ -72346,7 +72403,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1583,
+      "community": 1584,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_orderid_orderitemid_review_tsx",
       "label": "$orderItemId.review.tsx",
@@ -72355,7 +72412,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1584,
+      "community": 1585,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_index_tsx",
       "label": "index.tsx",
@@ -72364,7 +72421,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1585,
+      "community": 1586,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_shoplayout_shop_categoryslug_subcategoryslug_tsx",
       "label": "$subcategorySlug.tsx",
@@ -72373,7 +72430,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1586,
+      "community": 1587,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_shoplayout_shop_categoryslug_index_tsx",
       "label": "index.tsx",
@@ -72382,7 +72439,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1587,
+      "community": 1588,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_rewards_index_tsx",
       "label": "rewards.index.tsx",
@@ -72391,21 +72448,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1588,
+      "community": 1589,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_shop_saved_index_tsx",
       "label": "shop.saved.index.tsx",
       "norm_label": "shop.saved.index.tsx",
       "source_file": "packages/storefront-webapp/src/routes/_layout/shop.saved.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1589,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_shop_bag_index_tsx",
-      "label": "bag.index.tsx",
-      "norm_label": "bag.index.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/shop/bag.index.tsx",
       "source_location": "L1"
     },
     {
@@ -72465,6 +72513,15 @@
     {
       "community": 1590,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_shop_bag_index_tsx",
+      "label": "bag.index.tsx",
+      "norm_label": "bag.index.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/shop/bag.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1591,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_complete_tsx",
       "label": "complete.tsx",
       "norm_label": "complete.tsx",
@@ -72472,7 +72529,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1591,
+      "community": 1592,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_incomplete_tsx",
       "label": "incomplete.tsx",
@@ -72481,7 +72538,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1592,
+      "community": 1593,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_index_tsx",
       "label": "index.tsx",
@@ -72490,7 +72547,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1593,
+      "community": 1594,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_pending_tsx",
       "label": "pending.tsx",
@@ -72499,7 +72556,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1594,
+      "community": 1595,
       "file_type": "code",
       "id": "packages_storefront_webapp_tailwind_config_js",
       "label": "tailwind.config.js",
@@ -72508,7 +72565,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1595,
+      "community": 1596,
       "file_type": "code",
       "id": "packages_storefront_webapp_tests_e2e_storefront_boot_e2e_ts",
       "label": "storefront-boot.e2e.ts",
@@ -72517,7 +72574,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1596,
+      "community": 1597,
       "file_type": "code",
       "id": "packages_storefront_webapp_vitest_config_ts",
       "label": "vitest.config.ts",
@@ -72526,7 +72583,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1597,
+      "community": 1598,
       "file_type": "code",
       "id": "packages_storefront_webapp_vitest_setup_ts",
       "label": "vitest.setup.ts",
@@ -72535,21 +72592,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1598,
+      "community": 1599,
       "file_type": "code",
       "id": "packages_valkey_proxy_server_index_js",
       "label": "index.js",
       "norm_label": "index.js",
       "source_file": "packages/valkey-proxy-server/index.js",
-      "source_location": "L1"
-    },
-    {
-      "community": 1599,
-      "file_type": "code",
-      "id": "scripts_harness_app_registry_test_ts",
-      "label": "harness-app-registry.test.ts",
-      "norm_label": "harness-app-registry.test.ts",
-      "source_file": "scripts/harness-app-registry.test.ts",
       "source_location": "L1"
     },
     {
@@ -72834,6 +72882,15 @@
     {
       "community": 1600,
       "file_type": "code",
+      "id": "scripts_harness_app_registry_test_ts",
+      "label": "harness-app-registry.test.ts",
+      "norm_label": "harness-app-registry.test.ts",
+      "source_file": "scripts/harness-app-registry.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1601,
+      "file_type": "code",
       "id": "scripts_harness_behavior_fixtures_athena_runtime_app_test_ts",
       "label": "athena-runtime-app.test.ts",
       "norm_label": "athena-runtime-app.test.ts",
@@ -72841,7 +72898,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1601,
+      "community": 1602,
       "file_type": "code",
       "id": "scripts_harness_behavior_fixtures_storefront_runtime_api_test_ts",
       "label": "storefront-runtime-api.test.ts",
@@ -72850,7 +72907,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1602,
+      "community": 1603,
       "file_type": "code",
       "id": "scripts_harness_behavior_fixtures_valkey_runtime_app_test_ts",
       "label": "valkey-runtime-app.test.ts",
@@ -72859,7 +72916,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1603,
+      "community": 1604,
       "file_type": "code",
       "id": "scripts_harness_behavior_scenarios_test_ts",
       "label": "harness-behavior-scenarios.test.ts",
@@ -72868,7 +72925,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1604,
+      "community": 1605,
       "file_type": "code",
       "id": "scripts_harness_repo_validation_test_ts",
       "label": "harness-repo-validation.test.ts",
@@ -82662,6 +82719,42 @@
     {
       "community": 304,
       "file_type": "code",
+      "id": "capabilities_canaccessfulladminsurface",
+      "label": "canAccessFullAdminSurface()",
+      "norm_label": "canaccessfulladminsurface()",
+      "source_file": "packages/athena-webapp/src/lib/access/capabilities.ts",
+      "source_location": "L42"
+    },
+    {
+      "community": 304,
+      "file_type": "code",
+      "id": "capabilities_canaccessstoredaysurface",
+      "label": "canAccessStoreDaySurface()",
+      "norm_label": "canaccessstoredaysurface()",
+      "source_file": "packages/athena-webapp/src/lib/access/capabilities.ts",
+      "source_location": "L48"
+    },
+    {
+      "community": 304,
+      "file_type": "code",
+      "id": "capabilities_getsurfaceaccess",
+      "label": "getSurfaceAccess()",
+      "norm_label": "getsurfaceaccess()",
+      "source_file": "packages/athena-webapp/src/lib/access/capabilities.ts",
+      "source_location": "L55"
+    },
+    {
+      "community": 304,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_access_capabilities_ts",
+      "label": "capabilities.ts",
+      "norm_label": "capabilities.ts",
+      "source_file": "packages/athena-webapp/src/lib/access/capabilities.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 305,
+      "file_type": "code",
       "id": "customerobservabilitytimeline_formatobservabilitylabel",
       "label": "formatObservabilityLabel()",
       "norm_label": "formatobservabilitylabel()",
@@ -82669,7 +82762,7 @@
       "source_location": "L66"
     },
     {
-      "community": 304,
+      "community": 305,
       "file_type": "code",
       "id": "customerobservabilitytimeline_getdeviceicon",
       "label": "getDeviceIcon()",
@@ -82678,7 +82771,7 @@
       "source_location": "L121"
     },
     {
-      "community": 304,
+      "community": 305,
       "file_type": "code",
       "id": "customerobservabilitytimeline_getobservabilitystatusstyles",
       "label": "getObservabilityStatusStyles()",
@@ -82687,7 +82780,7 @@
       "source_location": "L74"
     },
     {
-      "community": 304,
+      "community": 305,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_customerobservabilitytimeline_ts",
       "label": "customerObservabilityTimeline.ts",
@@ -82696,7 +82789,7 @@
       "source_location": "L1"
     },
     {
-      "community": 305,
+      "community": 306,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_runcommand_ts",
       "label": "runCommand.ts",
@@ -82705,7 +82798,7 @@
       "source_location": "L1"
     },
     {
-      "community": 305,
+      "community": 306,
       "file_type": "code",
       "id": "runcommand_extracttraceid",
       "label": "extractTraceId()",
@@ -82714,7 +82807,7 @@
       "source_location": "L34"
     },
     {
-      "community": 305,
+      "community": 306,
       "file_type": "code",
       "id": "runcommand_isapprovalrequiredresult",
       "label": "isApprovalRequiredResult()",
@@ -82723,7 +82816,7 @@
       "source_location": "L28"
     },
     {
-      "community": 305,
+      "community": 306,
       "file_type": "code",
       "id": "runcommand_runcommand",
       "label": "runCommand()",
@@ -82732,7 +82825,7 @@
       "source_location": "L48"
     },
     {
-      "community": 306,
+      "community": 307,
       "file_type": "code",
       "id": "barcodeutils_extractbarcodefrominput",
       "label": "extractBarcodeFromInput()",
@@ -82741,7 +82834,7 @@
       "source_location": "L51"
     },
     {
-      "community": 306,
+      "community": 307,
       "file_type": "code",
       "id": "barcodeutils_isurlorbarcode",
       "label": "isUrlOrBarcode()",
@@ -82750,7 +82843,7 @@
       "source_location": "L92"
     },
     {
-      "community": 306,
+      "community": 307,
       "file_type": "code",
       "id": "barcodeutils_isvalidconvexid",
       "label": "isValidConvexId()",
@@ -82759,7 +82852,7 @@
       "source_location": "L16"
     },
     {
-      "community": 306,
+      "community": 307,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_barcodeutils_ts",
       "label": "barcodeUtils.ts",
@@ -82768,7 +82861,7 @@
       "source_location": "L1"
     },
     {
-      "community": 307,
+      "community": 308,
       "file_type": "code",
       "id": "displayamounts_formatstoredamount",
       "label": "formatStoredAmount()",
@@ -82777,7 +82870,7 @@
       "source_location": "L8"
     },
     {
-      "community": 307,
+      "community": 308,
       "file_type": "code",
       "id": "displayamounts_formatstoredcurrencyamount",
       "label": "formatStoredCurrencyAmount()",
@@ -82786,7 +82879,7 @@
       "source_location": "L15"
     },
     {
-      "community": 307,
+      "community": 308,
       "file_type": "code",
       "id": "displayamounts_parsedisplayamountinput",
       "label": "parseDisplayAmountInput()",
@@ -82795,7 +82888,7 @@
       "source_location": "L32"
     },
     {
-      "community": 307,
+      "community": 308,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_displayamounts_ts",
       "label": "displayAmounts.ts",
@@ -82804,7 +82897,7 @@
       "source_location": "L1"
     },
     {
-      "community": 308,
+      "community": 309,
       "file_type": "code",
       "id": "customergateway_useconvexposcustomercreate",
       "label": "useConvexPosCustomerCreate()",
@@ -82813,7 +82906,7 @@
       "source_location": "L22"
     },
     {
-      "community": 308,
+      "community": 309,
       "file_type": "code",
       "id": "customergateway_useconvexposcustomersearch",
       "label": "useConvexPosCustomerSearch()",
@@ -82822,7 +82915,7 @@
       "source_location": "L10"
     },
     {
-      "community": 308,
+      "community": 309,
       "file_type": "code",
       "id": "customergateway_useconvexposcustomerupdate",
       "label": "useConvexPosCustomerUpdate()",
@@ -82831,49 +82924,13 @@
       "source_location": "L57"
     },
     {
-      "community": 308,
+      "community": 309,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_customergateway_ts",
       "label": "customerGateway.ts",
       "norm_label": "customergateway.ts",
       "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/customerGateway.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 309,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_sessiongateway_mapper_ts",
-      "label": "sessionGateway.mapper.ts",
-      "norm_label": "sessiongateway.mapper.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/sessionGateway.mapper.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 309,
-      "file_type": "code",
-      "id": "sessiongateway_mapper_mapactivesessiondto",
-      "label": "mapActiveSessionDto()",
-      "norm_label": "mapactivesessiondto()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/sessionGateway.mapper.ts",
-      "source_location": "L83"
-    },
-    {
-      "community": 309,
-      "file_type": "code",
-      "id": "sessiongateway_mapper_mapheldsessionsdto",
-      "label": "mapHeldSessionsDto()",
-      "norm_label": "mapheldsessionsdto()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/sessionGateway.mapper.ts",
-      "source_location": "L100"
-    },
-    {
-      "community": 309,
-      "file_type": "code",
-      "id": "sessiongateway_mapper_normalizecartitems",
-      "label": "normalizeCartItems()",
-      "norm_label": "normalizecartitems()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/sessionGateway.mapper.ts",
-      "source_location": "L79"
     },
     {
       "community": 31,
@@ -83049,6 +83106,42 @@
     {
       "community": 310,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_sessiongateway_mapper_ts",
+      "label": "sessionGateway.mapper.ts",
+      "norm_label": "sessiongateway.mapper.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/sessionGateway.mapper.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 310,
+      "file_type": "code",
+      "id": "sessiongateway_mapper_mapactivesessiondto",
+      "label": "mapActiveSessionDto()",
+      "norm_label": "mapactivesessiondto()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/sessionGateway.mapper.ts",
+      "source_location": "L83"
+    },
+    {
+      "community": 310,
+      "file_type": "code",
+      "id": "sessiongateway_mapper_mapheldsessionsdto",
+      "label": "mapHeldSessionsDto()",
+      "norm_label": "mapheldsessionsdto()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/sessionGateway.mapper.ts",
+      "source_location": "L100"
+    },
+    {
+      "community": 310,
+      "file_type": "code",
+      "id": "sessiongateway_mapper_normalizecartitems",
+      "label": "normalizeCartItems()",
+      "norm_label": "normalizecartitems()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/sessionGateway.mapper.ts",
+      "source_location": "L79"
+    },
+    {
+      "community": 311,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_sessiongateway_ts",
       "label": "sessionGateway.ts",
       "norm_label": "sessiongateway.ts",
@@ -83056,7 +83149,7 @@
       "source_location": "L1"
     },
     {
-      "community": 310,
+      "community": 311,
       "file_type": "code",
       "id": "sessiongateway_useconvexactivesession",
       "label": "useConvexActiveSession()",
@@ -83065,7 +83158,7 @@
       "source_location": "L38"
     },
     {
-      "community": 310,
+      "community": 311,
       "file_type": "code",
       "id": "sessiongateway_useconvexheldsessions",
       "label": "useConvexHeldSessions()",
@@ -83074,7 +83167,7 @@
       "source_location": "L65"
     },
     {
-      "community": 310,
+      "community": 311,
       "file_type": "code",
       "id": "sessiongateway_useconvexsessionactions",
       "label": "useConvexSessionActions()",
@@ -83083,7 +83176,7 @@
       "source_location": "L91"
     },
     {
-      "community": 311,
+      "community": 312,
       "file_type": "code",
       "id": "fingerprint_isbrowserfingerprintresult",
       "label": "isBrowserFingerprintResult()",
@@ -83092,7 +83185,7 @@
       "source_location": "L4"
     },
     {
-      "community": 311,
+      "community": 312,
       "file_type": "code",
       "id": "fingerprint_readstoredterminalfingerprint",
       "label": "readStoredTerminalFingerprint()",
@@ -83101,7 +83194,7 @@
       "source_location": "L20"
     },
     {
-      "community": 311,
+      "community": 312,
       "file_type": "code",
       "id": "fingerprint_readstoredterminalfingerprinthash",
       "label": "readStoredTerminalFingerprintHash()",
@@ -83110,7 +83203,7 @@
       "source_location": "L42"
     },
     {
-      "community": 311,
+      "community": 312,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_terminal_fingerprint_ts",
       "label": "fingerprint.ts",
@@ -83119,7 +83212,7 @@
       "source_location": "L1"
     },
     {
-      "community": 312,
+      "community": 313,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_presentation_expense_useexpenseregisterviewmodel_ts",
       "label": "useExpenseRegisterViewModel.ts",
@@ -83128,7 +83221,7 @@
       "source_location": "L1"
     },
     {
-      "community": 312,
+      "community": 313,
       "file_type": "code",
       "id": "useexpenseregisterviewmodel_getcashierdisplayname",
       "label": "getCashierDisplayName()",
@@ -83137,7 +83230,7 @@
       "source_location": "L37"
     },
     {
-      "community": 312,
+      "community": 313,
       "file_type": "code",
       "id": "useexpenseregisterviewmodel_getexpensesessionloadkey",
       "label": "getExpenseSessionLoadKey()",
@@ -83146,7 +83239,7 @@
       "source_location": "L49"
     },
     {
-      "community": 312,
+      "community": 313,
       "file_type": "code",
       "id": "useexpenseregisterviewmodel_useexpenseregisterviewmodel",
       "label": "useExpenseRegisterViewModel()",
@@ -83155,7 +83248,7 @@
       "source_location": "L68"
     },
     {
-      "community": 313,
+      "community": 314,
       "file_type": "code",
       "id": "offers_getbaseurl",
       "label": "getBaseUrl()",
@@ -83164,7 +83257,7 @@
       "source_location": "L13"
     },
     {
-      "community": 313,
+      "community": 314,
       "file_type": "code",
       "id": "offers_getuserredeemedoffers",
       "label": "getUserRedeemedOffers()",
@@ -83173,7 +83266,7 @@
       "source_location": "L46"
     },
     {
-      "community": 313,
+      "community": 314,
       "file_type": "code",
       "id": "offers_submitoffer",
       "label": "submitOffer()",
@@ -83182,7 +83275,7 @@
       "source_location": "L21"
     },
     {
-      "community": 313,
+      "community": 314,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_offers_ts",
       "label": "offers.ts",
@@ -83191,7 +83284,7 @@
       "source_location": "L1"
     },
     {
-      "community": 314,
+      "community": 315,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_stores_ts",
       "label": "stores.ts",
@@ -83200,7 +83293,7 @@
       "source_location": "L1"
     },
     {
-      "community": 314,
+      "community": 315,
       "file_type": "code",
       "id": "stores_getallstores",
       "label": "getAllStores()",
@@ -83209,7 +83302,7 @@
       "source_location": "L8"
     },
     {
-      "community": 314,
+      "community": 315,
       "file_type": "code",
       "id": "stores_getbaseurl",
       "label": "getBaseUrl()",
@@ -83218,7 +83311,7 @@
       "source_location": "L5"
     },
     {
-      "community": 314,
+      "community": 315,
       "file_type": "code",
       "id": "stores_getstore",
       "label": "getStore()",
@@ -83227,7 +83320,7 @@
       "source_location": "L20"
     },
     {
-      "community": 315,
+      "community": 316,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_subcategory_ts",
       "label": "subcategory.ts",
@@ -83236,7 +83329,7 @@
       "source_location": "L1"
     },
     {
-      "community": 315,
+      "community": 316,
       "file_type": "code",
       "id": "subcategory_getallsubcategories",
       "label": "getAllSubcategories()",
@@ -83245,7 +83338,7 @@
       "source_location": "L11"
     },
     {
-      "community": 315,
+      "community": 316,
       "file_type": "code",
       "id": "subcategory_getbaseurl",
       "label": "getBaseUrl()",
@@ -83254,7 +83347,7 @@
       "source_location": "L9"
     },
     {
-      "community": 315,
+      "community": 316,
       "file_type": "code",
       "id": "subcategory_getsubategory",
       "label": "getSubategory()",
@@ -83263,7 +83356,7 @@
       "source_location": "L25"
     },
     {
-      "community": 316,
+      "community": 317,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_productactionbar_tsx",
       "label": "ProductActionBar.tsx",
@@ -83272,7 +83365,7 @@
       "source_location": "L1"
     },
     {
-      "community": 316,
+      "community": 317,
       "file_type": "code",
       "id": "productactionbar_checkscroll",
       "label": "checkScroll()",
@@ -83281,7 +83374,7 @@
       "source_location": "L50"
     },
     {
-      "community": 316,
+      "community": 317,
       "file_type": "code",
       "id": "productactionbar_handleaction",
       "label": "handleAction()",
@@ -83290,7 +83383,7 @@
       "source_location": "L92"
     },
     {
-      "community": 316,
+      "community": 317,
       "file_type": "code",
       "id": "productactionbar_handledismiss",
       "label": "handleDismiss()",
@@ -83299,7 +83392,7 @@
       "source_location": "L74"
     },
     {
-      "community": 317,
+      "community": 318,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_productreminderbar_tsx",
       "label": "ProductReminderBar.tsx",
@@ -83308,7 +83401,7 @@
       "source_location": "L1"
     },
     {
-      "community": 317,
+      "community": 318,
       "file_type": "code",
       "id": "productreminderbar_checkscroll",
       "label": "checkScroll()",
@@ -83317,7 +83410,7 @@
       "source_location": "L62"
     },
     {
-      "community": 317,
+      "community": 318,
       "file_type": "code",
       "id": "productreminderbar_handleaddtobag",
       "label": "handleAddToBag()",
@@ -83326,7 +83419,7 @@
       "source_location": "L109"
     },
     {
-      "community": 317,
+      "community": 318,
       "file_type": "code",
       "id": "productreminderbar_handledismiss",
       "label": "handleDismiss()",
@@ -83335,7 +83428,7 @@
       "source_location": "L177"
     },
     {
-      "community": 318,
+      "community": 319,
       "file_type": "code",
       "id": "billingdetailssection_clearform",
       "label": "clearForm()",
@@ -83344,7 +83437,7 @@
       "source_location": "L18"
     },
     {
-      "community": 318,
+      "community": 319,
       "file_type": "code",
       "id": "billingdetailssection_handleusebillingaddressonfile",
       "label": "handleUseBillingAddressOnFile()",
@@ -83353,7 +83446,7 @@
       "source_location": "L52"
     },
     {
-      "community": 318,
+      "community": 319,
       "file_type": "code",
       "id": "billingdetailssection_togglesameasdelivery",
       "label": "toggleSameAsDelivery()",
@@ -83362,48 +83455,12 @@
       "source_location": "L68"
     },
     {
-      "community": 318,
+      "community": 319,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_billingdetailssection_tsx",
       "label": "BillingDetailsSection.tsx",
       "norm_label": "billingdetailssection.tsx",
       "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetailsSection.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 319,
-      "file_type": "code",
-      "id": "hooks_usegetshopsearchparams",
-      "label": "useGetShopSearchParams()",
-      "norm_label": "usegetshopsearchparams()",
-      "source_file": "packages/storefront-webapp/src/components/navigation/hooks.ts",
-      "source_location": "L68"
-    },
-    {
-      "community": 319,
-      "file_type": "code",
-      "id": "hooks_usegetstorecategories",
-      "label": "useGetStoreCategories()",
-      "norm_label": "usegetstorecategories()",
-      "source_file": "packages/storefront-webapp/src/components/navigation/hooks.ts",
-      "source_location": "L26"
-    },
-    {
-      "community": 319,
-      "file_type": "code",
-      "id": "hooks_usegetstoresubcategories",
-      "label": "useGetStoreSubcategories()",
-      "norm_label": "usegetstoresubcategories()",
-      "source_file": "packages/storefront-webapp/src/components/navigation/hooks.ts",
-      "source_location": "L7"
-    },
-    {
-      "community": 319,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_navigation_hooks_ts",
-      "label": "hooks.ts",
-      "norm_label": "hooks.ts",
-      "source_file": "packages/storefront-webapp/src/components/navigation/hooks.ts",
       "source_location": "L1"
     },
     {
@@ -83580,6 +83637,42 @@
     {
       "community": 320,
       "file_type": "code",
+      "id": "hooks_usegetshopsearchparams",
+      "label": "useGetShopSearchParams()",
+      "norm_label": "usegetshopsearchparams()",
+      "source_file": "packages/storefront-webapp/src/components/navigation/hooks.ts",
+      "source_location": "L68"
+    },
+    {
+      "community": 320,
+      "file_type": "code",
+      "id": "hooks_usegetstorecategories",
+      "label": "useGetStoreCategories()",
+      "norm_label": "usegetstorecategories()",
+      "source_file": "packages/storefront-webapp/src/components/navigation/hooks.ts",
+      "source_location": "L26"
+    },
+    {
+      "community": 320,
+      "file_type": "code",
+      "id": "hooks_usegetstoresubcategories",
+      "label": "useGetStoreSubcategories()",
+      "norm_label": "usegetstoresubcategories()",
+      "source_file": "packages/storefront-webapp/src/components/navigation/hooks.ts",
+      "source_location": "L7"
+    },
+    {
+      "community": 320,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_navigation_hooks_ts",
+      "label": "hooks.ts",
+      "norm_label": "hooks.ts",
+      "source_file": "packages/storefront-webapp/src/components/navigation/hooks.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 321,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productattribute_tsx",
       "label": "ProductAttribute.tsx",
       "norm_label": "productattribute.tsx",
@@ -83587,7 +83680,7 @@
       "source_location": "L1"
     },
     {
-      "community": 320,
+      "community": 321,
       "file_type": "code",
       "id": "productattribute_findsize",
       "label": "findSize()",
@@ -83596,7 +83689,7 @@
       "source_location": "L81"
     },
     {
-      "community": 320,
+      "community": 321,
       "file_type": "code",
       "id": "productattribute_handleclick",
       "label": "handleClick()",
@@ -83605,7 +83698,7 @@
       "source_location": "L85"
     },
     {
-      "community": 320,
+      "community": 321,
       "file_type": "code",
       "id": "productattribute_optionclassname",
       "label": "optionClassName()",
@@ -83614,7 +83707,7 @@
       "source_location": "L27"
     },
     {
-      "community": 321,
+      "community": 322,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productdetails_tsx",
       "label": "ProductDetails.tsx",
@@ -83623,7 +83716,7 @@
       "source_location": "L1"
     },
     {
-      "community": 321,
+      "community": 322,
       "file_type": "code",
       "id": "productdetails_bagproduct",
       "label": "BagProduct()",
@@ -83632,7 +83725,7 @@
       "source_location": "L43"
     },
     {
-      "community": 321,
+      "community": 322,
       "file_type": "code",
       "id": "productdetails_pickupdetails",
       "label": "PickupDetails()",
@@ -83641,7 +83734,7 @@
       "source_location": "L13"
     },
     {
-      "community": 321,
+      "community": 322,
       "file_type": "code",
       "id": "productdetails_shippingpolicy",
       "label": "ShippingPolicy()",
@@ -83650,7 +83743,7 @@
       "source_location": "L88"
     },
     {
-      "community": 322,
+      "community": 323,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_upsellmodal_tsx",
       "label": "UpsellModal.tsx",
@@ -83659,7 +83752,7 @@
       "source_location": "L1"
     },
     {
-      "community": 322,
+      "community": 323,
       "file_type": "code",
       "id": "upsellmodal_handleclose",
       "label": "handleClose()",
@@ -83668,7 +83761,7 @@
       "source_location": "L111"
     },
     {
-      "community": 322,
+      "community": 323,
       "file_type": "code",
       "id": "upsellmodal_handlescroll",
       "label": "handleScroll()",
@@ -83677,7 +83770,7 @@
       "source_location": "L66"
     },
     {
-      "community": 322,
+      "community": 323,
       "file_type": "code",
       "id": "upsellmodal_handlesuccess",
       "label": "handleSuccess()",
@@ -83686,7 +83779,7 @@
       "source_location": "L127"
     },
     {
-      "community": 323,
+      "community": 324,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_upsellmodalform_tsx",
       "label": "UpsellModalForm.tsx",
@@ -83695,7 +83788,7 @@
       "source_location": "L1"
     },
     {
-      "community": 323,
+      "community": 324,
       "file_type": "code",
       "id": "upsellmodalform_formatstoredamount",
       "label": "formatStoredAmount()",
@@ -83704,7 +83797,7 @@
       "source_location": "L92"
     },
     {
-      "community": 323,
+      "community": 324,
       "file_type": "code",
       "id": "upsellmodalform_handleinputchange",
       "label": "handleInputChange()",
@@ -83713,7 +83806,7 @@
       "source_location": "L64"
     },
     {
-      "community": 323,
+      "community": 324,
       "file_type": "code",
       "id": "upsellmodalform_handlesubmit",
       "label": "handleSubmit()",
@@ -83722,7 +83815,7 @@
       "source_location": "L49"
     },
     {
-      "community": 324,
+      "community": 325,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_contexts_storecontext_tsx",
       "label": "StoreContext.tsx",
@@ -83731,7 +83824,7 @@
       "source_location": "L1"
     },
     {
-      "community": 324,
+      "community": 325,
       "file_type": "code",
       "id": "storecontext_storeprovider",
       "label": "StoreProvider()",
@@ -83740,7 +83833,7 @@
       "source_location": "L25"
     },
     {
-      "community": 324,
+      "community": 325,
       "file_type": "code",
       "id": "storecontext_useoptionalstorecontext",
       "label": "useOptionalStoreContext()",
@@ -83749,7 +83842,7 @@
       "source_location": "L90"
     },
     {
-      "community": 324,
+      "community": 325,
       "file_type": "code",
       "id": "storecontext_usestorecontext",
       "label": "useStoreContext()",
@@ -83758,7 +83851,7 @@
       "source_location": "L82"
     },
     {
-      "community": 325,
+      "community": 326,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_shoplayout_tsx",
       "label": "_shopLayout.tsx",
@@ -83767,7 +83860,7 @@
       "source_location": "L1"
     },
     {
-      "community": 325,
+      "community": 326,
       "file_type": "code",
       "id": "shoplayout_clearfilters",
       "label": "clearFilters()",
@@ -83776,7 +83869,7 @@
       "source_location": "L115"
     },
     {
-      "community": 325,
+      "community": 326,
       "file_type": "code",
       "id": "shoplayout_onclickonmobilefilters",
       "label": "onClickOnMobileFilters()",
@@ -83785,7 +83878,7 @@
       "source_location": "L105"
     },
     {
-      "community": 325,
+      "community": 326,
       "file_type": "code",
       "id": "shoplayout_onmobilefilterscloseclick",
       "label": "onMobileFiltersCloseClick()",
@@ -83794,7 +83887,7 @@
       "source_location": "L110"
     },
     {
-      "community": 326,
+      "community": 327,
       "file_type": "code",
       "id": "index_cancelorder",
       "label": "cancelOrder()",
@@ -83803,7 +83896,7 @@
       "source_location": "L121"
     },
     {
-      "community": 326,
+      "community": 327,
       "file_type": "code",
       "id": "index_geterrormessage",
       "label": "getErrorMessage()",
@@ -83812,7 +83905,7 @@
       "source_location": "L26"
     },
     {
-      "community": 326,
+      "community": 327,
       "file_type": "code",
       "id": "index_placeorder",
       "label": "placeOrder()",
@@ -83821,7 +83914,7 @@
       "source_location": "L71"
     },
     {
-      "community": 326,
+      "community": 327,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_index_tsx",
       "label": "index.tsx",
@@ -83830,7 +83923,7 @@
       "source_location": "L1"
     },
     {
-      "community": 327,
+      "community": 328,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_receipt_posreceiptpage_tsx",
       "label": "-PosReceiptPage.tsx",
@@ -83839,7 +83932,7 @@
       "source_location": "L1"
     },
     {
-      "community": 327,
+      "community": 328,
       "file_type": "code",
       "id": "posreceiptpage_money",
       "label": "money()",
@@ -83848,7 +83941,7 @@
       "source_location": "L51"
     },
     {
-      "community": 327,
+      "community": 328,
       "file_type": "code",
       "id": "posreceiptpage_paymentlabel",
       "label": "paymentLabel()",
@@ -83857,7 +83950,7 @@
       "source_location": "L13"
     },
     {
-      "community": 327,
+      "community": 328,
       "file_type": "code",
       "id": "posreceiptpage_shouldretryreceiptlookup",
       "label": "shouldRetryReceiptLookup()",
@@ -83866,7 +83959,7 @@
       "source_location": "L21"
     },
     {
-      "community": 328,
+      "community": 329,
       "file_type": "code",
       "id": "bootstrap_bootstrapcheckout",
       "label": "bootstrapCheckout()",
@@ -83875,7 +83968,7 @@
       "source_location": "L46"
     },
     {
-      "community": 328,
+      "community": 329,
       "file_type": "code",
       "id": "bootstrap_createbootstraptoken",
       "label": "createBootstrapToken()",
@@ -83884,7 +83977,7 @@
       "source_location": "L24"
     },
     {
-      "community": 328,
+      "community": 329,
       "file_type": "code",
       "id": "bootstrap_createmarker",
       "label": "createMarker()",
@@ -83893,48 +83986,12 @@
       "source_location": "L20"
     },
     {
-      "community": 328,
+      "community": 329,
       "file_type": "code",
       "id": "packages_storefront_webapp_tests_e2e_helpers_bootstrap_ts",
       "label": "bootstrap.ts",
       "norm_label": "bootstrap.ts",
       "source_file": "packages/storefront-webapp/tests/e2e/helpers/bootstrap.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 329,
-      "file_type": "code",
-      "id": "graphify_check_test_createfixtureroot",
-      "label": "createFixtureRoot()",
-      "norm_label": "createfixtureroot()",
-      "source_file": "scripts/graphify-check.test.ts",
-      "source_location": "L17"
-    },
-    {
-      "community": 329,
-      "file_type": "code",
-      "id": "graphify_check_test_write",
-      "label": "write()",
-      "norm_label": "write()",
-      "source_file": "scripts/graphify-check.test.ts",
-      "source_location": "L11"
-    },
-    {
-      "community": 329,
-      "file_type": "code",
-      "id": "graphify_check_test_writegraphifywikiartifacts",
-      "label": "writeGraphifyWikiArtifacts()",
-      "norm_label": "writegraphifywikiartifacts()",
-      "source_file": "scripts/graphify-check.test.ts",
-      "source_location": "L24"
-    },
-    {
-      "community": 329,
-      "file_type": "code",
-      "id": "scripts_graphify_check_test_ts",
-      "label": "graphify-check.test.ts",
-      "norm_label": "graphify-check.test.ts",
-      "source_file": "scripts/graphify-check.test.ts",
       "source_location": "L1"
     },
     {
@@ -84111,6 +84168,42 @@
     {
       "community": 330,
       "file_type": "code",
+      "id": "graphify_check_test_createfixtureroot",
+      "label": "createFixtureRoot()",
+      "norm_label": "createfixtureroot()",
+      "source_file": "scripts/graphify-check.test.ts",
+      "source_location": "L17"
+    },
+    {
+      "community": 330,
+      "file_type": "code",
+      "id": "graphify_check_test_write",
+      "label": "write()",
+      "norm_label": "write()",
+      "source_file": "scripts/graphify-check.test.ts",
+      "source_location": "L11"
+    },
+    {
+      "community": 330,
+      "file_type": "code",
+      "id": "graphify_check_test_writegraphifywikiartifacts",
+      "label": "writeGraphifyWikiArtifacts()",
+      "norm_label": "writegraphifywikiartifacts()",
+      "source_file": "scripts/graphify-check.test.ts",
+      "source_location": "L24"
+    },
+    {
+      "community": 330,
+      "file_type": "code",
+      "id": "scripts_graphify_check_test_ts",
+      "label": "graphify-check.test.ts",
+      "norm_label": "graphify-check.test.ts",
+      "source_file": "scripts/graphify-check.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 331,
+      "file_type": "code",
       "id": "graphify_rebuild_test_createfixtureroot",
       "label": "createFixtureRoot()",
       "norm_label": "createfixtureroot()",
@@ -84118,7 +84211,7 @@
       "source_location": "L20"
     },
     {
-      "community": 330,
+      "community": 331,
       "file_type": "code",
       "id": "graphify_rebuild_test_spawn",
       "label": "spawn()",
@@ -84127,7 +84220,7 @@
       "source_location": "L65"
     },
     {
-      "community": 330,
+      "community": 331,
       "file_type": "code",
       "id": "graphify_rebuild_test_write",
       "label": "write()",
@@ -84136,7 +84229,7 @@
       "source_location": "L14"
     },
     {
-      "community": 330,
+      "community": 331,
       "file_type": "code",
       "id": "scripts_graphify_rebuild_test_ts",
       "label": "graphify-rebuild.test.ts",
@@ -84145,7 +84238,7 @@
       "source_location": "L1"
     },
     {
-      "community": 331,
+      "community": 332,
       "file_type": "code",
       "id": "harness_app_registry_buildharnessdocpaths",
       "label": "buildHarnessDocPaths()",
@@ -84154,7 +84247,7 @@
       "source_location": "L129"
     },
     {
-      "community": 331,
+      "community": 332,
       "file_type": "code",
       "id": "harness_app_registry_buildharnessdocpathsforarchetype",
       "label": "buildHarnessDocPathsForArchetype()",
@@ -84163,7 +84256,7 @@
       "source_location": "L133"
     },
     {
-      "community": 331,
+      "community": 332,
       "file_type": "code",
       "id": "harness_app_registry_getharnesspackageregistration",
       "label": "getHarnessPackageRegistration()",
@@ -84172,7 +84265,7 @@
       "source_location": "L974"
     },
     {
-      "community": 331,
+      "community": 332,
       "file_type": "code",
       "id": "scripts_harness_app_registry_ts",
       "label": "harness-app-registry.ts",
@@ -84181,7 +84274,7 @@
       "source_location": "L1"
     },
     {
-      "community": 332,
+      "community": 333,
       "file_type": "code",
       "id": "scripts_harness_behavior_fixtures_valkey_runtime_app_ts",
       "label": "valkey-runtime-app.ts",
@@ -84190,7 +84283,7 @@
       "source_location": "L1"
     },
     {
-      "community": 332,
+      "community": 333,
       "file_type": "code",
       "id": "valkey_runtime_app_createvalkeyruntimeserver",
       "label": "createValkeyRuntimeServer()",
@@ -84199,7 +84292,7 @@
       "source_location": "L8"
     },
     {
-      "community": 332,
+      "community": 333,
       "file_type": "code",
       "id": "valkey_runtime_app_shutdown",
       "label": "shutdown()",
@@ -84208,7 +84301,7 @@
       "source_location": "L79"
     },
     {
-      "community": 332,
+      "community": 333,
       "file_type": "code",
       "id": "valkey_runtime_app_stopvalkeyruntimeserver",
       "label": "stopValkeyRuntimeServer()",
@@ -84217,7 +84310,7 @@
       "source_location": "L61"
     },
     {
-      "community": 333,
+      "community": 334,
       "file_type": "code",
       "id": "harness_scorecard_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -84226,7 +84319,7 @@
       "source_location": "L49"
     },
     {
-      "community": 333,
+      "community": 334,
       "file_type": "code",
       "id": "harness_scorecard_test_createinferentialartifact",
       "label": "createInferentialArtifact()",
@@ -84235,7 +84328,7 @@
       "source_location": "L17"
     },
     {
-      "community": 333,
+      "community": 334,
       "file_type": "code",
       "id": "harness_scorecard_test_write",
       "label": "write()",
@@ -84244,7 +84337,7 @@
       "source_location": "L11"
     },
     {
-      "community": 333,
+      "community": 334,
       "file_type": "code",
       "id": "scripts_harness_scorecard_test_ts",
       "label": "harness-scorecard.test.ts",
@@ -84253,7 +84346,7 @@
       "source_location": "L1"
     },
     {
-      "community": 334,
+      "community": 335,
       "file_type": "code",
       "id": "harness_test_collectharnesstesttargets",
       "label": "collectHarnessTestTargets()",
@@ -84262,7 +84355,7 @@
       "source_location": "L26"
     },
     {
-      "community": 334,
+      "community": 335,
       "file_type": "code",
       "id": "harness_test_parseharnesstestcliargs",
       "label": "parseHarnessTestCliArgs()",
@@ -84271,7 +84364,7 @@
       "source_location": "L72"
     },
     {
-      "community": 334,
+      "community": 335,
       "file_type": "code",
       "id": "harness_test_runharnesstest",
       "label": "runHarnessTest()",
@@ -84280,7 +84373,7 @@
       "source_location": "L36"
     },
     {
-      "community": 334,
+      "community": 335,
       "file_type": "code",
       "id": "scripts_harness_test_ts",
       "label": "harness-test.ts",
@@ -84289,7 +84382,7 @@
       "source_location": "L1"
     },
     {
-      "community": 335,
+      "community": 336,
       "file_type": "code",
       "id": "pre_push_review_test_error",
       "label": "error()",
@@ -84298,7 +84391,7 @@
       "source_location": "L96"
     },
     {
-      "community": 335,
+      "community": 336,
       "file_type": "code",
       "id": "pre_push_review_test_log",
       "label": "log()",
@@ -84307,7 +84400,7 @@
       "source_location": "L94"
     },
     {
-      "community": 335,
+      "community": 336,
       "file_type": "code",
       "id": "pre_push_review_test_warn",
       "label": "warn()",
@@ -84316,7 +84409,7 @@
       "source_location": "L95"
     },
     {
-      "community": 335,
+      "community": 336,
       "file_type": "code",
       "id": "scripts_pre_push_review_test_ts",
       "label": "pre-push-review.test.ts",
@@ -84325,7 +84418,7 @@
       "source_location": "L1"
     },
     {
-      "community": 336,
+      "community": 337,
       "file_type": "code",
       "id": "preview_worktree_test_makedir",
       "label": "makeDir()",
@@ -84334,7 +84427,7 @@
       "source_location": "L17"
     },
     {
-      "community": 336,
+      "community": 337,
       "file_type": "code",
       "id": "preview_worktree_test_previewoptions",
       "label": "previewOptions()",
@@ -84343,7 +84436,7 @@
       "source_location": "L23"
     },
     {
-      "community": 336,
+      "community": 337,
       "file_type": "code",
       "id": "preview_worktree_test_real",
       "label": "real()",
@@ -84352,7 +84445,7 @@
       "source_location": "L40"
     },
     {
-      "community": 336,
+      "community": 337,
       "file_type": "code",
       "id": "scripts_preview_worktree_test_ts",
       "label": "preview-worktree.test.ts",
@@ -84361,7 +84454,7 @@
       "source_location": "L1"
     },
     {
-      "community": 337,
+      "community": 338,
       "file_type": "code",
       "id": "closeouts_test_gethandler",
       "label": "getHandler()",
@@ -84370,7 +84463,7 @@
       "source_location": "L16"
     },
     {
-      "community": 337,
+      "community": 338,
       "file_type": "code",
       "id": "closeouts_test_getsource",
       "label": "getSource()",
@@ -84379,7 +84472,7 @@
       "source_location": "L12"
     },
     {
-      "community": 337,
+      "community": 338,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cashcontrols_closeouts_test_ts",
       "label": "closeouts.test.ts",
@@ -84388,7 +84481,7 @@
       "source_location": "L1"
     },
     {
-      "community": 338,
+      "community": 339,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_customermessaging_public_ts",
       "label": "public.ts",
@@ -84397,7 +84490,7 @@
       "source_location": "L1"
     },
     {
-      "community": 338,
+      "community": 339,
       "file_type": "code",
       "id": "public_resolverecipient",
       "label": "resolveRecipient()",
@@ -84406,40 +84499,13 @@
       "source_location": "L57"
     },
     {
-      "community": 338,
+      "community": 339,
       "file_type": "code",
       "id": "public_topublicreceipttransaction",
       "label": "toPublicReceiptTransaction()",
       "norm_label": "topublicreceipttransaction()",
       "source_file": "packages/athena-webapp/convex/customerMessaging/public.ts",
       "source_location": "L29"
-    },
-    {
-      "community": 339,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_customermessaging_whatsappclient_ts",
-      "label": "whatsappClient.ts",
-      "norm_label": "whatsappclient.ts",
-      "source_file": "packages/athena-webapp/convex/customerMessaging/whatsappClient.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 339,
-      "file_type": "code",
-      "id": "whatsappclient_providererrorcategory",
-      "label": "providerErrorCategory()",
-      "norm_label": "providererrorcategory()",
-      "source_file": "packages/athena-webapp/convex/customerMessaging/whatsappClient.ts",
-      "source_location": "L20"
-    },
-    {
-      "community": 339,
-      "file_type": "code",
-      "id": "whatsappclient_sendwhatsappreceipttemplate",
-      "label": "sendWhatsAppReceiptTemplate()",
-      "norm_label": "sendwhatsappreceipttemplate()",
-      "source_file": "packages/athena-webapp/convex/customerMessaging/whatsappClient.ts",
-      "source_location": "L27"
     },
     {
       "community": 34,
@@ -84606,6 +84672,33 @@
     {
       "community": 340,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_customermessaging_whatsappclient_ts",
+      "label": "whatsappClient.ts",
+      "norm_label": "whatsappclient.ts",
+      "source_file": "packages/athena-webapp/convex/customerMessaging/whatsappClient.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 340,
+      "file_type": "code",
+      "id": "whatsappclient_providererrorcategory",
+      "label": "providerErrorCategory()",
+      "norm_label": "providererrorcategory()",
+      "source_file": "packages/athena-webapp/convex/customerMessaging/whatsappClient.ts",
+      "source_location": "L20"
+    },
+    {
+      "community": 340,
+      "file_type": "code",
+      "id": "whatsappclient_sendwhatsappreceipttemplate",
+      "label": "sendWhatsAppReceiptTemplate()",
+      "norm_label": "sendwhatsappreceipttemplate()",
+      "source_file": "packages/athena-webapp/convex/customerMessaging/whatsappClient.ts",
+      "source_location": "L27"
+    },
+    {
+      "community": 341,
+      "file_type": "code",
       "id": "discountcode_chunkproducts",
       "label": "chunkProducts()",
       "norm_label": "chunkproducts()",
@@ -84613,7 +84706,7 @@
       "source_location": "L98"
     },
     {
-      "community": 340,
+      "community": 341,
       "file_type": "code",
       "id": "discountcode_productcard",
       "label": "ProductCard()",
@@ -84622,7 +84715,7 @@
       "source_location": "L33"
     },
     {
-      "community": 340,
+      "community": 341,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_discountcode_tsx",
       "label": "DiscountCode.tsx",
@@ -84631,7 +84724,7 @@
       "source_location": "L1"
     },
     {
-      "community": 341,
+      "community": 342,
       "file_type": "code",
       "id": "discountreminder_chunkproducts",
       "label": "chunkProducts()",
@@ -84640,7 +84733,7 @@
       "source_location": "L85"
     },
     {
-      "community": 341,
+      "community": 342,
       "file_type": "code",
       "id": "discountreminder_productcard",
       "label": "ProductCard()",
@@ -84649,7 +84742,7 @@
       "source_location": "L31"
     },
     {
-      "community": 341,
+      "community": 342,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_discountreminder_tsx",
       "label": "DiscountReminder.tsx",
@@ -84658,7 +84751,7 @@
       "source_location": "L1"
     },
     {
-      "community": 342,
+      "community": 343,
       "file_type": "code",
       "id": "categories_removestorefronthiddencategories",
       "label": "removeStorefrontHiddenCategories()",
@@ -84667,7 +84760,7 @@
       "source_location": "L12"
     },
     {
-      "community": 342,
+      "community": 343,
       "file_type": "code",
       "id": "categories_removestorefronthiddensubcategories",
       "label": "removeStorefrontHiddenSubcategories()",
@@ -84676,7 +84769,7 @@
       "source_location": "L21"
     },
     {
-      "community": 342,
+      "community": 343,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_core_routes_categories_ts",
       "label": "categories.ts",
@@ -84685,7 +84778,7 @@
       "source_location": "L1"
     },
     {
-      "community": 343,
+      "community": 344,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_utils_ts",
       "label": "utils.ts",
@@ -84694,7 +84787,7 @@
       "source_location": "L1"
     },
     {
-      "community": 343,
+      "community": 344,
       "file_type": "code",
       "id": "utils_getstoredatafromrequest",
       "label": "getStoreDataFromRequest()",
@@ -84703,7 +84796,7 @@
       "source_location": "L5"
     },
     {
-      "community": 343,
+      "community": 344,
       "file_type": "code",
       "id": "utils_getstorefrontuserfromrequest",
       "label": "getStorefrontUserFromRequest()",
@@ -84712,7 +84805,7 @@
       "source_location": "L12"
     },
     {
-      "community": 344,
+      "community": 345,
       "file_type": "code",
       "id": "inventoryholds_test_buildhold",
       "label": "buildHold()",
@@ -84721,7 +84814,7 @@
       "source_location": "L566"
     },
     {
-      "community": 344,
+      "community": 345,
       "file_type": "code",
       "id": "inventoryholds_test_createdb",
       "label": "createDb()",
@@ -84730,7 +84823,7 @@
       "source_location": "L40"
     },
     {
-      "community": 344,
+      "community": 345,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_helpers_inventoryholds_test_ts",
       "label": "inventoryHolds.test.ts",
@@ -84739,7 +84832,7 @@
       "source_location": "L1"
     },
     {
-      "community": 345,
+      "community": 346,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_sessionqueryindexes_test_ts",
       "label": "sessionQueryIndexes.test.ts",
@@ -84748,7 +84841,7 @@
       "source_location": "L1"
     },
     {
-      "community": 345,
+      "community": 346,
       "file_type": "code",
       "id": "sessionqueryindexes_test_readprojectfile",
       "label": "readProjectFile()",
@@ -84757,7 +84850,7 @@
       "source_location": "L6"
     },
     {
-      "community": 345,
+      "community": 346,
       "file_type": "code",
       "id": "sessionqueryindexes_test_readsourceslice",
       "label": "readSourceSlice()",
@@ -84766,7 +84859,7 @@
       "source_location": "L9"
     },
     {
-      "community": 346,
+      "community": 347,
       "file_type": "code",
       "id": "analyticsutils_calculateactivitytrend",
       "label": "calculateActivityTrend()",
@@ -84775,7 +84868,7 @@
       "source_location": "L43"
     },
     {
-      "community": 346,
+      "community": 347,
       "file_type": "code",
       "id": "analyticsutils_calculatedevicedistribution",
       "label": "calculateDeviceDistribution()",
@@ -84784,7 +84877,7 @@
       "source_location": "L11"
     },
     {
-      "community": 346,
+      "community": 347,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_utils_analyticsutils_ts",
       "label": "analyticsUtils.ts",
@@ -84793,7 +84886,7 @@
       "source_location": "L1"
     },
     {
-      "community": 347,
+      "community": 348,
       "file_type": "code",
       "id": "dailyopening_test_completeddailyclose",
       "label": "completedDailyClose()",
@@ -84802,7 +84895,7 @@
       "source_location": "L168"
     },
     {
-      "community": 347,
+      "community": 348,
       "file_type": "code",
       "id": "dailyopening_test_createdb",
       "label": "createDb()",
@@ -84811,7 +84904,7 @@
       "source_location": "L21"
     },
     {
-      "community": 347,
+      "community": 348,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_dailyopening_test_ts",
       "label": "dailyOpening.test.ts",
@@ -84820,7 +84913,7 @@
       "source_location": "L1"
     },
     {
-      "community": 348,
+      "community": 349,
       "file_type": "code",
       "id": "dailyoperations_test_buildctx",
       "label": "buildCtx()",
@@ -84829,7 +84922,7 @@
       "source_location": "L211"
     },
     {
-      "community": 348,
+      "community": 349,
       "file_type": "code",
       "id": "dailyoperations_test_createdb",
       "label": "createDb()",
@@ -84838,39 +84931,12 @@
       "source_location": "L23"
     },
     {
-      "community": 348,
+      "community": 349,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_dailyoperations_test_ts",
       "label": "dailyOperations.test.ts",
       "norm_label": "dailyoperations.test.ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperations.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 349,
-      "file_type": "code",
-      "id": "managerelevations_test_createmanagerelevationsctx",
-      "label": "createManagerElevationsCtx()",
-      "norm_label": "createmanagerelevationsctx()",
-      "source_file": "packages/athena-webapp/convex/operations/managerElevations.test.ts",
-      "source_location": "L26"
-    },
-    {
-      "community": 349,
-      "file_type": "code",
-      "id": "managerelevations_test_startargs",
-      "label": "startArgs()",
-      "norm_label": "startargs()",
-      "source_file": "packages/athena-webapp/convex/operations/managerElevations.test.ts",
-      "source_location": "L177"
-    },
-    {
-      "community": 349,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_managerelevations_test_ts",
-      "label": "managerElevations.test.ts",
-      "norm_label": "managerelevations.test.ts",
-      "source_file": "packages/athena-webapp/convex/operations/managerElevations.test.ts",
       "source_location": "L1"
     },
     {
@@ -85038,6 +85104,33 @@
     {
       "community": 350,
       "file_type": "code",
+      "id": "managerelevations_test_createmanagerelevationsctx",
+      "label": "createManagerElevationsCtx()",
+      "norm_label": "createmanagerelevationsctx()",
+      "source_file": "packages/athena-webapp/convex/operations/managerElevations.test.ts",
+      "source_location": "L26"
+    },
+    {
+      "community": 350,
+      "file_type": "code",
+      "id": "managerelevations_test_startargs",
+      "label": "startArgs()",
+      "norm_label": "startargs()",
+      "source_file": "packages/athena-webapp/convex/operations/managerElevations.test.ts",
+      "source_location": "L177"
+    },
+    {
+      "community": 350,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_managerelevations_test_ts",
+      "label": "managerElevations.test.ts",
+      "norm_label": "managerelevations.test.ts",
+      "source_file": "packages/athena-webapp/convex/operations/managerElevations.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 351,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_staffcredentials_test_ts",
       "label": "staffCredentials.test.ts",
       "norm_label": "staffcredentials.test.ts",
@@ -85045,7 +85138,7 @@
       "source_location": "L1"
     },
     {
-      "community": 350,
+      "community": 351,
       "file_type": "code",
       "id": "staffcredentials_test_createstaffcredentialsmutationctx",
       "label": "createStaffCredentialsMutationCtx()",
@@ -85054,7 +85147,7 @@
       "source_location": "L26"
     },
     {
-      "community": 350,
+      "community": 351,
       "file_type": "code",
       "id": "staffcredentials_test_gethandler",
       "label": "getHandler()",
@@ -85063,7 +85156,7 @@
       "source_location": "L118"
     },
     {
-      "community": 351,
+      "community": 352,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_staffprofiles_test_ts",
       "label": "staffProfiles.test.ts",
@@ -85072,7 +85165,7 @@
       "source_location": "L1"
     },
     {
-      "community": 351,
+      "community": 352,
       "file_type": "code",
       "id": "staffprofiles_test_createstaffprofilesmutationctx",
       "label": "createStaffProfilesMutationCtx()",
@@ -85081,7 +85174,7 @@
       "source_location": "L16"
     },
     {
-      "community": 351,
+      "community": 352,
       "file_type": "code",
       "id": "staffprofiles_test_gethandler",
       "label": "getHandler()",
@@ -85090,7 +85183,7 @@
       "source_location": "L92"
     },
     {
-      "community": 352,
+      "community": 353,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_staffroles_ts",
       "label": "staffRoles.ts",
@@ -85099,7 +85192,7 @@
       "source_location": "L1"
     },
     {
-      "community": 352,
+      "community": 353,
       "file_type": "code",
       "id": "staffroles_derivedefaultoperationalroles",
       "label": "deriveDefaultOperationalRoles()",
@@ -85108,7 +85201,7 @@
       "source_location": "L21"
     },
     {
-      "community": 352,
+      "community": 353,
       "file_type": "code",
       "id": "staffroles_uniqueoperationalroles",
       "label": "uniqueOperationalRoles()",
@@ -85117,7 +85210,7 @@
       "source_location": "L31"
     },
     {
-      "community": 353,
+      "community": 354,
       "file_type": "code",
       "id": "index_listtransactions",
       "label": "listTransactions()",
@@ -85126,7 +85219,7 @@
       "source_location": "L7"
     },
     {
-      "community": 353,
+      "community": 354,
       "file_type": "code",
       "id": "index_verifytransaction",
       "label": "verifyTransaction()",
@@ -85135,7 +85228,7 @@
       "source_location": "L109"
     },
     {
-      "community": 353,
+      "community": 354,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_paystack_index_ts",
       "label": "index.ts",
@@ -85144,7 +85237,7 @@
       "source_location": "L1"
     },
     {
-      "community": 354,
+      "community": 355,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_queries_terminals_ts",
       "label": "terminals.ts",
@@ -85153,7 +85246,7 @@
       "source_location": "L1"
     },
     {
-      "community": 354,
+      "community": 355,
       "file_type": "code",
       "id": "terminals_getterminalbyfingerprint",
       "label": "getTerminalByFingerprint()",
@@ -85162,7 +85255,7 @@
       "source_location": "L18"
     },
     {
-      "community": 354,
+      "community": 355,
       "file_type": "code",
       "id": "terminals_listterminals",
       "label": "listTerminals()",
@@ -85171,7 +85264,7 @@
       "source_location": "L9"
     },
     {
-      "community": 355,
+      "community": 356,
       "file_type": "code",
       "id": "errors_posservererror",
       "label": "PosServerError",
@@ -85180,7 +85273,7 @@
       "source_location": "L8"
     },
     {
-      "community": 355,
+      "community": 356,
       "file_type": "code",
       "id": "errors_posservererror_constructor",
       "label": ".constructor()",
@@ -85189,7 +85282,7 @@
       "source_location": "L9"
     },
     {
-      "community": 355,
+      "community": 356,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_domain_errors_ts",
       "label": "errors.ts",
@@ -85198,7 +85291,7 @@
       "source_location": "L1"
     },
     {
-      "community": 356,
+      "community": 357,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_domain_sessionrules_ts",
       "label": "sessionRules.ts",
@@ -85207,7 +85300,7 @@
       "source_location": "L1"
     },
     {
-      "community": 356,
+      "community": 357,
       "file_type": "code",
       "id": "sessionrules_deriveregisterphase",
       "label": "deriveRegisterPhase()",
@@ -85216,7 +85309,7 @@
       "source_location": "L7"
     },
     {
-      "community": 356,
+      "community": 357,
       "file_type": "code",
       "id": "sessionrules_selectresumablesession",
       "label": "selectResumableSession()",
@@ -85225,7 +85318,7 @@
       "source_location": "L29"
     },
     {
-      "community": 357,
+      "community": 358,
       "file_type": "code",
       "id": "inventoryholdgateway_test_createctx",
       "label": "createCtx()",
@@ -85234,7 +85327,7 @@
       "source_location": "L16"
     },
     {
-      "community": 357,
+      "community": 358,
       "file_type": "code",
       "id": "inventoryholdgateway_test_createlegacypatchctx",
       "label": "createLegacyPatchCtx()",
@@ -85243,7 +85336,7 @@
       "source_location": "L22"
     },
     {
-      "community": 357,
+      "community": 358,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_integrations_inventoryholdgateway_test_ts",
       "label": "inventoryHoldGateway.test.ts",
@@ -85252,7 +85345,7 @@
       "source_location": "L1"
     },
     {
-      "community": 358,
+      "community": 359,
       "file_type": "code",
       "id": "inventoryholdgateway_assertobjectshapedholdargs",
       "label": "assertObjectShapedHoldArgs()",
@@ -85261,7 +85354,7 @@
       "source_location": "L43"
     },
     {
-      "community": 358,
+      "community": 359,
       "file_type": "code",
       "id": "inventoryholdgateway_createinventoryholdgateway",
       "label": "createInventoryHoldGateway()",
@@ -85270,40 +85363,13 @@
       "source_location": "L24"
     },
     {
-      "community": 358,
+      "community": 359,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_integrations_inventoryholdgateway_ts",
       "label": "inventoryHoldGateway.ts",
       "norm_label": "inventoryholdgateway.ts",
       "source_file": "packages/athena-webapp/convex/pos/infrastructure/integrations/inventoryHoldGateway.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 359,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_infrastructure_integrations_paymentallocationservice_ts",
-      "label": "paymentAllocationService.ts",
-      "norm_label": "paymentallocationservice.ts",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/integrations/paymentAllocationService.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 359,
-      "file_type": "code",
-      "id": "paymentallocationservice_recordretailsalepaymentallocations",
-      "label": "recordRetailSalePaymentAllocations()",
-      "norm_label": "recordretailsalepaymentallocations()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/integrations/paymentAllocationService.ts",
-      "source_location": "L13"
-    },
-    {
-      "community": 359,
-      "file_type": "code",
-      "id": "paymentallocationservice_recordretailvoidpaymentallocations",
-      "label": "recordRetailVoidPaymentAllocations()",
-      "norm_label": "recordretailvoidpaymentallocations()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/integrations/paymentAllocationService.ts",
-      "source_location": "L45"
     },
     {
       "community": 36,
@@ -85470,6 +85536,33 @@
     {
       "community": 360,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_infrastructure_integrations_paymentallocationservice_ts",
+      "label": "paymentAllocationService.ts",
+      "norm_label": "paymentallocationservice.ts",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/integrations/paymentAllocationService.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 360,
+      "file_type": "code",
+      "id": "paymentallocationservice_recordretailsalepaymentallocations",
+      "label": "recordRetailSalePaymentAllocations()",
+      "norm_label": "recordretailsalepaymentallocations()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/integrations/paymentAllocationService.ts",
+      "source_location": "L13"
+    },
+    {
+      "community": 360,
+      "file_type": "code",
+      "id": "paymentallocationservice_recordretailvoidpaymentallocations",
+      "label": "recordRetailVoidPaymentAllocations()",
+      "norm_label": "recordretailvoidpaymentallocations()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/integrations/paymentAllocationService.ts",
+      "source_location": "L45"
+    },
+    {
+      "community": 361,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_registersessionrepository_ts",
       "label": "registerSessionRepository.ts",
       "norm_label": "registersessionrepository.ts",
@@ -85477,7 +85570,7 @@
       "source_location": "L1"
     },
     {
-      "community": 360,
+      "community": 361,
       "file_type": "code",
       "id": "registersessionrepository_getactiveregistersessionforregisterstate",
       "label": "getActiveRegisterSessionForRegisterState()",
@@ -85486,7 +85579,7 @@
       "source_location": "L36"
     },
     {
-      "community": 360,
+      "community": 361,
       "file_type": "code",
       "id": "registersessionrepository_mapregistersessiontocashdrawersummary",
       "label": "mapRegisterSessionToCashDrawerSummary()",
@@ -85495,7 +85588,7 @@
       "source_location": "L13"
     },
     {
-      "community": 361,
+      "community": 362,
       "file_type": "code",
       "id": "appointments_buildserviceappointment",
       "label": "buildServiceAppointment()",
@@ -85504,7 +85597,7 @@
       "source_location": "L17"
     },
     {
-      "community": 361,
+      "community": 362,
       "file_type": "code",
       "id": "appointments_findoverlappingappointment",
       "label": "findOverlappingAppointment()",
@@ -85513,7 +85606,7 @@
       "source_location": "L61"
     },
     {
-      "community": 361,
+      "community": 362,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_serviceops_appointments_ts",
       "label": "appointments.ts",
@@ -85522,7 +85615,7 @@
       "source_location": "L1"
     },
     {
-      "community": 362,
+      "community": 363,
       "file_type": "code",
       "id": "catalog_buildservicecatalogitem",
       "label": "buildServiceCatalogItem()",
@@ -85531,7 +85624,7 @@
       "source_location": "L13"
     },
     {
-      "community": 362,
+      "community": 363,
       "file_type": "code",
       "id": "catalog_normalizeservicecatalognamekey",
       "label": "normalizeServiceCatalogNameKey()",
@@ -85540,7 +85633,7 @@
       "source_location": "L9"
     },
     {
-      "community": 362,
+      "community": 363,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_serviceops_catalog_ts",
       "label": "catalog.ts",
@@ -85549,7 +85642,7 @@
       "source_location": "L1"
     },
     {
-      "community": 363,
+      "community": 364,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_serviceops_servicecases_test_ts",
       "label": "serviceCases.test.ts",
@@ -85558,7 +85651,7 @@
       "source_location": "L1"
     },
     {
-      "community": 363,
+      "community": 364,
       "file_type": "code",
       "id": "servicecases_test_expectindex",
       "label": "expectIndex()",
@@ -85567,7 +85660,7 @@
       "source_location": "L23"
     },
     {
-      "community": 363,
+      "community": 364,
       "file_type": "code",
       "id": "servicecases_test_gettableindexes",
       "label": "getTableIndexes()",
@@ -85576,7 +85669,7 @@
       "source_location": "L16"
     },
     {
-      "community": 364,
+      "community": 365,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_purchaseorders_test_ts",
       "label": "purchaseOrders.test.ts",
@@ -85585,7 +85678,7 @@
       "source_location": "L1"
     },
     {
-      "community": 364,
+      "community": 365,
       "file_type": "code",
       "id": "purchaseorders_test_createpurchaseordermutationctx",
       "label": "createPurchaseOrderMutationCtx()",
@@ -85594,7 +85687,7 @@
       "source_location": "L26"
     },
     {
-      "community": 364,
+      "community": 365,
       "file_type": "code",
       "id": "purchaseorders_test_getsource",
       "label": "getSource()",
@@ -85603,7 +85696,7 @@
       "source_location": "L22"
     },
     {
-      "community": 365,
+      "community": 366,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_receiving_test_ts",
       "label": "receiving.test.ts",
@@ -85612,7 +85705,7 @@
       "source_location": "L1"
     },
     {
-      "community": 365,
+      "community": 366,
       "file_type": "code",
       "id": "receiving_test_createreceivingmutationctx",
       "label": "createReceivingMutationCtx()",
@@ -85621,7 +85714,7 @@
       "source_location": "L28"
     },
     {
-      "community": 365,
+      "community": 366,
       "file_type": "code",
       "id": "receiving_test_getsource",
       "label": "getSource()",
@@ -85630,7 +85723,7 @@
       "source_location": "L24"
     },
     {
-      "community": 366,
+      "community": 367,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_vendors_test_ts",
       "label": "vendors.test.ts",
@@ -85639,7 +85732,7 @@
       "source_location": "L1"
     },
     {
-      "community": 366,
+      "community": 367,
       "file_type": "code",
       "id": "vendors_test_createvendormutationctx",
       "label": "createVendorMutationCtx()",
@@ -85648,7 +85741,7 @@
       "source_location": "L24"
     },
     {
-      "community": 366,
+      "community": 367,
       "file_type": "code",
       "id": "vendors_test_getsource",
       "label": "getSource()",
@@ -85657,7 +85750,7 @@
       "source_location": "L20"
     },
     {
-      "community": 367,
+      "community": 368,
       "file_type": "code",
       "id": "errorfoundation_test_gethandler",
       "label": "getHandler()",
@@ -85666,7 +85759,7 @@
       "source_location": "L25"
     },
     {
-      "community": 367,
+      "community": 368,
       "file_type": "code",
       "id": "errorfoundation_test_getsource",
       "label": "getSource()",
@@ -85675,7 +85768,7 @@
       "source_location": "L21"
     },
     {
-      "community": 367,
+      "community": 368,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_errorfoundation_test_ts",
       "label": "errorFoundation.test.ts",
@@ -85684,7 +85777,7 @@
       "source_location": "L1"
     },
     {
-      "community": 368,
+      "community": 369,
       "file_type": "code",
       "id": "bag_listbagitems",
       "label": "listBagItems()",
@@ -85693,7 +85786,7 @@
       "source_location": "L7"
     },
     {
-      "community": 368,
+      "community": 369,
       "file_type": "code",
       "id": "bag_loadbagwithitems",
       "label": "loadBagWithItems()",
@@ -85702,40 +85795,13 @@
       "source_location": "L14"
     },
     {
-      "community": 368,
+      "community": 369,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_helpers_bag_ts",
       "label": "bag.ts",
       "norm_label": "bag.ts",
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/bag.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 369,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_workflowtraces_adapters_registersession_ts",
-      "label": "registerSession.ts",
-      "norm_label": "registersession.ts",
-      "source_file": "packages/athena-webapp/convex/workflowTraces/adapters/registerSession.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 369,
-      "file_type": "code",
-      "id": "registersession_buildregistersessiontraceseed",
-      "label": "buildRegisterSessionTraceSeed()",
-      "norm_label": "buildregistersessiontraceseed()",
-      "source_file": "packages/athena-webapp/convex/workflowTraces/adapters/registerSession.ts",
-      "source_location": "L45"
-    },
-    {
-      "community": 369,
-      "file_type": "code",
-      "id": "registersession_formatregistersessionlabel",
-      "label": "formatRegisterSessionLabel()",
-      "norm_label": "formatregistersessionlabel()",
-      "source_file": "packages/athena-webapp/convex/workflowTraces/adapters/registerSession.ts",
-      "source_location": "L37"
     },
     {
       "community": 37,
@@ -85902,6 +85968,33 @@
     {
       "community": 370,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_workflowtraces_adapters_registersession_ts",
+      "label": "registerSession.ts",
+      "norm_label": "registersession.ts",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/adapters/registerSession.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 370,
+      "file_type": "code",
+      "id": "registersession_buildregistersessiontraceseed",
+      "label": "buildRegisterSessionTraceSeed()",
+      "norm_label": "buildregistersessiontraceseed()",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/adapters/registerSession.ts",
+      "source_location": "L45"
+    },
+    {
+      "community": 370,
+      "file_type": "code",
+      "id": "registersession_formatregistersessionlabel",
+      "label": "formatRegisterSessionLabel()",
+      "norm_label": "formatregistersessionlabel()",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/adapters/registerSession.ts",
+      "source_location": "L37"
+    },
+    {
+      "community": 371,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_public_ts",
       "label": "public.ts",
       "norm_label": "public.ts",
@@ -85909,7 +86002,7 @@
       "source_location": "L1"
     },
     {
-      "community": 370,
+      "community": 371,
       "file_type": "code",
       "id": "public_getworkflowtraceviewbyidwithctx",
       "label": "getWorkflowTraceViewByIdWithCtx()",
@@ -85918,7 +86011,7 @@
       "source_location": "L10"
     },
     {
-      "community": 370,
+      "community": 371,
       "file_type": "code",
       "id": "public_getworkflowtraceviewbylookupwithctx",
       "label": "getWorkflowTraceViewByLookupWithCtx()",
@@ -85927,7 +86020,7 @@
       "source_location": "L44"
     },
     {
-      "community": 371,
+      "community": 372,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_queryusage_test_ts",
       "label": "queryUsage.test.ts",
@@ -85936,7 +86029,7 @@
       "source_location": "L1"
     },
     {
-      "community": 371,
+      "community": 372,
       "file_type": "code",
       "id": "queryusage_test_comparebyfields",
       "label": "compareByFields()",
@@ -85945,7 +86038,7 @@
       "source_location": "L84"
     },
     {
-      "community": 371,
+      "community": 372,
       "file_type": "code",
       "id": "queryusage_test_createtestctx",
       "label": "createTestCtx()",
@@ -85954,7 +86047,7 @@
       "source_location": "L100"
     },
     {
-      "community": 372,
+      "community": 373,
       "file_type": "code",
       "id": "currencyformatter_currencydisplaysymbol",
       "label": "currencyDisplaySymbol()",
@@ -85963,7 +86056,7 @@
       "source_location": "L10"
     },
     {
-      "community": 372,
+      "community": 373,
       "file_type": "code",
       "id": "currencyformatter_currencyformatter",
       "label": "currencyFormatter()",
@@ -85972,7 +86065,7 @@
       "source_location": "L30"
     },
     {
-      "community": 372,
+      "community": 373,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_currencyformatter_ts",
       "label": "currencyFormatter.ts",
@@ -85981,7 +86074,7 @@
       "source_location": "L1"
     },
     {
-      "community": 373,
+      "community": 374,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_workflowtrace_ts",
       "label": "workflowTrace.ts",
@@ -85990,7 +86083,7 @@
       "source_location": "L1"
     },
     {
-      "community": 373,
+      "community": 374,
       "file_type": "code",
       "id": "workflowtrace_createworkflowtraceid",
       "label": "createWorkflowTraceId()",
@@ -85999,7 +86092,7 @@
       "source_location": "L35"
     },
     {
-      "community": 373,
+      "community": 374,
       "file_type": "code",
       "id": "workflowtrace_normalizeworkflowtracelookupvalue",
       "label": "normalizeWorkflowTraceLookupValue()",
@@ -86008,7 +86101,7 @@
       "source_location": "L25"
     },
     {
-      "community": 374,
+      "community": 375,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_view_tsx",
       "label": "View.tsx",
@@ -86017,7 +86110,7 @@
       "source_location": "L1"
     },
     {
-      "community": 374,
+      "community": 375,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_view_tsx",
       "label": "View.tsx",
@@ -86026,7 +86119,7 @@
       "source_location": "L1"
     },
     {
-      "community": 374,
+      "community": 375,
       "file_type": "code",
       "id": "view_view",
       "label": "View()",
@@ -86035,7 +86128,7 @@
       "source_location": "L4"
     },
     {
-      "community": 375,
+      "community": 376,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productavailability_tsx",
       "label": "ProductAvailability.tsx",
@@ -86044,7 +86137,7 @@
       "source_location": "L1"
     },
     {
-      "community": 375,
+      "community": 376,
       "file_type": "code",
       "id": "productavailability_productavailability",
       "label": "ProductAvailability()",
@@ -86053,7 +86146,7 @@
       "source_location": "L19"
     },
     {
-      "community": 375,
+      "community": 376,
       "file_type": "code",
       "id": "productavailability_productavailabilityview",
       "label": "ProductAvailabilityView()",
@@ -86062,7 +86155,7 @@
       "source_location": "L5"
     },
     {
-      "community": 376,
+      "community": 377,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_sheetprovider_tsx",
       "label": "SheetProvider.tsx",
@@ -86071,7 +86164,7 @@
       "source_location": "L1"
     },
     {
-      "community": 376,
+      "community": 377,
       "file_type": "code",
       "id": "sheetprovider_sheetprovider",
       "label": "SheetProvider()",
@@ -86080,7 +86173,7 @@
       "source_location": "L19"
     },
     {
-      "community": 376,
+      "community": 377,
       "file_type": "code",
       "id": "sheetprovider_usesheet",
       "label": "useSheet()",
@@ -86089,7 +86182,7 @@
       "source_location": "L11"
     },
     {
-      "community": 377,
+      "community": 378,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_wigtype_tsx",
       "label": "WigType.tsx",
@@ -86098,7 +86191,7 @@
       "source_location": "L1"
     },
     {
-      "community": 377,
+      "community": 378,
       "file_type": "code",
       "id": "wigtype_wigtype",
       "label": "WigType()",
@@ -86107,7 +86200,7 @@
       "source_location": "L22"
     },
     {
-      "community": 377,
+      "community": 378,
       "file_type": "code",
       "id": "wigtype_wigtypeview",
       "label": "WigTypeView()",
@@ -86116,7 +86209,7 @@
       "source_location": "L8"
     },
     {
-      "community": 378,
+      "community": 379,
       "file_type": "code",
       "id": "copyimagesprovider_copyimagesprovider",
       "label": "CopyImagesProvider()",
@@ -86125,7 +86218,7 @@
       "source_location": "L21"
     },
     {
-      "community": 378,
+      "community": 379,
       "file_type": "code",
       "id": "copyimagesprovider_usecopyimages",
       "label": "useCopyImages()",
@@ -86134,39 +86227,12 @@
       "source_location": "L13"
     },
     {
-      "community": 378,
+      "community": 379,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_copyimagesprovider_tsx",
       "label": "CopyImagesProvider.tsx",
       "norm_label": "copyimagesprovider.tsx",
       "source_file": "packages/athena-webapp/src/components/add-product/copy-images/CopyImagesProvider.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 379,
-      "file_type": "code",
-      "id": "analyticstopusers_analyticstopusers",
-      "label": "AnalyticsTopUsers()",
-      "norm_label": "analyticstopusers()",
-      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsTopUsers.tsx",
-      "source_location": "L100"
-    },
-    {
-      "community": 379,
-      "file_type": "code",
-      "id": "analyticstopusers_processanalyticstousers",
-      "label": "processAnalyticsToUsers()",
-      "norm_label": "processanalyticstousers()",
-      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsTopUsers.tsx",
-      "source_location": "L10"
-    },
-    {
-      "community": 379,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analyticstopusers_tsx",
-      "label": "AnalyticsTopUsers.tsx",
-      "norm_label": "analyticstopusers.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsTopUsers.tsx",
       "source_location": "L1"
     },
     {
@@ -86334,6 +86400,33 @@
     {
       "community": 380,
       "file_type": "code",
+      "id": "analyticstopusers_analyticstopusers",
+      "label": "AnalyticsTopUsers()",
+      "norm_label": "analyticstopusers()",
+      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsTopUsers.tsx",
+      "source_location": "L100"
+    },
+    {
+      "community": 380,
+      "file_type": "code",
+      "id": "analyticstopusers_processanalyticstousers",
+      "label": "processAnalyticsToUsers()",
+      "norm_label": "processanalyticstousers()",
+      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsTopUsers.tsx",
+      "source_location": "L10"
+    },
+    {
+      "community": 380,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_analyticstopusers_tsx",
+      "label": "AnalyticsTopUsers.tsx",
+      "norm_label": "analyticstopusers.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsTopUsers.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 381,
+      "file_type": "code",
       "id": "log_items_provider_logitemsprovider",
       "label": "LogItemsProvider()",
       "norm_label": "logitemsprovider()",
@@ -86341,7 +86434,7 @@
       "source_location": "L15"
     },
     {
-      "community": 380,
+      "community": 381,
       "file_type": "code",
       "id": "log_items_provider_uselogitems",
       "label": "useLogItems()",
@@ -86350,7 +86443,7 @@
       "source_location": "L39"
     },
     {
-      "community": 380,
+      "community": 381,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_log_items_provider_tsx",
       "label": "log-items-provider.tsx",
@@ -86359,7 +86452,7 @@
       "source_location": "L1"
     },
     {
-      "community": 381,
+      "community": 382,
       "file_type": "code",
       "id": "index_header",
       "label": "Header()",
@@ -86368,7 +86461,7 @@
       "source_location": "L15"
     },
     {
-      "community": 381,
+      "community": 382,
       "file_type": "code",
       "id": "index_storeassets",
       "label": "StoreAssets()",
@@ -86377,7 +86470,7 @@
       "source_location": "L23"
     },
     {
-      "community": 381,
+      "community": 382,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_index_tsx",
       "label": "index.tsx",
@@ -86386,7 +86479,7 @@
       "source_location": "L1"
     },
     {
-      "community": 382,
+      "community": 383,
       "file_type": "code",
       "id": "fadein_fadein",
       "label": "FadeIn()",
@@ -86395,7 +86488,7 @@
       "source_location": "L3"
     },
     {
-      "community": 382,
+      "community": 383,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_common_fadein_tsx",
       "label": "FadeIn.tsx",
@@ -86404,7 +86497,7 @@
       "source_location": "L1"
     },
     {
-      "community": 382,
+      "community": 383,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_common_fadein_tsx",
       "label": "FadeIn.tsx",
@@ -86413,7 +86506,7 @@
       "source_location": "L1"
     },
     {
-      "community": 383,
+      "community": 384,
       "file_type": "code",
       "id": "bestsellers_handleremovebestseller",
       "label": "handleRemoveBestSeller()",
@@ -86422,7 +86515,7 @@
       "source_location": "L53"
     },
     {
-      "community": 383,
+      "community": 384,
       "file_type": "code",
       "id": "bestsellers_ondragend",
       "label": "onDragEnd()",
@@ -86431,7 +86524,7 @@
       "source_location": "L65"
     },
     {
-      "community": 383,
+      "community": 384,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_bestsellers_tsx",
       "label": "BestSellers.tsx",
@@ -86440,7 +86533,7 @@
       "source_location": "L1"
     },
     {
-      "community": 384,
+      "community": 385,
       "file_type": "code",
       "id": "featuredsection_handlehighlighteditem",
       "label": "handleHighlightedItem()",
@@ -86449,7 +86542,7 @@
       "source_location": "L47"
     },
     {
-      "community": 384,
+      "community": 385,
       "file_type": "code",
       "id": "featuredsection_ondragend",
       "label": "onDragEnd()",
@@ -86458,7 +86551,7 @@
       "source_location": "L53"
     },
     {
-      "community": 384,
+      "community": 385,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_featuredsection_tsx",
       "label": "FeaturedSection.tsx",
@@ -86467,7 +86560,7 @@
       "source_location": "L1"
     },
     {
-      "community": 385,
+      "community": 386,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_videoplayer_tsx",
       "label": "VideoPlayer.tsx",
@@ -86476,7 +86569,7 @@
       "source_location": "L1"
     },
     {
-      "community": 385,
+      "community": 386,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_videoplayer_tsx",
       "label": "VideoPlayer.tsx",
@@ -86485,7 +86578,7 @@
       "source_location": "L1"
     },
     {
-      "community": 385,
+      "community": 386,
       "file_type": "code",
       "id": "videoplayer_videoplayer",
       "label": "VideoPlayer()",
@@ -86494,7 +86587,7 @@
       "source_location": "L9"
     },
     {
-      "community": 386,
+      "community": 387,
       "file_type": "code",
       "id": "orderview_handlerefundorder",
       "label": "handleRefundOrder()",
@@ -86503,7 +86596,7 @@
       "source_location": "L70"
     },
     {
-      "community": 386,
+      "community": 387,
       "file_type": "code",
       "id": "orderview_toast",
       "label": "toast()",
@@ -86512,7 +86605,7 @@
       "source_location": "L227"
     },
     {
-      "community": 386,
+      "community": 387,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orderview_tsx",
       "label": "OrderView.tsx",
@@ -86521,7 +86614,7 @@
       "source_location": "L1"
     },
     {
-      "community": 387,
+      "community": 388,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_pickupdetailsview_tsx",
       "label": "PickupDetailsView.tsx",
@@ -86530,7 +86623,7 @@
       "source_location": "L1"
     },
     {
-      "community": 387,
+      "community": 388,
       "file_type": "code",
       "id": "pickupdetailsview_deliverydetails",
       "label": "DeliveryDetails()",
@@ -86539,7 +86632,7 @@
       "source_location": "L71"
     },
     {
-      "community": 387,
+      "community": 388,
       "file_type": "code",
       "id": "pickupdetailsview_pickupdetailsview",
       "label": "PickupDetailsView()",
@@ -86548,7 +86641,7 @@
       "source_location": "L9"
     },
     {
-      "community": 388,
+      "community": 389,
       "file_type": "code",
       "id": "index_onsubmit",
       "label": "onSubmit()",
@@ -86557,7 +86650,7 @@
       "source_location": "L119"
     },
     {
-      "community": 388,
+      "community": 389,
       "file_type": "code",
       "id": "index_sectionheader",
       "label": "SectionHeader()",
@@ -86566,39 +86659,12 @@
       "source_location": "L45"
     },
     {
-      "community": 388,
+      "community": 389,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
       "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 389,
-      "file_type": "code",
-      "id": "cashierauthdialog_cashierauthdialog",
-      "label": "CashierAuthDialog()",
-      "norm_label": "cashierauthdialog()",
-      "source_file": "packages/athena-webapp/src/components/pos/CashierAuthDialog.tsx",
-      "source_location": "L33"
-    },
-    {
-      "community": 389,
-      "file_type": "code",
-      "id": "cashierauthdialog_getstaffdisplayname",
-      "label": "getStaffDisplayName()",
-      "norm_label": "getstaffdisplayname()",
-      "source_file": "packages/athena-webapp/src/components/pos/CashierAuthDialog.tsx",
-      "source_location": "L24"
-    },
-    {
-      "community": 389,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_cashierauthdialog_tsx",
-      "label": "CashierAuthDialog.tsx",
-      "norm_label": "cashierauthdialog.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/CashierAuthDialog.tsx",
       "source_location": "L1"
     },
     {
@@ -86757,6 +86823,33 @@
     {
       "community": 390,
       "file_type": "code",
+      "id": "cashierauthdialog_cashierauthdialog",
+      "label": "CashierAuthDialog()",
+      "norm_label": "cashierauthdialog()",
+      "source_file": "packages/athena-webapp/src/components/pos/CashierAuthDialog.tsx",
+      "source_location": "L33"
+    },
+    {
+      "community": 390,
+      "file_type": "code",
+      "id": "cashierauthdialog_getstaffdisplayname",
+      "label": "getStaffDisplayName()",
+      "norm_label": "getstaffdisplayname()",
+      "source_file": "packages/athena-webapp/src/components/pos/CashierAuthDialog.tsx",
+      "source_location": "L24"
+    },
+    {
+      "community": 390,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_cashierauthdialog_tsx",
+      "label": "CashierAuthDialog.tsx",
+      "norm_label": "cashierauthdialog.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/CashierAuthDialog.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 391,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_searchresultssection_tsx",
       "label": "SearchResultsSection.tsx",
       "norm_label": "searchresultssection.tsx",
@@ -86764,7 +86857,7 @@
       "source_location": "L1"
     },
     {
-      "community": 390,
+      "community": 391,
       "file_type": "code",
       "id": "searchresultssection_handlequickaddproductshortcut",
       "label": "handleQuickAddProductShortcut()",
@@ -86773,7 +86866,7 @@
       "source_location": "L117"
     },
     {
-      "community": 390,
+      "community": 391,
       "file_type": "code",
       "id": "searchresultssection_handlequickaddvariantshortcut",
       "label": "handleQuickAddVariantShortcut()",
@@ -86782,7 +86875,7 @@
       "source_location": "L84"
     },
     {
-      "community": 391,
+      "community": 392,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_posregisteropeningguard_tsx",
       "label": "POSRegisterOpeningGuard.tsx",
@@ -86791,7 +86884,7 @@
       "source_location": "L1"
     },
     {
-      "community": 391,
+      "community": 392,
       "file_type": "code",
       "id": "posregisteropeningguard_getlocaloperatingdate",
       "label": "getLocalOperatingDate()",
@@ -86800,7 +86893,7 @@
       "source_location": "L17"
     },
     {
-      "community": 391,
+      "community": 392,
       "file_type": "code",
       "id": "posregisteropeningguard_getlocaloperatingdaterange",
       "label": "getLocalOperatingDateRange()",
@@ -86809,7 +86902,7 @@
       "source_location": "L25"
     },
     {
-      "community": 392,
+      "community": 393,
       "file_type": "code",
       "id": "heldsessionslist_getsessioncartitemscount",
       "label": "getSessionCartItemsCount()",
@@ -86818,7 +86911,7 @@
       "source_location": "L36"
     },
     {
-      "community": 392,
+      "community": 393,
       "file_type": "code",
       "id": "heldsessionslist_hasexpired",
       "label": "hasExpired()",
@@ -86827,7 +86920,7 @@
       "source_location": "L32"
     },
     {
-      "community": 392,
+      "community": 393,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_session_heldsessionslist_tsx",
       "label": "HeldSessionsList.tsx",
@@ -86836,7 +86929,7 @@
       "source_location": "L1"
     },
     {
-      "community": 393,
+      "community": 394,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_settings_possettingsview_tsx",
       "label": "POSSettingsView.tsx",
@@ -86845,7 +86938,7 @@
       "source_location": "L1"
     },
     {
-      "community": 393,
+      "community": 394,
       "file_type": "code",
       "id": "possettingsview_fingerprintregistrationcard",
       "label": "FingerprintRegistrationCard()",
@@ -86854,7 +86947,7 @@
       "source_location": "L57"
     },
     {
-      "community": 393,
+      "community": 394,
       "file_type": "code",
       "id": "possettingsview_possettingsview",
       "label": "POSSettingsView()",
@@ -86863,7 +86956,7 @@
       "source_location": "L184"
     },
     {
-      "community": 394,
+      "community": 395,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_productstatus_test_tsx",
       "label": "ProductStatus.test.tsx",
@@ -86872,7 +86965,7 @@
       "source_location": "L1"
     },
     {
-      "community": 394,
+      "community": 395,
       "file_type": "code",
       "id": "productstatus_test_makeproduct",
       "label": "makeProduct()",
@@ -86881,7 +86974,7 @@
       "source_location": "L8"
     },
     {
-      "community": 394,
+      "community": 395,
       "file_type": "code",
       "id": "productstatus_test_makevariant",
       "label": "makeVariant()",
@@ -86890,7 +86983,7 @@
       "source_location": "L18"
     },
     {
-      "community": 395,
+      "community": 396,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_productslistview_tsx",
       "label": "ProductsListView.tsx",
@@ -86899,7 +86992,7 @@
       "source_location": "L1"
     },
     {
-      "community": 395,
+      "community": 396,
       "file_type": "code",
       "id": "productslistview_handleclearcache",
       "label": "handleClearCache()",
@@ -86908,7 +87001,7 @@
       "source_location": "L65"
     },
     {
-      "community": 395,
+      "community": 396,
       "file_type": "code",
       "id": "productslistview_productactionstogglegroup",
       "label": "ProductActionsToggleGroup()",
@@ -86917,7 +87010,7 @@
       "source_location": "L20"
     },
     {
-      "community": 396,
+      "community": 397,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_productstablecontext_tsx",
       "label": "ProductsTableContext.tsx",
@@ -86926,7 +87019,7 @@
       "source_location": "L1"
     },
     {
-      "community": 396,
+      "community": 397,
       "file_type": "code",
       "id": "productstablecontext_productstableprovider",
       "label": "ProductsTableProvider()",
@@ -86935,7 +87028,7 @@
       "source_location": "L16"
     },
     {
-      "community": 396,
+      "community": 397,
       "file_type": "code",
       "id": "productstablecontext_useproductstablestate",
       "label": "useProductsTableState()",
@@ -86944,7 +87037,7 @@
       "source_location": "L60"
     },
     {
-      "community": 397,
+      "community": 398,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_storeproductsview_tsx",
       "label": "StoreProductsView.tsx",
@@ -86953,7 +87046,7 @@
       "source_location": "L1"
     },
     {
-      "community": 397,
+      "community": 398,
       "file_type": "code",
       "id": "storeproductsview_navigation",
       "label": "Navigation()",
@@ -86962,7 +87055,7 @@
       "source_location": "L45"
     },
     {
-      "community": 397,
+      "community": 398,
       "file_type": "code",
       "id": "storeproductsview_productactionstogglegroup",
       "label": "ProductActionsToggleGroup()",
@@ -86971,7 +87064,7 @@
       "source_location": "L19"
     },
     {
-      "community": 398,
+      "community": 399,
       "file_type": "code",
       "id": "addcomplimentaryproduct_addcomplimentaryproduct",
       "label": "AddComplimentaryProduct()",
@@ -86980,7 +87073,7 @@
       "source_location": "L128"
     },
     {
-      "community": 398,
+      "community": 399,
       "file_type": "code",
       "id": "addcomplimentaryproduct_handleaddcomplimentaryproducts",
       "label": "handleAddComplimentaryProducts()",
@@ -86989,39 +87082,12 @@
       "source_location": "L40"
     },
     {
-      "community": 398,
+      "community": 399,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_complimentary_addcomplimentaryproduct_tsx",
       "label": "AddComplimentaryProduct.tsx",
       "norm_label": "addcomplimentaryproduct.tsx",
       "source_file": "packages/athena-webapp/src/components/products/complimentary/AddComplimentaryProduct.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 399,
-      "file_type": "code",
-      "id": "color_picker_handleblur",
-      "label": "handleBlur()",
-      "norm_label": "handleblur()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/color-picker.tsx",
-      "source_location": "L24"
-    },
-    {
-      "community": 399,
-      "file_type": "code",
-      "id": "color_picker_handleinputchange",
-      "label": "handleInputChange()",
-      "norm_label": "handleinputchange()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/color-picker.tsx",
-      "source_location": "L20"
-    },
-    {
-      "community": 399,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_modals_color_picker_tsx",
-      "label": "color-picker.tsx",
-      "norm_label": "color-picker.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/color-picker.tsx",
       "source_location": "L1"
     },
     {
@@ -87540,6 +87606,33 @@
     {
       "community": 400,
       "file_type": "code",
+      "id": "color_picker_handleblur",
+      "label": "handleBlur()",
+      "norm_label": "handleblur()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/color-picker.tsx",
+      "source_location": "L24"
+    },
+    {
+      "community": 400,
+      "file_type": "code",
+      "id": "color_picker_handleinputchange",
+      "label": "handleInputChange()",
+      "norm_label": "handleinputchange()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/color-picker.tsx",
+      "source_location": "L20"
+    },
+    {
+      "community": 400,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_modals_color_picker_tsx",
+      "label": "color-picker.tsx",
+      "norm_label": "color-picker.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/color-picker.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 401,
+      "file_type": "code",
       "id": "currency_provider_currencyprovider",
       "label": "CurrencyProvider()",
       "norm_label": "currencyprovider()",
@@ -87547,7 +87640,7 @@
       "source_location": "L25"
     },
     {
-      "community": 400,
+      "community": 401,
       "file_type": "code",
       "id": "currency_provider_usestorecurrency",
       "label": "useStoreCurrency()",
@@ -87556,7 +87649,7 @@
       "source_location": "L17"
     },
     {
-      "community": 400,
+      "community": 401,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_providers_currency_provider_tsx",
       "label": "currency-provider.tsx",
@@ -87565,7 +87658,7 @@
       "source_location": "L1"
     },
     {
-      "community": 401,
+      "community": 402,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_serviceappointmentsview_test_tsx",
       "label": "ServiceAppointmentsView.test.tsx",
@@ -87574,7 +87667,7 @@
       "source_location": "L1"
     },
     {
-      "community": 401,
+      "community": 402,
       "file_type": "code",
       "id": "serviceappointmentsview_test_choosedatetime",
       "label": "chooseDateTime()",
@@ -87583,7 +87676,7 @@
       "source_location": "L59"
     },
     {
-      "community": 401,
+      "community": 402,
       "file_type": "code",
       "id": "serviceappointmentsview_test_chooseselectoption",
       "label": "chooseSelectOption()",
@@ -87592,7 +87685,7 @@
       "source_location": "L50"
     },
     {
-      "community": 402,
+      "community": 403,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_serviceintakeview_tsx",
       "label": "ServiceIntakeView.tsx",
@@ -87601,7 +87694,7 @@
       "source_location": "L1"
     },
     {
-      "community": 402,
+      "community": 403,
       "file_type": "code",
       "id": "serviceintakeview_serviceintakeview",
       "label": "ServiceIntakeView()",
@@ -87610,7 +87703,7 @@
       "source_location": "L216"
     },
     {
-      "community": 402,
+      "community": 403,
       "file_type": "code",
       "id": "serviceintakeview_serviceintakeviewcontent",
       "label": "ServiceIntakeViewContent()",
@@ -87619,7 +87712,7 @@
       "source_location": "L84"
     },
     {
-      "community": 403,
+      "community": 404,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_staff_staffmanagement_test_tsx",
       "label": "StaffManagement.test.tsx",
@@ -87628,7 +87721,7 @@
       "source_location": "L1"
     },
     {
-      "community": 403,
+      "community": 404,
       "file_type": "code",
       "id": "staffmanagement_test_chooserole",
       "label": "chooseRole()",
@@ -87637,7 +87730,7 @@
       "source_location": "L163"
     },
     {
-      "community": 403,
+      "community": 404,
       "file_type": "code",
       "id": "staffmanagement_test_mockconvex",
       "label": "mockConvex()",
@@ -87646,7 +87739,7 @@
       "source_location": "L107"
     },
     {
-      "community": 404,
+      "community": 405,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_staff_auth_staffauthenticationdialog_tsx",
       "label": "StaffAuthenticationDialog.tsx",
@@ -87655,7 +87748,7 @@
       "source_location": "L1"
     },
     {
-      "community": 404,
+      "community": 405,
       "file_type": "code",
       "id": "staffauthenticationdialog_handlekeydown",
       "label": "handleKeyDown()",
@@ -87664,7 +87757,7 @@
       "source_location": "L169"
     },
     {
-      "community": 404,
+      "community": 405,
       "file_type": "code",
       "id": "staffauthenticationdialog_handlesubmit",
       "label": "handleSubmit()",
@@ -87673,7 +87766,7 @@
       "source_location": "L111"
     },
     {
-      "community": 405,
+      "community": 406,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_error_singlelineerror_tsx",
       "label": "SingleLineError.tsx",
@@ -87682,7 +87775,7 @@
       "source_location": "L1"
     },
     {
-      "community": 405,
+      "community": 406,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_error_singlelineerror_tsx",
       "label": "SingleLineError.tsx",
@@ -87691,7 +87784,7 @@
       "source_location": "L1"
     },
     {
-      "community": 405,
+      "community": 406,
       "file_type": "code",
       "id": "singlelineerror_singlelineerror",
       "label": "SingleLineError()",
@@ -87700,7 +87793,7 @@
       "source_location": "L3"
     },
     {
-      "community": 406,
+      "community": 407,
       "file_type": "code",
       "id": "index_errorpage",
       "label": "ErrorPage()",
@@ -87709,7 +87802,7 @@
       "source_location": "L9"
     },
     {
-      "community": 406,
+      "community": 407,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_error_index_tsx",
       "label": "index.tsx",
@@ -87718,7 +87811,7 @@
       "source_location": "L1"
     },
     {
-      "community": 406,
+      "community": 407,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_error_index_tsx",
       "label": "index.tsx",
@@ -87727,7 +87820,7 @@
       "source_location": "L1"
     },
     {
-      "community": 407,
+      "community": 408,
       "file_type": "code",
       "id": "app_skeleton_appskeleton",
       "label": "AppSkeleton()",
@@ -87736,7 +87829,7 @@
       "source_location": "L3"
     },
     {
-      "community": 407,
+      "community": 408,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_loading_app_skeleton_tsx",
       "label": "app-skeleton.tsx",
@@ -87745,7 +87838,7 @@
       "source_location": "L1"
     },
     {
-      "community": 407,
+      "community": 408,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_loading_app_skeleton_tsx",
       "label": "app-skeleton.tsx",
@@ -87754,7 +87847,7 @@
       "source_location": "L1"
     },
     {
-      "community": 408,
+      "community": 409,
       "file_type": "code",
       "id": "dashboard_skeleton_dashboardskeleton",
       "label": "DashboardSkeleton()",
@@ -87763,7 +87856,7 @@
       "source_location": "L3"
     },
     {
-      "community": 408,
+      "community": 409,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_loading_dashboard_skeleton_tsx",
       "label": "dashboard-skeleton.tsx",
@@ -87772,40 +87865,13 @@
       "source_location": "L1"
     },
     {
-      "community": 408,
+      "community": 409,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_loading_dashboard_skeleton_tsx",
       "label": "dashboard-skeleton.tsx",
       "norm_label": "dashboard-skeleton.tsx",
       "source_file": "packages/storefront-webapp/src/components/states/loading/dashboard-skeleton.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 409,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_states_loading_table_skeleton_tsx",
-      "label": "table-skeleton.tsx",
-      "norm_label": "table-skeleton.tsx",
-      "source_file": "packages/athena-webapp/src/components/states/loading/table-skeleton.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 409,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_states_loading_table_skeleton_tsx",
-      "label": "table-skeleton.tsx",
-      "norm_label": "table-skeleton.tsx",
-      "source_file": "packages/storefront-webapp/src/components/states/loading/table-skeleton.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 409,
-      "file_type": "code",
-      "id": "table_skeleton_tableskeleton",
-      "label": "TableSkeleton()",
-      "norm_label": "tableskeleton()",
-      "source_file": "packages/storefront-webapp/src/components/states/loading/table-skeleton.tsx",
-      "source_location": "L3"
     },
     {
       "community": 41,
@@ -87963,6 +88029,33 @@
     {
       "community": 410,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_states_loading_table_skeleton_tsx",
+      "label": "table-skeleton.tsx",
+      "norm_label": "table-skeleton.tsx",
+      "source_file": "packages/athena-webapp/src/components/states/loading/table-skeleton.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 410,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_states_loading_table_skeleton_tsx",
+      "label": "table-skeleton.tsx",
+      "norm_label": "table-skeleton.tsx",
+      "source_file": "packages/storefront-webapp/src/components/states/loading/table-skeleton.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 410,
+      "file_type": "code",
+      "id": "table_skeleton_tableskeleton",
+      "label": "TableSkeleton()",
+      "norm_label": "tableskeleton()",
+      "source_file": "packages/storefront-webapp/src/components/states/loading/table-skeleton.tsx",
+      "source_location": "L3"
+    },
+    {
+      "community": 411,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_loading_transactions_skeleton_tsx",
       "label": "transactions-skeleton.tsx",
       "norm_label": "transactions-skeleton.tsx",
@@ -87970,7 +88063,7 @@
       "source_location": "L1"
     },
     {
-      "community": 410,
+      "community": 411,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_loading_transactions_skeleton_tsx",
       "label": "transactions-skeleton.tsx",
@@ -87979,7 +88072,7 @@
       "source_location": "L1"
     },
     {
-      "community": 410,
+      "community": 411,
       "file_type": "code",
       "id": "transactions_skeleton_transactionsskeleton",
       "label": "TransactionsSkeleton()",
@@ -87988,7 +88081,7 @@
       "source_location": "L3"
     },
     {
-      "community": 411,
+      "community": 412,
       "file_type": "code",
       "id": "notfound_notfound",
       "label": "NotFound()",
@@ -87997,7 +88090,7 @@
       "source_location": "L4"
     },
     {
-      "community": 411,
+      "community": 412,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_not_found_notfound_tsx",
       "label": "NotFound.tsx",
@@ -88006,7 +88099,7 @@
       "source_location": "L1"
     },
     {
-      "community": 411,
+      "community": 412,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_not_found_notfound_tsx",
       "label": "NotFound.tsx",
@@ -88015,7 +88108,7 @@
       "source_location": "L1"
     },
     {
-      "community": 412,
+      "community": 413,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_traces_workflowtraceroutelink_tsx",
       "label": "WorkflowTraceRouteLink.tsx",
@@ -88024,7 +88117,7 @@
       "source_location": "L1"
     },
     {
-      "community": 412,
+      "community": 413,
       "file_type": "code",
       "id": "workflowtraceroutelink_getworkflowtraceroutetarget",
       "label": "getWorkflowTraceRouteTarget()",
@@ -88033,7 +88126,7 @@
       "source_location": "L23"
     },
     {
-      "community": 412,
+      "community": 413,
       "file_type": "code",
       "id": "workflowtraceroutelink_workflowtraceroutelink",
       "label": "WorkflowTraceRouteLink()",
@@ -88042,7 +88135,7 @@
       "source_location": "L41"
     },
     {
-      "community": 413,
+      "community": 414,
       "file_type": "code",
       "id": "app_context_menu_appcontextmenu",
       "label": "AppContextMenu()",
@@ -88051,7 +88144,7 @@
       "source_location": "L20"
     },
     {
-      "community": 413,
+      "community": 414,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_app_context_menu_tsx",
       "label": "app-context-menu.tsx",
@@ -88060,7 +88153,7 @@
       "source_location": "L1"
     },
     {
-      "community": 413,
+      "community": 414,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_app_context_menu_tsx",
       "label": "app-context-menu.tsx",
@@ -88069,7 +88162,7 @@
       "source_location": "L1"
     },
     {
-      "community": 414,
+      "community": 415,
       "file_type": "code",
       "id": "badge_badge",
       "label": "Badge()",
@@ -88078,7 +88171,7 @@
       "source_location": "L30"
     },
     {
-      "community": 414,
+      "community": 415,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_badge_tsx",
       "label": "badge.tsx",
@@ -88087,7 +88180,7 @@
       "source_location": "L1"
     },
     {
-      "community": 414,
+      "community": 415,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_badge_tsx",
       "label": "badge.tsx",
@@ -88096,7 +88189,7 @@
       "source_location": "L1"
     },
     {
-      "community": 415,
+      "community": 416,
       "file_type": "code",
       "id": "calendar_calendar",
       "label": "Calendar()",
@@ -88105,7 +88198,7 @@
       "source_location": "L12"
     },
     {
-      "community": 415,
+      "community": 416,
       "file_type": "code",
       "id": "calendar_cn",
       "label": "cn()",
@@ -88114,7 +88207,7 @@
       "source_location": "L201"
     },
     {
-      "community": 415,
+      "community": 416,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_calendar_tsx",
       "label": "calendar.tsx",
@@ -88123,7 +88216,7 @@
       "source_location": "L1"
     },
     {
-      "community": 416,
+      "community": 417,
       "file_type": "code",
       "id": "loading_button_loadingbutton",
       "label": "LoadingButton()",
@@ -88132,7 +88225,7 @@
       "source_location": "L9"
     },
     {
-      "community": 416,
+      "community": 417,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_loading_button_tsx",
       "label": "loading-button.tsx",
@@ -88141,7 +88234,7 @@
       "source_location": "L1"
     },
     {
-      "community": 416,
+      "community": 417,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_loading_button_tsx",
       "label": "loading-button.tsx",
@@ -88150,7 +88243,7 @@
       "source_location": "L1"
     },
     {
-      "community": 417,
+      "community": 418,
       "file_type": "code",
       "id": "modal_onchange",
       "label": "onChange()",
@@ -88159,7 +88252,7 @@
       "source_location": "L38"
     },
     {
-      "community": 417,
+      "community": 418,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modal_tsx",
       "label": "modal.tsx",
@@ -88168,7 +88261,7 @@
       "source_location": "L1"
     },
     {
-      "community": 417,
+      "community": 418,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modal_tsx",
       "label": "modal.tsx",
@@ -88177,7 +88270,7 @@
       "source_location": "L1"
     },
     {
-      "community": 418,
+      "community": 419,
       "file_type": "code",
       "id": "alert_modal_alertmodal",
       "label": "AlertModal()",
@@ -88186,7 +88279,7 @@
       "source_location": "L20"
     },
     {
-      "community": 418,
+      "community": 419,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_alert_modal_tsx",
       "label": "alert-modal.tsx",
@@ -88195,39 +88288,12 @@
       "source_location": "L1"
     },
     {
-      "community": 418,
+      "community": 419,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_alert_modal_tsx",
       "label": "alert-modal.tsx",
       "norm_label": "alert-modal.tsx",
       "source_file": "packages/storefront-webapp/src/components/ui/modals/alert-modal.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 419,
-      "file_type": "code",
-      "id": "overlay_modal_overlaymodal",
-      "label": "OverlayModal()",
-      "norm_label": "overlaymodal()",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/overlay-modal.tsx",
-      "source_location": "L12"
-    },
-    {
-      "community": 419,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_modals_overlay_modal_tsx",
-      "label": "overlay-modal.tsx",
-      "norm_label": "overlay-modal.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/modals/overlay-modal.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 419,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_modals_overlay_modal_tsx",
-      "label": "overlay-modal.tsx",
-      "norm_label": "overlay-modal.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/overlay-modal.tsx",
       "source_location": "L1"
     },
     {
@@ -88386,6 +88452,33 @@
     {
       "community": 420,
       "file_type": "code",
+      "id": "overlay_modal_overlaymodal",
+      "label": "OverlayModal()",
+      "norm_label": "overlaymodal()",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/overlay-modal.tsx",
+      "source_location": "L12"
+    },
+    {
+      "community": 420,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_modals_overlay_modal_tsx",
+      "label": "overlay-modal.tsx",
+      "norm_label": "overlay-modal.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/modals/overlay-modal.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 420,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_modals_overlay_modal_tsx",
+      "label": "overlay-modal.tsx",
+      "norm_label": "overlay-modal.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/overlay-modal.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 421,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_skeleton_tsx",
       "label": "skeleton.tsx",
       "norm_label": "skeleton.tsx",
@@ -88393,7 +88486,7 @@
       "source_location": "L1"
     },
     {
-      "community": 420,
+      "community": 421,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_skeleton_tsx",
       "label": "skeleton.tsx",
@@ -88402,7 +88495,7 @@
       "source_location": "L1"
     },
     {
-      "community": 420,
+      "community": 421,
       "file_type": "code",
       "id": "skeleton_skeleton",
       "label": "Skeleton()",
@@ -88411,7 +88504,7 @@
       "source_location": "L3"
     },
     {
-      "community": 421,
+      "community": 422,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_sonner_tsx",
       "label": "sonner.tsx",
@@ -88420,7 +88513,7 @@
       "source_location": "L1"
     },
     {
-      "community": 421,
+      "community": 422,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_sonner_tsx",
       "label": "sonner.tsx",
@@ -88429,7 +88522,7 @@
       "source_location": "L1"
     },
     {
-      "community": 421,
+      "community": 422,
       "file_type": "code",
       "id": "sonner_toaster",
       "label": "Toaster()",
@@ -88438,7 +88531,7 @@
       "source_location": "L6"
     },
     {
-      "community": 422,
+      "community": 423,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_spinner_tsx",
       "label": "spinner.tsx",
@@ -88447,7 +88540,7 @@
       "source_location": "L1"
     },
     {
-      "community": 422,
+      "community": 423,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_spinner_tsx",
       "label": "spinner.tsx",
@@ -88456,7 +88549,7 @@
       "source_location": "L1"
     },
     {
-      "community": 422,
+      "community": 423,
       "file_type": "code",
       "id": "spinner_spinner",
       "label": "Spinner()",
@@ -88465,7 +88558,7 @@
       "source_location": "L3"
     },
     {
-      "community": 423,
+      "community": 424,
       "file_type": "code",
       "id": "activitysummarycards_activitysummarycards",
       "label": "ActivitySummaryCards()",
@@ -88474,7 +88567,7 @@
       "source_location": "L44"
     },
     {
-      "community": 423,
+      "community": 424,
       "file_type": "code",
       "id": "activitysummarycards_summarycard",
       "label": "SummaryCard()",
@@ -88483,7 +88576,7 @@
       "source_location": "L19"
     },
     {
-      "community": 423,
+      "community": 424,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_activitysummarycards_tsx",
       "label": "ActivitySummaryCards.tsx",
@@ -88492,7 +88585,7 @@
       "source_location": "L1"
     },
     {
-      "community": 424,
+      "community": 425,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_timelineeventcard_tsx",
       "label": "TimelineEventCard.tsx",
@@ -88501,7 +88594,7 @@
       "source_location": "L1"
     },
     {
-      "community": 424,
+      "community": 425,
       "file_type": "code",
       "id": "timelineeventcard_formatobservabilitylabel",
       "label": "formatObservabilityLabel()",
@@ -88510,7 +88603,7 @@
       "source_location": "L162"
     },
     {
-      "community": 424,
+      "community": 425,
       "file_type": "code",
       "id": "timelineeventcard_loadmore",
       "label": "loadMore()",
@@ -88519,7 +88612,7 @@
       "source_location": "L198"
     },
     {
-      "community": 425,
+      "community": 426,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_useractivity_tsx",
       "label": "UserActivity.tsx",
@@ -88528,7 +88621,7 @@
       "source_location": "L1"
     },
     {
-      "community": 425,
+      "community": 426,
       "file_type": "code",
       "id": "useractivity_activityheader",
       "label": "ActivityHeader()",
@@ -88537,7 +88630,7 @@
       "source_location": "L22"
     },
     {
-      "community": 425,
+      "community": 426,
       "file_type": "code",
       "id": "useractivity_useractivity",
       "label": "UserActivity()",
@@ -88546,7 +88639,7 @@
       "source_location": "L45"
     },
     {
-      "community": 426,
+      "community": 427,
       "file_type": "code",
       "id": "onlineordercontext_onlineorderprovider",
       "label": "OnlineOrderProvider()",
@@ -88555,7 +88648,7 @@
       "source_location": "L24"
     },
     {
-      "community": 426,
+      "community": 427,
       "file_type": "code",
       "id": "onlineordercontext_useonlineorder",
       "label": "useOnlineOrder()",
@@ -88564,7 +88657,7 @@
       "source_location": "L38"
     },
     {
-      "community": 426,
+      "community": 427,
       "file_type": "code",
       "id": "packages_athena_webapp_src_contexts_onlineordercontext_tsx",
       "label": "OnlineOrderContext.tsx",
@@ -88573,7 +88666,7 @@
       "source_location": "L1"
     },
     {
-      "community": 427,
+      "community": 428,
       "file_type": "code",
       "id": "packages_athena_webapp_src_contexts_permissionscontext_tsx",
       "label": "PermissionsContext.tsx",
@@ -88582,7 +88675,7 @@
       "source_location": "L1"
     },
     {
-      "community": 427,
+      "community": 428,
       "file_type": "code",
       "id": "permissionscontext_permissionsprovider",
       "label": "PermissionsProvider()",
@@ -88591,7 +88684,7 @@
       "source_location": "L23"
     },
     {
-      "community": 427,
+      "community": 428,
       "file_type": "code",
       "id": "permissionscontext_usepermissionscontext",
       "label": "usePermissionsContext()",
@@ -88600,7 +88693,7 @@
       "source_location": "L51"
     },
     {
-      "community": 428,
+      "community": 429,
       "file_type": "code",
       "id": "packages_athena_webapp_src_contexts_productcontext_tsx",
       "label": "ProductContext.tsx",
@@ -88609,7 +88702,7 @@
       "source_location": "L1"
     },
     {
-      "community": 428,
+      "community": 429,
       "file_type": "code",
       "id": "productcontext_productprovider",
       "label": "ProductProvider()",
@@ -88618,40 +88711,13 @@
       "source_location": "L54"
     },
     {
-      "community": 428,
+      "community": 429,
       "file_type": "code",
       "id": "productcontext_useproduct",
       "label": "useProduct()",
       "norm_label": "useproduct()",
       "source_file": "packages/athena-webapp/src/contexts/ProductContext.tsx",
       "source_location": "L282"
-    },
-    {
-      "community": 429,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_contexts_usercontext_tsx",
-      "label": "UserContext.tsx",
-      "norm_label": "usercontext.tsx",
-      "source_file": "packages/athena-webapp/src/contexts/UserContext.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 429,
-      "file_type": "code",
-      "id": "usercontext_userprovider",
-      "label": "UserProvider()",
-      "norm_label": "userprovider()",
-      "source_file": "packages/athena-webapp/src/contexts/UserContext.tsx",
-      "source_location": "L12"
-    },
-    {
-      "community": 429,
-      "file_type": "code",
-      "id": "usercontext_useusercontext",
-      "label": "useUserContext()",
-      "norm_label": "useusercontext()",
-      "source_file": "packages/athena-webapp/src/contexts/UserContext.tsx",
-      "source_location": "L37"
     },
     {
       "community": 43,
@@ -88800,6 +88866,33 @@
     {
       "community": 430,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_contexts_usercontext_tsx",
+      "label": "UserContext.tsx",
+      "norm_label": "usercontext.tsx",
+      "source_file": "packages/athena-webapp/src/contexts/UserContext.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 430,
+      "file_type": "code",
+      "id": "usercontext_userprovider",
+      "label": "UserProvider()",
+      "norm_label": "userprovider()",
+      "source_file": "packages/athena-webapp/src/contexts/UserContext.tsx",
+      "source_location": "L12"
+    },
+    {
+      "community": 430,
+      "file_type": "code",
+      "id": "usercontext_useusercontext",
+      "label": "useUserContext()",
+      "norm_label": "useusercontext()",
+      "source_file": "packages/athena-webapp/src/contexts/UserContext.tsx",
+      "source_location": "L37"
+    },
+    {
+      "community": 431,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useauth_ts",
       "label": "useAuth.ts",
       "norm_label": "useauth.ts",
@@ -88807,7 +88900,7 @@
       "source_location": "L1"
     },
     {
-      "community": 430,
+      "community": 431,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useauth_ts",
       "label": "useAuth.ts",
@@ -88816,7 +88909,7 @@
       "source_location": "L1"
     },
     {
-      "community": 430,
+      "community": 431,
       "file_type": "code",
       "id": "useauth_useauth",
       "label": "useAuth()",
@@ -88825,7 +88918,7 @@
       "source_location": "L4"
     },
     {
-      "community": 431,
+      "community": 432,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetactivestore_ts",
       "label": "useGetActiveStore.ts",
@@ -88834,7 +88927,7 @@
       "source_location": "L1"
     },
     {
-      "community": 431,
+      "community": 432,
       "file_type": "code",
       "id": "usegetactivestore_usegetactivestore",
       "label": "useGetActiveStore()",
@@ -88843,7 +88936,7 @@
       "source_location": "L9"
     },
     {
-      "community": 431,
+      "community": 432,
       "file_type": "code",
       "id": "usegetactivestore_usegetstores",
       "label": "useGetStores()",
@@ -88852,7 +88945,7 @@
       "source_location": "L50"
     },
     {
-      "community": 432,
+      "community": 433,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetorganizations_ts",
       "label": "useGetOrganizations.ts",
@@ -88861,7 +88954,7 @@
       "source_location": "L1"
     },
     {
-      "community": 432,
+      "community": 433,
       "file_type": "code",
       "id": "usegetorganizations_usegetactiveorganization",
       "label": "useGetActiveOrganization()",
@@ -88870,7 +88963,7 @@
       "source_location": "L6"
     },
     {
-      "community": 432,
+      "community": 433,
       "file_type": "code",
       "id": "usegetorganizations_usegetorganizations",
       "label": "useGetOrganizations()",
@@ -88879,7 +88972,7 @@
       "source_location": "L31"
     },
     {
-      "community": 433,
+      "community": 434,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usesessionmanagementexpense_ts",
       "label": "useSessionManagementExpense.ts",
@@ -88888,7 +88981,7 @@
       "source_location": "L1"
     },
     {
-      "community": 433,
+      "community": 434,
       "file_type": "code",
       "id": "usesessionmanagementexpense_getcommanderrormessage",
       "label": "getCommandErrorMessage()",
@@ -88897,40 +88990,13 @@
       "source_location": "L19"
     },
     {
-      "community": 433,
+      "community": 434,
       "file_type": "code",
       "id": "usesessionmanagementexpense_usesessionmanagementexpense",
       "label": "useSessionManagementExpense()",
       "norm_label": "usesessionmanagementexpense()",
       "source_file": "packages/athena-webapp/src/hooks/useSessionManagementExpense.ts",
       "source_location": "L33"
-    },
-    {
-      "community": 434,
-      "file_type": "code",
-      "id": "capabilities_canaccessfulladminsurface",
-      "label": "canAccessFullAdminSurface()",
-      "norm_label": "canaccessfulladminsurface()",
-      "source_file": "packages/athena-webapp/src/lib/access/capabilities.ts",
-      "source_location": "L4"
-    },
-    {
-      "community": 434,
-      "file_type": "code",
-      "id": "capabilities_canaccessstoredaysurface",
-      "label": "canAccessStoreDaySurface()",
-      "norm_label": "canaccessstoredaysurface()",
-      "source_file": "packages/athena-webapp/src/lib/access/capabilities.ts",
-      "source_location": "L8"
-    },
-    {
-      "community": 434,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_access_capabilities_ts",
-      "label": "capabilities.ts",
-      "norm_label": "capabilities.ts",
-      "source_file": "packages/athena-webapp/src/lib/access/capabilities.ts",
-      "source_location": "L1"
     },
     {
       "community": 435,

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -7,10 +7,10 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 - [packages/AGENTS.md](../../packages/AGENTS.md) - package router plus the operational guides for each harnessed package
 
 ## Repo Summary
-- Code files discovered: 1676
-- Graph nodes: 5045
-- Graph edges: 5048
-- Communities: 1605
+- Code files discovered: 1677
+- Graph nodes: 5047
+- Graph edges: 5052
+- Communities: 1606
 
 ## Graph Hotspots
 - `DailyCloseView.tsx` (71 edges, Community 0) - [`packages/athena-webapp/src/components/operations/DailyCloseView.tsx`](../../packages/athena-webapp/src/components/operations/DailyCloseView.tsx)

--- a/packages/athena-webapp/docs/agent/key-folder-index.md
+++ b/packages/athena-webapp/docs/agent/key-folder-index.md
@@ -13,7 +13,7 @@ This key-folder index highlights the main directories agents are likely to need 
 - [`src/components/procurement`](../../src/components/procurement) — Procurement planning and receiving views for replenishment pressure and purchase-order execution. Currently 4 file(s); key children: ProcurementView.test.tsx, ProcurementView.tsx, ReceivingView.test.tsx, ReceivingView.tsx.
 - [`src/hooks`](../../src/hooks) — React hooks that fan out auth, shell, and feature state. Currently 41 file(s); key children: use-image-upload.ts, use-mobile.tsx, use-navigate-back.ts, use-navigation-keyboard-shortcuts.ts, use-pagination-persistence.ts.
 - [`src/contexts`](../../src/contexts) — Context providers for app-wide state and wiring. Currently 7 file(s); key children: ManagerElevationContext.test.tsx, ManagerElevationContext.tsx, OnlineOrderContext.tsx, PermissionsContext.tsx, ProductContext.tsx.
-- [`src/lib`](../../src/lib) — Shared frontend helpers, schemas, and package utilities. Currently 83 file(s); key children: access, aws.ts, behaviorUtils.ts, browserFingerprint.ts, constants.ts.
+- [`src/lib`](../../src/lib) — Shared frontend helpers, schemas, and package utilities. Currently 84 file(s); key children: access, aws.ts, behaviorUtils.ts, browserFingerprint.ts, constants.ts.
 - [`shared`](../../shared) — Browser-safe helpers shared with Convex-backed workflows. Currently 13 file(s); key children: approvalPolicy.ts, auth.ts, commandResult.test.ts, commandResult.ts, currencyFormatter.test.ts.
 - [`src/utils`](../../src/utils) — Cross-cutting browser helpers and lower-level utilities. Currently 3 file(s); key children: formatNumber.ts, index.ts, versionChecker.ts.
 

--- a/packages/athena-webapp/docs/agent/test-index.md
+++ b/packages/athena-webapp/docs/agent/test-index.md
@@ -212,6 +212,7 @@ This index enumerates the current automated test files and ties them back to the
 - [`src/hooks/useBulkOperations.test.ts`](../../src/hooks/useBulkOperations.test.ts)
 - [`src/hooks/useExpenseSessions.test.ts`](../../src/hooks/useExpenseSessions.test.ts)
 - [`src/hooks/useProtectedAdminPageState.test.tsx`](../../src/hooks/useProtectedAdminPageState.test.tsx)
+- [`src/lib/access/capabilities.test.ts`](../../src/lib/access/capabilities.test.ts)
 - [`src/lib/errors/operatorMessages.test.ts`](../../src/lib/errors/operatorMessages.test.ts)
 - [`src/lib/errors/presentCommandToast.test.ts`](../../src/lib/errors/presentCommandToast.test.ts)
 - [`src/lib/errors/presentUnexpectedErrorToast.test.ts`](../../src/lib/errors/presentUnexpectedErrorToast.test.ts)

--- a/packages/athena-webapp/src/lib/access/capabilities.test.ts
+++ b/packages/athena-webapp/src/lib/access/capabilities.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  canAccessFullAdminSurface,
+  canAccessStoreDaySurface,
+  getSurfaceAccess,
+  type ManagerElevationAccessState,
+} from "./capabilities";
+
+const activeElevation: ManagerElevationAccessState = {
+  displayName: "Adjoa Mensah",
+  staffProfileId: "staff-manager-1",
+  startedAt: 1_000,
+};
+
+describe("surface capability access", () => {
+  it("keeps full-admin access as the only full-admin surface capability", () => {
+    expect(canAccessFullAdminSurface({ role: "full_admin" })).toBe(true);
+    expect(
+      canAccessFullAdminSurface({
+        role: "pos_only",
+        activeManagerElevation: activeElevation,
+      }),
+    ).toBe(false);
+    expect(
+      canAccessFullAdminSurface({
+        role: null,
+        activeManagerElevation: activeElevation,
+      }),
+    ).toBe(false);
+  });
+
+  it("allows active manager elevation to unlock only store-day surfaces", () => {
+    expect(
+      canAccessStoreDaySurface({
+        role: "pos_only",
+        activeManagerElevation: activeElevation,
+      }),
+    ).toBe(true);
+    expect(canAccessStoreDaySurface({ role: "full_admin" })).toBe(true);
+    expect(canAccessStoreDaySurface({ role: "pos_only" })).toBe(false);
+  });
+
+  it("keeps excluded admin surfaces full-admin only", () => {
+    const elevatedPosOnly = {
+      role: "pos_only" as const,
+      activeManagerElevation: activeElevation,
+    };
+
+    expect(getSurfaceAccess("cash_controls", elevatedPosOnly)).toBe(true);
+    expect(getSurfaceAccess("daily_operations", elevatedPosOnly)).toBe(true);
+    expect(getSurfaceAccess("open_work", elevatedPosOnly)).toBe(true);
+    expect(getSurfaceAccess("approvals", elevatedPosOnly)).toBe(true);
+    expect(getSurfaceAccess("stock_adjustments", elevatedPosOnly)).toBe(true);
+
+    expect(getSurfaceAccess("procurement", elevatedPosOnly)).toBe(false);
+    expect(getSurfaceAccess("analytics", elevatedPosOnly)).toBe(false);
+    expect(getSurfaceAccess("configuration", elevatedPosOnly)).toBe(false);
+    expect(getSurfaceAccess("members", elevatedPosOnly)).toBe(false);
+    expect(getSurfaceAccess("storefront_admin", elevatedPosOnly)).toBe(false);
+    expect(getSurfaceAccess("bulk_operations", elevatedPosOnly)).toBe(false);
+    expect(getSurfaceAccess("promo_codes", elevatedPosOnly)).toBe(false);
+    expect(getSurfaceAccess("reviews_admin", elevatedPosOnly)).toBe(false);
+    expect(getSurfaceAccess("services_admin", elevatedPosOnly)).toBe(false);
+  });
+});

--- a/packages/athena-webapp/src/lib/access/capabilities.ts
+++ b/packages/athena-webapp/src/lib/access/capabilities.ts
@@ -1,16 +1,64 @@
-import type { ManagerElevation } from "@/contexts/ManagerElevationContext";
 import type { Role } from "~/types";
 
-export function canAccessFullAdminSurface({ role }: { role: Role | null }) {
+export type ManagerElevationAccessState = {
+  displayName?: string;
+  staffProfileId: string;
+  startedAt: number;
+} | null;
+
+export type StoreDaySurface =
+  | "cash_controls"
+  | "daily_operations"
+  | "open_work"
+  | "approvals"
+  | "stock_adjustments";
+
+export type FullAdminSurface =
+  | "procurement"
+  | "analytics"
+  | "configuration"
+  | "members"
+  | "storefront_admin"
+  | "bulk_operations"
+  | "promo_codes"
+  | "reviews_admin"
+  | "services_admin";
+
+export type SurfaceCapability = StoreDaySurface | FullAdminSurface;
+
+type SurfaceAccessContext = {
+  activeManagerElevation?: ManagerElevationAccessState;
+  role: Role | null;
+};
+
+const STORE_DAY_SURFACES = new Set<SurfaceCapability>([
+  "cash_controls",
+  "daily_operations",
+  "open_work",
+  "approvals",
+  "stock_adjustments",
+]);
+
+export function canAccessFullAdminSurface({
+  role,
+}: SurfaceAccessContext): boolean {
   return role === "full_admin";
 }
 
 export function canAccessStoreDaySurface({
   activeManagerElevation,
   role,
-}: {
-  activeManagerElevation: ManagerElevation | null;
-  role: Role | null;
-}) {
-  return role === "full_admin" || Boolean(activeManagerElevation);
+}: SurfaceAccessContext): boolean {
+  return canAccessFullAdminSurface({ role }) || Boolean(activeManagerElevation);
+}
+
+export function getSurfaceAccess(
+  surface: SurfaceCapability,
+  context: SurfaceAccessContext,
+): boolean {
+  if (STORE_DAY_SURFACES.has(surface)) {
+    return canAccessStoreDaySurface(context);
+  }
+
+  return canAccessFullAdminSurface(context);
 }


### PR DESCRIPTION
## Summary
- include the leftover local access helper/test work that was still dirty in root after PR #419
- make the surface-capability mapping explicit and test store-day versus full-admin surfaces
- refresh graphify artifacts for the additional test file

## Validation
- bun run --filter '@athena/webapp' test -- src/lib/access/capabilities.test.ts src/hooks/usePermissions.test.tsx src/hooks/useProtectedAdminPageState.test.tsx src/components/app-sidebar.test.tsx
- bunx tsc --noEmit -p packages/athena-webapp/tsconfig.json
- bun run graphify:rebuild
- git push pre-push validation suite
