### PR TITLE
Add Athena landing page and polish daily close

### DIFF
--- a/docs/solutions/logic-errors/athena-operational-status-surfaces-2026-05-10.md
+++ b/docs/solutions/logic-errors/athena-operational-status-surfaces-2026-05-10.md
@@ -1,0 +1,65 @@
+---
+title: Athena Operational Status Surfaces Should Use Backend State As The Visual Contract
+date: 2026-05-10
+category: logic-errors
+module: athena-webapp
+problem_type: operational_status_drift
+component: operations-workspace
+symptoms:
+  - "Daily close blockers showed lower-priority register state above approval work"
+  - "Approval blockers did not visually distinguish variance reviews even though the backend exposed the approval type"
+  - "Closed and clear operational states used too much explanatory copy instead of concise status cues"
+root_cause: presentation_order_and_status_cues_not_anchored_to_domain_state
+resolution_type: status_surface_contract_alignment
+severity: medium
+tags:
+  - athena-webapp
+  - operations
+  - daily-close
+  - approvals
+  - frontend
+---
+
+# Athena Operational Status Surfaces Should Use Backend State As The Visual Contract
+
+## Problem
+
+Operational workspaces are read under time pressure. If the UI sorts blockers by
+incidental construction order, uses generic labels for typed approval work, or
+adds explanatory copy around already-final states, operators have to parse more
+than the domain actually requires.
+
+In the daily close flow, pending approval work needed to appear before register
+session mechanics because approvals are the highest-precedence blocker. Variance
+approval requests also needed a first-glance visual cue, because the backend
+already distinguished `variance_review` approval requests through blocker
+metadata. Historical closed-day panels had the opposite problem: the state was
+already final, so explanatory copy competed with the only useful action.
+
+## Solution
+
+Treat backend status and metadata as the presentation contract:
+
+- Sort daily-close blockers by domain precedence before deriving readiness:
+  approval requests first, then register sessions, then POS sessions.
+- Preserve approval metadata on daily-close blockers and use it for small visual
+  distinctions, such as a variance-review badge.
+- Use icon-only success cues when checklist rows are clear; keep textual counts
+  only when work remains.
+- Collapse closed historical panels down to the review action when the operating
+  date is already closed.
+
+The UI should still be restrained. Avoid adding explanatory paragraphs when the
+state, label, and available action already communicate the next move.
+
+## Prevention
+
+- Add tests around ordering when a backend snapshot combines approvals,
+  register sessions, and POS sessions.
+- Add component tests for visual state contracts that depend on metadata, not
+  only the visible title string.
+- When copy appears in a completed or closed state, check whether it changes the
+  operator's next action. If it does not, prefer the action and concise status
+  cue.
+- Keep new operational badges scoped to typed backend state so they do not
+  become decorative labels.

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,11 +1,11 @@
 # Graph Report - .
 
 ## Corpus Check
-- 1677 files · ~0 words
+- 1679 files · ~0 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 5048 nodes · 5053 edges · 1606 communities detected
+- 5055 nodes · 5061 edges · 1608 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -1616,10 +1616,12 @@
 - [[_COMMUNITY_Community 1603|Community 1603]]
 - [[_COMMUNITY_Community 1604|Community 1604]]
 - [[_COMMUNITY_Community 1605|Community 1605]]
+- [[_COMMUNITY_Community 1606|Community 1606]]
+- [[_COMMUNITY_Community 1607|Community 1607]]
 
 ## God Nodes (most connected - your core abstractions)
 1. `createJourneyEvent()` - 40 edges
-2. `buildDailyCloseSnapshotWithCtx()` - 25 edges
+2. `buildDailyCloseSnapshotWithCtx()` - 26 edges
 3. `getStoreConfigV2()` - 17 edges
 4. `DataTableViewOptions()` - 16 edges
 5. `buildDailyOpeningSnapshotWithCtx()` - 15 edges
@@ -1645,11 +1647,11 @@
 
 ### Community 0 - "Community 0"
 Cohesion: 0.05
-Nodes (45): buildDailyCloseTransactionSearch(), cn(), formatCarriedOverRegisterCount(), formatDailyCloseMoney(), formatExpenseTransactionCount(), formatMetadataDisplayValue(), formatMetadataValue(), formatTimestampMetadata() (+37 more)
+Nodes (46): buildDailyCloseTransactionSearch(), cn(), formatCarriedOverRegisterCount(), formatDailyCloseMoney(), formatExpenseTransactionCount(), formatMetadataDisplayValue(), formatMetadataValue(), formatTimestampMetadata() (+38 more)
 
 ### Community 1 - "Community 1"
 Cohesion: 0.07
-Nodes (47): approvalBelongsToRange(), approvalRequestTypeLabel(), buildDailyCloseApprovalSubject(), buildDailyCloseCompletionApprovalRequirement(), buildDailyCloseReportSnapshot(), buildDailyCloseSnapshotWithCtx(), buildExpenseSessionsById(), buildPaymentTotals() (+39 more)
+Nodes (48): approvalBelongsToRange(), approvalRequestTypeLabel(), buildDailyCloseApprovalSubject(), buildDailyCloseCompletionApprovalRequirement(), buildDailyCloseReportSnapshot(), buildDailyCloseSnapshotWithCtx(), buildExpenseSessionsById(), buildPaymentTotals() (+40 more)
 
 ### Community 2 - "Community 2"
 Cohesion: 0.1
@@ -2292,12 +2294,12 @@ Cohesion: 0.33
 Nodes (1): DataTableToolbar()
 
 ### Community 162 - "Community 162"
-Cohesion: 0.53
-Nodes (2): SelectedProductsProvider(), useSelectedProducts()
-
-### Community 163 - "Community 163"
 Cohesion: 0.4
 Nodes (2): handlePinChange(), normalizeOtpCode()
+
+### Community 163 - "Community 163"
+Cohesion: 0.53
+Nodes (2): SelectedProductsProvider(), useSelectedProducts()
 
 ### Community 164 - "Community 164"
 Cohesion: 0.33
@@ -8067,6 +8069,14 @@ Nodes (0):
 Cohesion: 1.0
 Nodes (0):
 
+### Community 1606 - "Community 1606"
+Cohesion: 1.0
+Nodes (0):
+
+### Community 1607 - "Community 1607"
+Cohesion: 1.0
+Nodes (0):
+
 ## Knowledge Gaps
 - **1 isolated node(s):** `HelpRequested`
   These have ≤1 connection - possible missing edges or undocumented components.
@@ -8314,1993 +8324,1997 @@ Nodes (0):
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 611`** (2 nodes): `JoinTeam()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 612`** (2 nodes): `cn()`, `OperationReviewItemCard.tsx`
+- **Thin community `Community 612`** (2 nodes): `Reveal()`, `AthenaLandingPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 613`** (2 nodes): `buildParams()`, `OperationsSummaryMetric.tsx`
+- **Thin community `Community 613`** (2 nodes): `cn()`, `OperationReviewItemCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 614`** (2 nodes): `StockAdjustmentWorkspace.test.tsx`, `renderStockAdjustmentWorkspace()`
+- **Thin community `Community 614`** (2 nodes): `buildParams()`, `OperationsSummaryMetric.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 615`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
+- **Thin community `Community 615`** (2 nodes): `StockAdjustmentWorkspace.test.tsx`, `renderStockAdjustmentWorkspace()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 616`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
+- **Thin community `Community 616`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 617`** (2 nodes): `handleTimeRangeChange()`, `OrderMetricsPanel.tsx`
+- **Thin community `Community 617`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 618`** (2 nodes): `getTimeFilter()`, `OrdersView.tsx`
+- **Thin community `Community 618`** (2 nodes): `handleTimeRangeChange()`, `OrderMetricsPanel.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 619`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
+- **Thin community `Community 619`** (2 nodes): `getTimeFilter()`, `OrdersView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 620`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
+- **Thin community `Community 620`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 621`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
+- **Thin community `Community 621`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 622`** (2 nodes): `if()`, `orderColumns.tsx`
+- **Thin community `Community 622`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 623`** (2 nodes): `OrganizationSwitcher()`, `organization-switcher.tsx`
+- **Thin community `Community 623`** (2 nodes): `if()`, `orderColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 624`** (2 nodes): `cn()`, `CartItems.tsx`
+- **Thin community `Community 624`** (2 nodes): `OrganizationSwitcher()`, `organization-switcher.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 625`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
+- **Thin community `Community 625`** (2 nodes): `cn()`, `CartItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 626`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
+- **Thin community `Community 626`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 627`** (2 nodes): `PinInput.tsx`, `PinInput()`
+- **Thin community `Community 627`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 628`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
+- **Thin community `Community 628`** (2 nodes): `PinInput.tsx`, `PinInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 629`** (2 nodes): `ProductCard.tsx`, `ProductCard()`
+- **Thin community `Community 629`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 630`** (2 nodes): `SearchResultsSection.test.tsx`, `buildProduct()`
+- **Thin community `Community 630`** (2 nodes): `ProductCard.tsx`, `ProductCard()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 631`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
+- **Thin community `Community 631`** (2 nodes): `SearchResultsSection.test.tsx`, `buildProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 632`** (2 nodes): `isToday()`, `ExpenseReportsView.tsx`
+- **Thin community `Community 632`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 633`** (2 nodes): `toExpenseReportRows()`, `expenseReportRows.ts`
+- **Thin community `Community 633`** (2 nodes): `isToday()`, `ExpenseReportsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 634`** (2 nodes): `ExpenseCompletionPanel()`, `ExpenseCompletionPanel.tsx`
+- **Thin community `Community 634`** (2 nodes): `toExpenseReportRows()`, `expenseReportRows.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 635`** (2 nodes): `RegisterCustomerAttribution.test.tsx`, `makeCustomer()`
+- **Thin community `Community 635`** (2 nodes): `ExpenseCompletionPanel()`, `ExpenseCompletionPanel.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 636`** (2 nodes): `RegisterCustomerPanel.tsx`, `RegisterCustomerPanel()`
+- **Thin community `Community 636`** (2 nodes): `RegisterCustomerAttribution.test.tsx`, `makeCustomer()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 637`** (2 nodes): `RegisterDrawerGate.test.tsx`, `renderGate()`
+- **Thin community `Community 637`** (2 nodes): `RegisterCustomerPanel.tsx`, `RegisterCustomerPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 638`** (2 nodes): `RegisterSessionPanel.tsx`, `RegisterSessionPanel()`
+- **Thin community `Community 638`** (2 nodes): `RegisterDrawerGate.test.tsx`, `renderGate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 639`** (2 nodes): `transactionColumns.test.tsx`, `renderTransactionCell()`
+- **Thin community `Community 639`** (2 nodes): `RegisterSessionPanel.tsx`, `RegisterSessionPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 640`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
+- **Thin community `Community 640`** (2 nodes): `transactionColumns.test.tsx`, `renderTransactionCell()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 641`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
+- **Thin community `Community 641`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 642`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
+- **Thin community `Community 642`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 643`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
+- **Thin community `Community 643`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 644`** (2 nodes): `ProductStatus.tsx`, `ProductStatus()`
+- **Thin community `Community 644`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 645`** (2 nodes): `SKUSelector.tsx`, `SKUSelector()`
+- **Thin community `Community 645`** (2 nodes): `ProductStatus.tsx`, `ProductStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 646`** (2 nodes): `product-actions.tsx`, `useArchiveProduct()`
+- **Thin community `Community 646`** (2 nodes): `SKUSelector.tsx`, `SKUSelector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 647`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
+- **Thin community `Community 647`** (2 nodes): `product-actions.tsx`, `useArchiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 648`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
+- **Thin community `Community 648`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 649`** (2 nodes): `Products.tsx`, `Products()`
+- **Thin community `Community 649`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 650`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
+- **Thin community `Community 650`** (2 nodes): `Products.tsx`, `Products()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 651`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
+- **Thin community `Community 651`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 652`** (2 nodes): `PromoCodePreview.tsx`, `Discount()`
+- **Thin community `Community 652`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 653`** (2 nodes): `PromoCodesView.test.tsx`, `readSource()`
+- **Thin community `Community 653`** (2 nodes): `PromoCodePreview.tsx`, `Discount()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 654`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
+- **Thin community `Community 654`** (2 nodes): `PromoCodesView.test.tsx`, `readSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 655`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
+- **Thin community `Community 655`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 656`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
+- **Thin community `Community 656`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 657`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
+- **Thin community `Community 657`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 658`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
+- **Thin community `Community 658`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 659`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
+- **Thin community `Community 659`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 660`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
+- **Thin community `Community 660`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 661`** (2 nodes): `ServiceCasesView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 661`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 662`** (2 nodes): `ServiceCatalogView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 662`** (2 nodes): `ServiceCasesView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 663`** (2 nodes): `ServiceIntakeForm.tsx`, `ServiceIntakeForm()`
+- **Thin community `Community 663`** (2 nodes): `ServiceCatalogView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 664`** (2 nodes): `ServiceIntakeView.auth.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 664`** (2 nodes): `ServiceIntakeForm.tsx`, `ServiceIntakeForm()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 665`** (2 nodes): `ServiceIntakeView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 665`** (2 nodes): `ServiceIntakeView.auth.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 666`** (2 nodes): `onClick()`, `empty-state.tsx`
+- **Thin community `Community 666`** (2 nodes): `ServiceIntakeView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 667`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
+- **Thin community `Community 667`** (2 nodes): `onClick()`, `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 668`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
+- **Thin community `Community 668`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 669`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
+- **Thin community `Community 669`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 670`** (2 nodes): `ProtectedAdminSignInView.tsx`, `ProtectedAdminSignInView()`
+- **Thin community `Community 670`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 671`** (2 nodes): `ContactView()`, `ContactView.tsx`
+- **Thin community `Community 671`** (2 nodes): `ProtectedAdminSignInView.tsx`, `ProtectedAdminSignInView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 672`** (2 nodes): `Header()`, `Header.tsx`
+- **Thin community `Community 672`** (2 nodes): `ContactView()`, `ContactView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 673`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
+- **Thin community `Community 673`** (2 nodes): `Header()`, `Header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 674`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
+- **Thin community `Community 674`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 675`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
+- **Thin community `Community 675`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 676`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
+- **Thin community `Community 676`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 677`** (2 nodes): `useChart()`, `chart.tsx`
+- **Thin community `Community 677`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 678`** (2 nodes): `handleCopy()`, `copy-button.tsx`
+- **Thin community `Community 678`** (2 nodes): `useChart()`, `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 679`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
+- **Thin community `Community 679`** (2 nodes): `handleCopy()`, `copy-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 680`** (2 nodes): `Label()`, `label.tsx`
+- **Thin community `Community 680`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 681`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
+- **Thin community `Community 681`** (2 nodes): `Label()`, `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 682`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
+- **Thin community `Community 682`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 683`** (2 nodes): `store-modal.tsx`, `onSubmit()`
+- **Thin community `Community 683`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 684`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
+- **Thin community `Community 684`** (2 nodes): `store-modal.tsx`, `onSubmit()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 685`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
+- **Thin community `Community 685`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 686`** (2 nodes): `select-native.tsx`, `cn()`
+- **Thin community `Community 686`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 687`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
+- **Thin community `Community 687`** (2 nodes): `select-native.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 688`** (2 nodes): `webp-image.tsx`, `WebpImage()`
+- **Thin community `Community 688`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 689`** (2 nodes): `BagItems()`, `BagItems.tsx`
+- **Thin community `Community 689`** (2 nodes): `webp-image.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 690`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
+- **Thin community `Community 690`** (2 nodes): `BagItems()`, `BagItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 691`** (2 nodes): `Bags()`, `Bags.tsx`
+- **Thin community `Community 691`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 692`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
+- **Thin community `Community 692`** (2 nodes): `Bags()`, `Bags.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 693`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
+- **Thin community `Community 693`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 694`** (2 nodes): `UserBag.tsx`, `UserBag()`
+- **Thin community `Community 694`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 695`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
+- **Thin community `Community 695`** (2 nodes): `UserBag.tsx`, `UserBag()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 696`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
+- **Thin community `Community 696`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 697`** (2 nodes): `UserView.tsx`, `UserActions()`
+- **Thin community `Community 697`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 698`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
+- **Thin community `Community 698`** (2 nodes): `UserView.tsx`, `UserActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 699`** (2 nodes): `wrapper()`, `ManagerElevationContext.test.tsx`
+- **Thin community `Community 699`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 700`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
+- **Thin community `Community 700`** (2 nodes): `wrapper()`, `ManagerElevationContext.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 701`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
+- **Thin community `Community 701`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 702`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
+- **Thin community `Community 702`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 703`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
+- **Thin community `Community 703`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 704`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
+- **Thin community `Community 704`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 705`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
+- **Thin community `Community 705`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 706`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
+- **Thin community `Community 706`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 707`** (2 nodes): `useConvexAuthIdentity.ts`, `useConvexAuthIdentity()`
+- **Thin community `Community 707`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 708`** (2 nodes): `useCopyText.ts`, `useCopyText()`
+- **Thin community `Community 708`** (2 nodes): `useConvexAuthIdentity.ts`, `useConvexAuthIdentity()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 709`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
+- **Thin community `Community 709`** (2 nodes): `useCopyText.ts`, `useCopyText()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 710`** (2 nodes): `useDebounce.ts`, `useDebounce()`
+- **Thin community `Community 710`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 711`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
+- **Thin community `Community 711`** (2 nodes): `useDebounce.ts`, `useDebounce()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 712`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
+- **Thin community `Community 712`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 713`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
+- **Thin community `Community 713`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 714`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
+- **Thin community `Community 714`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 715`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
+- **Thin community `Community 715`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 716`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
+- **Thin community `Community 716`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 717`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
+- **Thin community `Community 717`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 718`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
+- **Thin community `Community 718`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 719`** (2 nodes): `usePermissions.ts`, `usePermissions()`
+- **Thin community `Community 719`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 720`** (2 nodes): `usePrint.ts`, `usePrint()`
+- **Thin community `Community 720`** (2 nodes): `usePermissions.ts`, `usePermissions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 721`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
+- **Thin community `Community 721`** (2 nodes): `usePrint.ts`, `usePrint()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 722`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
+- **Thin community `Community 722`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 723`** (2 nodes): `useProtectedAdminPageState.ts`, `useProtectedAdminPageState()`
+- **Thin community `Community 723`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 724`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
+- **Thin community `Community 724`** (2 nodes): `useProtectedAdminPageState.ts`, `useProtectedAdminPageState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 725`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
+- **Thin community `Community 725`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 726`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
+- **Thin community `Community 726`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 727`** (2 nodes): `toOperatorMessage()`, `operatorMessages.ts`
+- **Thin community `Community 727`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 728`** (2 nodes): `presentUnexpectedErrorToast.ts`, `presentUnexpectedErrorToast()`
+- **Thin community `Community 728`** (2 nodes): `toOperatorMessage()`, `operatorMessages.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 729`** (2 nodes): `getOrigin()`, `navigationUtils.ts`
+- **Thin community `Community 729`** (2 nodes): `presentUnexpectedErrorToast.ts`, `presentUnexpectedErrorToast()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 730`** (2 nodes): `addItem()`, `addItem.ts`
+- **Thin community `Community 730`** (2 nodes): `getOrigin()`, `navigationUtils.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 731`** (2 nodes): `bootstrapRegister()`, `bootstrapRegister.ts`
+- **Thin community `Community 731`** (2 nodes): `addItem()`, `addItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 732`** (2 nodes): `holdSession()`, `holdSession.ts`
+- **Thin community `Community 732`** (2 nodes): `bootstrapRegister()`, `bootstrapRegister.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 733`** (2 nodes): `openDrawer()`, `openDrawer.ts`
+- **Thin community `Community 733`** (2 nodes): `holdSession()`, `holdSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 734`** (2 nodes): `startSession.ts`, `startSession()`
+- **Thin community `Community 734`** (2 nodes): `openDrawer()`, `openDrawer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 735`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
+- **Thin community `Community 735`** (2 nodes): `startSession.ts`, `startSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 736`** (2 nodes): `useRegisterCatalogIndex.ts`, `useRegisterCatalogIndex()`
+- **Thin community `Community 736`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 737`** (2 nodes): `pinHash.ts`, `hashPin()`
+- **Thin community `Community 737`** (2 nodes): `useRegisterCatalogIndex.ts`, `useRegisterCatalogIndex()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 738`** (2 nodes): `hasOrgNotFoundPayload()`, `index.tsx`
+- **Thin community `Community 738`** (2 nodes): `pinHash.ts`, `hashPin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 739`** (2 nodes): `$sessionId.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 739`** (2 nodes): `hasOrgNotFoundPayload()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 740`** (2 nodes): `registers.index.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 740`** (2 nodes): `$sessionId.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 741`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
+- **Thin community `Community 741`** (2 nodes): `registers.index.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 742`** (2 nodes): `ApprovalsRoute()`, `approvals.tsx`
+- **Thin community `Community 742`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 743`** (2 nodes): `DailyCloseHistoryRoute()`, `daily-close-history.tsx`
+- **Thin community `Community 743`** (2 nodes): `ApprovalsRoute()`, `approvals.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 744`** (2 nodes): `DailyCloseRoute()`, `daily-close.tsx`
+- **Thin community `Community 744`** (2 nodes): `DailyCloseHistoryRoute()`, `daily-close-history.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 745`** (2 nodes): `OpenWorkRoute()`, `open-work.tsx`
+- **Thin community `Community 745`** (2 nodes): `DailyCloseRoute()`, `daily-close.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 746`** (2 nodes): `DailyOpeningRoute()`, `opening.tsx`
+- **Thin community `Community 746`** (2 nodes): `OpenWorkRoute()`, `open-work.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 747`** (2 nodes): `stock-adjustments.tsx`, `StockAdjustmentsRoute()`
+- **Thin community `Community 747`** (2 nodes): `DailyOpeningRoute()`, `opening.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 748`** (2 nodes): `ExpenseRouteComponent()`, `expense.index.tsx`
+- **Thin community `Community 748`** (2 nodes): `stock-adjustments.tsx`, `StockAdjustmentsRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 749`** (2 nodes): `published.index.tsx`, `RouteComponent()`
+- **Thin community `Community 749`** (2 nodes): `ExpenseRouteComponent()`, `expense.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 750`** (2 nodes): `Index()`, `index.tsx`
+- **Thin community `Community 750`** (2 nodes): `published.index.tsx`, `RouteComponent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 751`** (2 nodes): `AthenaLoginReadyView()`, `_layout.index.tsx`
+- **Thin community `Community 751`** (2 nodes): `Index()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 752`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
+- **Thin community `Community 752`** (2 nodes): `AthenaLoginReadyView()`, `_layout.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 753`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 753`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 754`** (2 nodes): `view-patterns.tsx`, `cn()`
+- **Thin community `Community 754`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 755`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
+- **Thin community `Community 755`** (2 nodes): `view-patterns.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 756`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
+- **Thin community `Community 756`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 757`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
+- **Thin community `Community 757`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 758`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 758`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 759`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
+- **Thin community `Community 759`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 760`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
+- **Thin community `Community 760`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 761`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
+- **Thin community `Community 761`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 762`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 762`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 763`** (2 nodes): `formatNumber()`, `formatNumber.ts`
+- **Thin community `Community 763`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 764`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
+- **Thin community `Community 764`** (2 nodes): `formatNumber()`, `formatNumber.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 765`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
+- **Thin community `Community 765`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 766`** (2 nodes): `updateGuest()`, `guest.ts`
+- **Thin community `Community 766`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 767`** (2 nodes): `posTransaction.test.ts`, `jsonResponse()`
+- **Thin community `Community 767`** (2 nodes): `updateGuest()`, `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 768`** (2 nodes): `storefront.ts`, `getStore()`
+- **Thin community `Community 768`** (2 nodes): `posTransaction.test.ts`, `jsonResponse()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 769`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
+- **Thin community `Community 769`** (2 nodes): `storefront.ts`, `getStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 770`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
+- **Thin community `Community 770`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 771`** (2 nodes): `AuthComponent()`, `Auth.tsx`
+- **Thin community `Community 771`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 772`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
+- **Thin community `Community 772`** (2 nodes): `AuthComponent()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 773`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
+- **Thin community `Community 773`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 774`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
+- **Thin community `Community 774`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 775`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
+- **Thin community `Community 775`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 776`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
+- **Thin community `Community 776`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 777`** (2 nodes): `PickupDetails()`, `index.tsx`
+- **Thin community `Community 777`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 778`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
+- **Thin community `Community 778`** (2 nodes): `PickupDetails()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 779`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
+- **Thin community `Community 779`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 780`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
+- **Thin community `Community 780`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 781`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
+- **Thin community `Community 781`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 782`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
+- **Thin community `Community 782`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 783`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
+- **Thin community `Community 783`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 784`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
+- **Thin community `Community 784`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 785`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
+- **Thin community `Community 785`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 786`** (2 nodes): `useCountdown()`, `hooks.ts`
+- **Thin community `Community 786`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 787`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
+- **Thin community `Community 787`** (2 nodes): `useCountdown()`, `hooks.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 788`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
+- **Thin community `Community 788`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 789`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
+- **Thin community `Community 789`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 790`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
+- **Thin community `Community 790`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 791`** (2 nodes): `resolveHomepageContent()`, `homePageContent.ts`
+- **Thin community `Community 791`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 792`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
+- **Thin community `Community 792`** (2 nodes): `resolveHomepageContent()`, `homePageContent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 793`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
+- **Thin community `Community 793`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 794`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
+- **Thin community `Community 794`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 795`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
+- **Thin community `Community 795`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 796`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
+- **Thin community `Community 796`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 797`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
+- **Thin community `Community 797`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 798`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
+- **Thin community `Community 798`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 799`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
+- **Thin community `Community 799`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 800`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
+- **Thin community `Community 800`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 801`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
+- **Thin community `Community 801`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 802`** (2 nodes): `ProductPage.test.tsx`, `makePageState()`
+- **Thin community `Community 802`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 803`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
+- **Thin community `Community 803`** (2 nodes): `ProductPage.test.tsx`, `makePageState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 804`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
+- **Thin community `Community 804`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 805`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
+- **Thin community `Community 805`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 806`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
+- **Thin community `Community 806`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 807`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
+- **Thin community `Community 807`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 808`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
+- **Thin community `Community 808`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 809`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
+- **Thin community `Community 809`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 810`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
+- **Thin community `Community 810`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 811`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
+- **Thin community `Community 811`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 812`** (2 nodes): `BagItem()`, `BagItem.tsx`
+- **Thin community `Community 812`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 813`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
+- **Thin community `Community 813`** (2 nodes): `BagItem()`, `BagItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 814`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
+- **Thin community `Community 814`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 815`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
+- **Thin community `Community 815`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 816`** (2 nodes): `CountrySelect()`, `country-select.tsx`
+- **Thin community `Community 816`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 817`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
+- **Thin community `Community 817`** (2 nodes): `CountrySelect()`, `country-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 818`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
+- **Thin community `Community 818`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 819`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
+- **Thin community `Community 819`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 820`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
+- **Thin community `Community 820`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 821`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
+- **Thin community `Community 821`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 822`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
+- **Thin community `Community 822`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 823`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
+- **Thin community `Community 823`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 824`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
+- **Thin community `Community 824`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 825`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
+- **Thin community `Community 825`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 826`** (2 nodes): `useCheckout.ts`, `useCheckout()`
+- **Thin community `Community 826`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 827`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
+- **Thin community `Community 827`** (2 nodes): `useCheckout.ts`, `useCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 828`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
+- **Thin community `Community 828`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 829`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
+- **Thin community `Community 829`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 830`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
+- **Thin community `Community 830`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 831`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
+- **Thin community `Community 831`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 832`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
+- **Thin community `Community 832`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 833`** (2 nodes): `useGetStore.ts`, `useGetStore()`
+- **Thin community `Community 833`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 834`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
+- **Thin community `Community 834`** (2 nodes): `useGetStore.ts`, `useGetStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 835`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
+- **Thin community `Community 835`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 836`** (2 nodes): `useLogout.ts`, `useLogout()`
+- **Thin community `Community 836`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 837`** (2 nodes): `useModalState.tsx`, `useModalState()`
+- **Thin community `Community 837`** (2 nodes): `useLogout.ts`, `useLogout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 838`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
+- **Thin community `Community 838`** (2 nodes): `useModalState.tsx`, `useModalState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 839`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
+- **Thin community `Community 839`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 840`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
+- **Thin community `Community 840`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 841`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
+- **Thin community `Community 841`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 842`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
+- **Thin community `Community 842`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 843`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
+- **Thin community `Community 843`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 844`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
+- **Thin community `Community 844`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 845`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
+- **Thin community `Community 845`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 846`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
+- **Thin community `Community 846`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 847`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
+- **Thin community `Community 847`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 848`** (2 nodes): `useBagQueries()`, `bag.ts`
+- **Thin community `Community 848`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 849`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
+- **Thin community `Community 849`** (2 nodes): `useBagQueries()`, `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 850`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
+- **Thin community `Community 850`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 851`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
+- **Thin community `Community 851`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 852`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
+- **Thin community `Community 852`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 853`** (2 nodes): `posTransaction.ts`, `usePosTransactionQueries()`
+- **Thin community `Community 853`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 854`** (2 nodes): `product.ts`, `useProductQueries()`
+- **Thin community `Community 854`** (2 nodes): `posTransaction.ts`, `usePosTransactionQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 855`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
+- **Thin community `Community 855`** (2 nodes): `product.ts`, `useProductQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 856`** (2 nodes): `reviews.ts`, `useReviewQueries()`
+- **Thin community `Community 856`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 857`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
+- **Thin community `Community 857`** (2 nodes): `reviews.ts`, `useReviewQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 858`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
+- **Thin community `Community 858`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 859`** (2 nodes): `user.ts`, `useUserQueries()`
+- **Thin community `Community 859`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 860`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
+- **Thin community `Community 860`** (2 nodes): `user.ts`, `useUserQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 861`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
+- **Thin community `Community 861`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 862`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
+- **Thin community `Community 862`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 863`** (2 nodes): `validateEmail()`, `email.ts`
+- **Thin community `Community 863`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 864`** (2 nodes): `router.tsx`, `createRouter()`
+- **Thin community `Community 864`** (2 nodes): `validateEmail()`, `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 865`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
+- **Thin community `Community 865`** (2 nodes): `router.tsx`, `createRouter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 866`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
+- **Thin community `Community 866`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 867`** (2 nodes): `ContactUs()`, `contact-us.tsx`
+- **Thin community `Community 867`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 868`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
+- **Thin community `Community 868`** (2 nodes): `ContactUs()`, `contact-us.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 869`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
+- **Thin community `Community 869`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 870`** (2 nodes): `tos.index.tsx`, `TosSection()`
+- **Thin community `Community 870`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 871`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
+- **Thin community `Community 871`** (2 nodes): `tos.index.tsx`, `TosSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 872`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
+- **Thin community `Community 872`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 873`** (2 nodes): `HomeRoute()`, `index.tsx`
+- **Thin community `Community 873`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 874`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
+- **Thin community `Community 874`** (2 nodes): `HomeRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 875`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
+- **Thin community `Community 875`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 876`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
+- **Thin community `Community 876`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 877`** (2 nodes): `ReceiptShareRoute()`, `index.tsx`
+- **Thin community `Community 877`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 878`** (2 nodes): `test-connection.js`, `main()`
+- **Thin community `Community 878`** (2 nodes): `ReceiptShareRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 879`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
+- **Thin community `Community 879`** (2 nodes): `test-connection.js`, `main()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 880`** (2 nodes): `run()`, `architecture-boundary-check.ts`
+- **Thin community `Community 880`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 881`** (2 nodes): `readRepoFile()`, `deploy-qa-vps.test.ts`
+- **Thin community `Community 881`** (2 nodes): `run()`, `architecture-boundary-check.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 882`** (2 nodes): `runCommand()`, `github-pr-merge.test.ts`
+- **Thin community `Community 882`** (2 nodes): `readRepoFile()`, `deploy-qa-vps.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 883`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
+- **Thin community `Community 883`** (2 nodes): `runCommand()`, `github-pr-merge.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 884`** (2 nodes): `shutdown()`, `sample-app.ts`
+- **Thin community `Community 884`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 885`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
+- **Thin community `Community 885`** (2 nodes): `shutdown()`, `sample-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 886`** (1 nodes): `api.d.ts`
+- **Thin community `Community 886`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 887`** (1 nodes): `api.js`
+- **Thin community `Community 887`** (1 nodes): `api.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 888`** (1 nodes): `dataModel.d.ts`
+- **Thin community `Community 888`** (1 nodes): `api.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 889`** (1 nodes): `server.d.ts`
+- **Thin community `Community 889`** (1 nodes): `dataModel.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 890`** (1 nodes): `server.js`
+- **Thin community `Community 890`** (1 nodes): `server.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 891`** (1 nodes): `app.ts`
+- **Thin community `Community 891`** (1 nodes): `server.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 892`** (1 nodes): `auth.config.js`
+- **Thin community `Community 892`** (1 nodes): `app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 893`** (1 nodes): `auth.ts`
+- **Thin community `Community 893`** (1 nodes): `auth.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 894`** (1 nodes): `registerSessions.test.ts`
+- **Thin community `Community 894`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 895`** (1 nodes): `r2.test.ts`
+- **Thin community `Community 895`** (1 nodes): `registerSessions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 896`** (1 nodes): `countries.ts`
+- **Thin community `Community 896`** (1 nodes): `r2.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 897`** (1 nodes): `email.ts`
+- **Thin community `Community 897`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 898`** (1 nodes): `ghana.ts`
+- **Thin community `Community 898`** (1 nodes): `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 899`** (1 nodes): `payment.ts`
+- **Thin community `Community 899`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 900`** (1 nodes): `crons.ts`
+- **Thin community `Community 900`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 901`** (1 nodes): `domain.test.ts`
+- **Thin community `Community 901`** (1 nodes): `crons.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 902`** (1 nodes): `internal.ts`
+- **Thin community `Community 902`** (1 nodes): `domain.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 903`** (1 nodes): `public.test.ts`
+- **Thin community `Community 903`** (1 nodes): `internal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 904`** (1 nodes): `token.test.ts`
+- **Thin community `Community 904`** (1 nodes): `public.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 905`** (1 nodes): `whatsappClient.test.ts`
+- **Thin community `Community 905`** (1 nodes): `token.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 906`** (1 nodes): `whatsappConfig.test.ts`
+- **Thin community `Community 906`** (1 nodes): `whatsappClient.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 907`** (1 nodes): `devPatchBadTransaction.ts`
+- **Thin community `Community 907`** (1 nodes): `whatsappConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 908`** (1 nodes): `FeedbackRequest.tsx`
+- **Thin community `Community 908`** (1 nodes): `devPatchBadTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 909`** (1 nodes): `NewOrderAdmin.tsx`
+- **Thin community `Community 909`** (1 nodes): `FeedbackRequest.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 910`** (1 nodes): `OrderEmail.tsx`
+- **Thin community `Community 910`** (1 nodes): `NewOrderAdmin.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 911`** (1 nodes): `PosReceiptEmail.tsx`
+- **Thin community `Community 911`** (1 nodes): `OrderEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 912`** (1 nodes): `env.ts`
+- **Thin community `Community 912`** (1 nodes): `PosReceiptEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 913`** (1 nodes): `analytics.ts`
+- **Thin community `Community 913`** (1 nodes): `env.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 914`** (1 nodes): `auth.ts`
+- **Thin community `Community 914`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 915`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 915`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 916`** (1 nodes): `colors.ts`
+- **Thin community `Community 916`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 917`** (1 nodes): `index.ts`
+- **Thin community `Community 917`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 918`** (1 nodes): `organizations.ts`
+- **Thin community `Community 918`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 919`** (1 nodes): `products.ts`
+- **Thin community `Community 919`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 920`** (1 nodes): `storefrontHidden.test.ts`
+- **Thin community `Community 920`** (1 nodes): `products.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 921`** (1 nodes): `stores.ts`
+- **Thin community `Community 921`** (1 nodes): `storefrontHidden.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 922`** (1 nodes): `bag.ts`
+- **Thin community `Community 922`** (1 nodes): `stores.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 923`** (1 nodes): `guest.ts`
+- **Thin community `Community 923`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 924`** (1 nodes): `index.ts`
+- **Thin community `Community 924`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 925`** (1 nodes): `me.ts`
+- **Thin community `Community 925`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 926`** (1 nodes): `offers.ts`
+- **Thin community `Community 926`** (1 nodes): `me.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 927`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 927`** (1 nodes): `offers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 928`** (1 nodes): `paystack.ts`
+- **Thin community `Community 928`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 929`** (1 nodes): `posTransaction.ts`
+- **Thin community `Community 929`** (1 nodes): `paystack.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 930`** (1 nodes): `reviews.ts`
+- **Thin community `Community 930`** (1 nodes): `posTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 931`** (1 nodes): `rewards.ts`
+- **Thin community `Community 931`** (1 nodes): `reviews.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 932`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 932`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 933`** (1 nodes): `security.test.ts`
+- **Thin community `Community 933`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 934`** (1 nodes): `storefront.ts`
+- **Thin community `Community 934`** (1 nodes): `security.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 935`** (1 nodes): `upsells.ts`
+- **Thin community `Community 935`** (1 nodes): `storefront.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 936`** (1 nodes): `user.ts`
+- **Thin community `Community 936`** (1 nodes): `upsells.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 937`** (1 nodes): `userOffers.ts`
+- **Thin community `Community 937`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 938`** (1 nodes): `index.ts`
+- **Thin community `Community 938`** (1 nodes): `userOffers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 939`** (1 nodes): `health.test.ts`
+- **Thin community `Community 939`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 940`** (1 nodes): `http.ts`
+- **Thin community `Community 940`** (1 nodes): `health.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 941`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 941`** (1 nodes): `http.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 942`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 942`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 943`** (1 nodes): `bestSeller.ts`
+- **Thin community `Community 943`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 944`** (1 nodes): `categories.ts`
+- **Thin community `Community 944`** (1 nodes): `bestSeller.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 945`** (1 nodes): `colors.ts`
+- **Thin community `Community 945`** (1 nodes): `categories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 946`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 946`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 947`** (1 nodes): `expenseTransactions.test.ts`
+- **Thin community `Community 947`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 948`** (1 nodes): `featuredItem.ts`
+- **Thin community `Community 948`** (1 nodes): `expenseTransactions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 949`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 949`** (1 nodes): `featuredItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 950`** (1 nodes): `organizationMembers.ts`
+- **Thin community `Community 950`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 951`** (1 nodes): `organizations.ts`
+- **Thin community `Community 951`** (1 nodes): `organizationMembers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 952`** (1 nodes): `pos.ts`
+- **Thin community `Community 952`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 953`** (1 nodes): `posCustomers.ts`
+- **Thin community `Community 953`** (1 nodes): `pos.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 954`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 954`** (1 nodes): `posCustomers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 955`** (1 nodes): `productSku.ts`
+- **Thin community `Community 955`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 956`** (1 nodes): `productUtil.test.ts`
+- **Thin community `Community 956`** (1 nodes): `productSku.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 957`** (1 nodes): `promoCode.test.ts`
+- **Thin community `Community 957`** (1 nodes): `productUtil.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 958`** (1 nodes): `stockValidation.ts`
+- **Thin community `Community 958`** (1 nodes): `promoCode.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 959`** (1 nodes): `storeConfigV2.test.ts`
+- **Thin community `Community 959`** (1 nodes): `stockValidation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 960`** (1 nodes): `subcategories.ts`
+- **Thin community `Community 960`** (1 nodes): `storeConfigV2.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 961`** (1 nodes): `commandResultValidators.test.ts`
+- **Thin community `Community 961`** (1 nodes): `subcategories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 962`** (1 nodes): `currency.test.ts`
+- **Thin community `Community 962`** (1 nodes): `commandResultValidators.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 963`** (1 nodes): `storeInsights.ts`
+- **Thin community `Community 963`** (1 nodes): `currency.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 964`** (1 nodes): `userInsights.ts`
+- **Thin community `Community 964`** (1 nodes): `storeInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 965`** (1 nodes): `migrateAmountsToPesewas.ts`
+- **Thin community `Community 965`** (1 nodes): `userInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 966`** (1 nodes): `client.test.ts`
+- **Thin community `Community 966`** (1 nodes): `migrateAmountsToPesewas.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 967`** (1 nodes): `config.test.ts`
+- **Thin community `Community 967`** (1 nodes): `client.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 968`** (1 nodes): `normalize.test.ts`
+- **Thin community `Community 968`** (1 nodes): `config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 969`** (1 nodes): `types.ts`
+- **Thin community `Community 969`** (1 nodes): `normalize.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 970`** (1 nodes): `customerProfiles.test.ts`
+- **Thin community `Community 970`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 971`** (1 nodes): `inventoryMovements.test.ts`
+- **Thin community `Community 971`** (1 nodes): `customerProfiles.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 972`** (1 nodes): `paymentAllocations.test.ts`
+- **Thin community `Community 972`** (1 nodes): `inventoryMovements.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 973`** (1 nodes): `EmailOTP.test.ts`
+- **Thin community `Community 973`** (1 nodes): `paymentAllocations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 974`** (1 nodes): `correctTransactionCustomer.test.ts`
+- **Thin community `Community 974`** (1 nodes): `EmailOTP.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 975`** (1 nodes): `correctionEvents.test.ts`
+- **Thin community `Community 975`** (1 nodes): `correctTransactionCustomer.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 976`** (1 nodes): `correctionPolicy.test.ts`
+- **Thin community `Community 976`** (1 nodes): `correctionEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 977`** (1 nodes): `dto.ts`
+- **Thin community `Community 977`** (1 nodes): `correctionPolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 978`** (1 nodes): `getRegisterState.test.ts`
+- **Thin community `Community 978`** (1 nodes): `dto.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 979`** (1 nodes): `posSessionTracing.test.ts`
+- **Thin community `Community 979`** (1 nodes): `getRegisterState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 980`** (1 nodes): `terminals.test.ts`
+- **Thin community `Community 980`** (1 nodes): `posSessionTracing.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 981`** (1 nodes): `types.ts`
+- **Thin community `Community 981`** (1 nodes): `terminals.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 982`** (1 nodes): `registerSessionRepository.test.ts`
+- **Thin community `Community 982`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 983`** (1 nodes): `catalog.ts`
+- **Thin community `Community 983`** (1 nodes): `registerSessionRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 984`** (1 nodes): `customers.ts`
+- **Thin community `Community 984`** (1 nodes): `catalog.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 985`** (1 nodes): `register.ts`
+- **Thin community `Community 985`** (1 nodes): `customers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 986`** (1 nodes): `terminals.ts`
+- **Thin community `Community 986`** (1 nodes): `register.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 987`** (1 nodes): `schema.ts`
+- **Thin community `Community 987`** (1 nodes): `terminals.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 988`** (1 nodes): `customerMessageDelivery.ts`
+- **Thin community `Community 988`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 989`** (1 nodes): `index.ts`
+- **Thin community `Community 989`** (1 nodes): `customerMessageDelivery.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 990`** (1 nodes): `receiptShareToken.ts`
+- **Thin community `Community 990`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 991`** (1 nodes): `appVerificationCode.ts`
+- **Thin community `Community 991`** (1 nodes): `receiptShareToken.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 992`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 992`** (1 nodes): `appVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 993`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 993`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 994`** (1 nodes): `bestSeller.ts`
+- **Thin community `Community 994`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 995`** (1 nodes): `category.ts`
+- **Thin community `Community 995`** (1 nodes): `bestSeller.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 996`** (1 nodes): `color.ts`
+- **Thin community `Community 996`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 997`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 997`** (1 nodes): `color.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 998`** (1 nodes): `featuredItem.ts`
+- **Thin community `Community 998`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 999`** (1 nodes): `index.ts`
+- **Thin community `Community 999`** (1 nodes): `featuredItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1000`** (1 nodes): `inventoryHold.ts`
+- **Thin community `Community 1000`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1001`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 1001`** (1 nodes): `inventoryHold.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1002`** (1 nodes): `organization.ts`
+- **Thin community `Community 1002`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1003`** (1 nodes): `organizationMember.ts`
+- **Thin community `Community 1003`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1004`** (1 nodes): `product.ts`
+- **Thin community `Community 1004`** (1 nodes): `organizationMember.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1005`** (1 nodes): `promoCode.ts`
+- **Thin community `Community 1005`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1006`** (1 nodes): `redeemedPromoCode.ts`
+- **Thin community `Community 1006`** (1 nodes): `promoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1007`** (1 nodes): `store.ts`
+- **Thin community `Community 1007`** (1 nodes): `redeemedPromoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1008`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1008`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1009`** (1 nodes): `index.ts`
+- **Thin community `Community 1009`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1010`** (1 nodes): `workflowTrace.ts`
+- **Thin community `Community 1010`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1011`** (1 nodes): `workflowTraceEvent.ts`
+- **Thin community `Community 1011`** (1 nodes): `workflowTrace.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1012`** (1 nodes): `workflowTraceLookup.ts`
+- **Thin community `Community 1012`** (1 nodes): `workflowTraceEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1013`** (1 nodes): `approvalRequest.ts`
+- **Thin community `Community 1013`** (1 nodes): `workflowTraceLookup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1014`** (1 nodes): `customerProfile.ts`
+- **Thin community `Community 1014`** (1 nodes): `approvalRequest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1015`** (1 nodes): `dailyClose.ts`
+- **Thin community `Community 1015`** (1 nodes): `customerProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1016`** (1 nodes): `dailyOpening.ts`
+- **Thin community `Community 1016`** (1 nodes): `dailyClose.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1017`** (1 nodes): `index.ts`
+- **Thin community `Community 1017`** (1 nodes): `dailyOpening.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1018`** (1 nodes): `inventoryMovement.ts`
+- **Thin community `Community 1018`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1019`** (1 nodes): `managerElevation.ts`
+- **Thin community `Community 1019`** (1 nodes): `inventoryMovement.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1020`** (1 nodes): `operationalEvent.ts`
+- **Thin community `Community 1020`** (1 nodes): `managerElevation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1021`** (1 nodes): `operationalWorkItem.ts`
+- **Thin community `Community 1021`** (1 nodes): `operationalEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1022`** (1 nodes): `paymentAllocation.ts`
+- **Thin community `Community 1022`** (1 nodes): `operationalWorkItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1023`** (1 nodes): `registerSession.ts`
+- **Thin community `Community 1023`** (1 nodes): `paymentAllocation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1024`** (1 nodes): `staffCredential.ts`
+- **Thin community `Community 1024`** (1 nodes): `registerSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1025`** (1 nodes): `staffProfile.ts`
+- **Thin community `Community 1025`** (1 nodes): `staffCredential.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1026`** (1 nodes): `staffRoleAssignment.ts`
+- **Thin community `Community 1026`** (1 nodes): `staffProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1027`** (1 nodes): `mtnCollections.ts`
+- **Thin community `Community 1027`** (1 nodes): `staffRoleAssignment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1028`** (1 nodes): `customer.ts`
+- **Thin community `Community 1028`** (1 nodes): `mtnCollections.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1029`** (1 nodes): `expenseSession.ts`
+- **Thin community `Community 1029`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1030`** (1 nodes): `expenseSessionItem.ts`
+- **Thin community `Community 1030`** (1 nodes): `expenseSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1031`** (1 nodes): `expenseTransaction.ts`
+- **Thin community `Community 1031`** (1 nodes): `expenseSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1032`** (1 nodes): `expenseTransactionItem.ts`
+- **Thin community `Community 1032`** (1 nodes): `expenseTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1033`** (1 nodes): `index.ts`
+- **Thin community `Community 1033`** (1 nodes): `expenseTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1034`** (1 nodes): `posSession.ts`
+- **Thin community `Community 1034`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1035`** (1 nodes): `posSessionItem.ts`
+- **Thin community `Community 1035`** (1 nodes): `posSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1036`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 1036`** (1 nodes): `posSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1037`** (1 nodes): `posTransaction.ts`
+- **Thin community `Community 1037`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1038`** (1 nodes): `posTransactionItem.ts`
+- **Thin community `Community 1038`** (1 nodes): `posTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1039`** (1 nodes): `index.ts`
+- **Thin community `Community 1039`** (1 nodes): `posTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1040`** (1 nodes): `serviceAppointment.ts`
+- **Thin community `Community 1040`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1041`** (1 nodes): `serviceCase.ts`
+- **Thin community `Community 1041`** (1 nodes): `serviceAppointment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1042`** (1 nodes): `serviceCaseLineItem.ts`
+- **Thin community `Community 1042`** (1 nodes): `serviceCase.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1043`** (1 nodes): `serviceCatalog.ts`
+- **Thin community `Community 1043`** (1 nodes): `serviceCaseLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1044`** (1 nodes): `serviceInventoryUsage.ts`
+- **Thin community `Community 1044`** (1 nodes): `serviceCatalog.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1045`** (1 nodes): `cycleCountDraft.ts`
+- **Thin community `Community 1045`** (1 nodes): `serviceInventoryUsage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1046`** (1 nodes): `index.ts`
+- **Thin community `Community 1046`** (1 nodes): `cycleCountDraft.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1047`** (1 nodes): `purchaseOrder.ts`
+- **Thin community `Community 1047`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1048`** (1 nodes): `purchaseOrderLineItem.ts`
+- **Thin community `Community 1048`** (1 nodes): `purchaseOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1049`** (1 nodes): `receivingBatch.ts`
+- **Thin community `Community 1049`** (1 nodes): `purchaseOrderLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1050`** (1 nodes): `stockAdjustmentBatch.ts`
+- **Thin community `Community 1050`** (1 nodes): `receivingBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1051`** (1 nodes): `vendor.ts`
+- **Thin community `Community 1051`** (1 nodes): `stockAdjustmentBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1052`** (1 nodes): `analytics.ts`
+- **Thin community `Community 1052`** (1 nodes): `vendor.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1053`** (1 nodes): `bag.ts`
+- **Thin community `Community 1053`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1054`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1054`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1055`** (1 nodes): `checkoutSession.ts`
+- **Thin community `Community 1055`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1056`** (1 nodes): `checkoutSessionItem.ts`
+- **Thin community `Community 1056`** (1 nodes): `checkoutSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1057`** (1 nodes): `guest.ts`
+- **Thin community `Community 1057`** (1 nodes): `checkoutSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1058`** (1 nodes): `index.ts`
+- **Thin community `Community 1058`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1059`** (1 nodes): `offer.ts`
+- **Thin community `Community 1059`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1060`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 1060`** (1 nodes): `offer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1061`** (1 nodes): `onlineOrderItem.ts`
+- **Thin community `Community 1061`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1062`** (1 nodes): `review.ts`
+- **Thin community `Community 1062`** (1 nodes): `onlineOrderItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1063`** (1 nodes): `rewards.ts`
+- **Thin community `Community 1063`** (1 nodes): `review.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1064`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 1064`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1065`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 1065`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1066`** (1 nodes): `storeFrontSession.ts`
+- **Thin community `Community 1066`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1067`** (1 nodes): `storeFrontUser.ts`
+- **Thin community `Community 1067`** (1 nodes): `storeFrontSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1068`** (1 nodes): `storeFrontVerificationCode.ts`
+- **Thin community `Community 1068`** (1 nodes): `storeFrontUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1069`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 1069`** (1 nodes): `storeFrontVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1070`** (1 nodes): `catalogAppointments.test.ts`
+- **Thin community `Community 1070`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1071`** (1 nodes): `bag.ts`
+- **Thin community `Community 1071`** (1 nodes): `catalogAppointments.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1072`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1072`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1073`** (1 nodes): `checkoutSession.test.ts`
+- **Thin community `Community 1073`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1074`** (1 nodes): `customer.ts`
+- **Thin community `Community 1074`** (1 nodes): `checkoutSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1075`** (1 nodes): `guest.ts`
+- **Thin community `Community 1075`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1076`** (1 nodes): `offers.test.ts`
+- **Thin community `Community 1076`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1077`** (1 nodes): `onlineOrderUtilFns.ts`
+- **Thin community `Community 1077`** (1 nodes): `offers.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1078`** (1 nodes): `orderOperations.test.ts`
+- **Thin community `Community 1078`** (1 nodes): `onlineOrderUtilFns.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1079`** (1 nodes): `payment.test.ts`
+- **Thin community `Community 1079`** (1 nodes): `orderOperations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1080`** (1 nodes): `payment.ts`
+- **Thin community `Community 1080`** (1 nodes): `payment.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1081`** (1 nodes): `paystackActions.ts`
+- **Thin community `Community 1081`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1082`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 1082`** (1 nodes): `paystackActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1083`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 1083`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1084`** (1 nodes): `users.ts`
+- **Thin community `Community 1084`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1085`** (1 nodes): `payment.ts`
+- **Thin community `Community 1085`** (1 nodes): `users.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1086`** (1 nodes): `posSession.test.ts`
+- **Thin community `Community 1086`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1087`** (1 nodes): `registerSession.test.ts`
+- **Thin community `Community 1087`** (1 nodes): `posSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1088`** (1 nodes): `presentation.test.ts`
+- **Thin community `Community 1088`** (1 nodes): `registerSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1089`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 1089`** (1 nodes): `presentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1090`** (1 nodes): `index.ts`
+- **Thin community `Community 1090`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1091`** (1 nodes): `postcss.config.js`
+- **Thin community `Community 1091`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1092`** (1 nodes): `approvalPolicy.ts`
+- **Thin community `Community 1092`** (1 nodes): `postcss.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1093`** (1 nodes): `auth.ts`
+- **Thin community `Community 1093`** (1 nodes): `approvalPolicy.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1094`** (1 nodes): `commandResult.test.ts`
+- **Thin community `Community 1094`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1095`** (1 nodes): `currencyFormatter.test.ts`
+- **Thin community `Community 1095`** (1 nodes): `commandResult.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1096`** (1 nodes): `registerSessionStatus.test.ts`
+- **Thin community `Community 1096`** (1 nodes): `currencyFormatter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1097`** (1 nodes): `staffDisplayName.test.ts`
+- **Thin community `Community 1097`** (1 nodes): `registerSessionStatus.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1098`** (1 nodes): `GenericComboBox.tsx`
+- **Thin community `Community 1098`** (1 nodes): `staffDisplayName.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1099`** (1 nodes): `StoreAccordion.tsx`
+- **Thin community `Community 1099`** (1 nodes): `GenericComboBox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1100`** (1 nodes): `StoresAccordion.tsx`
+- **Thin community `Community 1100`** (1 nodes): `StoreAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1101`** (1 nodes): `ThemeToggle.tsx`
+- **Thin community `Community 1101`** (1 nodes): `StoresAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1102`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
+- **Thin community `Community 1102`** (1 nodes): `ThemeToggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1103`** (1 nodes): `ProductAttributesView.tsx`
+- **Thin community `Community 1103`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1104`** (1 nodes): `ProductStock.test.ts`
+- **Thin community `Community 1104`** (1 nodes): `ProductAttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1105`** (1 nodes): `ProductView.test.tsx`
+- **Thin community `Community 1105`** (1 nodes): `ProductStock.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1106`** (1 nodes): `constants.ts`
+- **Thin community `Community 1106`** (1 nodes): `ProductView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1107`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1107`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1108`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1108`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1109`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1109`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1110`** (1 nodes): `types.ts`
+- **Thin community `Community 1110`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1111`** (1 nodes): `ConversionFunnelChart.tsx`
+- **Thin community `Community 1111`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1112`** (1 nodes): `RevenueChart.tsx`
+- **Thin community `Community 1112`** (1 nodes): `ConversionFunnelChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1113`** (1 nodes): `analytics-columns.tsx`
+- **Thin community `Community 1113`** (1 nodes): `RevenueChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1114`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1114`** (1 nodes): `analytics-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1115`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1115`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1116`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1116`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1117`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1117`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1118`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1118`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1119`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1119`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1120`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1120`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1121`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1121`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1122`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1122`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1123`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1123`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1124`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1124`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1125`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1125`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1126`** (1 nodes): `chart.tsx`
+- **Thin community `Community 1126`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1127`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1127`** (1 nodes): `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1128`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1128`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1129`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1129`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1130`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1130`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1131`** (1 nodes): `constants.ts`
+- **Thin community `Community 1131`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1132`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1132`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1133`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1133`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1134`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1134`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1135`** (1 nodes): `data.ts`
+- **Thin community `Community 1135`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1136`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1136`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1137`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1137`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1138`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1138`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1139`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1139`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1140`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1140`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1141`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1141`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1142`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1142`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1143`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1143`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1144`** (1 nodes): `assetsColumns.tsx`
+- **Thin community `Community 1144`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1145`** (1 nodes): `constants.ts`
+- **Thin community `Community 1145`** (1 nodes): `assetsColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1146`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1146`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1147`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1147`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1148`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1148`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1149`** (1 nodes): `data.ts`
+- **Thin community `Community 1149`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1150`** (1 nodes): `DefaultCatchBoundary.test.tsx`
+- **Thin community `Community 1150`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1151`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 1151`** (1 nodes): `DefaultCatchBoundary.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1152`** (1 nodes): `LoginForm.test.tsx`
+- **Thin community `Community 1152`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1153`** (1 nodes): `LoginForm.tsx`
+- **Thin community `Community 1153`** (1 nodes): `LoginForm.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1154`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1154`** (1 nodes): `LoginForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1155`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1155`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1156`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1156`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1157`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1157`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1158`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1158`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1159`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1159`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1160`** (1 nodes): `constants.ts`
+- **Thin community `Community 1160`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1161`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1161`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1162`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1162`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1163`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1163`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1164`** (1 nodes): `BulkOperationsPage.tsx`
+- **Thin community `Community 1164`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1165`** (1 nodes): `CashControlsDashboard.auth.test.tsx`
+- **Thin community `Community 1165`** (1 nodes): `BulkOperationsPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1166`** (1 nodes): `CashControlsDashboard.test.tsx`
+- **Thin community `Community 1166`** (1 nodes): `CashControlsDashboard.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1167`** (1 nodes): `CashControlsWorkspaceHeader.tsx`
+- **Thin community `Community 1167`** (1 nodes): `CashControlsDashboard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1168`** (1 nodes): `RegisterSessionView.auth.test.tsx`
+- **Thin community `Community 1168`** (1 nodes): `CashControlsWorkspaceHeader.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1169`** (1 nodes): `RegisterSessionView.test.tsx`
+- **Thin community `Community 1169`** (1 nodes): `RegisterSessionView.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1170`** (1 nodes): `RegisterSessionsView.test.tsx`
+- **Thin community `Community 1170`** (1 nodes): `RegisterSessionView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1171`** (1 nodes): `formatReviewReason.test.ts`
+- **Thin community `Community 1171`** (1 nodes): `RegisterSessionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1172`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1172`** (1 nodes): `formatReviewReason.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1173`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1173`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1174`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1174`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1175`** (1 nodes): `ListPagination.tsx`
+- **Thin community `Community 1175`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1176`** (1 nodes): `PageLevelHeader.test.tsx`
+- **Thin community `Community 1176`** (1 nodes): `ListPagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1177`** (1 nodes): `PageLevelHeader.tsx`
+- **Thin community `Community 1177`** (1 nodes): `PageLevelHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1178`** (1 nodes): `MetricCard.tsx`
+- **Thin community `Community 1178`** (1 nodes): `PageLevelHeader.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1179`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 1179`** (1 nodes): `MetricCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1180`** (1 nodes): `CommandApprovalDialog.test.tsx`
+- **Thin community `Community 1180`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1181`** (1 nodes): `OperationReviewWorkspace.tsx`
+- **Thin community `Community 1181`** (1 nodes): `CommandApprovalDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1182`** (1 nodes): `OperationsQueueView.auth.test.tsx`
+- **Thin community `Community 1182`** (1 nodes): `OperationReviewWorkspace.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1183`** (1 nodes): `useApprovedCommand.test.tsx`
+- **Thin community `Community 1183`** (1 nodes): `OperationsQueueView.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1184`** (1 nodes): `OrderStatus.test.tsx`
+- **Thin community `Community 1184`** (1 nodes): `useApprovedCommand.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1185`** (1 nodes): `OrderStatus.tsx`
+- **Thin community `Community 1185`** (1 nodes): `OrderStatus.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1186`** (1 nodes): `OrderSummary.tsx`
+- **Thin community `Community 1186`** (1 nodes): `OrderStatus.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1187`** (1 nodes): `Orders.tsx`
+- **Thin community `Community 1187`** (1 nodes): `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1188`** (1 nodes): `RefundsView.test.tsx`
+- **Thin community `Community 1188`** (1 nodes): `Orders.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1189`** (1 nodes): `ReturnExchangeView.test.tsx`
+- **Thin community `Community 1189`** (1 nodes): `RefundsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1190`** (1 nodes): `constants.ts`
+- **Thin community `Community 1190`** (1 nodes): `ReturnExchangeView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1191`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1191`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1192`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1192`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1193`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1193`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1194`** (1 nodes): `data.ts`
+- **Thin community `Community 1194`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1195`** (1 nodes): `refundUtils.test.ts`
+- **Thin community `Community 1195`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1196`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1196`** (1 nodes): `refundUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1197`** (1 nodes): `constants.ts`
+- **Thin community `Community 1197`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1198`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1198`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1199`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1199`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1200`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1200`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1201`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1201`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1202`** (1 nodes): `data.ts`
+- **Thin community `Community 1202`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1203`** (1 nodes): `inviteColumns.tsx`
+- **Thin community `Community 1203`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1204`** (1 nodes): `constants.ts`
+- **Thin community `Community 1204`** (1 nodes): `inviteColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1205`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1205`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1206`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1206`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1207`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1207`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1208`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1208`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1209`** (1 nodes): `data.ts`
+- **Thin community `Community 1209`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1210`** (1 nodes): `membersColumns.tsx`
+- **Thin community `Community 1210`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1211`** (1 nodes): `organization-switcher.test.tsx`
+- **Thin community `Community 1211`** (1 nodes): `membersColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1212`** (1 nodes): `CashierAuthDialog.test.tsx`
+- **Thin community `Community 1212`** (1 nodes): `organization-switcher.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1213`** (1 nodes): `CashierView.tsx`
+- **Thin community `Community 1213`** (1 nodes): `CashierAuthDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1214`** (1 nodes): `POSRegisterView.tsx`
+- **Thin community `Community 1214`** (1 nodes): `CashierView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1215`** (1 nodes): `PaymentView.test.tsx`
+- **Thin community `Community 1215`** (1 nodes): `POSRegisterView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1216`** (1 nodes): `PointOfSaleView.test.tsx`
+- **Thin community `Community 1216`** (1 nodes): `PaymentView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1217`** (1 nodes): `PointOfSaleView.tsx`
+- **Thin community `Community 1217`** (1 nodes): `PointOfSaleView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1218`** (1 nodes): `ProductLookup.tsx`
+- **Thin community `Community 1218`** (1 nodes): `PointOfSaleView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1219`** (1 nodes): `RegisterActions.tsx`
+- **Thin community `Community 1219`** (1 nodes): `ProductLookup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1220`** (1 nodes): `SessionManager.test.tsx`
+- **Thin community `Community 1220`** (1 nodes): `RegisterActions.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1221`** (1 nodes): `SessionManager.tsx`
+- **Thin community `Community 1221`** (1 nodes): `SessionManager.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1222`** (1 nodes): `TotalsDisplay.test.tsx`
+- **Thin community `Community 1222`** (1 nodes): `SessionManager.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1223`** (1 nodes): `TotalsDisplay.tsx`
+- **Thin community `Community 1223`** (1 nodes): `TotalsDisplay.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1224`** (1 nodes): `ExpenseReportView.tsx`
+- **Thin community `Community 1224`** (1 nodes): `TotalsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1225`** (1 nodes): `ExpenseReportsView.test.ts`
+- **Thin community `Community 1225`** (1 nodes): `ExpenseReportView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1226`** (1 nodes): `ExpenseReportsView.test.tsx`
+- **Thin community `Community 1226`** (1 nodes): `ExpenseReportsView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1227`** (1 nodes): `expenseReportColumns.tsx`
+- **Thin community `Community 1227`** (1 nodes): `ExpenseReportsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1228`** (1 nodes): `PosReceiptShareControl.test.tsx`
+- **Thin community `Community 1228`** (1 nodes): `expenseReportColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1229`** (1 nodes): `POSRegisterOpeningGuard.test.tsx`
+- **Thin community `Community 1229`** (1 nodes): `PosReceiptShareControl.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1230`** (1 nodes): `POSRegisterView.test.tsx`
+- **Thin community `Community 1230`** (1 nodes): `POSRegisterOpeningGuard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1231`** (1 nodes): `RegisterActionBar.test.tsx`
+- **Thin community `Community 1231`** (1 nodes): `POSRegisterView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1232`** (1 nodes): `RegisterActionBar.tsx`
+- **Thin community `Community 1232`** (1 nodes): `RegisterActionBar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1233`** (1 nodes): `RegisterCheckoutPanel.tsx`
+- **Thin community `Community 1233`** (1 nodes): `RegisterActionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1234`** (1 nodes): `HeldSessionsList.test.tsx`
+- **Thin community `Community 1234`** (1 nodes): `RegisterCheckoutPanel.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1235`** (1 nodes): `POSSessionsView.test.tsx`
+- **Thin community `Community 1235`** (1 nodes): `HeldSessionsList.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1236`** (1 nodes): `posSessionColumns.tsx`
+- **Thin community `Community 1236`** (1 nodes): `POSSessionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1237`** (1 nodes): `TransactionsView.test.tsx`
+- **Thin community `Community 1237`** (1 nodes): `posSessionColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1238`** (1 nodes): `types.ts`
+- **Thin community `Community 1238`** (1 nodes): `TransactionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1239`** (1 nodes): `ReceivingView.test.tsx`
+- **Thin community `Community 1239`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1240`** (1 nodes): `AnalyticsInsights.tsx`
+- **Thin community `Community 1240`** (1 nodes): `ReceivingView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1241`** (1 nodes): `AttributesView.tsx`
+- **Thin community `Community 1241`** (1 nodes): `AnalyticsInsights.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1242`** (1 nodes): `DetailsView.tsx`
+- **Thin community `Community 1242`** (1 nodes): `AttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1243`** (1 nodes): `ProductDetailView.tsx`
+- **Thin community `Community 1243`** (1 nodes): `DetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1244`** (1 nodes): `ArchivedProducts.tsx`
+- **Thin community `Community 1244`** (1 nodes): `ProductDetailView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1245`** (1 nodes): `CategoryListView.tsx`
+- **Thin community `Community 1245`** (1 nodes): `ArchivedProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1246`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
+- **Thin community `Community 1246`** (1 nodes): `CategoryListView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1247`** (1 nodes): `Products.tsx`
+- **Thin community `Community 1247`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1248`** (1 nodes): `StoreProducts.tsx`
+- **Thin community `Community 1248`** (1 nodes): `Products.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1249`** (1 nodes): `UnresolvedProducts.tsx`
+- **Thin community `Community 1249`** (1 nodes): `StoreProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1250`** (1 nodes): `ComplimentaryProducts.tsx`
+- **Thin community `Community 1250`** (1 nodes): `UnresolvedProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1251`** (1 nodes): `complimentaryProductsColumn.tsx`
+- **Thin community `Community 1251`** (1 nodes): `ComplimentaryProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1252`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1252`** (1 nodes): `complimentaryProductsColumn.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1253`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1253`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1254`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1254`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1255`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1255`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1256`** (1 nodes): `data.ts`
+- **Thin community `Community 1256`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1257`** (1 nodes): `productColumns.tsx`
+- **Thin community `Community 1257`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1258`** (1 nodes): `PromoCodeHeader.test.tsx`
+- **Thin community `Community 1258`** (1 nodes): `productColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1259`** (1 nodes): `PromoCodes.tsx`
+- **Thin community `Community 1259`** (1 nodes): `PromoCodeHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1260`** (1 nodes): `PromoCodeAnalytics.tsx`
+- **Thin community `Community 1260`** (1 nodes): `PromoCodes.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1261`** (1 nodes): `captured-emails-columns.tsx`
+- **Thin community `Community 1261`** (1 nodes): `PromoCodeAnalytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1262`** (1 nodes): `promoCodeMoney.test.ts`
+- **Thin community `Community 1262`** (1 nodes): `captured-emails-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1263`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1263`** (1 nodes): `promoCodeMoney.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1264`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1264`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1265`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1265`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1266`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1266`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1267`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1267`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1268`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1268`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1269`** (1 nodes): `constants.ts`
+- **Thin community `Community 1269`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1270`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1270`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1271`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1271`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1272`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1272`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1273`** (1 nodes): `data.ts`
+- **Thin community `Community 1273`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1274`** (1 nodes): `types.ts`
+- **Thin community `Community 1274`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1275`** (1 nodes): `welcome-offer-card.tsx`
+- **Thin community `Community 1275`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1276`** (1 nodes): `RatingStars.tsx`
+- **Thin community `Community 1276`** (1 nodes): `welcome-offer-card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1277`** (1 nodes): `ReviewCard.tsx`
+- **Thin community `Community 1277`** (1 nodes): `RatingStars.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1278`** (1 nodes): `ReviewMetadata.tsx`
+- **Thin community `Community 1278`** (1 nodes): `ReviewCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1279`** (1 nodes): `ServicesWorkspaceView.test.tsx`
+- **Thin community `Community 1279`** (1 nodes): `ReviewMetadata.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1280`** (1 nodes): `index.tsx`
+- **Thin community `Community 1280`** (1 nodes): `ServicesWorkspaceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1281`** (1 nodes): `StaffAuthenticationDialog.test.tsx`
+- **Thin community `Community 1281`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1282`** (1 nodes): `FeesView.test.ts`
+- **Thin community `Community 1282`** (1 nodes): `StaffAuthenticationDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1283`** (1 nodes): `FulfillmentView.test.tsx`
+- **Thin community `Community 1283`** (1 nodes): `FeesView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1284`** (1 nodes): `MaintenanceView.test.tsx`
+- **Thin community `Community 1284`** (1 nodes): `FulfillmentView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1285`** (1 nodes): `MtnMomoView.test.tsx`
+- **Thin community `Community 1285`** (1 nodes): `MaintenanceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1286`** (1 nodes): `useStoreConfigUpdate.test.tsx`
+- **Thin community `Community 1286`** (1 nodes): `MtnMomoView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1287`** (1 nodes): `index.tsx`
+- **Thin community `Community 1287`** (1 nodes): `useStoreConfigUpdate.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1288`** (1 nodes): `WorkflowTraceView.test.tsx`
+- **Thin community `Community 1288`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1289`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 1289`** (1 nodes): `WorkflowTraceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1290`** (1 nodes): `button.test.tsx`
+- **Thin community `Community 1290`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1291`** (1 nodes): `button.tsx`
+- **Thin community `Community 1291`** (1 nodes): `button.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1292`** (1 nodes): `calendar.test.tsx`
+- **Thin community `Community 1292`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1293`** (1 nodes): `card.tsx`
+- **Thin community `Community 1293`** (1 nodes): `calendar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1294`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 1294`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1295`** (1 nodes): `collapsible.tsx`
+- **Thin community `Community 1295`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1296`** (1 nodes): `command.tsx`
+- **Thin community `Community 1296`** (1 nodes): `collapsible.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1297`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 1297`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1298`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 1298`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1299`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 1299`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1300`** (1 nodes): `form.tsx`
+- **Thin community `Community 1300`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1301`** (1 nodes): `icons.tsx`
+- **Thin community `Community 1301`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1302`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 1302`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1303`** (1 nodes): `input.tsx`
+- **Thin community `Community 1303`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1304`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 1304`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1305`** (1 nodes): `panel-header.tsx`
+- **Thin community `Community 1305`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1306`** (1 nodes): `popover.tsx`
+- **Thin community `Community 1306`** (1 nodes): `panel-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1307`** (1 nodes): `primitives.test.tsx`
+- **Thin community `Community 1307`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1308`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 1308`** (1 nodes): `primitives.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1309`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 1309`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1310`** (1 nodes): `select.tsx`
+- **Thin community `Community 1310`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1311`** (1 nodes): `separator.tsx`
+- **Thin community `Community 1311`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1312`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 1312`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1313`** (1 nodes): `switch.tsx`
+- **Thin community `Community 1313`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1314`** (1 nodes): `table.tsx`
+- **Thin community `Community 1314`** (1 nodes): `switch.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1315`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 1315`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1316`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 1316`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1317`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 1317`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1318`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 1318`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1319`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 1319`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1320`** (1 nodes): `upload-button.tsx`
+- **Thin community `Community 1320`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1321`** (1 nodes): `BagView.tsx`
+- **Thin community `Community 1321`** (1 nodes): `upload-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1322`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1322`** (1 nodes): `BagView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1323`** (1 nodes): `constants.ts`
+- **Thin community `Community 1323`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1324`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1324`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1325`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1325`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1326`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1326`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1327`** (1 nodes): `data.ts`
+- **Thin community `Community 1327`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1328`** (1 nodes): `bag-columns.tsx`
+- **Thin community `Community 1328`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1329`** (1 nodes): `bags-table.tsx`
+- **Thin community `Community 1329`** (1 nodes): `bag-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1330`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1330`** (1 nodes): `bags-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1331`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1331`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1332`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1332`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1333`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1333`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1334`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1334`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1335`** (1 nodes): `LinkedAccounts.tsx`
+- **Thin community `Community 1335`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1336`** (1 nodes): `TimelineEventCard.test.tsx`
+- **Thin community `Community 1336`** (1 nodes): `LinkedAccounts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1337`** (1 nodes): `UserCheckoutSession.tsx`
+- **Thin community `Community 1337`** (1 nodes): `TimelineEventCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1338`** (1 nodes): `UserInsightsSection.tsx`
+- **Thin community `Community 1338`** (1 nodes): `UserCheckoutSession.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1339`** (1 nodes): `UserBehaviorInsights.tsx`
+- **Thin community `Community 1339`** (1 nodes): `UserInsightsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1340`** (1 nodes): `index.ts`
+- **Thin community `Community 1340`** (1 nodes): `UserBehaviorInsights.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1341`** (1 nodes): `config.test.ts`
+- **Thin community `Community 1341`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1342`** (1 nodes): `ThemeContext.tsx`
+- **Thin community `Community 1342`** (1 nodes): `config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1343`** (1 nodes): `design-system-build-config.test.ts`
+- **Thin community `Community 1343`** (1 nodes): `ThemeContext.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1344`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 1344`** (1 nodes): `design-system-build-config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1345`** (1 nodes): `useAuth.test.tsx`
+- **Thin community `Community 1345`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1346`** (1 nodes): `useExpenseSessions.test.ts`
+- **Thin community `Community 1346`** (1 nodes): `useAuth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1347`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 1347`** (1 nodes): `useExpenseSessions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1348`** (1 nodes): `useProtectedAdminPageState.test.tsx`
+- **Thin community `Community 1348`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1349`** (1 nodes): `capabilities.test.ts`
+- **Thin community `Community 1349`** (1 nodes): `useProtectedAdminPageState.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1350`** (1 nodes): `aws.ts`
+- **Thin community `Community 1350`** (1 nodes): `capabilities.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1351`** (1 nodes): `constants.ts`
+- **Thin community `Community 1351`** (1 nodes): `aws.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1352`** (1 nodes): `countries.ts`
+- **Thin community `Community 1352`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1353`** (1 nodes): `operatorMessages.test.ts`
+- **Thin community `Community 1353`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1354`** (1 nodes): `presentCommandToast.test.ts`
+- **Thin community `Community 1354`** (1 nodes): `operatorMessages.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1355`** (1 nodes): `presentUnexpectedErrorToast.test.ts`
+- **Thin community `Community 1355`** (1 nodes): `presentCommandToast.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1356`** (1 nodes): `runCommand.test.ts`
+- **Thin community `Community 1356`** (1 nodes): `presentUnexpectedErrorToast.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1357`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1357`** (1 nodes): `runCommand.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1358`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 1358`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1359`** (1 nodes): `dto.ts`
+- **Thin community `Community 1359`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1360`** (1 nodes): `ports.ts`
+- **Thin community `Community 1360`** (1 nodes): `dto.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1361`** (1 nodes): `constants.ts`
+- **Thin community `Community 1361`** (1 nodes): `ports.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1362`** (1 nodes): `displayAmounts.test.ts`
+- **Thin community `Community 1362`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1363`** (1 nodes): `cart.test.ts`
+- **Thin community `Community 1363`** (1 nodes): `displayAmounts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1364`** (1 nodes): `index.ts`
+- **Thin community `Community 1364`** (1 nodes): `cart.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1365`** (1 nodes): `session.test.ts`
+- **Thin community `Community 1365`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1366`** (1 nodes): `types.ts`
+- **Thin community `Community 1366`** (1 nodes): `session.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1367`** (1 nodes): `registerGateway.test.ts`
+- **Thin community `Community 1367`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1368`** (1 nodes): `sessionGateway.test.ts`
+- **Thin community `Community 1368`** (1 nodes): `registerGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1369`** (1 nodes): `loggerGateway.ts`
+- **Thin community `Community 1369`** (1 nodes): `sessionGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1370`** (1 nodes): `catalogSearch.test.ts`
+- **Thin community `Community 1370`** (1 nodes): `loggerGateway.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1371`** (1 nodes): `registerUiState.ts`
+- **Thin community `Community 1371`** (1 nodes): `catalogSearch.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1372`** (1 nodes): `productUtils.test.ts`
+- **Thin community `Community 1372`** (1 nodes): `registerUiState.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1373`** (1 nodes): `category.ts`
+- **Thin community `Community 1373`** (1 nodes): `productUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1374`** (1 nodes): `product.ts`
+- **Thin community `Community 1374`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1375`** (1 nodes): `store.ts`
+- **Thin community `Community 1375`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1376`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1376`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1377`** (1 nodes): `user.ts`
+- **Thin community `Community 1377`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1378`** (1 nodes): `storeConfig.test.ts`
+- **Thin community `Community 1378`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1379`** (1 nodes): `createWorkflowTraceId.test.ts`
+- **Thin community `Community 1379`** (1 nodes): `storeConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1380`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1380`** (1 nodes): `createWorkflowTraceId.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1381`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 1381`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1382`** (1 nodes): `__root.tsx`
+- **Thin community `Community 1382`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1383`** (1 nodes): `index.tsx`
+- **Thin community `Community 1383`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1384`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1385`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1386`** (1 nodes): `$storeUrlSlug.tsx`
+- **Thin community `Community 1386`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1387`** (1 nodes): `analytics.tsx`
+- **Thin community `Community 1387`** (1 nodes): `$storeUrlSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1388`** (1 nodes): `assets.index.tsx`
+- **Thin community `Community 1388`** (1 nodes): `analytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1389`** (1 nodes): `bags.$bagId.tsx`
+- **Thin community `Community 1389`** (1 nodes): `assets.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1390`** (1 nodes): `bags.index.tsx`
+- **Thin community `Community 1390`** (1 nodes): `bags.$bagId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1391`** (1 nodes): `index.tsx`
+- **Thin community `Community 1391`** (1 nodes): `bags.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1392`** (1 nodes): `checkout-sessions.index.tsx`
+- **Thin community `Community 1392`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1393`** (1 nodes): `configuration.index.tsx`
+- **Thin community `Community 1393`** (1 nodes): `checkout-sessions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1394`** (1 nodes): `dashboard.index.tsx`
+- **Thin community `Community 1394`** (1 nodes): `configuration.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1395`** (1 nodes): `home.tsx`
+- **Thin community `Community 1395`** (1 nodes): `dashboard.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1396`** (1 nodes): `logs.$logId.tsx`
+- **Thin community `Community 1396`** (1 nodes): `home.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1397`** (1 nodes): `logs.index.tsx`
+- **Thin community `Community 1397`** (1 nodes): `logs.$logId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1398`** (1 nodes): `members.index.tsx`
+- **Thin community `Community 1398`** (1 nodes): `logs.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1399`** (1 nodes): `index.tsx`
+- **Thin community `Community 1399`** (1 nodes): `members.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1400`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1401`** (1 nodes): `all.index.tsx`
+- **Thin community `Community 1401`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1402`** (1 nodes): `cancelled.index.tsx`
+- **Thin community `Community 1402`** (1 nodes): `all.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1403`** (1 nodes): `completed.index.tsx`
+- **Thin community `Community 1403`** (1 nodes): `cancelled.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1404`** (1 nodes): `index.tsx`
+- **Thin community `Community 1404`** (1 nodes): `completed.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1405`** (1 nodes): `open.index.tsx`
+- **Thin community `Community 1405`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1406`** (1 nodes): `out-for-delivery.index.tsx`
+- **Thin community `Community 1406`** (1 nodes): `open.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1407`** (1 nodes): `ready.index.tsx`
+- **Thin community `Community 1407`** (1 nodes): `out-for-delivery.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1408`** (1 nodes): `refunded.index.tsx`
+- **Thin community `Community 1408`** (1 nodes): `ready.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1409`** (1 nodes): `$reportId.tsx`
+- **Thin community `Community 1409`** (1 nodes): `refunded.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1410`** (1 nodes): `expense-reports.index.tsx`
+- **Thin community `Community 1410`** (1 nodes): `$reportId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1411`** (1 nodes): `index.tsx`
+- **Thin community `Community 1411`** (1 nodes): `expense-reports.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1412`** (1 nodes): `register.index.tsx`
+- **Thin community `Community 1412`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1413`** (1 nodes): `sessions.index.tsx`
+- **Thin community `Community 1413`** (1 nodes): `register.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1414`** (1 nodes): `settings.index.tsx`
+- **Thin community `Community 1414`** (1 nodes): `sessions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1415`** (1 nodes): `$transactionId.tsx`
+- **Thin community `Community 1415`** (1 nodes): `settings.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1416`** (1 nodes): `transactions.index.tsx`
+- **Thin community `Community 1416`** (1 nodes): `$transactionId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1417`** (1 nodes): `procurement.index.test.ts`
+- **Thin community `Community 1417`** (1 nodes): `transactions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1418`** (1 nodes): `edit.tsx`
+- **Thin community `Community 1418`** (1 nodes): `procurement.index.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1419`** (1 nodes): `index.tsx`
+- **Thin community `Community 1419`** (1 nodes): `edit.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1420`** (1 nodes): `archived.tsx`
+- **Thin community `Community 1420`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1421`** (1 nodes): `index.tsx`
+- **Thin community `Community 1421`** (1 nodes): `archived.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1422`** (1 nodes): `new.tsx`
+- **Thin community `Community 1422`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1423`** (1 nodes): `index.tsx`
+- **Thin community `Community 1423`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1424`** (1 nodes): `new.tsx`
+- **Thin community `Community 1424`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1425`** (1 nodes): `unresolved.tsx`
+- **Thin community `Community 1425`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1426`** (1 nodes): `$promoCodeSlug.tsx`
+- **Thin community `Community 1426`** (1 nodes): `unresolved.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1427`** (1 nodes): `index.tsx`
+- **Thin community `Community 1427`** (1 nodes): `$promoCodeSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1428`** (1 nodes): `new.tsx`
+- **Thin community `Community 1428`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1429`** (1 nodes): `index.tsx`
+- **Thin community `Community 1429`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1430`** (1 nodes): `new.index.tsx`
+- **Thin community `Community 1430`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1431`** (1 nodes): `active-cases.index.tsx`
+- **Thin community `Community 1431`** (1 nodes): `new.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1432`** (1 nodes): `appointments.index.tsx`
+- **Thin community `Community 1432`** (1 nodes): `active-cases.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1433`** (1 nodes): `catalog-management.index.tsx`
+- **Thin community `Community 1433`** (1 nodes): `appointments.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1434`** (1 nodes): `index.tsx`
+- **Thin community `Community 1434`** (1 nodes): `catalog-management.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1435`** (1 nodes): `intake.index.tsx`
+- **Thin community `Community 1435`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1436`** (1 nodes): `$traceId.test.tsx`
+- **Thin community `Community 1436`** (1 nodes): `intake.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1437`** (1 nodes): `users.$userId.tsx`
+- **Thin community `Community 1437`** (1 nodes): `$traceId.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1438`** (1 nodes): `index.tsx`
+- **Thin community `Community 1438`** (1 nodes): `users.$userId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1439`** (1 nodes): `_authed.test.tsx`
+- **Thin community `Community 1439`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1440`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 1440`** (1 nodes): `_authed.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1441`** (1 nodes): `join-team.index.tsx`
+- **Thin community `Community 1441`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1442`** (1 nodes): `_layout.index.test.tsx`
+- **Thin community `Community 1442`** (1 nodes): `join-team.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1443`** (1 nodes): `_layout.test.tsx`
+- **Thin community `Community 1443`** (1 nodes): `landing.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1444`** (1 nodes): `StoresSettingsAccordion.tsx`
+- **Thin community `Community 1444`** (1 nodes): `_layout.index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1445`** (1 nodes): `expenseStore.ts`
+- **Thin community `Community 1445`** (1 nodes): `_layout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1446`** (1 nodes): `Overview.stories.tsx`
+- **Thin community `Community 1446`** (1 nodes): `StoresSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1447`** (1 nodes): `foundations-content.test.tsx`
+- **Thin community `Community 1447`** (1 nodes): `expenseStore.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1448`** (1 nodes): `Introduction.stories.tsx`
+- **Thin community `Community 1448`** (1 nodes): `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1449`** (1 nodes): `introduction-content.test.tsx`
+- **Thin community `Community 1449`** (1 nodes): `foundations-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1450`** (1 nodes): `introduction-content.tsx`
+- **Thin community `Community 1450`** (1 nodes): `Introduction.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1451`** (1 nodes): `AdminShell.stories.tsx`
+- **Thin community `Community 1451`** (1 nodes): `introduction-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1452`** (1 nodes): `View.stories.tsx`
+- **Thin community `Community 1452`** (1 nodes): `introduction-content.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1453`** (1 nodes): `admin-shell-patterns.test.tsx`
+- **Thin community `Community 1453`** (1 nodes): `AdminShell.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1454`** (1 nodes): `view-patterns.test.tsx`
+- **Thin community `Community 1454`** (1 nodes): `View.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1455`** (1 nodes): `Surfaces.stories.tsx`
+- **Thin community `Community 1455`** (1 nodes): `admin-shell-patterns.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1456`** (1 nodes): `DashboardWorkspace.stories.tsx`
+- **Thin community `Community 1456`** (1 nodes): `view-patterns.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1457`** (1 nodes): `DataWorkspace.stories.tsx`
+- **Thin community `Community 1457`** (1 nodes): `Surfaces.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1458`** (1 nodes): `SettingsWorkspace.stories.tsx`
+- **Thin community `Community 1458`** (1 nodes): `DashboardWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1459`** (1 nodes): `reference-fixtures.test.tsx`
+- **Thin community `Community 1459`** (1 nodes): `DataWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1460`** (1 nodes): `storybook-config.test.ts`
+- **Thin community `Community 1460`** (1 nodes): `SettingsWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1461`** (1 nodes): `storybook-theme-decorator.test.ts`
+- **Thin community `Community 1461`** (1 nodes): `reference-fixtures.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1462`** (1 nodes): `setup.ts`
+- **Thin community `Community 1462`** (1 nodes): `storybook-config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1463`** (1 nodes): `usePrint.test.ts`
+- **Thin community `Community 1463`** (1 nodes): `storybook-theme-decorator.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1464`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 1464`** (1 nodes): `setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1465`** (1 nodes): `types.ts`
+- **Thin community `Community 1465`** (1 nodes): `usePrint.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1466`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 1466`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1467`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 1467`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1468`** (1 nodes): `global.d.ts`
+- **Thin community `Community 1468`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1469`** (1 nodes): `playwright.config.ts`
+- **Thin community `Community 1469`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1470`** (1 nodes): `analytics.test.ts`
+- **Thin community `Community 1470`** (1 nodes): `global.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1471`** (1 nodes): `types.ts`
+- **Thin community `Community 1471`** (1 nodes): `playwright.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1472`** (1 nodes): `HeartIconFilled.tsx`
+- **Thin community `Community 1472`** (1 nodes): `analytics.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1473`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 1473`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1474`** (1 nodes): `HomePage.test.tsx`
+- **Thin community `Community 1474`** (1 nodes): `HeartIconFilled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1475`** (1 nodes): `ProductCard.test.tsx`
+- **Thin community `Community 1475`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1476`** (1 nodes): `ProductCard.tsx`
+- **Thin community `Community 1476`** (1 nodes): `HomePage.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1477`** (1 nodes): `Upsell.tsx`
+- **Thin community `Community 1477`** (1 nodes): `ProductCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1478`** (1 nodes): `Checkout.test.tsx`
+- **Thin community `Community 1478`** (1 nodes): `ProductCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1479`** (1 nodes): `Checkout.tsx`
+- **Thin community `Community 1479`** (1 nodes): `Upsell.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1480`** (1 nodes): `CustomerInfoSection.tsx`
+- **Thin community `Community 1480`** (1 nodes): `Checkout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1481`** (1 nodes): `schema.ts`
+- **Thin community `Community 1481`** (1 nodes): `Checkout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1482`** (1 nodes): `DeliveryDetailsSection.tsx`
+- **Thin community `Community 1482`** (1 nodes): `CustomerInfoSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1483`** (1 nodes): `checkoutStorage.test.ts`
+- **Thin community `Community 1483`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1484`** (1 nodes): `deliveryFees.test.ts`
+- **Thin community `Community 1484`** (1 nodes): `DeliveryDetailsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1485`** (1 nodes): `deriveCheckoutState.test.ts`
+- **Thin community `Community 1485`** (1 nodes): `checkoutStorage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1486`** (1 nodes): `billingDetailsSchema.ts`
+- **Thin community `Community 1486`** (1 nodes): `deliveryFees.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1487`** (1 nodes): `checkoutFormSchema.ts`
+- **Thin community `Community 1487`** (1 nodes): `deriveCheckoutState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1488`** (1 nodes): `customerDetailsSchema.ts`
+- **Thin community `Community 1488`** (1 nodes): `billingDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1489`** (1 nodes): `deliveryDetailsSchema.ts`
+- **Thin community `Community 1489`** (1 nodes): `checkoutFormSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1490`** (1 nodes): `webOrderSchema.ts`
+- **Thin community `Community 1490`** (1 nodes): `customerDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1491`** (1 nodes): `types.ts`
+- **Thin community `Community 1491`** (1 nodes): `deliveryDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1492`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1492`** (1 nodes): `webOrderSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1493`** (1 nodes): `ProductFilterBar.tsx`
+- **Thin community `Community 1493`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1494`** (1 nodes): `BestSellersSection.test.tsx`
+- **Thin community `Community 1494`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1495`** (1 nodes): `HomeHero.tsx`
+- **Thin community `Community 1495`** (1 nodes): `ProductFilterBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1496`** (1 nodes): `HomeHeroSection.tsx`
+- **Thin community `Community 1496`** (1 nodes): `BestSellersSection.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1497`** (1 nodes): `homePageContent.test.ts`
+- **Thin community `Community 1497`** (1 nodes): `HomeHero.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1498`** (1 nodes): `MobileMenu.tsx`
+- **Thin community `Community 1498`** (1 nodes): `HomeHeroSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1499`** (1 nodes): `constants.ts`
+- **Thin community `Community 1499`** (1 nodes): `homePageContent.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1500`** (1 nodes): `navBarConstants.ts`
+- **Thin community `Community 1500`** (1 nodes): `MobileMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1501`** (1 nodes): `About.tsx`
+- **Thin community `Community 1501`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1502`** (1 nodes): `AboutProduct.tsx`
+- **Thin community `Community 1502`** (1 nodes): `navBarConstants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1503`** (1 nodes): `ProductActions.test.tsx`
+- **Thin community `Community 1503`** (1 nodes): `About.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1504`** (1 nodes): `ProductInfo.tsx`
+- **Thin community `Community 1504`** (1 nodes): `AboutProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1505`** (1 nodes): `ProductReviews.tsx`
+- **Thin community `Community 1505`** (1 nodes): `ProductActions.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1506`** (1 nodes): `ProductsNavigationBar.tsx`
+- **Thin community `Community 1506`** (1 nodes): `ProductInfo.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1507`** (1 nodes): `ErrorMessage.tsx`
+- **Thin community `Community 1507`** (1 nodes): `ProductReviews.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1508`** (1 nodes): `ExistingReviewMessage.tsx`
+- **Thin community `Community 1508`** (1 nodes): `ProductsNavigationBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1509`** (1 nodes): `OrderItem.test.tsx`
+- **Thin community `Community 1509`** (1 nodes): `ErrorMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1510`** (1 nodes): `ReviewForm.tsx`
+- **Thin community `Community 1510`** (1 nodes): `ExistingReviewMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1511`** (1 nodes): `SuccessMessage.tsx`
+- **Thin community `Community 1511`** (1 nodes): `OrderItem.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1512`** (1 nodes): `types.ts`
+- **Thin community `Community 1512`** (1 nodes): `ReviewForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1513`** (1 nodes): `SavedBag.tsx`
+- **Thin community `Community 1513`** (1 nodes): `SuccessMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1514`** (1 nodes): `SavedIcon.tsx`
+- **Thin community `Community 1514`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1515`** (1 nodes): `CartIcon.tsx`
+- **Thin community `Community 1515`** (1 nodes): `SavedBag.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1516`** (1 nodes): `ShoppingBag.test.tsx`
+- **Thin community `Community 1516`** (1 nodes): `SavedIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1517`** (1 nodes): `empty-state.tsx`
+- **Thin community `Community 1517`** (1 nodes): `CartIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1518`** (1 nodes): `Maintenance.test.tsx`
+- **Thin community `Community 1518`** (1 nodes): `ShoppingBag.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1519`** (1 nodes): `Maintenance.tsx`
+- **Thin community `Community 1519`** (1 nodes): `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1520`** (1 nodes): `AnimatedCard.tsx`
+- **Thin community `Community 1520`** (1 nodes): `Maintenance.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1521`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 1521`** (1 nodes): `Maintenance.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1522`** (1 nodes): `alert.tsx`
+- **Thin community `Community 1522`** (1 nodes): `AnimatedCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1523`** (1 nodes): `breadcrumb.tsx`
+- **Thin community `Community 1523`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1524`** (1 nodes): `button.tsx`
+- **Thin community `Community 1524`** (1 nodes): `alert.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1525`** (1 nodes): `card.tsx`
+- **Thin community `Community 1525`** (1 nodes): `breadcrumb.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1526`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 1526`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1527`** (1 nodes): `command.tsx`
+- **Thin community `Community 1527`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1528`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 1528`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1529`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 1529`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1530`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 1530`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1531`** (1 nodes): `form.tsx`
+- **Thin community `Community 1531`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1532`** (1 nodes): `icons.tsx`
+- **Thin community `Community 1532`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1533`** (1 nodes): `image-with-fallback.tsx`
+- **Thin community `Community 1533`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1534`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 1534`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1535`** (1 nodes): `input-with-end-button.tsx`
+- **Thin community `Community 1535`** (1 nodes): `image-with-fallback.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1536`** (1 nodes): `input.tsx`
+- **Thin community `Community 1536`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1537`** (1 nodes): `label.tsx`
+- **Thin community `Community 1537`** (1 nodes): `input-with-end-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1538`** (1 nodes): `LeaveAReviewModalForm.tsx`
+- **Thin community `Community 1538`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1539`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 1539`** (1 nodes): `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1540`** (1 nodes): `welcomeBackModalAnimations.ts`
+- **Thin community `Community 1540`** (1 nodes): `LeaveAReviewModalForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1541`** (1 nodes): `index.ts`
+- **Thin community `Community 1541`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1542`** (1 nodes): `types.ts`
+- **Thin community `Community 1542`** (1 nodes): `welcomeBackModalAnimations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1543`** (1 nodes): `navigation-menu.tsx`
+- **Thin community `Community 1543`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1544`** (1 nodes): `popover.tsx`
+- **Thin community `Community 1544`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1545`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 1545`** (1 nodes): `navigation-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1546`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 1546`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1547`** (1 nodes): `select.tsx`
+- **Thin community `Community 1547`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1548`** (1 nodes): `separator.tsx`
+- **Thin community `Community 1548`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1549`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 1549`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1550`** (1 nodes): `table.tsx`
+- **Thin community `Community 1550`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1551`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 1551`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1552`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 1552`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1553`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 1553`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1554`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 1554`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1555`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 1555`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1556`** (1 nodes): `config.ts`
+- **Thin community `Community 1556`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1557`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 1557`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1558`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 1558`** (1 nodes): `config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1559`** (1 nodes): `useQueryEnabled.test.ts`
+- **Thin community `Community 1559`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1560`** (1 nodes): `useStorefrontObservability.ts`
+- **Thin community `Community 1560`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1561`** (1 nodes): `constants.ts`
+- **Thin community `Community 1561`** (1 nodes): `useQueryEnabled.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1562`** (1 nodes): `countries.ts`
+- **Thin community `Community 1562`** (1 nodes): `useStorefrontObservability.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1563`** (1 nodes): `feeUtils.test.ts`
+- **Thin community `Community 1563`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1564`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1564`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1565`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 1565`** (1 nodes): `feeUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1566`** (1 nodes): `maintenanceUtils.test.ts`
+- **Thin community `Community 1566`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1567`** (1 nodes): `index.ts`
+- **Thin community `Community 1567`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1568`** (1 nodes): `store.ts`
+- **Thin community `Community 1568`** (1 nodes): `maintenanceUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1569`** (1 nodes): `bag.ts`
+- **Thin community `Community 1569`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1570`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1570`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1571`** (1 nodes): `category.ts`
+- **Thin community `Community 1571`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1572`** (1 nodes): `organization.ts`
+- **Thin community `Community 1572`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1573`** (1 nodes): `product.ts`
+- **Thin community `Community 1573`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1574`** (1 nodes): `store.ts`
+- **Thin community `Community 1574`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1575`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1575`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1576`** (1 nodes): `user.ts`
+- **Thin community `Community 1576`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1577`** (1 nodes): `states.ts`
+- **Thin community `Community 1577`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1578`** (1 nodes): `storefrontFailureObservability.test.ts`
+- **Thin community `Community 1578`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1579`** (1 nodes): `storefrontJourneyEvents.test.ts`
+- **Thin community `Community 1579`** (1 nodes): `states.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1580`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1580`** (1 nodes): `storefrontFailureObservability.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1581`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 1581`** (1 nodes): `storefrontJourneyEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1582`** (1 nodes): `-homePageLoader.test.ts`
+- **Thin community `Community 1582`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1583`** (1 nodes): `__root.tsx`
+- **Thin community `Community 1583`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1584`** (1 nodes): `$orderItemId.review.tsx`
+- **Thin community `Community 1584`** (1 nodes): `-homePageLoader.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1585`** (1 nodes): `index.tsx`
+- **Thin community `Community 1585`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1586`** (1 nodes): `$subcategorySlug.tsx`
+- **Thin community `Community 1586`** (1 nodes): `$orderItemId.review.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1587`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1588`** (1 nodes): `rewards.index.tsx`
+- **Thin community `Community 1588`** (1 nodes): `$subcategorySlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1589`** (1 nodes): `shop.saved.index.tsx`
+- **Thin community `Community 1589`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1590`** (1 nodes): `bag.index.tsx`
+- **Thin community `Community 1590`** (1 nodes): `rewards.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1591`** (1 nodes): `complete.tsx`
+- **Thin community `Community 1591`** (1 nodes): `shop.saved.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1592`** (1 nodes): `incomplete.tsx`
+- **Thin community `Community 1592`** (1 nodes): `bag.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1593`** (1 nodes): `index.tsx`
+- **Thin community `Community 1593`** (1 nodes): `complete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1594`** (1 nodes): `pending.tsx`
+- **Thin community `Community 1594`** (1 nodes): `incomplete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1595`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 1595`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1596`** (1 nodes): `storefront-boot.e2e.ts`
+- **Thin community `Community 1596`** (1 nodes): `pending.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1597`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 1597`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1598`** (1 nodes): `vitest.setup.ts`
+- **Thin community `Community 1598`** (1 nodes): `storefront-boot.e2e.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1599`** (1 nodes): `index.js`
+- **Thin community `Community 1599`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1600`** (1 nodes): `harness-app-registry.test.ts`
+- **Thin community `Community 1600`** (1 nodes): `vitest.setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1601`** (1 nodes): `athena-runtime-app.test.ts`
+- **Thin community `Community 1601`** (1 nodes): `index.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1602`** (1 nodes): `storefront-runtime-api.test.ts`
+- **Thin community `Community 1602`** (1 nodes): `harness-app-registry.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1603`** (1 nodes): `valkey-runtime-app.test.ts`
+- **Thin community `Community 1603`** (1 nodes): `athena-runtime-app.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1604`** (1 nodes): `harness-behavior-scenarios.test.ts`
+- **Thin community `Community 1604`** (1 nodes): `storefront-runtime-api.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1605`** (1 nodes): `harness-repo-validation.test.ts`
+- **Thin community `Community 1605`** (1 nodes): `valkey-runtime-app.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1606`** (1 nodes): `harness-behavior-scenarios.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1607`** (1 nodes): `harness-repo-validation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -3611,7 +3611,7 @@
       "relation": "calls",
       "source": "dailyclose_isinrange",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L644",
+      "source_location": "L664",
       "target": "dailyclose_approvalbelongstorange",
       "weight": 1
     },
@@ -3623,7 +3623,7 @@
       "relation": "calls",
       "source": "dailyclose_registersessionbelongstorange",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L661",
+      "source_location": "L681",
       "target": "dailyclose_approvalbelongstorange",
       "weight": 1
     },
@@ -3635,7 +3635,7 @@
       "relation": "calls",
       "source": "dailyclose_formatpaymentmethodlabel",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L395",
+      "source_location": "L415",
       "target": "dailyclose_approvalrequesttypelabel",
       "weight": 1
     },
@@ -3647,7 +3647,7 @@
       "relation": "calls",
       "source": "dailyclose_builddailycloseapprovalsubject",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L245",
+      "source_location": "L265",
       "target": "dailyclose_builddailyclosecompletionapprovalrequirement",
       "weight": 1
     },
@@ -3659,7 +3659,7 @@
       "relation": "calls",
       "source": "dailyclose_builddailyclosereportsnapshot",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L920",
+      "source_location": "L940",
       "target": "dailyclose_snapshotrevieweditems",
       "weight": 1
     },
@@ -3671,7 +3671,7 @@
       "relation": "calls",
       "source": "dailyclose_uniquedailycloseitems",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L921",
+      "source_location": "L941",
       "target": "dailyclose_builddailyclosereportsnapshot",
       "weight": 1
     },
@@ -3683,7 +3683,7 @@
       "relation": "calls",
       "source": "dailyclose_buildexpensesessionsbyid",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1142",
+      "source_location": "L1162",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -3695,7 +3695,7 @@
       "relation": "calls",
       "source": "dailyclose_buildpaymenttotals",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1672",
+      "source_location": "L1692",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -3707,7 +3707,7 @@
       "relation": "calls",
       "source": "dailyclose_buildreadiness",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1674",
+      "source_location": "L1695",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -3719,7 +3719,7 @@
       "relation": "calls",
       "source": "dailyclose_buildregistersessionsbyid",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1135",
+      "source_location": "L1155",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -3731,7 +3731,7 @@
       "relation": "calls",
       "source": "dailyclose_buildstaffnamesbyid",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1074",
+      "source_location": "L1094",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -3743,7 +3743,7 @@
       "relation": "calls",
       "source": "dailyclose_buildterminallabelsbyid",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1157",
+      "source_location": "L1177",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -3755,7 +3755,7 @@
       "relation": "calls",
       "source": "dailyclose_cashdeltasbyregistersessionid",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1132",
+      "source_location": "L1152",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -3767,7 +3767,7 @@
       "relation": "calls",
       "source": "dailyclose_emptysummary",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1060",
+      "source_location": "L1080",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -3779,7 +3779,7 @@
       "relation": "calls",
       "source": "dailyclose_getdailyclosecompletioneventstaffprofileid",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1070",
+      "source_location": "L1090",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -3791,7 +3791,7 @@
       "relation": "calls",
       "source": "dailyclose_getdailyclosefordate",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1065",
+      "source_location": "L1085",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -3803,7 +3803,7 @@
       "relation": "calls",
       "source": "dailyclose_getpriorcompleteddailyclose",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1119",
+      "source_location": "L1139",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -3815,7 +3815,7 @@
       "relation": "calls",
       "source": "dailyclose_getstore",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1024",
+      "source_location": "L1044",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -3827,7 +3827,7 @@
       "relation": "calls",
       "source": "dailyclose_listactiveregistersessions",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1102",
+      "source_location": "L1122",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -3839,7 +3839,7 @@
       "relation": "calls",
       "source": "dailyclose_listclosedregistersessionsforday",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1103",
+      "source_location": "L1123",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -3851,7 +3851,7 @@
       "relation": "calls",
       "source": "dailyclose_listdepositsforday",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1118",
+      "source_location": "L1138",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -3863,7 +3863,7 @@
       "relation": "calls",
       "source": "dailyclose_listexpensesforday",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1117",
+      "source_location": "L1137",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -3875,7 +3875,7 @@
       "relation": "calls",
       "source": "dailyclose_listopenoperationalworkitems",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1106",
+      "source_location": "L1126",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -3887,7 +3887,7 @@
       "relation": "calls",
       "source": "dailyclose_listopenpossessions",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1105",
+      "source_location": "L1125",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -3899,7 +3899,7 @@
       "relation": "calls",
       "source": "dailyclose_listpendingcloseoutapprovals",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1104",
+      "source_location": "L1124",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -3911,7 +3911,7 @@
       "relation": "calls",
       "source": "dailyclose_listtransactionsforday",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1107",
+      "source_location": "L1127",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -3923,7 +3923,7 @@
       "relation": "calls",
       "source": "dailyclose_normalizecompleteddailyclosesnapshot",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1077",
+      "source_location": "L1097",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -3935,7 +3935,19 @@
       "relation": "calls",
       "source": "dailyclose_resolveoperatingdaterange",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1023",
+      "source_location": "L1043",
+      "target": "dailyclose_builddailyclosesnapshotwithctx",
+      "weight": 1
+    },
+    {
+      "_src": "dailyclose_builddailyclosesnapshotwithctx",
+      "_tgt": "dailyclose_sortdailycloseblockers",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "dailyclose_sortdailycloseblockers",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
+      "source_location": "L1694",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -3947,7 +3959,7 @@
       "relation": "calls",
       "source": "dailyclose_uniquesourcesubjects",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1720",
+      "source_location": "L1741",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -3959,7 +3971,7 @@
       "relation": "calls",
       "source": "dailyclose_builddailycloseapprovalsubject",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1935",
+      "source_location": "L1956",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -3971,7 +3983,7 @@
       "relation": "calls",
       "source": "dailyclose_builddailyclosecompletionapprovalrequirement",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1922",
+      "source_location": "L1943",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -3983,7 +3995,7 @@
       "relation": "calls",
       "source": "dailyclose_builddailyclosereportsnapshot",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1988",
+      "source_location": "L2009",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -3995,7 +4007,7 @@
       "relation": "calls",
       "source": "dailyclose_builddailyclosesnapshotwithctx",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1857",
+      "source_location": "L1878",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -4007,7 +4019,7 @@
       "relation": "calls",
       "source": "dailyclose_createcarryforwardworkitems",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1945",
+      "source_location": "L1966",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -4019,7 +4031,7 @@
       "relation": "calls",
       "source": "dailyclose_getstore",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1832",
+      "source_location": "L1853",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -4031,7 +4043,7 @@
       "relation": "calls",
       "source": "dailyclose_markotherdailyclosesnotcurrent",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2020",
+      "source_location": "L2041",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -4043,7 +4055,7 @@
       "relation": "calls",
       "source": "dailyclose_resolveoperatingdaterange",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1848",
+      "source_location": "L1869",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -4055,7 +4067,7 @@
       "relation": "calls",
       "source": "dailyclose_trimoptional",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1970",
+      "source_location": "L1991",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -4067,7 +4079,7 @@
       "relation": "calls",
       "source": "dailyclose_validatecarryforwardworkitemids",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1908",
+      "source_location": "L1929",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -4079,7 +4091,7 @@
       "relation": "calls",
       "source": "dailyclose_trimoptional",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1766",
+      "source_location": "L1787",
       "target": "dailyclose_createcarryforwardworkitems",
       "weight": 1
     },
@@ -4091,7 +4103,7 @@
       "relation": "calls",
       "source": "dailyclose_buildstaffnamesbyid",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2189",
+      "source_location": "L2210",
       "target": "dailyclose_getcompleteddailyclosehistorydetailwithctx",
       "weight": 1
     },
@@ -4103,7 +4115,7 @@
       "relation": "calls",
       "source": "dailyclose_getdailyclosecompletioneventstaffprofileid",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2185",
+      "source_location": "L2206",
       "target": "dailyclose_getcompleteddailyclosehistorydetailwithctx",
       "weight": 1
     },
@@ -4115,7 +4127,7 @@
       "relation": "calls",
       "source": "dailyclose_getpriorcompleteddailyclose",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2087",
+      "source_location": "L2108",
       "target": "dailyclose_getdailycloseopeningcontextwithctx",
       "weight": 1
     },
@@ -4127,7 +4139,7 @@
       "relation": "calls",
       "source": "dailyclose_buildstaffnamesbyid",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2147",
+      "source_location": "L2168",
       "target": "dailyclose_listcompleteddailyclosehistorywithctx",
       "weight": 1
     },
@@ -4139,7 +4151,7 @@
       "relation": "calls",
       "source": "dailyclose_isinrange",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L606",
+      "source_location": "L626",
       "target": "dailyclose_registersessionbelongstorange",
       "weight": 1
     },
@@ -4151,7 +4163,7 @@
       "relation": "calls",
       "source": "dailyclose_registersessioncloseoutoperatingat",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L603",
+      "source_location": "L623",
       "target": "dailyclose_registersessionbelongstorange",
       "weight": 1
     },
@@ -4163,7 +4175,7 @@
       "relation": "calls",
       "source": "dailyclose_registersessionintersectsrange",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L609",
+      "source_location": "L629",
       "target": "dailyclose_registersessionbelongstorange",
       "weight": 1
     },
@@ -4175,7 +4187,7 @@
       "relation": "calls",
       "source": "dailyclose_isvalidoperatingdaterange",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L308",
+      "source_location": "L328",
       "target": "dailyclose_resolveoperatingdaterange",
       "weight": 1
     },
@@ -4187,7 +4199,7 @@
       "relation": "calls",
       "source": "dailyclose_safeoperatingdaterange",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L302",
+      "source_location": "L322",
       "target": "dailyclose_resolveoperatingdaterange",
       "weight": 1
     },
@@ -4199,7 +4211,7 @@
       "relation": "calls",
       "source": "dailyclose_formatpaymentmethodlabel",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L374",
+      "source_location": "L394",
       "target": "dailyclose_transactionpaymentsummary",
       "weight": 1
     },
@@ -4259,7 +4271,7 @@
       "relation": "calls",
       "source": "dailycloseview_getlocaloperatingdate",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L489",
+      "source_location": "L529",
       "target": "dailycloseview_builddailyclosetransactionsearch",
       "weight": 1
     },
@@ -4271,7 +4283,7 @@
       "relation": "calls",
       "source": "dailycloseview_formatcarriedoverregistercount",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L2776",
+      "source_location": "L2843",
       "target": "dailycloseview_formatdailyclosemoney",
       "weight": 1
     },
@@ -4283,7 +4295,7 @@
       "relation": "calls",
       "source": "dailycloseview_formatdailyclosemoney",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L2777",
+      "source_location": "L2844",
       "target": "dailycloseview_getsummarycount",
       "weight": 1
     },
@@ -4295,7 +4307,7 @@
       "relation": "calls",
       "source": "dailycloseview_formatmetadatavalue",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L910",
+      "source_location": "L961",
       "target": "dailycloseview_formatmetadatadisplayvalue",
       "weight": 1
     },
@@ -4307,7 +4319,7 @@
       "relation": "calls",
       "source": "dailycloseview_getmetadatastringvalue",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L912",
+      "source_location": "L963",
       "target": "dailycloseview_formatmetadatadisplayvalue",
       "weight": 1
     },
@@ -4319,7 +4331,7 @@
       "relation": "calls",
       "source": "dailycloseview_getnumericmetadatavalue",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L961",
+      "source_location": "L1012",
       "target": "dailycloseview_formatmetadatadisplayvalue",
       "weight": 1
     },
@@ -4331,7 +4343,7 @@
       "relation": "calls",
       "source": "dailycloseview_getvariancetone",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L966",
+      "source_location": "L1017",
       "target": "dailycloseview_formatmetadatadisplayvalue",
       "weight": 1
     },
@@ -4343,7 +4355,7 @@
       "relation": "calls",
       "source": "dailycloseview_normalizemetadatalabel",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L920",
+      "source_location": "L971",
       "target": "dailycloseview_formatmetadatadisplayvalue",
       "weight": 1
     },
@@ -4355,7 +4367,7 @@
       "relation": "calls",
       "source": "dailycloseview_formatdailyclosemoney",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L854",
+      "source_location": "L905",
       "target": "dailycloseview_formatmetadatavalue",
       "weight": 1
     },
@@ -4367,7 +4379,7 @@
       "relation": "calls",
       "source": "dailycloseview_formattimestampmetadata",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L850",
+      "source_location": "L901",
       "target": "dailycloseview_formatmetadatavalue",
       "weight": 1
     },
@@ -4379,7 +4391,7 @@
       "relation": "calls",
       "source": "dailycloseview_humanizemetadatalabel",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L882",
+      "source_location": "L933",
       "target": "dailycloseview_formatmetadatavalue",
       "weight": 1
     },
@@ -4391,7 +4403,7 @@
       "relation": "calls",
       "source": "dailycloseview_ismoneymetadatalabel",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L853",
+      "source_location": "L904",
       "target": "dailycloseview_formatmetadatavalue",
       "weight": 1
     },
@@ -4403,7 +4415,7 @@
       "relation": "calls",
       "source": "dailycloseview_istimestampmetadatalabel",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L849",
+      "source_location": "L900",
       "target": "dailycloseview_formatmetadatavalue",
       "weight": 1
     },
@@ -4415,7 +4427,7 @@
       "relation": "calls",
       "source": "dailycloseview_normalizemetadatalabel",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L842",
+      "source_location": "L893",
       "target": "dailycloseview_formatmetadatavalue",
       "weight": 1
     },
@@ -4427,7 +4439,7 @@
       "relation": "calls",
       "source": "dailycloseview_iszeroactivitydailyclose",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1382",
+      "source_location": "L1433",
       "target": "dailycloseview_getbucketconfigs",
       "weight": 1
     },
@@ -4439,7 +4451,7 @@
       "relation": "calls",
       "source": "dailycloseview_getbucketcountclassname",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L382",
+      "source_location": "L422",
       "target": "dailycloseview_cn",
       "weight": 1
     },
@@ -4451,7 +4463,7 @@
       "relation": "calls",
       "source": "dailycloseview_getitemid",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L576",
+      "source_location": "L616",
       "target": "dailycloseview_getcarryforwardworkitemid",
       "weight": 1
     },
@@ -4463,7 +4475,7 @@
       "relation": "calls",
       "source": "dailycloseview_getlocaloperatingdate",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L495",
+      "source_location": "L535",
       "target": "dailycloseview_getdailyclosesalesmetriclabels",
       "weight": 1
     },
@@ -4475,7 +4487,7 @@
       "relation": "calls",
       "source": "dailycloseview_humanizemetadatalabel",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L818",
+      "source_location": "L858",
       "target": "dailycloseview_getdisplaymetadatalabel",
       "weight": 1
     },
@@ -4487,7 +4499,7 @@
       "relation": "calls",
       "source": "dailycloseview_normalizemetadatalabel",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L806",
+      "source_location": "L846",
       "target": "dailycloseview_getdisplaymetadatalabel",
       "weight": 1
     },
@@ -4499,7 +4511,7 @@
       "relation": "calls",
       "source": "dailycloseview_getitemcontextlabel",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L595",
+      "source_location": "L635",
       "target": "dailycloseview_humanizemetadatalabel",
       "weight": 1
     },
@@ -4511,7 +4523,7 @@
       "relation": "calls",
       "source": "dailycloseview_getlocaloperatingdate",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L516",
+      "source_location": "L556",
       "target": "dailycloseview_getlocaloperatingdaterange",
       "weight": 1
     },
@@ -4523,7 +4535,7 @@
       "relation": "calls",
       "source": "dailycloseview_getlocaldatefromoperatingdate",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L524",
+      "source_location": "L564",
       "target": "dailycloseview_getlocaloperatingdaterangefromsearch",
       "weight": 1
     },
@@ -4535,7 +4547,7 @@
       "relation": "calls",
       "source": "dailycloseview_getlocaloperatingdaterange",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L527",
+      "source_location": "L567",
       "target": "dailycloseview_getlocaloperatingdaterangefromsearch",
       "weight": 1
     },
@@ -4547,7 +4559,7 @@
       "relation": "calls",
       "source": "dailycloseview_normalizemetadatalabel",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L985",
+      "source_location": "L1036",
       "target": "dailycloseview_getmetadataentries",
       "weight": 1
     },
@@ -4559,7 +4571,7 @@
       "relation": "calls",
       "source": "dailycloseview_getmetadatavalue",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1454",
+      "source_location": "L1505",
       "target": "dailycloseview_getmetadatastringornumber",
       "weight": 1
     },
@@ -4571,7 +4583,7 @@
       "relation": "calls",
       "source": "dailycloseview_normalizemetadatalabel",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L832",
+      "source_location": "L883",
       "target": "dailycloseview_getmetadatavalue",
       "weight": 1
     },
@@ -4583,7 +4595,7 @@
       "relation": "calls",
       "source": "dailycloseview_iszeroactivitydailyclose",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1308",
+      "source_location": "L1359",
       "target": "dailycloseview_getstatusdisplaycopy",
       "weight": 1
     },
@@ -4595,7 +4607,7 @@
       "relation": "calls",
       "source": "dailycloseview_getstatuslabelclassname",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L350",
+      "source_location": "L351",
       "target": "dailycloseview_cn",
       "weight": 1
     },
@@ -4607,7 +4619,7 @@
       "relation": "calls",
       "source": "dailycloseview_getstatusrailbadgeclassname",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L373",
+      "source_location": "L413",
       "target": "dailycloseview_cn",
       "weight": 1
     },
@@ -4619,7 +4631,7 @@
       "relation": "calls",
       "source": "dailycloseview_getstatusrailiconclassname",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L362",
+      "source_location": "L363",
       "target": "dailycloseview_cn",
       "weight": 1
     },
@@ -4631,7 +4643,7 @@
       "relation": "calls",
       "source": "dailycloseview_formatexpensetransactioncount",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L2794",
+      "source_location": "L2861",
       "target": "dailycloseview_getsummaryamount",
       "weight": 1
     },
@@ -4643,7 +4655,7 @@
       "relation": "calls",
       "source": "dailycloseview_getsummaryamount",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L2795",
+      "source_location": "L2862",
       "target": "dailycloseview_getexpensetransactioncount",
       "weight": 1
     },
@@ -4655,7 +4667,7 @@
       "relation": "calls",
       "source": "dailycloseview_getsummaryamount",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1231",
+      "source_location": "L1282",
       "target": "dailycloseview_getsummaryregistervariancecount",
       "weight": 1
     },
@@ -4667,7 +4679,7 @@
       "relation": "calls",
       "source": "dailycloseview_formatdailyclosemoney",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1473",
+      "source_location": "L1524",
       "target": "dailycloseview_gettransactionreportamount",
       "weight": 1
     },
@@ -4679,7 +4691,7 @@
       "relation": "calls",
       "source": "dailycloseview_getmetadatastringornumber",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1470",
+      "source_location": "L1521",
       "target": "dailycloseview_gettransactionreportamount",
       "weight": 1
     },
@@ -4691,7 +4703,7 @@
       "relation": "calls",
       "source": "dailycloseview_getnumericmetadatavalue",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1469",
+      "source_location": "L1520",
       "target": "dailycloseview_gettransactionreportamount",
       "weight": 1
     },
@@ -4703,7 +4715,7 @@
       "relation": "calls",
       "source": "dailycloseview_getmetadatastringornumber",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1460",
+      "source_location": "L1511",
       "target": "dailycloseview_gettransactionreportidentifier",
       "weight": 1
     },
@@ -4715,7 +4727,7 @@
       "relation": "calls",
       "source": "dailycloseview_getmetadatastringornumber",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1482",
+      "source_location": "L1533",
       "target": "dailycloseview_gettransactionreportpayment",
       "weight": 1
     },
@@ -4727,7 +4739,7 @@
       "relation": "calls",
       "source": "dailycloseview_getmetadatastringornumber",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1477",
+      "source_location": "L1528",
       "target": "dailycloseview_gettransactionreportstaff",
       "weight": 1
     },
@@ -4739,7 +4751,7 @@
       "relation": "calls",
       "source": "dailycloseview_formattimestampmetadata",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1535",
+      "source_location": "L1586",
       "target": "dailycloseview_gettransactionreporttime",
       "weight": 1
     },
@@ -4751,7 +4763,7 @@
       "relation": "calls",
       "source": "dailycloseview_getmetadatastringornumber",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1531",
+      "source_location": "L1582",
       "target": "dailycloseview_gettransactionreporttime",
       "weight": 1
     },
@@ -4763,7 +4775,7 @@
       "relation": "calls",
       "source": "dailycloseview_getnumericmetadatavalue",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1530",
+      "source_location": "L1581",
       "target": "dailycloseview_gettransactionreporttime",
       "weight": 1
     },
@@ -4775,7 +4787,7 @@
       "relation": "calls",
       "source": "dailycloseview_normalizemetadatalabel",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L752",
+      "source_location": "L792",
       "target": "dailycloseview_ismoneymetadatalabel",
       "weight": 1
     },
@@ -4787,8 +4799,32 @@
       "relation": "calls",
       "source": "dailycloseview_normalizemetadatalabel",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L756",
+      "source_location": "L796",
       "target": "dailycloseview_istimestampmetadatalabel",
+      "weight": 1
+    },
+    {
+      "_src": "dailycloseview_isvarianceapprovalitem",
+      "_tgt": "dailycloseview_getmetadatastringvalue",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "dailycloseview_getmetadatastringvalue",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
+      "source_location": "L876",
+      "target": "dailycloseview_isvarianceapprovalitem",
+      "weight": 1
+    },
+    {
+      "_src": "dailycloseview_isvarianceapprovalitem",
+      "_tgt": "dailycloseview_normalizemetadatalabel",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "dailycloseview_normalizemetadatalabel",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
+      "source_location": "L872",
+      "target": "dailycloseview_isvarianceapprovalitem",
       "weight": 1
     },
     {
@@ -4799,7 +4835,7 @@
       "relation": "calls",
       "source": "dailycloseview_getexpensestaffcount",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1286",
+      "source_location": "L1337",
       "target": "dailycloseview_iszeroactivitydailyclose",
       "weight": 1
     },
@@ -4811,7 +4847,7 @@
       "relation": "calls",
       "source": "dailycloseview_getsummaryamount",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1288",
+      "source_location": "L1339",
       "target": "dailycloseview_iszeroactivitydailyclose",
       "weight": 1
     },
@@ -4823,7 +4859,7 @@
       "relation": "calls",
       "source": "dailycloseview_getsummarycount",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1271",
+      "source_location": "L1322",
       "target": "dailycloseview_iszeroactivitydailyclose",
       "weight": 1
     },
@@ -4835,7 +4871,7 @@
       "relation": "calls",
       "source": "dailycloseview_getsummaryregistervariancecount",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1287",
+      "source_location": "L1338",
       "target": "dailycloseview_iszeroactivitydailyclose",
       "weight": 1
     },
@@ -4847,7 +4883,7 @@
       "relation": "calls",
       "source": "dailycloseview_getnumericmetadatavalue",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L788",
+      "source_location": "L828",
       "target": "dailycloseview_shouldshowmetadataentry",
       "weight": 1
     },
@@ -4859,7 +4895,7 @@
       "relation": "calls",
       "source": "dailycloseview_normalizemetadatalabel",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L781",
+      "source_location": "L821",
       "target": "dailycloseview_shouldshowmetadataentry",
       "weight": 1
     },
@@ -5891,7 +5927,7 @@
       "relation": "calls",
       "source": "dailyoperationsview_getlocaloperatingdaterange",
       "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L1163",
+      "source_location": "L1165",
       "target": "dailyoperationsview_handleoperatingdatechange",
       "weight": 1
     },
@@ -5903,7 +5939,7 @@
       "relation": "calls",
       "source": "dailyoperationsview_getsaturdayweekendoperatingdate",
       "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L1164",
+      "source_location": "L1166",
       "target": "dailyoperationsview_handleoperatingdatechange",
       "weight": 1
     },
@@ -16019,7 +16055,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L628",
+      "source_location": "L648",
       "target": "dailyclose_approvalbelongstorange",
       "weight": 1
     },
@@ -16031,7 +16067,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L382",
+      "source_location": "L402",
       "target": "dailyclose_approvalrequesttypelabel",
       "weight": 1
     },
@@ -16043,7 +16079,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L478",
+      "source_location": "L498",
       "target": "dailyclose_ascarryforwarditem",
       "weight": 1
     },
@@ -16055,7 +16091,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L225",
+      "source_location": "L245",
       "target": "dailyclose_builddailycloseapprovalsubject",
       "weight": 1
     },
@@ -16067,7 +16103,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L236",
+      "source_location": "L256",
       "target": "dailyclose_builddailyclosecompletionapprovalrequirement",
       "weight": 1
     },
@@ -16079,7 +16115,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L892",
+      "source_location": "L912",
       "target": "dailyclose_builddailyclosereportsnapshot",
       "weight": 1
     },
@@ -16091,7 +16127,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1014",
+      "source_location": "L1034",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -16103,7 +16139,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L458",
+      "source_location": "L478",
       "target": "dailyclose_buildexpensesessionsbyid",
       "weight": 1
     },
@@ -16115,7 +16151,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L807",
+      "source_location": "L827",
       "target": "dailyclose_buildpaymenttotals",
       "weight": 1
     },
@@ -16127,7 +16163,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L854",
+      "source_location": "L874",
       "target": "dailyclose_buildreadiness",
       "weight": 1
     },
@@ -16139,7 +16175,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L438",
+      "source_location": "L458",
       "target": "dailyclose_buildregistersessionsbyid",
       "weight": 1
     },
@@ -16151,7 +16187,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L418",
+      "source_location": "L438",
       "target": "dailyclose_buildstaffnamesbyid",
       "weight": 1
     },
@@ -16163,7 +16199,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L398",
+      "source_location": "L418",
       "target": "dailyclose_buildterminallabelsbyid",
       "weight": 1
     },
@@ -16175,7 +16211,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L836",
+      "source_location": "L856",
       "target": "dailyclose_cashdeltasbyregistersessionid",
       "weight": 1
     },
@@ -16187,7 +16223,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1828",
+      "source_location": "L1849",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -16199,7 +16235,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1752",
+      "source_location": "L1773",
       "target": "dailyclose_createcarryforwardworkitems",
       "weight": 1
     },
@@ -16211,7 +16247,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L990",
+      "source_location": "L1010",
       "target": "dailyclose_emptysummary",
       "weight": 1
     },
@@ -16223,7 +16259,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L354",
+      "source_location": "L374",
       "target": "dailyclose_formatpaymentmethodlabel",
       "weight": 1
     },
@@ -16235,7 +16271,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2165",
+      "source_location": "L2186",
       "target": "dailyclose_getcompleteddailyclosehistorydetailwithctx",
       "weight": 1
     },
@@ -16247,7 +16283,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L963",
+      "source_location": "L983",
       "target": "dailyclose_getdailyclosecompletioneventstaffprofileid",
       "weight": 1
     },
@@ -16259,7 +16295,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L507",
+      "source_location": "L527",
       "target": "dailyclose_getdailyclosefordate",
       "weight": 1
     },
@@ -16271,7 +16307,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2080",
+      "source_location": "L2101",
       "target": "dailyclose_getdailycloseopeningcontextwithctx",
       "weight": 1
     },
@@ -16283,7 +16319,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L522",
+      "source_location": "L542",
       "target": "dailyclose_getpriorcompleteddailyclose",
       "weight": 1
     },
@@ -16295,7 +16331,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L500",
+      "source_location": "L520",
       "target": "dailyclose_getstore",
       "weight": 1
     },
@@ -16307,7 +16343,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L318",
+      "source_location": "L338",
       "target": "dailyclose_isinrange",
       "weight": 1
     },
@@ -16319,7 +16355,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L286",
+      "source_location": "L306",
       "target": "dailyclose_isvalidoperatingdaterange",
       "weight": 1
     },
@@ -16331,7 +16367,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L544",
+      "source_location": "L564",
       "target": "dailyclose_listactiveregistersessions",
       "weight": 1
     },
@@ -16343,7 +16379,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L562",
+      "source_location": "L582",
       "target": "dailyclose_listclosedregistersessionsforday",
       "weight": 1
     },
@@ -16355,7 +16391,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2116",
+      "source_location": "L2137",
       "target": "dailyclose_listcompleteddailyclosehistorywithctx",
       "weight": 1
     },
@@ -16367,7 +16403,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L785",
+      "source_location": "L805",
       "target": "dailyclose_listdepositsforday",
       "weight": 1
     },
@@ -16379,7 +16415,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L765",
+      "source_location": "L785",
       "target": "dailyclose_listexpensesforday",
       "weight": 1
     },
@@ -16391,7 +16427,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L730",
+      "source_location": "L750",
       "target": "dailyclose_listopenoperationalworkitems",
       "weight": 1
     },
@@ -16403,7 +16439,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L702",
+      "source_location": "L722",
       "target": "dailyclose_listopenpossessions",
       "weight": 1
     },
@@ -16415,7 +16451,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L668",
+      "source_location": "L688",
       "target": "dailyclose_listpendingcloseoutapprovals",
       "weight": 1
     },
@@ -16427,7 +16463,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L744",
+      "source_location": "L764",
       "target": "dailyclose_listtransactionsforday",
       "weight": 1
     },
@@ -16439,7 +16475,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1805",
+      "source_location": "L1826",
       "target": "dailyclose_markotherdailyclosesnotcurrent",
       "weight": 1
     },
@@ -16451,7 +16487,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L378",
+      "source_location": "L398",
       "target": "dailyclose_nonzerovariancemetadata",
       "weight": 1
     },
@@ -16463,7 +16499,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L143",
+      "source_location": "L163",
       "target": "dailyclose_normalizecompleteddailyclosesnapshot",
       "weight": 1
     },
@@ -16475,7 +16511,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L612",
+      "source_location": "L632",
       "target": "dailyclose_possessionintersectsrange",
       "weight": 1
     },
@@ -16487,7 +16523,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L341",
+      "source_location": "L361",
       "target": "dailyclose_registermetadatalabel",
       "weight": 1
     },
@@ -16499,7 +16535,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L596",
+      "source_location": "L616",
       "target": "dailyclose_registersessionbelongstorange",
       "weight": 1
     },
@@ -16511,7 +16547,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L322",
+      "source_location": "L342",
       "target": "dailyclose_registersessioncloseoutoperatingat",
       "weight": 1
     },
@@ -16523,7 +16559,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L586",
+      "source_location": "L606",
       "target": "dailyclose_registersessionintersectsrange",
       "weight": 1
     },
@@ -16535,7 +16571,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L333",
+      "source_location": "L353",
       "target": "dailyclose_registersessionlabel",
       "weight": 1
     },
@@ -16547,7 +16583,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L297",
+      "source_location": "L317",
       "target": "dailyclose_resolveoperatingdaterange",
       "weight": 1
     },
@@ -16559,7 +16595,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L269",
+      "source_location": "L289",
       "target": "dailyclose_safeoperatingdaterange",
       "weight": 1
     },
@@ -16571,8 +16607,20 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L930",
+      "source_location": "L950",
       "target": "dailyclose_snapshotrevieweditems",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_convex_operations_dailyclose_ts",
+      "_tgt": "dailyclose_sortdailycloseblockers",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
+      "source_location": "L126",
+      "target": "dailyclose_sortdailycloseblockers",
       "weight": 1
     },
     {
@@ -16583,7 +16631,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L942",
+      "source_location": "L962",
       "target": "dailyclose_todailyclosehistorylistitem",
       "weight": 1
     },
@@ -16595,7 +16643,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L825",
+      "source_location": "L845",
       "target": "dailyclose_transactioncashdelta",
       "weight": 1
     },
@@ -16607,7 +16655,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L360",
+      "source_location": "L380",
       "target": "dailyclose_transactionpaymentsummary",
       "weight": 1
     },
@@ -16619,7 +16667,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L264",
+      "source_location": "L284",
       "target": "dailyclose_trimoptional",
       "weight": 1
     },
@@ -16631,7 +16679,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L884",
+      "source_location": "L904",
       "target": "dailyclose_uniquedailycloseitems",
       "weight": 1
     },
@@ -16643,7 +16691,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L874",
+      "source_location": "L894",
       "target": "dailyclose_uniquesourcesubjects",
       "weight": 1
     },
@@ -16655,7 +16703,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1724",
+      "source_location": "L1745",
       "target": "dailyclose_validatecarryforwardworkitemids",
       "weight": 1
     },
@@ -28312,6 +28360,18 @@
       "weight": 1
     },
     {
+      "_src": "packages_athena_webapp_src_components_landing_athenalandingpage_tsx",
+      "_tgt": "athenalandingpage_reveal",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_components_landing_athenalandingpage_tsx",
+      "source_file": "packages/athena-webapp/src/components/landing/AthenaLandingPage.tsx",
+      "source_location": "L88",
+      "target": "athenalandingpage_reveal",
+      "weight": 1
+    },
+    {
       "_src": "packages_athena_webapp_src_components_navbar_tsx",
       "_tgt": "navbar_appheader",
       "confidence": "EXTRACTED",
@@ -28667,7 +28727,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L480",
+      "source_location": "L520",
       "target": "dailycloseview_builddailyclosetransactionsearch",
       "weight": 1
     },
@@ -28679,8 +28739,20 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L2417",
+      "source_location": "L2475",
       "target": "dailycloseview_cn",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
+      "_tgt": "dailycloseview_dailyclosestatustitle",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
+      "source_location": "L373",
+      "target": "dailycloseview_dailyclosestatustitle",
       "weight": 1
     },
     {
@@ -28691,7 +28763,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L337",
+      "source_location": "L338",
       "target": "dailycloseview_formatcarriedoverregistercount",
       "weight": 1
     },
@@ -28703,7 +28775,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L320",
+      "source_location": "L321",
       "target": "dailycloseview_formatchecklistcount",
       "weight": 1
     },
@@ -28715,7 +28787,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L460",
+      "source_location": "L500",
       "target": "dailycloseview_formatdailyclosecompletedat",
       "weight": 1
     },
@@ -28727,7 +28799,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L2766",
+      "source_location": "L2833",
       "target": "dailycloseview_formatdailyclosemoney",
       "weight": 1
     },
@@ -28739,7 +28811,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L426",
+      "source_location": "L466",
       "target": "dailycloseview_formatdailycloseoperatingdate",
       "weight": 1
     },
@@ -28751,7 +28823,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L310",
+      "source_location": "L311",
       "target": "dailycloseview_formatentitycount",
       "weight": 1
     },
@@ -28763,7 +28835,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L393",
+      "source_location": "L433",
       "target": "dailycloseview_formatexpensetransactioncount",
       "weight": 1
     },
@@ -28775,7 +28847,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L895",
+      "source_location": "L946",
       "target": "dailycloseview_formatmetadatadisplayvalue",
       "weight": 1
     },
@@ -28787,7 +28859,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L839",
+      "source_location": "L890",
       "target": "dailycloseview_formatmetadatavalue",
       "weight": 1
     },
@@ -28799,7 +28871,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L399",
+      "source_location": "L439",
       "target": "dailycloseview_formatpossalecount",
       "weight": 1
     },
@@ -28811,7 +28883,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L343",
+      "source_location": "L344",
       "target": "dailycloseview_formatregistervariancecount",
       "weight": 1
     },
@@ -28823,7 +28895,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L795",
+      "source_location": "L835",
       "target": "dailycloseview_formattimestampmetadata",
       "weight": 1
     },
@@ -28835,7 +28907,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L331",
+      "source_location": "L332",
       "target": "dailycloseview_formattodaycashtransactioncount",
       "weight": 1
     },
@@ -28847,7 +28919,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L405",
+      "source_location": "L445",
       "target": "dailycloseview_formatvoidedsalecount",
       "weight": 1
     },
@@ -28859,7 +28931,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1381",
+      "source_location": "L1432",
       "target": "dailycloseview_getbucketconfigs",
       "weight": 1
     },
@@ -28871,7 +28943,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L381",
+      "source_location": "L421",
       "target": "dailycloseview_getbucketcountclassname",
       "weight": 1
     },
@@ -28883,7 +28955,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L573",
+      "source_location": "L613",
       "target": "dailycloseview_getcarryforwardworkitemid",
       "weight": 1
     },
@@ -28895,7 +28967,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L579",
+      "source_location": "L619",
       "target": "dailycloseview_getcarryforwardworkitemids",
       "weight": 1
     },
@@ -28907,7 +28979,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1170",
+      "source_location": "L1221",
       "target": "dailycloseview_getcollapsedmetadataentries",
       "weight": 1
     },
@@ -28919,7 +28991,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L300",
+      "source_location": "L301",
       "target": "dailycloseview_getdailycloseapi",
       "weight": 1
     },
@@ -28931,7 +29003,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L494",
+      "source_location": "L534",
       "target": "dailycloseview_getdailyclosesalesmetriclabels",
       "weight": 1
     },
@@ -28943,7 +29015,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L547",
+      "source_location": "L587",
       "target": "dailycloseview_getdailyclosestatus",
       "weight": 1
     },
@@ -28955,7 +29027,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1358",
+      "source_location": "L1409",
       "target": "dailycloseview_getdefaultbucketvalue",
       "weight": 1
     },
@@ -28967,7 +29039,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L805",
+      "source_location": "L845",
       "target": "dailycloseview_getdisplaymetadatalabel",
       "weight": 1
     },
@@ -28979,7 +29051,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1239",
+      "source_location": "L1290",
       "target": "dailycloseview_getexpensestaffcount",
       "weight": 1
     },
@@ -28991,7 +29063,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1251",
+      "source_location": "L1302",
       "target": "dailycloseview_getexpensetransactioncount",
       "weight": 1
     },
@@ -29003,7 +29075,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L593",
+      "source_location": "L633",
       "target": "dailycloseview_getitemcontextlabel",
       "weight": 1
     },
@@ -29015,7 +29087,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L583",
+      "source_location": "L623",
       "target": "dailycloseview_getitemdescription",
       "weight": 1
     },
@@ -29027,7 +29099,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L561",
+      "source_location": "L601",
       "target": "dailycloseview_getitemid",
       "weight": 1
     },
@@ -29039,7 +29111,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L441",
+      "source_location": "L481",
       "target": "dailycloseview_getlocaldatefromoperatingdate",
       "weight": 1
     },
@@ -29051,7 +29123,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L472",
+      "source_location": "L512",
       "target": "dailycloseview_getlocaloperatingdate",
       "weight": 1
     },
@@ -29063,7 +29135,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L503",
+      "source_location": "L543",
       "target": "dailycloseview_getlocaloperatingdaterange",
       "weight": 1
     },
@@ -29075,7 +29147,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L522",
+      "source_location": "L562",
       "target": "dailycloseview_getlocaloperatingdaterangefromsearch",
       "weight": 1
     },
@@ -29087,7 +29159,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L977",
+      "source_location": "L1028",
       "target": "dailycloseview_getmetadataentries",
       "weight": 1
     },
@@ -29099,7 +29171,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1448",
+      "source_location": "L1499",
       "target": "dailycloseview_getmetadatastringornumber",
       "weight": 1
     },
@@ -29111,7 +29183,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L821",
+      "source_location": "L861",
       "target": "dailycloseview_getmetadatastringvalue",
       "weight": 1
     },
@@ -29123,7 +29195,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L831",
+      "source_location": "L882",
       "target": "dailycloseview_getmetadatavalue",
       "weight": 1
     },
@@ -29135,7 +29207,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L767",
+      "source_location": "L807",
       "target": "dailycloseview_getnumericmetadatavalue",
       "weight": 1
     },
@@ -29147,7 +29219,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L569",
+      "source_location": "L609",
       "target": "dailycloseview_getrevieweditemkeys",
       "weight": 1
     },
@@ -29159,7 +29231,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1304",
+      "source_location": "L1355",
       "target": "dailycloseview_getstatusdisplaycopy",
       "weight": 1
     },
@@ -29171,7 +29243,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L349",
+      "source_location": "L350",
       "target": "dailycloseview_getstatuslabelclassname",
       "weight": 1
     },
@@ -29183,7 +29255,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L372",
+      "source_location": "L412",
       "target": "dailycloseview_getstatusrailbadgeclassname",
       "weight": 1
     },
@@ -29195,7 +29267,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L361",
+      "source_location": "L362",
       "target": "dailycloseview_getstatusrailiconclassname",
       "weight": 1
     },
@@ -29207,7 +29279,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L2786",
+      "source_location": "L2853",
       "target": "dailycloseview_getsummaryamount",
       "weight": 1
     },
@@ -29219,7 +29291,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1209",
+      "source_location": "L1260",
       "target": "dailycloseview_getsummarycount",
       "weight": 1
     },
@@ -29231,7 +29303,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1224",
+      "source_location": "L1275",
       "target": "dailycloseview_getsummaryregistervariancecount",
       "weight": 1
     },
@@ -29243,7 +29315,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1468",
+      "source_location": "L1519",
       "target": "dailycloseview_gettransactionreportamount",
       "weight": 1
     },
@@ -29255,7 +29327,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1458",
+      "source_location": "L1509",
       "target": "dailycloseview_gettransactionreportidentifier",
       "weight": 1
     },
@@ -29267,7 +29339,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1429",
+      "source_location": "L1480",
       "target": "dailycloseview_gettransactionreportitems",
       "weight": 1
     },
@@ -29279,7 +29351,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1538",
+      "source_location": "L1589",
       "target": "dailycloseview_gettransactionreportlink",
       "weight": 1
     },
@@ -29291,7 +29363,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1481",
+      "source_location": "L1532",
       "target": "dailycloseview_gettransactionreportpayment",
       "weight": 1
     },
@@ -29303,7 +29375,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1476",
+      "source_location": "L1527",
       "target": "dailycloseview_gettransactionreportstaff",
       "weight": 1
     },
@@ -29315,7 +29387,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1529",
+      "source_location": "L1580",
       "target": "dailycloseview_gettransactionreporttime",
       "weight": 1
     },
@@ -29327,7 +29399,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L759",
+      "source_location": "L799",
       "target": "dailycloseview_getvariancetone",
       "weight": 1
     },
@@ -29339,7 +29411,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1773",
+      "source_location": "L1830",
       "target": "dailycloseview_handlepagechange",
       "weight": 1
     },
@@ -29351,7 +29423,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L601",
+      "source_location": "L641",
       "target": "dailycloseview_humanizemetadatalabel",
       "weight": 1
     },
@@ -29363,7 +29435,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L751",
+      "source_location": "L791",
       "target": "dailycloseview_ismoneymetadatalabel",
       "weight": 1
     },
@@ -29375,8 +29447,20 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L755",
+      "source_location": "L795",
       "target": "dailycloseview_istimestampmetadatalabel",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
+      "_tgt": "dailycloseview_isvarianceapprovalitem",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
+      "source_location": "L871",
+      "target": "dailycloseview_isvarianceapprovalitem",
       "weight": 1
     },
     {
@@ -29387,7 +29471,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1265",
+      "source_location": "L1316",
       "target": "dailycloseview_iszeroactivitydailyclose",
       "weight": 1
     },
@@ -29399,7 +29483,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1368",
+      "source_location": "L1419",
       "target": "dailycloseview_normalizebuckettab",
       "weight": 1
     },
@@ -29411,7 +29495,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L534",
+      "source_location": "L574",
       "target": "dailycloseview_normalizecommandmessage",
       "weight": 1
     },
@@ -29423,7 +29507,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1320",
+      "source_location": "L1371",
       "target": "dailycloseview_normalizecompletedreportsnapshot",
       "weight": 1
     },
@@ -29435,7 +29519,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L747",
+      "source_location": "L787",
       "target": "dailycloseview_normalizemetadatalabel",
       "weight": 1
     },
@@ -29447,7 +29531,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1375",
+      "source_location": "L1426",
       "target": "dailycloseview_normalizepage",
       "weight": 1
     },
@@ -29459,7 +29543,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1494",
+      "source_location": "L1545",
       "target": "dailycloseview_normalizetransactionreportpaymentmethod",
       "weight": 1
     },
@@ -29471,7 +29555,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L411",
+      "source_location": "L451",
       "target": "dailycloseview_sentencefragment",
       "weight": 1
     },
@@ -29483,7 +29567,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L587",
+      "source_location": "L627",
       "target": "dailycloseview_shouldshowcollapseddescription",
       "weight": 1
     },
@@ -29495,8 +29579,20 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L780",
+      "source_location": "L820",
       "target": "dailycloseview_shouldshowmetadataentry",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
+      "_tgt": "dailycloseview_successcheckicon",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
+      "source_location": "L390",
+      "target": "dailycloseview_successcheckicon",
       "weight": 1
     },
     {
@@ -29507,7 +29603,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1501",
+      "source_location": "L1552",
       "target": "dailycloseview_transactionreportpaymenticon",
       "weight": 1
     },
@@ -30347,7 +30443,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailyoperationsview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L901",
+      "source_location": "L903",
       "target": "dailyoperationsview_getworkflowsearch",
       "weight": 1
     },
@@ -30359,7 +30455,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailyoperationsview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L1162",
+      "source_location": "L1164",
       "target": "dailyoperationsview_handleoperatingdatechange",
       "weight": 1
     },
@@ -60649,7 +60745,7 @@
       "label": "buildDailyCloseTransactionSearch()",
       "norm_label": "builddailyclosetransactionsearch()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L480"
+      "source_location": "L520"
     },
     {
       "community": 0,
@@ -60658,7 +60754,16 @@
       "label": "cn()",
       "norm_label": "cn()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1895"
+      "source_location": "L1952"
+    },
+    {
+      "community": 0,
+      "file_type": "code",
+      "id": "dailycloseview_dailyclosestatustitle",
+      "label": "DailyCloseStatusTitle()",
+      "norm_label": "dailyclosestatustitle()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
+      "source_location": "L373"
     },
     {
       "community": 0,
@@ -60667,7 +60772,7 @@
       "label": "formatCarriedOverRegisterCount()",
       "norm_label": "formatcarriedoverregistercount()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L337"
+      "source_location": "L338"
     },
     {
       "community": 0,
@@ -60676,7 +60781,7 @@
       "label": "formatChecklistCount()",
       "norm_label": "formatchecklistcount()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L320"
+      "source_location": "L321"
     },
     {
       "community": 0,
@@ -60685,7 +60790,7 @@
       "label": "formatDailyCloseCompletedAt()",
       "norm_label": "formatdailyclosecompletedat()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L460"
+      "source_location": "L500"
     },
     {
       "community": 0,
@@ -60694,7 +60799,7 @@
       "label": "formatDailyCloseMoney()",
       "norm_label": "formatdailyclosemoney()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L415"
+      "source_location": "L455"
     },
     {
       "community": 0,
@@ -60703,7 +60808,7 @@
       "label": "formatDailyCloseOperatingDate()",
       "norm_label": "formatdailycloseoperatingdate()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L426"
+      "source_location": "L466"
     },
     {
       "community": 0,
@@ -60712,7 +60817,7 @@
       "label": "formatEntityCount()",
       "norm_label": "formatentitycount()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L310"
+      "source_location": "L311"
     },
     {
       "community": 0,
@@ -60721,7 +60826,7 @@
       "label": "formatExpenseTransactionCount()",
       "norm_label": "formatexpensetransactioncount()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L393"
+      "source_location": "L433"
     },
     {
       "community": 0,
@@ -60730,7 +60835,7 @@
       "label": "formatMetadataDisplayValue()",
       "norm_label": "formatmetadatadisplayvalue()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L895"
+      "source_location": "L946"
     },
     {
       "community": 0,
@@ -60739,7 +60844,7 @@
       "label": "formatMetadataValue()",
       "norm_label": "formatmetadatavalue()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L839"
+      "source_location": "L890"
     },
     {
       "community": 0,
@@ -60748,7 +60853,7 @@
       "label": "formatPosSaleCount()",
       "norm_label": "formatpossalecount()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L399"
+      "source_location": "L439"
     },
     {
       "community": 0,
@@ -60757,7 +60862,7 @@
       "label": "formatRegisterVarianceCount()",
       "norm_label": "formatregistervariancecount()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L343"
+      "source_location": "L344"
     },
     {
       "community": 0,
@@ -60766,7 +60871,7 @@
       "label": "formatTimestampMetadata()",
       "norm_label": "formattimestampmetadata()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L795"
+      "source_location": "L835"
     },
     {
       "community": 0,
@@ -60775,7 +60880,7 @@
       "label": "formatTodayCashTransactionCount()",
       "norm_label": "formattodaycashtransactioncount()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L331"
+      "source_location": "L332"
     },
     {
       "community": 0,
@@ -60784,7 +60889,7 @@
       "label": "formatVoidedSaleCount()",
       "norm_label": "formatvoidedsalecount()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L405"
+      "source_location": "L445"
     },
     {
       "community": 0,
@@ -60793,7 +60898,7 @@
       "label": "getBucketConfigs()",
       "norm_label": "getbucketconfigs()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1381"
+      "source_location": "L1432"
     },
     {
       "community": 0,
@@ -60802,7 +60907,7 @@
       "label": "getBucketCountClassName()",
       "norm_label": "getbucketcountclassname()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L381"
+      "source_location": "L421"
     },
     {
       "community": 0,
@@ -60811,7 +60916,7 @@
       "label": "getCarryForwardWorkItemId()",
       "norm_label": "getcarryforwardworkitemid()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L573"
+      "source_location": "L613"
     },
     {
       "community": 0,
@@ -60820,7 +60925,7 @@
       "label": "getCarryForwardWorkItemIds()",
       "norm_label": "getcarryforwardworkitemids()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L579"
+      "source_location": "L619"
     },
     {
       "community": 0,
@@ -60829,7 +60934,7 @@
       "label": "getCollapsedMetadataEntries()",
       "norm_label": "getcollapsedmetadataentries()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1170"
+      "source_location": "L1221"
     },
     {
       "community": 0,
@@ -60838,7 +60943,7 @@
       "label": "getDailyCloseApi()",
       "norm_label": "getdailycloseapi()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L300"
+      "source_location": "L301"
     },
     {
       "community": 0,
@@ -60847,7 +60952,7 @@
       "label": "getDailyCloseSalesMetricLabels()",
       "norm_label": "getdailyclosesalesmetriclabels()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L494"
+      "source_location": "L534"
     },
     {
       "community": 0,
@@ -60856,7 +60961,7 @@
       "label": "getDailyCloseStatus()",
       "norm_label": "getdailyclosestatus()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L547"
+      "source_location": "L587"
     },
     {
       "community": 0,
@@ -60865,7 +60970,7 @@
       "label": "getDefaultBucketValue()",
       "norm_label": "getdefaultbucketvalue()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1358"
+      "source_location": "L1409"
     },
     {
       "community": 0,
@@ -60874,7 +60979,7 @@
       "label": "getDisplayMetadataLabel()",
       "norm_label": "getdisplaymetadatalabel()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L805"
+      "source_location": "L845"
     },
     {
       "community": 0,
@@ -60883,7 +60988,7 @@
       "label": "getExpenseStaffCount()",
       "norm_label": "getexpensestaffcount()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1239"
+      "source_location": "L1290"
     },
     {
       "community": 0,
@@ -60892,7 +60997,7 @@
       "label": "getExpenseTransactionCount()",
       "norm_label": "getexpensetransactioncount()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1251"
+      "source_location": "L1302"
     },
     {
       "community": 0,
@@ -60901,7 +61006,7 @@
       "label": "getItemContextLabel()",
       "norm_label": "getitemcontextlabel()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L593"
+      "source_location": "L633"
     },
     {
       "community": 0,
@@ -60910,7 +61015,7 @@
       "label": "getItemDescription()",
       "norm_label": "getitemdescription()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L583"
+      "source_location": "L623"
     },
     {
       "community": 0,
@@ -60919,7 +61024,7 @@
       "label": "getItemId()",
       "norm_label": "getitemid()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L561"
+      "source_location": "L601"
     },
     {
       "community": 0,
@@ -60928,7 +61033,7 @@
       "label": "getLocalDateFromOperatingDate()",
       "norm_label": "getlocaldatefromoperatingdate()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L441"
+      "source_location": "L481"
     },
     {
       "community": 0,
@@ -60937,7 +61042,7 @@
       "label": "getLocalOperatingDate()",
       "norm_label": "getlocaloperatingdate()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L472"
+      "source_location": "L512"
     },
     {
       "community": 0,
@@ -60946,7 +61051,7 @@
       "label": "getLocalOperatingDateRange()",
       "norm_label": "getlocaloperatingdaterange()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L503"
+      "source_location": "L543"
     },
     {
       "community": 0,
@@ -60955,7 +61060,7 @@
       "label": "getLocalOperatingDateRangeFromSearch()",
       "norm_label": "getlocaloperatingdaterangefromsearch()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L522"
+      "source_location": "L562"
     },
     {
       "community": 0,
@@ -60964,7 +61069,7 @@
       "label": "getMetadataEntries()",
       "norm_label": "getmetadataentries()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L977"
+      "source_location": "L1028"
     },
     {
       "community": 0,
@@ -60973,7 +61078,7 @@
       "label": "getMetadataStringOrNumber()",
       "norm_label": "getmetadatastringornumber()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1448"
+      "source_location": "L1499"
     },
     {
       "community": 0,
@@ -60982,7 +61087,7 @@
       "label": "getMetadataStringValue()",
       "norm_label": "getmetadatastringvalue()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L821"
+      "source_location": "L861"
     },
     {
       "community": 0,
@@ -60991,7 +61096,7 @@
       "label": "getMetadataValue()",
       "norm_label": "getmetadatavalue()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L831"
+      "source_location": "L882"
     },
     {
       "community": 0,
@@ -61000,7 +61105,7 @@
       "label": "getNumericMetadataValue()",
       "norm_label": "getnumericmetadatavalue()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L767"
+      "source_location": "L807"
     },
     {
       "community": 0,
@@ -61009,7 +61114,7 @@
       "label": "getReviewedItemKeys()",
       "norm_label": "getrevieweditemkeys()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L569"
+      "source_location": "L609"
     },
     {
       "community": 0,
@@ -61018,7 +61123,7 @@
       "label": "getStatusDisplayCopy()",
       "norm_label": "getstatusdisplaycopy()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1304"
+      "source_location": "L1355"
     },
     {
       "community": 0,
@@ -61027,7 +61132,7 @@
       "label": "getStatusLabelClassName()",
       "norm_label": "getstatuslabelclassname()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L349"
+      "source_location": "L350"
     },
     {
       "community": 0,
@@ -61036,7 +61141,7 @@
       "label": "getStatusRailBadgeClassName()",
       "norm_label": "getstatusrailbadgeclassname()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L372"
+      "source_location": "L412"
     },
     {
       "community": 0,
@@ -61045,7 +61150,7 @@
       "label": "getStatusRailIconClassName()",
       "norm_label": "getstatusrailiconclassname()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L361"
+      "source_location": "L362"
     },
     {
       "community": 0,
@@ -61054,7 +61159,7 @@
       "label": "getSummaryAmount()",
       "norm_label": "getsummaryamount()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1194"
+      "source_location": "L1245"
     },
     {
       "community": 0,
@@ -61063,7 +61168,7 @@
       "label": "getSummaryCount()",
       "norm_label": "getsummarycount()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1209"
+      "source_location": "L1260"
     },
     {
       "community": 0,
@@ -61072,7 +61177,7 @@
       "label": "getSummaryRegisterVarianceCount()",
       "norm_label": "getsummaryregistervariancecount()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1224"
+      "source_location": "L1275"
     },
     {
       "community": 0,
@@ -61081,7 +61186,7 @@
       "label": "getTransactionReportAmount()",
       "norm_label": "gettransactionreportamount()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1468"
+      "source_location": "L1519"
     },
     {
       "community": 0,
@@ -61090,7 +61195,7 @@
       "label": "getTransactionReportIdentifier()",
       "norm_label": "gettransactionreportidentifier()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1458"
+      "source_location": "L1509"
     },
     {
       "community": 0,
@@ -61099,7 +61204,7 @@
       "label": "getTransactionReportItems()",
       "norm_label": "gettransactionreportitems()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1429"
+      "source_location": "L1480"
     },
     {
       "community": 0,
@@ -61108,7 +61213,7 @@
       "label": "getTransactionReportLink()",
       "norm_label": "gettransactionreportlink()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1538"
+      "source_location": "L1589"
     },
     {
       "community": 0,
@@ -61117,7 +61222,7 @@
       "label": "getTransactionReportPayment()",
       "norm_label": "gettransactionreportpayment()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1481"
+      "source_location": "L1532"
     },
     {
       "community": 0,
@@ -61126,7 +61231,7 @@
       "label": "getTransactionReportStaff()",
       "norm_label": "gettransactionreportstaff()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1476"
+      "source_location": "L1527"
     },
     {
       "community": 0,
@@ -61135,7 +61240,7 @@
       "label": "getTransactionReportTime()",
       "norm_label": "gettransactionreporttime()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1529"
+      "source_location": "L1580"
     },
     {
       "community": 0,
@@ -61144,7 +61249,7 @@
       "label": "getVarianceTone()",
       "norm_label": "getvariancetone()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L759"
+      "source_location": "L799"
     },
     {
       "community": 0,
@@ -61153,7 +61258,7 @@
       "label": "handlePageChange()",
       "norm_label": "handlepagechange()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1773"
+      "source_location": "L1830"
     },
     {
       "community": 0,
@@ -61162,7 +61267,7 @@
       "label": "humanizeMetadataLabel()",
       "norm_label": "humanizemetadatalabel()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L601"
+      "source_location": "L641"
     },
     {
       "community": 0,
@@ -61171,7 +61276,7 @@
       "label": "isMoneyMetadataLabel()",
       "norm_label": "ismoneymetadatalabel()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L751"
+      "source_location": "L791"
     },
     {
       "community": 0,
@@ -61180,7 +61285,16 @@
       "label": "isTimestampMetadataLabel()",
       "norm_label": "istimestampmetadatalabel()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L755"
+      "source_location": "L795"
+    },
+    {
+      "community": 0,
+      "file_type": "code",
+      "id": "dailycloseview_isvarianceapprovalitem",
+      "label": "isVarianceApprovalItem()",
+      "norm_label": "isvarianceapprovalitem()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
+      "source_location": "L871"
     },
     {
       "community": 0,
@@ -61189,7 +61303,7 @@
       "label": "isZeroActivityDailyClose()",
       "norm_label": "iszeroactivitydailyclose()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1265"
+      "source_location": "L1316"
     },
     {
       "community": 0,
@@ -61198,7 +61312,7 @@
       "label": "normalizeBucketTab()",
       "norm_label": "normalizebuckettab()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1368"
+      "source_location": "L1419"
     },
     {
       "community": 0,
@@ -61207,7 +61321,7 @@
       "label": "normalizeCommandMessage()",
       "norm_label": "normalizecommandmessage()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L534"
+      "source_location": "L574"
     },
     {
       "community": 0,
@@ -61216,7 +61330,7 @@
       "label": "normalizeCompletedReportSnapshot()",
       "norm_label": "normalizecompletedreportsnapshot()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1320"
+      "source_location": "L1371"
     },
     {
       "community": 0,
@@ -61225,7 +61339,7 @@
       "label": "normalizeMetadataLabel()",
       "norm_label": "normalizemetadatalabel()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L747"
+      "source_location": "L787"
     },
     {
       "community": 0,
@@ -61234,7 +61348,7 @@
       "label": "normalizePage()",
       "norm_label": "normalizepage()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1375"
+      "source_location": "L1426"
     },
     {
       "community": 0,
@@ -61243,7 +61357,7 @@
       "label": "normalizeTransactionReportPaymentMethod()",
       "norm_label": "normalizetransactionreportpaymentmethod()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1494"
+      "source_location": "L1545"
     },
     {
       "community": 0,
@@ -61252,7 +61366,7 @@
       "label": "sentenceFragment()",
       "norm_label": "sentencefragment()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L411"
+      "source_location": "L451"
     },
     {
       "community": 0,
@@ -61261,7 +61375,7 @@
       "label": "shouldShowCollapsedDescription()",
       "norm_label": "shouldshowcollapseddescription()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L587"
+      "source_location": "L627"
     },
     {
       "community": 0,
@@ -61270,7 +61384,16 @@
       "label": "shouldShowMetadataEntry()",
       "norm_label": "shouldshowmetadataentry()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L780"
+      "source_location": "L820"
+    },
+    {
+      "community": 0,
+      "file_type": "code",
+      "id": "dailycloseview_successcheckicon",
+      "label": "SuccessCheckIcon()",
+      "norm_label": "successcheckicon()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
+      "source_location": "L390"
     },
     {
       "community": 0,
@@ -61279,7 +61402,7 @@
       "label": "TransactionReportPaymentIcon()",
       "norm_label": "transactionreportpaymenticon()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1501"
+      "source_location": "L1552"
     },
     {
       "community": 0,
@@ -61297,7 +61420,7 @@
       "label": "approvalBelongsToRange()",
       "norm_label": "approvalbelongstorange()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L628"
+      "source_location": "L648"
     },
     {
       "community": 1,
@@ -61306,7 +61429,7 @@
       "label": "approvalRequestTypeLabel()",
       "norm_label": "approvalrequesttypelabel()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L382"
+      "source_location": "L402"
     },
     {
       "community": 1,
@@ -61315,7 +61438,7 @@
       "label": "asCarryForwardItem()",
       "norm_label": "ascarryforwarditem()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L478"
+      "source_location": "L498"
     },
     {
       "community": 1,
@@ -61324,7 +61447,7 @@
       "label": "buildDailyCloseApprovalSubject()",
       "norm_label": "builddailycloseapprovalsubject()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L225"
+      "source_location": "L245"
     },
     {
       "community": 1,
@@ -61333,7 +61456,7 @@
       "label": "buildDailyCloseCompletionApprovalRequirement()",
       "norm_label": "builddailyclosecompletionapprovalrequirement()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L236"
+      "source_location": "L256"
     },
     {
       "community": 1,
@@ -61342,7 +61465,7 @@
       "label": "buildDailyCloseReportSnapshot()",
       "norm_label": "builddailyclosereportsnapshot()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L892"
+      "source_location": "L912"
     },
     {
       "community": 1,
@@ -61351,7 +61474,7 @@
       "label": "buildDailyCloseSnapshotWithCtx()",
       "norm_label": "builddailyclosesnapshotwithctx()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1014"
+      "source_location": "L1034"
     },
     {
       "community": 1,
@@ -61360,7 +61483,7 @@
       "label": "buildExpenseSessionsById()",
       "norm_label": "buildexpensesessionsbyid()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L458"
+      "source_location": "L478"
     },
     {
       "community": 1,
@@ -61369,7 +61492,7 @@
       "label": "buildPaymentTotals()",
       "norm_label": "buildpaymenttotals()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L807"
+      "source_location": "L827"
     },
     {
       "community": 1,
@@ -61378,7 +61501,7 @@
       "label": "buildReadiness()",
       "norm_label": "buildreadiness()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L854"
+      "source_location": "L874"
     },
     {
       "community": 1,
@@ -61387,7 +61510,7 @@
       "label": "buildRegisterSessionsById()",
       "norm_label": "buildregistersessionsbyid()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L438"
+      "source_location": "L458"
     },
     {
       "community": 1,
@@ -61396,7 +61519,7 @@
       "label": "buildStaffNamesById()",
       "norm_label": "buildstaffnamesbyid()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L418"
+      "source_location": "L438"
     },
     {
       "community": 1,
@@ -61405,7 +61528,7 @@
       "label": "buildTerminalLabelsById()",
       "norm_label": "buildterminallabelsbyid()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L398"
+      "source_location": "L418"
     },
     {
       "community": 1,
@@ -61414,7 +61537,7 @@
       "label": "cashDeltasByRegisterSessionId()",
       "norm_label": "cashdeltasbyregistersessionid()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L836"
+      "source_location": "L856"
     },
     {
       "community": 1,
@@ -61423,7 +61546,7 @@
       "label": "completeDailyCloseWithCtx()",
       "norm_label": "completedailyclosewithctx()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1828"
+      "source_location": "L1849"
     },
     {
       "community": 1,
@@ -61432,7 +61555,7 @@
       "label": "createCarryForwardWorkItems()",
       "norm_label": "createcarryforwardworkitems()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1752"
+      "source_location": "L1773"
     },
     {
       "community": 1,
@@ -61441,7 +61564,7 @@
       "label": "emptySummary()",
       "norm_label": "emptysummary()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L990"
+      "source_location": "L1010"
     },
     {
       "community": 1,
@@ -61450,7 +61573,7 @@
       "label": "formatPaymentMethodLabel()",
       "norm_label": "formatpaymentmethodlabel()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L354"
+      "source_location": "L374"
     },
     {
       "community": 1,
@@ -61459,7 +61582,7 @@
       "label": "getCompletedDailyCloseHistoryDetailWithCtx()",
       "norm_label": "getcompleteddailyclosehistorydetailwithctx()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2165"
+      "source_location": "L2186"
     },
     {
       "community": 1,
@@ -61468,7 +61591,7 @@
       "label": "getDailyCloseCompletionEventStaffProfileId()",
       "norm_label": "getdailyclosecompletioneventstaffprofileid()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L963"
+      "source_location": "L983"
     },
     {
       "community": 1,
@@ -61477,7 +61600,7 @@
       "label": "getDailyCloseForDate()",
       "norm_label": "getdailyclosefordate()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L507"
+      "source_location": "L527"
     },
     {
       "community": 1,
@@ -61486,7 +61609,7 @@
       "label": "getDailyCloseOpeningContextWithCtx()",
       "norm_label": "getdailycloseopeningcontextwithctx()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2080"
+      "source_location": "L2101"
     },
     {
       "community": 1,
@@ -61495,7 +61618,7 @@
       "label": "getPriorCompletedDailyClose()",
       "norm_label": "getpriorcompleteddailyclose()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L522"
+      "source_location": "L542"
     },
     {
       "community": 1,
@@ -61504,7 +61627,7 @@
       "label": "getStore()",
       "norm_label": "getstore()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L500"
+      "source_location": "L520"
     },
     {
       "community": 1,
@@ -61513,7 +61636,7 @@
       "label": "isInRange()",
       "norm_label": "isinrange()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L318"
+      "source_location": "L338"
     },
     {
       "community": 1,
@@ -61522,7 +61645,7 @@
       "label": "isValidOperatingDateRange()",
       "norm_label": "isvalidoperatingdaterange()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L286"
+      "source_location": "L306"
     },
     {
       "community": 1,
@@ -61531,7 +61654,7 @@
       "label": "listActiveRegisterSessions()",
       "norm_label": "listactiveregistersessions()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L544"
+      "source_location": "L564"
     },
     {
       "community": 1,
@@ -61540,7 +61663,7 @@
       "label": "listClosedRegisterSessionsForDay()",
       "norm_label": "listclosedregistersessionsforday()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L562"
+      "source_location": "L582"
     },
     {
       "community": 1,
@@ -61549,7 +61672,7 @@
       "label": "listCompletedDailyCloseHistoryWithCtx()",
       "norm_label": "listcompleteddailyclosehistorywithctx()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2116"
+      "source_location": "L2137"
     },
     {
       "community": 1,
@@ -61558,7 +61681,7 @@
       "label": "listDepositsForDay()",
       "norm_label": "listdepositsforday()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L785"
+      "source_location": "L805"
     },
     {
       "community": 1,
@@ -61567,7 +61690,7 @@
       "label": "listExpensesForDay()",
       "norm_label": "listexpensesforday()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L765"
+      "source_location": "L785"
     },
     {
       "community": 1,
@@ -61576,7 +61699,7 @@
       "label": "listOpenOperationalWorkItems()",
       "norm_label": "listopenoperationalworkitems()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L730"
+      "source_location": "L750"
     },
     {
       "community": 1,
@@ -61585,7 +61708,7 @@
       "label": "listOpenPosSessions()",
       "norm_label": "listopenpossessions()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L702"
+      "source_location": "L722"
     },
     {
       "community": 1,
@@ -61594,7 +61717,7 @@
       "label": "listPendingCloseoutApprovals()",
       "norm_label": "listpendingcloseoutapprovals()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L668"
+      "source_location": "L688"
     },
     {
       "community": 1,
@@ -61603,7 +61726,7 @@
       "label": "listTransactionsForDay()",
       "norm_label": "listtransactionsforday()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L744"
+      "source_location": "L764"
     },
     {
       "community": 1,
@@ -61612,7 +61735,7 @@
       "label": "markOtherDailyClosesNotCurrent()",
       "norm_label": "markotherdailyclosesnotcurrent()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1805"
+      "source_location": "L1826"
     },
     {
       "community": 1,
@@ -61621,7 +61744,7 @@
       "label": "nonZeroVarianceMetadata()",
       "norm_label": "nonzerovariancemetadata()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L378"
+      "source_location": "L398"
     },
     {
       "community": 1,
@@ -61630,7 +61753,7 @@
       "label": "normalizeCompletedDailyCloseSnapshot()",
       "norm_label": "normalizecompleteddailyclosesnapshot()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L143"
+      "source_location": "L163"
     },
     {
       "community": 1,
@@ -61639,7 +61762,7 @@
       "label": "posSessionIntersectsRange()",
       "norm_label": "possessionintersectsrange()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L612"
+      "source_location": "L632"
     },
     {
       "community": 1,
@@ -61648,7 +61771,7 @@
       "label": "registerMetadataLabel()",
       "norm_label": "registermetadatalabel()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L341"
+      "source_location": "L361"
     },
     {
       "community": 1,
@@ -61657,7 +61780,7 @@
       "label": "registerSessionBelongsToRange()",
       "norm_label": "registersessionbelongstorange()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L596"
+      "source_location": "L616"
     },
     {
       "community": 1,
@@ -61666,7 +61789,7 @@
       "label": "registerSessionCloseoutOperatingAt()",
       "norm_label": "registersessioncloseoutoperatingat()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L322"
+      "source_location": "L342"
     },
     {
       "community": 1,
@@ -61675,7 +61798,7 @@
       "label": "registerSessionIntersectsRange()",
       "norm_label": "registersessionintersectsrange()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L586"
+      "source_location": "L606"
     },
     {
       "community": 1,
@@ -61684,7 +61807,7 @@
       "label": "registerSessionLabel()",
       "norm_label": "registersessionlabel()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L333"
+      "source_location": "L353"
     },
     {
       "community": 1,
@@ -61693,7 +61816,7 @@
       "label": "resolveOperatingDateRange()",
       "norm_label": "resolveoperatingdaterange()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L297"
+      "source_location": "L317"
     },
     {
       "community": 1,
@@ -61702,7 +61825,7 @@
       "label": "safeOperatingDateRange()",
       "norm_label": "safeoperatingdaterange()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L269"
+      "source_location": "L289"
     },
     {
       "community": 1,
@@ -61711,7 +61834,16 @@
       "label": "snapshotReviewedItems()",
       "norm_label": "snapshotrevieweditems()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L930"
+      "source_location": "L950"
+    },
+    {
+      "community": 1,
+      "file_type": "code",
+      "id": "dailyclose_sortdailycloseblockers",
+      "label": "sortDailyCloseBlockers()",
+      "norm_label": "sortdailycloseblockers()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
+      "source_location": "L126"
     },
     {
       "community": 1,
@@ -61720,7 +61852,7 @@
       "label": "toDailyCloseHistoryListItem()",
       "norm_label": "todailyclosehistorylistitem()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L942"
+      "source_location": "L962"
     },
     {
       "community": 1,
@@ -61729,7 +61861,7 @@
       "label": "transactionCashDelta()",
       "norm_label": "transactioncashdelta()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L825"
+      "source_location": "L845"
     },
     {
       "community": 1,
@@ -61738,7 +61870,7 @@
       "label": "transactionPaymentSummary()",
       "norm_label": "transactionpaymentsummary()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L360"
+      "source_location": "L380"
     },
     {
       "community": 1,
@@ -61747,7 +61879,7 @@
       "label": "trimOptional()",
       "norm_label": "trimoptional()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L264"
+      "source_location": "L284"
     },
     {
       "community": 1,
@@ -61756,7 +61888,7 @@
       "label": "uniqueDailyCloseItems()",
       "norm_label": "uniquedailycloseitems()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L884"
+      "source_location": "L904"
     },
     {
       "community": 1,
@@ -61765,7 +61897,7 @@
       "label": "uniqueSourceSubjects()",
       "norm_label": "uniquesourcesubjects()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L874"
+      "source_location": "L894"
     },
     {
       "community": 1,
@@ -61774,7 +61906,7 @@
       "label": "validateCarryForwardWorkItemIds()",
       "norm_label": "validatecarryforwardworkitemids()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1724"
+      "source_location": "L1745"
     },
     {
       "community": 1,
@@ -62139,6 +62271,15 @@
     {
       "community": 1000,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_inventory_index_ts",
+      "label": "index.ts",
+      "norm_label": "index.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/inventory/index.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1001,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_inventoryhold_ts",
       "label": "inventoryHold.ts",
       "norm_label": "inventoryhold.ts",
@@ -62146,7 +62287,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1001,
+      "community": 1002,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_invitecode_ts",
       "label": "inviteCode.ts",
@@ -62155,7 +62296,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1002,
+      "community": 1003,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_organization_ts",
       "label": "organization.ts",
@@ -62164,7 +62305,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1003,
+      "community": 1004,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_organizationmember_ts",
       "label": "organizationMember.ts",
@@ -62173,7 +62314,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1004,
+      "community": 1005,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_product_ts",
       "label": "product.ts",
@@ -62182,7 +62323,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1005,
+      "community": 1006,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_promocode_ts",
       "label": "promoCode.ts",
@@ -62191,7 +62332,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1006,
+      "community": 1007,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_redeemedpromocode_ts",
       "label": "redeemedPromoCode.ts",
@@ -62200,7 +62341,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1007,
+      "community": 1008,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_store_ts",
       "label": "store.ts",
@@ -62209,21 +62350,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1008,
+      "community": 1009,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_subcategory_ts",
       "label": "subcategory.ts",
       "norm_label": "subcategory.ts",
       "source_file": "packages/athena-webapp/convex/schemas/inventory/subcategory.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1009,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_observability_index_ts",
-      "label": "index.ts",
-      "norm_label": "index.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/observability/index.ts",
       "source_location": "L1"
     },
     {
@@ -62301,6 +62433,15 @@
     {
       "community": 1010,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_observability_index_ts",
+      "label": "index.ts",
+      "norm_label": "index.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/observability/index.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1011,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_observability_workflowtrace_ts",
       "label": "workflowTrace.ts",
       "norm_label": "workflowtrace.ts",
@@ -62308,7 +62449,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1011,
+      "community": 1012,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_observability_workflowtraceevent_ts",
       "label": "workflowTraceEvent.ts",
@@ -62317,7 +62458,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1012,
+      "community": 1013,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_observability_workflowtracelookup_ts",
       "label": "workflowTraceLookup.ts",
@@ -62326,7 +62467,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1013,
+      "community": 1014,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_approvalrequest_ts",
       "label": "approvalRequest.ts",
@@ -62335,7 +62476,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1014,
+      "community": 1015,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_customerprofile_ts",
       "label": "customerProfile.ts",
@@ -62344,7 +62485,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1015,
+      "community": 1016,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_dailyclose_ts",
       "label": "dailyClose.ts",
@@ -62353,7 +62494,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1016,
+      "community": 1017,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_dailyopening_ts",
       "label": "dailyOpening.ts",
@@ -62362,7 +62503,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1017,
+      "community": 1018,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_index_ts",
       "label": "index.ts",
@@ -62371,21 +62512,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1018,
+      "community": 1019,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_inventorymovement_ts",
       "label": "inventoryMovement.ts",
       "norm_label": "inventorymovement.ts",
       "source_file": "packages/athena-webapp/convex/schemas/operations/inventoryMovement.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1019,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_operations_managerelevation_ts",
-      "label": "managerElevation.ts",
-      "norm_label": "managerelevation.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/operations/managerElevation.ts",
       "source_location": "L1"
     },
     {
@@ -62463,6 +62595,15 @@
     {
       "community": 1020,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_operations_managerelevation_ts",
+      "label": "managerElevation.ts",
+      "norm_label": "managerelevation.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/operations/managerElevation.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1021,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_operationalevent_ts",
       "label": "operationalEvent.ts",
       "norm_label": "operationalevent.ts",
@@ -62470,7 +62611,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1021,
+      "community": 1022,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_operationalworkitem_ts",
       "label": "operationalWorkItem.ts",
@@ -62479,7 +62620,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1022,
+      "community": 1023,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_paymentallocation_ts",
       "label": "paymentAllocation.ts",
@@ -62488,7 +62629,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1023,
+      "community": 1024,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_registersession_ts",
       "label": "registerSession.ts",
@@ -62497,7 +62638,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1024,
+      "community": 1025,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_staffcredential_ts",
       "label": "staffCredential.ts",
@@ -62506,7 +62647,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1025,
+      "community": 1026,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_staffprofile_ts",
       "label": "staffProfile.ts",
@@ -62515,7 +62656,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1026,
+      "community": 1027,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_staffroleassignment_ts",
       "label": "staffRoleAssignment.ts",
@@ -62524,7 +62665,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1027,
+      "community": 1028,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_payments_mtncollections_ts",
       "label": "mtnCollections.ts",
@@ -62533,21 +62674,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1028,
+      "community": 1029,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_customer_ts",
       "label": "customer.ts",
       "norm_label": "customer.ts",
       "source_file": "packages/athena-webapp/convex/schemas/pos/customer.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1029,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_pos_expensesession_ts",
-      "label": "expenseSession.ts",
-      "norm_label": "expensesession.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/pos/expenseSession.ts",
       "source_location": "L1"
     },
     {
@@ -62625,6 +62757,15 @@
     {
       "community": 1030,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_pos_expensesession_ts",
+      "label": "expenseSession.ts",
+      "norm_label": "expensesession.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/pos/expenseSession.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1031,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_expensesessionitem_ts",
       "label": "expenseSessionItem.ts",
       "norm_label": "expensesessionitem.ts",
@@ -62632,7 +62773,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1031,
+      "community": 1032,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_expensetransaction_ts",
       "label": "expenseTransaction.ts",
@@ -62641,7 +62782,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1032,
+      "community": 1033,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_expensetransactionitem_ts",
       "label": "expenseTransactionItem.ts",
@@ -62650,7 +62791,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1033,
+      "community": 1034,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_index_ts",
       "label": "index.ts",
@@ -62659,7 +62800,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1034,
+      "community": 1035,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_possession_ts",
       "label": "posSession.ts",
@@ -62668,7 +62809,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1035,
+      "community": 1036,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_possessionitem_ts",
       "label": "posSessionItem.ts",
@@ -62677,7 +62818,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1036,
+      "community": 1037,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_posterminal_ts",
       "label": "posTerminal.ts",
@@ -62686,7 +62827,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1037,
+      "community": 1038,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_postransaction_ts",
       "label": "posTransaction.ts",
@@ -62695,21 +62836,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1038,
+      "community": 1039,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_postransactionitem_ts",
       "label": "posTransactionItem.ts",
       "norm_label": "postransactionitem.ts",
       "source_file": "packages/athena-webapp/convex/schemas/pos/posTransactionItem.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1039,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_serviceops_index_ts",
-      "label": "index.ts",
-      "norm_label": "index.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/serviceOps/index.ts",
       "source_location": "L1"
     },
     {
@@ -62787,6 +62919,15 @@
     {
       "community": 1040,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_serviceops_index_ts",
+      "label": "index.ts",
+      "norm_label": "index.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/serviceOps/index.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1041,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_serviceappointment_ts",
       "label": "serviceAppointment.ts",
       "norm_label": "serviceappointment.ts",
@@ -62794,7 +62935,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1041,
+      "community": 1042,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_servicecase_ts",
       "label": "serviceCase.ts",
@@ -62803,7 +62944,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1042,
+      "community": 1043,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_servicecaselineitem_ts",
       "label": "serviceCaseLineItem.ts",
@@ -62812,7 +62953,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1043,
+      "community": 1044,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_servicecatalog_ts",
       "label": "serviceCatalog.ts",
@@ -62821,7 +62962,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1044,
+      "community": 1045,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_serviceinventoryusage_ts",
       "label": "serviceInventoryUsage.ts",
@@ -62830,7 +62971,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1045,
+      "community": 1046,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_stockops_cyclecountdraft_ts",
       "label": "cycleCountDraft.ts",
@@ -62839,7 +62980,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1046,
+      "community": 1047,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_stockops_index_ts",
       "label": "index.ts",
@@ -62848,7 +62989,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1047,
+      "community": 1048,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_stockops_purchaseorder_ts",
       "label": "purchaseOrder.ts",
@@ -62857,21 +62998,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1048,
+      "community": 1049,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_stockops_purchaseorderlineitem_ts",
       "label": "purchaseOrderLineItem.ts",
       "norm_label": "purchaseorderlineitem.ts",
       "source_file": "packages/athena-webapp/convex/schemas/stockOps/purchaseOrderLineItem.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1049,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_stockops_receivingbatch_ts",
-      "label": "receivingBatch.ts",
-      "norm_label": "receivingbatch.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/stockOps/receivingBatch.ts",
       "source_location": "L1"
     },
     {
@@ -62949,6 +63081,15 @@
     {
       "community": 1050,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_stockops_receivingbatch_ts",
+      "label": "receivingBatch.ts",
+      "norm_label": "receivingbatch.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/stockOps/receivingBatch.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1051,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_stockops_stockadjustmentbatch_ts",
       "label": "stockAdjustmentBatch.ts",
       "norm_label": "stockadjustmentbatch.ts",
@@ -62956,7 +63097,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1051,
+      "community": 1052,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_stockops_vendor_ts",
       "label": "vendor.ts",
@@ -62965,7 +63106,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1052,
+      "community": 1053,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_analytics_ts",
       "label": "analytics.ts",
@@ -62974,7 +63115,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1053,
+      "community": 1054,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_bag_ts",
       "label": "bag.ts",
@@ -62983,7 +63124,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1054,
+      "community": 1055,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_bagitem_ts",
       "label": "bagItem.ts",
@@ -62992,7 +63133,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1055,
+      "community": 1056,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_checkoutsession_ts",
       "label": "checkoutSession.ts",
@@ -63001,7 +63142,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1056,
+      "community": 1057,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_checkoutsessionitem_ts",
       "label": "checkoutSessionItem.ts",
@@ -63010,7 +63151,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1057,
+      "community": 1058,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_guest_ts",
       "label": "guest.ts",
@@ -63019,21 +63160,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1058,
+      "community": 1059,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_index_ts",
       "label": "index.ts",
       "norm_label": "index.ts",
       "source_file": "packages/athena-webapp/convex/schemas/storeFront/index.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1059,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_storefront_offer_ts",
-      "label": "offer.ts",
-      "norm_label": "offer.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/storeFront/offer.ts",
       "source_location": "L1"
     },
     {
@@ -63111,6 +63243,15 @@
     {
       "community": 1060,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_storefront_offer_ts",
+      "label": "offer.ts",
+      "norm_label": "offer.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/storeFront/offer.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1061,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_onlineorder_onlineorder_ts",
       "label": "onlineOrder.ts",
       "norm_label": "onlineorder.ts",
@@ -63118,7 +63259,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1061,
+      "community": 1062,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_onlineorder_onlineorderitem_ts",
       "label": "onlineOrderItem.ts",
@@ -63127,7 +63268,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1062,
+      "community": 1063,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_review_ts",
       "label": "review.ts",
@@ -63136,7 +63277,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1063,
+      "community": 1064,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_rewards_ts",
       "label": "rewards.ts",
@@ -63145,7 +63286,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1064,
+      "community": 1065,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_savedbag_ts",
       "label": "savedBag.ts",
@@ -63154,7 +63295,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1065,
+      "community": 1066,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_savedbagitem_ts",
       "label": "savedBagItem.ts",
@@ -63163,7 +63304,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1066,
+      "community": 1067,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_storefrontsession_ts",
       "label": "storeFrontSession.ts",
@@ -63172,7 +63313,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1067,
+      "community": 1068,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_storefrontuser_ts",
       "label": "storeFrontUser.ts",
@@ -63181,21 +63322,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1068,
+      "community": 1069,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_storefrontverificationcode_ts",
       "label": "storeFrontVerificationCode.ts",
       "norm_label": "storefrontverificationcode.ts",
       "source_file": "packages/athena-webapp/convex/schemas/storeFront/storeFrontVerificationCode.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1069,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_storefront_supportticket_ts",
-      "label": "supportTicket.ts",
-      "norm_label": "supportticket.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/storeFront/supportTicket.ts",
       "source_location": "L1"
     },
     {
@@ -63273,6 +63405,15 @@
     {
       "community": 1070,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_storefront_supportticket_ts",
+      "label": "supportTicket.ts",
+      "norm_label": "supportticket.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/storeFront/supportTicket.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1071,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_serviceops_catalogappointments_test_ts",
       "label": "catalogAppointments.test.ts",
       "norm_label": "catalogappointments.test.ts",
@@ -63280,7 +63421,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1071,
+      "community": 1072,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_bag_ts",
       "label": "bag.ts",
@@ -63289,7 +63430,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1072,
+      "community": 1073,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_bagitem_ts",
       "label": "bagItem.ts",
@@ -63298,7 +63439,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1073,
+      "community": 1074,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_checkoutsession_test_ts",
       "label": "checkoutSession.test.ts",
@@ -63307,7 +63448,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1074,
+      "community": 1075,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_customer_ts",
       "label": "customer.ts",
@@ -63316,7 +63457,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1075,
+      "community": 1076,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_guest_ts",
       "label": "guest.ts",
@@ -63325,7 +63466,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1076,
+      "community": 1077,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_offers_test_ts",
       "label": "offers.test.ts",
@@ -63334,7 +63475,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1077,
+      "community": 1078,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_onlineorderutilfns_ts",
       "label": "onlineOrderUtilFns.ts",
@@ -63343,21 +63484,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1078,
+      "community": 1079,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_orderoperations_test_ts",
       "label": "orderOperations.test.ts",
       "norm_label": "orderoperations.test.ts",
       "source_file": "packages/athena-webapp/convex/storeFront/orderOperations.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1079,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_payment_test_ts",
-      "label": "payment.test.ts",
-      "norm_label": "payment.test.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/payment.test.ts",
       "source_location": "L1"
     },
     {
@@ -63435,6 +63567,15 @@
     {
       "community": 1080,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_payment_test_ts",
+      "label": "payment.test.ts",
+      "norm_label": "payment.test.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/payment.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1081,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_payment_ts",
       "label": "payment.ts",
       "norm_label": "payment.ts",
@@ -63442,7 +63583,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1081,
+      "community": 1082,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_paystackactions_ts",
       "label": "paystackActions.ts",
@@ -63451,7 +63592,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1082,
+      "community": 1083,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_savedbagitem_ts",
       "label": "savedBagItem.ts",
@@ -63460,7 +63601,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1083,
+      "community": 1084,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_supportticket_ts",
       "label": "supportTicket.ts",
@@ -63469,7 +63610,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1084,
+      "community": 1085,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_users_ts",
       "label": "users.ts",
@@ -63478,7 +63619,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1085,
+      "community": 1086,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_types_payment_ts",
       "label": "payment.ts",
@@ -63487,7 +63628,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1086,
+      "community": 1087,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_adapters_possession_test_ts",
       "label": "posSession.test.ts",
@@ -63496,7 +63637,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1087,
+      "community": 1088,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_adapters_registersession_test_ts",
       "label": "registerSession.test.ts",
@@ -63505,21 +63646,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1088,
+      "community": 1089,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_presentation_test_ts",
       "label": "presentation.test.ts",
       "norm_label": "presentation.test.ts",
       "source_file": "packages/athena-webapp/convex/workflowTraces/presentation.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1089,
-      "file_type": "code",
-      "id": "packages_athena_webapp_eslint_config_js",
-      "label": "eslint.config.js",
-      "norm_label": "eslint.config.js",
-      "source_file": "packages/athena-webapp/eslint.config.js",
       "source_location": "L1"
     },
     {
@@ -63597,6 +63729,15 @@
     {
       "community": 1090,
       "file_type": "code",
+      "id": "packages_athena_webapp_eslint_config_js",
+      "label": "eslint.config.js",
+      "norm_label": "eslint.config.js",
+      "source_file": "packages/athena-webapp/eslint.config.js",
+      "source_location": "L1"
+    },
+    {
+      "community": 1091,
+      "file_type": "code",
       "id": "packages_athena_webapp_index_ts",
       "label": "index.ts",
       "norm_label": "index.ts",
@@ -63604,7 +63745,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1091,
+      "community": 1092,
       "file_type": "code",
       "id": "packages_athena_webapp_postcss_config_js",
       "label": "postcss.config.js",
@@ -63613,7 +63754,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1092,
+      "community": 1093,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_approvalpolicy_ts",
       "label": "approvalPolicy.ts",
@@ -63622,7 +63763,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1093,
+      "community": 1094,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_auth_ts",
       "label": "auth.ts",
@@ -63631,7 +63772,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1094,
+      "community": 1095,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_commandresult_test_ts",
       "label": "commandResult.test.ts",
@@ -63640,7 +63781,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1095,
+      "community": 1096,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_currencyformatter_test_ts",
       "label": "currencyFormatter.test.ts",
@@ -63649,7 +63790,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1096,
+      "community": 1097,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_registersessionstatus_test_ts",
       "label": "registerSessionStatus.test.ts",
@@ -63658,7 +63799,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1097,
+      "community": 1098,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_staffdisplayname_test_ts",
       "label": "staffDisplayName.test.ts",
@@ -63667,21 +63808,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1098,
+      "community": 1099,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_genericcombobox_tsx",
       "label": "GenericComboBox.tsx",
       "norm_label": "genericcombobox.tsx",
       "source_file": "packages/athena-webapp/src/components/GenericComboBox.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1099,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_storeaccordion_tsx",
-      "label": "StoreAccordion.tsx",
-      "norm_label": "storeaccordion.tsx",
-      "source_file": "packages/athena-webapp/src/components/StoreAccordion.tsx",
       "source_location": "L1"
     },
     {
@@ -64038,6 +64170,15 @@
     {
       "community": 1100,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_storeaccordion_tsx",
+      "label": "StoreAccordion.tsx",
+      "norm_label": "storeaccordion.tsx",
+      "source_file": "packages/athena-webapp/src/components/StoreAccordion.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1101,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_storesaccordion_tsx",
       "label": "StoresAccordion.tsx",
       "norm_label": "storesaccordion.tsx",
@@ -64045,7 +64186,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1101,
+      "community": 1102,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_themetoggle_tsx",
       "label": "ThemeToggle.tsx",
@@ -64054,7 +64195,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1102,
+      "community": 1103,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_defaultattributestogglegroup_tsx",
       "label": "DefaultAttributesToggleGroup.tsx",
@@ -64063,7 +64204,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1103,
+      "community": 1104,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productattributesview_tsx",
       "label": "ProductAttributesView.tsx",
@@ -64072,7 +64213,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1104,
+      "community": 1105,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productstock_test_ts",
       "label": "ProductStock.test.ts",
@@ -64081,7 +64222,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1105,
+      "community": 1106,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productview_test_tsx",
       "label": "ProductView.test.tsx",
@@ -64090,7 +64231,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1106,
+      "community": 1107,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_constants_ts",
       "label": "constants.ts",
@@ -64099,7 +64240,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1107,
+      "community": 1108,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -64108,21 +64249,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1108,
+      "community": 1109,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
       "norm_label": "data-table-pagination.tsx",
       "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table-pagination.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1109,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_tsx",
-      "label": "data-table.tsx",
-      "norm_label": "data-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table.tsx",
       "source_location": "L1"
     },
     {
@@ -64200,6 +64332,15 @@
     {
       "community": 1110,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_tsx",
+      "label": "data-table.tsx",
+      "norm_label": "data-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1111,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_types_ts",
       "label": "types.ts",
       "norm_label": "types.ts",
@@ -64207,7 +64348,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1111,
+      "community": 1112,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_conversionfunnelchart_tsx",
       "label": "ConversionFunnelChart.tsx",
@@ -64216,7 +64357,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1112,
+      "community": 1113,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_revenuechart_tsx",
       "label": "RevenueChart.tsx",
@@ -64225,7 +64366,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1113,
+      "community": 1114,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_analytics_columns_tsx",
       "label": "analytics-columns.tsx",
@@ -64234,7 +64375,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1114,
+      "community": 1115,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -64243,7 +64384,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1115,
+      "community": 1116,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -64252,7 +64393,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1116,
+      "community": 1117,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -64261,7 +64402,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1117,
+      "community": 1118,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -64270,21 +64411,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1118,
+      "community": 1119,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_columns_tsx",
       "label": "columns.tsx",
       "norm_label": "columns.tsx",
       "source_file": "packages/athena-webapp/src/components/analytics/analytics-products-table/columns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1119,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_faceted_filter_tsx",
-      "label": "data-table-faceted-filter.tsx",
-      "norm_label": "data-table-faceted-filter.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-products-table/data-table-faceted-filter.tsx",
       "source_location": "L1"
     },
     {
@@ -64362,6 +64494,15 @@
     {
       "community": 1120,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_faceted_filter_tsx",
+      "label": "data-table-faceted-filter.tsx",
+      "norm_label": "data-table-faceted-filter.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-products-table/data-table-faceted-filter.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1121,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
       "norm_label": "data-table-pagination.tsx",
@@ -64369,7 +64510,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1121,
+      "community": 1122,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -64378,7 +64519,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1122,
+      "community": 1123,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -64387,7 +64528,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1123,
+      "community": 1124,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_users_table_columns_tsx",
       "label": "columns.tsx",
@@ -64396,7 +64537,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1124,
+      "community": 1125,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_users_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -64405,7 +64546,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1125,
+      "community": 1126,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_users_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -64414,7 +64555,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1126,
+      "community": 1127,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_chart_tsx",
       "label": "chart.tsx",
@@ -64423,7 +64564,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1127,
+      "community": 1128,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_combined_users_table_columns_tsx",
       "label": "columns.tsx",
@@ -64432,21 +64573,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1128,
+      "community": 1129,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_combined_users_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
       "norm_label": "data-table-pagination.tsx",
       "source_file": "packages/athena-webapp/src/components/analytics/combined-users-table/data-table-pagination.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1129,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_combined_users_table_data_table_tsx",
-      "label": "data-table.tsx",
-      "norm_label": "data-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/combined-users-table/data-table.tsx",
       "source_location": "L1"
     },
     {
@@ -64524,6 +64656,15 @@
     {
       "community": 1130,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_combined_users_table_data_table_tsx",
+      "label": "data-table.tsx",
+      "norm_label": "data-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/combined-users-table/data-table.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1131,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_columns_tsx",
       "label": "columns.tsx",
       "norm_label": "columns.tsx",
@@ -64531,7 +64672,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1131,
+      "community": 1132,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_constants_ts",
       "label": "constants.ts",
@@ -64540,7 +64681,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1132,
+      "community": 1133,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -64549,7 +64690,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1133,
+      "community": 1134,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -64558,7 +64699,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1134,
+      "community": 1135,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -64567,7 +64708,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1135,
+      "community": 1136,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_data_ts",
       "label": "data.ts",
@@ -64576,7 +64717,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1136,
+      "community": 1137,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_users_table_columns_tsx",
       "label": "columns.tsx",
@@ -64585,7 +64726,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1137,
+      "community": 1138,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_users_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -64594,21 +64735,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1138,
+      "community": 1139,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_users_table_data_table_tsx",
       "label": "data-table.tsx",
       "norm_label": "data-table.tsx",
       "source_file": "packages/athena-webapp/src/components/analytics/users-table/data-table.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1139,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_columns_tsx",
-      "label": "columns.tsx",
-      "norm_label": "columns.tsx",
-      "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/columns.tsx",
       "source_location": "L1"
     },
     {
@@ -64686,6 +64818,15 @@
     {
       "community": 1140,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_columns_tsx",
+      "label": "columns.tsx",
+      "norm_label": "columns.tsx",
+      "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/columns.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1141,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
       "norm_label": "data-table-faceted-filter.tsx",
@@ -64693,7 +64834,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1141,
+      "community": 1142,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -64702,7 +64843,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1142,
+      "community": 1143,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -64711,7 +64852,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1143,
+      "community": 1144,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -64720,7 +64861,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1144,
+      "community": 1145,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_assetscolumns_tsx",
       "label": "assetsColumns.tsx",
@@ -64729,7 +64870,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1145,
+      "community": 1146,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_constants_ts",
       "label": "constants.ts",
@@ -64738,7 +64879,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1146,
+      "community": 1147,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -64747,7 +64888,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1147,
+      "community": 1148,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -64756,21 +64897,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1148,
+      "community": 1149,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_tsx",
       "label": "data-table.tsx",
       "norm_label": "data-table.tsx",
       "source_file": "packages/athena-webapp/src/components/assets/assets-table/data-table.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1149,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_assets_assets_table_data_ts",
-      "label": "data.ts",
-      "norm_label": "data.ts",
-      "source_file": "packages/athena-webapp/src/components/assets/assets-table/data.ts",
       "source_location": "L1"
     },
     {
@@ -64848,6 +64980,15 @@
     {
       "community": 1150,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_assets_assets_table_data_ts",
+      "label": "data.ts",
+      "norm_label": "data.ts",
+      "source_file": "packages/athena-webapp/src/components/assets/assets-table/data.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1151,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_defaultcatchboundary_test_tsx",
       "label": "DefaultCatchBoundary.test.tsx",
       "norm_label": "defaultcatchboundary.test.tsx",
@@ -64855,7 +64996,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1151,
+      "community": 1152,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_defaultcatchboundary_tsx",
       "label": "DefaultCatchBoundary.tsx",
@@ -64864,7 +65005,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1152,
+      "community": 1153,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_login_loginform_test_tsx",
       "label": "LoginForm.test.tsx",
@@ -64873,7 +65014,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1153,
+      "community": 1154,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_login_loginform_tsx",
       "label": "LoginForm.tsx",
@@ -64882,7 +65023,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1154,
+      "community": 1155,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_columns_tsx",
       "label": "columns.tsx",
@@ -64891,7 +65032,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1155,
+      "community": 1156,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -64900,7 +65041,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1156,
+      "community": 1157,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -64909,7 +65050,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1157,
+      "community": 1158,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -64918,21 +65059,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1158,
+      "community": 1159,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_tsx",
       "label": "data-table.tsx",
       "norm_label": "data-table.tsx",
       "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/data-table.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1159,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_base_table_columns_tsx",
-      "label": "columns.tsx",
-      "norm_label": "columns.tsx",
-      "source_file": "packages/athena-webapp/src/components/base/table/columns.tsx",
       "source_location": "L1"
     },
     {
@@ -65010,6 +65142,15 @@
     {
       "community": 1160,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_base_table_columns_tsx",
+      "label": "columns.tsx",
+      "norm_label": "columns.tsx",
+      "source_file": "packages/athena-webapp/src/components/base/table/columns.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1161,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_constants_ts",
       "label": "constants.ts",
       "norm_label": "constants.ts",
@@ -65017,7 +65158,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1161,
+      "community": 1162,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -65026,7 +65167,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1162,
+      "community": 1163,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -65035,7 +65176,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1163,
+      "community": 1164,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -65044,7 +65185,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1164,
+      "community": 1165,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationspage_tsx",
       "label": "BulkOperationsPage.tsx",
@@ -65053,7 +65194,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1165,
+      "community": 1166,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_cashcontrolsdashboard_auth_test_tsx",
       "label": "CashControlsDashboard.auth.test.tsx",
@@ -65062,7 +65203,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1166,
+      "community": 1167,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_cashcontrolsdashboard_test_tsx",
       "label": "CashControlsDashboard.test.tsx",
@@ -65071,7 +65212,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1167,
+      "community": 1168,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_cashcontrolsworkspaceheader_tsx",
       "label": "CashControlsWorkspaceHeader.tsx",
@@ -65080,21 +65221,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1168,
+      "community": 1169,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_registersessionview_auth_test_tsx",
       "label": "RegisterSessionView.auth.test.tsx",
       "norm_label": "registersessionview.auth.test.tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.auth.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1169,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_cash_controls_registersessionview_test_tsx",
-      "label": "RegisterSessionView.test.tsx",
-      "norm_label": "registersessionview.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.test.tsx",
       "source_location": "L1"
     },
     {
@@ -65172,6 +65304,15 @@
     {
       "community": 1170,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_cash_controls_registersessionview_test_tsx",
+      "label": "RegisterSessionView.test.tsx",
+      "norm_label": "registersessionview.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1171,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_registersessionsview_test_tsx",
       "label": "RegisterSessionsView.test.tsx",
       "norm_label": "registersessionsview.test.tsx",
@@ -65179,7 +65320,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1171,
+      "community": 1172,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_formatreviewreason_test_ts",
       "label": "formatReviewReason.test.ts",
@@ -65188,7 +65329,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1172,
+      "community": 1173,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkout_sessions_table_columns_tsx",
       "label": "columns.tsx",
@@ -65197,7 +65338,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1173,
+      "community": 1174,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkout_sessions_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -65206,7 +65347,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1174,
+      "community": 1175,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkout_sessions_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -65215,7 +65356,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1175,
+      "community": 1176,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_common_listpagination_tsx",
       "label": "ListPagination.tsx",
@@ -65224,7 +65365,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1176,
+      "community": 1177,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_common_pagelevelheader_test_tsx",
       "label": "PageLevelHeader.test.tsx",
@@ -65233,7 +65374,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1177,
+      "community": 1178,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_common_pagelevelheader_tsx",
       "label": "PageLevelHeader.tsx",
@@ -65242,21 +65383,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1178,
+      "community": 1179,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_dashboard_metriccard_tsx",
       "label": "MetricCard.tsx",
       "norm_label": "metriccard.tsx",
       "source_file": "packages/athena-webapp/src/components/dashboard/MetricCard.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1179,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_join_team_index_test_tsx",
-      "label": "index.test.tsx",
-      "norm_label": "index.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/join-team/index.test.tsx",
       "source_location": "L1"
     },
     {
@@ -65334,6 +65466,15 @@
     {
       "community": 1180,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_join_team_index_test_tsx",
+      "label": "index.test.tsx",
+      "norm_label": "index.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/join-team/index.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1181,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_commandapprovaldialog_test_tsx",
       "label": "CommandApprovalDialog.test.tsx",
       "norm_label": "commandapprovaldialog.test.tsx",
@@ -65341,7 +65482,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1181,
+      "community": 1182,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_operationreviewworkspace_tsx",
       "label": "OperationReviewWorkspace.tsx",
@@ -65350,7 +65491,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1182,
+      "community": 1183,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_operationsqueueview_auth_test_tsx",
       "label": "OperationsQueueView.auth.test.tsx",
@@ -65359,7 +65500,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1183,
+      "community": 1184,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_useapprovedcommand_test_tsx",
       "label": "useApprovedCommand.test.tsx",
@@ -65368,7 +65509,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1184,
+      "community": 1185,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orderstatus_test_tsx",
       "label": "OrderStatus.test.tsx",
@@ -65377,7 +65518,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1185,
+      "community": 1186,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orderstatus_tsx",
       "label": "OrderStatus.tsx",
@@ -65386,7 +65527,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1186,
+      "community": 1187,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_ordersummary_tsx",
       "label": "OrderSummary.tsx",
@@ -65395,7 +65536,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1187,
+      "community": 1188,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_tsx",
       "label": "Orders.tsx",
@@ -65404,21 +65545,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1188,
+      "community": 1189,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_refundsview_test_tsx",
       "label": "RefundsView.test.tsx",
       "norm_label": "refundsview.test.tsx",
       "source_file": "packages/athena-webapp/src/components/orders/RefundsView.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1189,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_returnexchangeview_test_tsx",
-      "label": "ReturnExchangeView.test.tsx",
-      "norm_label": "returnexchangeview.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/ReturnExchangeView.test.tsx",
       "source_location": "L1"
     },
     {
@@ -65496,6 +65628,15 @@
     {
       "community": 1190,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_returnexchangeview_test_tsx",
+      "label": "ReturnExchangeView.test.tsx",
+      "norm_label": "returnexchangeview.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/ReturnExchangeView.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1191,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_constants_ts",
       "label": "constants.ts",
       "norm_label": "constants.ts",
@@ -65503,7 +65644,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1191,
+      "community": 1192,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -65512,7 +65653,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1192,
+      "community": 1193,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -65521,7 +65662,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1193,
+      "community": 1194,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_tsx",
       "label": "data-table.tsx",
@@ -65530,7 +65671,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1194,
+      "community": 1195,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_ts",
       "label": "data.ts",
@@ -65539,7 +65680,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1195,
+      "community": 1196,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_refundutils_test_ts",
       "label": "refundUtils.test.ts",
@@ -65548,7 +65689,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1196,
+      "community": 1197,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_utils_test_ts",
       "label": "utils.test.ts",
@@ -65557,7 +65698,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1197,
+      "community": 1198,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_constants_ts",
       "label": "constants.ts",
@@ -65566,21 +65707,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1198,
+      "community": 1199,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
       "norm_label": "data-table-faceted-filter.tsx",
       "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table-faceted-filter.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1199,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_pagination_tsx",
-      "label": "data-table-pagination.tsx",
-      "norm_label": "data-table-pagination.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table-pagination.tsx",
       "source_location": "L1"
     },
     {
@@ -65910,6 +66042,15 @@
     {
       "community": 1200,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_pagination_tsx",
+      "label": "data-table-pagination.tsx",
+      "norm_label": "data-table-pagination.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table-pagination.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1201,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
       "norm_label": "data-table-toolbar.tsx",
@@ -65917,7 +66058,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1201,
+      "community": 1202,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_tsx",
       "label": "data-table.tsx",
@@ -65926,7 +66067,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1202,
+      "community": 1203,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_ts",
       "label": "data.ts",
@@ -65935,7 +66076,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1203,
+      "community": 1204,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_invitecolumns_tsx",
       "label": "inviteColumns.tsx",
@@ -65944,7 +66085,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1204,
+      "community": 1205,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_constants_ts",
       "label": "constants.ts",
@@ -65953,7 +66094,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1205,
+      "community": 1206,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -65962,7 +66103,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1206,
+      "community": 1207,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -65971,7 +66112,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1207,
+      "community": 1208,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -65980,21 +66121,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1208,
+      "community": 1209,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_tsx",
       "label": "data-table.tsx",
       "norm_label": "data-table.tsx",
       "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data-table.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1209,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_ts",
-      "label": "data.ts",
-      "norm_label": "data.ts",
-      "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data.ts",
       "source_location": "L1"
     },
     {
@@ -66072,6 +66204,15 @@
     {
       "community": 1210,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_ts",
+      "label": "data.ts",
+      "norm_label": "data.ts",
+      "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1211,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_memberscolumns_tsx",
       "label": "membersColumns.tsx",
       "norm_label": "memberscolumns.tsx",
@@ -66079,7 +66220,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1211,
+      "community": 1212,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_switcher_test_tsx",
       "label": "organization-switcher.test.tsx",
@@ -66088,7 +66229,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1212,
+      "community": 1213,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_cashierauthdialog_test_tsx",
       "label": "CashierAuthDialog.test.tsx",
@@ -66097,7 +66238,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1213,
+      "community": 1214,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_cashierview_tsx",
       "label": "CashierView.tsx",
@@ -66106,7 +66247,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1214,
+      "community": 1215,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_posregisterview_tsx",
       "label": "POSRegisterView.tsx",
@@ -66115,7 +66256,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1215,
+      "community": 1216,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_paymentview_test_tsx",
       "label": "PaymentView.test.tsx",
@@ -66124,7 +66265,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1216,
+      "community": 1217,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_pointofsaleview_test_tsx",
       "label": "PointOfSaleView.test.tsx",
@@ -66133,7 +66274,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1217,
+      "community": 1218,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_pointofsaleview_tsx",
       "label": "PointOfSaleView.tsx",
@@ -66142,21 +66283,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1218,
+      "community": 1219,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_productlookup_tsx",
       "label": "ProductLookup.tsx",
       "norm_label": "productlookup.tsx",
       "source_file": "packages/athena-webapp/src/components/pos/ProductLookup.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1219,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_registeractions_tsx",
-      "label": "RegisterActions.tsx",
-      "norm_label": "registeractions.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/RegisterActions.tsx",
       "source_location": "L1"
     },
     {
@@ -66234,6 +66366,15 @@
     {
       "community": 1220,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_registeractions_tsx",
+      "label": "RegisterActions.tsx",
+      "norm_label": "registeractions.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/RegisterActions.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1221,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_sessionmanager_test_tsx",
       "label": "SessionManager.test.tsx",
       "norm_label": "sessionmanager.test.tsx",
@@ -66241,7 +66382,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1221,
+      "community": 1222,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_sessionmanager_tsx",
       "label": "SessionManager.tsx",
@@ -66250,7 +66391,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1222,
+      "community": 1223,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_totalsdisplay_test_tsx",
       "label": "TotalsDisplay.test.tsx",
@@ -66259,7 +66400,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1223,
+      "community": 1224,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_totalsdisplay_tsx",
       "label": "TotalsDisplay.tsx",
@@ -66268,7 +66409,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1224,
+      "community": 1225,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportview_tsx",
       "label": "ExpenseReportView.tsx",
@@ -66277,7 +66418,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1225,
+      "community": 1226,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportsview_test_ts",
       "label": "ExpenseReportsView.test.ts",
@@ -66286,7 +66427,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1226,
+      "community": 1227,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportsview_test_tsx",
       "label": "ExpenseReportsView.test.tsx",
@@ -66295,7 +66436,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1227,
+      "community": 1228,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportcolumns_tsx",
       "label": "expenseReportColumns.tsx",
@@ -66304,21 +66445,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1228,
+      "community": 1229,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_receipt_posreceiptsharecontrol_test_tsx",
       "label": "PosReceiptShareControl.test.tsx",
       "norm_label": "posreceiptsharecontrol.test.tsx",
       "source_file": "packages/athena-webapp/src/components/pos/receipt/PosReceiptShareControl.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1229,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_register_posregisteropeningguard_test_tsx",
-      "label": "POSRegisterOpeningGuard.test.tsx",
-      "norm_label": "posregisteropeningguard.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterOpeningGuard.test.tsx",
       "source_location": "L1"
     },
     {
@@ -66387,6 +66519,15 @@
     {
       "community": 1230,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_register_posregisteropeningguard_test_tsx",
+      "label": "POSRegisterOpeningGuard.test.tsx",
+      "norm_label": "posregisteropeningguard.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterOpeningGuard.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1231,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_posregisterview_test_tsx",
       "label": "POSRegisterView.test.tsx",
       "norm_label": "posregisterview.test.tsx",
@@ -66394,7 +66535,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1231,
+      "community": 1232,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_registeractionbar_test_tsx",
       "label": "RegisterActionBar.test.tsx",
@@ -66403,7 +66544,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1232,
+      "community": 1233,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_registeractionbar_tsx",
       "label": "RegisterActionBar.tsx",
@@ -66412,7 +66553,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1233,
+      "community": 1234,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_registercheckoutpanel_tsx",
       "label": "RegisterCheckoutPanel.tsx",
@@ -66421,7 +66562,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1234,
+      "community": 1235,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_session_heldsessionslist_test_tsx",
       "label": "HeldSessionsList.test.tsx",
@@ -66430,7 +66571,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1235,
+      "community": 1236,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_sessions_possessionsview_test_tsx",
       "label": "POSSessionsView.test.tsx",
@@ -66439,7 +66580,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1236,
+      "community": 1237,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_sessions_possessioncolumns_tsx",
       "label": "posSessionColumns.tsx",
@@ -66448,7 +66589,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1237,
+      "community": 1238,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_transactions_transactionsview_test_tsx",
       "label": "TransactionsView.test.tsx",
@@ -66457,21 +66598,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1238,
+      "community": 1239,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_types_ts",
       "label": "types.ts",
       "norm_label": "types.ts",
       "source_file": "packages/athena-webapp/src/components/pos/types.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1239,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_procurement_receivingview_test_tsx",
-      "label": "ReceivingView.test.tsx",
-      "norm_label": "receivingview.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/procurement/ReceivingView.test.tsx",
       "source_location": "L1"
     },
     {
@@ -66540,6 +66672,15 @@
     {
       "community": 1240,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_procurement_receivingview_test_tsx",
+      "label": "ReceivingView.test.tsx",
+      "norm_label": "receivingview.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/procurement/ReceivingView.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1241,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_analyticsinsights_tsx",
       "label": "AnalyticsInsights.tsx",
       "norm_label": "analyticsinsights.tsx",
@@ -66547,7 +66688,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1241,
+      "community": 1242,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_attributesview_tsx",
       "label": "AttributesView.tsx",
@@ -66556,7 +66697,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1242,
+      "community": 1243,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_detailsview_tsx",
       "label": "DetailsView.tsx",
@@ -66565,7 +66706,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1243,
+      "community": 1244,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_productdetailview_tsx",
       "label": "ProductDetailView.tsx",
@@ -66574,7 +66715,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1244,
+      "community": 1245,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_archivedproducts_tsx",
       "label": "ArchivedProducts.tsx",
@@ -66583,7 +66724,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1245,
+      "community": 1246,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_categorylistview_tsx",
       "label": "CategoryListView.tsx",
@@ -66592,7 +66733,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1246,
+      "community": 1247,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_productsubcategorytogglegroup_tsx",
       "label": "ProductSubcategoryToggleGroup.tsx",
@@ -66601,7 +66742,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1247,
+      "community": 1248,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_tsx",
       "label": "Products.tsx",
@@ -66610,21 +66751,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1248,
+      "community": 1249,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_storeproducts_tsx",
       "label": "StoreProducts.tsx",
       "norm_label": "storeproducts.tsx",
       "source_file": "packages/athena-webapp/src/components/products/StoreProducts.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1249,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_unresolvedproducts_tsx",
-      "label": "UnresolvedProducts.tsx",
-      "norm_label": "unresolvedproducts.tsx",
-      "source_file": "packages/athena-webapp/src/components/products/UnresolvedProducts.tsx",
       "source_location": "L1"
     },
     {
@@ -66693,6 +66825,15 @@
     {
       "community": 1250,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_products_unresolvedproducts_tsx",
+      "label": "UnresolvedProducts.tsx",
+      "norm_label": "unresolvedproducts.tsx",
+      "source_file": "packages/athena-webapp/src/components/products/UnresolvedProducts.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1251,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_complimentary_complimentaryproducts_tsx",
       "label": "ComplimentaryProducts.tsx",
       "norm_label": "complimentaryproducts.tsx",
@@ -66700,7 +66841,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1251,
+      "community": 1252,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_complimentary_complimentaryproductscolumn_tsx",
       "label": "complimentaryProductsColumn.tsx",
@@ -66709,7 +66850,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1252,
+      "community": 1253,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -66718,7 +66859,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1253,
+      "community": 1254,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -66727,7 +66868,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1254,
+      "community": 1255,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -66736,7 +66877,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1255,
+      "community": 1256,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_tsx",
       "label": "data-table.tsx",
@@ -66745,7 +66886,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1256,
+      "community": 1257,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_ts",
       "label": "data.ts",
@@ -66754,7 +66895,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1257,
+      "community": 1258,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_productcolumns_tsx",
       "label": "productColumns.tsx",
@@ -66763,21 +66904,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1258,
+      "community": 1259,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodeheader_test_tsx",
       "label": "PromoCodeHeader.test.tsx",
       "norm_label": "promocodeheader.test.tsx",
       "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeHeader.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1259,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_promocodes_tsx",
-      "label": "PromoCodes.tsx",
-      "norm_label": "promocodes.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodes.tsx",
       "source_location": "L1"
     },
     {
@@ -66846,6 +66978,15 @@
     {
       "community": 1260,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_promocodes_tsx",
+      "label": "PromoCodes.tsx",
+      "norm_label": "promocodes.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodes.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1261,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_analytics_promocodeanalytics_tsx",
       "label": "PromoCodeAnalytics.tsx",
       "norm_label": "promocodeanalytics.tsx",
@@ -66853,7 +66994,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1261,
+      "community": 1262,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_captured_captured_emails_columns_tsx",
       "label": "captured-emails-columns.tsx",
@@ -66862,7 +67003,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1262,
+      "community": 1263,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodemoney_test_ts",
       "label": "promoCodeMoney.test.ts",
@@ -66871,7 +67012,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1263,
+      "community": 1264,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_columns_tsx",
       "label": "columns.tsx",
@@ -66880,7 +67021,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1264,
+      "community": 1265,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -66889,7 +67030,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1265,
+      "community": 1266,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -66898,7 +67039,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1266,
+      "community": 1267,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -66907,7 +67048,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1267,
+      "community": 1268,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -66916,21 +67057,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1268,
+      "community": 1269,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_columns_tsx",
       "label": "columns.tsx",
       "norm_label": "columns.tsx",
       "source_file": "packages/athena-webapp/src/components/promo-codes/table/columns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1269,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_table_constants_ts",
-      "label": "constants.ts",
-      "norm_label": "constants.ts",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/table/constants.ts",
       "source_location": "L1"
     },
     {
@@ -66999,6 +67131,15 @@
     {
       "community": 1270,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_table_constants_ts",
+      "label": "constants.ts",
+      "norm_label": "constants.ts",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/table/constants.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1271,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
       "norm_label": "data-table-faceted-filter.tsx",
@@ -67006,7 +67147,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1271,
+      "community": 1272,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -67015,7 +67156,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1272,
+      "community": 1273,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -67024,7 +67165,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1273,
+      "community": 1274,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_data_ts",
       "label": "data.ts",
@@ -67033,7 +67174,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1274,
+      "community": 1275,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_types_ts",
       "label": "types.ts",
@@ -67042,7 +67183,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1275,
+      "community": 1276,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_welcome_offer_card_tsx",
       "label": "welcome-offer-card.tsx",
@@ -67051,7 +67192,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1276,
+      "community": 1277,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reviews_ratingstars_tsx",
       "label": "RatingStars.tsx",
@@ -67060,7 +67201,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1277,
+      "community": 1278,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reviews_reviewcard_tsx",
       "label": "ReviewCard.tsx",
@@ -67069,21 +67210,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1278,
+      "community": 1279,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reviews_reviewmetadata_tsx",
       "label": "ReviewMetadata.tsx",
       "norm_label": "reviewmetadata.tsx",
       "source_file": "packages/athena-webapp/src/components/reviews/ReviewMetadata.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1279,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_services_servicesworkspaceview_test_tsx",
-      "label": "ServicesWorkspaceView.test.tsx",
-      "norm_label": "servicesworkspaceview.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/services/ServicesWorkspaceView.test.tsx",
       "source_location": "L1"
     },
     {
@@ -67152,6 +67284,15 @@
     {
       "community": 1280,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_services_servicesworkspaceview_test_tsx",
+      "label": "ServicesWorkspaceView.test.tsx",
+      "norm_label": "servicesworkspaceview.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/services/ServicesWorkspaceView.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1281,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_staff_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
@@ -67159,7 +67300,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1281,
+      "community": 1282,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_staff_auth_staffauthenticationdialog_test_tsx",
       "label": "StaffAuthenticationDialog.test.tsx",
@@ -67168,7 +67309,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1282,
+      "community": 1283,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_feesview_test_ts",
       "label": "FeesView.test.ts",
@@ -67177,7 +67318,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1283,
+      "community": 1284,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_fulfillmentview_test_tsx",
       "label": "FulfillmentView.test.tsx",
@@ -67186,7 +67327,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1284,
+      "community": 1285,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_maintenanceview_test_tsx",
       "label": "MaintenanceView.test.tsx",
@@ -67195,7 +67336,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1285,
+      "community": 1286,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_mtnmomoview_test_tsx",
       "label": "MtnMomoView.test.tsx",
@@ -67204,7 +67345,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1286,
+      "community": 1287,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_hooks_usestoreconfigupdate_test_tsx",
       "label": "useStoreConfigUpdate.test.tsx",
@@ -67213,7 +67354,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1287,
+      "community": 1288,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_index_tsx",
       "label": "index.tsx",
@@ -67222,21 +67363,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1288,
+      "community": 1289,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_traces_workflowtraceview_test_tsx",
       "label": "WorkflowTraceView.test.tsx",
       "norm_label": "workflowtraceview.test.tsx",
       "source_file": "packages/athena-webapp/src/components/traces/WorkflowTraceView.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1289,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_accordion_tsx",
-      "label": "accordion.tsx",
-      "norm_label": "accordion.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/accordion.tsx",
       "source_location": "L1"
     },
     {
@@ -67305,6 +67437,15 @@
     {
       "community": 1290,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_accordion_tsx",
+      "label": "accordion.tsx",
+      "norm_label": "accordion.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/accordion.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1291,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_button_test_tsx",
       "label": "button.test.tsx",
       "norm_label": "button.test.tsx",
@@ -67312,7 +67453,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1291,
+      "community": 1292,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_button_tsx",
       "label": "button.tsx",
@@ -67321,7 +67462,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1292,
+      "community": 1293,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_calendar_test_tsx",
       "label": "calendar.test.tsx",
@@ -67330,7 +67471,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1293,
+      "community": 1294,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_card_tsx",
       "label": "card.tsx",
@@ -67339,7 +67480,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1294,
+      "community": 1295,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_checkbox_tsx",
       "label": "checkbox.tsx",
@@ -67348,7 +67489,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1295,
+      "community": 1296,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_collapsible_tsx",
       "label": "collapsible.tsx",
@@ -67357,7 +67498,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1296,
+      "community": 1297,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_command_tsx",
       "label": "command.tsx",
@@ -67366,7 +67507,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1297,
+      "community": 1298,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_context_menu_tsx",
       "label": "context-menu.tsx",
@@ -67375,21 +67516,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1298,
+      "community": 1299,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_dialog_tsx",
       "label": "dialog.tsx",
       "norm_label": "dialog.tsx",
       "source_file": "packages/athena-webapp/src/components/ui/dialog.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1299,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_dropdown_menu_tsx",
-      "label": "dropdown-menu.tsx",
-      "norm_label": "dropdown-menu.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/dropdown-menu.tsx",
       "source_location": "L1"
     },
     {
@@ -67710,6 +67842,15 @@
     {
       "community": 1300,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_dropdown_menu_tsx",
+      "label": "dropdown-menu.tsx",
+      "norm_label": "dropdown-menu.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/dropdown-menu.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1301,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_form_tsx",
       "label": "form.tsx",
       "norm_label": "form.tsx",
@@ -67717,7 +67858,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1301,
+      "community": 1302,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_icons_tsx",
       "label": "icons.tsx",
@@ -67726,7 +67867,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1302,
+      "community": 1303,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_input_otp_tsx",
       "label": "input-otp.tsx",
@@ -67735,7 +67876,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1303,
+      "community": 1304,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_input_tsx",
       "label": "input.tsx",
@@ -67744,7 +67885,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1304,
+      "community": 1305,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_action_modal_tsx",
       "label": "action-modal.tsx",
@@ -67753,7 +67894,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1305,
+      "community": 1306,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_panel_header_tsx",
       "label": "panel-header.tsx",
@@ -67762,7 +67903,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1306,
+      "community": 1307,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_popover_tsx",
       "label": "popover.tsx",
@@ -67771,7 +67912,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1307,
+      "community": 1308,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_primitives_test_tsx",
       "label": "primitives.test.tsx",
@@ -67780,21 +67921,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1308,
+      "community": 1309,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_radio_group_tsx",
       "label": "radio-group.tsx",
       "norm_label": "radio-group.tsx",
       "source_file": "packages/athena-webapp/src/components/ui/radio-group.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1309,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_scroll_area_tsx",
-      "label": "scroll-area.tsx",
-      "norm_label": "scroll-area.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/scroll-area.tsx",
       "source_location": "L1"
     },
     {
@@ -67863,6 +67995,15 @@
     {
       "community": 1310,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_scroll_area_tsx",
+      "label": "scroll-area.tsx",
+      "norm_label": "scroll-area.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/scroll-area.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1311,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_select_tsx",
       "label": "select.tsx",
       "norm_label": "select.tsx",
@@ -67870,7 +68011,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1311,
+      "community": 1312,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_separator_tsx",
       "label": "separator.tsx",
@@ -67879,7 +68020,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1312,
+      "community": 1313,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_sheet_tsx",
       "label": "sheet.tsx",
@@ -67888,7 +68029,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1313,
+      "community": 1314,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_switch_tsx",
       "label": "switch.tsx",
@@ -67897,7 +68038,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1314,
+      "community": 1315,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_table_tsx",
       "label": "table.tsx",
@@ -67906,7 +68047,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1315,
+      "community": 1316,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_tabs_tsx",
       "label": "tabs.tsx",
@@ -67915,7 +68056,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1316,
+      "community": 1317,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_textarea_tsx",
       "label": "textarea.tsx",
@@ -67924,7 +68065,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1317,
+      "community": 1318,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_toggle_group_tsx",
       "label": "toggle-group.tsx",
@@ -67933,21 +68074,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1318,
+      "community": 1319,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_toggle_tsx",
       "label": "toggle.tsx",
       "norm_label": "toggle.tsx",
       "source_file": "packages/athena-webapp/src/components/ui/toggle.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1319,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_tooltip_tsx",
-      "label": "tooltip.tsx",
-      "norm_label": "tooltip.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/tooltip.tsx",
       "source_location": "L1"
     },
     {
@@ -68016,6 +68148,15 @@
     {
       "community": 1320,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_tooltip_tsx",
+      "label": "tooltip.tsx",
+      "norm_label": "tooltip.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/tooltip.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1321,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_upload_button_tsx",
       "label": "upload-button.tsx",
       "norm_label": "upload-button.tsx",
@@ -68023,7 +68164,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1321,
+      "community": 1322,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_bagview_tsx",
       "label": "BagView.tsx",
@@ -68032,7 +68173,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1322,
+      "community": 1323,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_columns_tsx",
       "label": "columns.tsx",
@@ -68041,7 +68182,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1323,
+      "community": 1324,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_constants_ts",
       "label": "constants.ts",
@@ -68050,7 +68191,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1324,
+      "community": 1325,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -68059,7 +68200,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1325,
+      "community": 1326,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -68068,7 +68209,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1326,
+      "community": 1327,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -68077,7 +68218,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1327,
+      "community": 1328,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_data_ts",
       "label": "data.ts",
@@ -68086,21 +68227,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1328,
+      "community": 1329,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_bag_columns_tsx",
       "label": "bag-columns.tsx",
       "norm_label": "bag-columns.tsx",
       "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/bag-columns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1329,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_bags_table_tsx",
-      "label": "bags-table.tsx",
-      "norm_label": "bags-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/bags-table.tsx",
       "source_location": "L1"
     },
     {
@@ -68169,6 +68301,15 @@
     {
       "community": 1330,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_bags_table_tsx",
+      "label": "bags-table.tsx",
+      "norm_label": "bags-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/bags-table.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1331,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_columns_tsx",
       "label": "columns.tsx",
       "norm_label": "columns.tsx",
@@ -68176,7 +68317,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1331,
+      "community": 1332,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -68185,7 +68326,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1332,
+      "community": 1333,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -68194,7 +68335,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1333,
+      "community": 1334,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -68203,7 +68344,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1334,
+      "community": 1335,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -68212,7 +68353,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1335,
+      "community": 1336,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_linkedaccounts_tsx",
       "label": "LinkedAccounts.tsx",
@@ -68221,7 +68362,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1336,
+      "community": 1337,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_timelineeventcard_test_tsx",
       "label": "TimelineEventCard.test.tsx",
@@ -68230,7 +68371,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1337,
+      "community": 1338,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_usercheckoutsession_tsx",
       "label": "UserCheckoutSession.tsx",
@@ -68239,21 +68380,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1338,
+      "community": 1339,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_userinsightssection_tsx",
       "label": "UserInsightsSection.tsx",
       "norm_label": "userinsightssection.tsx",
       "source_file": "packages/athena-webapp/src/components/users/UserInsightsSection.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1339,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_users_behavioral_insights_userbehaviorinsights_tsx",
-      "label": "UserBehaviorInsights.tsx",
-      "norm_label": "userbehaviorinsights.tsx",
-      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/UserBehaviorInsights.tsx",
       "source_location": "L1"
     },
     {
@@ -68322,6 +68454,15 @@
     {
       "community": 1340,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_users_behavioral_insights_userbehaviorinsights_tsx",
+      "label": "UserBehaviorInsights.tsx",
+      "norm_label": "userbehaviorinsights.tsx",
+      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/UserBehaviorInsights.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1341,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_index_ts",
       "label": "index.ts",
       "norm_label": "index.ts",
@@ -68329,7 +68470,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1341,
+      "community": 1342,
       "file_type": "code",
       "id": "packages_athena_webapp_src_config_test_ts",
       "label": "config.test.ts",
@@ -68338,7 +68479,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1342,
+      "community": 1343,
       "file_type": "code",
       "id": "packages_athena_webapp_src_contexts_themecontext_tsx",
       "label": "ThemeContext.tsx",
@@ -68347,7 +68488,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1343,
+      "community": 1344,
       "file_type": "code",
       "id": "packages_athena_webapp_src_design_system_build_config_test_ts",
       "label": "design-system-build-config.test.ts",
@@ -68356,7 +68497,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1344,
+      "community": 1345,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_store_modal_tsx",
       "label": "use-store-modal.tsx",
@@ -68365,7 +68506,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1345,
+      "community": 1346,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useauth_test_tsx",
       "label": "useAuth.test.tsx",
@@ -68374,7 +68515,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1346,
+      "community": 1347,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useexpensesessions_test_ts",
       "label": "useExpenseSessions.test.ts",
@@ -68383,7 +68524,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1347,
+      "community": 1348,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useorganizationmodal_tsx",
       "label": "useOrganizationModal.tsx",
@@ -68392,21 +68533,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1348,
+      "community": 1349,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useprotectedadminpagestate_test_tsx",
       "label": "useProtectedAdminPageState.test.tsx",
       "norm_label": "useprotectedadminpagestate.test.tsx",
       "source_file": "packages/athena-webapp/src/hooks/useProtectedAdminPageState.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1349,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_access_capabilities_test_ts",
-      "label": "capabilities.test.ts",
-      "norm_label": "capabilities.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/access/capabilities.test.ts",
       "source_location": "L1"
     },
     {
@@ -68475,6 +68607,15 @@
     {
       "community": 1350,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_access_capabilities_test_ts",
+      "label": "capabilities.test.ts",
+      "norm_label": "capabilities.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/access/capabilities.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1351,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_lib_aws_ts",
       "label": "aws.ts",
       "norm_label": "aws.ts",
@@ -68482,7 +68623,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1351,
+      "community": 1352,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_constants_ts",
       "label": "constants.ts",
@@ -68491,7 +68632,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1352,
+      "community": 1353,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_countries_ts",
       "label": "countries.ts",
@@ -68500,7 +68641,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1353,
+      "community": 1354,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_operatormessages_test_ts",
       "label": "operatorMessages.test.ts",
@@ -68509,7 +68650,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1354,
+      "community": 1355,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_presentcommandtoast_test_ts",
       "label": "presentCommandToast.test.ts",
@@ -68518,7 +68659,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1355,
+      "community": 1356,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_presentunexpectederrortoast_test_ts",
       "label": "presentUnexpectedErrorToast.test.ts",
@@ -68527,7 +68668,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1356,
+      "community": 1357,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_runcommand_test_ts",
       "label": "runCommand.test.ts",
@@ -68536,7 +68677,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1357,
+      "community": 1358,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_ghana_ts",
       "label": "ghana.ts",
@@ -68545,21 +68686,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1358,
+      "community": 1359,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_ghanaregions_ts",
       "label": "ghanaRegions.ts",
       "norm_label": "ghanaregions.ts",
       "source_file": "packages/athena-webapp/src/lib/ghanaRegions.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1359,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_application_dto_ts",
-      "label": "dto.ts",
-      "norm_label": "dto.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/dto.ts",
       "source_location": "L1"
     },
     {
@@ -68628,6 +68760,15 @@
     {
       "community": 1360,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_application_dto_ts",
+      "label": "dto.ts",
+      "norm_label": "dto.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/dto.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1361,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_ports_ts",
       "label": "ports.ts",
       "norm_label": "ports.ts",
@@ -68635,7 +68776,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1361,
+      "community": 1362,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_constants_ts",
       "label": "constants.ts",
@@ -68644,7 +68785,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1362,
+      "community": 1363,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_displayamounts_test_ts",
       "label": "displayAmounts.test.ts",
@@ -68653,7 +68794,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1363,
+      "community": 1364,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_domain_cart_test_ts",
       "label": "cart.test.ts",
@@ -68662,7 +68803,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1364,
+      "community": 1365,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_domain_index_ts",
       "label": "index.ts",
@@ -68671,7 +68812,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1365,
+      "community": 1366,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_domain_session_test_ts",
       "label": "session.test.ts",
@@ -68680,7 +68821,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1366,
+      "community": 1367,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_domain_types_ts",
       "label": "types.ts",
@@ -68689,7 +68830,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1367,
+      "community": 1368,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_registergateway_test_ts",
       "label": "registerGateway.test.ts",
@@ -68698,21 +68839,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1368,
+      "community": 1369,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_sessiongateway_test_ts",
       "label": "sessionGateway.test.ts",
       "norm_label": "sessiongateway.test.ts",
       "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/sessionGateway.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1369,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_infrastructure_telemetry_loggergateway_ts",
-      "label": "loggerGateway.ts",
-      "norm_label": "loggergateway.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/loggerGateway.ts",
       "source_location": "L1"
     },
     {
@@ -68781,6 +68913,15 @@
     {
       "community": 1370,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_infrastructure_telemetry_loggergateway_ts",
+      "label": "loggerGateway.ts",
+      "norm_label": "loggergateway.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/loggerGateway.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1371,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_presentation_register_catalogsearch_test_ts",
       "label": "catalogSearch.test.ts",
       "norm_label": "catalogsearch.test.ts",
@@ -68788,7 +68929,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1371,
+      "community": 1372,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_presentation_register_registeruistate_ts",
       "label": "registerUiState.ts",
@@ -68797,7 +68938,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1372,
+      "community": 1373,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_productutils_test_ts",
       "label": "productUtils.test.ts",
@@ -68806,7 +68947,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1373,
+      "community": 1374,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_schemas_category_ts",
       "label": "category.ts",
@@ -68815,7 +68956,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1374,
+      "community": 1375,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_schemas_product_ts",
       "label": "product.ts",
@@ -68824,7 +68965,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1375,
+      "community": 1376,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_schemas_store_ts",
       "label": "store.ts",
@@ -68833,7 +68974,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1376,
+      "community": 1377,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_schemas_subcategory_ts",
       "label": "subcategory.ts",
@@ -68842,7 +68983,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1377,
+      "community": 1378,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_schemas_user_ts",
       "label": "user.ts",
@@ -68851,21 +68992,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1378,
+      "community": 1379,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_storeconfig_test_ts",
       "label": "storeConfig.test.ts",
       "norm_label": "storeconfig.test.ts",
       "source_file": "packages/athena-webapp/src/lib/storeConfig.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1379,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_traces_createworkflowtraceid_test_ts",
-      "label": "createWorkflowTraceId.test.ts",
-      "norm_label": "createworkflowtraceid.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/traces/createWorkflowTraceId.test.ts",
       "source_location": "L1"
     },
     {
@@ -68934,6 +69066,15 @@
     {
       "community": 1380,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_traces_createworkflowtraceid_test_ts",
+      "label": "createWorkflowTraceId.test.ts",
+      "norm_label": "createworkflowtraceid.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/traces/createWorkflowTraceId.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1381,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_lib_utils_test_ts",
       "label": "utils.test.ts",
       "norm_label": "utils.test.ts",
@@ -68941,7 +69082,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1381,
+      "community": 1382,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routetree_gen_ts",
       "label": "routeTree.gen.ts",
@@ -68950,7 +69091,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1382,
+      "community": 1383,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_root_tsx",
       "label": "__root.tsx",
@@ -68959,7 +69100,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1383,
+      "community": 1384,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_index_tsx",
       "label": "index.tsx",
@@ -68968,7 +69109,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1384,
+      "community": 1385,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_settings_index_tsx",
       "label": "index.tsx",
@@ -68977,7 +69118,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1385,
+      "community": 1386,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_settings_organization_index_tsx",
       "label": "index.tsx",
@@ -68986,7 +69127,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1386,
+      "community": 1387,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_settings_stores_storeurlslug_tsx",
       "label": "$storeUrlSlug.tsx",
@@ -68995,7 +69136,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1387,
+      "community": 1388,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_analytics_tsx",
       "label": "analytics.tsx",
@@ -69004,21 +69145,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1388,
+      "community": 1389,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_assets_index_tsx",
       "label": "assets.index.tsx",
       "norm_label": "assets.index.tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/assets.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1389,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_bags_bagid_tsx",
-      "label": "bags.$bagId.tsx",
-      "norm_label": "bags.$bagid.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/bags.$bagId.tsx",
       "source_location": "L1"
     },
     {
@@ -69087,6 +69219,15 @@
     {
       "community": 1390,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_bags_bagid_tsx",
+      "label": "bags.$bagId.tsx",
+      "norm_label": "bags.$bagid.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/bags.$bagId.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1391,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_bags_index_tsx",
       "label": "bags.index.tsx",
       "norm_label": "bags.index.tsx",
@@ -69094,7 +69235,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1391,
+      "community": 1392,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_bulk_operations_index_tsx",
       "label": "index.tsx",
@@ -69103,7 +69244,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1392,
+      "community": 1393,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_checkout_sessions_index_tsx",
       "label": "checkout-sessions.index.tsx",
@@ -69112,7 +69253,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1393,
+      "community": 1394,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_configuration_index_tsx",
       "label": "configuration.index.tsx",
@@ -69121,7 +69262,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1394,
+      "community": 1395,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_dashboard_index_tsx",
       "label": "dashboard.index.tsx",
@@ -69130,7 +69271,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1395,
+      "community": 1396,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_home_tsx",
       "label": "home.tsx",
@@ -69139,7 +69280,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1396,
+      "community": 1397,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_logs_logid_tsx",
       "label": "logs.$logId.tsx",
@@ -69148,7 +69289,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1397,
+      "community": 1398,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_logs_index_tsx",
       "label": "logs.index.tsx",
@@ -69157,21 +69298,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1398,
+      "community": 1399,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_members_index_tsx",
       "label": "members.index.tsx",
       "norm_label": "members.index.tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/members.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1399,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_operations_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/index.tsx",
       "source_location": "L1"
     },
     {
@@ -69465,6 +69597,15 @@
     {
       "community": 1400,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_operations_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1401,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_orderslug_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
@@ -69472,7 +69613,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1401,
+      "community": 1402,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_all_index_tsx",
       "label": "all.index.tsx",
@@ -69481,7 +69622,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1402,
+      "community": 1403,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_cancelled_index_tsx",
       "label": "cancelled.index.tsx",
@@ -69490,7 +69631,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1403,
+      "community": 1404,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_completed_index_tsx",
       "label": "completed.index.tsx",
@@ -69499,7 +69640,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1404,
+      "community": 1405,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_index_tsx",
       "label": "index.tsx",
@@ -69508,7 +69649,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1405,
+      "community": 1406,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_open_index_tsx",
       "label": "open.index.tsx",
@@ -69517,7 +69658,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1406,
+      "community": 1407,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_out_for_delivery_index_tsx",
       "label": "out-for-delivery.index.tsx",
@@ -69526,7 +69667,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1407,
+      "community": 1408,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_ready_index_tsx",
       "label": "ready.index.tsx",
@@ -69535,21 +69676,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1408,
+      "community": 1409,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_refunded_index_tsx",
       "label": "refunded.index.tsx",
       "norm_label": "refunded.index.tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/refunded.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1409,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_reports_reportid_tsx",
-      "label": "$reportId.tsx",
-      "norm_label": "$reportid.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/expense-reports/$reportId.tsx",
       "source_location": "L1"
     },
     {
@@ -69618,6 +69750,15 @@
     {
       "community": 1410,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_reports_reportid_tsx",
+      "label": "$reportId.tsx",
+      "norm_label": "$reportid.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/expense-reports/$reportId.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1411,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_reports_index_tsx",
       "label": "expense-reports.index.tsx",
       "norm_label": "expense-reports.index.tsx",
@@ -69625,7 +69766,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1411,
+      "community": 1412,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_index_tsx",
       "label": "index.tsx",
@@ -69634,7 +69775,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1412,
+      "community": 1413,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_register_index_tsx",
       "label": "register.index.tsx",
@@ -69643,7 +69784,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1413,
+      "community": 1414,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_sessions_index_tsx",
       "label": "sessions.index.tsx",
@@ -69652,7 +69793,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1414,
+      "community": 1415,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_settings_index_tsx",
       "label": "settings.index.tsx",
@@ -69661,7 +69802,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1415,
+      "community": 1416,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_transactions_transactionid_tsx",
       "label": "$transactionId.tsx",
@@ -69670,7 +69811,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1416,
+      "community": 1417,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_transactions_index_tsx",
       "label": "transactions.index.tsx",
@@ -69679,7 +69820,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1417,
+      "community": 1418,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_procurement_index_test_ts",
       "label": "procurement.index.test.ts",
@@ -69688,21 +69829,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1418,
+      "community": 1419,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_productslug_edit_tsx",
       "label": "edit.tsx",
       "norm_label": "edit.tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/$productSlug/edit.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1419,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_productslug_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/$productSlug/index.tsx",
       "source_location": "L1"
     },
     {
@@ -69771,6 +69903,15 @@
     {
       "community": 1420,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_productslug_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/$productSlug/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1421,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_archived_tsx",
       "label": "archived.tsx",
       "norm_label": "archived.tsx",
@@ -69778,7 +69919,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1421,
+      "community": 1422,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_complimentary_index_tsx",
       "label": "index.tsx",
@@ -69787,7 +69928,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1422,
+      "community": 1423,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_complimentary_new_tsx",
       "label": "new.tsx",
@@ -69796,7 +69937,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1423,
+      "community": 1424,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_index_tsx",
       "label": "index.tsx",
@@ -69805,7 +69946,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1424,
+      "community": 1425,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_new_tsx",
       "label": "new.tsx",
@@ -69814,7 +69955,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1425,
+      "community": 1426,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_unresolved_tsx",
       "label": "unresolved.tsx",
@@ -69823,7 +69964,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1426,
+      "community": 1427,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_promocodeslug_tsx",
       "label": "$promoCodeSlug.tsx",
@@ -69832,7 +69973,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1427,
+      "community": 1428,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_index_tsx",
       "label": "index.tsx",
@@ -69841,21 +69982,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1428,
+      "community": 1429,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_new_tsx",
       "label": "new.tsx",
       "norm_label": "new.tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/promo-codes/new.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1429,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reviews_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/reviews/index.tsx",
       "source_location": "L1"
     },
     {
@@ -69924,6 +70056,15 @@
     {
       "community": 1430,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reviews_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/reviews/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1431,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reviews_new_index_tsx",
       "label": "new.index.tsx",
       "norm_label": "new.index.tsx",
@@ -69931,7 +70072,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1431,
+      "community": 1432,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_active_cases_index_tsx",
       "label": "active-cases.index.tsx",
@@ -69940,7 +70081,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1432,
+      "community": 1433,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_appointments_index_tsx",
       "label": "appointments.index.tsx",
@@ -69949,7 +70090,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1433,
+      "community": 1434,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_catalog_management_index_tsx",
       "label": "catalog-management.index.tsx",
@@ -69958,7 +70099,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1434,
+      "community": 1435,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_index_tsx",
       "label": "index.tsx",
@@ -69967,7 +70108,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1435,
+      "community": 1436,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_intake_index_tsx",
       "label": "intake.index.tsx",
@@ -69976,7 +70117,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1436,
+      "community": 1437,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_traces_traceid_test_tsx",
       "label": "$traceId.test.tsx",
@@ -69985,7 +70126,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1437,
+      "community": 1438,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_users_userid_tsx",
       "label": "users.$userId.tsx",
@@ -69994,21 +70135,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1438,
+      "community": 1439,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1439,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_test_tsx",
-      "label": "_authed.test.tsx",
-      "norm_label": "_authed.test.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed.test.tsx",
       "source_location": "L1"
     },
     {
@@ -70077,6 +70209,15 @@
     {
       "community": 1440,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_test_tsx",
+      "label": "_authed.test.tsx",
+      "norm_label": "_authed.test.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1441,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_index_test_tsx",
       "label": "index.test.tsx",
       "norm_label": "index.test.tsx",
@@ -70084,7 +70225,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1441,
+      "community": 1442,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_join_team_index_tsx",
       "label": "join-team.index.tsx",
@@ -70093,7 +70234,16 @@
       "source_location": "L1"
     },
     {
-      "community": 1442,
+      "community": 1443,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_landing_tsx",
+      "label": "landing.tsx",
+      "norm_label": "landing.tsx",
+      "source_file": "packages/athena-webapp/src/routes/landing.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1444,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_login_layout_index_test_tsx",
       "label": "_layout.index.test.tsx",
@@ -70102,7 +70252,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1443,
+      "community": 1445,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_login_layout_test_tsx",
       "label": "_layout.test.tsx",
@@ -70111,7 +70261,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1444,
+      "community": 1446,
       "file_type": "code",
       "id": "packages_athena_webapp_src_settings_store_storessettingsaccordion_tsx",
       "label": "StoresSettingsAccordion.tsx",
@@ -70120,7 +70270,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1445,
+      "community": 1447,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stores_expensestore_ts",
       "label": "expenseStore.ts",
@@ -70129,7 +70279,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1446,
+      "community": 1448,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_foundations_overview_stories_tsx",
       "label": "Overview.stories.tsx",
@@ -70138,30 +70288,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1447,
+      "community": 1449,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_foundations_foundations_content_test_tsx",
       "label": "foundations-content.test.tsx",
       "norm_label": "foundations-content.test.tsx",
       "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1448,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_guidance_introduction_stories_tsx",
-      "label": "Introduction.stories.tsx",
-      "norm_label": "introduction.stories.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Guidance/Introduction.stories.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1449,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_guidance_introduction_content_test_tsx",
-      "label": "introduction-content.test.tsx",
-      "norm_label": "introduction-content.test.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Guidance/introduction-content.test.tsx",
       "source_location": "L1"
     },
     {
@@ -70230,6 +70362,24 @@
     {
       "community": 1450,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_guidance_introduction_stories_tsx",
+      "label": "Introduction.stories.tsx",
+      "norm_label": "introduction.stories.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Guidance/Introduction.stories.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1451,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_guidance_introduction_content_test_tsx",
+      "label": "introduction-content.test.tsx",
+      "norm_label": "introduction-content.test.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Guidance/introduction-content.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1452,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_stories_guidance_introduction_content_tsx",
       "label": "introduction-content.tsx",
       "norm_label": "introduction-content.tsx",
@@ -70237,7 +70387,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1451,
+      "community": 1453,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_patterns_adminshell_stories_tsx",
       "label": "AdminShell.stories.tsx",
@@ -70246,7 +70396,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1452,
+      "community": 1454,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_patterns_view_stories_tsx",
       "label": "View.stories.tsx",
@@ -70255,7 +70405,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1453,
+      "community": 1455,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_patterns_admin_shell_patterns_test_tsx",
       "label": "admin-shell-patterns.test.tsx",
@@ -70264,7 +70414,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1454,
+      "community": 1456,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_patterns_view_patterns_test_tsx",
       "label": "view-patterns.test.tsx",
@@ -70273,7 +70423,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1455,
+      "community": 1457,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_surfaces_stories_tsx",
       "label": "Surfaces.stories.tsx",
@@ -70282,7 +70432,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1456,
+      "community": 1458,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_templates_dashboardworkspace_stories_tsx",
       "label": "DashboardWorkspace.stories.tsx",
@@ -70291,30 +70441,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1457,
+      "community": 1459,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_templates_dataworkspace_stories_tsx",
       "label": "DataWorkspace.stories.tsx",
       "norm_label": "dataworkspace.stories.tsx",
       "source_file": "packages/athena-webapp/src/stories/Templates/DataWorkspace.stories.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1458,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_templates_settingsworkspace_stories_tsx",
-      "label": "SettingsWorkspace.stories.tsx",
-      "norm_label": "settingsworkspace.stories.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Templates/SettingsWorkspace.stories.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1459,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_templates_reference_fixtures_test_tsx",
-      "label": "reference-fixtures.test.tsx",
-      "norm_label": "reference-fixtures.test.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.test.tsx",
       "source_location": "L1"
     },
     {
@@ -70383,6 +70515,24 @@
     {
       "community": 1460,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_templates_settingsworkspace_stories_tsx",
+      "label": "SettingsWorkspace.stories.tsx",
+      "norm_label": "settingsworkspace.stories.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Templates/SettingsWorkspace.stories.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1461,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_templates_reference_fixtures_test_tsx",
+      "label": "reference-fixtures.test.tsx",
+      "norm_label": "reference-fixtures.test.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1462,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_stories_storybook_config_test_ts",
       "label": "storybook-config.test.ts",
       "norm_label": "storybook-config.test.ts",
@@ -70390,7 +70540,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1461,
+      "community": 1463,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_storybook_theme_decorator_test_ts",
       "label": "storybook-theme-decorator.test.ts",
@@ -70399,7 +70549,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1462,
+      "community": 1464,
       "file_type": "code",
       "id": "packages_athena_webapp_src_test_setup_ts",
       "label": "setup.ts",
@@ -70408,7 +70558,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1463,
+      "community": 1465,
       "file_type": "code",
       "id": "packages_athena_webapp_src_tests_pos_useprint_test_ts",
       "label": "usePrint.test.ts",
@@ -70417,7 +70567,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1464,
+      "community": 1466,
       "file_type": "code",
       "id": "packages_athena_webapp_tailwind_config_js",
       "label": "tailwind.config.js",
@@ -70426,7 +70576,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1465,
+      "community": 1467,
       "file_type": "code",
       "id": "packages_athena_webapp_types_ts",
       "label": "types.ts",
@@ -70435,7 +70585,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1466,
+      "community": 1468,
       "file_type": "code",
       "id": "packages_athena_webapp_vitest_config_ts",
       "label": "vitest.config.ts",
@@ -70444,30 +70594,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1467,
+      "community": 1469,
       "file_type": "code",
       "id": "packages_storefront_webapp_eslint_config_js",
       "label": "eslint.config.js",
       "norm_label": "eslint.config.js",
       "source_file": "packages/storefront-webapp/eslint.config.js",
-      "source_location": "L1"
-    },
-    {
-      "community": 1468,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_global_d_ts",
-      "label": "global.d.ts",
-      "norm_label": "global.d.ts",
-      "source_file": "packages/storefront-webapp/global.d.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1469,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_playwright_config_ts",
-      "label": "playwright.config.ts",
-      "norm_label": "playwright.config.ts",
-      "source_file": "packages/storefront-webapp/playwright.config.ts",
       "source_location": "L1"
     },
     {
@@ -70536,6 +70668,24 @@
     {
       "community": 1470,
       "file_type": "code",
+      "id": "packages_storefront_webapp_global_d_ts",
+      "label": "global.d.ts",
+      "norm_label": "global.d.ts",
+      "source_file": "packages/storefront-webapp/global.d.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1471,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_playwright_config_ts",
+      "label": "playwright.config.ts",
+      "norm_label": "playwright.config.ts",
+      "source_file": "packages/storefront-webapp/playwright.config.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1472,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_api_analytics_test_ts",
       "label": "analytics.test.ts",
       "norm_label": "analytics.test.ts",
@@ -70543,7 +70693,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1471,
+      "community": 1473,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_types_ts",
       "label": "types.ts",
@@ -70552,7 +70702,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1472,
+      "community": 1474,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_assets_icons_hearticonfilled_tsx",
       "label": "HeartIconFilled.tsx",
@@ -70561,7 +70711,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1473,
+      "community": 1475,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_defaultcatchboundary_tsx",
       "label": "DefaultCatchBoundary.tsx",
@@ -70570,7 +70720,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1474,
+      "community": 1476,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_homepage_test_tsx",
       "label": "HomePage.test.tsx",
@@ -70579,7 +70729,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1475,
+      "community": 1477,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_productcard_test_tsx",
       "label": "ProductCard.test.tsx",
@@ -70588,7 +70738,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1476,
+      "community": 1478,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_productcard_tsx",
       "label": "ProductCard.tsx",
@@ -70597,30 +70747,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1477,
+      "community": 1479,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_upsell_tsx",
       "label": "Upsell.tsx",
       "norm_label": "upsell.tsx",
       "source_file": "packages/storefront-webapp/src/components/Upsell.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1478,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_checkout_test_tsx",
-      "label": "Checkout.test.tsx",
-      "norm_label": "checkout.test.tsx",
-      "source_file": "packages/storefront-webapp/src/components/checkout/Checkout.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1479,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_checkout_tsx",
-      "label": "Checkout.tsx",
-      "norm_label": "checkout.tsx",
-      "source_file": "packages/storefront-webapp/src/components/checkout/Checkout.tsx",
       "source_location": "L1"
     },
     {
@@ -70689,6 +70821,24 @@
     {
       "community": 1480,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_checkout_test_tsx",
+      "label": "Checkout.test.tsx",
+      "norm_label": "checkout.test.tsx",
+      "source_file": "packages/storefront-webapp/src/components/checkout/Checkout.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1481,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_checkout_tsx",
+      "label": "Checkout.tsx",
+      "norm_label": "checkout.tsx",
+      "source_file": "packages/storefront-webapp/src/components/checkout/Checkout.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1482,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_customerinfosection_tsx",
       "label": "CustomerInfoSection.tsx",
       "norm_label": "customerinfosection.tsx",
@@ -70696,7 +70846,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1481,
+      "community": 1483,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_schema_ts",
       "label": "schema.ts",
@@ -70705,7 +70855,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1482,
+      "community": 1484,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliverydetailssection_tsx",
       "label": "DeliveryDetailsSection.tsx",
@@ -70714,7 +70864,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1483,
+      "community": 1485,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkoutstorage_test_ts",
       "label": "checkoutStorage.test.ts",
@@ -70723,7 +70873,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1484,
+      "community": 1486,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliveryfees_test_ts",
       "label": "deliveryFees.test.ts",
@@ -70732,7 +70882,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1485,
+      "community": 1487,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_derivecheckoutstate_test_ts",
       "label": "deriveCheckoutState.test.ts",
@@ -70741,7 +70891,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1486,
+      "community": 1488,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_billingdetailsschema_ts",
       "label": "billingDetailsSchema.ts",
@@ -70750,30 +70900,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1487,
+      "community": 1489,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_checkoutformschema_ts",
       "label": "checkoutFormSchema.ts",
       "norm_label": "checkoutformschema.ts",
       "source_file": "packages/storefront-webapp/src/components/checkout/schemas/checkoutFormSchema.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1488,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_schemas_customerdetailsschema_ts",
-      "label": "customerDetailsSchema.ts",
-      "norm_label": "customerdetailsschema.ts",
-      "source_file": "packages/storefront-webapp/src/components/checkout/schemas/customerDetailsSchema.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1489,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_schemas_deliverydetailsschema_ts",
-      "label": "deliveryDetailsSchema.ts",
-      "norm_label": "deliverydetailsschema.ts",
-      "source_file": "packages/storefront-webapp/src/components/checkout/schemas/deliveryDetailsSchema.ts",
       "source_location": "L1"
     },
     {
@@ -70842,6 +70974,24 @@
     {
       "community": 1490,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_schemas_customerdetailsschema_ts",
+      "label": "customerDetailsSchema.ts",
+      "norm_label": "customerdetailsschema.ts",
+      "source_file": "packages/storefront-webapp/src/components/checkout/schemas/customerDetailsSchema.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1491,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_schemas_deliverydetailsschema_ts",
+      "label": "deliveryDetailsSchema.ts",
+      "norm_label": "deliverydetailsschema.ts",
+      "source_file": "packages/storefront-webapp/src/components/checkout/schemas/deliveryDetailsSchema.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1492,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_weborderschema_ts",
       "label": "webOrderSchema.ts",
       "norm_label": "weborderschema.ts",
@@ -70849,7 +70999,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1491,
+      "community": 1493,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_types_ts",
       "label": "types.ts",
@@ -70858,7 +71008,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1492,
+      "community": 1494,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_utils_test_ts",
       "label": "utils.test.ts",
@@ -70867,7 +71017,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1493,
+      "community": 1495,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_filter_productfilterbar_tsx",
       "label": "ProductFilterBar.tsx",
@@ -70876,7 +71026,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1494,
+      "community": 1496,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_bestsellerssection_test_tsx",
       "label": "BestSellersSection.test.tsx",
@@ -70885,7 +71035,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1495,
+      "community": 1497,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_homehero_tsx",
       "label": "HomeHero.tsx",
@@ -70894,7 +71044,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1496,
+      "community": 1498,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_homeherosection_tsx",
       "label": "HomeHeroSection.tsx",
@@ -70903,30 +71053,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1497,
+      "community": 1499,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_homepagecontent_test_ts",
       "label": "homePageContent.test.ts",
       "norm_label": "homepagecontent.test.ts",
       "source_file": "packages/storefront-webapp/src/components/home/homePageContent.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1498,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_navigation_bar_mobilemenu_tsx",
-      "label": "MobileMenu.tsx",
-      "norm_label": "mobilemenu.tsx",
-      "source_file": "packages/storefront-webapp/src/components/navigation-bar/MobileMenu.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1499,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_navigation_bar_constants_ts",
-      "label": "constants.ts",
-      "norm_label": "constants.ts",
-      "source_file": "packages/storefront-webapp/src/components/navigation-bar/constants.ts",
       "source_location": "L1"
     },
     {
@@ -71220,6 +71352,24 @@
     {
       "community": 1500,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_navigation_bar_mobilemenu_tsx",
+      "label": "MobileMenu.tsx",
+      "norm_label": "mobilemenu.tsx",
+      "source_file": "packages/storefront-webapp/src/components/navigation-bar/MobileMenu.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1501,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_navigation_bar_constants_ts",
+      "label": "constants.ts",
+      "norm_label": "constants.ts",
+      "source_file": "packages/storefront-webapp/src/components/navigation-bar/constants.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1502,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_navbarconstants_ts",
       "label": "navBarConstants.ts",
       "norm_label": "navbarconstants.ts",
@@ -71227,7 +71377,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1501,
+      "community": 1503,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_about_tsx",
       "label": "About.tsx",
@@ -71236,7 +71386,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1502,
+      "community": 1504,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_aboutproduct_tsx",
       "label": "AboutProduct.tsx",
@@ -71245,7 +71395,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1503,
+      "community": 1505,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productactions_test_tsx",
       "label": "ProductActions.test.tsx",
@@ -71254,7 +71404,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1504,
+      "community": 1506,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productinfo_tsx",
       "label": "ProductInfo.tsx",
@@ -71263,7 +71413,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1505,
+      "community": 1507,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productreviews_tsx",
       "label": "ProductReviews.tsx",
@@ -71272,7 +71422,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1506,
+      "community": 1508,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productsnavigationbar_tsx",
       "label": "ProductsNavigationBar.tsx",
@@ -71281,30 +71431,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1507,
+      "community": 1509,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_errormessage_tsx",
       "label": "ErrorMessage.tsx",
       "norm_label": "errormessage.tsx",
       "source_file": "packages/storefront-webapp/src/components/product-reviews/ErrorMessage.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1508,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_reviews_existingreviewmessage_tsx",
-      "label": "ExistingReviewMessage.tsx",
-      "norm_label": "existingreviewmessage.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-reviews/ExistingReviewMessage.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1509,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_reviews_orderitem_test_tsx",
-      "label": "OrderItem.test.tsx",
-      "norm_label": "orderitem.test.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-reviews/OrderItem.test.tsx",
       "source_location": "L1"
     },
     {
@@ -71373,6 +71505,24 @@
     {
       "community": 1510,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_reviews_existingreviewmessage_tsx",
+      "label": "ExistingReviewMessage.tsx",
+      "norm_label": "existingreviewmessage.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-reviews/ExistingReviewMessage.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1511,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_reviews_orderitem_test_tsx",
+      "label": "OrderItem.test.tsx",
+      "norm_label": "orderitem.test.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-reviews/OrderItem.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1512,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_reviewform_tsx",
       "label": "ReviewForm.tsx",
       "norm_label": "reviewform.tsx",
@@ -71380,7 +71530,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1511,
+      "community": 1513,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_successmessage_tsx",
       "label": "SuccessMessage.tsx",
@@ -71389,7 +71539,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1512,
+      "community": 1514,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_types_ts",
       "label": "types.ts",
@@ -71398,7 +71548,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1513,
+      "community": 1515,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_saved_items_savedbag_tsx",
       "label": "SavedBag.tsx",
@@ -71407,7 +71557,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1514,
+      "community": 1516,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_saved_items_savedicon_tsx",
       "label": "SavedIcon.tsx",
@@ -71416,7 +71566,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1515,
+      "community": 1517,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_shopping_bag_carticon_tsx",
       "label": "CartIcon.tsx",
@@ -71425,7 +71575,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1516,
+      "community": 1518,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_shopping_bag_shoppingbag_test_tsx",
       "label": "ShoppingBag.test.tsx",
@@ -71434,30 +71584,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1517,
+      "community": 1519,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_empty_empty_state_tsx",
       "label": "empty-state.tsx",
       "norm_label": "empty-state.tsx",
       "source_file": "packages/storefront-webapp/src/components/states/empty/empty-state.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1518,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_states_maintenance_maintenance_test_tsx",
-      "label": "Maintenance.test.tsx",
-      "norm_label": "maintenance.test.tsx",
-      "source_file": "packages/storefront-webapp/src/components/states/maintenance/Maintenance.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1519,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_states_maintenance_maintenance_tsx",
-      "label": "Maintenance.tsx",
-      "norm_label": "maintenance.tsx",
-      "source_file": "packages/storefront-webapp/src/components/states/maintenance/Maintenance.tsx",
       "source_location": "L1"
     },
     {
@@ -71517,6 +71649,24 @@
     {
       "community": 1520,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_states_maintenance_maintenance_test_tsx",
+      "label": "Maintenance.test.tsx",
+      "norm_label": "maintenance.test.tsx",
+      "source_file": "packages/storefront-webapp/src/components/states/maintenance/Maintenance.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1521,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_states_maintenance_maintenance_tsx",
+      "label": "Maintenance.tsx",
+      "norm_label": "maintenance.tsx",
+      "source_file": "packages/storefront-webapp/src/components/states/maintenance/Maintenance.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1522,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_animatedcard_tsx",
       "label": "AnimatedCard.tsx",
       "norm_label": "animatedcard.tsx",
@@ -71524,7 +71674,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1521,
+      "community": 1523,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_accordion_tsx",
       "label": "accordion.tsx",
@@ -71533,7 +71683,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1522,
+      "community": 1524,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_alert_tsx",
       "label": "alert.tsx",
@@ -71542,7 +71692,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1523,
+      "community": 1525,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_breadcrumb_tsx",
       "label": "breadcrumb.tsx",
@@ -71551,7 +71701,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1524,
+      "community": 1526,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_button_tsx",
       "label": "button.tsx",
@@ -71560,7 +71710,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1525,
+      "community": 1527,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_card_tsx",
       "label": "card.tsx",
@@ -71569,7 +71719,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1526,
+      "community": 1528,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_checkbox_tsx",
       "label": "checkbox.tsx",
@@ -71578,30 +71728,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1527,
+      "community": 1529,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_command_tsx",
       "label": "command.tsx",
       "norm_label": "command.tsx",
       "source_file": "packages/storefront-webapp/src/components/ui/command.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1528,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_context_menu_tsx",
-      "label": "context-menu.tsx",
-      "norm_label": "context-menu.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/context-menu.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1529,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_dialog_tsx",
-      "label": "dialog.tsx",
-      "norm_label": "dialog.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/dialog.tsx",
       "source_location": "L1"
     },
     {
@@ -71661,6 +71793,24 @@
     {
       "community": 1530,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_context_menu_tsx",
+      "label": "context-menu.tsx",
+      "norm_label": "context-menu.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/context-menu.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1531,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_dialog_tsx",
+      "label": "dialog.tsx",
+      "norm_label": "dialog.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/dialog.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1532,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_dropdown_menu_tsx",
       "label": "dropdown-menu.tsx",
       "norm_label": "dropdown-menu.tsx",
@@ -71668,7 +71818,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1531,
+      "community": 1533,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_form_tsx",
       "label": "form.tsx",
@@ -71677,7 +71827,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1532,
+      "community": 1534,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_icons_tsx",
       "label": "icons.tsx",
@@ -71686,7 +71836,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1533,
+      "community": 1535,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_image_with_fallback_tsx",
       "label": "image-with-fallback.tsx",
@@ -71695,7 +71845,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1534,
+      "community": 1536,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_input_otp_tsx",
       "label": "input-otp.tsx",
@@ -71704,7 +71854,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1535,
+      "community": 1537,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_input_with_end_button_tsx",
       "label": "input-with-end-button.tsx",
@@ -71713,7 +71863,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1536,
+      "community": 1538,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_input_tsx",
       "label": "input.tsx",
@@ -71722,30 +71872,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1537,
+      "community": 1539,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_label_tsx",
       "label": "label.tsx",
       "norm_label": "label.tsx",
       "source_file": "packages/storefront-webapp/src/components/ui/label.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1538,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_modals_leaveareviewmodalform_tsx",
-      "label": "LeaveAReviewModalForm.tsx",
-      "norm_label": "leaveareviewmodalform.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/LeaveAReviewModalForm.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1539,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_modals_action_modal_tsx",
-      "label": "action-modal.tsx",
-      "norm_label": "action-modal.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/action-modal.tsx",
       "source_location": "L1"
     },
     {
@@ -71805,6 +71937,24 @@
     {
       "community": 1540,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_modals_leaveareviewmodalform_tsx",
+      "label": "LeaveAReviewModalForm.tsx",
+      "norm_label": "leaveareviewmodalform.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/LeaveAReviewModalForm.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1541,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_modals_action_modal_tsx",
+      "label": "action-modal.tsx",
+      "norm_label": "action-modal.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/action-modal.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1542,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_animations_welcomebackmodalanimations_ts",
       "label": "welcomeBackModalAnimations.ts",
       "norm_label": "welcomebackmodalanimations.ts",
@@ -71812,7 +71962,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1541,
+      "community": 1543,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_index_ts",
       "label": "index.ts",
@@ -71821,7 +71971,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1542,
+      "community": 1544,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_types_ts",
       "label": "types.ts",
@@ -71830,7 +71980,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1543,
+      "community": 1545,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_navigation_menu_tsx",
       "label": "navigation-menu.tsx",
@@ -71839,7 +71989,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1544,
+      "community": 1546,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_popover_tsx",
       "label": "popover.tsx",
@@ -71848,7 +71998,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1545,
+      "community": 1547,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_radio_group_tsx",
       "label": "radio-group.tsx",
@@ -71857,7 +72007,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1546,
+      "community": 1548,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_scroll_area_tsx",
       "label": "scroll-area.tsx",
@@ -71866,30 +72016,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1547,
+      "community": 1549,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_select_tsx",
       "label": "select.tsx",
       "norm_label": "select.tsx",
       "source_file": "packages/storefront-webapp/src/components/ui/select.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1548,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_separator_tsx",
-      "label": "separator.tsx",
-      "norm_label": "separator.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/separator.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1549,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_sheet_tsx",
-      "label": "sheet.tsx",
-      "norm_label": "sheet.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/sheet.tsx",
       "source_location": "L1"
     },
     {
@@ -71949,6 +72081,24 @@
     {
       "community": 1550,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_separator_tsx",
+      "label": "separator.tsx",
+      "norm_label": "separator.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/separator.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1551,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_sheet_tsx",
+      "label": "sheet.tsx",
+      "norm_label": "sheet.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/sheet.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1552,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_table_tsx",
       "label": "table.tsx",
       "norm_label": "table.tsx",
@@ -71956,7 +72106,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1551,
+      "community": 1553,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_tabs_tsx",
       "label": "tabs.tsx",
@@ -71965,7 +72115,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1552,
+      "community": 1554,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_textarea_tsx",
       "label": "textarea.tsx",
@@ -71974,7 +72124,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1553,
+      "community": 1555,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_toggle_group_tsx",
       "label": "toggle-group.tsx",
@@ -71983,7 +72133,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1554,
+      "community": 1556,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_toggle_tsx",
       "label": "toggle.tsx",
@@ -71992,7 +72142,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1555,
+      "community": 1557,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_tooltip_tsx",
       "label": "tooltip.tsx",
@@ -72001,7 +72151,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1556,
+      "community": 1558,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_config_ts",
       "label": "config.ts",
@@ -72010,30 +72160,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1557,
+      "community": 1559,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_use_store_modal_tsx",
       "label": "use-store-modal.tsx",
       "norm_label": "use-store-modal.tsx",
       "source_file": "packages/storefront-webapp/src/hooks/use-store-modal.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1558,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_useorganizationmodal_tsx",
-      "label": "useOrganizationModal.tsx",
-      "norm_label": "useorganizationmodal.tsx",
-      "source_file": "packages/storefront-webapp/src/hooks/useOrganizationModal.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1559,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_usequeryenabled_test_ts",
-      "label": "useQueryEnabled.test.ts",
-      "norm_label": "usequeryenabled.test.ts",
-      "source_file": "packages/storefront-webapp/src/hooks/useQueryEnabled.test.ts",
       "source_location": "L1"
     },
     {
@@ -72093,6 +72225,24 @@
     {
       "community": 1560,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_useorganizationmodal_tsx",
+      "label": "useOrganizationModal.tsx",
+      "norm_label": "useorganizationmodal.tsx",
+      "source_file": "packages/storefront-webapp/src/hooks/useOrganizationModal.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1561,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_usequeryenabled_test_ts",
+      "label": "useQueryEnabled.test.ts",
+      "norm_label": "usequeryenabled.test.ts",
+      "source_file": "packages/storefront-webapp/src/hooks/useQueryEnabled.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1562,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usestorefrontobservability_ts",
       "label": "useStorefrontObservability.ts",
       "norm_label": "usestorefrontobservability.ts",
@@ -72100,7 +72250,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1561,
+      "community": 1563,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_constants_ts",
       "label": "constants.ts",
@@ -72109,7 +72259,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1562,
+      "community": 1564,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_countries_ts",
       "label": "countries.ts",
@@ -72118,7 +72268,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1563,
+      "community": 1565,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_feeutils_test_ts",
       "label": "feeUtils.test.ts",
@@ -72127,7 +72277,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1564,
+      "community": 1566,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_ghana_ts",
       "label": "ghana.ts",
@@ -72136,7 +72286,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1565,
+      "community": 1567,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_ghanaregions_ts",
       "label": "ghanaRegions.ts",
@@ -72145,7 +72295,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1566,
+      "community": 1568,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_maintenanceutils_test_ts",
       "label": "maintenanceUtils.test.ts",
@@ -72154,30 +72304,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1567,
+      "community": 1569,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_mutations_ts_index_ts",
       "label": "index.ts",
       "norm_label": "index.ts",
       "source_file": "packages/storefront-webapp/src/lib/mutations.ts/index.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1568,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_queries_store_ts",
-      "label": "store.ts",
-      "norm_label": "store.ts",
-      "source_file": "packages/storefront-webapp/src/lib/queries/store.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1569,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_schemas_bag_ts",
-      "label": "bag.ts",
-      "norm_label": "bag.ts",
-      "source_file": "packages/storefront-webapp/src/lib/schemas/bag.ts",
       "source_location": "L1"
     },
     {
@@ -72237,6 +72369,24 @@
     {
       "community": 1570,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_queries_store_ts",
+      "label": "store.ts",
+      "norm_label": "store.ts",
+      "source_file": "packages/storefront-webapp/src/lib/queries/store.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1571,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_schemas_bag_ts",
+      "label": "bag.ts",
+      "norm_label": "bag.ts",
+      "source_file": "packages/storefront-webapp/src/lib/schemas/bag.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1572,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_bagitem_ts",
       "label": "bagItem.ts",
       "norm_label": "bagitem.ts",
@@ -72244,7 +72394,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1571,
+      "community": 1573,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_category_ts",
       "label": "category.ts",
@@ -72253,7 +72403,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1572,
+      "community": 1574,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_organization_ts",
       "label": "organization.ts",
@@ -72262,7 +72412,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1573,
+      "community": 1575,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_product_ts",
       "label": "product.ts",
@@ -72271,7 +72421,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1574,
+      "community": 1576,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_store_ts",
       "label": "store.ts",
@@ -72280,7 +72430,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1575,
+      "community": 1577,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_subcategory_ts",
       "label": "subcategory.ts",
@@ -72289,7 +72439,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1576,
+      "community": 1578,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_user_ts",
       "label": "user.ts",
@@ -72298,30 +72448,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1577,
+      "community": 1579,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_states_ts",
       "label": "states.ts",
       "norm_label": "states.ts",
       "source_file": "packages/storefront-webapp/src/lib/states.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1578,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_storefrontfailureobservability_test_ts",
-      "label": "storefrontFailureObservability.test.ts",
-      "norm_label": "storefrontfailureobservability.test.ts",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontFailureObservability.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1579,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_storefrontjourneyevents_test_ts",
-      "label": "storefrontJourneyEvents.test.ts",
-      "norm_label": "storefrontjourneyevents.test.ts",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.test.ts",
       "source_location": "L1"
     },
     {
@@ -72381,6 +72513,24 @@
     {
       "community": 1580,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_storefrontfailureobservability_test_ts",
+      "label": "storefrontFailureObservability.test.ts",
+      "norm_label": "storefrontfailureobservability.test.ts",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontFailureObservability.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1581,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_storefrontjourneyevents_test_ts",
+      "label": "storefrontJourneyEvents.test.ts",
+      "norm_label": "storefrontjourneyevents.test.ts",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1582,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_utils_test_ts",
       "label": "utils.test.ts",
       "norm_label": "utils.test.ts",
@@ -72388,7 +72538,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1581,
+      "community": 1583,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routetree_gen_ts",
       "label": "routeTree.gen.ts",
@@ -72397,7 +72547,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1582,
+      "community": 1584,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_homepageloader_test_ts",
       "label": "-homePageLoader.test.ts",
@@ -72406,7 +72556,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1583,
+      "community": 1585,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_root_tsx",
       "label": "__root.tsx",
@@ -72415,7 +72565,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1584,
+      "community": 1586,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_orderid_orderitemid_review_tsx",
       "label": "$orderItemId.review.tsx",
@@ -72424,7 +72574,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1585,
+      "community": 1587,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_index_tsx",
       "label": "index.tsx",
@@ -72433,7 +72583,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1586,
+      "community": 1588,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_shoplayout_shop_categoryslug_subcategoryslug_tsx",
       "label": "$subcategorySlug.tsx",
@@ -72442,30 +72592,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1587,
+      "community": 1589,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_shoplayout_shop_categoryslug_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
       "source_file": "packages/storefront-webapp/src/routes/_layout/_shopLayout/shop/$categorySlug/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1588,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_layout_rewards_index_tsx",
-      "label": "rewards.index.tsx",
-      "norm_label": "rewards.index.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/rewards.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1589,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_layout_shop_saved_index_tsx",
-      "label": "shop.saved.index.tsx",
-      "norm_label": "shop.saved.index.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/shop.saved.index.tsx",
       "source_location": "L1"
     },
     {
@@ -72525,6 +72657,24 @@
     {
       "community": 1590,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_layout_rewards_index_tsx",
+      "label": "rewards.index.tsx",
+      "norm_label": "rewards.index.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/rewards.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1591,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_layout_shop_saved_index_tsx",
+      "label": "shop.saved.index.tsx",
+      "norm_label": "shop.saved.index.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/shop.saved.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1592,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_bag_index_tsx",
       "label": "bag.index.tsx",
       "norm_label": "bag.index.tsx",
@@ -72532,7 +72682,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1591,
+      "community": 1593,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_complete_tsx",
       "label": "complete.tsx",
@@ -72541,7 +72691,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1592,
+      "community": 1594,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_incomplete_tsx",
       "label": "incomplete.tsx",
@@ -72550,7 +72700,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1593,
+      "community": 1595,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_index_tsx",
       "label": "index.tsx",
@@ -72559,7 +72709,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1594,
+      "community": 1596,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_pending_tsx",
       "label": "pending.tsx",
@@ -72568,7 +72718,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1595,
+      "community": 1597,
       "file_type": "code",
       "id": "packages_storefront_webapp_tailwind_config_js",
       "label": "tailwind.config.js",
@@ -72577,7 +72727,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1596,
+      "community": 1598,
       "file_type": "code",
       "id": "packages_storefront_webapp_tests_e2e_storefront_boot_e2e_ts",
       "label": "storefront-boot.e2e.ts",
@@ -72586,30 +72736,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1597,
+      "community": 1599,
       "file_type": "code",
       "id": "packages_storefront_webapp_vitest_config_ts",
       "label": "vitest.config.ts",
       "norm_label": "vitest.config.ts",
       "source_file": "packages/storefront-webapp/vitest.config.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1598,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_vitest_setup_ts",
-      "label": "vitest.setup.ts",
-      "norm_label": "vitest.setup.ts",
-      "source_file": "packages/storefront-webapp/vitest.setup.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1599,
-      "file_type": "code",
-      "id": "packages_valkey_proxy_server_index_js",
-      "label": "index.js",
-      "norm_label": "index.js",
-      "source_file": "packages/valkey-proxy-server/index.js",
       "source_location": "L1"
     },
     {
@@ -72894,6 +73026,24 @@
     {
       "community": 1600,
       "file_type": "code",
+      "id": "packages_storefront_webapp_vitest_setup_ts",
+      "label": "vitest.setup.ts",
+      "norm_label": "vitest.setup.ts",
+      "source_file": "packages/storefront-webapp/vitest.setup.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1601,
+      "file_type": "code",
+      "id": "packages_valkey_proxy_server_index_js",
+      "label": "index.js",
+      "norm_label": "index.js",
+      "source_file": "packages/valkey-proxy-server/index.js",
+      "source_location": "L1"
+    },
+    {
+      "community": 1602,
+      "file_type": "code",
       "id": "scripts_harness_app_registry_test_ts",
       "label": "harness-app-registry.test.ts",
       "norm_label": "harness-app-registry.test.ts",
@@ -72901,7 +73051,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1601,
+      "community": 1603,
       "file_type": "code",
       "id": "scripts_harness_behavior_fixtures_athena_runtime_app_test_ts",
       "label": "athena-runtime-app.test.ts",
@@ -72910,7 +73060,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1602,
+      "community": 1604,
       "file_type": "code",
       "id": "scripts_harness_behavior_fixtures_storefront_runtime_api_test_ts",
       "label": "storefront-runtime-api.test.ts",
@@ -72919,7 +73069,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1603,
+      "community": 1605,
       "file_type": "code",
       "id": "scripts_harness_behavior_fixtures_valkey_runtime_app_test_ts",
       "label": "valkey-runtime-app.test.ts",
@@ -72928,7 +73078,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1604,
+      "community": 1606,
       "file_type": "code",
       "id": "scripts_harness_behavior_scenarios_test_ts",
       "label": "harness-behavior-scenarios.test.ts",
@@ -72937,7 +73087,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1605,
+      "community": 1607,
       "file_type": "code",
       "id": "scripts_harness_repo_validation_test_ts",
       "label": "harness-repo-validation.test.ts",
@@ -73002,60 +73152,6 @@
     {
       "community": 162,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_selectable_data_provider_tsx",
-      "label": "selectable-data-provider.tsx",
-      "norm_label": "selectable-data-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/selectable-data-provider.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 162,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_base_selectable_products_table_selectable_data_provider_tsx",
-      "label": "selectable-data-provider.tsx",
-      "norm_label": "selectable-data-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/selectable-data-provider.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 162,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_selectable_data_provider_tsx",
-      "label": "selectable-data-provider.tsx",
-      "norm_label": "selectable-data-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/selectable-data-provider.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 162,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_selectable_data_provider_tsx",
-      "label": "selectable-data-provider.tsx",
-      "norm_label": "selectable-data-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/selectable-data-provider.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 162,
-      "file_type": "code",
-      "id": "selectable_data_provider_selectedproductsprovider",
-      "label": "SelectedProductsProvider()",
-      "norm_label": "selectedproductsprovider()",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/selectable-data-provider.tsx",
-      "source_location": "L16"
-    },
-    {
-      "community": 162,
-      "file_type": "code",
-      "id": "selectable_data_provider_useselectedproducts",
-      "label": "useSelectedProducts()",
-      "norm_label": "useselectedproducts()",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/selectable-data-provider.tsx",
-      "source_location": "L37"
-    },
-    {
-      "community": 163,
-      "file_type": "code",
       "id": "inputotp_formatrequestdelay",
       "label": "formatRequestDelay()",
       "norm_label": "formatrequestdelay()",
@@ -73063,7 +73159,7 @@
       "source_location": "L46"
     },
     {
-      "community": 163,
+      "community": 162,
       "file_type": "code",
       "id": "inputotp_handlepinchange",
       "label": "handlePinChange()",
@@ -73072,7 +73168,7 @@
       "source_location": "L95"
     },
     {
-      "community": 163,
+      "community": 162,
       "file_type": "code",
       "id": "inputotp_handlerequestnewcode",
       "label": "handleRequestNewCode()",
@@ -73081,7 +73177,7 @@
       "source_location": "L143"
     },
     {
-      "community": 163,
+      "community": 162,
       "file_type": "code",
       "id": "inputotp_normalizeotpcode",
       "label": "normalizeOtpCode()",
@@ -73090,7 +73186,7 @@
       "source_location": "L30"
     },
     {
-      "community": 163,
+      "community": 162,
       "file_type": "code",
       "id": "inputotp_onsubmit",
       "label": "onSubmit()",
@@ -73099,13 +73195,67 @@
       "source_location": "L105"
     },
     {
-      "community": 163,
+      "community": 162,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_login_inputotp_tsx",
       "label": "InputOTP.tsx",
       "norm_label": "inputotp.tsx",
       "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
       "source_location": "L1"
+    },
+    {
+      "community": 163,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_selectable_data_provider_tsx",
+      "label": "selectable-data-provider.tsx",
+      "norm_label": "selectable-data-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/selectable-data-provider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 163,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_base_selectable_products_table_selectable_data_provider_tsx",
+      "label": "selectable-data-provider.tsx",
+      "norm_label": "selectable-data-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/selectable-data-provider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 163,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_selectable_data_provider_tsx",
+      "label": "selectable-data-provider.tsx",
+      "norm_label": "selectable-data-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/selectable-data-provider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 163,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_selectable_data_provider_tsx",
+      "label": "selectable-data-provider.tsx",
+      "norm_label": "selectable-data-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/selectable-data-provider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 163,
+      "file_type": "code",
+      "id": "selectable_data_provider_selectedproductsprovider",
+      "label": "SelectedProductsProvider()",
+      "norm_label": "selectedproductsprovider()",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/selectable-data-provider.tsx",
+      "source_location": "L16"
+    },
+    {
+      "community": 163,
+      "file_type": "code",
+      "id": "selectable_data_provider_useselectedproducts",
+      "label": "useSelectedProducts()",
+      "norm_label": "useselectedproducts()",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/selectable-data-provider.tsx",
+      "source_location": "L37"
     },
     {
       "community": 164,
@@ -95191,7 +95341,7 @@
       "label": "handleOperatingDateChange()",
       "norm_label": "handleoperatingdatechange()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L1162"
+      "source_location": "L1164"
     },
     {
       "community": 6,
@@ -95718,6 +95868,24 @@
     {
       "community": 612,
       "file_type": "code",
+      "id": "athenalandingpage_reveal",
+      "label": "Reveal()",
+      "norm_label": "reveal()",
+      "source_file": "packages/athena-webapp/src/components/landing/AthenaLandingPage.tsx",
+      "source_location": "L88"
+    },
+    {
+      "community": 612,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_landing_athenalandingpage_tsx",
+      "label": "AthenaLandingPage.tsx",
+      "norm_label": "athenalandingpage.tsx",
+      "source_file": "packages/athena-webapp/src/components/landing/AthenaLandingPage.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 613,
+      "file_type": "code",
       "id": "operationreviewitemcard_cn",
       "label": "cn()",
       "norm_label": "cn()",
@@ -95725,7 +95893,7 @@
       "source_location": "L82"
     },
     {
-      "community": 612,
+      "community": 613,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_operationreviewitemcard_tsx",
       "label": "OperationReviewItemCard.tsx",
@@ -95734,7 +95902,7 @@
       "source_location": "L1"
     },
     {
-      "community": 613,
+      "community": 614,
       "file_type": "code",
       "id": "operationssummarymetric_buildparams",
       "label": "buildParams()",
@@ -95743,7 +95911,7 @@
       "source_location": "L15"
     },
     {
-      "community": 613,
+      "community": 614,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_operationssummarymetric_tsx",
       "label": "OperationsSummaryMetric.tsx",
@@ -95752,7 +95920,7 @@
       "source_location": "L1"
     },
     {
-      "community": 614,
+      "community": 615,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_test_tsx",
       "label": "StockAdjustmentWorkspace.test.tsx",
@@ -95761,7 +95929,7 @@
       "source_location": "L1"
     },
     {
-      "community": 614,
+      "community": 615,
       "file_type": "code",
       "id": "stockadjustmentworkspace_test_renderstockadjustmentworkspace",
       "label": "renderStockAdjustmentWorkspace()",
@@ -95770,7 +95938,7 @@
       "source_location": "L88"
     },
     {
-      "community": 615,
+      "community": 616,
       "file_type": "code",
       "id": "customerdetailsview_customerdetailsview",
       "label": "CustomerDetailsView()",
@@ -95779,7 +95947,7 @@
       "source_location": "L13"
     },
     {
-      "community": 615,
+      "community": 616,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_customerdetailsview_tsx",
       "label": "CustomerDetailsView.tsx",
@@ -95788,7 +95956,7 @@
       "source_location": "L1"
     },
     {
-      "community": 616,
+      "community": 617,
       "file_type": "code",
       "id": "emailstatusview_handlesendorderemail",
       "label": "handleSendOrderEmail()",
@@ -95797,7 +95965,7 @@
       "source_location": "L43"
     },
     {
-      "community": 616,
+      "community": 617,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_emailstatusview_tsx",
       "label": "EmailStatusView.tsx",
@@ -95806,7 +95974,7 @@
       "source_location": "L1"
     },
     {
-      "community": 617,
+      "community": 618,
       "file_type": "code",
       "id": "ordermetricspanel_handletimerangechange",
       "label": "handleTimeRangeChange()",
@@ -95815,7 +95983,7 @@
       "source_location": "L33"
     },
     {
-      "community": 617,
+      "community": 618,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_ordermetricspanel_tsx",
       "label": "OrderMetricsPanel.tsx",
@@ -95824,7 +95992,7 @@
       "source_location": "L1"
     },
     {
-      "community": 618,
+      "community": 619,
       "file_type": "code",
       "id": "ordersview_gettimefilter",
       "label": "getTimeFilter()",
@@ -95833,31 +96001,13 @@
       "source_location": "L35"
     },
     {
-      "community": 618,
+      "community": 619,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_ordersview_tsx",
       "label": "OrdersView.tsx",
       "norm_label": "ordersview.tsx",
       "source_file": "packages/athena-webapp/src/components/orders/OrdersView.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 619,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_refundsview_tsx",
-      "label": "RefundsView.tsx",
-      "norm_label": "refundsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/RefundsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 619,
-      "file_type": "code",
-      "id": "refundsview_handlerefundorder",
-      "label": "handleRefundOrder()",
-      "norm_label": "handlerefundorder()",
-      "source_file": "packages/athena-webapp/src/components/orders/RefundsView.tsx",
-      "source_location": "L83"
     },
     {
       "community": 62,
@@ -95979,6 +96129,24 @@
     {
       "community": 620,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_refundsview_tsx",
+      "label": "RefundsView.tsx",
+      "norm_label": "refundsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/RefundsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 620,
+      "file_type": "code",
+      "id": "refundsview_handlerefundorder",
+      "label": "handleRefundOrder()",
+      "norm_label": "handlerefundorder()",
+      "source_file": "packages/athena-webapp/src/components/orders/RefundsView.tsx",
+      "source_location": "L83"
+    },
+    {
+      "community": 621,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_hooks_usegetactiveonlineorder_ts",
       "label": "useGetActiveOnlineOrder.ts",
       "norm_label": "usegetactiveonlineorder.ts",
@@ -95986,7 +96154,7 @@
       "source_location": "L1"
     },
     {
-      "community": 620,
+      "community": 621,
       "file_type": "code",
       "id": "usegetactiveonlineorder_usegetactiveonlineorder",
       "label": "useGetActiveOnlineOrder()",
@@ -95995,7 +96163,7 @@
       "source_location": "L6"
     },
     {
-      "community": 621,
+      "community": 622,
       "file_type": "code",
       "id": "data_table_toolbar_handleclearfilters",
       "label": "handleClearFilters()",
@@ -96004,7 +96172,7 @@
       "source_location": "L34"
     },
     {
-      "community": 621,
+      "community": 622,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -96013,7 +96181,7 @@
       "source_location": "L1"
     },
     {
-      "community": 622,
+      "community": 623,
       "file_type": "code",
       "id": "ordercolumns_if",
       "label": "if()",
@@ -96022,7 +96190,7 @@
       "source_location": "L89"
     },
     {
-      "community": 622,
+      "community": 623,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_ordercolumns_tsx",
       "label": "orderColumns.tsx",
@@ -96031,7 +96199,7 @@
       "source_location": "L1"
     },
     {
-      "community": 623,
+      "community": 624,
       "file_type": "code",
       "id": "organization_switcher_organizationswitcher",
       "label": "OrganizationSwitcher()",
@@ -96040,7 +96208,7 @@
       "source_location": "L37"
     },
     {
-      "community": 623,
+      "community": 624,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_switcher_tsx",
       "label": "organization-switcher.tsx",
@@ -96049,7 +96217,7 @@
       "source_location": "L1"
     },
     {
-      "community": 624,
+      "community": 625,
       "file_type": "code",
       "id": "cartitems_cn",
       "label": "cn()",
@@ -96058,7 +96226,7 @@
       "source_location": "L215"
     },
     {
-      "community": 624,
+      "community": 625,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_cartitems_tsx",
       "label": "CartItems.tsx",
@@ -96067,7 +96235,7 @@
       "source_location": "L1"
     },
     {
-      "community": 625,
+      "community": 626,
       "file_type": "code",
       "id": "debugproducts_debugproducts",
       "label": "DebugProducts()",
@@ -96076,7 +96244,7 @@
       "source_location": "L5"
     },
     {
-      "community": 625,
+      "community": 626,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_debugproducts_tsx",
       "label": "DebugProducts.tsx",
@@ -96085,7 +96253,7 @@
       "source_location": "L1"
     },
     {
-      "community": 626,
+      "community": 627,
       "file_type": "code",
       "id": "noresultsmessage_noresultsmessage",
       "label": "NoResultsMessage()",
@@ -96094,7 +96262,7 @@
       "source_location": "L7"
     },
     {
-      "community": 626,
+      "community": 627,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_noresultsmessage_tsx",
       "label": "NoResultsMessage.tsx",
@@ -96103,7 +96271,7 @@
       "source_location": "L1"
     },
     {
-      "community": 627,
+      "community": 628,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_pininput_tsx",
       "label": "PinInput.tsx",
@@ -96112,7 +96280,7 @@
       "source_location": "L1"
     },
     {
-      "community": 627,
+      "community": 628,
       "file_type": "code",
       "id": "pininput_pininput",
       "label": "PinInput()",
@@ -96121,7 +96289,7 @@
       "source_location": "L13"
     },
     {
-      "community": 628,
+      "community": 629,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_printinstructions_tsx",
       "label": "PrintInstructions.tsx",
@@ -96130,31 +96298,13 @@
       "source_location": "L1"
     },
     {
-      "community": 628,
+      "community": 629,
       "file_type": "code",
       "id": "printinstructions_printinstructions",
       "label": "PrintInstructions()",
       "norm_label": "printinstructions()",
       "source_file": "packages/athena-webapp/src/components/pos/PrintInstructions.tsx",
       "source_location": "L3"
-    },
-    {
-      "community": 629,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_productcard_tsx",
-      "label": "ProductCard.tsx",
-      "norm_label": "productcard.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/ProductCard.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 629,
-      "file_type": "code",
-      "id": "productcard_productcard",
-      "label": "ProductCard()",
-      "norm_label": "productcard()",
-      "source_file": "packages/athena-webapp/src/components/pos/ProductCard.tsx",
-      "source_location": "L14"
     },
     {
       "community": 63,
@@ -96276,6 +96426,24 @@
     {
       "community": 630,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_productcard_tsx",
+      "label": "ProductCard.tsx",
+      "norm_label": "productcard.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/ProductCard.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 630,
+      "file_type": "code",
+      "id": "productcard_productcard",
+      "label": "ProductCard()",
+      "norm_label": "productcard()",
+      "source_file": "packages/athena-webapp/src/components/pos/ProductCard.tsx",
+      "source_location": "L14"
+    },
+    {
+      "community": 631,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_searchresultssection_test_tsx",
       "label": "SearchResultsSection.test.tsx",
       "norm_label": "searchresultssection.test.tsx",
@@ -96283,7 +96451,7 @@
       "source_location": "L1"
     },
     {
-      "community": 630,
+      "community": 631,
       "file_type": "code",
       "id": "searchresultssection_test_buildproduct",
       "label": "buildProduct()",
@@ -96292,7 +96460,7 @@
       "source_location": "L12"
     },
     {
-      "community": 631,
+      "community": 632,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_sessiondemo_tsx",
       "label": "SessionDemo.tsx",
@@ -96301,7 +96469,7 @@
       "source_location": "L1"
     },
     {
-      "community": 631,
+      "community": 632,
       "file_type": "code",
       "id": "sessiondemo_sessiondemo",
       "label": "SessionDemo()",
@@ -96310,7 +96478,7 @@
       "source_location": "L15"
     },
     {
-      "community": 632,
+      "community": 633,
       "file_type": "code",
       "id": "expensereportsview_istoday",
       "label": "isToday()",
@@ -96319,7 +96487,7 @@
       "source_location": "L21"
     },
     {
-      "community": 632,
+      "community": 633,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportsview_tsx",
       "label": "ExpenseReportsView.tsx",
@@ -96328,7 +96496,7 @@
       "source_location": "L1"
     },
     {
-      "community": 633,
+      "community": 634,
       "file_type": "code",
       "id": "expensereportrows_toexpensereportrows",
       "label": "toExpenseReportRows()",
@@ -96337,7 +96505,7 @@
       "source_location": "L15"
     },
     {
-      "community": 633,
+      "community": 634,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportrows_ts",
       "label": "expenseReportRows.ts",
@@ -96346,7 +96514,7 @@
       "source_location": "L1"
     },
     {
-      "community": 634,
+      "community": 635,
       "file_type": "code",
       "id": "expensecompletionpanel_expensecompletionpanel",
       "label": "ExpenseCompletionPanel()",
@@ -96355,7 +96523,7 @@
       "source_location": "L9"
     },
     {
-      "community": 634,
+      "community": 635,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_expensecompletionpanel_tsx",
       "label": "ExpenseCompletionPanel.tsx",
@@ -96364,7 +96532,7 @@
       "source_location": "L1"
     },
     {
-      "community": 635,
+      "community": 636,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_registercustomerattribution_test_tsx",
       "label": "RegisterCustomerAttribution.test.tsx",
@@ -96373,7 +96541,7 @@
       "source_location": "L1"
     },
     {
-      "community": 635,
+      "community": 636,
       "file_type": "code",
       "id": "registercustomerattribution_test_makecustomer",
       "label": "makeCustomer()",
@@ -96382,7 +96550,7 @@
       "source_location": "L28"
     },
     {
-      "community": 636,
+      "community": 637,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_registercustomerpanel_tsx",
       "label": "RegisterCustomerPanel.tsx",
@@ -96391,7 +96559,7 @@
       "source_location": "L1"
     },
     {
-      "community": 636,
+      "community": 637,
       "file_type": "code",
       "id": "registercustomerpanel_registercustomerpanel",
       "label": "RegisterCustomerPanel()",
@@ -96400,7 +96568,7 @@
       "source_location": "L9"
     },
     {
-      "community": 637,
+      "community": 638,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_registerdrawergate_test_tsx",
       "label": "RegisterDrawerGate.test.tsx",
@@ -96409,7 +96577,7 @@
       "source_location": "L1"
     },
     {
-      "community": 637,
+      "community": 638,
       "file_type": "code",
       "id": "registerdrawergate_test_rendergate",
       "label": "renderGate()",
@@ -96418,7 +96586,7 @@
       "source_location": "L23"
     },
     {
-      "community": 638,
+      "community": 639,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_registersessionpanel_tsx",
       "label": "RegisterSessionPanel.tsx",
@@ -96427,31 +96595,13 @@
       "source_location": "L1"
     },
     {
-      "community": 638,
+      "community": 639,
       "file_type": "code",
       "id": "registersessionpanel_registersessionpanel",
       "label": "RegisterSessionPanel()",
       "norm_label": "registersessionpanel()",
       "source_file": "packages/athena-webapp/src/components/pos/register/RegisterSessionPanel.tsx",
       "source_location": "L9"
-    },
-    {
-      "community": 639,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_transactions_transactioncolumns_test_tsx",
-      "label": "transactionColumns.test.tsx",
-      "norm_label": "transactioncolumns.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/transactionColumns.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 639,
-      "file_type": "code",
-      "id": "transactioncolumns_test_rendertransactioncell",
-      "label": "renderTransactionCell()",
-      "norm_label": "rendertransactioncell()",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/transactionColumns.test.tsx",
-      "source_location": "L34"
     },
     {
       "community": 64,
@@ -96573,6 +96723,24 @@
     {
       "community": 640,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_transactions_transactioncolumns_test_tsx",
+      "label": "transactionColumns.test.tsx",
+      "norm_label": "transactioncolumns.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/transactionColumns.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 640,
+      "file_type": "code",
+      "id": "transactioncolumns_test_rendertransactioncell",
+      "label": "renderTransactionCell()",
+      "norm_label": "rendertransactioncell()",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/transactionColumns.test.tsx",
+      "source_location": "L34"
+    },
+    {
+      "community": 641,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_transactions_transactioncolumns_tsx",
       "label": "transactionColumns.tsx",
       "norm_label": "transactioncolumns.tsx",
@@ -96580,7 +96748,7 @@
       "source_location": "L1"
     },
     {
-      "community": 640,
+      "community": 641,
       "file_type": "code",
       "id": "transactioncolumns_getpaymentmethodicon",
       "label": "getPaymentMethodIcon()",
@@ -96589,7 +96757,7 @@
       "source_location": "L27"
     },
     {
-      "community": 641,
+      "community": 642,
       "file_type": "code",
       "id": "barcodeview_barcodeview",
       "label": "BarcodeView()",
@@ -96598,7 +96766,7 @@
       "source_location": "L14"
     },
     {
-      "community": 641,
+      "community": 642,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_barcodeview_tsx",
       "label": "BarcodeView.tsx",
@@ -96607,7 +96775,7 @@
       "source_location": "L1"
     },
     {
-      "community": 642,
+      "community": 643,
       "file_type": "code",
       "id": "categorizationview_categorizationview",
       "label": "CategorizationView()",
@@ -96616,7 +96784,7 @@
       "source_location": "L6"
     },
     {
-      "community": 642,
+      "community": 643,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_categorizationview_tsx",
       "label": "CategorizationView.tsx",
@@ -96625,7 +96793,7 @@
       "source_location": "L1"
     },
     {
-      "community": 643,
+      "community": 644,
       "file_type": "code",
       "id": "imagesview_handlekeydown",
       "label": "handleKeyDown()",
@@ -96634,7 +96802,7 @@
       "source_location": "L37"
     },
     {
-      "community": 643,
+      "community": 644,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_imagesview_tsx",
       "label": "ImagesView.tsx",
@@ -96643,7 +96811,7 @@
       "source_location": "L1"
     },
     {
-      "community": 644,
+      "community": 645,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_productstatus_tsx",
       "label": "ProductStatus.tsx",
@@ -96652,7 +96820,7 @@
       "source_location": "L1"
     },
     {
-      "community": 644,
+      "community": 645,
       "file_type": "code",
       "id": "productstatus_productstatus",
       "label": "ProductStatus()",
@@ -96661,7 +96829,7 @@
       "source_location": "L11"
     },
     {
-      "community": 645,
+      "community": 646,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_skuselector_tsx",
       "label": "SKUSelector.tsx",
@@ -96670,7 +96838,7 @@
       "source_location": "L1"
     },
     {
-      "community": 645,
+      "community": 646,
       "file_type": "code",
       "id": "skuselector_skuselector",
       "label": "SKUSelector()",
@@ -96679,7 +96847,7 @@
       "source_location": "L10"
     },
     {
-      "community": 646,
+      "community": 647,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_actions_tsx",
       "label": "product-actions.tsx",
@@ -96688,7 +96856,7 @@
       "source_location": "L1"
     },
     {
-      "community": 646,
+      "community": 647,
       "file_type": "code",
       "id": "product_actions_usearchiveproduct",
       "label": "useArchiveProduct()",
@@ -96697,7 +96865,7 @@
       "source_location": "L6"
     },
     {
-      "community": 647,
+      "community": 648,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_productsview_tsx",
       "label": "ProductsView.tsx",
@@ -96706,7 +96874,7 @@
       "source_location": "L1"
     },
     {
-      "community": 647,
+      "community": 648,
       "file_type": "code",
       "id": "productsview_productsview",
       "label": "ProductsView()",
@@ -96715,7 +96883,7 @@
       "source_location": "L5"
     },
     {
-      "community": 648,
+      "community": 649,
       "file_type": "code",
       "id": "add_product_command_addproductcommand",
       "label": "AddProductCommand()",
@@ -96724,31 +96892,13 @@
       "source_location": "L17"
     },
     {
-      "community": 648,
+      "community": 649,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_add_product_command_tsx",
       "label": "add-product-command.tsx",
       "norm_label": "add-product-command.tsx",
       "source_file": "packages/athena-webapp/src/components/products/products-table/components/add-product-command.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 649,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_products_tsx",
-      "label": "Products.tsx",
-      "norm_label": "products.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/Products.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 649,
-      "file_type": "code",
-      "id": "products_products",
-      "label": "Products()",
-      "norm_label": "products()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/Products.tsx",
-      "source_location": "L4"
     },
     {
       "community": 65,
@@ -96870,6 +97020,24 @@
     {
       "community": 650,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_products_tsx",
+      "label": "Products.tsx",
+      "norm_label": "products.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/Products.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 650,
+      "file_type": "code",
+      "id": "products_products",
+      "label": "Products()",
+      "norm_label": "products()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/Products.tsx",
+      "source_location": "L4"
+    },
+    {
+      "community": 651,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodeform_tsx",
       "label": "PromoCodeForm.tsx",
       "norm_label": "promocodeform.tsx",
@@ -96877,7 +97045,7 @@
       "source_location": "L1"
     },
     {
-      "community": 650,
+      "community": 651,
       "file_type": "code",
       "id": "promocodeform_togglediscounttype",
       "label": "toggleDiscountType()",
@@ -96886,7 +97054,7 @@
       "source_location": "L82"
     },
     {
-      "community": 651,
+      "community": 652,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodeheader_tsx",
       "label": "PromoCodeHeader.tsx",
@@ -96895,7 +97063,7 @@
       "source_location": "L1"
     },
     {
-      "community": 651,
+      "community": 652,
       "file_type": "code",
       "id": "promocodeheader_handledeletepromocode",
       "label": "handleDeletePromoCode()",
@@ -96904,7 +97072,7 @@
       "source_location": "L23"
     },
     {
-      "community": 652,
+      "community": 653,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodepreview_tsx",
       "label": "PromoCodePreview.tsx",
@@ -96913,7 +97081,7 @@
       "source_location": "L1"
     },
     {
-      "community": 652,
+      "community": 653,
       "file_type": "code",
       "id": "promocodepreview_discount",
       "label": "Discount()",
@@ -96922,7 +97090,7 @@
       "source_location": "L37"
     },
     {
-      "community": 653,
+      "community": 654,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodesview_test_tsx",
       "label": "PromoCodesView.test.tsx",
@@ -96931,7 +97099,7 @@
       "source_location": "L1"
     },
     {
-      "community": 653,
+      "community": 654,
       "file_type": "code",
       "id": "promocodesview_test_readsource",
       "label": "readSource()",
@@ -96940,7 +97108,7 @@
       "source_location": "L5"
     },
     {
-      "community": 654,
+      "community": 655,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodesview_tsx",
       "label": "PromoCodesView.tsx",
@@ -96949,7 +97117,7 @@
       "source_location": "L1"
     },
     {
-      "community": 654,
+      "community": 655,
       "file_type": "code",
       "id": "promocodesview_promocodesview",
       "label": "PromoCodesView()",
@@ -96958,7 +97126,7 @@
       "source_location": "L10"
     },
     {
-      "community": 655,
+      "community": 656,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectablecategories_tsx",
       "label": "SelectableCategories.tsx",
@@ -96967,7 +97135,7 @@
       "source_location": "L1"
     },
     {
-      "community": 655,
+      "community": 656,
       "file_type": "code",
       "id": "selectablecategories_toggle",
       "label": "toggle()",
@@ -96976,7 +97144,7 @@
       "source_location": "L23"
     },
     {
-      "community": 656,
+      "community": 657,
       "file_type": "code",
       "id": "discounttypetogglegroup_discounttypetogglegroup",
       "label": "DiscountTypeToggleGroup()",
@@ -96985,7 +97153,7 @@
       "source_location": "L5"
     },
     {
-      "community": 656,
+      "community": 657,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_add_promo_code_discounttypetogglegroup_tsx",
       "label": "DiscountTypeToggleGroup.tsx",
@@ -96994,7 +97162,7 @@
       "source_location": "L1"
     },
     {
-      "community": 657,
+      "community": 658,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_add_promo_code_promocodespantogglegroup_tsx",
       "label": "PromoCodeSpanToggleGroup.tsx",
@@ -97003,7 +97171,7 @@
       "source_location": "L1"
     },
     {
-      "community": 657,
+      "community": 658,
       "file_type": "code",
       "id": "promocodespantogglegroup_promocodespantogglegroup",
       "label": "PromoCodeSpanToggleGroup()",
@@ -97012,7 +97180,7 @@
       "source_location": "L4"
     },
     {
-      "community": 658,
+      "community": 659,
       "file_type": "code",
       "id": "capturedemails_capturedemails",
       "label": "CapturedEmails()",
@@ -97021,31 +97189,13 @@
       "source_location": "L13"
     },
     {
-      "community": 658,
+      "community": 659,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_captured_capturedemails_tsx",
       "label": "CapturedEmails.tsx",
       "norm_label": "capturedemails.tsx",
       "source_file": "packages/athena-webapp/src/components/promo-codes/captured/CapturedEmails.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 659,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_modals_promo_code_modal_tsx",
-      "label": "promo-code-modal.tsx",
-      "norm_label": "promo-code-modal.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/promo-code-modal.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 659,
-      "file_type": "code",
-      "id": "promo_code_modal_promocodemodal",
-      "label": "PromoCodeModal()",
-      "norm_label": "promocodemodal()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/promo-code-modal.tsx",
-      "source_location": "L29"
     },
     {
       "community": 66,
@@ -97167,6 +97317,24 @@
     {
       "community": 660,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_modals_promo_code_modal_tsx",
+      "label": "promo-code-modal.tsx",
+      "norm_label": "promo-code-modal.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/promo-code-modal.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 660,
+      "file_type": "code",
+      "id": "promo_code_modal_promocodemodal",
+      "label": "PromoCodeModal()",
+      "norm_label": "promocodemodal()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/promo-code-modal.tsx",
+      "source_location": "L29"
+    },
+    {
+      "community": 661,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_reviews_reviewactions_tsx",
       "label": "ReviewActions.tsx",
       "norm_label": "reviewactions.tsx",
@@ -97174,7 +97342,7 @@
       "source_location": "L1"
     },
     {
-      "community": 660,
+      "community": 661,
       "file_type": "code",
       "id": "reviewactions_reviewactions",
       "label": "ReviewActions()",
@@ -97183,7 +97351,7 @@
       "source_location": "L20"
     },
     {
-      "community": 661,
+      "community": 662,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_servicecasesview_test_tsx",
       "label": "ServiceCasesView.test.tsx",
@@ -97192,7 +97360,7 @@
       "source_location": "L1"
     },
     {
-      "community": 661,
+      "community": 662,
       "file_type": "code",
       "id": "servicecasesview_test_chooseselectoption",
       "label": "chooseSelectOption()",
@@ -97201,7 +97369,7 @@
       "source_location": "L63"
     },
     {
-      "community": 662,
+      "community": 663,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_servicecatalogview_test_tsx",
       "label": "ServiceCatalogView.test.tsx",
@@ -97210,7 +97378,7 @@
       "source_location": "L1"
     },
     {
-      "community": 662,
+      "community": 663,
       "file_type": "code",
       "id": "servicecatalogview_test_chooseselectoption",
       "label": "chooseSelectOption()",
@@ -97219,7 +97387,7 @@
       "source_location": "L60"
     },
     {
-      "community": 663,
+      "community": 664,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_serviceintakeform_tsx",
       "label": "ServiceIntakeForm.tsx",
@@ -97228,7 +97396,7 @@
       "source_location": "L1"
     },
     {
-      "community": 663,
+      "community": 664,
       "file_type": "code",
       "id": "serviceintakeform_serviceintakeform",
       "label": "ServiceIntakeForm()",
@@ -97237,7 +97405,7 @@
       "source_location": "L59"
     },
     {
-      "community": 664,
+      "community": 665,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_serviceintakeview_auth_test_tsx",
       "label": "ServiceIntakeView.auth.test.tsx",
@@ -97246,7 +97414,7 @@
       "source_location": "L1"
     },
     {
-      "community": 664,
+      "community": 665,
       "file_type": "code",
       "id": "serviceintakeview_auth_test_chooseselectoption",
       "label": "chooseSelectOption()",
@@ -97255,7 +97423,7 @@
       "source_location": "L45"
     },
     {
-      "community": 665,
+      "community": 666,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_serviceintakeview_test_tsx",
       "label": "ServiceIntakeView.test.tsx",
@@ -97264,7 +97432,7 @@
       "source_location": "L1"
     },
     {
-      "community": 665,
+      "community": 666,
       "file_type": "code",
       "id": "serviceintakeview_test_chooseselectoption",
       "label": "chooseSelectOption()",
@@ -97273,7 +97441,7 @@
       "source_location": "L47"
     },
     {
-      "community": 666,
+      "community": 667,
       "file_type": "code",
       "id": "empty_state_onclick",
       "label": "onClick()",
@@ -97282,7 +97450,7 @@
       "source_location": "L29"
     },
     {
-      "community": 666,
+      "community": 667,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_empty_empty_state_tsx",
       "label": "empty-state.tsx",
@@ -97291,7 +97459,7 @@
       "source_location": "L1"
     },
     {
-      "community": 667,
+      "community": 668,
       "file_type": "code",
       "id": "nopermission_nopermission",
       "label": "NoPermission()",
@@ -97300,7 +97468,7 @@
       "source_location": "L3"
     },
     {
-      "community": 667,
+      "community": 668,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_no_permission_nopermission_tsx",
       "label": "NoPermission.tsx",
@@ -97309,7 +97477,7 @@
       "source_location": "L1"
     },
     {
-      "community": 668,
+      "community": 669,
       "file_type": "code",
       "id": "nopermissionview_nopermissionview",
       "label": "NoPermissionView()",
@@ -97318,30 +97486,12 @@
       "source_location": "L4"
     },
     {
-      "community": 668,
+      "community": 669,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_no_permission_nopermissionview_tsx",
       "label": "NoPermissionView.tsx",
       "norm_label": "nopermissionview.tsx",
       "source_file": "packages/athena-webapp/src/components/states/no-permission/NoPermissionView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 669,
-      "file_type": "code",
-      "id": "notfoundview_notfoundview",
-      "label": "NotFoundView()",
-      "norm_label": "notfoundview()",
-      "source_file": "packages/athena-webapp/src/components/states/not-found/NotFoundView.tsx",
-      "source_location": "L4"
-    },
-    {
-      "community": 669,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_states_not_found_notfoundview_tsx",
-      "label": "NotFoundView.tsx",
-      "norm_label": "notfoundview.tsx",
-      "source_file": "packages/athena-webapp/src/components/states/not-found/NotFoundView.tsx",
       "source_location": "L1"
     },
     {
@@ -97455,6 +97605,24 @@
     {
       "community": 670,
       "file_type": "code",
+      "id": "notfoundview_notfoundview",
+      "label": "NotFoundView()",
+      "norm_label": "notfoundview()",
+      "source_file": "packages/athena-webapp/src/components/states/not-found/NotFoundView.tsx",
+      "source_location": "L4"
+    },
+    {
+      "community": 670,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_states_not_found_notfoundview_tsx",
+      "label": "NotFoundView.tsx",
+      "norm_label": "notfoundview.tsx",
+      "source_file": "packages/athena-webapp/src/components/states/not-found/NotFoundView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 671,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_signed_out_protectedadminsigninview_tsx",
       "label": "ProtectedAdminSignInView.tsx",
       "norm_label": "protectedadminsigninview.tsx",
@@ -97462,7 +97630,7 @@
       "source_location": "L1"
     },
     {
-      "community": 670,
+      "community": 671,
       "file_type": "code",
       "id": "protectedadminsigninview_protectedadminsigninview",
       "label": "ProtectedAdminSignInView()",
@@ -97471,7 +97639,7 @@
       "source_location": "L9"
     },
     {
-      "community": 671,
+      "community": 672,
       "file_type": "code",
       "id": "contactview_contactview",
       "label": "ContactView()",
@@ -97480,7 +97648,7 @@
       "source_location": "L9"
     },
     {
-      "community": 671,
+      "community": 672,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_contactview_tsx",
       "label": "ContactView.tsx",
@@ -97489,7 +97657,7 @@
       "source_location": "L1"
     },
     {
-      "community": 672,
+      "community": 673,
       "file_type": "code",
       "id": "header_header",
       "label": "Header()",
@@ -97498,7 +97666,7 @@
       "source_location": "L1"
     },
     {
-      "community": 672,
+      "community": 673,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_header_tsx",
       "label": "Header.tsx",
@@ -97507,7 +97675,7 @@
       "source_location": "L1"
     },
     {
-      "community": 673,
+      "community": 674,
       "file_type": "code",
       "id": "maintenanceview_maintenanceview",
       "label": "MaintenanceView()",
@@ -97516,7 +97684,7 @@
       "source_location": "L11"
     },
     {
-      "community": 673,
+      "community": 674,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_maintenanceview_tsx",
       "label": "MaintenanceView.tsx",
@@ -97525,7 +97693,7 @@
       "source_location": "L1"
     },
     {
-      "community": 674,
+      "community": 675,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_taxview_tsx",
       "label": "TaxView.tsx",
@@ -97534,7 +97702,7 @@
       "source_location": "L1"
     },
     {
-      "community": 674,
+      "community": 675,
       "file_type": "code",
       "id": "taxview_handleupdatetaxsettings",
       "label": "handleUpdateTaxSettings()",
@@ -97543,7 +97711,7 @@
       "source_location": "L25"
     },
     {
-      "community": 675,
+      "community": 676,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_hooks_usestoreconfigupdate_ts",
       "label": "useStoreConfigUpdate.ts",
@@ -97552,7 +97720,7 @@
       "source_location": "L1"
     },
     {
-      "community": 675,
+      "community": 676,
       "file_type": "code",
       "id": "usestoreconfigupdate_usestoreconfigupdate",
       "label": "useStoreConfigUpdate()",
@@ -97561,7 +97729,7 @@
       "source_location": "L21"
     },
     {
-      "community": 676,
+      "community": 677,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_switcher_tsx",
       "label": "store-switcher.tsx",
@@ -97570,7 +97738,7 @@
       "source_location": "L1"
     },
     {
-      "community": 676,
+      "community": 677,
       "file_type": "code",
       "id": "store_switcher_onstoreselect",
       "label": "onStoreSelect()",
@@ -97579,7 +97747,7 @@
       "source_location": "L63"
     },
     {
-      "community": 677,
+      "community": 678,
       "file_type": "code",
       "id": "chart_usechart",
       "label": "useChart()",
@@ -97588,7 +97756,7 @@
       "source_location": "L25"
     },
     {
-      "community": 677,
+      "community": 678,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_chart_tsx",
       "label": "chart.tsx",
@@ -97597,7 +97765,7 @@
       "source_location": "L1"
     },
     {
-      "community": 678,
+      "community": 679,
       "file_type": "code",
       "id": "copy_button_handlecopy",
       "label": "handleCopy()",
@@ -97606,30 +97774,12 @@
       "source_location": "L15"
     },
     {
-      "community": 678,
+      "community": 679,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_copy_button_tsx",
       "label": "copy-button.tsx",
       "norm_label": "copy-button.tsx",
       "source_file": "packages/athena-webapp/src/components/ui/copy-button.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 679,
-      "file_type": "code",
-      "id": "copy_wrapper_handlecopy",
-      "label": "handleCopy()",
-      "norm_label": "handlecopy()",
-      "source_file": "packages/athena-webapp/src/components/ui/copy-wrapper.tsx",
-      "source_location": "L21"
-    },
-    {
-      "community": 679,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_copy_wrapper_tsx",
-      "label": "copy-wrapper.tsx",
-      "norm_label": "copy-wrapper.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/copy-wrapper.tsx",
       "source_location": "L1"
     },
     {
@@ -97743,6 +97893,24 @@
     {
       "community": 680,
       "file_type": "code",
+      "id": "copy_wrapper_handlecopy",
+      "label": "handleCopy()",
+      "norm_label": "handlecopy()",
+      "source_file": "packages/athena-webapp/src/components/ui/copy-wrapper.tsx",
+      "source_location": "L21"
+    },
+    {
+      "community": 680,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_copy_wrapper_tsx",
+      "label": "copy-wrapper.tsx",
+      "norm_label": "copy-wrapper.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/copy-wrapper.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 681,
+      "file_type": "code",
       "id": "label_label",
       "label": "Label()",
       "norm_label": "label()",
@@ -97750,7 +97918,7 @@
       "source_location": "L6"
     },
     {
-      "community": 680,
+      "community": 681,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_label_tsx",
       "label": "label.tsx",
@@ -97759,7 +97927,7 @@
       "source_location": "L1"
     },
     {
-      "community": 681,
+      "community": 682,
       "file_type": "code",
       "id": "custom_modal_custommodal",
       "label": "CustomModal()",
@@ -97768,7 +97936,7 @@
       "source_location": "L25"
     },
     {
-      "community": 681,
+      "community": 682,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_custom_modal_tsx",
       "label": "custom-modal.tsx",
@@ -97777,7 +97945,7 @@
       "source_location": "L1"
     },
     {
-      "community": 682,
+      "community": 683,
       "file_type": "code",
       "id": "organization_modal_onsubmit",
       "label": "onSubmit()",
@@ -97786,7 +97954,7 @@
       "source_location": "L49"
     },
     {
-      "community": 682,
+      "community": 683,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_organization_modal_tsx",
       "label": "organization-modal.tsx",
@@ -97795,7 +97963,7 @@
       "source_location": "L1"
     },
     {
-      "community": 683,
+      "community": 684,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_store_modal_tsx",
       "label": "store-modal.tsx",
@@ -97804,7 +97972,7 @@
       "source_location": "L1"
     },
     {
-      "community": 683,
+      "community": 684,
       "file_type": "code",
       "id": "store_modal_onsubmit",
       "label": "onSubmit()",
@@ -97813,7 +97981,7 @@
       "source_location": "L63"
     },
     {
-      "community": 684,
+      "community": 685,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_welcome_back_modal_example_tsx",
       "label": "welcome-back-modal-example.tsx",
@@ -97822,7 +97990,7 @@
       "source_location": "L1"
     },
     {
-      "community": 684,
+      "community": 685,
       "file_type": "code",
       "id": "welcome_back_modal_example_welcomebackmodalexample",
       "label": "WelcomeBackModalExample()",
@@ -97831,7 +97999,7 @@
       "source_location": "L5"
     },
     {
-      "community": 685,
+      "community": 686,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_welcome_back_modal_tsx",
       "label": "welcome-back-modal.tsx",
@@ -97840,7 +98008,7 @@
       "source_location": "L1"
     },
     {
-      "community": 685,
+      "community": 686,
       "file_type": "code",
       "id": "welcome_back_modal_welcomebackmodal",
       "label": "WelcomeBackModal()",
@@ -97849,7 +98017,7 @@
       "source_location": "L12"
     },
     {
-      "community": 686,
+      "community": 687,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_select_native_tsx",
       "label": "select-native.tsx",
@@ -97858,7 +98026,7 @@
       "source_location": "L1"
     },
     {
-      "community": 686,
+      "community": 687,
       "file_type": "code",
       "id": "select_native_cn",
       "label": "cn()",
@@ -97867,7 +98035,7 @@
       "source_location": "L15"
     },
     {
-      "community": 687,
+      "community": 688,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_timeline_item_tsx",
       "label": "timeline-item.tsx",
@@ -97876,7 +98044,7 @@
       "source_location": "L1"
     },
     {
-      "community": 687,
+      "community": 688,
       "file_type": "code",
       "id": "timeline_item_timelineitem",
       "label": "TimelineItem()",
@@ -97885,7 +98053,7 @@
       "source_location": "L3"
     },
     {
-      "community": 688,
+      "community": 689,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_webp_image_tsx",
       "label": "webp-image.tsx",
@@ -97894,30 +98062,12 @@
       "source_location": "L1"
     },
     {
-      "community": 688,
+      "community": 689,
       "file_type": "code",
       "id": "webp_image_webpimage",
       "label": "WebpImage()",
       "norm_label": "webpimage()",
       "source_file": "packages/athena-webapp/src/components/ui/webp-image.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 689,
-      "file_type": "code",
-      "id": "bagitems_bagitems",
-      "label": "BagItems()",
-      "norm_label": "bagitems()",
-      "source_file": "packages/athena-webapp/src/components/user-bags/BagItems.tsx",
-      "source_location": "L5"
-    },
-    {
-      "community": 689,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_bagitems_tsx",
-      "label": "BagItems.tsx",
-      "norm_label": "bagitems.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/BagItems.tsx",
       "source_location": "L1"
     },
     {
@@ -98031,6 +98181,24 @@
     {
       "community": 690,
       "file_type": "code",
+      "id": "bagitems_bagitems",
+      "label": "BagItems()",
+      "norm_label": "bagitems()",
+      "source_file": "packages/athena-webapp/src/components/user-bags/BagItems.tsx",
+      "source_location": "L5"
+    },
+    {
+      "community": 690,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_bagitems_tsx",
+      "label": "BagItems.tsx",
+      "norm_label": "bagitems.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/BagItems.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 691,
+      "file_type": "code",
       "id": "bagitemsview_bagitemsview",
       "label": "BagItemsView()",
       "norm_label": "bagitemsview()",
@@ -98038,7 +98206,7 @@
       "source_location": "L11"
     },
     {
-      "community": 690,
+      "community": 691,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_bagitemsview_tsx",
       "label": "BagItemsView.tsx",
@@ -98047,7 +98215,7 @@
       "source_location": "L1"
     },
     {
-      "community": 691,
+      "community": 692,
       "file_type": "code",
       "id": "bags_bags",
       "label": "Bags()",
@@ -98056,7 +98224,7 @@
       "source_location": "L4"
     },
     {
-      "community": 691,
+      "community": 692,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_bags_tsx",
       "label": "Bags.tsx",
@@ -98065,7 +98233,7 @@
       "source_location": "L1"
     },
     {
-      "community": 692,
+      "community": 693,
       "file_type": "code",
       "id": "customerbehaviortimeline_string",
       "label": "String()",
@@ -98074,7 +98242,7 @@
       "source_location": "L102"
     },
     {
-      "community": 692,
+      "community": 693,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_customerbehaviortimeline_tsx",
       "label": "CustomerBehaviorTimeline.tsx",
@@ -98083,7 +98251,7 @@
       "source_location": "L1"
     },
     {
-      "community": 693,
+      "community": 694,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_useranalyticsname_tsx",
       "label": "UserAnalyticsName.tsx",
@@ -98092,7 +98260,7 @@
       "source_location": "L1"
     },
     {
-      "community": 693,
+      "community": 694,
       "file_type": "code",
       "id": "useranalyticsname_useranalyticsname",
       "label": "UserAnalyticsName()",
@@ -98101,7 +98269,7 @@
       "source_location": "L13"
     },
     {
-      "community": 694,
+      "community": 695,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_userbag_tsx",
       "label": "UserBag.tsx",
@@ -98110,7 +98278,7 @@
       "source_location": "L1"
     },
     {
-      "community": 694,
+      "community": 695,
       "file_type": "code",
       "id": "userbag_userbag",
       "label": "UserBag()",
@@ -98119,7 +98287,7 @@
       "source_location": "L7"
     },
     {
-      "community": 695,
+      "community": 696,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_useronlineorders_tsx",
       "label": "UserOnlineOrders.tsx",
@@ -98128,7 +98296,7 @@
       "source_location": "L1"
     },
     {
-      "community": 695,
+      "community": 696,
       "file_type": "code",
       "id": "useronlineorders_useronlineorders",
       "label": "UserOnlineOrders()",
@@ -98137,7 +98305,7 @@
       "source_location": "L11"
     },
     {
-      "community": 696,
+      "community": 697,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_userstatus_tsx",
       "label": "UserStatus.tsx",
@@ -98146,7 +98314,7 @@
       "source_location": "L1"
     },
     {
-      "community": 696,
+      "community": 697,
       "file_type": "code",
       "id": "userstatus_userstatus",
       "label": "UserStatus()",
@@ -98155,7 +98323,7 @@
       "source_location": "L7"
     },
     {
-      "community": 697,
+      "community": 698,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_userview_tsx",
       "label": "UserView.tsx",
@@ -98164,7 +98332,7 @@
       "source_location": "L1"
     },
     {
-      "community": 697,
+      "community": 698,
       "file_type": "code",
       "id": "userview_useractions",
       "label": "UserActions()",
@@ -98173,7 +98341,7 @@
       "source_location": "L45"
     },
     {
-      "community": 698,
+      "community": 699,
       "file_type": "code",
       "id": "customerjourneystage_customerjourneystagecard",
       "label": "CustomerJourneyStageCard()",
@@ -98182,30 +98350,12 @@
       "source_location": "L13"
     },
     {
-      "community": 698,
+      "community": 699,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_customerjourneystage_tsx",
       "label": "CustomerJourneyStage.tsx",
       "norm_label": "customerjourneystage.tsx",
       "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/CustomerJourneyStage.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 699,
-      "file_type": "code",
-      "id": "managerelevationcontext_test_wrapper",
-      "label": "wrapper()",
-      "norm_label": "wrapper()",
-      "source_file": "packages/athena-webapp/src/contexts/ManagerElevationContext.test.tsx",
-      "source_location": "L64"
-    },
-    {
-      "community": 699,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_contexts_managerelevationcontext_test_tsx",
-      "label": "ManagerElevationContext.test.tsx",
-      "norm_label": "managerelevationcontext.test.tsx",
-      "source_file": "packages/athena-webapp/src/contexts/ManagerElevationContext.test.tsx",
       "source_location": "L1"
     },
     {
@@ -98607,6 +98757,24 @@
     {
       "community": 700,
       "file_type": "code",
+      "id": "managerelevationcontext_test_wrapper",
+      "label": "wrapper()",
+      "norm_label": "wrapper()",
+      "source_file": "packages/athena-webapp/src/contexts/ManagerElevationContext.test.tsx",
+      "source_location": "L64"
+    },
+    {
+      "community": 700,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_contexts_managerelevationcontext_test_tsx",
+      "label": "ManagerElevationContext.test.tsx",
+      "norm_label": "managerelevationcontext.test.tsx",
+      "source_file": "packages/athena-webapp/src/contexts/ManagerElevationContext.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 701,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_image_upload_ts",
       "label": "use-image-upload.ts",
       "norm_label": "use-image-upload.ts",
@@ -98614,7 +98782,7 @@
       "source_location": "L1"
     },
     {
-      "community": 700,
+      "community": 701,
       "file_type": "code",
       "id": "use_image_upload_useimageupload",
       "label": "useImageUpload()",
@@ -98623,7 +98791,7 @@
       "source_location": "L7"
     },
     {
-      "community": 701,
+      "community": 702,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_mobile_tsx",
       "label": "use-mobile.tsx",
@@ -98632,7 +98800,7 @@
       "source_location": "L1"
     },
     {
-      "community": 701,
+      "community": 702,
       "file_type": "code",
       "id": "use_mobile_useismobile",
       "label": "useIsMobile()",
@@ -98641,7 +98809,7 @@
       "source_location": "L5"
     },
     {
-      "community": 702,
+      "community": 703,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_navigate_back_ts",
       "label": "use-navigate-back.ts",
@@ -98650,7 +98818,7 @@
       "source_location": "L1"
     },
     {
-      "community": 702,
+      "community": 703,
       "file_type": "code",
       "id": "use_navigate_back_usenavigateback",
       "label": "useNavigateBack()",
@@ -98659,7 +98827,7 @@
       "source_location": "L5"
     },
     {
-      "community": 703,
+      "community": 704,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_navigation_keyboard_shortcuts_ts",
       "label": "use-navigation-keyboard-shortcuts.ts",
@@ -98668,7 +98836,7 @@
       "source_location": "L1"
     },
     {
-      "community": 703,
+      "community": 704,
       "file_type": "code",
       "id": "use_navigation_keyboard_shortcuts_usenavigationkeyboardshortcuts",
       "label": "useNavigationKeyboardShortcuts()",
@@ -98677,7 +98845,7 @@
       "source_location": "L7"
     },
     {
-      "community": 704,
+      "community": 705,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_pagination_persistence_ts",
       "label": "use-pagination-persistence.ts",
@@ -98686,7 +98854,7 @@
       "source_location": "L1"
     },
     {
-      "community": 704,
+      "community": 705,
       "file_type": "code",
       "id": "use_pagination_persistence_usepaginationpersistence",
       "label": "usePaginationPersistence()",
@@ -98695,7 +98863,7 @@
       "source_location": "L11"
     },
     {
-      "community": 705,
+      "community": 706,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_table_keyboard_pagination_ts",
       "label": "use-table-keyboard-pagination.ts",
@@ -98704,7 +98872,7 @@
       "source_location": "L1"
     },
     {
-      "community": 705,
+      "community": 706,
       "file_type": "code",
       "id": "use_table_keyboard_pagination_usetablekeyboardpagination",
       "label": "useTableKeyboardPagination()",
@@ -98713,7 +98881,7 @@
       "source_location": "L6"
     },
     {
-      "community": 706,
+      "community": 707,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usebulkoperations_test_ts",
       "label": "useBulkOperations.test.ts",
@@ -98722,7 +98890,7 @@
       "source_location": "L1"
     },
     {
-      "community": 706,
+      "community": 707,
       "file_type": "code",
       "id": "usebulkoperations_test_makesku",
       "label": "makeSku()",
@@ -98731,7 +98899,7 @@
       "source_location": "L189"
     },
     {
-      "community": 707,
+      "community": 708,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useconvexauthidentity_ts",
       "label": "useConvexAuthIdentity.ts",
@@ -98740,7 +98908,7 @@
       "source_location": "L1"
     },
     {
-      "community": 707,
+      "community": 708,
       "file_type": "code",
       "id": "useconvexauthidentity_useconvexauthidentity",
       "label": "useConvexAuthIdentity()",
@@ -98749,7 +98917,7 @@
       "source_location": "L5"
     },
     {
-      "community": 708,
+      "community": 709,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usecopytext_ts",
       "label": "useCopyText.ts",
@@ -98758,31 +98926,13 @@
       "source_location": "L1"
     },
     {
-      "community": 708,
+      "community": 709,
       "file_type": "code",
       "id": "usecopytext_usecopytext",
       "label": "useCopyText()",
       "norm_label": "usecopytext()",
       "source_file": "packages/athena-webapp/src/hooks/useCopyText.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 709,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_usecreatecomplimentaryproduct_ts",
-      "label": "useCreateComplimentaryProduct.ts",
-      "norm_label": "usecreatecomplimentaryproduct.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useCreateComplimentaryProduct.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 709,
-      "file_type": "code",
-      "id": "usecreatecomplimentaryproduct_usecreatecomplimentaryproduct",
-      "label": "useCreateComplimentaryProduct()",
-      "norm_label": "usecreatecomplimentaryproduct()",
-      "source_file": "packages/athena-webapp/src/hooks/useCreateComplimentaryProduct.ts",
-      "source_location": "L6"
     },
     {
       "community": 71,
@@ -98886,6 +99036,24 @@
     {
       "community": 710,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_usecreatecomplimentaryproduct_ts",
+      "label": "useCreateComplimentaryProduct.ts",
+      "norm_label": "usecreatecomplimentaryproduct.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useCreateComplimentaryProduct.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 710,
+      "file_type": "code",
+      "id": "usecreatecomplimentaryproduct_usecreatecomplimentaryproduct",
+      "label": "useCreateComplimentaryProduct()",
+      "norm_label": "usecreatecomplimentaryproduct()",
+      "source_file": "packages/athena-webapp/src/hooks/useCreateComplimentaryProduct.ts",
+      "source_location": "L6"
+    },
+    {
+      "community": 711,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usedebounce_ts",
       "label": "useDebounce.ts",
       "norm_label": "usedebounce.ts",
@@ -98893,7 +99061,7 @@
       "source_location": "L1"
     },
     {
-      "community": 710,
+      "community": 711,
       "file_type": "code",
       "id": "usedebounce_usedebounce",
       "label": "useDebounce()",
@@ -98902,7 +99070,7 @@
       "source_location": "L12"
     },
     {
-      "community": 711,
+      "community": 712,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetactiveproduct_ts",
       "label": "useGetActiveProduct.ts",
@@ -98911,7 +99079,7 @@
       "source_location": "L1"
     },
     {
-      "community": 711,
+      "community": 712,
       "file_type": "code",
       "id": "usegetactiveproduct_usegetactiveproduct",
       "label": "useGetActiveProduct()",
@@ -98920,7 +99088,7 @@
       "source_location": "L6"
     },
     {
-      "community": 712,
+      "community": 713,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetautheduser_ts",
       "label": "useGetAuthedUser.ts",
@@ -98929,7 +99097,7 @@
       "source_location": "L1"
     },
     {
-      "community": 712,
+      "community": 713,
       "file_type": "code",
       "id": "usegetautheduser_usegetautheduser",
       "label": "useGetAuthedUser()",
@@ -98938,7 +99106,7 @@
       "source_location": "L4"
     },
     {
-      "community": 713,
+      "community": 714,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetcategories_ts",
       "label": "useGetCategories.ts",
@@ -98947,7 +99115,7 @@
       "source_location": "L1"
     },
     {
-      "community": 713,
+      "community": 714,
       "file_type": "code",
       "id": "usegetcategories_usegetcategories",
       "label": "useGetCategories()",
@@ -98956,7 +99124,7 @@
       "source_location": "L5"
     },
     {
-      "community": 714,
+      "community": 715,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetcomplimentaryproducts_ts",
       "label": "useGetComplimentaryProducts.ts",
@@ -98965,7 +99133,7 @@
       "source_location": "L1"
     },
     {
-      "community": 714,
+      "community": 715,
       "file_type": "code",
       "id": "usegetcomplimentaryproducts_usegetcomplimentaryproducts",
       "label": "useGetComplimentaryProducts()",
@@ -98974,7 +99142,7 @@
       "source_location": "L5"
     },
     {
-      "community": 715,
+      "community": 716,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetcurrencyformatter_ts",
       "label": "useGetCurrencyFormatter.ts",
@@ -98983,7 +99151,7 @@
       "source_location": "L1"
     },
     {
-      "community": 715,
+      "community": 716,
       "file_type": "code",
       "id": "usegetcurrencyformatter_usegetcurrencyformatter",
       "label": "useGetCurrencyFormatter()",
@@ -98992,7 +99160,7 @@
       "source_location": "L4"
     },
     {
-      "community": 716,
+      "community": 717,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetsubcategories_ts",
       "label": "useGetSubcategories.ts",
@@ -99001,7 +99169,7 @@
       "source_location": "L1"
     },
     {
-      "community": 716,
+      "community": 717,
       "file_type": "code",
       "id": "usegetsubcategories_usegetsubcategories",
       "label": "useGetSubcategories()",
@@ -99010,7 +99178,7 @@
       "source_location": "L5"
     },
     {
-      "community": 717,
+      "community": 718,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetterminal_ts",
       "label": "useGetTerminal.ts",
@@ -99019,7 +99187,7 @@
       "source_location": "L1"
     },
     {
-      "community": 717,
+      "community": 718,
       "file_type": "code",
       "id": "usegetterminal_usegetterminal",
       "label": "useGetTerminal()",
@@ -99028,7 +99196,7 @@
       "source_location": "L5"
     },
     {
-      "community": 718,
+      "community": 719,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usenewordernotification_ts",
       "label": "useNewOrderNotification.ts",
@@ -99037,31 +99205,13 @@
       "source_location": "L1"
     },
     {
-      "community": 718,
+      "community": 719,
       "file_type": "code",
       "id": "usenewordernotification_usenewordernotification",
       "label": "useNewOrderNotification()",
       "norm_label": "usenewordernotification()",
       "source_file": "packages/athena-webapp/src/hooks/useNewOrderNotification.ts",
       "source_location": "L8"
-    },
-    {
-      "community": 719,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_usepermissions_ts",
-      "label": "usePermissions.ts",
-      "norm_label": "usepermissions.ts",
-      "source_file": "packages/athena-webapp/src/hooks/usePermissions.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 719,
-      "file_type": "code",
-      "id": "usepermissions_usepermissions",
-      "label": "usePermissions()",
-      "norm_label": "usepermissions()",
-      "source_file": "packages/athena-webapp/src/hooks/usePermissions.ts",
-      "source_location": "L21"
     },
     {
       "community": 72,
@@ -99165,6 +99315,24 @@
     {
       "community": 720,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_usepermissions_ts",
+      "label": "usePermissions.ts",
+      "norm_label": "usepermissions.ts",
+      "source_file": "packages/athena-webapp/src/hooks/usePermissions.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 720,
+      "file_type": "code",
+      "id": "usepermissions_usepermissions",
+      "label": "usePermissions()",
+      "norm_label": "usepermissions()",
+      "source_file": "packages/athena-webapp/src/hooks/usePermissions.ts",
+      "source_location": "L21"
+    },
+    {
+      "community": 721,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useprint_ts",
       "label": "usePrint.ts",
       "norm_label": "useprint.ts",
@@ -99172,7 +99340,7 @@
       "source_location": "L1"
     },
     {
-      "community": 720,
+      "community": 721,
       "file_type": "code",
       "id": "useprint_useprint",
       "label": "usePrint()",
@@ -99181,7 +99349,7 @@
       "source_location": "L3"
     },
     {
-      "community": 721,
+      "community": 722,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useproductsearchresults_ts",
       "label": "useProductSearchResults.ts",
@@ -99190,7 +99358,7 @@
       "source_location": "L1"
     },
     {
-      "community": 721,
+      "community": 722,
       "file_type": "code",
       "id": "useproductsearchresults_useproductsearchresults",
       "label": "useProductSearchResults()",
@@ -99199,7 +99367,7 @@
       "source_location": "L27"
     },
     {
-      "community": 722,
+      "community": 723,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useproductwithnoimagesnotification_tsx",
       "label": "useProductWithNoImagesNotification.tsx",
@@ -99208,7 +99376,7 @@
       "source_location": "L1"
     },
     {
-      "community": 722,
+      "community": 723,
       "file_type": "code",
       "id": "useproductwithnoimagesnotification_useproductwithnoimagesnotification",
       "label": "useProductWithNoImagesNotification()",
@@ -99217,7 +99385,7 @@
       "source_location": "L7"
     },
     {
-      "community": 723,
+      "community": 724,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useprotectedadminpagestate_ts",
       "label": "useProtectedAdminPageState.ts",
@@ -99226,7 +99394,7 @@
       "source_location": "L1"
     },
     {
-      "community": 723,
+      "community": 724,
       "file_type": "code",
       "id": "useprotectedadminpagestate_useprotectedadminpagestate",
       "label": "useProtectedAdminPageState()",
@@ -99235,7 +99403,7 @@
       "source_location": "L7"
     },
     {
-      "community": 724,
+      "community": 725,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useskusreservedincheckout_ts",
       "label": "useSkusReservedInCheckout.ts",
@@ -99244,7 +99412,7 @@
       "source_location": "L1"
     },
     {
-      "community": 724,
+      "community": 725,
       "file_type": "code",
       "id": "useskusreservedincheckout_useskusreservedincheckout",
       "label": "useSkusReservedInCheckout()",
@@ -99253,7 +99421,7 @@
       "source_location": "L12"
     },
     {
-      "community": 725,
+      "community": 726,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useskusreservedinpossession_ts",
       "label": "useSkusReservedInPosSession.ts",
@@ -99262,7 +99430,7 @@
       "source_location": "L1"
     },
     {
-      "community": 725,
+      "community": 726,
       "file_type": "code",
       "id": "useskusreservedinpossession_useskusreservedinpossession",
       "label": "useSkusReservedInPosSession()",
@@ -99271,7 +99439,7 @@
       "source_location": "L12"
     },
     {
-      "community": 726,
+      "community": 727,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usetogglecomplimentaryproductactive_ts",
       "label": "useToggleComplimentaryProductActive.ts",
@@ -99280,7 +99448,7 @@
       "source_location": "L1"
     },
     {
-      "community": 726,
+      "community": 727,
       "file_type": "code",
       "id": "usetogglecomplimentaryproductactive_usetogglecomplimentaryproductactive",
       "label": "useToggleComplimentaryProductActive()",
@@ -99289,7 +99457,7 @@
       "source_location": "L5"
     },
     {
-      "community": 727,
+      "community": 728,
       "file_type": "code",
       "id": "operatormessages_tooperatormessage",
       "label": "toOperatorMessage()",
@@ -99298,7 +99466,7 @@
       "source_location": "L48"
     },
     {
-      "community": 727,
+      "community": 728,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_operatormessages_ts",
       "label": "operatorMessages.ts",
@@ -99307,7 +99475,7 @@
       "source_location": "L1"
     },
     {
-      "community": 728,
+      "community": 729,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_presentunexpectederrortoast_ts",
       "label": "presentUnexpectedErrorToast.ts",
@@ -99316,31 +99484,13 @@
       "source_location": "L1"
     },
     {
-      "community": 728,
+      "community": 729,
       "file_type": "code",
       "id": "presentunexpectederrortoast_presentunexpectederrortoast",
       "label": "presentUnexpectedErrorToast()",
       "norm_label": "presentunexpectederrortoast()",
       "source_file": "packages/athena-webapp/src/lib/errors/presentUnexpectedErrorToast.ts",
       "source_location": "L7"
-    },
-    {
-      "community": 729,
-      "file_type": "code",
-      "id": "navigationutils_getorigin",
-      "label": "getOrigin()",
-      "norm_label": "getorigin()",
-      "source_file": "packages/athena-webapp/src/lib/navigationUtils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 729,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_navigationutils_ts",
-      "label": "navigationUtils.ts",
-      "norm_label": "navigationutils.ts",
-      "source_file": "packages/athena-webapp/src/lib/navigationUtils.ts",
-      "source_location": "L1"
     },
     {
       "community": 73,
@@ -99444,6 +99594,24 @@
     {
       "community": 730,
       "file_type": "code",
+      "id": "navigationutils_getorigin",
+      "label": "getOrigin()",
+      "norm_label": "getorigin()",
+      "source_file": "packages/athena-webapp/src/lib/navigationUtils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 730,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_navigationutils_ts",
+      "label": "navigationUtils.ts",
+      "norm_label": "navigationutils.ts",
+      "source_file": "packages/athena-webapp/src/lib/navigationUtils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 731,
+      "file_type": "code",
       "id": "additem_additem",
       "label": "addItem()",
       "norm_label": "additem()",
@@ -99451,7 +99619,7 @@
       "source_location": "L5"
     },
     {
-      "community": 730,
+      "community": 731,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_usecases_additem_ts",
       "label": "addItem.ts",
@@ -99460,7 +99628,7 @@
       "source_location": "L1"
     },
     {
-      "community": 731,
+      "community": 732,
       "file_type": "code",
       "id": "bootstrapregister_bootstrapregister",
       "label": "bootstrapRegister()",
@@ -99469,7 +99637,7 @@
       "source_location": "L6"
     },
     {
-      "community": 731,
+      "community": 732,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_usecases_bootstrapregister_ts",
       "label": "bootstrapRegister.ts",
@@ -99478,7 +99646,7 @@
       "source_location": "L1"
     },
     {
-      "community": 732,
+      "community": 733,
       "file_type": "code",
       "id": "holdsession_holdsession",
       "label": "holdSession()",
@@ -99487,7 +99655,7 @@
       "source_location": "L5"
     },
     {
-      "community": 732,
+      "community": 733,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_usecases_holdsession_ts",
       "label": "holdSession.ts",
@@ -99496,7 +99664,7 @@
       "source_location": "L1"
     },
     {
-      "community": 733,
+      "community": 734,
       "file_type": "code",
       "id": "opendrawer_opendrawer",
       "label": "openDrawer()",
@@ -99505,7 +99673,7 @@
       "source_location": "L5"
     },
     {
-      "community": 733,
+      "community": 734,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_usecases_opendrawer_ts",
       "label": "openDrawer.ts",
@@ -99514,7 +99682,7 @@
       "source_location": "L1"
     },
     {
-      "community": 734,
+      "community": 735,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_usecases_startsession_ts",
       "label": "startSession.ts",
@@ -99523,7 +99691,7 @@
       "source_location": "L1"
     },
     {
-      "community": 734,
+      "community": 735,
       "file_type": "code",
       "id": "startsession_startsession",
       "label": "startSession()",
@@ -99532,7 +99700,7 @@
       "source_location": "L5"
     },
     {
-      "community": 735,
+      "community": 736,
       "file_type": "code",
       "id": "calculations_calculatecarttotals",
       "label": "calculateCartTotals()",
@@ -99541,7 +99709,7 @@
       "source_location": "L10"
     },
     {
-      "community": 735,
+      "community": 736,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_calculations_ts",
       "label": "calculations.ts",
@@ -99550,7 +99718,7 @@
       "source_location": "L1"
     },
     {
-      "community": 736,
+      "community": 737,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_presentation_register_useregistercatalogindex_ts",
       "label": "useRegisterCatalogIndex.ts",
@@ -99559,7 +99727,7 @@
       "source_location": "L1"
     },
     {
-      "community": 736,
+      "community": 737,
       "file_type": "code",
       "id": "useregistercatalogindex_useregistercatalogindex",
       "label": "useRegisterCatalogIndex()",
@@ -99568,7 +99736,7 @@
       "source_location": "L8"
     },
     {
-      "community": 737,
+      "community": 738,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_security_pinhash_ts",
       "label": "pinHash.ts",
@@ -99577,7 +99745,7 @@
       "source_location": "L1"
     },
     {
-      "community": 737,
+      "community": 738,
       "file_type": "code",
       "id": "pinhash_hashpin",
       "label": "hashPin()",
@@ -99586,7 +99754,7 @@
       "source_location": "L12"
     },
     {
-      "community": 738,
+      "community": 739,
       "file_type": "code",
       "id": "index_hasorgnotfoundpayload",
       "label": "hasOrgNotFoundPayload()",
@@ -99595,31 +99763,13 @@
       "source_location": "L6"
     },
     {
-      "community": 738,
+      "community": 739,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_cash_controls_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/cash-controls/index.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 739,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_cash_controls_registers_sessionid_tsx",
-      "label": "$sessionId.tsx",
-      "norm_label": "$sessionid.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/cash-controls/registers/$sessionId.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 739,
-      "file_type": "code",
-      "id": "sessionid_hasorgnotfoundpayload",
-      "label": "hasOrgNotFoundPayload()",
-      "norm_label": "hasorgnotfoundpayload()",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/cash-controls/registers/$sessionId.tsx",
-      "source_location": "L6"
     },
     {
       "community": 74,
@@ -99723,6 +99873,24 @@
     {
       "community": 740,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_cash_controls_registers_sessionid_tsx",
+      "label": "$sessionId.tsx",
+      "norm_label": "$sessionid.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/cash-controls/registers/$sessionId.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 740,
+      "file_type": "code",
+      "id": "sessionid_hasorgnotfoundpayload",
+      "label": "hasOrgNotFoundPayload()",
+      "norm_label": "hasorgnotfoundpayload()",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/cash-controls/registers/$sessionId.tsx",
+      "source_location": "L6"
+    },
+    {
+      "community": 741,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_cash_controls_registers_index_tsx",
       "label": "registers.index.tsx",
       "norm_label": "registers.index.tsx",
@@ -99730,7 +99898,7 @@
       "source_location": "L1"
     },
     {
-      "community": 740,
+      "community": 741,
       "file_type": "code",
       "id": "registers_index_hasorgnotfoundpayload",
       "label": "hasOrgNotFoundPayload()",
@@ -99739,7 +99907,7 @@
       "source_location": "L6"
     },
     {
-      "community": 741,
+      "community": 742,
       "file_type": "code",
       "id": "index_storerootredirect",
       "label": "StoreRootRedirect()",
@@ -99748,7 +99916,7 @@
       "source_location": "L7"
     },
     {
-      "community": 741,
+      "community": 742,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_index_tsx",
       "label": "index.tsx",
@@ -99757,7 +99925,7 @@
       "source_location": "L1"
     },
     {
-      "community": 742,
+      "community": 743,
       "file_type": "code",
       "id": "approvals_approvalsroute",
       "label": "ApprovalsRoute()",
@@ -99766,7 +99934,7 @@
       "source_location": "L11"
     },
     {
-      "community": 742,
+      "community": 743,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_operations_approvals_tsx",
       "label": "approvals.tsx",
@@ -99775,7 +99943,7 @@
       "source_location": "L1"
     },
     {
-      "community": 743,
+      "community": 744,
       "file_type": "code",
       "id": "daily_close_history_dailyclosehistoryroute",
       "label": "DailyCloseHistoryRoute()",
@@ -99784,7 +99952,7 @@
       "source_location": "L11"
     },
     {
-      "community": 743,
+      "community": 744,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_operations_daily_close_history_tsx",
       "label": "daily-close-history.tsx",
@@ -99793,7 +99961,7 @@
       "source_location": "L1"
     },
     {
-      "community": 744,
+      "community": 745,
       "file_type": "code",
       "id": "daily_close_dailycloseroute",
       "label": "DailyCloseRoute()",
@@ -99802,7 +99970,7 @@
       "source_location": "L19"
     },
     {
-      "community": 744,
+      "community": 745,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_operations_daily_close_tsx",
       "label": "daily-close.tsx",
@@ -99811,7 +99979,7 @@
       "source_location": "L1"
     },
     {
-      "community": 745,
+      "community": 746,
       "file_type": "code",
       "id": "open_work_openworkroute",
       "label": "OpenWorkRoute()",
@@ -99820,7 +99988,7 @@
       "source_location": "L11"
     },
     {
-      "community": 745,
+      "community": 746,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_operations_open_work_tsx",
       "label": "open-work.tsx",
@@ -99829,7 +99997,7 @@
       "source_location": "L1"
     },
     {
-      "community": 746,
+      "community": 747,
       "file_type": "code",
       "id": "opening_dailyopeningroute",
       "label": "DailyOpeningRoute()",
@@ -99838,7 +100006,7 @@
       "source_location": "L11"
     },
     {
-      "community": 746,
+      "community": 747,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_operations_opening_tsx",
       "label": "opening.tsx",
@@ -99847,7 +100015,7 @@
       "source_location": "L1"
     },
     {
-      "community": 747,
+      "community": 748,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_operations_stock_adjustments_tsx",
       "label": "stock-adjustments.tsx",
@@ -99856,7 +100024,7 @@
       "source_location": "L1"
     },
     {
-      "community": 747,
+      "community": 748,
       "file_type": "code",
       "id": "stock_adjustments_stockadjustmentsroute",
       "label": "StockAdjustmentsRoute()",
@@ -99865,7 +100033,7 @@
       "source_location": "L25"
     },
     {
-      "community": 748,
+      "community": 749,
       "file_type": "code",
       "id": "expense_index_expenseroutecomponent",
       "label": "ExpenseRouteComponent()",
@@ -99874,31 +100042,13 @@
       "source_location": "L6"
     },
     {
-      "community": 748,
+      "community": 749,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_index_tsx",
       "label": "expense.index.tsx",
       "norm_label": "expense.index.tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/expense.index.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 749,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reviews_published_index_tsx",
-      "label": "published.index.tsx",
-      "norm_label": "published.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/reviews/published.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 749,
-      "file_type": "code",
-      "id": "published_index_routecomponent",
-      "label": "RouteComponent()",
-      "norm_label": "routecomponent()",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/reviews/published.index.tsx",
-      "source_location": "L9"
     },
     {
       "community": 75,
@@ -100002,6 +100152,24 @@
     {
       "community": 750,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reviews_published_index_tsx",
+      "label": "published.index.tsx",
+      "norm_label": "published.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/reviews/published.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 750,
+      "file_type": "code",
+      "id": "published_index_routecomponent",
+      "label": "RouteComponent()",
+      "norm_label": "routecomponent()",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/reviews/published.index.tsx",
+      "source_location": "L9"
+    },
+    {
+      "community": 751,
+      "file_type": "code",
       "id": "index_index",
       "label": "Index()",
       "norm_label": "index()",
@@ -100009,7 +100177,7 @@
       "source_location": "L13"
     },
     {
-      "community": 750,
+      "community": 751,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_index_tsx",
       "label": "index.tsx",
@@ -100018,7 +100186,7 @@
       "source_location": "L1"
     },
     {
-      "community": 751,
+      "community": 752,
       "file_type": "code",
       "id": "layout_index_athenaloginreadyview",
       "label": "AthenaLoginReadyView()",
@@ -100027,7 +100195,7 @@
       "source_location": "L4"
     },
     {
-      "community": 751,
+      "community": 752,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_login_layout_index_tsx",
       "label": "_layout.index.tsx",
@@ -100036,7 +100204,7 @@
       "source_location": "L1"
     },
     {
-      "community": 752,
+      "community": 753,
       "file_type": "code",
       "id": "organizationssettingsaccordion_organizationsettingsaccordion",
       "label": "OrganizationSettingsAccordion()",
@@ -100045,7 +100213,7 @@
       "source_location": "L13"
     },
     {
-      "community": 752,
+      "community": 753,
       "file_type": "code",
       "id": "packages_athena_webapp_src_settings_organization_components_organizationssettingsaccordion_tsx",
       "label": "OrganizationsSettingsAccordion.tsx",
@@ -100054,7 +100222,7 @@
       "source_location": "L1"
     },
     {
-      "community": 753,
+      "community": 754,
       "file_type": "code",
       "id": "overview_stories_patternsoverview",
       "label": "PatternsOverview()",
@@ -100063,7 +100231,7 @@
       "source_location": "L5"
     },
     {
-      "community": 753,
+      "community": 754,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_patterns_overview_stories_tsx",
       "label": "Overview.stories.tsx",
@@ -100072,7 +100240,7 @@
       "source_location": "L1"
     },
     {
-      "community": 754,
+      "community": 755,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_patterns_view_patterns_tsx",
       "label": "view-patterns.tsx",
@@ -100081,7 +100249,7 @@
       "source_location": "L1"
     },
     {
-      "community": 754,
+      "community": 755,
       "file_type": "code",
       "id": "view_patterns_cn",
       "label": "cn()",
@@ -100090,7 +100258,7 @@
       "source_location": "L142"
     },
     {
-      "community": 755,
+      "community": 756,
       "file_type": "code",
       "id": "controls_stories_controlsshowcase",
       "label": "ControlsShowcase()",
@@ -100099,7 +100267,7 @@
       "source_location": "L17"
     },
     {
-      "community": 755,
+      "community": 756,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_controls_stories_tsx",
       "label": "Controls.stories.tsx",
@@ -100108,7 +100276,7 @@
       "source_location": "L1"
     },
     {
-      "community": 756,
+      "community": 757,
       "file_type": "code",
       "id": "dialog_stories_dialogshowcase",
       "label": "DialogShowcase()",
@@ -100117,7 +100285,7 @@
       "source_location": "L15"
     },
     {
-      "community": 756,
+      "community": 757,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_dialog_stories_tsx",
       "label": "Dialog.stories.tsx",
@@ -100126,7 +100294,7 @@
       "source_location": "L1"
     },
     {
-      "community": 757,
+      "community": 758,
       "file_type": "code",
       "id": "feedback_stories_feedbackshowcase",
       "label": "FeedbackShowcase()",
@@ -100135,7 +100303,7 @@
       "source_location": "L12"
     },
     {
-      "community": 757,
+      "community": 758,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_feedback_stories_tsx",
       "label": "Feedback.stories.tsx",
@@ -100144,7 +100312,7 @@
       "source_location": "L1"
     },
     {
-      "community": 758,
+      "community": 759,
       "file_type": "code",
       "id": "overview_stories_primitivesoverview",
       "label": "PrimitivesOverview()",
@@ -100153,31 +100321,13 @@
       "source_location": "L5"
     },
     {
-      "community": 758,
+      "community": 759,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_overview_stories_tsx",
       "label": "Overview.stories.tsx",
       "norm_label": "overview.stories.tsx",
       "source_file": "packages/athena-webapp/src/stories/Primitives/Overview.stories.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 759,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_primitives_popover_stories_tsx",
-      "label": "Popover.stories.tsx",
-      "norm_label": "popover.stories.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Primitives/Popover.stories.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 759,
-      "file_type": "code",
-      "id": "popover_stories_popovershowcase",
-      "label": "PopoverShowcase()",
-      "norm_label": "popovershowcase()",
-      "source_file": "packages/athena-webapp/src/stories/Primitives/Popover.stories.tsx",
-      "source_location": "L13"
     },
     {
       "community": 76,
@@ -100281,6 +100431,24 @@
     {
       "community": 760,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_primitives_popover_stories_tsx",
+      "label": "Popover.stories.tsx",
+      "norm_label": "popover.stories.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Primitives/Popover.stories.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 760,
+      "file_type": "code",
+      "id": "popover_stories_popovershowcase",
+      "label": "PopoverShowcase()",
+      "norm_label": "popovershowcase()",
+      "source_file": "packages/athena-webapp/src/stories/Primitives/Popover.stories.tsx",
+      "source_location": "L13"
+    },
+    {
+      "community": 761,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_sheet_stories_tsx",
       "label": "Sheet.stories.tsx",
       "norm_label": "sheet.stories.tsx",
@@ -100288,7 +100456,7 @@
       "source_location": "L1"
     },
     {
-      "community": 760,
+      "community": 761,
       "file_type": "code",
       "id": "sheet_stories_sheetshowcase",
       "label": "SheetShowcase()",
@@ -100297,7 +100465,7 @@
       "source_location": "L14"
     },
     {
-      "community": 761,
+      "community": 762,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_tooltip_stories_tsx",
       "label": "Tooltip.stories.tsx",
@@ -100306,7 +100474,7 @@
       "source_location": "L1"
     },
     {
-      "community": 761,
+      "community": 762,
       "file_type": "code",
       "id": "tooltip_stories_tooltipshowcase",
       "label": "TooltipShowcase()",
@@ -100315,7 +100483,7 @@
       "source_location": "L13"
     },
     {
-      "community": 762,
+      "community": 763,
       "file_type": "code",
       "id": "overview_stories_templatesoverview",
       "label": "TemplatesOverview()",
@@ -100324,7 +100492,7 @@
       "source_location": "L5"
     },
     {
-      "community": 762,
+      "community": 763,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_templates_overview_stories_tsx",
       "label": "Overview.stories.tsx",
@@ -100333,7 +100501,7 @@
       "source_location": "L1"
     },
     {
-      "community": 763,
+      "community": 764,
       "file_type": "code",
       "id": "formatnumber_formatnumber",
       "label": "formatNumber()",
@@ -100342,7 +100510,7 @@
       "source_location": "L1"
     },
     {
-      "community": 763,
+      "community": 764,
       "file_type": "code",
       "id": "packages_athena_webapp_src_utils_formatnumber_ts",
       "label": "formatNumber.ts",
@@ -100351,7 +100519,7 @@
       "source_location": "L1"
     },
     {
-      "community": 764,
+      "community": 765,
       "file_type": "code",
       "id": "bannermessage_getbannermessage",
       "label": "getBannerMessage()",
@@ -100360,7 +100528,7 @@
       "source_location": "L4"
     },
     {
-      "community": 764,
+      "community": 765,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_bannermessage_ts",
       "label": "bannerMessage.ts",
@@ -100369,7 +100537,7 @@
       "source_location": "L1"
     },
     {
-      "community": 765,
+      "community": 766,
       "file_type": "code",
       "id": "checkoutsession_test_jsonresponse",
       "label": "jsonResponse()",
@@ -100378,7 +100546,7 @@
       "source_location": "L27"
     },
     {
-      "community": 765,
+      "community": 766,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_checkoutsession_test_ts",
       "label": "checkoutSession.test.ts",
@@ -100387,7 +100555,7 @@
       "source_location": "L1"
     },
     {
-      "community": 766,
+      "community": 767,
       "file_type": "code",
       "id": "guest_updateguest",
       "label": "updateGuest()",
@@ -100396,7 +100564,7 @@
       "source_location": "L4"
     },
     {
-      "community": 766,
+      "community": 767,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_guest_ts",
       "label": "guest.ts",
@@ -100405,7 +100573,7 @@
       "source_location": "L1"
     },
     {
-      "community": 767,
+      "community": 768,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_postransaction_test_ts",
       "label": "posTransaction.test.ts",
@@ -100414,7 +100582,7 @@
       "source_location": "L1"
     },
     {
-      "community": 767,
+      "community": 768,
       "file_type": "code",
       "id": "postransaction_test_jsonresponse",
       "label": "jsonResponse()",
@@ -100423,7 +100591,7 @@
       "source_location": "L10"
     },
     {
-      "community": 768,
+      "community": 769,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_storefront_ts",
       "label": "storefront.ts",
@@ -100432,31 +100600,13 @@
       "source_location": "L1"
     },
     {
-      "community": 768,
+      "community": 769,
       "file_type": "code",
       "id": "storefront_getstore",
       "label": "getStore()",
       "norm_label": "getstore()",
       "source_file": "packages/storefront-webapp/src/api/storefront.ts",
       "source_location": "L5"
-    },
-    {
-      "community": 769,
-      "file_type": "code",
-      "id": "entitypage_entitypage",
-      "label": "EntityPage()",
-      "norm_label": "entitypage()",
-      "source_file": "packages/storefront-webapp/src/components/EntityPage.tsx",
-      "source_location": "L10"
-    },
-    {
-      "community": 769,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_entitypage_tsx",
-      "label": "EntityPage.tsx",
-      "norm_label": "entitypage.tsx",
-      "source_file": "packages/storefront-webapp/src/components/EntityPage.tsx",
-      "source_location": "L1"
     },
     {
       "community": 77,
@@ -100551,6 +100701,24 @@
     {
       "community": 770,
       "file_type": "code",
+      "id": "entitypage_entitypage",
+      "label": "EntityPage()",
+      "norm_label": "entitypage()",
+      "source_file": "packages/storefront-webapp/src/components/EntityPage.tsx",
+      "source_location": "L10"
+    },
+    {
+      "community": 770,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_entitypage_tsx",
+      "label": "EntityPage.tsx",
+      "norm_label": "entitypage.tsx",
+      "source_file": "packages/storefront-webapp/src/components/EntityPage.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 771,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_productspage_tsx",
       "label": "ProductsPage.tsx",
       "norm_label": "productspage.tsx",
@@ -100558,7 +100726,7 @@
       "source_location": "L1"
     },
     {
-      "community": 770,
+      "community": 771,
       "file_type": "code",
       "id": "productspage_productcardloadingskeleton",
       "label": "ProductCardLoadingSkeleton()",
@@ -100567,7 +100735,7 @@
       "source_location": "L10"
     },
     {
-      "community": 771,
+      "community": 772,
       "file_type": "code",
       "id": "auth_authcomponent",
       "label": "AuthComponent()",
@@ -100576,7 +100744,7 @@
       "source_location": "L4"
     },
     {
-      "community": 771,
+      "community": 772,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_auth_auth_tsx",
       "label": "Auth.tsx",
@@ -100585,7 +100753,7 @@
       "source_location": "L1"
     },
     {
-      "community": 772,
+      "community": 773,
       "file_type": "code",
       "id": "bagsummary_tobagsummaryitems",
       "label": "toBagSummaryItems()",
@@ -100594,7 +100762,7 @@
       "source_location": "L39"
     },
     {
-      "community": 772,
+      "community": 773,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_bagsummary_tsx",
       "label": "BagSummary.tsx",
@@ -100603,7 +100771,7 @@
       "source_location": "L1"
     },
     {
-      "community": 773,
+      "community": 774,
       "file_type": "code",
       "id": "checkoutform_checkoutform",
       "label": "CheckoutForm()",
@@ -100612,7 +100780,7 @@
       "source_location": "L18"
     },
     {
-      "community": 773,
+      "community": 774,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkoutform_tsx",
       "label": "CheckoutForm.tsx",
@@ -100621,7 +100789,7 @@
       "source_location": "L1"
     },
     {
-      "community": 774,
+      "community": 775,
       "file_type": "code",
       "id": "checkoutprovider_checkoutprovider",
       "label": "CheckoutProvider()",
@@ -100630,7 +100798,7 @@
       "source_location": "L71"
     },
     {
-      "community": 774,
+      "community": 775,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkoutprovider_tsx",
       "label": "CheckoutProvider.tsx",
@@ -100639,7 +100807,7 @@
       "source_location": "L1"
     },
     {
-      "community": 775,
+      "community": 776,
       "file_type": "code",
       "id": "enteredbillingaddressdetails_enteredbillingaddressdetails",
       "label": "EnteredBillingAddressDetails()",
@@ -100648,7 +100816,7 @@
       "source_location": "L6"
     },
     {
-      "community": 775,
+      "community": 776,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_enteredbillingaddressdetails_tsx",
       "label": "EnteredBillingAddressDetails.tsx",
@@ -100657,7 +100825,7 @@
       "source_location": "L1"
     },
     {
-      "community": 776,
+      "community": 777,
       "file_type": "code",
       "id": "ordersummary_ordersummary",
       "label": "OrderSummary()",
@@ -100666,7 +100834,7 @@
       "source_location": "L18"
     },
     {
-      "community": 776,
+      "community": 777,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_orderdetails_ordersummary_tsx",
       "label": "OrderSummary.tsx",
@@ -100675,7 +100843,7 @@
       "source_location": "L1"
     },
     {
-      "community": 777,
+      "community": 778,
       "file_type": "code",
       "id": "index_pickupdetails",
       "label": "PickupDetails()",
@@ -100684,7 +100852,7 @@
       "source_location": "L11"
     },
     {
-      "community": 777,
+      "community": 778,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_orderdetails_index_tsx",
       "label": "index.tsx",
@@ -100693,7 +100861,7 @@
       "source_location": "L1"
     },
     {
-      "community": 778,
+      "community": 779,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_paymentmethodsection_tsx",
       "label": "PaymentMethodSection.tsx",
@@ -100702,31 +100870,13 @@
       "source_location": "L1"
     },
     {
-      "community": 778,
+      "community": 779,
       "file_type": "code",
       "id": "paymentmethodsection_paymentmethodsection",
       "label": "PaymentMethodSection()",
       "norm_label": "paymentmethodsection()",
       "source_file": "packages/storefront-webapp/src/components/checkout/PaymentMethodSection.tsx",
       "source_location": "L8"
-    },
-    {
-      "community": 779,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_paymentsection_tsx",
-      "label": "PaymentSection.tsx",
-      "norm_label": "paymentsection.tsx",
-      "source_file": "packages/storefront-webapp/src/components/checkout/PaymentSection.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 779,
-      "file_type": "code",
-      "id": "paymentsection_paymentsection",
-      "label": "PaymentSection()",
-      "norm_label": "paymentsection()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/PaymentSection.tsx",
-      "source_location": "L27"
     },
     {
       "community": 78,
@@ -100821,6 +100971,24 @@
     {
       "community": 780,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_paymentsection_tsx",
+      "label": "PaymentSection.tsx",
+      "norm_label": "paymentsection.tsx",
+      "source_file": "packages/storefront-webapp/src/components/checkout/PaymentSection.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 780,
+      "file_type": "code",
+      "id": "paymentsection_paymentsection",
+      "label": "PaymentSection()",
+      "norm_label": "paymentsection()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/PaymentSection.tsx",
+      "source_location": "L27"
+    },
+    {
+      "community": 781,
+      "file_type": "code",
       "id": "deliveryfees_calculatedeliveryfee",
       "label": "calculateDeliveryFee()",
       "norm_label": "calculatedeliveryfee()",
@@ -100828,7 +100996,7 @@
       "source_location": "L40"
     },
     {
-      "community": 780,
+      "community": 781,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliveryfees_ts",
       "label": "deliveryFees.ts",
@@ -100837,7 +101005,7 @@
       "source_location": "L1"
     },
     {
-      "community": 781,
+      "community": 782,
       "file_type": "code",
       "id": "derivecheckoutstate_derivecheckoutstate",
       "label": "deriveCheckoutState()",
@@ -100846,7 +101014,7 @@
       "source_location": "L3"
     },
     {
-      "community": 781,
+      "community": 782,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_derivecheckoutstate_ts",
       "label": "deriveCheckoutState.ts",
@@ -100855,7 +101023,7 @@
       "source_location": "L1"
     },
     {
-      "community": 782,
+      "community": 783,
       "file_type": "code",
       "id": "checkoutschemas_test_getissuemap",
       "label": "getIssueMap()",
@@ -100864,7 +101032,7 @@
       "source_location": "L8"
     },
     {
-      "community": 782,
+      "community": 783,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_checkoutschemas_test_ts",
       "label": "checkoutSchemas.test.ts",
@@ -100873,7 +101041,7 @@
       "source_location": "L1"
     },
     {
-      "community": 783,
+      "community": 784,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_weborderschema_test_ts",
       "label": "webOrderSchema.test.ts",
@@ -100882,7 +101050,7 @@
       "source_location": "L1"
     },
     {
-      "community": 783,
+      "community": 784,
       "file_type": "code",
       "id": "weborderschema_test_getissuemap",
       "label": "getIssueMap()",
@@ -100891,7 +101059,7 @@
       "source_location": "L12"
     },
     {
-      "community": 784,
+      "community": 785,
       "file_type": "code",
       "id": "customerdetailsform_onsubmit",
       "label": "onSubmit()",
@@ -100900,7 +101068,7 @@
       "source_location": "L77"
     },
     {
-      "community": 784,
+      "community": 785,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_common_forms_customerdetailsform_tsx",
       "label": "CustomerDetailsForm.tsx",
@@ -100909,7 +101077,7 @@
       "source_location": "L1"
     },
     {
-      "community": 785,
+      "community": 786,
       "file_type": "code",
       "id": "deliverydetailsform_onsubmit",
       "label": "onSubmit()",
@@ -100918,7 +101086,7 @@
       "source_location": "L161"
     },
     {
-      "community": 785,
+      "community": 786,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_common_forms_deliverydetailsform_tsx",
       "label": "DeliveryDetailsForm.tsx",
@@ -100927,7 +101095,7 @@
       "source_location": "L1"
     },
     {
-      "community": 786,
+      "community": 787,
       "file_type": "code",
       "id": "hooks_usecountdown",
       "label": "useCountdown()",
@@ -100936,7 +101104,7 @@
       "source_location": "L3"
     },
     {
-      "community": 786,
+      "community": 787,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_common_hooks_ts",
       "label": "hooks.ts",
@@ -100945,7 +101113,7 @@
       "source_location": "L1"
     },
     {
-      "community": 787,
+      "community": 788,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_communication_trustsignals_tsx",
       "label": "TrustSignals.tsx",
@@ -100954,7 +101122,7 @@
       "source_location": "L1"
     },
     {
-      "community": 787,
+      "community": 788,
       "file_type": "code",
       "id": "trustsignals_trustsignals",
       "label": "TrustSignals()",
@@ -100963,7 +101131,7 @@
       "source_location": "L4"
     },
     {
-      "community": 788,
+      "community": 789,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_filter_productfilter_tsx",
       "label": "ProductFilter.tsx",
@@ -100972,31 +101140,13 @@
       "source_location": "L1"
     },
     {
-      "community": 788,
+      "community": 789,
       "file_type": "code",
       "id": "productfilter_productfilter",
       "label": "ProductFilter()",
       "norm_label": "productfilter()",
       "source_file": "packages/storefront-webapp/src/components/filter/ProductFilter.tsx",
       "source_location": "L14"
-    },
-    {
-      "community": 789,
-      "file_type": "code",
-      "id": "filter_handlecheckboxchange",
-      "label": "handleCheckboxChange()",
-      "norm_label": "handlecheckboxchange()",
-      "source_file": "packages/storefront-webapp/src/components/footer/Filter.tsx",
-      "source_location": "L27"
-    },
-    {
-      "community": 789,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_footer_filter_tsx",
-      "label": "Filter.tsx",
-      "norm_label": "filter.tsx",
-      "source_file": "packages/storefront-webapp/src/components/footer/Filter.tsx",
-      "source_location": "L1"
     },
     {
       "community": 79,
@@ -101091,6 +101241,24 @@
     {
       "community": 790,
       "file_type": "code",
+      "id": "filter_handlecheckboxchange",
+      "label": "handleCheckboxChange()",
+      "norm_label": "handlecheckboxchange()",
+      "source_file": "packages/storefront-webapp/src/components/footer/Filter.tsx",
+      "source_location": "L27"
+    },
+    {
+      "community": 790,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_footer_filter_tsx",
+      "label": "Filter.tsx",
+      "norm_label": "filter.tsx",
+      "source_file": "packages/storefront-webapp/src/components/footer/Filter.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 791,
+      "file_type": "code",
       "id": "bestsellerssection_bestsellerssection",
       "label": "BestSellersSection()",
       "norm_label": "bestsellerssection()",
@@ -101098,7 +101266,7 @@
       "source_location": "L17"
     },
     {
-      "community": 790,
+      "community": 791,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_bestsellerssection_tsx",
       "label": "BestSellersSection.tsx",
@@ -101107,7 +101275,7 @@
       "source_location": "L1"
     },
     {
-      "community": 791,
+      "community": 792,
       "file_type": "code",
       "id": "homepagecontent_resolvehomepagecontent",
       "label": "resolveHomepageContent()",
@@ -101116,7 +101284,7 @@
       "source_location": "L13"
     },
     {
-      "community": 791,
+      "community": 792,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_homepagecontent_ts",
       "label": "homePageContent.ts",
@@ -101125,7 +101293,7 @@
       "source_location": "L1"
     },
     {
-      "community": 792,
+      "community": 793,
       "file_type": "code",
       "id": "bagmenu_handleonlinkclick",
       "label": "handleOnLinkClick()",
@@ -101134,7 +101302,7 @@
       "source_location": "L47"
     },
     {
-      "community": 792,
+      "community": 793,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_bagmenu_tsx",
       "label": "BagMenu.tsx",
@@ -101143,7 +101311,7 @@
       "source_location": "L1"
     },
     {
-      "community": 793,
+      "community": 794,
       "file_type": "code",
       "id": "mobilebagmenu_mobilebagmenu",
       "label": "MobileBagMenu()",
@@ -101152,7 +101320,7 @@
       "source_location": "L7"
     },
     {
-      "community": 793,
+      "community": 794,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_mobilebagmenu_tsx",
       "label": "MobileBagMenu.tsx",
@@ -101161,7 +101329,7 @@
       "source_location": "L1"
     },
     {
-      "community": 794,
+      "community": 795,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_sitebanner_tsx",
       "label": "SiteBanner.tsx",
@@ -101170,7 +101338,7 @@
       "source_location": "L1"
     },
     {
-      "community": 794,
+      "community": 795,
       "file_type": "code",
       "id": "sitebanner_sitebanner",
       "label": "SiteBanner()",
@@ -101179,7 +101347,7 @@
       "source_location": "L18"
     },
     {
-      "community": 795,
+      "community": 796,
       "file_type": "code",
       "id": "notificationpill_notificationpill",
       "label": "NotificationPill()",
@@ -101188,7 +101356,7 @@
       "source_location": "L1"
     },
     {
-      "community": 795,
+      "community": 796,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_notification_notificationpill_tsx",
       "label": "NotificationPill.tsx",
@@ -101197,7 +101365,7 @@
       "source_location": "L1"
     },
     {
-      "community": 796,
+      "community": 797,
       "file_type": "code",
       "id": "dimensionbar_mapvaluetolabelindex",
       "label": "mapValueToLabelIndex()",
@@ -101206,7 +101374,7 @@
       "source_location": "L12"
     },
     {
-      "community": 796,
+      "community": 797,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_dimensionbar_tsx",
       "label": "DimensionBar.tsx",
@@ -101215,7 +101383,7 @@
       "source_location": "L1"
     },
     {
-      "community": 797,
+      "community": 798,
       "file_type": "code",
       "id": "discountbadge_discountbadge",
       "label": "DiscountBadge()",
@@ -101224,7 +101392,7 @@
       "source_location": "L8"
     },
     {
-      "community": 797,
+      "community": 798,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_discountbadge_tsx",
       "label": "DiscountBadge.tsx",
@@ -101233,7 +101401,7 @@
       "source_location": "L1"
     },
     {
-      "community": 798,
+      "community": 799,
       "file_type": "code",
       "id": "galleryviewer_handleclickonpreview",
       "label": "handleClickOnPreview()",
@@ -101242,30 +101410,12 @@
       "source_location": "L45"
     },
     {
-      "community": 798,
+      "community": 799,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_galleryviewer_tsx",
       "label": "GalleryViewer.tsx",
       "norm_label": "galleryviewer.tsx",
       "source_file": "packages/storefront-webapp/src/components/product-page/GalleryViewer.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 799,
-      "file_type": "code",
-      "id": "onsaleproduct_onsaleproduct",
-      "label": "OnsaleProduct()",
-      "norm_label": "onsaleproduct()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/OnSaleProduct.tsx",
-      "source_location": "L5"
-    },
-    {
-      "community": 799,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_page_onsaleproduct_tsx",
-      "label": "OnSaleProduct.tsx",
-      "norm_label": "onsaleproduct.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-page/OnSaleProduct.tsx",
       "source_location": "L1"
     },
     {
@@ -101649,6 +101799,24 @@
     {
       "community": 800,
       "file_type": "code",
+      "id": "onsaleproduct_onsaleproduct",
+      "label": "OnsaleProduct()",
+      "norm_label": "onsaleproduct()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/OnSaleProduct.tsx",
+      "source_location": "L5"
+    },
+    {
+      "community": 800,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_page_onsaleproduct_tsx",
+      "label": "OnSaleProduct.tsx",
+      "norm_label": "onsaleproduct.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-page/OnSaleProduct.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 801,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productactions_tsx",
       "label": "ProductActions.tsx",
       "norm_label": "productactions.tsx",
@@ -101656,7 +101824,7 @@
       "source_location": "L1"
     },
     {
-      "community": 800,
+      "community": 801,
       "file_type": "code",
       "id": "productactions_productactions",
       "label": "ProductActions()",
@@ -101665,7 +101833,7 @@
       "source_location": "L17"
     },
     {
-      "community": 801,
+      "community": 802,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productattributes_tsx",
       "label": "ProductAttributes.tsx",
@@ -101674,7 +101842,7 @@
       "source_location": "L1"
     },
     {
-      "community": 801,
+      "community": 802,
       "file_type": "code",
       "id": "productattributes_productattributes",
       "label": "ProductAttributes()",
@@ -101683,7 +101851,7 @@
       "source_location": "L3"
     },
     {
-      "community": 802,
+      "community": 803,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productpage_test_tsx",
       "label": "ProductPage.test.tsx",
@@ -101692,7 +101860,7 @@
       "source_location": "L1"
     },
     {
-      "community": 802,
+      "community": 803,
       "file_type": "code",
       "id": "productpage_test_makepagestate",
       "label": "makePageState()",
@@ -101701,7 +101869,7 @@
       "source_location": "L37"
     },
     {
-      "community": 803,
+      "community": 804,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productpage_tsx",
       "label": "ProductPage.tsx",
@@ -101710,7 +101878,7 @@
       "source_location": "L1"
     },
     {
-      "community": 803,
+      "community": 804,
       "file_type": "code",
       "id": "productpage_showshippingpolicy",
       "label": "showShippingPolicy()",
@@ -101719,7 +101887,7 @@
       "source_location": "L79"
     },
     {
-      "community": 804,
+      "community": 805,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productreview_tsx",
       "label": "ProductReview.tsx",
@@ -101728,7 +101896,7 @@
       "source_location": "L1"
     },
     {
-      "community": 804,
+      "community": 805,
       "file_type": "code",
       "id": "productreview_handlehelpful",
       "label": "handleHelpful()",
@@ -101737,7 +101905,7 @@
       "source_location": "L87"
     },
     {
-      "community": 805,
+      "community": 806,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_reviewsummary_tsx",
       "label": "ReviewSummary.tsx",
@@ -101746,7 +101914,7 @@
       "source_location": "L1"
     },
     {
-      "community": 805,
+      "community": 806,
       "file_type": "code",
       "id": "reviewsummary_reviewsummary",
       "label": "ReviewSummary()",
@@ -101755,7 +101923,7 @@
       "source_location": "L8"
     },
     {
-      "community": 806,
+      "community": 807,
       "file_type": "code",
       "id": "orderitem_orderitem",
       "label": "OrderItem()",
@@ -101764,7 +101932,7 @@
       "source_location": "L13"
     },
     {
-      "community": 806,
+      "community": 807,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_orderitem_tsx",
       "label": "OrderItem.tsx",
@@ -101773,7 +101941,7 @@
       "source_location": "L1"
     },
     {
-      "community": 807,
+      "community": 808,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_ratingselector_tsx",
       "label": "RatingSelector.tsx",
@@ -101782,7 +101950,7 @@
       "source_location": "L1"
     },
     {
-      "community": 807,
+      "community": 808,
       "file_type": "code",
       "id": "ratingselector_ratingselector",
       "label": "RatingSelector()",
@@ -101791,7 +101959,7 @@
       "source_location": "L18"
     },
     {
-      "community": 808,
+      "community": 809,
       "file_type": "code",
       "id": "guestrewardsprompt_guestrewardsprompt",
       "label": "GuestRewardsPrompt()",
@@ -101800,30 +101968,12 @@
       "source_location": "L10"
     },
     {
-      "community": 808,
+      "community": 809,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_rewards_guestrewardsprompt_tsx",
       "label": "GuestRewardsPrompt.tsx",
       "norm_label": "guestrewardsprompt.tsx",
       "source_file": "packages/storefront-webapp/src/components/rewards/GuestRewardsPrompt.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 809,
-      "file_type": "code",
-      "id": "orderpointsdisplay_orderpointsdisplay",
-      "label": "OrderPointsDisplay()",
-      "norm_label": "orderpointsdisplay()",
-      "source_file": "packages/storefront-webapp/src/components/rewards/OrderPointsDisplay.tsx",
-      "source_location": "L11"
-    },
-    {
-      "community": 809,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_rewards_orderpointsdisplay_tsx",
-      "label": "OrderPointsDisplay.tsx",
-      "norm_label": "orderpointsdisplay.tsx",
-      "source_file": "packages/storefront-webapp/src/components/rewards/OrderPointsDisplay.tsx",
       "source_location": "L1"
     },
     {
@@ -101919,6 +102069,24 @@
     {
       "community": 810,
       "file_type": "code",
+      "id": "orderpointsdisplay_orderpointsdisplay",
+      "label": "OrderPointsDisplay()",
+      "norm_label": "orderpointsdisplay()",
+      "source_file": "packages/storefront-webapp/src/components/rewards/OrderPointsDisplay.tsx",
+      "source_location": "L11"
+    },
+    {
+      "community": 810,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_rewards_orderpointsdisplay_tsx",
+      "label": "OrderPointsDisplay.tsx",
+      "norm_label": "orderpointsdisplay.tsx",
+      "source_file": "packages/storefront-webapp/src/components/rewards/OrderPointsDisplay.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 811,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_rewards_pastordersrewards_tsx",
       "label": "PastOrdersRewards.tsx",
       "norm_label": "pastordersrewards.tsx",
@@ -101926,7 +102094,7 @@
       "source_location": "L1"
     },
     {
-      "community": 810,
+      "community": 811,
       "file_type": "code",
       "id": "pastordersrewards_handleclaimpoints",
       "label": "handleClaimPoints()",
@@ -101935,7 +102103,7 @@
       "source_location": "L60"
     },
     {
-      "community": 811,
+      "community": 812,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_rewards_rewardspanel_tsx",
       "label": "RewardsPanel.tsx",
@@ -101944,7 +102112,7 @@
       "source_location": "L1"
     },
     {
-      "community": 811,
+      "community": 812,
       "file_type": "code",
       "id": "rewardspanel_handleredeemreward",
       "label": "handleRedeemReward()",
@@ -101953,7 +102121,7 @@
       "source_location": "L33"
     },
     {
-      "community": 812,
+      "community": 813,
       "file_type": "code",
       "id": "bagitem_bagitem",
       "label": "BagItem()",
@@ -101962,7 +102130,7 @@
       "source_location": "L20"
     },
     {
-      "community": 812,
+      "community": 813,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_shopping_bag_bagitem_tsx",
       "label": "BagItem.tsx",
@@ -101971,7 +102139,7 @@
       "source_location": "L1"
     },
     {
-      "community": 813,
+      "community": 814,
       "file_type": "code",
       "id": "checkoutunavailable_checkoutunavailable",
       "label": "CheckoutUnavailable()",
@@ -101980,7 +102148,7 @@
       "source_location": "L4"
     },
     {
-      "community": 813,
+      "community": 814,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_checkout_unavailable_checkoutunavailable_tsx",
       "label": "CheckoutUnavailable.tsx",
@@ -101989,7 +102157,7 @@
       "source_location": "L1"
     },
     {
-      "community": 814,
+      "community": 815,
       "file_type": "code",
       "id": "errorboundary_errorboundary",
       "label": "ErrorBoundary()",
@@ -101998,7 +102166,7 @@
       "source_location": "L22"
     },
     {
-      "community": 814,
+      "community": 815,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_error_errorboundary_tsx",
       "label": "ErrorBoundary.tsx",
@@ -102007,7 +102175,7 @@
       "source_location": "L1"
     },
     {
-      "community": 815,
+      "community": 816,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_scrolldownbutton_tsx",
       "label": "ScrollDownButton.tsx",
@@ -102016,7 +102184,7 @@
       "source_location": "L1"
     },
     {
-      "community": 815,
+      "community": 816,
       "file_type": "code",
       "id": "scrolldownbutton_scrolldownbutton",
       "label": "ScrollDownButton()",
@@ -102025,7 +102193,7 @@
       "source_location": "L11"
     },
     {
-      "community": 816,
+      "community": 817,
       "file_type": "code",
       "id": "country_select_countryselect",
       "label": "CountrySelect()",
@@ -102034,7 +102202,7 @@
       "source_location": "L3"
     },
     {
-      "community": 816,
+      "community": 817,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_country_select_tsx",
       "label": "country-select.tsx",
@@ -102043,7 +102211,7 @@
       "source_location": "L1"
     },
     {
-      "community": 817,
+      "community": 818,
       "file_type": "code",
       "id": "ghana_region_select_ghanaregionselect",
       "label": "GhanaRegionSelect()",
@@ -102052,7 +102220,7 @@
       "source_location": "L3"
     },
     {
-      "community": 817,
+      "community": 818,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_ghana_region_select_tsx",
       "label": "ghana-region-select.tsx",
@@ -102061,7 +102229,7 @@
       "source_location": "L1"
     },
     {
-      "community": 818,
+      "community": 819,
       "file_type": "code",
       "id": "ghost_button_ghostbutton",
       "label": "GhostButton()",
@@ -102070,30 +102238,12 @@
       "source_location": "L9"
     },
     {
-      "community": 818,
+      "community": 819,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_ghost_button_tsx",
       "label": "ghost-button.tsx",
       "norm_label": "ghost-button.tsx",
       "source_file": "packages/storefront-webapp/src/components/ui/ghost-button.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 819,
-      "file_type": "code",
-      "id": "leaveareviewmodal_handleclose",
-      "label": "handleClose()",
-      "norm_label": "handleclose()",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/LeaveAReviewModal.tsx",
-      "source_location": "L66"
-    },
-    {
-      "community": 819,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_modals_leaveareviewmodal_tsx",
-      "label": "LeaveAReviewModal.tsx",
-      "norm_label": "leaveareviewmodal.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/LeaveAReviewModal.tsx",
       "source_location": "L1"
     },
     {
@@ -102189,6 +102339,24 @@
     {
       "community": 820,
       "file_type": "code",
+      "id": "leaveareviewmodal_handleclose",
+      "label": "handleClose()",
+      "norm_label": "handleclose()",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/LeaveAReviewModal.tsx",
+      "source_location": "L66"
+    },
+    {
+      "community": 820,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_modals_leaveareviewmodal_tsx",
+      "label": "LeaveAReviewModal.tsx",
+      "norm_label": "leaveareviewmodal.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/LeaveAReviewModal.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 821,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_upsellmodalsuccess_tsx",
       "label": "UpsellModalSuccess.tsx",
       "norm_label": "upsellmodalsuccess.tsx",
@@ -102196,7 +102364,7 @@
       "source_location": "L1"
     },
     {
-      "community": 820,
+      "community": 821,
       "file_type": "code",
       "id": "upsellmodalsuccess_upsellmodalsuccess",
       "label": "UpsellModalSuccess()",
@@ -102205,7 +102373,7 @@
       "source_location": "L19"
     },
     {
-      "community": 821,
+      "community": 822,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_welcomebackmodalsuccess_tsx",
       "label": "WelcomeBackModalSuccess.tsx",
@@ -102214,7 +102382,7 @@
       "source_location": "L1"
     },
     {
-      "community": 821,
+      "community": 822,
       "file_type": "code",
       "id": "welcomebackmodalsuccess_welcomebackmodalsuccess",
       "label": "WelcomeBackModalSuccess()",
@@ -102223,7 +102391,7 @@
       "source_location": "L13"
     },
     {
-      "community": 822,
+      "community": 823,
       "file_type": "code",
       "id": "leavereviewmodalconfig_getmodalconfig",
       "label": "getModalConfig()",
@@ -102232,7 +102400,7 @@
       "source_location": "L46"
     },
     {
-      "community": 822,
+      "community": 823,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_config_leavereviewmodalconfig_tsx",
       "label": "leaveReviewModalConfig.tsx",
@@ -102241,7 +102409,7 @@
       "source_location": "L1"
     },
     {
-      "community": 823,
+      "community": 824,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_config_welcomebackmodalconfig_tsx",
       "label": "welcomeBackModalConfig.tsx",
@@ -102250,7 +102418,7 @@
       "source_location": "L1"
     },
     {
-      "community": 823,
+      "community": 824,
       "file_type": "code",
       "id": "welcomebackmodalconfig_getmodalconfig",
       "label": "getModalConfig()",
@@ -102259,7 +102427,7 @@
       "source_location": "L46"
     },
     {
-      "community": 824,
+      "community": 825,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_webp_jpg_tsx",
       "label": "webp-jpg.tsx",
@@ -102268,7 +102436,7 @@
       "source_location": "L1"
     },
     {
-      "community": 824,
+      "community": 825,
       "file_type": "code",
       "id": "webp_jpg_webpimage",
       "label": "WebpImage()",
@@ -102277,7 +102445,7 @@
       "source_location": "L1"
     },
     {
-      "community": 825,
+      "community": 826,
       "file_type": "code",
       "id": "formsubmissionprovider_useformsubmission",
       "label": "useFormSubmission()",
@@ -102286,7 +102454,7 @@
       "source_location": "L15"
     },
     {
-      "community": 825,
+      "community": 826,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_contexts_formsubmissionprovider_tsx",
       "label": "FormSubmissionProvider.tsx",
@@ -102295,7 +102463,7 @@
       "source_location": "L1"
     },
     {
-      "community": 826,
+      "community": 827,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usecheckout_ts",
       "label": "useCheckout.ts",
@@ -102304,7 +102472,7 @@
       "source_location": "L1"
     },
     {
-      "community": 826,
+      "community": 827,
       "file_type": "code",
       "id": "usecheckout_usecheckout",
       "label": "useCheckout()",
@@ -102313,7 +102481,7 @@
       "source_location": "L5"
     },
     {
-      "community": 827,
+      "community": 828,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usediscountcodealert_tsx",
       "label": "useDiscountCodeAlert.tsx",
@@ -102322,7 +102490,7 @@
       "source_location": "L1"
     },
     {
-      "community": 827,
+      "community": 828,
       "file_type": "code",
       "id": "usediscountcodealert_usediscountcodealert",
       "label": "useDiscountCodeAlert()",
@@ -102331,7 +102499,7 @@
       "source_location": "L14"
     },
     {
-      "community": 828,
+      "community": 829,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useenhancedtracking_ts",
       "label": "useEnhancedTracking.ts",
@@ -102340,31 +102508,13 @@
       "source_location": "L1"
     },
     {
-      "community": 828,
+      "community": 829,
       "file_type": "code",
       "id": "useenhancedtracking_useenhancedtracking",
       "label": "useEnhancedTracking()",
       "norm_label": "useenhancedtracking()",
       "source_file": "packages/storefront-webapp/src/hooks/useEnhancedTracking.ts",
       "source_location": "L29"
-    },
-    {
-      "community": 829,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_usegetactivecheckoutsession_tsx",
-      "label": "useGetActiveCheckoutSession.tsx",
-      "norm_label": "usegetactivecheckoutsession.tsx",
-      "source_file": "packages/storefront-webapp/src/hooks/useGetActiveCheckoutSession.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 829,
-      "file_type": "code",
-      "id": "usegetactivecheckoutsession_usegetactivecheckoutsession",
-      "label": "useGetActiveCheckoutSession()",
-      "norm_label": "usegetactivecheckoutsession()",
-      "source_file": "packages/storefront-webapp/src/hooks/useGetActiveCheckoutSession.tsx",
-      "source_location": "L5"
     },
     {
       "community": 83,
@@ -102459,6 +102609,24 @@
     {
       "community": 830,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_usegetactivecheckoutsession_tsx",
+      "label": "useGetActiveCheckoutSession.tsx",
+      "norm_label": "usegetactivecheckoutsession.tsx",
+      "source_file": "packages/storefront-webapp/src/hooks/useGetActiveCheckoutSession.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 830,
+      "file_type": "code",
+      "id": "usegetactivecheckoutsession_usegetactivecheckoutsession",
+      "label": "useGetActiveCheckoutSession()",
+      "norm_label": "usegetactivecheckoutsession()",
+      "source_file": "packages/storefront-webapp/src/hooks/useGetActiveCheckoutSession.tsx",
+      "source_location": "L5"
+    },
+    {
+      "community": 831,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usegetproduct_tsx",
       "label": "useGetProduct.tsx",
       "norm_label": "usegetproduct.tsx",
@@ -102466,7 +102634,7 @@
       "source_location": "L1"
     },
     {
-      "community": 830,
+      "community": 831,
       "file_type": "code",
       "id": "usegetproduct_usegetproductquery",
       "label": "useGetProductQuery()",
@@ -102475,7 +102643,7 @@
       "source_location": "L5"
     },
     {
-      "community": 831,
+      "community": 832,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usegetproductfilters_ts",
       "label": "useGetProductFilters.ts",
@@ -102484,7 +102652,7 @@
       "source_location": "L1"
     },
     {
-      "community": 831,
+      "community": 832,
       "file_type": "code",
       "id": "usegetproductfilters_usegetproductfilters",
       "label": "useGetProductFilters()",
@@ -102493,7 +102661,7 @@
       "source_location": "L3"
     },
     {
-      "community": 832,
+      "community": 833,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usegetproductreviews_ts",
       "label": "useGetProductReviews.ts",
@@ -102502,7 +102670,7 @@
       "source_location": "L1"
     },
     {
-      "community": 832,
+      "community": 833,
       "file_type": "code",
       "id": "usegetproductreviews_usegetproductreviewsquery",
       "label": "useGetProductReviewsQuery()",
@@ -102511,7 +102679,7 @@
       "source_location": "L4"
     },
     {
-      "community": 833,
+      "community": 834,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usegetstore_ts",
       "label": "useGetStore.ts",
@@ -102520,7 +102688,7 @@
       "source_location": "L1"
     },
     {
-      "community": 833,
+      "community": 834,
       "file_type": "code",
       "id": "usegetstore_usegetstore",
       "label": "useGetStore()",
@@ -102529,7 +102697,7 @@
       "source_location": "L4"
     },
     {
-      "community": 834,
+      "community": 835,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useinventorystatus_ts",
       "label": "useInventoryStatus.ts",
@@ -102538,7 +102706,7 @@
       "source_location": "L1"
     },
     {
-      "community": 834,
+      "community": 835,
       "file_type": "code",
       "id": "useinventorystatus_useinventorystatus",
       "label": "useInventoryStatus()",
@@ -102547,7 +102715,7 @@
       "source_location": "L9"
     },
     {
-      "community": 835,
+      "community": 836,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useleaveareviewmodal_tsx",
       "label": "useLeaveAReviewModal.tsx",
@@ -102556,7 +102724,7 @@
       "source_location": "L1"
     },
     {
-      "community": 835,
+      "community": 836,
       "file_type": "code",
       "id": "useleaveareviewmodal_useleaveareviewmodal",
       "label": "useLeaveAReviewModal()",
@@ -102565,7 +102733,7 @@
       "source_location": "L17"
     },
     {
-      "community": 836,
+      "community": 837,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_uselogout_ts",
       "label": "useLogout.ts",
@@ -102574,7 +102742,7 @@
       "source_location": "L1"
     },
     {
-      "community": 836,
+      "community": 837,
       "file_type": "code",
       "id": "uselogout_uselogout",
       "label": "useLogout()",
@@ -102583,7 +102751,7 @@
       "source_location": "L5"
     },
     {
-      "community": 837,
+      "community": 838,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usemodalstate_tsx",
       "label": "useModalState.tsx",
@@ -102592,7 +102760,7 @@
       "source_location": "L1"
     },
     {
-      "community": 837,
+      "community": 838,
       "file_type": "code",
       "id": "usemodalstate_usemodalstate",
       "label": "useModalState()",
@@ -102601,7 +102769,7 @@
       "source_location": "L15"
     },
     {
-      "community": 838,
+      "community": 839,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useproductpagelogic_ts",
       "label": "useProductPageLogic.ts",
@@ -102610,31 +102778,13 @@
       "source_location": "L1"
     },
     {
-      "community": 838,
+      "community": 839,
       "file_type": "code",
       "id": "useproductpagelogic_useproductpagelogic",
       "label": "useProductPageLogic()",
       "norm_label": "useproductpagelogic()",
       "source_file": "packages/storefront-webapp/src/hooks/useProductPageLogic.ts",
       "source_location": "L18"
-    },
-    {
-      "community": 839,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_useproductreminder_tsx",
-      "label": "useProductReminder.tsx",
-      "norm_label": "useproductreminder.tsx",
-      "source_file": "packages/storefront-webapp/src/hooks/useProductReminder.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 839,
-      "file_type": "code",
-      "id": "useproductreminder_useproductreminder",
-      "label": "useProductReminder()",
-      "norm_label": "useproductreminder()",
-      "source_file": "packages/storefront-webapp/src/hooks/useProductReminder.tsx",
-      "source_location": "L9"
     },
     {
       "community": 84,
@@ -102729,6 +102879,24 @@
     {
       "community": 840,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_useproductreminder_tsx",
+      "label": "useProductReminder.tsx",
+      "norm_label": "useproductreminder.tsx",
+      "source_file": "packages/storefront-webapp/src/hooks/useProductReminder.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 840,
+      "file_type": "code",
+      "id": "useproductreminder_useproductreminder",
+      "label": "useProductReminder()",
+      "norm_label": "useproductreminder()",
+      "source_file": "packages/storefront-webapp/src/hooks/useProductReminder.tsx",
+      "source_location": "L9"
+    },
+    {
+      "community": 841,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usepromoalert_tsx",
       "label": "usePromoAlert.tsx",
       "norm_label": "usepromoalert.tsx",
@@ -102736,7 +102904,7 @@
       "source_location": "L1"
     },
     {
-      "community": 840,
+      "community": 841,
       "file_type": "code",
       "id": "usepromoalert_usepromoalert",
       "label": "usePromoAlert()",
@@ -102745,7 +102913,7 @@
       "source_location": "L16"
     },
     {
-      "community": 841,
+      "community": 842,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usequeryenabled_ts",
       "label": "useQueryEnabled.ts",
@@ -102754,7 +102922,7 @@
       "source_location": "L1"
     },
     {
-      "community": 841,
+      "community": 842,
       "file_type": "code",
       "id": "usequeryenabled_usequeryenabled",
       "label": "useQueryEnabled()",
@@ -102763,7 +102931,7 @@
       "source_location": "L3"
     },
     {
-      "community": 842,
+      "community": 843,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_userewardsalert_tsx",
       "label": "useRewardsAlert.tsx",
@@ -102772,7 +102940,7 @@
       "source_location": "L1"
     },
     {
-      "community": 842,
+      "community": 843,
       "file_type": "code",
       "id": "userewardsalert_userewardsalert",
       "label": "useRewardsAlert()",
@@ -102781,7 +102949,7 @@
       "source_location": "L11"
     },
     {
-      "community": 843,
+      "community": 844,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usescrolltotop_ts",
       "label": "useScrollToTop.ts",
@@ -102790,7 +102958,7 @@
       "source_location": "L1"
     },
     {
-      "community": 843,
+      "community": 844,
       "file_type": "code",
       "id": "usescrolltotop_usescrolltotop",
       "label": "useScrollToTop()",
@@ -102799,7 +102967,7 @@
       "source_location": "L3"
     },
     {
-      "community": 844,
+      "community": 845,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usetrackaction_ts",
       "label": "useTrackAction.ts",
@@ -102808,7 +102976,7 @@
       "source_location": "L1"
     },
     {
-      "community": 844,
+      "community": 845,
       "file_type": "code",
       "id": "usetrackaction_usetrackaction",
       "label": "useTrackAction()",
@@ -102817,7 +102985,7 @@
       "source_location": "L7"
     },
     {
-      "community": 845,
+      "community": 846,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usetrackevent_ts",
       "label": "useTrackEvent.ts",
@@ -102826,7 +102994,7 @@
       "source_location": "L1"
     },
     {
-      "community": 845,
+      "community": 846,
       "file_type": "code",
       "id": "usetrackevent_usetrackevent",
       "label": "useTrackEvent()",
@@ -102835,7 +103003,7 @@
       "source_location": "L4"
     },
     {
-      "community": 846,
+      "community": 847,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useupsellmodal_tsx",
       "label": "useUpsellModal.tsx",
@@ -102844,7 +103012,7 @@
       "source_location": "L1"
     },
     {
-      "community": 846,
+      "community": 847,
       "file_type": "code",
       "id": "useupsellmodal_useupsellmodal",
       "label": "useUpsellModal()",
@@ -102853,7 +103021,7 @@
       "source_location": "L14"
     },
     {
-      "community": 847,
+      "community": 848,
       "file_type": "code",
       "id": "analytics_usepostanalytics",
       "label": "usePostAnalytics()",
@@ -102862,7 +103030,7 @@
       "source_location": "L4"
     },
     {
-      "community": 847,
+      "community": 848,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_mutations_ts_analytics_ts",
       "label": "analytics.ts",
@@ -102871,7 +103039,7 @@
       "source_location": "L1"
     },
     {
-      "community": 848,
+      "community": 849,
       "file_type": "code",
       "id": "bag_usebagqueries",
       "label": "useBagQueries()",
@@ -102880,30 +103048,12 @@
       "source_location": "L7"
     },
     {
-      "community": 848,
+      "community": 849,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_bag_ts",
       "label": "bag.ts",
       "norm_label": "bag.ts",
       "source_file": "packages/storefront-webapp/src/lib/queries/bag.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 849,
-      "file_type": "code",
-      "id": "bannermessage_usebannermessagequeries",
-      "label": "useBannerMessageQueries()",
-      "norm_label": "usebannermessagequeries()",
-      "source_file": "packages/storefront-webapp/src/lib/queries/bannerMessage.ts",
-      "source_location": "L6"
-    },
-    {
-      "community": 849,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_queries_bannermessage_ts",
-      "label": "bannerMessage.ts",
-      "norm_label": "bannermessage.ts",
-      "source_file": "packages/storefront-webapp/src/lib/queries/bannerMessage.ts",
       "source_location": "L1"
     },
     {
@@ -102999,6 +103149,24 @@
     {
       "community": 850,
       "file_type": "code",
+      "id": "bannermessage_usebannermessagequeries",
+      "label": "useBannerMessageQueries()",
+      "norm_label": "usebannermessagequeries()",
+      "source_file": "packages/storefront-webapp/src/lib/queries/bannerMessage.ts",
+      "source_location": "L6"
+    },
+    {
+      "community": 850,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_queries_bannermessage_ts",
+      "label": "bannerMessage.ts",
+      "norm_label": "bannermessage.ts",
+      "source_file": "packages/storefront-webapp/src/lib/queries/bannerMessage.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 851,
+      "file_type": "code",
       "id": "checkout_usecheckoutsessionqueries",
       "label": "useCheckoutSessionQueries()",
       "norm_label": "usecheckoutsessionqueries()",
@@ -103006,7 +103174,7 @@
       "source_location": "L10"
     },
     {
-      "community": 850,
+      "community": 851,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_checkout_ts",
       "label": "checkout.ts",
@@ -103015,7 +103183,7 @@
       "source_location": "L1"
     },
     {
-      "community": 851,
+      "community": 852,
       "file_type": "code",
       "id": "inventory_useinventoryqueries",
       "label": "useInventoryQueries()",
@@ -103024,7 +103192,7 @@
       "source_location": "L6"
     },
     {
-      "community": 851,
+      "community": 852,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_inventory_ts",
       "label": "inventory.ts",
@@ -103033,7 +103201,7 @@
       "source_location": "L1"
     },
     {
-      "community": 852,
+      "community": 853,
       "file_type": "code",
       "id": "onlineorder_useonlineorderqueries",
       "label": "useOnlineOrderQueries()",
@@ -103042,7 +103210,7 @@
       "source_location": "L5"
     },
     {
-      "community": 852,
+      "community": 853,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_onlineorder_ts",
       "label": "onlineOrder.ts",
@@ -103051,7 +103219,7 @@
       "source_location": "L1"
     },
     {
-      "community": 853,
+      "community": 854,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_postransaction_ts",
       "label": "posTransaction.ts",
@@ -103060,7 +103228,7 @@
       "source_location": "L1"
     },
     {
-      "community": 853,
+      "community": 854,
       "file_type": "code",
       "id": "postransaction_usepostransactionqueries",
       "label": "usePosTransactionQueries()",
@@ -103069,7 +103237,7 @@
       "source_location": "L5"
     },
     {
-      "community": 854,
+      "community": 855,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_product_ts",
       "label": "product.ts",
@@ -103078,7 +103246,7 @@
       "source_location": "L1"
     },
     {
-      "community": 854,
+      "community": 855,
       "file_type": "code",
       "id": "product_useproductqueries",
       "label": "useProductQueries()",
@@ -103087,7 +103255,7 @@
       "source_location": "L14"
     },
     {
-      "community": 855,
+      "community": 856,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_promocode_ts",
       "label": "promoCode.ts",
@@ -103096,7 +103264,7 @@
       "source_location": "L1"
     },
     {
-      "community": 855,
+      "community": 856,
       "file_type": "code",
       "id": "promocode_usepromocodesqueries",
       "label": "usePromoCodesQueries()",
@@ -103105,7 +103273,7 @@
       "source_location": "L9"
     },
     {
-      "community": 856,
+      "community": 857,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_reviews_ts",
       "label": "reviews.ts",
@@ -103114,7 +103282,7 @@
       "source_location": "L1"
     },
     {
-      "community": 856,
+      "community": 857,
       "file_type": "code",
       "id": "reviews_usereviewqueries",
       "label": "useReviewQueries()",
@@ -103123,7 +103291,7 @@
       "source_location": "L10"
     },
     {
-      "community": 857,
+      "community": 858,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_rewards_ts",
       "label": "rewards.ts",
@@ -103132,7 +103300,7 @@
       "source_location": "L1"
     },
     {
-      "community": 857,
+      "community": 858,
       "file_type": "code",
       "id": "rewards_userewardsqueries",
       "label": "useRewardsQueries()",
@@ -103141,7 +103309,7 @@
       "source_location": "L11"
     },
     {
-      "community": 858,
+      "community": 859,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_upsells_ts",
       "label": "upsells.ts",
@@ -103150,31 +103318,13 @@
       "source_location": "L1"
     },
     {
-      "community": 858,
+      "community": 859,
       "file_type": "code",
       "id": "upsells_useupsellsqueries",
       "label": "useUpsellsQueries()",
       "norm_label": "useupsellsqueries()",
       "source_file": "packages/storefront-webapp/src/lib/queries/upsells.ts",
       "source_location": "L6"
-    },
-    {
-      "community": 859,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_queries_user_ts",
-      "label": "user.ts",
-      "norm_label": "user.ts",
-      "source_file": "packages/storefront-webapp/src/lib/queries/user.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 859,
-      "file_type": "code",
-      "id": "user_useuserqueries",
-      "label": "useUserQueries()",
-      "norm_label": "useuserqueries()",
-      "source_file": "packages/storefront-webapp/src/lib/queries/user.ts",
-      "source_location": "L5"
     },
     {
       "community": 86,
@@ -103269,6 +103419,24 @@
     {
       "community": 860,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_queries_user_ts",
+      "label": "user.ts",
+      "norm_label": "user.ts",
+      "source_file": "packages/storefront-webapp/src/lib/queries/user.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 860,
+      "file_type": "code",
+      "id": "user_useuserqueries",
+      "label": "useUserQueries()",
+      "norm_label": "useuserqueries()",
+      "source_file": "packages/storefront-webapp/src/lib/queries/user.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 861,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_useroffers_ts",
       "label": "userOffers.ts",
       "norm_label": "useroffers.ts",
@@ -103276,7 +103444,7 @@
       "source_location": "L1"
     },
     {
-      "community": 860,
+      "community": 861,
       "file_type": "code",
       "id": "useroffers_useuseroffersqueries",
       "label": "useUserOffersQueries()",
@@ -103285,7 +103453,7 @@
       "source_location": "L6"
     },
     {
-      "community": 861,
+      "community": 862,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_storeconfig_test_ts",
       "label": "storeConfig.test.ts",
@@ -103294,7 +103462,7 @@
       "source_location": "L1"
     },
     {
-      "community": 861,
+      "community": 862,
       "file_type": "code",
       "id": "storeconfig_test_buildv2config",
       "label": "buildV2Config()",
@@ -103303,7 +103471,7 @@
       "source_location": "L10"
     },
     {
-      "community": 862,
+      "community": 863,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_storefrontobservability_test_ts",
       "label": "storefrontObservability.test.ts",
@@ -103312,7 +103480,7 @@
       "source_location": "L1"
     },
     {
-      "community": 862,
+      "community": 863,
       "file_type": "code",
       "id": "storefrontobservability_test_creatememorystorage",
       "label": "createMemoryStorage()",
@@ -103321,7 +103489,7 @@
       "source_location": "L15"
     },
     {
-      "community": 863,
+      "community": 864,
       "file_type": "code",
       "id": "email_validateemail",
       "label": "validateEmail()",
@@ -103330,7 +103498,7 @@
       "source_location": "L14"
     },
     {
-      "community": 863,
+      "community": 864,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_validations_email_ts",
       "label": "email.ts",
@@ -103339,7 +103507,7 @@
       "source_location": "L1"
     },
     {
-      "community": 864,
+      "community": 865,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_router_tsx",
       "label": "router.tsx",
@@ -103348,7 +103516,7 @@
       "source_location": "L1"
     },
     {
-      "community": 864,
+      "community": 865,
       "file_type": "code",
       "id": "router_createrouter",
       "label": "createRouter()",
@@ -103357,7 +103525,7 @@
       "source_location": "L6"
     },
     {
-      "community": 865,
+      "community": 866,
       "file_type": "code",
       "id": "homepageloader_loadhomepagedata",
       "label": "loadHomePageData()",
@@ -103366,7 +103534,7 @@
       "source_location": "L14"
     },
     {
-      "community": 865,
+      "community": 866,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_homepageloader_ts",
       "label": "-homePageLoader.ts",
@@ -103375,7 +103543,7 @@
       "source_location": "L1"
     },
     {
-      "community": 866,
+      "community": 867,
       "file_type": "code",
       "id": "orderslayout_layoutcomponent",
       "label": "LayoutComponent()",
@@ -103384,7 +103552,7 @@
       "source_location": "L8"
     },
     {
-      "community": 866,
+      "community": 867,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_tsx",
       "label": "_ordersLayout.tsx",
@@ -103393,7 +103561,7 @@
       "source_location": "L1"
     },
     {
-      "community": 867,
+      "community": 868,
       "file_type": "code",
       "id": "contact_us_contactus",
       "label": "ContactUs()",
@@ -103402,7 +103570,7 @@
       "source_location": "L14"
     },
     {
-      "community": 867,
+      "community": 868,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_contact_us_tsx",
       "label": "contact-us.tsx",
@@ -103411,7 +103579,7 @@
       "source_location": "L1"
     },
     {
-      "community": 868,
+      "community": 869,
       "file_type": "code",
       "id": "delivery_returns_exchanges_index_onlineorderpolicy",
       "label": "OnlineOrderPolicy()",
@@ -103420,31 +103588,13 @@
       "source_location": "L13"
     },
     {
-      "community": 868,
+      "community": 869,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_policies_delivery_returns_exchanges_index_tsx",
       "label": "delivery-returns-exchanges.index.tsx",
       "norm_label": "delivery-returns-exchanges.index.tsx",
       "source_file": "packages/storefront-webapp/src/routes/_layout/policies/delivery-returns-exchanges.index.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 869,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_layout_policies_privacy_index_tsx",
-      "label": "privacy.index.tsx",
-      "norm_label": "privacy.index.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/policies/privacy.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 869,
-      "file_type": "code",
-      "id": "privacy_index_privacypolicy",
-      "label": "PrivacyPolicy()",
-      "norm_label": "privacypolicy()",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/policies/privacy.index.tsx",
-      "source_location": "L9"
     },
     {
       "community": 87,
@@ -103539,6 +103689,24 @@
     {
       "community": 870,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_layout_policies_privacy_index_tsx",
+      "label": "privacy.index.tsx",
+      "norm_label": "privacy.index.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/policies/privacy.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 870,
+      "file_type": "code",
+      "id": "privacy_index_privacypolicy",
+      "label": "PrivacyPolicy()",
+      "norm_label": "privacypolicy()",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/policies/privacy.index.tsx",
+      "source_location": "L9"
+    },
+    {
+      "community": 871,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_policies_tos_index_tsx",
       "label": "tos.index.tsx",
       "norm_label": "tos.index.tsx",
@@ -103546,7 +103714,7 @@
       "source_location": "L1"
     },
     {
-      "community": 870,
+      "community": 871,
       "file_type": "code",
       "id": "tos_index_tossection",
       "label": "TosSection()",
@@ -103555,7 +103723,7 @@
       "source_location": "L15"
     },
     {
-      "community": 871,
+      "community": 872,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_shop_product_productslug_tsx",
       "label": "shop.product.$productSlug.tsx",
@@ -103564,7 +103732,7 @@
       "source_location": "L1"
     },
     {
-      "community": 871,
+      "community": 872,
       "file_type": "code",
       "id": "shop_product_productslug_component",
       "label": "Component()",
@@ -103573,7 +103741,7 @@
       "source_location": "L16"
     },
     {
-      "community": 872,
+      "community": 873,
       "file_type": "code",
       "id": "layout_layoutcomponent",
       "label": "LayoutComponent()",
@@ -103582,7 +103750,7 @@
       "source_location": "L6"
     },
     {
-      "community": 872,
+      "community": 873,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_tsx",
       "label": "_layout.tsx",
@@ -103591,7 +103759,7 @@
       "source_location": "L1"
     },
     {
-      "community": 873,
+      "community": 874,
       "file_type": "code",
       "id": "index_homeroute",
       "label": "HomeRoute()",
@@ -103600,7 +103768,7 @@
       "source_location": "L10"
     },
     {
-      "community": 873,
+      "community": 874,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_index_tsx",
       "label": "index.tsx",
@@ -103609,7 +103777,7 @@
       "source_location": "L1"
     },
     {
-      "community": 874,
+      "community": 875,
       "file_type": "code",
       "id": "canceled_checkoutcanceledview",
       "label": "CheckoutCanceledView()",
@@ -103618,7 +103786,7 @@
       "source_location": "L21"
     },
     {
-      "community": 874,
+      "community": 875,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_canceled_tsx",
       "label": "canceled.tsx",
@@ -103627,7 +103795,7 @@
       "source_location": "L1"
     },
     {
-      "community": 875,
+      "community": 876,
       "file_type": "code",
       "id": "complete_index_checkoutcomplete",
       "label": "CheckoutComplete()",
@@ -103636,7 +103804,7 @@
       "source_location": "L33"
     },
     {
-      "community": 875,
+      "community": 876,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_complete_index_tsx",
       "label": "complete.index.tsx",
@@ -103645,7 +103813,7 @@
       "source_location": "L1"
     },
     {
-      "community": 876,
+      "community": 877,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_pod_confirmation_tsx",
       "label": "pod-confirmation.tsx",
@@ -103654,7 +103822,7 @@
       "source_location": "L1"
     },
     {
-      "community": 876,
+      "community": 877,
       "file_type": "code",
       "id": "pod_confirmation_completepodcheckoutsession",
       "label": "completePODCheckoutSession()",
@@ -103663,7 +103831,7 @@
       "source_location": "L196"
     },
     {
-      "community": 877,
+      "community": 878,
       "file_type": "code",
       "id": "index_receiptshareroute",
       "label": "ReceiptShareRoute()",
@@ -103672,7 +103840,7 @@
       "source_location": "L9"
     },
     {
-      "community": 877,
+      "community": 878,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_receipt_s_token_index_tsx",
       "label": "index.tsx",
@@ -103681,7 +103849,7 @@
       "source_location": "L1"
     },
     {
-      "community": 878,
+      "community": 879,
       "file_type": "code",
       "id": "packages_valkey_proxy_server_test_connection_js",
       "label": "test-connection.js",
@@ -103690,31 +103858,13 @@
       "source_location": "L1"
     },
     {
-      "community": 878,
+      "community": 879,
       "file_type": "code",
       "id": "test_connection_main",
       "label": "main()",
       "norm_label": "main()",
       "source_file": "packages/valkey-proxy-server/test-connection.js",
       "source_location": "L7"
-    },
-    {
-      "community": 879,
-      "file_type": "code",
-      "id": "architecture_boundaries_test_createsnippetlinter",
-      "label": "createSnippetLinter()",
-      "norm_label": "createsnippetlinter()",
-      "source_file": "scripts/architecture-boundaries.test.ts",
-      "source_location": "L10"
-    },
-    {
-      "community": 879,
-      "file_type": "code",
-      "id": "scripts_architecture_boundaries_test_ts",
-      "label": "architecture-boundaries.test.ts",
-      "norm_label": "architecture-boundaries.test.ts",
-      "source_file": "scripts/architecture-boundaries.test.ts",
-      "source_location": "L1"
     },
     {
       "community": 88,
@@ -103800,6 +103950,24 @@
     {
       "community": 880,
       "file_type": "code",
+      "id": "architecture_boundaries_test_createsnippetlinter",
+      "label": "createSnippetLinter()",
+      "norm_label": "createsnippetlinter()",
+      "source_file": "scripts/architecture-boundaries.test.ts",
+      "source_location": "L10"
+    },
+    {
+      "community": 880,
+      "file_type": "code",
+      "id": "scripts_architecture_boundaries_test_ts",
+      "label": "architecture-boundaries.test.ts",
+      "norm_label": "architecture-boundaries.test.ts",
+      "source_file": "scripts/architecture-boundaries.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 881,
+      "file_type": "code",
       "id": "architecture_boundary_check_run",
       "label": "run()",
       "norm_label": "run()",
@@ -103807,7 +103975,7 @@
       "source_location": "L32"
     },
     {
-      "community": 880,
+      "community": 881,
       "file_type": "code",
       "id": "scripts_architecture_boundary_check_ts",
       "label": "architecture-boundary-check.ts",
@@ -103816,7 +103984,7 @@
       "source_location": "L1"
     },
     {
-      "community": 881,
+      "community": 882,
       "file_type": "code",
       "id": "deploy_qa_vps_test_readrepofile",
       "label": "readRepoFile()",
@@ -103825,7 +103993,7 @@
       "source_location": "L7"
     },
     {
-      "community": 881,
+      "community": 882,
       "file_type": "code",
       "id": "scripts_deploy_qa_vps_test_ts",
       "label": "deploy-qa-vps.test.ts",
@@ -103834,7 +104002,7 @@
       "source_location": "L1"
     },
     {
-      "community": 882,
+      "community": 883,
       "file_type": "code",
       "id": "github_pr_merge_test_runcommand",
       "label": "runCommand()",
@@ -103843,7 +104011,7 @@
       "source_location": "L16"
     },
     {
-      "community": 882,
+      "community": 883,
       "file_type": "code",
       "id": "scripts_github_pr_merge_test_ts",
       "label": "github-pr-merge.test.ts",
@@ -103852,7 +104020,7 @@
       "source_location": "L1"
     },
     {
-      "community": 883,
+      "community": 884,
       "file_type": "code",
       "id": "athena_runtime_app_shutdown",
       "label": "shutdown()",
@@ -103861,7 +104029,7 @@
       "source_location": "L211"
     },
     {
-      "community": 883,
+      "community": 884,
       "file_type": "code",
       "id": "scripts_harness_behavior_fixtures_athena_runtime_app_ts",
       "label": "athena-runtime-app.ts",
@@ -103870,7 +104038,7 @@
       "source_location": "L1"
     },
     {
-      "community": 884,
+      "community": 885,
       "file_type": "code",
       "id": "sample_app_shutdown",
       "label": "shutdown()",
@@ -103879,7 +104047,7 @@
       "source_location": "L85"
     },
     {
-      "community": 884,
+      "community": 885,
       "file_type": "code",
       "id": "scripts_harness_behavior_fixtures_sample_app_ts",
       "label": "sample-app.ts",
@@ -103888,7 +104056,7 @@
       "source_location": "L1"
     },
     {
-      "community": 885,
+      "community": 886,
       "file_type": "code",
       "id": "harness_runtime_trends_test_buildreportline",
       "label": "buildReportLine()",
@@ -103897,7 +104065,7 @@
       "source_location": "L15"
     },
     {
-      "community": 885,
+      "community": 886,
       "file_type": "code",
       "id": "scripts_harness_runtime_trends_test_ts",
       "label": "harness-runtime-trends.test.ts",
@@ -103906,7 +104074,7 @@
       "source_location": "L1"
     },
     {
-      "community": 886,
+      "community": 887,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_generated_api_d_ts",
       "label": "api.d.ts",
@@ -103915,7 +104083,7 @@
       "source_location": "L1"
     },
     {
-      "community": 887,
+      "community": 888,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_generated_api_js",
       "label": "api.js",
@@ -103924,21 +104092,12 @@
       "source_location": "L1"
     },
     {
-      "community": 888,
+      "community": 889,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_generated_datamodel_d_ts",
       "label": "dataModel.d.ts",
       "norm_label": "datamodel.d.ts",
       "source_file": "packages/athena-webapp/convex/_generated/dataModel.d.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 889,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_generated_server_d_ts",
-      "label": "server.d.ts",
-      "norm_label": "server.d.ts",
-      "source_file": "packages/athena-webapp/convex/_generated/server.d.ts",
       "source_location": "L1"
     },
     {
@@ -104025,6 +104184,15 @@
     {
       "community": 890,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_generated_server_d_ts",
+      "label": "server.d.ts",
+      "norm_label": "server.d.ts",
+      "source_file": "packages/athena-webapp/convex/_generated/server.d.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 891,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_generated_server_js",
       "label": "server.js",
       "norm_label": "server.js",
@@ -104032,7 +104200,7 @@
       "source_location": "L1"
     },
     {
-      "community": 891,
+      "community": 892,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_app_ts",
       "label": "app.ts",
@@ -104041,7 +104209,7 @@
       "source_location": "L1"
     },
     {
-      "community": 892,
+      "community": 893,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_auth_config_js",
       "label": "auth.config.js",
@@ -104050,7 +104218,7 @@
       "source_location": "L1"
     },
     {
-      "community": 893,
+      "community": 894,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_auth_ts",
       "label": "auth.ts",
@@ -104059,7 +104227,7 @@
       "source_location": "L1"
     },
     {
-      "community": 894,
+      "community": 895,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cashcontrols_registersessions_test_ts",
       "label": "registerSessions.test.ts",
@@ -104068,7 +104236,7 @@
       "source_location": "L1"
     },
     {
-      "community": 895,
+      "community": 896,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cloudflare_r2_test_ts",
       "label": "r2.test.ts",
@@ -104077,7 +104245,7 @@
       "source_location": "L1"
     },
     {
-      "community": 896,
+      "community": 897,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_constants_countries_ts",
       "label": "countries.ts",
@@ -104086,7 +104254,7 @@
       "source_location": "L1"
     },
     {
-      "community": 897,
+      "community": 898,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_constants_email_ts",
       "label": "email.ts",
@@ -104095,21 +104263,12 @@
       "source_location": "L1"
     },
     {
-      "community": 898,
+      "community": 899,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_constants_ghana_ts",
       "label": "ghana.ts",
       "norm_label": "ghana.ts",
       "source_file": "packages/athena-webapp/convex/constants/ghana.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 899,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_constants_payment_ts",
-      "label": "payment.ts",
-      "norm_label": "payment.ts",
-      "source_file": "packages/athena-webapp/convex/constants/payment.ts",
       "source_location": "L1"
     },
     {
@@ -104484,6 +104643,15 @@
     {
       "community": 900,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_constants_payment_ts",
+      "label": "payment.ts",
+      "norm_label": "payment.ts",
+      "source_file": "packages/athena-webapp/convex/constants/payment.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 901,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_crons_ts",
       "label": "crons.ts",
       "norm_label": "crons.ts",
@@ -104491,7 +104659,7 @@
       "source_location": "L1"
     },
     {
-      "community": 901,
+      "community": 902,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_customermessaging_domain_test_ts",
       "label": "domain.test.ts",
@@ -104500,7 +104668,7 @@
       "source_location": "L1"
     },
     {
-      "community": 902,
+      "community": 903,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_customermessaging_internal_ts",
       "label": "internal.ts",
@@ -104509,7 +104677,7 @@
       "source_location": "L1"
     },
     {
-      "community": 903,
+      "community": 904,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_customermessaging_public_test_ts",
       "label": "public.test.ts",
@@ -104518,7 +104686,7 @@
       "source_location": "L1"
     },
     {
-      "community": 904,
+      "community": 905,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_customermessaging_token_test_ts",
       "label": "token.test.ts",
@@ -104527,7 +104695,7 @@
       "source_location": "L1"
     },
     {
-      "community": 905,
+      "community": 906,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_customermessaging_whatsappclient_test_ts",
       "label": "whatsappClient.test.ts",
@@ -104536,7 +104704,7 @@
       "source_location": "L1"
     },
     {
-      "community": 906,
+      "community": 907,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_customermessaging_whatsappconfig_test_ts",
       "label": "whatsappConfig.test.ts",
@@ -104545,7 +104713,7 @@
       "source_location": "L1"
     },
     {
-      "community": 907,
+      "community": 908,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_devpatchbadtransaction_ts",
       "label": "devPatchBadTransaction.ts",
@@ -104554,21 +104722,12 @@
       "source_location": "L1"
     },
     {
-      "community": 908,
+      "community": 909,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_feedbackrequest_tsx",
       "label": "FeedbackRequest.tsx",
       "norm_label": "feedbackrequest.tsx",
       "source_file": "packages/athena-webapp/convex/emails/FeedbackRequest.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 909,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_emails_neworderadmin_tsx",
-      "label": "NewOrderAdmin.tsx",
-      "norm_label": "neworderadmin.tsx",
-      "source_file": "packages/athena-webapp/convex/emails/NewOrderAdmin.tsx",
       "source_location": "L1"
     },
     {
@@ -104655,6 +104814,15 @@
     {
       "community": 910,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_emails_neworderadmin_tsx",
+      "label": "NewOrderAdmin.tsx",
+      "norm_label": "neworderadmin.tsx",
+      "source_file": "packages/athena-webapp/convex/emails/NewOrderAdmin.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 911,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_orderemail_tsx",
       "label": "OrderEmail.tsx",
       "norm_label": "orderemail.tsx",
@@ -104662,7 +104830,7 @@
       "source_location": "L1"
     },
     {
-      "community": 911,
+      "community": 912,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_posreceiptemail_tsx",
       "label": "PosReceiptEmail.tsx",
@@ -104671,7 +104839,7 @@
       "source_location": "L1"
     },
     {
-      "community": 912,
+      "community": 913,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_env_ts",
       "label": "env.ts",
@@ -104680,7 +104848,7 @@
       "source_location": "L1"
     },
     {
-      "community": 913,
+      "community": 914,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_core_routes_analytics_ts",
       "label": "analytics.ts",
@@ -104689,7 +104857,7 @@
       "source_location": "L1"
     },
     {
-      "community": 914,
+      "community": 915,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_core_routes_auth_ts",
       "label": "auth.ts",
@@ -104698,7 +104866,7 @@
       "source_location": "L1"
     },
     {
-      "community": 915,
+      "community": 916,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_core_routes_bannermessage_ts",
       "label": "bannerMessage.ts",
@@ -104707,7 +104875,7 @@
       "source_location": "L1"
     },
     {
-      "community": 916,
+      "community": 917,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_core_routes_colors_ts",
       "label": "colors.ts",
@@ -104716,7 +104884,7 @@
       "source_location": "L1"
     },
     {
-      "community": 917,
+      "community": 918,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_core_routes_index_ts",
       "label": "index.ts",
@@ -104725,21 +104893,12 @@
       "source_location": "L1"
     },
     {
-      "community": 918,
+      "community": 919,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_core_routes_organizations_ts",
       "label": "organizations.ts",
       "norm_label": "organizations.ts",
       "source_file": "packages/athena-webapp/convex/http/domains/core/routes/organizations.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 919,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_core_routes_products_ts",
-      "label": "products.ts",
-      "norm_label": "products.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/core/routes/products.ts",
       "source_location": "L1"
     },
     {
@@ -104826,6 +104985,15 @@
     {
       "community": 920,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_core_routes_products_ts",
+      "label": "products.ts",
+      "norm_label": "products.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/core/routes/products.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 921,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_core_routes_storefronthidden_test_ts",
       "label": "storefrontHidden.test.ts",
       "norm_label": "storefronthidden.test.ts",
@@ -104833,7 +105001,7 @@
       "source_location": "L1"
     },
     {
-      "community": 921,
+      "community": 922,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_core_routes_stores_ts",
       "label": "stores.ts",
@@ -104842,7 +105010,7 @@
       "source_location": "L1"
     },
     {
-      "community": 922,
+      "community": 923,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_bag_ts",
       "label": "bag.ts",
@@ -104851,7 +105019,7 @@
       "source_location": "L1"
     },
     {
-      "community": 923,
+      "community": 924,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_guest_ts",
       "label": "guest.ts",
@@ -104860,7 +105028,7 @@
       "source_location": "L1"
     },
     {
-      "community": 924,
+      "community": 925,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_index_ts",
       "label": "index.ts",
@@ -104869,7 +105037,7 @@
       "source_location": "L1"
     },
     {
-      "community": 925,
+      "community": 926,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_me_ts",
       "label": "me.ts",
@@ -104878,7 +105046,7 @@
       "source_location": "L1"
     },
     {
-      "community": 926,
+      "community": 927,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_offers_ts",
       "label": "offers.ts",
@@ -104887,7 +105055,7 @@
       "source_location": "L1"
     },
     {
-      "community": 927,
+      "community": 928,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_onlineorder_ts",
       "label": "onlineOrder.ts",
@@ -104896,21 +105064,12 @@
       "source_location": "L1"
     },
     {
-      "community": 928,
+      "community": 929,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_paystack_ts",
       "label": "paystack.ts",
       "norm_label": "paystack.ts",
       "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/paystack.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 929,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_postransaction_ts",
-      "label": "posTransaction.ts",
-      "norm_label": "postransaction.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/posTransaction.ts",
       "source_location": "L1"
     },
     {
@@ -104997,6 +105156,15 @@
     {
       "community": 930,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_postransaction_ts",
+      "label": "posTransaction.ts",
+      "norm_label": "postransaction.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/posTransaction.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 931,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_reviews_ts",
       "label": "reviews.ts",
       "norm_label": "reviews.ts",
@@ -105004,7 +105172,7 @@
       "source_location": "L1"
     },
     {
-      "community": 931,
+      "community": 932,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_rewards_ts",
       "label": "rewards.ts",
@@ -105013,7 +105181,7 @@
       "source_location": "L1"
     },
     {
-      "community": 932,
+      "community": 933,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_savedbag_ts",
       "label": "savedBag.ts",
@@ -105022,7 +105190,7 @@
       "source_location": "L1"
     },
     {
-      "community": 933,
+      "community": 934,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_security_test_ts",
       "label": "security.test.ts",
@@ -105031,7 +105199,7 @@
       "source_location": "L1"
     },
     {
-      "community": 934,
+      "community": 935,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_storefront_ts",
       "label": "storefront.ts",
@@ -105040,7 +105208,7 @@
       "source_location": "L1"
     },
     {
-      "community": 935,
+      "community": 936,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_upsells_ts",
       "label": "upsells.ts",
@@ -105049,7 +105217,7 @@
       "source_location": "L1"
     },
     {
-      "community": 936,
+      "community": 937,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_user_ts",
       "label": "user.ts",
@@ -105058,7 +105226,7 @@
       "source_location": "L1"
     },
     {
-      "community": 937,
+      "community": 938,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_useroffers_ts",
       "label": "userOffers.ts",
@@ -105067,21 +105235,12 @@
       "source_location": "L1"
     },
     {
-      "community": 938,
+      "community": 939,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_moneymovement_routes_index_ts",
       "label": "index.ts",
       "norm_label": "index.ts",
       "source_file": "packages/athena-webapp/convex/http/domains/moneyMovement/routes/index.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 939,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_health_test_ts",
-      "label": "health.test.ts",
-      "norm_label": "health.test.ts",
-      "source_file": "packages/athena-webapp/convex/http/health.test.ts",
       "source_location": "L1"
     },
     {
@@ -105168,6 +105327,15 @@
     {
       "community": 940,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_health_test_ts",
+      "label": "health.test.ts",
+      "norm_label": "health.test.ts",
+      "source_file": "packages/athena-webapp/convex/http/health.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 941,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_http_ts",
       "label": "http.ts",
       "norm_label": "http.ts",
@@ -105175,7 +105343,7 @@
       "source_location": "L1"
     },
     {
-      "community": 941,
+      "community": 942,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_athenauser_ts",
       "label": "athenaUser.ts",
@@ -105184,7 +105352,7 @@
       "source_location": "L1"
     },
     {
-      "community": 942,
+      "community": 943,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_bannermessage_ts",
       "label": "bannerMessage.ts",
@@ -105193,7 +105361,7 @@
       "source_location": "L1"
     },
     {
-      "community": 943,
+      "community": 944,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_bestseller_ts",
       "label": "bestSeller.ts",
@@ -105202,7 +105370,7 @@
       "source_location": "L1"
     },
     {
-      "community": 944,
+      "community": 945,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_categories_ts",
       "label": "categories.ts",
@@ -105211,7 +105379,7 @@
       "source_location": "L1"
     },
     {
-      "community": 945,
+      "community": 946,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_colors_ts",
       "label": "colors.ts",
@@ -105220,7 +105388,7 @@
       "source_location": "L1"
     },
     {
-      "community": 946,
+      "community": 947,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_complimentaryproduct_ts",
       "label": "complimentaryProduct.ts",
@@ -105229,7 +105397,7 @@
       "source_location": "L1"
     },
     {
-      "community": 947,
+      "community": 948,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_expensetransactions_test_ts",
       "label": "expenseTransactions.test.ts",
@@ -105238,21 +105406,12 @@
       "source_location": "L1"
     },
     {
-      "community": 948,
+      "community": 949,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_featureditem_ts",
       "label": "featuredItem.ts",
       "norm_label": "featureditem.ts",
       "source_file": "packages/athena-webapp/convex/inventory/featuredItem.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 949,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_invitecode_ts",
-      "label": "inviteCode.ts",
-      "norm_label": "invitecode.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/inviteCode.ts",
       "source_location": "L1"
     },
     {
@@ -105339,6 +105498,15 @@
     {
       "community": 950,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_invitecode_ts",
+      "label": "inviteCode.ts",
+      "norm_label": "invitecode.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/inviteCode.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 951,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_organizationmembers_ts",
       "label": "organizationMembers.ts",
       "norm_label": "organizationmembers.ts",
@@ -105346,7 +105514,7 @@
       "source_location": "L1"
     },
     {
-      "community": 951,
+      "community": 952,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_organizations_ts",
       "label": "organizations.ts",
@@ -105355,7 +105523,7 @@
       "source_location": "L1"
     },
     {
-      "community": 952,
+      "community": 953,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_pos_ts",
       "label": "pos.ts",
@@ -105364,7 +105532,7 @@
       "source_location": "L1"
     },
     {
-      "community": 953,
+      "community": 954,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_poscustomers_ts",
       "label": "posCustomers.ts",
@@ -105373,7 +105541,7 @@
       "source_location": "L1"
     },
     {
-      "community": 954,
+      "community": 955,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_posterminal_ts",
       "label": "posTerminal.ts",
@@ -105382,7 +105550,7 @@
       "source_location": "L1"
     },
     {
-      "community": 955,
+      "community": 956,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_productsku_ts",
       "label": "productSku.ts",
@@ -105391,7 +105559,7 @@
       "source_location": "L1"
     },
     {
-      "community": 956,
+      "community": 957,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_productutil_test_ts",
       "label": "productUtil.test.ts",
@@ -105400,7 +105568,7 @@
       "source_location": "L1"
     },
     {
-      "community": 957,
+      "community": 958,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_promocode_test_ts",
       "label": "promoCode.test.ts",
@@ -105409,21 +105577,12 @@
       "source_location": "L1"
     },
     {
-      "community": 958,
+      "community": 959,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_stockvalidation_ts",
       "label": "stockValidation.ts",
       "norm_label": "stockvalidation.ts",
       "source_file": "packages/athena-webapp/convex/inventory/stockValidation.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 959,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_storeconfigv2_test_ts",
-      "label": "storeConfigV2.test.ts",
-      "norm_label": "storeconfigv2.test.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.test.ts",
       "source_location": "L1"
     },
     {
@@ -105501,6 +105660,15 @@
     {
       "community": 960,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_storeconfigv2_test_ts",
+      "label": "storeConfigV2.test.ts",
+      "norm_label": "storeconfigv2.test.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 961,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_subcategories_ts",
       "label": "subcategories.ts",
       "norm_label": "subcategories.ts",
@@ -105508,7 +105676,7 @@
       "source_location": "L1"
     },
     {
-      "community": 961,
+      "community": 962,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_lib_commandresultvalidators_test_ts",
       "label": "commandResultValidators.test.ts",
@@ -105517,7 +105685,7 @@
       "source_location": "L1"
     },
     {
-      "community": 962,
+      "community": 963,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_lib_currency_test_ts",
       "label": "currency.test.ts",
@@ -105526,7 +105694,7 @@
       "source_location": "L1"
     },
     {
-      "community": 963,
+      "community": 964,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_storeinsights_ts",
       "label": "storeInsights.ts",
@@ -105535,7 +105703,7 @@
       "source_location": "L1"
     },
     {
-      "community": 964,
+      "community": 965,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_userinsights_ts",
       "label": "userInsights.ts",
@@ -105544,7 +105712,7 @@
       "source_location": "L1"
     },
     {
-      "community": 965,
+      "community": 966,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_migrations_migrateamountstopesewas_ts",
       "label": "migrateAmountsToPesewas.ts",
@@ -105553,7 +105721,7 @@
       "source_location": "L1"
     },
     {
-      "community": 966,
+      "community": 967,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_client_test_ts",
       "label": "client.test.ts",
@@ -105562,7 +105730,7 @@
       "source_location": "L1"
     },
     {
-      "community": 967,
+      "community": 968,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_config_test_ts",
       "label": "config.test.ts",
@@ -105571,21 +105739,12 @@
       "source_location": "L1"
     },
     {
-      "community": 968,
+      "community": 969,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_normalize_test_ts",
       "label": "normalize.test.ts",
       "norm_label": "normalize.test.ts",
       "source_file": "packages/athena-webapp/convex/mtn/normalize.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 969,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_mtn_types_ts",
-      "label": "types.ts",
-      "norm_label": "types.ts",
-      "source_file": "packages/athena-webapp/convex/mtn/types.ts",
       "source_location": "L1"
     },
     {
@@ -105663,6 +105822,15 @@
     {
       "community": 970,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_mtn_types_ts",
+      "label": "types.ts",
+      "norm_label": "types.ts",
+      "source_file": "packages/athena-webapp/convex/mtn/types.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 971,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_customerprofiles_test_ts",
       "label": "customerProfiles.test.ts",
       "norm_label": "customerprofiles.test.ts",
@@ -105670,7 +105838,7 @@
       "source_location": "L1"
     },
     {
-      "community": 971,
+      "community": 972,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_inventorymovements_test_ts",
       "label": "inventoryMovements.test.ts",
@@ -105679,7 +105847,7 @@
       "source_location": "L1"
     },
     {
-      "community": 972,
+      "community": 973,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_paymentallocations_test_ts",
       "label": "paymentAllocations.test.ts",
@@ -105688,7 +105856,7 @@
       "source_location": "L1"
     },
     {
-      "community": 973,
+      "community": 974,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_otp_emailotp_test_ts",
       "label": "EmailOTP.test.ts",
@@ -105697,7 +105865,7 @@
       "source_location": "L1"
     },
     {
-      "community": 974,
+      "community": 975,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_correcttransactioncustomer_test_ts",
       "label": "correctTransactionCustomer.test.ts",
@@ -105706,7 +105874,7 @@
       "source_location": "L1"
     },
     {
-      "community": 975,
+      "community": 976,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_corrections_correctionevents_test_ts",
       "label": "correctionEvents.test.ts",
@@ -105715,7 +105883,7 @@
       "source_location": "L1"
     },
     {
-      "community": 976,
+      "community": 977,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_corrections_correctionpolicy_test_ts",
       "label": "correctionPolicy.test.ts",
@@ -105724,7 +105892,7 @@
       "source_location": "L1"
     },
     {
-      "community": 977,
+      "community": 978,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_dto_ts",
       "label": "dto.ts",
@@ -105733,21 +105901,12 @@
       "source_location": "L1"
     },
     {
-      "community": 978,
+      "community": 979,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_getregisterstate_test_ts",
       "label": "getRegisterState.test.ts",
       "norm_label": "getregisterstate.test.ts",
       "source_file": "packages/athena-webapp/convex/pos/application/getRegisterState.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 979,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_possessiontracing_test_ts",
-      "label": "posSessionTracing.test.ts",
-      "norm_label": "possessiontracing.test.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/posSessionTracing.test.ts",
       "source_location": "L1"
     },
     {
@@ -105825,6 +105984,15 @@
     {
       "community": 980,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_possessiontracing_test_ts",
+      "label": "posSessionTracing.test.ts",
+      "norm_label": "possessiontracing.test.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/posSessionTracing.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 981,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_terminals_test_ts",
       "label": "terminals.test.ts",
       "norm_label": "terminals.test.ts",
@@ -105832,7 +106000,7 @@
       "source_location": "L1"
     },
     {
-      "community": 981,
+      "community": 982,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_domain_types_ts",
       "label": "types.ts",
@@ -105841,7 +106009,7 @@
       "source_location": "L1"
     },
     {
-      "community": 982,
+      "community": 983,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_registersessionrepository_test_ts",
       "label": "registerSessionRepository.test.ts",
@@ -105850,7 +106018,7 @@
       "source_location": "L1"
     },
     {
-      "community": 983,
+      "community": 984,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_catalog_ts",
       "label": "catalog.ts",
@@ -105859,7 +106027,7 @@
       "source_location": "L1"
     },
     {
-      "community": 984,
+      "community": 985,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_customers_ts",
       "label": "customers.ts",
@@ -105868,7 +106036,7 @@
       "source_location": "L1"
     },
     {
-      "community": 985,
+      "community": 986,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_register_ts",
       "label": "register.ts",
@@ -105877,7 +106045,7 @@
       "source_location": "L1"
     },
     {
-      "community": 986,
+      "community": 987,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_terminals_ts",
       "label": "terminals.ts",
@@ -105886,7 +106054,7 @@
       "source_location": "L1"
     },
     {
-      "community": 987,
+      "community": 988,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schema_ts",
       "label": "schema.ts",
@@ -105895,21 +106063,12 @@
       "source_location": "L1"
     },
     {
-      "community": 988,
+      "community": 989,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_customermessaging_customermessagedelivery_ts",
       "label": "customerMessageDelivery.ts",
       "norm_label": "customermessagedelivery.ts",
       "source_file": "packages/athena-webapp/convex/schemas/customerMessaging/customerMessageDelivery.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 989,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_customermessaging_index_ts",
-      "label": "index.ts",
-      "norm_label": "index.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/customerMessaging/index.ts",
       "source_location": "L1"
     },
     {
@@ -105987,6 +106146,15 @@
     {
       "community": 990,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_customermessaging_index_ts",
+      "label": "index.ts",
+      "norm_label": "index.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/customerMessaging/index.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 991,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_customermessaging_receiptsharetoken_ts",
       "label": "receiptShareToken.ts",
       "norm_label": "receiptsharetoken.ts",
@@ -105994,7 +106162,7 @@
       "source_location": "L1"
     },
     {
-      "community": 991,
+      "community": 992,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_appverificationcode_ts",
       "label": "appVerificationCode.ts",
@@ -106003,7 +106171,7 @@
       "source_location": "L1"
     },
     {
-      "community": 992,
+      "community": 993,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_athenauser_ts",
       "label": "athenaUser.ts",
@@ -106012,7 +106180,7 @@
       "source_location": "L1"
     },
     {
-      "community": 993,
+      "community": 994,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_bannermessage_ts",
       "label": "bannerMessage.ts",
@@ -106021,7 +106189,7 @@
       "source_location": "L1"
     },
     {
-      "community": 994,
+      "community": 995,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_bestseller_ts",
       "label": "bestSeller.ts",
@@ -106030,7 +106198,7 @@
       "source_location": "L1"
     },
     {
-      "community": 995,
+      "community": 996,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_category_ts",
       "label": "category.ts",
@@ -106039,7 +106207,7 @@
       "source_location": "L1"
     },
     {
-      "community": 996,
+      "community": 997,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_color_ts",
       "label": "color.ts",
@@ -106048,7 +106216,7 @@
       "source_location": "L1"
     },
     {
-      "community": 997,
+      "community": 998,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_complimentaryproduct_ts",
       "label": "complimentaryProduct.ts",
@@ -106057,21 +106225,12 @@
       "source_location": "L1"
     },
     {
-      "community": 998,
+      "community": 999,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_featureditem_ts",
       "label": "featuredItem.ts",
       "norm_label": "featureditem.ts",
       "source_file": "packages/athena-webapp/convex/schemas/inventory/featuredItem.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 999,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_inventory_index_ts",
-      "label": "index.ts",
-      "norm_label": "index.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/inventory/index.ts",
       "source_location": "L1"
     }
   ]

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -7,14 +7,14 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 - [packages/AGENTS.md](../../packages/AGENTS.md) - package router plus the operational guides for each harnessed package
 
 ## Repo Summary
-- Code files discovered: 1677
-- Graph nodes: 5048
-- Graph edges: 5053
-- Communities: 1606
+- Code files discovered: 1679
+- Graph nodes: 5055
+- Graph edges: 5061
+- Communities: 1608
 
 ## Graph Hotspots
-- `DailyCloseView.tsx` (71 edges, Community 0) - [`packages/athena-webapp/src/components/operations/DailyCloseView.tsx`](../../packages/athena-webapp/src/components/operations/DailyCloseView.tsx)
-- `dailyClose.ts` (54 edges, Community 1) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../packages/athena-webapp/convex/operations/dailyClose.ts)
+- `DailyCloseView.tsx` (74 edges, Community 0) - [`packages/athena-webapp/src/components/operations/DailyCloseView.tsx`](../../packages/athena-webapp/src/components/operations/DailyCloseView.tsx)
+- `dailyClose.ts` (55 edges, Community 1) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../packages/athena-webapp/convex/operations/dailyClose.ts)
 - `harness-inferential-review.ts` (46 edges, Community 2) - [`scripts/harness-inferential-review.ts`](../../scripts/harness-inferential-review.ts)
 - `storefrontJourneyEvents.ts` (45 edges, Community 3) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
 - `createJourneyEvent()` (40 edges, Community 3) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)

--- a/graphify-out/wiki/packages/athena-webapp.md
+++ b/graphify-out/wiki/packages/athena-webapp.md
@@ -17,8 +17,8 @@ Landing page for packages/athena-webapp. Use this page to orient around graph ho
 - [validation-map.json](../../../packages/athena-webapp/docs/agent/validation-map.json)
 
 ## Graph Hotspots
-- `DailyCloseView.tsx` (71 edges, Community 0) - [`packages/athena-webapp/src/components/operations/DailyCloseView.tsx`](../../../packages/athena-webapp/src/components/operations/DailyCloseView.tsx)
-- `dailyClose.ts` (54 edges, Community 1) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../../packages/athena-webapp/convex/operations/dailyClose.ts)
+- `DailyCloseView.tsx` (74 edges, Community 0) - [`packages/athena-webapp/src/components/operations/DailyCloseView.tsx`](../../../packages/athena-webapp/src/components/operations/DailyCloseView.tsx)
+- `dailyClose.ts` (55 edges, Community 1) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../../packages/athena-webapp/convex/operations/dailyClose.ts)
 - `ProcurementView.tsx` (39 edges, Community 4) - [`packages/athena-webapp/src/components/procurement/ProcurementView.tsx`](../../../packages/athena-webapp/src/components/procurement/ProcurementView.tsx)
 - `DailyOpeningView.tsx` (36 edges, Community 5) - [`packages/athena-webapp/src/components/operations/DailyOpeningView.tsx`](../../../packages/athena-webapp/src/components/operations/DailyOpeningView.tsx)
 - `DailyOperationsView.tsx` (33 edges, Community 6) - [`packages/athena-webapp/src/components/operations/DailyOperationsView.tsx`](../../../packages/athena-webapp/src/components/operations/DailyOperationsView.tsx)

--- a/packages/athena-webapp/convex/operations/dailyClose.test.ts
+++ b/packages/athena-webapp/convex/operations/dailyClose.test.ts
@@ -557,12 +557,12 @@ describe("end-of-day review backend foundation", () => {
 
     expect(snapshot.readiness.status).toBe("blocked");
     expect(snapshot.blockers.map((item) => item.key)).toEqual([
-      "register_session:register-open:open",
-      "register_session:register-closing:closing",
       "approval_request:approval-1:pending",
+      "register_session:register-closing:closing",
+      "register_session:register-open:open",
       "pos_session:pos-held:held",
     ]);
-    expect(snapshot.blockers[0].metadata).toMatchObject({
+    expect(snapshot.blockers[2].metadata).toMatchObject({
       openedAt: Date.UTC(2026, 4, 6, 20),
       operatingScope: "Carried over from prior day",
       register: "Register A1",
@@ -579,12 +579,12 @@ describe("end-of-day review backend foundation", () => {
       terminal: "Front counter terminal",
       variance: -2000,
     });
-    expect(snapshot.blockers[0].link).toEqual({
+    expect(snapshot.blockers[2].link).toEqual({
       label: "View session",
       params: { sessionId: "register-open" },
       to: "/$orgUrlSlug/store/$storeUrlSlug/cash-controls/registers/$sessionId",
     });
-    expect(snapshot.blockers[2]).toMatchObject({
+    expect(snapshot.blockers[0]).toMatchObject({
       link: {
         label: "View approvals",
         to: "/$orgUrlSlug/store/$storeUrlSlug/operations/approvals",
@@ -605,11 +605,11 @@ describe("end-of-day review backend foundation", () => {
       },
       title: "Payment method correction pending",
     });
-    expect(snapshot.blockers[2].metadata).not.toHaveProperty("openedAt");
-    expect(snapshot.blockers[2].metadata).not.toHaveProperty("expectedCash");
-    expect(snapshot.blockers[2].metadata).not.toHaveProperty("countedCash");
-    expect(snapshot.blockers[2].metadata).not.toHaveProperty("variance");
-    expect(snapshot.blockers[2].metadata).not.toHaveProperty("closedAt");
+    expect(snapshot.blockers[0].metadata).not.toHaveProperty("openedAt");
+    expect(snapshot.blockers[0].metadata).not.toHaveProperty("expectedCash");
+    expect(snapshot.blockers[0].metadata).not.toHaveProperty("countedCash");
+    expect(snapshot.blockers[0].metadata).not.toHaveProperty("variance");
+    expect(snapshot.blockers[0].metadata).not.toHaveProperty("closedAt");
     expect(snapshot.blockers[3].metadata).toMatchObject({
       customer: "Ama Mensah",
       expiresAt: Date.UTC(2026, 4, 7, 20),

--- a/packages/athena-webapp/convex/operations/dailyClose.ts
+++ b/packages/athena-webapp/convex/operations/dailyClose.ts
@@ -30,6 +30,11 @@ const TERMINAL_WORK_ITEM_STATUSES = new Set(["completed", "cancelled"]);
 const ACTIVE_REGISTER_STATUSES = ["open", "active", "closing"] as const;
 const OPEN_POS_SESSION_STATUSES = ["active", "held"] as const;
 const DAILY_CLOSE_COMPLETION_ACTION = APPROVAL_ACTIONS.dailyCloseCompletion;
+const DAILY_CLOSE_BLOCKER_CATEGORY_PRECEDENCE: Record<string, number> = {
+  approval: 0,
+  register_session: 10,
+  pos_session: 20,
+};
 
 type DailyCloseSeverity = "blocker" | "review" | "carry_forward" | "ready";
 
@@ -117,6 +122,21 @@ type DailyCloseSnapshot = {
     label?: string;
   }>;
 };
+
+function sortDailyCloseBlockers(blockers: DailyCloseItem[]) {
+  return blockers.sort((left, right) => {
+    const leftPriority =
+      DAILY_CLOSE_BLOCKER_CATEGORY_PRECEDENCE[left.category] ?? 100;
+    const rightPriority =
+      DAILY_CLOSE_BLOCKER_CATEGORY_PRECEDENCE[right.category] ?? 100;
+
+    if (leftPriority !== rightPriority) {
+      return leftPriority - rightPriority;
+    }
+
+    return left.key.localeCompare(right.key);
+  });
+}
 
 type DailyCloseReportSnapshot = {
   closeMetadata: {
@@ -1671,6 +1691,7 @@ export async function buildDailyCloseSnapshotWithCtx(
     voidedTransactionCount: voidedTransactions.length,
     paymentTotals: buildPaymentTotals(completedTransactions),
   };
+  sortDailyCloseBlockers(blockers);
   const readiness = buildReadiness({
     blockers,
     carryForwardItems,

--- a/packages/athena-webapp/docs/agent/key-folder-index.md
+++ b/packages/athena-webapp/docs/agent/key-folder-index.md
@@ -6,8 +6,8 @@ This key-folder index highlights the main directories agents are likely to need 
 
 ## Core app surfaces
 
-- [`src/routes`](../../src/routes) — TanStack route entrypoints and authenticated shells. Currently 80 file(s); key children: __root.tsx, _authed, _authed.test.tsx, _authed.tsx, index.test.tsx.
-- [`src/components`](../../src/components) — UI components, views, and package-local feature widgets. Currently 559 file(s); key children: GenericComboBox.tsx, Navbar.tsx, OrganizationView.tsx, OrganizationsView.tsx, PermissionGate.tsx.
+- [`src/routes`](../../src/routes) — TanStack route entrypoints and authenticated shells. Currently 81 file(s); key children: __root.tsx, _authed, _authed.test.tsx, _authed.tsx, index.test.tsx.
+- [`src/components`](../../src/components) — UI components, views, and package-local feature widgets. Currently 560 file(s); key children: GenericComboBox.tsx, Navbar.tsx, OrganizationView.tsx, OrganizationsView.tsx, PermissionGate.tsx.
 - [`src/components/traces`](../../src/components/traces) — Shared workflow trace screens, ordered timelines, and trace detail primitives. Currently 3 file(s); key children: WorkflowTraceRouteLink.tsx, WorkflowTraceView.test.tsx, WorkflowTraceView.tsx.
 - [`src/components/operations`](../../src/components/operations) — Manager-queue and stock-adjustment workflows that share approval rails with other operational surfaces. Currently 20 file(s); key children: CommandApprovalDialog.test.tsx, CommandApprovalDialog.tsx, DailyCloseHistoryView.test.tsx, DailyCloseHistoryView.tsx, DailyCloseView.test.tsx.
 - [`src/components/procurement`](../../src/components/procurement) — Procurement planning and receiving views for replenishment pressure and purchase-order execution. Currently 4 file(s); key children: ProcurementView.test.tsx, ProcurementView.tsx, ReceivingView.test.tsx, ReceivingView.tsx.

--- a/packages/athena-webapp/docs/agent/route-index.md
+++ b/packages/athena-webapp/docs/agent/route-index.md
@@ -12,6 +12,7 @@ This route index enumerates the current files under `src/routes` so agents can o
 - [`src/routes/index.test.tsx`](../../src/routes/index.test.tsx)
 - [`src/routes/index.tsx`](../../src/routes/index.tsx)
 - [`src/routes/join-team.index.tsx`](../../src/routes/join-team.index.tsx)
+- [`src/routes/landing.tsx`](../../src/routes/landing.tsx)
 
 ## Section `_authed`
 

--- a/packages/athena-webapp/src/components/landing/AthenaLandingPage.tsx
+++ b/packages/athena-webapp/src/components/landing/AthenaLandingPage.tsx
@@ -1,0 +1,577 @@
+import { Link } from "@tanstack/react-router";
+import { motion, useReducedMotion, useScroll, useTransform } from "framer-motion";
+import type { ReactNode } from "react";
+import {
+  ArrowRight,
+  Banknote,
+  BarChart3,
+  Boxes,
+  CalendarCheck,
+  CheckCircle2,
+  ClipboardCheck,
+  Eye,
+  FileClock,
+  ScanBarcode,
+  ShieldCheck,
+  ShoppingBag,
+  Sparkles,
+  Store,
+  Truck,
+  Users,
+  Workflow,
+} from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+type Capability = {
+  description: string;
+  icon: typeof Store;
+  title: string;
+};
+
+const capabilities: Capability[] = [
+  {
+    description: "In-person checkout, online orders, returns, exchanges, refunds, saved bags, reviews, offers, and rewards share one operating record.",
+    icon: ShoppingBag,
+    title: "Sales stay connected",
+  },
+  {
+    description: "Catalog, SKUs, adjustments, replenishment, purchase orders, receiving, vendors, and unresolved stock cleanup live in the same control loop.",
+    icon: Boxes,
+    title: "Inventory has memory",
+  },
+  {
+    description: "Daily open, daily close, open work, register sessions, cash controls, approvals, logs, and workflow traces show what happened and who touched it.",
+    icon: Workflow,
+    title: "Operations are accountable",
+  },
+  {
+    description: "Service intake, appointments, active cases, catalog setup, deposits, inventory usage, and staff ownership work beside retail flows.",
+    icon: CalendarCheck,
+    title: "Services are first class",
+  },
+  {
+    description: "Analytics, behavior timelines, storefront observability, and production health views turn scattered activity into owner visibility.",
+    icon: BarChart3,
+    title: "Signals become decisions",
+  },
+  {
+    description: "Staff profiles, credentials, permissions, manager approval, and audit evidence keep delegation tight without forcing everything through the owner.",
+    icon: ShieldCheck,
+    title: "Control can be delegated",
+  },
+];
+
+const workspaceTabs = [
+  "Daily operations",
+  "Register",
+  "Procurement",
+  "Services",
+  "Analytics",
+];
+
+const timelineItems = [
+  "Store opened with drawer proof",
+  "Register sale completed",
+  "Variance needs manager review",
+  "Purchase order received",
+];
+
+const metricRows = [
+  ["Sales", "GH₵ 8,420", "Healthy"],
+  ["Cash variance", "GH₵ 0", "Clear"],
+  ["Open work", "6", "Review"],
+];
+
+function Reveal({
+  children,
+  className,
+  delay = 0,
+}: {
+  children: ReactNode;
+  className?: string;
+  delay?: number;
+}) {
+  const shouldReduceMotion = useReducedMotion();
+
+  return (
+    <motion.div
+      className={className}
+      initial={shouldReduceMotion ? false : { opacity: 1, y: 28 }}
+      transition={{ delay, duration: 0.58, ease: [0.22, 1, 0.36, 1] }}
+      viewport={{ once: true, margin: "-80px" }}
+      whileInView={{ opacity: 1, y: 0 }}
+    >
+      {children}
+    </motion.div>
+  );
+}
+
+export function AthenaLandingPage() {
+  const { scrollYProgress } = useScroll();
+  const heroLift = useTransform(scrollYProgress, [0, 0.22], [0, -54]);
+  const railShift = useTransform(scrollYProgress, [0, 0.32], [0, 42]);
+
+  return (
+    <main className="-m-8 overflow-hidden bg-background text-foreground">
+      <section className="relative min-h-screen border-b border-border bg-shell text-shell-foreground">
+        <div className="absolute inset-0 bg-[linear-gradient(120deg,hsl(var(--shell))_0%,hsl(var(--action-workflow)/0.42)_58%,hsl(var(--shell))_100%)]" />
+        <motion.div
+          className="absolute inset-x-4 bottom-4 top-24 overflow-hidden rounded-[calc(var(--radius)*1.4)] border border-action-workflow-border/35 bg-background/10 shadow-overlay backdrop-blur-sm md:inset-x-8 md:bottom-8"
+          style={{ y: heroLift }}
+        >
+          <HeroWorkspace />
+        </motion.div>
+        <div className="absolute inset-0 bg-[linear-gradient(90deg,hsl(var(--shell))_0%,hsl(var(--shell)/0.92)_22%,hsl(var(--shell)/0.38)_56%,transparent_84%)]" />
+        <div className="absolute inset-0 bg-shell/35 md:bg-transparent" />
+        <div className="absolute inset-x-0 bottom-0 h-[46%] bg-[linear-gradient(0deg,hsl(var(--shell))_0%,hsl(var(--shell)/0.82)_46%,transparent_100%)]" />
+
+        <div className="relative z-10 flex min-h-screen items-end px-layout-lg pb-layout-3xl pt-28 md:px-layout-2xl">
+          <motion.div
+            className="max-w-5xl space-y-layout-lg"
+            initial={{ opacity: 0, y: 24 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.7, ease: [0.22, 1, 0.36, 1] }}
+          >
+            <Badge className="border-action-workflow-border bg-action-workflow-soft text-action-workflow">
+              Built for the owner-operator
+            </Badge>
+            <div className="space-y-layout-md">
+              <h1 className="max-w-3xl font-display text-5xl leading-none text-shell-foreground md:text-7xl">
+                Athena is the control room for a solo business.
+              </h1>
+              <p className="max-w-2xl text-lg leading-8 text-shell-foreground/82 md:text-xl">
+                Sell, stock, fulfill, close the day, trace exceptions, and see
+                the business clearly without becoming a full-time systems
+                operator.
+              </p>
+            </div>
+            <div className="flex flex-col gap-layout-sm sm:flex-row">
+              <Button
+                asChild
+                className="h-control-standard bg-action-workflow text-action-workflow-foreground hover:bg-action-workflow/90"
+              >
+                <Link to="/login">
+                  Open Athena
+                  <ArrowRight className="ml-2 h-4 w-4" />
+                </Link>
+              </Button>
+              <a
+                href="#capabilities"
+                className="inline-flex h-control-standard items-center justify-center rounded-lg border border-shell-foreground/25 px-layout-md text-sm font-medium text-shell-foreground transition duration-standard ease-standard hover:border-shell-foreground/55 hover:bg-shell-foreground/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-action-workflow"
+              >
+                See the system
+              </a>
+            </div>
+          </motion.div>
+        </div>
+      </section>
+
+      <section
+        id="capabilities"
+        className="px-layout-lg py-layout-3xl md:px-layout-2xl"
+      >
+        <Reveal className="mx-auto max-w-6xl space-y-layout-lg">
+          <div className="max-w-4xl space-y-layout-sm border-b border-border pb-layout-lg">
+            <p className="text-xs font-semibold uppercase tracking-[0.28em] text-action-workflow">
+              Complete operational control
+            </p>
+            <h2 className="font-display text-5xl leading-none md:text-7xl">
+              One owner. Every loop in view.
+            </h2>
+            <p className="max-w-3xl text-lg leading-8 text-muted-foreground">
+              Athena already covers the daily operating surface of a retail and
+              service business: checkout, storefront, stock, procurement, cash,
+              staff work, services, analytics, and evidence.
+            </p>
+          </div>
+        </Reveal>
+
+        <div className="mx-auto mt-layout-2xl grid max-w-6xl gap-layout-md md:grid-cols-2 xl:grid-cols-3">
+          {capabilities.map((capability, index) => (
+            <Reveal key={capability.title} delay={index * 0.04}>
+              <motion.article
+                className="group h-full rounded-lg border border-border bg-surface p-layout-lg shadow-surface transition duration-standard ease-standard hover:-translate-y-1 hover:border-action-workflow-border hover:bg-action-workflow-soft/30"
+                whileHover={{ y: -6 }}
+              >
+                <capability.icon className="h-5 w-5 text-action-workflow transition duration-standard ease-standard group-hover:scale-110" />
+                <div className="mt-layout-lg space-y-layout-sm">
+                  <h3 className="text-xl font-semibold">{capability.title}</h3>
+                  <p className="leading-7 text-muted-foreground">
+                    {capability.description}
+                  </p>
+                </div>
+              </motion.article>
+            </Reveal>
+          ))}
+        </div>
+      </section>
+
+      <section className="bg-surface px-layout-lg py-layout-3xl md:px-layout-2xl">
+        <div className="mx-auto grid max-w-7xl gap-layout-2xl xl:grid-cols-[0.8fr_1.2fr]">
+          <Reveal className="space-y-layout-lg">
+            <div className="space-y-layout-sm">
+              <p className="text-xs font-semibold uppercase tracking-[0.28em] text-action-workflow">
+                Workspace depth
+              </p>
+              <h2 className="font-display text-5xl leading-none md:text-7xl">
+                It looks like work because it is work.
+              </h2>
+              <p className="text-lg leading-8 text-muted-foreground">
+                The landing page uses Athena's real workspace language: large
+                orientation headers, quiet rails, dense review zones, state
+                chips, and workflow-colored actions.
+              </p>
+            </div>
+            <div className="grid gap-layout-sm sm:grid-cols-2">
+              {[
+                ["Open work", "Exceptions, approvals, and carry-forward tasks."],
+                ["Daily close", "Sales, expenses, drawer variance, and evidence."],
+                ["Receiving", "Inbound purchase orders tied back to stock."],
+                ["Trace review", "Business-readable timelines for what happened."],
+              ].map(([title, detail]) => (
+                <div
+                  key={title}
+                  className="rounded-lg border border-border bg-background p-layout-md"
+                >
+                  <p className="font-semibold">{title}</p>
+                  <p className="mt-1 text-sm leading-6 text-muted-foreground">
+                    {detail}
+                  </p>
+                </div>
+              ))}
+            </div>
+          </Reveal>
+
+          <Reveal delay={0.12}>
+            <motion.div
+              className="rounded-[calc(var(--radius)*1.35)] border border-border bg-background p-layout-md shadow-overlay"
+              style={{ y: railShift }}
+            >
+              <WorkspaceShowcase />
+            </motion.div>
+          </Reveal>
+        </div>
+      </section>
+
+      <section className="px-layout-lg py-layout-3xl md:px-layout-2xl">
+        <div className="mx-auto max-w-7xl space-y-layout-2xl">
+          <Reveal className="max-w-5xl space-y-layout-sm border-b border-border pb-layout-lg">
+            <p className="text-xs font-semibold uppercase tracking-[0.28em] text-action-workflow">
+              Operating evidence
+            </p>
+            <h2 className="font-display text-5xl leading-none md:text-7xl">
+              Know what happened without hunting for it.
+            </h2>
+          </Reveal>
+
+          <div className="grid gap-layout-lg lg:grid-cols-[1fr_0.82fr]">
+            <Reveal>
+              <TracePanel />
+            </Reveal>
+            <Reveal delay={0.08}>
+              <OwnerPanel />
+            </Reveal>
+          </div>
+        </div>
+      </section>
+
+      <section className="border-t border-border bg-shell px-layout-lg py-layout-3xl text-shell-foreground md:px-layout-2xl">
+        <Reveal className="mx-auto flex max-w-6xl flex-col gap-layout-xl md:flex-row md:items-end md:justify-between">
+          <div className="max-w-3xl space-y-layout-md">
+            <p className="text-xs font-semibold uppercase tracking-[0.28em] text-action-workflow-foreground/80">
+              Athena
+            </p>
+            <h2 className="font-display text-5xl leading-none md:text-7xl">
+              Run the day from one place.
+            </h2>
+            <p className="text-lg leading-8 text-shell-foreground/78">
+              The point is not another dashboard. It is a business operating
+              system with enough structure for control and enough calm for daily
+              use.
+            </p>
+          </div>
+          <Button
+            asChild
+            className="h-control-standard bg-action-workflow text-action-workflow-foreground hover:bg-action-workflow/90"
+          >
+            <Link to="/login">
+              Open Athena
+              <ArrowRight className="ml-2 h-4 w-4" />
+            </Link>
+          </Button>
+        </Reveal>
+      </section>
+    </main>
+  );
+}
+
+function HeroWorkspace() {
+  return (
+    <div className="grid h-full min-h-[560px] grid-cols-[72px_minmax(0,1fr)] bg-background text-foreground">
+      <aside className="border-r border-border bg-shell p-layout-sm text-shell-foreground">
+        <div className="mb-layout-xl flex h-10 w-10 items-center justify-center rounded-lg bg-action-workflow text-action-workflow-foreground">
+          <Store className="h-5 w-5" />
+        </div>
+        <div className="space-y-layout-sm">
+          {[ScanBarcode, Banknote, Workflow, Boxes, Users].map((Icon, index) => (
+            <div
+              key={index}
+              className={cn(
+                "flex h-10 w-10 items-center justify-center rounded-md border border-shell-foreground/10 text-shell-foreground/72",
+                index === 2 ? "bg-action-workflow text-action-workflow-foreground" : null,
+              )}
+            >
+              <Icon className="h-4 w-4" />
+            </div>
+          ))}
+        </div>
+      </aside>
+      <div className="grid min-w-0 grid-rows-[auto_minmax(0,1fr)]">
+        <header className="flex items-center justify-between border-b border-border bg-surface px-layout-lg py-layout-md">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-[0.24em] text-muted-foreground">
+              Daily operations
+            </p>
+            <h2 className="mt-1 text-2xl font-semibold">Sunday control room</h2>
+          </div>
+          <Badge className="border-action-workflow-border bg-action-workflow-soft text-action-workflow">
+            Operating
+          </Badge>
+        </header>
+        <div className="grid min-h-0 gap-layout-lg p-layout-lg lg:grid-cols-[minmax(0,1fr)_300px]">
+          <div className="min-w-0 space-y-layout-lg">
+            <div className="grid gap-layout-md md:grid-cols-3">
+              {metricRows.map(([label, value, status]) => (
+                <div
+                  key={label}
+                  className="rounded-lg border border-border bg-surface-raised p-layout-md shadow-surface"
+                >
+                  <p className="text-xs uppercase tracking-[0.18em] text-muted-foreground">
+                    {label}
+                  </p>
+                  <p className="mt-3 font-numeric text-3xl font-semibold">
+                    {value}
+                  </p>
+                  <p className="mt-2 text-sm text-action-workflow">{status}</p>
+                </div>
+              ))}
+            </div>
+            <div className="rounded-lg border border-border bg-surface-raised p-layout-lg shadow-surface">
+              <div className="mb-layout-md flex items-center justify-between">
+                <h3 className="font-semibold">Close readiness</h3>
+                <span className="text-sm text-muted-foreground">4 lanes</span>
+              </div>
+              <div className="space-y-layout-sm">
+                {["Register proof", "Open work", "Cash summary", "Stock exceptions"].map(
+                  (label, index) => (
+                    <div
+                      key={label}
+                      className="flex items-center gap-layout-sm rounded-md border border-border bg-background p-layout-sm"
+                    >
+                      <div
+                        className={cn(
+                          "h-2.5 w-2.5 rounded-full",
+                          index === 1 ? "bg-warning" : "bg-success",
+                        )}
+                      />
+                      <span className="font-medium">{label}</span>
+                      <span className="ml-auto text-sm text-muted-foreground">
+                        {index === 1 ? "Review" : "Ready"}
+                      </span>
+                    </div>
+                  ),
+                )}
+              </div>
+            </div>
+          </div>
+          <aside className="space-y-layout-md rounded-lg border border-border bg-surface-raised p-layout-md shadow-surface">
+            <p className="text-xs font-semibold uppercase tracking-[0.22em] text-muted-foreground">
+              Timeline
+            </p>
+            {timelineItems.map((item, index) => (
+              <div key={item} className="flex gap-layout-sm">
+                <div className="flex flex-col items-center">
+                  <span className="mt-1 h-3 w-3 rounded-full bg-action-workflow" />
+                  {index < timelineItems.length - 1 ? (
+                    <span className="h-10 w-px bg-border" />
+                  ) : null}
+                </div>
+                <p className="text-sm leading-6">{item}</p>
+              </div>
+            ))}
+          </aside>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function WorkspaceShowcase() {
+  return (
+    <div className="space-y-layout-lg">
+      <div className="flex flex-wrap gap-layout-xs">
+        {workspaceTabs.map((tab, index) => (
+          <button
+            key={tab}
+            className={cn(
+              "rounded-full border px-layout-sm py-layout-xs text-sm transition duration-standard ease-standard hover:-translate-y-0.5 hover:border-action-workflow-border hover:bg-action-workflow-soft hover:text-action-workflow",
+              index === 0
+                ? "border-action-workflow bg-action-workflow text-action-workflow-foreground"
+                : "border-border bg-surface text-muted-foreground",
+            )}
+            type="button"
+          >
+            {tab}
+          </button>
+        ))}
+      </div>
+
+      <div className="grid gap-layout-lg lg:grid-cols-[minmax(0,1fr)_270px]">
+        <div className="rounded-lg border border-border bg-surface p-layout-lg">
+          <div className="mb-layout-lg flex items-start justify-between gap-layout-md">
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-[0.22em] text-muted-foreground">
+                Work queue
+              </p>
+              <h3 className="mt-2 text-3xl font-semibold">Owner attention</h3>
+            </div>
+            <Badge className="bg-warning text-warning-foreground">
+              6 open
+            </Badge>
+          </div>
+          <div className="grid gap-layout-sm">
+            {[
+              ["Manager approval", "Register variance review", ShieldCheck],
+              ["Receiving", "PO-1042 short receipt", Truck],
+              ["Customer follow-up", "Refund email pending", FileClock],
+              ["Stock adjustment", "Cycle count draft ready", ClipboardCheck],
+            ].map(([title, detail, Icon]) => (
+              <motion.div
+                key={title as string}
+                className="grid grid-cols-[40px_minmax(0,1fr)_auto] items-center gap-layout-sm rounded-lg border border-border bg-background p-layout-md transition duration-standard ease-standard hover:border-action-workflow-border hover:bg-action-workflow-soft/40"
+                whileHover={{ x: 6 }}
+              >
+                <div className="flex h-10 w-10 items-center justify-center rounded-md bg-action-workflow-soft text-action-workflow">
+                  <Icon className="h-4 w-4" />
+                </div>
+                <div className="min-w-0">
+                  <p className="font-medium">{title as string}</p>
+                  <p className="truncate text-sm text-muted-foreground">
+                    {detail as string}
+                  </p>
+                </div>
+                <ArrowRight className="h-4 w-4 text-muted-foreground" />
+              </motion.div>
+            ))}
+          </div>
+        </div>
+
+        <aside className="space-y-layout-md rounded-lg border border-border bg-surface p-layout-md">
+          <div className="rounded-md bg-action-workflow-soft p-layout-md text-action-workflow">
+            <Sparkles className="mb-layout-sm h-5 w-5" />
+            <p className="font-semibold">Next best action</p>
+            <p className="mt-2 text-sm leading-6">
+              Clear the variance review before closing today's store day.
+            </p>
+          </div>
+          {["Drawer proof", "Open orders", "Stock exceptions"].map((item) => (
+            <div
+              key={item}
+              className="flex items-center justify-between border-b border-border pb-layout-sm last:border-b-0 last:pb-0"
+            >
+              <span className="text-sm">{item}</span>
+              <CheckCircle2 className="h-4 w-4 text-success" />
+            </div>
+          ))}
+        </aside>
+      </div>
+    </div>
+  );
+}
+
+function TracePanel() {
+  return (
+    <motion.article
+      className="rounded-lg border border-border bg-surface p-layout-lg shadow-surface"
+      whileHover={{ y: -4 }}
+    >
+      <div className="flex flex-col gap-layout-md border-b border-border pb-layout-lg sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.22em] text-action-workflow">
+            Workflow trace
+          </p>
+          <h3 className="mt-2 text-3xl font-semibold">
+            Receipt 2026-0510-042
+          </h3>
+        </div>
+        <Badge className="border-success/30 bg-success/10 text-success">
+          Complete
+        </Badge>
+      </div>
+      <div className="mt-layout-lg grid gap-layout-md md:grid-cols-2">
+        {[
+          ["Started", "Staff profile verified"],
+          ["Items added", "3 SKUs reserved"],
+          ["Payment allocated", "Cash and mobile money reconciled"],
+          ["Receipt issued", "Customer timeline updated"],
+        ].map(([title, detail], index) => (
+          <div key={title} className="flex gap-layout-sm">
+            <div className="flex flex-col items-center">
+              <span className="flex h-8 w-8 items-center justify-center rounded-full bg-action-workflow text-action-workflow-foreground">
+                {index + 1}
+              </span>
+            </div>
+            <div>
+              <p className="font-semibold">{title}</p>
+              <p className="text-sm leading-6 text-muted-foreground">
+                {detail}
+              </p>
+            </div>
+          </div>
+        ))}
+      </div>
+    </motion.article>
+  );
+}
+
+function OwnerPanel() {
+  return (
+    <motion.article
+      className="h-full rounded-lg border border-border bg-shell p-layout-lg text-shell-foreground shadow-overlay"
+      whileHover={{ y: -4 }}
+    >
+      <div className="space-y-layout-md">
+        <Eye className="h-6 w-6 text-action-workflow-foreground" />
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.22em] text-shell-foreground/62">
+            Owner visibility
+          </p>
+          <h3 className="mt-2 text-3xl font-semibold">The audit trail is part of the product.</h3>
+        </div>
+        <p className="leading-7 text-shell-foreground/76">
+          Athena records the operational facts owners actually need: staff
+          action, store-day state, payment allocation, stock movement, customer
+          follow-up, and exceptions that still need a decision.
+        </p>
+      </div>
+      <div className="mt-layout-xl grid gap-layout-sm">
+        {["Store day", "Register session", "Purchase order", "Service case"].map(
+          (item, index) => (
+            <div
+              key={item}
+              className="flex items-center justify-between rounded-md border border-shell-foreground/10 bg-shell-foreground/5 px-layout-md py-layout-sm"
+            >
+              <span>{item}</span>
+              <span className="font-numeric text-sm text-action-workflow-foreground">
+                {index + 12} events
+              </span>
+            </div>
+          ),
+        )}
+      </div>
+    </motion.article>
+  );
+}

--- a/packages/athena-webapp/src/components/operations/DailyCloseView.test.tsx
+++ b/packages/athena-webapp/src/components/operations/DailyCloseView.test.tsx
@@ -333,7 +333,12 @@ describe("DailyCloseViewContent", () => {
       o: "%2Fwigclub%2Fstore%2Fwigclub%2Foperations%2Fopening",
     };
 
-    renderContent(readySnapshot);
+    renderContent({
+      ...readySnapshot,
+      blockers: [],
+      carryForwardItems: [],
+      reviewItems: [],
+    });
 
     await user.click(screen.getByRole("button", { name: /go back/i }));
 
@@ -425,10 +430,43 @@ describe("DailyCloseViewContent", () => {
     ).toBeDisabled();
   });
 
+  it("marks variance approval blockers for first-glance scanning", () => {
+    renderContent({
+      ...blockedSnapshot,
+      blockers: [
+        {
+          ...blockedSnapshot.blockers[1],
+          metadata: {
+            ...(blockedSnapshot.blockers[1].metadata as Record<
+              string,
+              unknown
+            >),
+            approval: "Register closeout variance review",
+          },
+          title: "Register closeout variance review pending",
+        },
+      ],
+    });
+
+    const approvalItem = screen
+      .getByText("Register closeout variance review pending")
+      .closest("article");
+
+    expect(approvalItem).not.toBeNull();
+    expect(
+      within(approvalItem as HTMLElement).getByText("Variance review"),
+    ).toBeInTheDocument();
+  });
+
   it("shows ready summary totals and enables completion", async () => {
     const user = userEvent.setup();
 
-    renderContent(readySnapshot);
+    renderContent({
+      ...readySnapshot,
+      blockers: [],
+      carryForwardItems: [],
+      reviewItems: [],
+    });
 
     expect(screen.getByText("Ready to close")).toBeInTheDocument();
     expect(screen.getByText("14 transactions")).toBeInTheDocument();
@@ -556,15 +594,21 @@ describe("DailyCloseViewContent", () => {
     ).toBeEnabled();
     const checklist = screen.getByText("Close checklist").closest("div");
     expect(checklist).not.toBeNull();
-    within(checklist as HTMLElement)
-      .getAllByText("Clear")
-      .forEach((value) => {
-        expect(value).not.toHaveClass("text-success");
-        expect(value).not.toHaveClass("text-warning-foreground");
-      });
-    expect(within(checklist as HTMLElement).getByText("None")).not.toHaveClass(
-      "text-action-workflow",
-    );
+    expect(
+      within(checklist as HTMLElement).getByLabelText(
+        "Resolve blockers clear",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      within(checklist as HTMLElement).getByLabelText(
+        "Review exceptions clear",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      within(checklist as HTMLElement).getByLabelText("Carry forward clear"),
+    ).toBeInTheDocument();
+    expect(within(checklist as HTMLElement).queryByText("Clear")).toBeNull();
+    expect(within(checklist as HTMLElement).queryByText("None")).toBeNull();
   });
 
   it("paginates daily close item cards at five items per page", async () => {

--- a/packages/athena-webapp/src/components/operations/DailyCloseView.tsx
+++ b/packages/athena-webapp/src/components/operations/DailyCloseView.tsx
@@ -11,6 +11,7 @@ import {
   Banknote,
   Ban,
   Calendar as CalendarIcon,
+  Check,
   CheckCircle2,
   ClipboardCheck,
   CreditCardIcon,
@@ -348,7 +349,7 @@ function formatRegisterVarianceCount(value: number) {
 
 function getStatusLabelClassName(status: DailyCloseStatus) {
   return cn(
-    "inline-flex w-fit rounded-md px-layout-sm py-1 text-base font-medium",
+    "inline-flex w-fit items-center rounded-md px-layout-sm py-1 text-base font-medium",
     status === "blocked" && "bg-danger/10 text-danger",
     status === "needs_review" && "bg-warning/15 text-warning-foreground",
     status === "carry_forward" &&
@@ -366,6 +367,45 @@ function getStatusRailIconClassName(status: DailyCloseStatus) {
       "bg-action-workflow-soft text-action-workflow",
     (status === "ready" || status === "completed") &&
       "bg-success/10 text-success",
+  );
+}
+
+function DailyCloseStatusTitle({
+  status,
+  title,
+}: {
+  status: DailyCloseStatus;
+  title: string;
+}) {
+  return (
+    <h2 className={getStatusLabelClassName(status)}>
+      {status === "completed" ? (
+        <SuccessCheckIcon className="-ml-0.5 mr-1.5" />
+      ) : null}
+      {title}
+    </h2>
+  );
+}
+
+function SuccessCheckIcon({
+  className,
+  label,
+}: {
+  className?: string;
+  label?: string;
+}) {
+  return (
+    <span
+      aria-hidden={label ? undefined : "true"}
+      aria-label={label}
+      className={cn(
+        "inline-flex h-4 w-4 shrink-0 items-center justify-center rounded-full bg-success text-surface",
+        className,
+      )}
+      role={label ? "img" : undefined}
+    >
+      <Check aria-hidden="true" className="h-2.5 w-2.5" />
+    </span>
   );
 }
 
@@ -826,6 +866,17 @@ function getMetadataStringValue(
 
   const value = metadata[label];
   return typeof value === "string" && value.trim() !== "" ? value : undefined;
+}
+
+function isVarianceApprovalItem(item: DailyCloseItem) {
+  if (normalizeMetadataLabel(item.category ?? "") !== "approval") {
+    return false;
+  }
+
+  const approvalType = getMetadataStringValue(item.metadata, "approval");
+  const approvalText = `${approvalType ?? ""} ${item.title}`.toLowerCase();
+
+  return approvalText.includes("variance");
 }
 
 function getMetadataValue(metadata: Record<string, unknown>, label: string) {
@@ -1680,6 +1731,11 @@ function DailyCloseItemCard({
   );
   const collapsedMetadataEntries = getCollapsedMetadataEntries(metadataEntries);
   const hasSourceLink = Boolean(item.link);
+  const badgeSlot = isVarianceApprovalItem(item) ? (
+    <Badge className="border-warning/30 bg-warning/10 text-warning-foreground">
+      Variance review
+    </Badge>
+  ) : null;
 
   return (
     <OperationReviewItemCard
@@ -1708,6 +1764,7 @@ function DailyCloseItemCard({
           />
         ) : null
       }
+      badgeSlot={badgeSlot}
       showCollapsedDescription={showCollapsedDescription}
       title={item.title}
     />
@@ -2069,9 +2126,7 @@ export function DailyCloseReadOnlyReport({
       <section className="space-y-layout-lg">
         <div className="flex flex-col gap-layout-md lg:flex-row lg:items-end lg:justify-between">
           <div className="space-y-layout-xs">
-            <h2 className={getStatusLabelClassName(status)}>
-              {displayCopy.title}
-            </h2>
+            <DailyCloseStatusTitle status={status} title={displayCopy.title} />
             <p className="max-w-2xl text-sm leading-6 text-muted-foreground">
               {displayCopy.description}
             </p>
@@ -2335,18 +2390,21 @@ function CompletionRail({
   const copy = statusCopy[status];
   const checklistItems = [
     {
+      isClear: snapshot.blockers.length === 0,
       label: "Resolve blockers",
       tone: snapshot.blockers.length > 0 ? "danger" : "success",
       value: formatChecklistCount(snapshot.blockers.length, "blocker"),
       valueTone: snapshot.blockers.length > 0 ? "danger" : "plain",
     },
     {
+      isClear: snapshot.reviewItems.length === 0,
       label: "Review exceptions",
       tone: "warning",
       value: formatChecklistCount(snapshot.reviewItems.length, "item"),
       valueTone: snapshot.reviewItems.length > 0 ? "warning" : "plain",
     },
     {
+      isClear: snapshot.carryForwardItems.length === 0,
       label: "Carry forward",
       tone: "workflow",
       value: formatChecklistCount(
@@ -2433,7 +2491,14 @@ function CompletionRail({
                     item.valueTone === "workflow" && "text-action-workflow",
                   )}
                 >
-                  {item.value}
+                  {item.isClear ? (
+                    <SuccessCheckIcon
+                      className="ml-auto"
+                      label={`${item.label} clear`}
+                    />
+                  ) : (
+                    item.value
+                  )}
                 </dd>
               </div>
             ))}
@@ -2593,7 +2658,9 @@ export function DailyCloseViewContent({
   const displaySnapshot = snapshot
     ? normalizeCompletedReportSnapshot(snapshot)
     : undefined;
-  const status = displaySnapshot ? getDailyCloseStatus(displaySnapshot) : "ready";
+  const status = displaySnapshot
+    ? getDailyCloseStatus(displaySnapshot)
+    : "ready";
   const isBlocked = status === "blocked";
   const isCompleted = status === "completed";
   const displayCopy = displaySnapshot
@@ -2835,7 +2902,7 @@ export function DailyCloseViewContent({
       showBackButton={typeof search.o === "string" && search.o.length > 0}
       statusDescription={displayCopy.description}
       statusTitle={
-        <h2 className={getStatusLabelClassName(status)}>{displayCopy.title}</h2>
+        <DailyCloseStatusTitle status={status} title={displayCopy.title} />
       }
       title="End-of-Day Review"
     />

--- a/packages/athena-webapp/src/components/operations/DailyOperationsView.test.tsx
+++ b/packages/athena-webapp/src/components/operations/DailyOperationsView.test.tsx
@@ -645,10 +645,15 @@ describe("DailyOperationsViewContent", () => {
       screen.getByRole("heading", { name: "Closed store-day record" }),
     ).toBeInTheDocument();
     expect(
-      screen.getByText(
+      screen.queryByText(
         "This operating date is closed. The saved End-of-Day Review is available for this store-day record.",
       ),
-    ).toBeInTheDocument();
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(
+        "Metrics and timeline remain available for this historical day.",
+      ),
+    ).not.toBeInTheDocument();
     expect(
       screen.getByRole("link", { name: "Review End-of-Day Review" }),
     ).toHaveAttribute(

--- a/packages/athena-webapp/src/components/operations/DailyOperationsView.tsx
+++ b/packages/athena-webapp/src/components/operations/DailyOperationsView.tsx
@@ -556,16 +556,8 @@ function HistoricalWorkflowPanel({
         {isClosed ? "Closed store-day record" : "Historical store-day view"}
       </h3>
       <div className="rounded-lg border border-border bg-surface-raised p-layout-md shadow-surface">
-        <p className="text-sm leading-6 text-foreground">
-          {isClosed
-            ? "This operating date is closed. The saved End-of-Day Review is available for this store-day record."
-            : "This historical operating date is view-only. Workflow actions are available only on the current operating date."}
-        </p>
-        <p className="mt-layout-xs text-sm leading-6 text-muted-foreground">
-          Metrics and timeline remain available for this historical day.
-        </p>
         {isClosed ? (
-          <Button asChild className="mt-layout-md" size="sm" variant="outline">
+          <Button asChild size="sm" variant="outline">
             <Link
               params={buildParams(orgUrlSlug, storeUrlSlug)}
               search={
@@ -580,7 +572,17 @@ function HistoricalWorkflowPanel({
               <ArrowUpRight aria-hidden="true" className="h-4 w-4" />
             </Link>
           </Button>
-        ) : null}
+        ) : (
+          <>
+            <p className="text-sm leading-6 text-foreground">
+              This historical operating date is view-only. Workflow actions are
+              available only on the current operating date.
+            </p>
+            <p className="mt-layout-xs text-sm leading-6 text-muted-foreground">
+              Metrics and timeline remain available for this historical day.
+            </p>
+          </>
+        )}
       </div>
     </section>
   );

--- a/packages/athena-webapp/src/routeTree.gen.ts
+++ b/packages/athena-webapp/src/routeTree.gen.ts
@@ -9,6 +9,7 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
+import { Route as LandingRouteImport } from './routes/landing'
 import { Route as AuthedRouteImport } from './routes/_authed'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as JoinTeamIndexRouteImport } from './routes/join-team.index'
@@ -83,6 +84,11 @@ import { Route as AuthedOrgUrlSlugStoreStoreUrlSlugPosTransactionsTransactionIdR
 import { Route as AuthedOrgUrlSlugStoreStoreUrlSlugPosExpenseReportsReportIdRouteImport } from './routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/expense-reports/$reportId'
 import { Route as AuthedOrgUrlSlugStoreStoreUrlSlugCashControlsRegistersSessionIdRouteImport } from './routes/_authed/$orgUrlSlug/store/$storeUrlSlug/cash-controls/registers/$sessionId'
 
+const LandingRoute = LandingRouteImport.update({
+  id: '/landing',
+  path: '/landing',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const AuthedRoute = AuthedRouteImport.update({
   id: '/_authed',
   getParentRoute: () => rootRouteImport,
@@ -531,6 +537,7 @@ const AuthedOrgUrlSlugStoreStoreUrlSlugCashControlsRegistersSessionIdRoute =
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/landing': typeof LandingRoute
   '/login': typeof LoginLayoutRouteWithChildren
   '/join-team/': typeof JoinTeamIndexRoute
   '/$orgUrlSlug/': typeof AuthedOrgUrlSlugIndexRoute
@@ -605,6 +612,7 @@ export interface FileRoutesByFullPath {
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/landing': typeof LandingRoute
   '/join-team': typeof JoinTeamIndexRoute
   '/$orgUrlSlug': typeof AuthedOrgUrlSlugIndexRoute
   '/login': typeof LoginLayoutIndexRoute
@@ -680,6 +688,7 @@ export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
   '/_authed': typeof AuthedRouteWithChildren
+  '/landing': typeof LandingRoute
   '/login/_layout': typeof LoginLayoutRouteWithChildren
   '/join-team/': typeof JoinTeamIndexRoute
   '/_authed/$orgUrlSlug/': typeof AuthedOrgUrlSlugIndexRoute
@@ -756,6 +765,7 @@ export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
     | '/'
+    | '/landing'
     | '/login'
     | '/join-team/'
     | '/$orgUrlSlug/'
@@ -830,6 +840,7 @@ export interface FileRouteTypes {
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
+    | '/landing'
     | '/join-team'
     | '/$orgUrlSlug'
     | '/login'
@@ -904,6 +915,7 @@ export interface FileRouteTypes {
     | '__root__'
     | '/'
     | '/_authed'
+    | '/landing'
     | '/login/_layout'
     | '/join-team/'
     | '/_authed/$orgUrlSlug/'
@@ -980,12 +992,20 @@ export interface FileRouteTypes {
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   AuthedRoute: typeof AuthedRouteWithChildren
+  LandingRoute: typeof LandingRoute
   LoginLayoutRoute: typeof LoginLayoutRouteWithChildren
   JoinTeamIndexRoute: typeof JoinTeamIndexRoute
 }
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/landing': {
+      id: '/landing'
+      path: '/landing'
+      fullPath: '/landing'
+      preLoaderRoute: typeof LandingRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/_authed': {
       id: '/_authed'
       path: ''
@@ -1725,6 +1745,7 @@ const LoginLayoutRouteWithChildren = LoginLayoutRoute._addFileChildren(
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   AuthedRoute: AuthedRouteWithChildren,
+  LandingRoute: LandingRoute,
   LoginLayoutRoute: LoginLayoutRouteWithChildren,
   JoinTeamIndexRoute: JoinTeamIndexRoute,
 }

--- a/packages/athena-webapp/src/routes/landing.tsx
+++ b/packages/athena-webapp/src/routes/landing.tsx
@@ -1,0 +1,7 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+import { AthenaLandingPage } from "@/components/landing/AthenaLandingPage";
+
+export const Route = createFileRoute("/landing")({
+  component: AthenaLandingPage,
+});


### PR DESCRIPTION
## Summary
- add the /landing route with an Athena business-OS landing page aligned to the existing workspace theme
- sort daily-close blockers so approvals take precedence and mark variance approval requests visually
- tighten completed/clear daily-close cues and simplify closed historical operations review copy
- add a reusable solution note for operational status surfaces

## Validation
- bun run pr:athena