### PR TITLE
Fix QA deploy dirty checkout recovery

### DIFF
--- a/scripts/deploy-qa-vps.test.ts
+++ b/scripts/deploy-qa-vps.test.ts
@@ -99,6 +99,17 @@ describe("VPS QA deploy contract", () => {
     expect(workflow).toContain('/src/main.tsx');
   });
 
+  it("resets generated remote checkout drift before switching deploy refs", async () => {
+    const deployScript = await readRepoFile("scripts/deploy-vps.sh");
+
+    expect(deployScript).toContain(
+      "Discarding local changes in %s before checking out %s.",
+    );
+    expect(deployScript).toMatch(
+      /git reset --hard[\s\S]*git fetch --prune origin[\s\S]*git checkout --detach "\$DEPLOY_REF"/,
+    );
+  });
+
   it("schedules browser-level Athena QA smoke checks", async () => {
     const workflow = await readRepoFile(".github/workflows/athena-qa-smoke.yml");
 

--- a/scripts/deploy-vps.sh
+++ b/scripts/deploy-vps.sh
@@ -129,6 +129,10 @@ MESSAGE
 fi
 
 cd "$REMOTE_SOURCE_DIR"
+if ! git diff --quiet || ! git diff --cached --quiet; then
+  printf 'Discarding local changes in %s before checking out %s.\n' "$REMOTE_SOURCE_DIR" "$DEPLOY_REF" >&2
+  git reset --hard
+fi
 git fetch --prune origin
 git checkout --detach "$DEPLOY_REF"
 bun install --ignore-scripts


### PR DESCRIPTION
## Summary
- reset tracked drift in the shared VPS checkout before checking out a deploy ref
- add a deploy contract regression test for the reset-before-checkout ordering

## Root Cause
Recent Athena QA Deploy runs failed in the `Deploy Athena QA` step because the VPS checkout at `/root/athena/repo` had a locally modified `bun.lockb` from `bun install --ignore-scripts`. The next workflow fetched the new main SHA, then `git checkout --detach "$DEPLOY_REF"` aborted because that dirty tracked file would be overwritten.

## Verification
- `bash -n scripts/deploy-vps.sh scripts/deploy-qa-vps.sh`
- `bun test scripts/deploy-qa-vps.test.ts scripts/convex-node-env.test.ts`
- `bun run test:coverage:scripts`
- `bun run compound:check`
- `bun run harness:check`
- `bun run harness:review --base origin/main`
- `bun run harness:inferential-review`
- `bun run graphify:rebuild`
- `bun run graphify:check`
- `REMOTE=root@178.128.161.200 DEPLOY_REF=$(git rev-parse origin/main) scripts/deploy-vps.sh qa-athena` twice
- `REMOTE=root@178.128.161.200 DEPLOY_REF=$(git rev-parse origin/main) scripts/deploy-vps.sh qa-storefront`
- Athena QA nginx smoke returned `HTTP/1.1 200 OK`
- Storefront QA nginx smoke returned `HTTP 200`
- pre-push hook completed all checks and passed