### PR TITLE
ci: reduce duplicate PR validation

### DIFF
--- a/.github/workflows/athena-pr-tests.yml
+++ b/.github/workflows/athena-pr-tests.yml
@@ -36,6 +36,12 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      - name: Check GitHub workflow YAML
+        run: bun run workflow:check
+
+      - name: Check compound solution docs
+        run: bun run compound:check
+
       - name: Install Graphify runtime
         run: python3 -m pip install -r .graphify-requirements.txt
 
@@ -46,7 +52,7 @@ jobs:
         run: bun run harness:self-review --base origin/main
 
       - name: Run harness review
-        run: bun run harness:review --base origin/main
+        run: bun run harness:review --base origin/main --validation-provided-by athena-pr-tests
 
       - name: Check harness docs
         run: bun run harness:check
@@ -172,8 +178,8 @@ jobs:
       - name: Run harness implementation tests
         run: bun run harness:test
 
-  test-athena-webapp:
-    name: Athena Webapp Validation
+  athena-webapp-validation:
+    name: Athena and Storefront Webapp Validation
     runs-on: ubuntu-latest
 
     steps:
@@ -190,38 +196,38 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
-      - name: Install ripgrep
-        run: |
-          cargo install ripgrep --locked
-          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
-
       - name: Audit Athena Convex baseline
         run: bun run --filter '@athena/webapp' audit:convex
 
       - name: Lint changed Athena Convex files
         run: bun run --filter '@athena/webapp' lint:convex:changed
 
-      - name: Run Athena webapp tests
-        run: bun run --filter '@athena/webapp' test
+      - name: Lint changed Athena frontend files
+        run: bun run --filter '@athena/webapp' lint:frontend:changed
+
+      - name: Build Athena webapp
+        run: bun run --filter '@athena/webapp' build
+
+      - name: Build storefront webapp
+        run: bun run --filter '@athena/storefront-webapp' build
 
       - name: Run repo coverage policy
         run: bun run test:coverage
 
-  test-storefront-webapp:
-    name: Storefront Webapp Test Suite
+  storefront-webapp-validation-context:
+    name: Storefront Webapp Validation Context
+    needs: athena-webapp-validation
+    if: always()
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v6
+      - name: Confirm consolidated storefront validation coverage
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "${{ needs.athena-webapp-validation.result }}" != "success" ]; then
+            echo "Consolidated webapp validation did not pass; storefront context cannot pass."
+            exit 1
+          fi
 
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version-file: package.json
-
-      - name: Install dependencies
-        run: bun install --frozen-lockfile
-
-      - name: Run storefront webapp tests
-        run: bun run --filter '@athena/storefront-webapp' test
+          echo "Storefront tests and build are covered by Athena and Storefront Webapp Validation."

--- a/docs/harness.md
+++ b/docs/harness.md
@@ -273,6 +273,13 @@ bun run harness:inferential-review
 bun run graphify:check
 ```
 
+The Athena PR workflow may run `harness:review` with
+`--validation-provided-by athena-pr-tests`. That CI-only mode still checks the
+validation maps and selected runtime behavior scenarios, but it skips package
+test/build/lint commands already enforced elsewhere in the same workflow. Keep
+standalone local `harness:review --base origin/main` fail-closed so agents can
+still get the full touched-surface command list outside CI.
+
 For runtime scenario work, use:
 
 ```sh

--- a/docs/solutions/harness/ci-duplicate-test-pruning-2026-05-10.md
+++ b/docs/solutions/harness/ci-duplicate-test-pruning-2026-05-10.md
@@ -1,0 +1,82 @@
+---
+title: CI Package Test Jobs Should Not Duplicate the Repo Coverage Policy
+date: 2026-05-10
+category: harness
+module: github-actions
+problem_type: ci_runtime
+component: athena-pr-tests
+resolution_type: workflow_pruning
+severity: medium
+tags:
+  - ci
+  - github-actions
+  - coverage
+  - vitest
+  - workflow-runtime
+---
+
+# CI Package Test Jobs Should Not Duplicate the Repo Coverage Policy
+
+## Problem
+
+Athena PR validation grew by accretion: app package test jobs were added first,
+then the repo coverage policy was wired in later. That left GitHub Actions
+running the same Vitest suites twice:
+
+- `bun run --filter '@athena/webapp' test`
+- `bun run --filter '@athena/webapp' test:coverage` through `bun run test:coverage`
+- `bun run --filter '@athena/storefront-webapp' test`
+- `bun run --filter '@athena/storefront-webapp' test:coverage` through `bun run test:coverage`
+
+The no-coverage runs still provide a clean package-test signal, but they do not
+cover a distinct sensor once coverage is mandatory in the same PR workflow.
+
+## Solution
+
+Keep `bun run test:coverage` as the package-test authority in PR CI. It runs the
+Athena webapp coverage suite, the storefront coverage suite, root script
+coverage, coverage toolchain parity, and the characterized baseline policy.
+
+Keep workflow syntax validation as its own cheap sensor. `bun run workflow:check`
+parses every `.github/workflows/*.yml` and `.github/workflows/*.yaml` file through
+Ruby's built-in YAML parser. That keeps workflow syntax checks available in local
+and GitHub runners without adding PyYAML or another dependency just for CI file
+validation. Include it in the repo-owned harness validation selection too, so
+standalone `harness:review` catches workflow syntax drift even when the full
+`pr:athena` wrapper is not the command being run.
+
+Remove standalone package test steps or jobs only when all of these stay true:
+
+- the same package suite still runs through the coverage command
+- the coverage summary still enforces the current baseline
+- package-specific lint and audit gates remain separate when they check
+  behavior that coverage does not check
+- workflow guard tests assert that the duplicate no-coverage jobs do not return
+
+If branch protection requires separate app check contexts, keep those contexts
+honest without reintroducing duplicated work. Name the consolidated job after the
+work it performs, update the required status checks to match, and use a small
+dependent context job only when GitHub needs a separate app-level status.
+
+Do not remove the local package `test` scripts. They remain useful for focused
+developer feedback and app-local validation maps. The CI optimization is only
+about avoiding repeated full-suite execution in the same remote PR run.
+
+## Prevention
+
+- Audit package test jobs against `bun run test:coverage` before adding new CI
+  jobs.
+- When `harness:review` runs inside the Athena PR workflow, pass
+  `--validation-provided-by athena-pr-tests` only after the workflow provides the
+  corresponding broad package gates directly: coverage, changed-file lint,
+  architecture checks, and app builds. This keeps harness review responsible for
+  coverage-map integrity and selected runtime behavior scenarios without
+  rerunning package test/build commands already enforced by sibling CI steps.
+- Run `bun run workflow:check` for workflow edits; do not rely on ad hoc
+  PyYAML-based validation unless the repo explicitly adds that dependency.
+- Prefer one authoritative CI gate per behavioral sensor, with focused local
+  commands left available for agents and developers.
+- If a no-coverage package test job is reintroduced, document the distinct
+  signal it catches that coverage cannot catch.
+- Keep workflow-sensitive changes covered by `compound:check` so future CI
+  runtime changes leave a reusable note.

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,11 +1,11 @@
 # Graph Report - .
 
 ## Corpus Check
-- 1679 files · ~0 words
+- 1681 files · ~0 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 5054 nodes · 5060 edges · 1608 communities detected
+- 5061 nodes · 5066 edges · 1610 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -1618,6 +1618,8 @@
 - [[_COMMUNITY_Community 1605|Community 1605]]
 - [[_COMMUNITY_Community 1606|Community 1606]]
 - [[_COMMUNITY_Community 1607|Community 1607]]
+- [[_COMMUNITY_Community 1608|Community 1608]]
+- [[_COMMUNITY_Community 1609|Community 1609]]
 
 ## God Nodes (most connected - your core abstractions)
 1. `createJourneyEvent()` - 40 edges
@@ -1722,20 +1724,20 @@ Cohesion: 0.15
 Nodes (19): acquireExpenseQuantityPatchHold(), adjustExpenseQuantityPatchHold(), createDefaultExpenseSessionCommandService(), createExpenseInventoryHoldGateway(), createExpenseSessionCommandService(), failure(), isActiveRegisterSession(), isSessionExpired() (+11 more)
 
 ### Community 19 - "Community 19"
+Cohesion: 0.15
+Nodes (16): buildGitProcessEnv(), collectCommandsForChangedFiles(), fileExists(), formatMissingPathPrefixError(), getChangedFilesForHarnessReview(), hasAnyHarnessDocs(), loadReviewTarget(), loadReviewTargets() (+8 more)
+
+### Community 20 - "Community 20"
 Cohesion: 0.18
 Nodes (20): attentionSeverity(), buildDailyOperationsSnapshotWithCtx(), buildLanes(), buildWeekMetricForDate(), buildWeekMetrics(), emptyCloseSummary(), getCloseItemCounts(), lifecycleCopy() (+12 more)
 
-### Community 20 - "Community 20"
+### Community 21 - "Community 21"
 Cohesion: 0.25
 Nodes (21): buildActiveCycleCountDraftsSubmissionKey(), buildCycleCountDraftSubmissionKey(), createCycleCountDraftWithCtx(), discardCycleCountDraftCommandWithCtx(), ensureCycleCountDraftCommandWithCtx(), ensureCycleCountDraftWithCtx(), findOpenCycleCountDraftWithCtx(), getActiveCycleCountDraftSummaryWithCtx() (+13 more)
 
-### Community 21 - "Community 21"
+### Community 22 - "Community 22"
 Cohesion: 0.27
 Nodes (20): asBoolean(), asMtnMomoSetupStatus(), asNumber(), asOptionalArray(), asRecord(), asString(), cleanUndefined(), firstDefined() (+12 more)
-
-### Community 22 - "Community 22"
-Cohesion: 0.16
-Nodes (16): buildGitProcessEnv(), collectCommandsForChangedFiles(), fileExists(), formatMissingPathPrefixError(), getChangedFilesForHarnessReview(), hasAnyHarnessDocs(), loadReviewTarget(), loadReviewTargets() (+8 more)
 
 ### Community 23 - "Community 23"
 Cohesion: 0.17
@@ -2294,12 +2296,12 @@ Cohesion: 0.33
 Nodes (1): DataTableToolbar()
 
 ### Community 162 - "Community 162"
-Cohesion: 0.4
-Nodes (2): handlePinChange(), normalizeOtpCode()
-
-### Community 163 - "Community 163"
 Cohesion: 0.53
 Nodes (2): SelectedProductsProvider(), useSelectedProducts()
+
+### Community 163 - "Community 163"
+Cohesion: 0.4
+Nodes (2): handlePinChange(), normalizeOtpCode()
 
 ### Community 164 - "Community 164"
 Cohesion: 0.33
@@ -3575,11 +3577,11 @@ Nodes (0):
 
 ### Community 482 - "Community 482"
 Cohesion: 1.0
-Nodes (2): createFixtureRepo(), write()
+Nodes (2): collectWorkflowFiles(), runWorkflowCheck()
 
 ### Community 483 - "Community 483"
-Cohesion: 1.0
-Nodes (2): createFixtureRepo(), write()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 484 - "Community 484"
 Cohesion: 1.0
@@ -3594,24 +3596,24 @@ Cohesion: 1.0
 Nodes (2): createFixtureRepo(), write()
 
 ### Community 487 - "Community 487"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): createFixtureRepo(), write()
 
 ### Community 488 - "Community 488"
+Cohesion: 1.0
+Nodes (2): createFixtureRepo(), write()
+
+### Community 489 - "Community 489"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 489 - "Community 489"
-Cohesion: 1.0
-Nodes (2): collectRootScriptTestFiles(), runRootScriptsCoverage()
-
 ### Community 490 - "Community 490"
-Cohesion: 1.0
+Cohesion: 0.67
 Nodes (0):
 
 ### Community 491 - "Community 491"
 Cohesion: 1.0
-Nodes (0):
+Nodes (2): collectRootScriptTestFiles(), runRootScriptsCoverage()
 
 ### Community 492 - "Community 492"
 Cohesion: 1.0
@@ -8077,2244 +8079,2252 @@ Nodes (0):
 Cohesion: 1.0
 Nodes (0):
 
+### Community 1608 - "Community 1608"
+Cohesion: 1.0
+Nodes (0):
+
+### Community 1609 - "Community 1609"
+Cohesion: 1.0
+Nodes (0):
+
 ## Knowledge Gaps
 - **1 isolated node(s):** `HelpRequested`
   These have ≤1 connection - possible missing edges or undocumented components.
-- **Thin community `Community 490`** (2 nodes): `getSource()`, `deposits.test.ts`
+- **Thin community `Community 492`** (2 nodes): `getSource()`, `deposits.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 491`** (2 nodes): `paymentAllocationAttribution.test.ts`, `readProjectFile()`
+- **Thin community `Community 493`** (2 nodes): `paymentAllocationAttribution.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 492`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
+- **Thin community `Community 494`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 493`** (2 nodes): `createCommandShimBin()`, `convexAuditScript.test.ts`
+- **Thin community `Community 495`** (2 nodes): `createCommandShimBin()`, `convexAuditScript.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 494`** (2 nodes): `policy.ts`, `assertSupportedCustomerMessagePolicy()`
+- **Thin community `Community 496`** (2 nodes): `policy.ts`, `assertSupportedCustomerMessagePolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 495`** (2 nodes): `repository.test.ts`, `queryResult()`
+- **Thin community `Community 497`** (2 nodes): `repository.test.ts`, `queryResult()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 496`** (2 nodes): `webhookSecurity.test.ts`, `sign()`
+- **Thin community `Community 498`** (2 nodes): `webhookSecurity.test.ts`, `sign()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 497`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
+- **Thin community `Community 499`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 498`** (2 nodes): `subcategories.ts`, `removeStorefrontHiddenSubcategoryList()`
+- **Thin community `Community 500`** (2 nodes): `subcategories.ts`, `removeStorefrontHiddenSubcategoryList()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 499`** (2 nodes): `storefrontCors.test.ts`, `readRouteFile()`
+- **Thin community `Community 501`** (2 nodes): `storefrontCors.test.ts`, `readRouteFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 500`** (2 nodes): `whatsapp.ts`, `mapWebhookStatus()`
+- **Thin community `Community 502`** (2 nodes): `whatsapp.ts`, `mapWebhookStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 501`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
+- **Thin community `Community 503`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 502`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
+- **Thin community `Community 504`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 503`** (2 nodes): `mapAthenaAuthSyncError()`, `auth.ts`
+- **Thin community `Community 505`** (2 nodes): `mapAthenaAuthSyncError()`, `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 504`** (2 nodes): `getHandler()`, `bestSeller.test.ts`
+- **Thin community `Community 506`** (2 nodes): `getHandler()`, `bestSeller.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 505`** (2 nodes): `userErrorFromExpenseItemCommandFailure()`, `expenseSessionItems.ts`
+- **Thin community `Community 507`** (2 nodes): `userErrorFromExpenseItemCommandFailure()`, `expenseSessionItems.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 506`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
+- **Thin community `Community 508`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 507`** (2 nodes): `posSessionItems.ts`, `userErrorFromSessionItemFailure()`
+- **Thin community `Community 509`** (2 nodes): `posSessionItems.ts`, `userErrorFromSessionItemFailure()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 508`** (2 nodes): `productUtil.ts`, `buildAllProductsCacheKey()`
+- **Thin community `Community 510`** (2 nodes): `productUtil.ts`, `buildAllProductsCacheKey()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 509`** (2 nodes): `promoCode.ts`, `calculateSelectedProductPromoDiscount()`
+- **Thin community `Community 511`** (2 nodes): `promoCode.ts`, `calculateSelectedProductPromoDiscount()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 510`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
+- **Thin community `Community 512`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 511`** (2 nodes): `commandResultValidator()`, `commandResultValidators.ts`
+- **Thin community `Community 513`** (2 nodes): `commandResultValidator()`, `commandResultValidators.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 512`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
+- **Thin community `Community 514`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 513`** (2 nodes): `callAnthropic()`, `anthropic.ts`
+- **Thin community `Community 515`** (2 nodes): `callAnthropic()`, `anthropic.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 514`** (2 nodes): `callOpenAi()`, `openai.ts`
+- **Thin community `Community 516`** (2 nodes): `callOpenAi()`, `openai.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 515`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
+- **Thin community `Community 517`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 516`** (2 nodes): `consumeCommandApprovalProofWithCtx()`, `approvalActions.ts`
+- **Thin community `Community 518`** (2 nodes): `consumeCommandApprovalProofWithCtx()`, `approvalActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 517`** (2 nodes): `createOperationalEventCtx()`, `approvalAuditEvents.test.ts`
+- **Thin community `Community 519`** (2 nodes): `createOperationalEventCtx()`, `approvalAuditEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 518`** (2 nodes): `createApprovalProofMutationCtx()`, `approvalProofs.test.ts`
+- **Thin community `Community 520`** (2 nodes): `createApprovalProofMutationCtx()`, `approvalProofs.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 519`** (2 nodes): `buildApprovalRequest()`, `approvalRequestHelpers.ts`
+- **Thin community `Community 521`** (2 nodes): `buildApprovalRequest()`, `approvalRequestHelpers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 520`** (2 nodes): `createApprovalRequestMutationCtx()`, `approvalRequests.test.ts`
+- **Thin community `Community 522`** (2 nodes): `createApprovalRequestMutationCtx()`, `approvalRequests.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 521`** (2 nodes): `buildOperationalEventMessage()`, `eventBuilders.ts`
+- **Thin community `Community 523`** (2 nodes): `buildOperationalEventMessage()`, `eventBuilders.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 522`** (2 nodes): `formatValidTime()`, `EmailOTP.ts`
+- **Thin community `Community 524`** (2 nodes): `formatValidTime()`, `EmailOTP.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 523`** (2 nodes): `quickAddCatalogItem.test.ts`, `createQuickAddCtx()`
+- **Thin community `Community 525`** (2 nodes): `quickAddCatalogItem.test.ts`, `createQuickAddCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 524`** (2 nodes): `expectNoCompletionSideEffects()`, `completeTransaction.test.ts`
+- **Thin community `Community 526`** (2 nodes): `expectNoCompletionSideEffects()`, `completeTransaction.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 525`** (2 nodes): `createMutationCtx()`, `correctTransactionPaymentMethod.test.ts`
+- **Thin community `Community 527`** (2 nodes): `createMutationCtx()`, `correctTransactionPaymentMethod.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 526`** (2 nodes): `buildCorrectionOperationalEvent()`, `correctionEvents.ts`
+- **Thin community `Community 528`** (2 nodes): `buildCorrectionOperationalEvent()`, `correctionEvents.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 527`** (2 nodes): `mockCorrectionHistoryDb()`, `getTransactions.test.ts`
+- **Thin community `Community 529`** (2 nodes): `mockCorrectionHistoryDb()`, `getTransactions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 528`** (2 nodes): `createRegisterCatalogCtx()`, `listRegisterCatalog.test.ts`
+- **Thin community `Community 530`** (2 nodes): `createRegisterCatalogCtx()`, `listRegisterCatalog.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 529`** (2 nodes): `getCashierForRegisterState()`, `cashierRepository.ts`
+- **Thin community `Community 531`** (2 nodes): `getCashierForRegisterState()`, `cashierRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 530`** (2 nodes): `createExpenseSessionCommandRepository()`, `expenseSessionCommandRepository.ts`
+- **Thin community `Community 532`** (2 nodes): `createExpenseSessionCommandRepository()`, `expenseSessionCommandRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 531`** (2 nodes): `sessionCommandRepository.test.ts`, `readProjectFile()`
+- **Thin community `Community 533`** (2 nodes): `sessionCommandRepository.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 532`** (2 nodes): `sessionRepository.test.ts`, `buildSession()`
+- **Thin community `Community 534`** (2 nodes): `sessionRepository.test.ts`, `buildSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 533`** (2 nodes): `transactions.ts`, `mapCorrectionError()`
+- **Thin community `Community 535`** (2 nodes): `transactions.ts`, `mapCorrectionError()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 534`** (2 nodes): `getSource()`, `moduleWiring.test.ts`
+- **Thin community `Community 536`** (2 nodes): `getSource()`, `moduleWiring.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 535`** (2 nodes): `createStockOpsAccessQueryCtx()`, `access.test.ts`
+- **Thin community `Community 537`** (2 nodes): `createStockOpsAccessQueryCtx()`, `access.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 536`** (2 nodes): `requireStoreFullAdminAccess()`, `access.ts`
+- **Thin community `Community 538`** (2 nodes): `requireStoreFullAdminAccess()`, `access.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 537`** (2 nodes): `createCycleCountDraftCtx()`, `cycleCountDrafts.test.ts`
+- **Thin community `Community 539`** (2 nodes): `createCycleCountDraftCtx()`, `cycleCountDrafts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 538`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
+- **Thin community `Community 540`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 539`** (2 nodes): `createQueryCtx()`, `customerBehaviorTimeline.test.ts`
+- **Thin community `Community 541`** (2 nodes): `createQueryCtx()`, `customerBehaviorTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 540`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
+- **Thin community `Community 542`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 541`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
+- **Thin community `Community 543`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 542`** (2 nodes): `createMutationCtx()`, `customerEngagementEvents.test.ts`
+- **Thin community `Community 544`** (2 nodes): `createMutationCtx()`, `customerEngagementEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 543`** (2 nodes): `getSource()`, `onlineOrder.test.ts`
+- **Thin community `Community 545`** (2 nodes): `getSource()`, `onlineOrder.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 544`** (2 nodes): `updateOnlineOrderItem()`, `onlineOrderItem.ts`
+- **Thin community `Community 546`** (2 nodes): `updateOnlineOrderItem()`, `onlineOrderItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 545`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
+- **Thin community `Community 547`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 546`** (2 nodes): `rewards.ts`, `formatPointsLabel()`
+- **Thin community `Community 548`** (2 nodes): `rewards.ts`, `formatPointsLabel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 547`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
+- **Thin community `Community 549`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 548`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
+- **Thin community `Community 550`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 549`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
+- **Thin community `Community 551`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 550`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
+- **Thin community `Community 552`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 551`** (2 nodes): `user.ts`, `getStoreFrontActorById()`
+- **Thin community `Community 553`** (2 nodes): `user.ts`, `getStoreFrontActorById()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 552`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
+- **Thin community `Community 554`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 553`** (2 nodes): `buildExpenseSessionTraceSeed()`, `expenseSession.ts`
+- **Thin community `Community 555`** (2 nodes): `buildExpenseSessionTraceSeed()`, `expenseSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 554`** (2 nodes): `posSession.ts`, `buildPosSessionTraceSeed()`
+- **Thin community `Community 556`** (2 nodes): `posSession.ts`, `buildPosSessionTraceSeed()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 555`** (2 nodes): `presentation.ts`, `buildWorkflowTraceViewModel()`
+- **Thin community `Community 557`** (2 nodes): `presentation.ts`, `buildWorkflowTraceViewModel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 556`** (2 nodes): `schemaIndexes.test.ts`, `getTableIndexes()`
+- **Thin community `Community 558`** (2 nodes): `schemaIndexes.test.ts`, `getTableIndexes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 557`** (2 nodes): `serviceIntake.ts`, `validateServiceIntakeInput()`
+- **Thin community `Community 559`** (2 nodes): `serviceIntake.ts`, `validateServiceIntakeInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 558`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
+- **Thin community `Community 560`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 559`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
+- **Thin community `Community 561`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 560`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
+- **Thin community `Community 562`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 561`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
+- **Thin community `Community 563`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 562`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
+- **Thin community `Community 564`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 563`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
+- **Thin community `Community 565`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 564`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
+- **Thin community `Community 566`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 565`** (2 nodes): `StoreView.tsx`, `Navigation()`
+- **Thin community `Community 567`** (2 nodes): `StoreView.tsx`, `Navigation()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 566`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
+- **Thin community `Community 568`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 567`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
+- **Thin community `Community 569`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 568`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
+- **Thin community `Community 570`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 569`** (2 nodes): `ProductAttributes.tsx`, `isAllowedAttribute()`
+- **Thin community `Community 571`** (2 nodes): `ProductAttributes.tsx`, `isAllowedAttribute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 570`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
+- **Thin community `Community 572`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 571`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
+- **Thin community `Community 573`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 572`** (2 nodes): `ProductImages.tsx`, `Header()`
+- **Thin community `Community 574`** (2 nodes): `ProductImages.tsx`, `Header()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 573`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
+- **Thin community `Community 575`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 574`** (2 nodes): `setIsUpdatingSku()`, `CopyImagesView.tsx`
+- **Thin community `Community 576`** (2 nodes): `setIsUpdatingSku()`, `CopyImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 575`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
+- **Thin community `Community 577`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 576`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
+- **Thin community `Community 578`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 577`** (2 nodes): `AnalyticsCombinedUsers()`, `AnalyticsCombinedUsers.tsx`
+- **Thin community `Community 579`** (2 nodes): `AnalyticsCombinedUsers()`, `AnalyticsCombinedUsers.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 578`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
+- **Thin community `Community 580`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 579`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
+- **Thin community `Community 581`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 580`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
+- **Thin community `Community 582`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 581`** (2 nodes): `formatMetric()`, `AnalyticsView.tsx`
+- **Thin community `Community 583`** (2 nodes): `formatMetric()`, `AnalyticsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 582`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
+- **Thin community `Community 584`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 583`** (2 nodes): `StoreInsights.tsx`, `getTrendIcon()`
+- **Thin community `Community 585`** (2 nodes): `StoreInsights.tsx`, `getTrendIcon()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 584`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
+- **Thin community `Community 586`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 585`** (2 nodes): `readSource()`, `analyticsWorkspaceEfficiency.test.ts`
+- **Thin community `Community 587`** (2 nodes): `readSource()`, `analyticsWorkspaceEfficiency.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 586`** (2 nodes): `LogItems()`, `LogItems.tsx`
+- **Thin community `Community 588`** (2 nodes): `LogItems()`, `LogItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 587`** (2 nodes): `Header()`, `LogView.tsx`
+- **Thin community `Community 589`** (2 nodes): `Header()`, `LogView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 588`** (2 nodes): `Navigation()`, `LogsView.tsx`
+- **Thin community `Community 590`** (2 nodes): `Navigation()`, `LogsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 589`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
+- **Thin community `Community 591`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 590`** (2 nodes): `Passthrough()`, `app-sidebar.test.tsx`
+- **Thin community `Community 592`** (2 nodes): `Passthrough()`, `app-sidebar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 591`** (2 nodes): `SidebarMenuCollapsible()`, `app-sidebar.tsx`
+- **Thin community `Community 593`** (2 nodes): `SidebarMenuCollapsible()`, `app-sidebar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 592`** (2 nodes): `Auth()`, `Auth.tsx`
+- **Thin community `Community 594`** (2 nodes): `Auth()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 593`** (2 nodes): `resolveSignIn()`, `InputOTP.test.tsx`
+- **Thin community `Community 595`** (2 nodes): `resolveSignIn()`, `InputOTP.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 594`** (2 nodes): `Login()`, `index.tsx`
+- **Thin community `Community 596`** (2 nodes): `Login()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 595`** (2 nodes): `DataTableColumnHeader()`, `data-table-column-header.tsx`
+- **Thin community `Community 597`** (2 nodes): `DataTableColumnHeader()`, `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 596`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
+- **Thin community `Community 598`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 597`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
+- **Thin community `Community 599`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 598`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
+- **Thin community `Community 600`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 599`** (2 nodes): `formatReviewReason()`, `formatReviewReason.ts`
+- **Thin community `Community 601`** (2 nodes): `formatReviewReason()`, `formatReviewReason.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 600`** (2 nodes): `registerSessionColumns.tsx`, `RegisterSessionLink()`
+- **Thin community `Community 602`** (2 nodes): `registerSessionColumns.tsx`, `RegisterSessionLink()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 601`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
+- **Thin community `Community 603`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 602`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
+- **Thin community `Community 604`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 603`** (2 nodes): `ExpenseCompletion()`, `ExpenseCompletion.tsx`
+- **Thin community `Community 605`** (2 nodes): `ExpenseCompletion()`, `ExpenseCompletion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 604`** (2 nodes): `ExpenseView()`, `ExpenseView.tsx`
+- **Thin community `Community 606`** (2 nodes): `ExpenseView()`, `ExpenseView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 605`** (2 nodes): `handleAddBestSeller()`, `BestSellersDialog.tsx`
+- **Thin community `Community 607`** (2 nodes): `handleAddBestSeller()`, `BestSellersDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 606`** (2 nodes): `handleAddFeaturedItem()`, `FeaturedSectionDialog.tsx`
+- **Thin community `Community 608`** (2 nodes): `handleAddFeaturedItem()`, `FeaturedSectionDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 607`** (2 nodes): `Navigation()`, `Home.tsx`
+- **Thin community `Community 609`** (2 nodes): `Navigation()`, `Home.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 608`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
+- **Thin community `Community 610`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 609`** (2 nodes): `ShopLookDialog.tsx`, `handleAddFeaturedItem()`
+- **Thin community `Community 611`** (2 nodes): `ShopLookDialog.tsx`, `handleAddFeaturedItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 610`** (2 nodes): `ShopLookImageUploader.tsx`, `ShopLookImageUploader()`
+- **Thin community `Community 612`** (2 nodes): `ShopLookImageUploader.tsx`, `ShopLookImageUploader()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 611`** (2 nodes): `JoinTeam()`, `index.tsx`
+- **Thin community `Community 613`** (2 nodes): `JoinTeam()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 612`** (2 nodes): `Reveal()`, `AthenaLandingPage.tsx`
+- **Thin community `Community 614`** (2 nodes): `Reveal()`, `AthenaLandingPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 613`** (2 nodes): `cn()`, `OperationReviewItemCard.tsx`
+- **Thin community `Community 615`** (2 nodes): `cn()`, `OperationReviewItemCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 614`** (2 nodes): `buildParams()`, `OperationsSummaryMetric.tsx`
+- **Thin community `Community 616`** (2 nodes): `buildParams()`, `OperationsSummaryMetric.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 615`** (2 nodes): `StockAdjustmentWorkspace.test.tsx`, `renderStockAdjustmentWorkspace()`
+- **Thin community `Community 617`** (2 nodes): `StockAdjustmentWorkspace.test.tsx`, `renderStockAdjustmentWorkspace()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 616`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
+- **Thin community `Community 618`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 617`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
+- **Thin community `Community 619`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 618`** (2 nodes): `handleTimeRangeChange()`, `OrderMetricsPanel.tsx`
+- **Thin community `Community 620`** (2 nodes): `handleTimeRangeChange()`, `OrderMetricsPanel.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 619`** (2 nodes): `getTimeFilter()`, `OrdersView.tsx`
+- **Thin community `Community 621`** (2 nodes): `getTimeFilter()`, `OrdersView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 620`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
+- **Thin community `Community 622`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 621`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
+- **Thin community `Community 623`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 622`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
+- **Thin community `Community 624`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 623`** (2 nodes): `if()`, `orderColumns.tsx`
+- **Thin community `Community 625`** (2 nodes): `if()`, `orderColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 624`** (2 nodes): `OrganizationSwitcher()`, `organization-switcher.tsx`
+- **Thin community `Community 626`** (2 nodes): `OrganizationSwitcher()`, `organization-switcher.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 625`** (2 nodes): `cn()`, `CartItems.tsx`
+- **Thin community `Community 627`** (2 nodes): `cn()`, `CartItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 626`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
+- **Thin community `Community 628`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 627`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
+- **Thin community `Community 629`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 628`** (2 nodes): `PinInput.tsx`, `PinInput()`
+- **Thin community `Community 630`** (2 nodes): `PinInput.tsx`, `PinInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 629`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
+- **Thin community `Community 631`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 630`** (2 nodes): `ProductCard.tsx`, `ProductCard()`
+- **Thin community `Community 632`** (2 nodes): `ProductCard.tsx`, `ProductCard()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 631`** (2 nodes): `SearchResultsSection.test.tsx`, `buildProduct()`
+- **Thin community `Community 633`** (2 nodes): `SearchResultsSection.test.tsx`, `buildProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 632`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
+- **Thin community `Community 634`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 633`** (2 nodes): `isToday()`, `ExpenseReportsView.tsx`
+- **Thin community `Community 635`** (2 nodes): `isToday()`, `ExpenseReportsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 634`** (2 nodes): `toExpenseReportRows()`, `expenseReportRows.ts`
+- **Thin community `Community 636`** (2 nodes): `toExpenseReportRows()`, `expenseReportRows.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 635`** (2 nodes): `ExpenseCompletionPanel()`, `ExpenseCompletionPanel.tsx`
+- **Thin community `Community 637`** (2 nodes): `ExpenseCompletionPanel()`, `ExpenseCompletionPanel.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 636`** (2 nodes): `RegisterCustomerAttribution.test.tsx`, `makeCustomer()`
+- **Thin community `Community 638`** (2 nodes): `RegisterCustomerAttribution.test.tsx`, `makeCustomer()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 637`** (2 nodes): `RegisterCustomerPanel.tsx`, `RegisterCustomerPanel()`
+- **Thin community `Community 639`** (2 nodes): `RegisterCustomerPanel.tsx`, `RegisterCustomerPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 638`** (2 nodes): `RegisterDrawerGate.test.tsx`, `renderGate()`
+- **Thin community `Community 640`** (2 nodes): `RegisterDrawerGate.test.tsx`, `renderGate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 639`** (2 nodes): `RegisterSessionPanel.tsx`, `RegisterSessionPanel()`
+- **Thin community `Community 641`** (2 nodes): `RegisterSessionPanel.tsx`, `RegisterSessionPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 640`** (2 nodes): `transactionColumns.test.tsx`, `renderTransactionCell()`
+- **Thin community `Community 642`** (2 nodes): `transactionColumns.test.tsx`, `renderTransactionCell()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 641`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
+- **Thin community `Community 643`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 642`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
+- **Thin community `Community 644`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 643`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
+- **Thin community `Community 645`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 644`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
+- **Thin community `Community 646`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 645`** (2 nodes): `ProductStatus.tsx`, `ProductStatus()`
+- **Thin community `Community 647`** (2 nodes): `ProductStatus.tsx`, `ProductStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 646`** (2 nodes): `SKUSelector.tsx`, `SKUSelector()`
+- **Thin community `Community 648`** (2 nodes): `SKUSelector.tsx`, `SKUSelector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 647`** (2 nodes): `product-actions.tsx`, `useArchiveProduct()`
+- **Thin community `Community 649`** (2 nodes): `product-actions.tsx`, `useArchiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 648`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
+- **Thin community `Community 650`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 649`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
+- **Thin community `Community 651`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 650`** (2 nodes): `Products.tsx`, `Products()`
+- **Thin community `Community 652`** (2 nodes): `Products.tsx`, `Products()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 651`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
+- **Thin community `Community 653`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 652`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
+- **Thin community `Community 654`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 653`** (2 nodes): `PromoCodePreview.tsx`, `Discount()`
+- **Thin community `Community 655`** (2 nodes): `PromoCodePreview.tsx`, `Discount()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 654`** (2 nodes): `PromoCodesView.test.tsx`, `readSource()`
+- **Thin community `Community 656`** (2 nodes): `PromoCodesView.test.tsx`, `readSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 655`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
+- **Thin community `Community 657`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 656`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
+- **Thin community `Community 658`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 657`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
+- **Thin community `Community 659`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 658`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
+- **Thin community `Community 660`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 659`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
+- **Thin community `Community 661`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 660`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
+- **Thin community `Community 662`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 661`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
+- **Thin community `Community 663`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 662`** (2 nodes): `ServiceCasesView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 664`** (2 nodes): `ServiceCasesView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 663`** (2 nodes): `ServiceCatalogView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 665`** (2 nodes): `ServiceCatalogView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 664`** (2 nodes): `ServiceIntakeForm.tsx`, `ServiceIntakeForm()`
+- **Thin community `Community 666`** (2 nodes): `ServiceIntakeForm.tsx`, `ServiceIntakeForm()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 665`** (2 nodes): `ServiceIntakeView.auth.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 667`** (2 nodes): `ServiceIntakeView.auth.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 666`** (2 nodes): `ServiceIntakeView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 668`** (2 nodes): `ServiceIntakeView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 667`** (2 nodes): `onClick()`, `empty-state.tsx`
+- **Thin community `Community 669`** (2 nodes): `onClick()`, `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 668`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
+- **Thin community `Community 670`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 669`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
+- **Thin community `Community 671`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 670`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
+- **Thin community `Community 672`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 671`** (2 nodes): `ProtectedAdminSignInView.tsx`, `ProtectedAdminSignInView()`
+- **Thin community `Community 673`** (2 nodes): `ProtectedAdminSignInView.tsx`, `ProtectedAdminSignInView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 672`** (2 nodes): `ContactView()`, `ContactView.tsx`
+- **Thin community `Community 674`** (2 nodes): `ContactView()`, `ContactView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 673`** (2 nodes): `Header()`, `Header.tsx`
+- **Thin community `Community 675`** (2 nodes): `Header()`, `Header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 674`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
+- **Thin community `Community 676`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 675`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
+- **Thin community `Community 677`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 676`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
+- **Thin community `Community 678`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 677`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
+- **Thin community `Community 679`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 678`** (2 nodes): `useChart()`, `chart.tsx`
+- **Thin community `Community 680`** (2 nodes): `useChart()`, `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 679`** (2 nodes): `handleCopy()`, `copy-button.tsx`
+- **Thin community `Community 681`** (2 nodes): `handleCopy()`, `copy-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 680`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
+- **Thin community `Community 682`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 681`** (2 nodes): `Label()`, `label.tsx`
+- **Thin community `Community 683`** (2 nodes): `Label()`, `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 682`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
+- **Thin community `Community 684`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 683`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
+- **Thin community `Community 685`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 684`** (2 nodes): `store-modal.tsx`, `onSubmit()`
+- **Thin community `Community 686`** (2 nodes): `store-modal.tsx`, `onSubmit()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 685`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
+- **Thin community `Community 687`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 686`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
+- **Thin community `Community 688`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 687`** (2 nodes): `select-native.tsx`, `cn()`
+- **Thin community `Community 689`** (2 nodes): `select-native.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 688`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
+- **Thin community `Community 690`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 689`** (2 nodes): `webp-image.tsx`, `WebpImage()`
+- **Thin community `Community 691`** (2 nodes): `webp-image.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 690`** (2 nodes): `BagItems()`, `BagItems.tsx`
+- **Thin community `Community 692`** (2 nodes): `BagItems()`, `BagItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 691`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
+- **Thin community `Community 693`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 692`** (2 nodes): `Bags()`, `Bags.tsx`
+- **Thin community `Community 694`** (2 nodes): `Bags()`, `Bags.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 693`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
+- **Thin community `Community 695`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 694`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
+- **Thin community `Community 696`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 695`** (2 nodes): `UserBag.tsx`, `UserBag()`
+- **Thin community `Community 697`** (2 nodes): `UserBag.tsx`, `UserBag()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 696`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
+- **Thin community `Community 698`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 697`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
+- **Thin community `Community 699`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 698`** (2 nodes): `UserView.tsx`, `UserActions()`
+- **Thin community `Community 700`** (2 nodes): `UserView.tsx`, `UserActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 699`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
+- **Thin community `Community 701`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 700`** (2 nodes): `wrapper()`, `ManagerElevationContext.test.tsx`
+- **Thin community `Community 702`** (2 nodes): `wrapper()`, `ManagerElevationContext.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 701`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
+- **Thin community `Community 703`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 702`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
+- **Thin community `Community 704`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 703`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
+- **Thin community `Community 705`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 704`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
+- **Thin community `Community 706`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 705`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
+- **Thin community `Community 707`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 706`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
+- **Thin community `Community 708`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 707`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
+- **Thin community `Community 709`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 708`** (2 nodes): `useConvexAuthIdentity.ts`, `useConvexAuthIdentity()`
+- **Thin community `Community 710`** (2 nodes): `useConvexAuthIdentity.ts`, `useConvexAuthIdentity()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 709`** (2 nodes): `useCopyText.ts`, `useCopyText()`
+- **Thin community `Community 711`** (2 nodes): `useCopyText.ts`, `useCopyText()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 710`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
+- **Thin community `Community 712`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 711`** (2 nodes): `useDebounce.ts`, `useDebounce()`
+- **Thin community `Community 713`** (2 nodes): `useDebounce.ts`, `useDebounce()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 712`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
+- **Thin community `Community 714`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 713`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
+- **Thin community `Community 715`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 714`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
+- **Thin community `Community 716`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 715`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
+- **Thin community `Community 717`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 716`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
+- **Thin community `Community 718`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 717`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
+- **Thin community `Community 719`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 718`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
+- **Thin community `Community 720`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 719`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
+- **Thin community `Community 721`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 720`** (2 nodes): `usePermissions.ts`, `usePermissions()`
+- **Thin community `Community 722`** (2 nodes): `usePermissions.ts`, `usePermissions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 721`** (2 nodes): `usePrint.ts`, `usePrint()`
+- **Thin community `Community 723`** (2 nodes): `usePrint.ts`, `usePrint()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 722`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
+- **Thin community `Community 724`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 723`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
+- **Thin community `Community 725`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 724`** (2 nodes): `useProtectedAdminPageState.ts`, `useProtectedAdminPageState()`
+- **Thin community `Community 726`** (2 nodes): `useProtectedAdminPageState.ts`, `useProtectedAdminPageState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 725`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
+- **Thin community `Community 727`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 726`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
+- **Thin community `Community 728`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 727`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
+- **Thin community `Community 729`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 728`** (2 nodes): `toOperatorMessage()`, `operatorMessages.ts`
+- **Thin community `Community 730`** (2 nodes): `toOperatorMessage()`, `operatorMessages.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 729`** (2 nodes): `presentUnexpectedErrorToast.ts`, `presentUnexpectedErrorToast()`
+- **Thin community `Community 731`** (2 nodes): `presentUnexpectedErrorToast.ts`, `presentUnexpectedErrorToast()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 730`** (2 nodes): `getOrigin()`, `navigationUtils.ts`
+- **Thin community `Community 732`** (2 nodes): `getOrigin()`, `navigationUtils.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 731`** (2 nodes): `addItem()`, `addItem.ts`
+- **Thin community `Community 733`** (2 nodes): `addItem()`, `addItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 732`** (2 nodes): `bootstrapRegister()`, `bootstrapRegister.ts`
+- **Thin community `Community 734`** (2 nodes): `bootstrapRegister()`, `bootstrapRegister.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 733`** (2 nodes): `holdSession()`, `holdSession.ts`
+- **Thin community `Community 735`** (2 nodes): `holdSession()`, `holdSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 734`** (2 nodes): `openDrawer()`, `openDrawer.ts`
+- **Thin community `Community 736`** (2 nodes): `openDrawer()`, `openDrawer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 735`** (2 nodes): `startSession.ts`, `startSession()`
+- **Thin community `Community 737`** (2 nodes): `startSession.ts`, `startSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 736`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
+- **Thin community `Community 738`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 737`** (2 nodes): `useRegisterCatalogIndex.ts`, `useRegisterCatalogIndex()`
+- **Thin community `Community 739`** (2 nodes): `useRegisterCatalogIndex.ts`, `useRegisterCatalogIndex()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 738`** (2 nodes): `pinHash.ts`, `hashPin()`
+- **Thin community `Community 740`** (2 nodes): `pinHash.ts`, `hashPin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 739`** (2 nodes): `hasOrgNotFoundPayload()`, `index.tsx`
+- **Thin community `Community 741`** (2 nodes): `hasOrgNotFoundPayload()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 740`** (2 nodes): `$sessionId.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 742`** (2 nodes): `$sessionId.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 741`** (2 nodes): `registers.index.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 743`** (2 nodes): `registers.index.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 742`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
+- **Thin community `Community 744`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 743`** (2 nodes): `ApprovalsRoute()`, `approvals.tsx`
+- **Thin community `Community 745`** (2 nodes): `ApprovalsRoute()`, `approvals.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 744`** (2 nodes): `DailyCloseHistoryRoute()`, `daily-close-history.tsx`
+- **Thin community `Community 746`** (2 nodes): `DailyCloseHistoryRoute()`, `daily-close-history.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 745`** (2 nodes): `DailyCloseRoute()`, `daily-close.tsx`
+- **Thin community `Community 747`** (2 nodes): `DailyCloseRoute()`, `daily-close.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 746`** (2 nodes): `OpenWorkRoute()`, `open-work.tsx`
+- **Thin community `Community 748`** (2 nodes): `OpenWorkRoute()`, `open-work.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 747`** (2 nodes): `DailyOpeningRoute()`, `opening.tsx`
+- **Thin community `Community 749`** (2 nodes): `DailyOpeningRoute()`, `opening.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 748`** (2 nodes): `stock-adjustments.tsx`, `StockAdjustmentsRoute()`
+- **Thin community `Community 750`** (2 nodes): `stock-adjustments.tsx`, `StockAdjustmentsRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 749`** (2 nodes): `ExpenseRouteComponent()`, `expense.index.tsx`
+- **Thin community `Community 751`** (2 nodes): `ExpenseRouteComponent()`, `expense.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 750`** (2 nodes): `published.index.tsx`, `RouteComponent()`
+- **Thin community `Community 752`** (2 nodes): `published.index.tsx`, `RouteComponent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 751`** (2 nodes): `Index()`, `index.tsx`
+- **Thin community `Community 753`** (2 nodes): `Index()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 752`** (2 nodes): `AthenaLoginReadyView()`, `_layout.index.tsx`
+- **Thin community `Community 754`** (2 nodes): `AthenaLoginReadyView()`, `_layout.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 753`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
+- **Thin community `Community 755`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 754`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 756`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 755`** (2 nodes): `view-patterns.tsx`, `cn()`
+- **Thin community `Community 757`** (2 nodes): `view-patterns.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 756`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
+- **Thin community `Community 758`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 757`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
+- **Thin community `Community 759`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 758`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
+- **Thin community `Community 760`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 759`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 761`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 760`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
+- **Thin community `Community 762`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 761`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
+- **Thin community `Community 763`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 762`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
+- **Thin community `Community 764`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 763`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 765`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 764`** (2 nodes): `formatNumber()`, `formatNumber.ts`
+- **Thin community `Community 766`** (2 nodes): `formatNumber()`, `formatNumber.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 765`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
+- **Thin community `Community 767`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 766`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
+- **Thin community `Community 768`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 767`** (2 nodes): `updateGuest()`, `guest.ts`
+- **Thin community `Community 769`** (2 nodes): `updateGuest()`, `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 768`** (2 nodes): `posTransaction.test.ts`, `jsonResponse()`
+- **Thin community `Community 770`** (2 nodes): `posTransaction.test.ts`, `jsonResponse()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 769`** (2 nodes): `storefront.ts`, `getStore()`
+- **Thin community `Community 771`** (2 nodes): `storefront.ts`, `getStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 770`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
+- **Thin community `Community 772`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 771`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
+- **Thin community `Community 773`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 772`** (2 nodes): `AuthComponent()`, `Auth.tsx`
+- **Thin community `Community 774`** (2 nodes): `AuthComponent()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 773`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
+- **Thin community `Community 775`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 774`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
+- **Thin community `Community 776`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 775`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
+- **Thin community `Community 777`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 776`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
+- **Thin community `Community 778`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 777`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
+- **Thin community `Community 779`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 778`** (2 nodes): `PickupDetails()`, `index.tsx`
+- **Thin community `Community 780`** (2 nodes): `PickupDetails()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 779`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
+- **Thin community `Community 781`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 780`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
+- **Thin community `Community 782`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 781`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
+- **Thin community `Community 783`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 782`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
+- **Thin community `Community 784`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 783`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
+- **Thin community `Community 785`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 784`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
+- **Thin community `Community 786`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 785`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
+- **Thin community `Community 787`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 786`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
+- **Thin community `Community 788`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 787`** (2 nodes): `useCountdown()`, `hooks.ts`
+- **Thin community `Community 789`** (2 nodes): `useCountdown()`, `hooks.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 788`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
+- **Thin community `Community 790`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 789`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
+- **Thin community `Community 791`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 790`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
+- **Thin community `Community 792`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 791`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
+- **Thin community `Community 793`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 792`** (2 nodes): `resolveHomepageContent()`, `homePageContent.ts`
+- **Thin community `Community 794`** (2 nodes): `resolveHomepageContent()`, `homePageContent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 793`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
+- **Thin community `Community 795`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 794`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
+- **Thin community `Community 796`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 795`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
+- **Thin community `Community 797`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 796`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
+- **Thin community `Community 798`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 797`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
+- **Thin community `Community 799`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 798`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
+- **Thin community `Community 800`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 799`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
+- **Thin community `Community 801`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 800`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
+- **Thin community `Community 802`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 801`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
+- **Thin community `Community 803`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 802`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
+- **Thin community `Community 804`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 803`** (2 nodes): `ProductPage.test.tsx`, `makePageState()`
+- **Thin community `Community 805`** (2 nodes): `ProductPage.test.tsx`, `makePageState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 804`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
+- **Thin community `Community 806`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 805`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
+- **Thin community `Community 807`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 806`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
+- **Thin community `Community 808`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 807`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
+- **Thin community `Community 809`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 808`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
+- **Thin community `Community 810`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 809`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
+- **Thin community `Community 811`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 810`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
+- **Thin community `Community 812`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 811`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
+- **Thin community `Community 813`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 812`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
+- **Thin community `Community 814`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 813`** (2 nodes): `BagItem()`, `BagItem.tsx`
+- **Thin community `Community 815`** (2 nodes): `BagItem()`, `BagItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 814`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
+- **Thin community `Community 816`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 815`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
+- **Thin community `Community 817`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 816`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
+- **Thin community `Community 818`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 817`** (2 nodes): `CountrySelect()`, `country-select.tsx`
+- **Thin community `Community 819`** (2 nodes): `CountrySelect()`, `country-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 818`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
+- **Thin community `Community 820`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 819`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
+- **Thin community `Community 821`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 820`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
+- **Thin community `Community 822`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 821`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
+- **Thin community `Community 823`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 822`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
+- **Thin community `Community 824`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 823`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
+- **Thin community `Community 825`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 824`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
+- **Thin community `Community 826`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 825`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
+- **Thin community `Community 827`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 826`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
+- **Thin community `Community 828`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 827`** (2 nodes): `useCheckout.ts`, `useCheckout()`
+- **Thin community `Community 829`** (2 nodes): `useCheckout.ts`, `useCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 828`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
+- **Thin community `Community 830`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 829`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
+- **Thin community `Community 831`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 830`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
+- **Thin community `Community 832`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 831`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
+- **Thin community `Community 833`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 832`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
+- **Thin community `Community 834`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 833`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
+- **Thin community `Community 835`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 834`** (2 nodes): `useGetStore.ts`, `useGetStore()`
+- **Thin community `Community 836`** (2 nodes): `useGetStore.ts`, `useGetStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 835`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
+- **Thin community `Community 837`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 836`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
+- **Thin community `Community 838`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 837`** (2 nodes): `useLogout.ts`, `useLogout()`
+- **Thin community `Community 839`** (2 nodes): `useLogout.ts`, `useLogout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 838`** (2 nodes): `useModalState.tsx`, `useModalState()`
+- **Thin community `Community 840`** (2 nodes): `useModalState.tsx`, `useModalState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 839`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
+- **Thin community `Community 841`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 840`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
+- **Thin community `Community 842`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 841`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
+- **Thin community `Community 843`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 842`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
+- **Thin community `Community 844`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 843`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
+- **Thin community `Community 845`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 844`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
+- **Thin community `Community 846`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 845`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
+- **Thin community `Community 847`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 846`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
+- **Thin community `Community 848`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 847`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
+- **Thin community `Community 849`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 848`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
+- **Thin community `Community 850`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 849`** (2 nodes): `useBagQueries()`, `bag.ts`
+- **Thin community `Community 851`** (2 nodes): `useBagQueries()`, `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 850`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
+- **Thin community `Community 852`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 851`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
+- **Thin community `Community 853`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 852`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
+- **Thin community `Community 854`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 853`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
+- **Thin community `Community 855`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 854`** (2 nodes): `posTransaction.ts`, `usePosTransactionQueries()`
+- **Thin community `Community 856`** (2 nodes): `posTransaction.ts`, `usePosTransactionQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 855`** (2 nodes): `product.ts`, `useProductQueries()`
+- **Thin community `Community 857`** (2 nodes): `product.ts`, `useProductQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 856`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
+- **Thin community `Community 858`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 857`** (2 nodes): `reviews.ts`, `useReviewQueries()`
+- **Thin community `Community 859`** (2 nodes): `reviews.ts`, `useReviewQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 858`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
+- **Thin community `Community 860`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 859`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
+- **Thin community `Community 861`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 860`** (2 nodes): `user.ts`, `useUserQueries()`
+- **Thin community `Community 862`** (2 nodes): `user.ts`, `useUserQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 861`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
+- **Thin community `Community 863`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 862`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
+- **Thin community `Community 864`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 863`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
+- **Thin community `Community 865`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 864`** (2 nodes): `validateEmail()`, `email.ts`
+- **Thin community `Community 866`** (2 nodes): `validateEmail()`, `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 865`** (2 nodes): `router.tsx`, `createRouter()`
+- **Thin community `Community 867`** (2 nodes): `router.tsx`, `createRouter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 866`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
+- **Thin community `Community 868`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 867`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
+- **Thin community `Community 869`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 868`** (2 nodes): `ContactUs()`, `contact-us.tsx`
+- **Thin community `Community 870`** (2 nodes): `ContactUs()`, `contact-us.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 869`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
+- **Thin community `Community 871`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 870`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
+- **Thin community `Community 872`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 871`** (2 nodes): `tos.index.tsx`, `TosSection()`
+- **Thin community `Community 873`** (2 nodes): `tos.index.tsx`, `TosSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 872`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
+- **Thin community `Community 874`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 873`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
+- **Thin community `Community 875`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 874`** (2 nodes): `HomeRoute()`, `index.tsx`
+- **Thin community `Community 876`** (2 nodes): `HomeRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 875`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
+- **Thin community `Community 877`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 876`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
+- **Thin community `Community 878`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 877`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
+- **Thin community `Community 879`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 878`** (2 nodes): `ReceiptShareRoute()`, `index.tsx`
+- **Thin community `Community 880`** (2 nodes): `ReceiptShareRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 879`** (2 nodes): `test-connection.js`, `main()`
+- **Thin community `Community 881`** (2 nodes): `test-connection.js`, `main()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 880`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
+- **Thin community `Community 882`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 881`** (2 nodes): `run()`, `architecture-boundary-check.ts`
+- **Thin community `Community 883`** (2 nodes): `run()`, `architecture-boundary-check.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 882`** (2 nodes): `readRepoFile()`, `deploy-qa-vps.test.ts`
+- **Thin community `Community 884`** (2 nodes): `readRepoFile()`, `deploy-qa-vps.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 883`** (2 nodes): `runCommand()`, `github-pr-merge.test.ts`
+- **Thin community `Community 885`** (2 nodes): `runCommand()`, `github-pr-merge.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 884`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
+- **Thin community `Community 886`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 885`** (2 nodes): `shutdown()`, `sample-app.ts`
+- **Thin community `Community 887`** (2 nodes): `shutdown()`, `sample-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 886`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
+- **Thin community `Community 888`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 887`** (1 nodes): `api.d.ts`
+- **Thin community `Community 889`** (1 nodes): `api.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 888`** (1 nodes): `api.js`
+- **Thin community `Community 890`** (1 nodes): `api.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 889`** (1 nodes): `dataModel.d.ts`
+- **Thin community `Community 891`** (1 nodes): `dataModel.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 890`** (1 nodes): `server.d.ts`
+- **Thin community `Community 892`** (1 nodes): `server.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 891`** (1 nodes): `server.js`
+- **Thin community `Community 893`** (1 nodes): `server.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 892`** (1 nodes): `app.ts`
+- **Thin community `Community 894`** (1 nodes): `app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 893`** (1 nodes): `auth.config.js`
+- **Thin community `Community 895`** (1 nodes): `auth.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 894`** (1 nodes): `auth.ts`
+- **Thin community `Community 896`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 895`** (1 nodes): `registerSessions.test.ts`
+- **Thin community `Community 897`** (1 nodes): `registerSessions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 896`** (1 nodes): `r2.test.ts`
+- **Thin community `Community 898`** (1 nodes): `r2.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 897`** (1 nodes): `countries.ts`
+- **Thin community `Community 899`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 898`** (1 nodes): `email.ts`
+- **Thin community `Community 900`** (1 nodes): `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 899`** (1 nodes): `ghana.ts`
+- **Thin community `Community 901`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 900`** (1 nodes): `payment.ts`
+- **Thin community `Community 902`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 901`** (1 nodes): `crons.ts`
+- **Thin community `Community 903`** (1 nodes): `crons.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 902`** (1 nodes): `domain.test.ts`
+- **Thin community `Community 904`** (1 nodes): `domain.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 903`** (1 nodes): `internal.ts`
+- **Thin community `Community 905`** (1 nodes): `internal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 904`** (1 nodes): `public.test.ts`
+- **Thin community `Community 906`** (1 nodes): `public.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 905`** (1 nodes): `token.test.ts`
+- **Thin community `Community 907`** (1 nodes): `token.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 906`** (1 nodes): `whatsappClient.test.ts`
+- **Thin community `Community 908`** (1 nodes): `whatsappClient.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 907`** (1 nodes): `whatsappConfig.test.ts`
+- **Thin community `Community 909`** (1 nodes): `whatsappConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 908`** (1 nodes): `devPatchBadTransaction.ts`
+- **Thin community `Community 910`** (1 nodes): `devPatchBadTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 909`** (1 nodes): `FeedbackRequest.tsx`
+- **Thin community `Community 911`** (1 nodes): `FeedbackRequest.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 910`** (1 nodes): `NewOrderAdmin.tsx`
+- **Thin community `Community 912`** (1 nodes): `NewOrderAdmin.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 911`** (1 nodes): `OrderEmail.tsx`
+- **Thin community `Community 913`** (1 nodes): `OrderEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 912`** (1 nodes): `PosReceiptEmail.tsx`
+- **Thin community `Community 914`** (1 nodes): `PosReceiptEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 913`** (1 nodes): `env.ts`
+- **Thin community `Community 915`** (1 nodes): `env.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 914`** (1 nodes): `analytics.ts`
+- **Thin community `Community 916`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 915`** (1 nodes): `auth.ts`
+- **Thin community `Community 917`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 916`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 918`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 917`** (1 nodes): `colors.ts`
+- **Thin community `Community 919`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 918`** (1 nodes): `index.ts`
+- **Thin community `Community 920`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 919`** (1 nodes): `organizations.ts`
+- **Thin community `Community 921`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 920`** (1 nodes): `products.ts`
+- **Thin community `Community 922`** (1 nodes): `products.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 921`** (1 nodes): `storefrontHidden.test.ts`
+- **Thin community `Community 923`** (1 nodes): `storefrontHidden.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 922`** (1 nodes): `stores.ts`
+- **Thin community `Community 924`** (1 nodes): `stores.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 923`** (1 nodes): `bag.ts`
+- **Thin community `Community 925`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 924`** (1 nodes): `guest.ts`
+- **Thin community `Community 926`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 925`** (1 nodes): `index.ts`
+- **Thin community `Community 927`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 926`** (1 nodes): `me.ts`
+- **Thin community `Community 928`** (1 nodes): `me.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 927`** (1 nodes): `offers.ts`
+- **Thin community `Community 929`** (1 nodes): `offers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 928`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 930`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 929`** (1 nodes): `paystack.ts`
+- **Thin community `Community 931`** (1 nodes): `paystack.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 930`** (1 nodes): `posTransaction.ts`
+- **Thin community `Community 932`** (1 nodes): `posTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 931`** (1 nodes): `reviews.ts`
+- **Thin community `Community 933`** (1 nodes): `reviews.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 932`** (1 nodes): `rewards.ts`
+- **Thin community `Community 934`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 933`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 935`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 934`** (1 nodes): `security.test.ts`
+- **Thin community `Community 936`** (1 nodes): `security.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 935`** (1 nodes): `storefront.ts`
+- **Thin community `Community 937`** (1 nodes): `storefront.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 936`** (1 nodes): `upsells.ts`
+- **Thin community `Community 938`** (1 nodes): `upsells.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 937`** (1 nodes): `user.ts`
+- **Thin community `Community 939`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 938`** (1 nodes): `userOffers.ts`
+- **Thin community `Community 940`** (1 nodes): `userOffers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 939`** (1 nodes): `index.ts`
+- **Thin community `Community 941`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 940`** (1 nodes): `health.test.ts`
+- **Thin community `Community 942`** (1 nodes): `health.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 941`** (1 nodes): `http.ts`
+- **Thin community `Community 943`** (1 nodes): `http.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 942`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 944`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 943`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 945`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 944`** (1 nodes): `bestSeller.ts`
+- **Thin community `Community 946`** (1 nodes): `bestSeller.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 945`** (1 nodes): `categories.ts`
+- **Thin community `Community 947`** (1 nodes): `categories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 946`** (1 nodes): `colors.ts`
+- **Thin community `Community 948`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 947`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 949`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 948`** (1 nodes): `expenseTransactions.test.ts`
+- **Thin community `Community 950`** (1 nodes): `expenseTransactions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 949`** (1 nodes): `featuredItem.ts`
+- **Thin community `Community 951`** (1 nodes): `featuredItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 950`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 952`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 951`** (1 nodes): `organizationMembers.ts`
+- **Thin community `Community 953`** (1 nodes): `organizationMembers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 952`** (1 nodes): `organizations.ts`
+- **Thin community `Community 954`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 953`** (1 nodes): `pos.ts`
+- **Thin community `Community 955`** (1 nodes): `pos.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 954`** (1 nodes): `posCustomers.ts`
+- **Thin community `Community 956`** (1 nodes): `posCustomers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 955`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 957`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 956`** (1 nodes): `productSku.ts`
+- **Thin community `Community 958`** (1 nodes): `productSku.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 957`** (1 nodes): `productUtil.test.ts`
+- **Thin community `Community 959`** (1 nodes): `productUtil.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 958`** (1 nodes): `promoCode.test.ts`
+- **Thin community `Community 960`** (1 nodes): `promoCode.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 959`** (1 nodes): `stockValidation.ts`
+- **Thin community `Community 961`** (1 nodes): `stockValidation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 960`** (1 nodes): `storeConfigV2.test.ts`
+- **Thin community `Community 962`** (1 nodes): `storeConfigV2.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 961`** (1 nodes): `subcategories.ts`
+- **Thin community `Community 963`** (1 nodes): `subcategories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 962`** (1 nodes): `commandResultValidators.test.ts`
+- **Thin community `Community 964`** (1 nodes): `commandResultValidators.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 963`** (1 nodes): `currency.test.ts`
+- **Thin community `Community 965`** (1 nodes): `currency.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 964`** (1 nodes): `storeInsights.ts`
+- **Thin community `Community 966`** (1 nodes): `storeInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 965`** (1 nodes): `userInsights.ts`
+- **Thin community `Community 967`** (1 nodes): `userInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 966`** (1 nodes): `migrateAmountsToPesewas.ts`
+- **Thin community `Community 968`** (1 nodes): `migrateAmountsToPesewas.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 967`** (1 nodes): `client.test.ts`
+- **Thin community `Community 969`** (1 nodes): `client.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 968`** (1 nodes): `config.test.ts`
+- **Thin community `Community 970`** (1 nodes): `config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 969`** (1 nodes): `normalize.test.ts`
+- **Thin community `Community 971`** (1 nodes): `normalize.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 970`** (1 nodes): `types.ts`
+- **Thin community `Community 972`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 971`** (1 nodes): `customerProfiles.test.ts`
+- **Thin community `Community 973`** (1 nodes): `customerProfiles.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 972`** (1 nodes): `inventoryMovements.test.ts`
+- **Thin community `Community 974`** (1 nodes): `inventoryMovements.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 973`** (1 nodes): `paymentAllocations.test.ts`
+- **Thin community `Community 975`** (1 nodes): `paymentAllocations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 974`** (1 nodes): `EmailOTP.test.ts`
+- **Thin community `Community 976`** (1 nodes): `EmailOTP.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 975`** (1 nodes): `correctTransactionCustomer.test.ts`
+- **Thin community `Community 977`** (1 nodes): `correctTransactionCustomer.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 976`** (1 nodes): `correctionEvents.test.ts`
+- **Thin community `Community 978`** (1 nodes): `correctionEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 977`** (1 nodes): `correctionPolicy.test.ts`
+- **Thin community `Community 979`** (1 nodes): `correctionPolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 978`** (1 nodes): `dto.ts`
+- **Thin community `Community 980`** (1 nodes): `dto.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 979`** (1 nodes): `getRegisterState.test.ts`
+- **Thin community `Community 981`** (1 nodes): `getRegisterState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 980`** (1 nodes): `posSessionTracing.test.ts`
+- **Thin community `Community 982`** (1 nodes): `posSessionTracing.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 981`** (1 nodes): `terminals.test.ts`
+- **Thin community `Community 983`** (1 nodes): `terminals.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 982`** (1 nodes): `types.ts`
+- **Thin community `Community 984`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 983`** (1 nodes): `registerSessionRepository.test.ts`
+- **Thin community `Community 985`** (1 nodes): `registerSessionRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 984`** (1 nodes): `catalog.ts`
+- **Thin community `Community 986`** (1 nodes): `catalog.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 985`** (1 nodes): `customers.ts`
+- **Thin community `Community 987`** (1 nodes): `customers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 986`** (1 nodes): `register.ts`
+- **Thin community `Community 988`** (1 nodes): `register.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 987`** (1 nodes): `terminals.ts`
+- **Thin community `Community 989`** (1 nodes): `terminals.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 988`** (1 nodes): `schema.ts`
+- **Thin community `Community 990`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 989`** (1 nodes): `customerMessageDelivery.ts`
+- **Thin community `Community 991`** (1 nodes): `customerMessageDelivery.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 990`** (1 nodes): `index.ts`
+- **Thin community `Community 992`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 991`** (1 nodes): `receiptShareToken.ts`
+- **Thin community `Community 993`** (1 nodes): `receiptShareToken.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 992`** (1 nodes): `appVerificationCode.ts`
+- **Thin community `Community 994`** (1 nodes): `appVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 993`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 995`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 994`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 996`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 995`** (1 nodes): `bestSeller.ts`
+- **Thin community `Community 997`** (1 nodes): `bestSeller.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 996`** (1 nodes): `category.ts`
+- **Thin community `Community 998`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 997`** (1 nodes): `color.ts`
+- **Thin community `Community 999`** (1 nodes): `color.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 998`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 1000`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 999`** (1 nodes): `featuredItem.ts`
+- **Thin community `Community 1001`** (1 nodes): `featuredItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1000`** (1 nodes): `index.ts`
+- **Thin community `Community 1002`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1001`** (1 nodes): `inventoryHold.ts`
+- **Thin community `Community 1003`** (1 nodes): `inventoryHold.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1002`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 1004`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1003`** (1 nodes): `organization.ts`
+- **Thin community `Community 1005`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1004`** (1 nodes): `organizationMember.ts`
+- **Thin community `Community 1006`** (1 nodes): `organizationMember.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1005`** (1 nodes): `product.ts`
+- **Thin community `Community 1007`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1006`** (1 nodes): `promoCode.ts`
+- **Thin community `Community 1008`** (1 nodes): `promoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1007`** (1 nodes): `redeemedPromoCode.ts`
+- **Thin community `Community 1009`** (1 nodes): `redeemedPromoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1008`** (1 nodes): `store.ts`
+- **Thin community `Community 1010`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1009`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1011`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1010`** (1 nodes): `index.ts`
+- **Thin community `Community 1012`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1011`** (1 nodes): `workflowTrace.ts`
+- **Thin community `Community 1013`** (1 nodes): `workflowTrace.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1012`** (1 nodes): `workflowTraceEvent.ts`
+- **Thin community `Community 1014`** (1 nodes): `workflowTraceEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1013`** (1 nodes): `workflowTraceLookup.ts`
+- **Thin community `Community 1015`** (1 nodes): `workflowTraceLookup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1014`** (1 nodes): `approvalRequest.ts`
+- **Thin community `Community 1016`** (1 nodes): `approvalRequest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1015`** (1 nodes): `customerProfile.ts`
+- **Thin community `Community 1017`** (1 nodes): `customerProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1016`** (1 nodes): `dailyClose.ts`
+- **Thin community `Community 1018`** (1 nodes): `dailyClose.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1017`** (1 nodes): `dailyOpening.ts`
+- **Thin community `Community 1019`** (1 nodes): `dailyOpening.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1018`** (1 nodes): `index.ts`
+- **Thin community `Community 1020`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1019`** (1 nodes): `inventoryMovement.ts`
+- **Thin community `Community 1021`** (1 nodes): `inventoryMovement.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1020`** (1 nodes): `managerElevation.ts`
+- **Thin community `Community 1022`** (1 nodes): `managerElevation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1021`** (1 nodes): `operationalEvent.ts`
+- **Thin community `Community 1023`** (1 nodes): `operationalEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1022`** (1 nodes): `operationalWorkItem.ts`
+- **Thin community `Community 1024`** (1 nodes): `operationalWorkItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1023`** (1 nodes): `paymentAllocation.ts`
+- **Thin community `Community 1025`** (1 nodes): `paymentAllocation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1024`** (1 nodes): `registerSession.ts`
+- **Thin community `Community 1026`** (1 nodes): `registerSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1025`** (1 nodes): `staffCredential.ts`
+- **Thin community `Community 1027`** (1 nodes): `staffCredential.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1026`** (1 nodes): `staffProfile.ts`
+- **Thin community `Community 1028`** (1 nodes): `staffProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1027`** (1 nodes): `staffRoleAssignment.ts`
+- **Thin community `Community 1029`** (1 nodes): `staffRoleAssignment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1028`** (1 nodes): `mtnCollections.ts`
+- **Thin community `Community 1030`** (1 nodes): `mtnCollections.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1029`** (1 nodes): `customer.ts`
+- **Thin community `Community 1031`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1030`** (1 nodes): `expenseSession.ts`
+- **Thin community `Community 1032`** (1 nodes): `expenseSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1031`** (1 nodes): `expenseSessionItem.ts`
+- **Thin community `Community 1033`** (1 nodes): `expenseSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1032`** (1 nodes): `expenseTransaction.ts`
+- **Thin community `Community 1034`** (1 nodes): `expenseTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1033`** (1 nodes): `expenseTransactionItem.ts`
+- **Thin community `Community 1035`** (1 nodes): `expenseTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1034`** (1 nodes): `index.ts`
+- **Thin community `Community 1036`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1035`** (1 nodes): `posSession.ts`
+- **Thin community `Community 1037`** (1 nodes): `posSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1036`** (1 nodes): `posSessionItem.ts`
+- **Thin community `Community 1038`** (1 nodes): `posSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1037`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 1039`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1038`** (1 nodes): `posTransaction.ts`
+- **Thin community `Community 1040`** (1 nodes): `posTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1039`** (1 nodes): `posTransactionItem.ts`
+- **Thin community `Community 1041`** (1 nodes): `posTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1040`** (1 nodes): `index.ts`
+- **Thin community `Community 1042`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1041`** (1 nodes): `serviceAppointment.ts`
+- **Thin community `Community 1043`** (1 nodes): `serviceAppointment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1042`** (1 nodes): `serviceCase.ts`
+- **Thin community `Community 1044`** (1 nodes): `serviceCase.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1043`** (1 nodes): `serviceCaseLineItem.ts`
+- **Thin community `Community 1045`** (1 nodes): `serviceCaseLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1044`** (1 nodes): `serviceCatalog.ts`
+- **Thin community `Community 1046`** (1 nodes): `serviceCatalog.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1045`** (1 nodes): `serviceInventoryUsage.ts`
+- **Thin community `Community 1047`** (1 nodes): `serviceInventoryUsage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1046`** (1 nodes): `cycleCountDraft.ts`
+- **Thin community `Community 1048`** (1 nodes): `cycleCountDraft.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1047`** (1 nodes): `index.ts`
+- **Thin community `Community 1049`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1048`** (1 nodes): `purchaseOrder.ts`
+- **Thin community `Community 1050`** (1 nodes): `purchaseOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1049`** (1 nodes): `purchaseOrderLineItem.ts`
+- **Thin community `Community 1051`** (1 nodes): `purchaseOrderLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1050`** (1 nodes): `receivingBatch.ts`
+- **Thin community `Community 1052`** (1 nodes): `receivingBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1051`** (1 nodes): `stockAdjustmentBatch.ts`
+- **Thin community `Community 1053`** (1 nodes): `stockAdjustmentBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1052`** (1 nodes): `vendor.ts`
+- **Thin community `Community 1054`** (1 nodes): `vendor.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1053`** (1 nodes): `analytics.ts`
+- **Thin community `Community 1055`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1054`** (1 nodes): `bag.ts`
+- **Thin community `Community 1056`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1055`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1057`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1056`** (1 nodes): `checkoutSession.ts`
+- **Thin community `Community 1058`** (1 nodes): `checkoutSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1057`** (1 nodes): `checkoutSessionItem.ts`
+- **Thin community `Community 1059`** (1 nodes): `checkoutSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1058`** (1 nodes): `guest.ts`
+- **Thin community `Community 1060`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1059`** (1 nodes): `index.ts`
+- **Thin community `Community 1061`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1060`** (1 nodes): `offer.ts`
+- **Thin community `Community 1062`** (1 nodes): `offer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1061`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 1063`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1062`** (1 nodes): `onlineOrderItem.ts`
+- **Thin community `Community 1064`** (1 nodes): `onlineOrderItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1063`** (1 nodes): `review.ts`
+- **Thin community `Community 1065`** (1 nodes): `review.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1064`** (1 nodes): `rewards.ts`
+- **Thin community `Community 1066`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1065`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 1067`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1066`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 1068`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1067`** (1 nodes): `storeFrontSession.ts`
+- **Thin community `Community 1069`** (1 nodes): `storeFrontSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1068`** (1 nodes): `storeFrontUser.ts`
+- **Thin community `Community 1070`** (1 nodes): `storeFrontUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1069`** (1 nodes): `storeFrontVerificationCode.ts`
+- **Thin community `Community 1071`** (1 nodes): `storeFrontVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1070`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 1072`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1071`** (1 nodes): `catalogAppointments.test.ts`
+- **Thin community `Community 1073`** (1 nodes): `catalogAppointments.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1072`** (1 nodes): `bag.ts`
+- **Thin community `Community 1074`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1073`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1075`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1074`** (1 nodes): `checkoutSession.test.ts`
+- **Thin community `Community 1076`** (1 nodes): `checkoutSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1075`** (1 nodes): `customer.ts`
+- **Thin community `Community 1077`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1076`** (1 nodes): `guest.ts`
+- **Thin community `Community 1078`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1077`** (1 nodes): `offers.test.ts`
+- **Thin community `Community 1079`** (1 nodes): `offers.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1078`** (1 nodes): `onlineOrderUtilFns.ts`
+- **Thin community `Community 1080`** (1 nodes): `onlineOrderUtilFns.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1079`** (1 nodes): `orderOperations.test.ts`
+- **Thin community `Community 1081`** (1 nodes): `orderOperations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1080`** (1 nodes): `payment.test.ts`
+- **Thin community `Community 1082`** (1 nodes): `payment.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1081`** (1 nodes): `payment.ts`
+- **Thin community `Community 1083`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1082`** (1 nodes): `paystackActions.ts`
+- **Thin community `Community 1084`** (1 nodes): `paystackActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1083`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 1085`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1084`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 1086`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1085`** (1 nodes): `users.ts`
+- **Thin community `Community 1087`** (1 nodes): `users.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1086`** (1 nodes): `payment.ts`
+- **Thin community `Community 1088`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1087`** (1 nodes): `posSession.test.ts`
+- **Thin community `Community 1089`** (1 nodes): `posSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1088`** (1 nodes): `registerSession.test.ts`
+- **Thin community `Community 1090`** (1 nodes): `registerSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1089`** (1 nodes): `presentation.test.ts`
+- **Thin community `Community 1091`** (1 nodes): `presentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1090`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 1092`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1091`** (1 nodes): `index.ts`
+- **Thin community `Community 1093`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1092`** (1 nodes): `postcss.config.js`
+- **Thin community `Community 1094`** (1 nodes): `postcss.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1093`** (1 nodes): `approvalPolicy.ts`
+- **Thin community `Community 1095`** (1 nodes): `approvalPolicy.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1094`** (1 nodes): `auth.ts`
+- **Thin community `Community 1096`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1095`** (1 nodes): `commandResult.test.ts`
+- **Thin community `Community 1097`** (1 nodes): `commandResult.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1096`** (1 nodes): `currencyFormatter.test.ts`
+- **Thin community `Community 1098`** (1 nodes): `currencyFormatter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1097`** (1 nodes): `registerSessionStatus.test.ts`
+- **Thin community `Community 1099`** (1 nodes): `registerSessionStatus.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1098`** (1 nodes): `staffDisplayName.test.ts`
+- **Thin community `Community 1100`** (1 nodes): `staffDisplayName.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1099`** (1 nodes): `GenericComboBox.tsx`
+- **Thin community `Community 1101`** (1 nodes): `GenericComboBox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1100`** (1 nodes): `StoreAccordion.tsx`
+- **Thin community `Community 1102`** (1 nodes): `StoreAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1101`** (1 nodes): `StoresAccordion.tsx`
+- **Thin community `Community 1103`** (1 nodes): `StoresAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1102`** (1 nodes): `ThemeToggle.tsx`
+- **Thin community `Community 1104`** (1 nodes): `ThemeToggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1103`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
+- **Thin community `Community 1105`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1104`** (1 nodes): `ProductAttributesView.tsx`
+- **Thin community `Community 1106`** (1 nodes): `ProductAttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1105`** (1 nodes): `ProductStock.test.ts`
+- **Thin community `Community 1107`** (1 nodes): `ProductStock.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1106`** (1 nodes): `ProductView.test.tsx`
+- **Thin community `Community 1108`** (1 nodes): `ProductView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1107`** (1 nodes): `constants.ts`
+- **Thin community `Community 1109`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1108`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1110`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1109`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1111`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1110`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1112`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1111`** (1 nodes): `types.ts`
+- **Thin community `Community 1113`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1112`** (1 nodes): `ConversionFunnelChart.tsx`
+- **Thin community `Community 1114`** (1 nodes): `ConversionFunnelChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1113`** (1 nodes): `RevenueChart.tsx`
+- **Thin community `Community 1115`** (1 nodes): `RevenueChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1114`** (1 nodes): `analytics-columns.tsx`
+- **Thin community `Community 1116`** (1 nodes): `analytics-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1115`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1117`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1116`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1118`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1117`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1119`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1118`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1120`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1119`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1121`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1120`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1122`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1121`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1123`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1122`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1124`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1123`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1125`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1124`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1126`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1125`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1127`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1126`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1128`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1127`** (1 nodes): `chart.tsx`
+- **Thin community `Community 1129`** (1 nodes): `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1128`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1130`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1129`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1131`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1130`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1132`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1131`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1133`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1132`** (1 nodes): `constants.ts`
+- **Thin community `Community 1134`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1133`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1135`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1134`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1136`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1135`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1137`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1136`** (1 nodes): `data.ts`
+- **Thin community `Community 1138`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1137`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1139`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1138`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1140`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1139`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1141`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1140`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1142`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1141`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1143`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1142`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1144`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1143`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1145`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1144`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1146`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1145`** (1 nodes): `assetsColumns.tsx`
+- **Thin community `Community 1147`** (1 nodes): `assetsColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1146`** (1 nodes): `constants.ts`
+- **Thin community `Community 1148`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1147`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1149`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1148`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1150`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1149`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1151`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1150`** (1 nodes): `data.ts`
+- **Thin community `Community 1152`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1151`** (1 nodes): `DefaultCatchBoundary.test.tsx`
+- **Thin community `Community 1153`** (1 nodes): `DefaultCatchBoundary.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1152`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 1154`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1153`** (1 nodes): `LoginForm.test.tsx`
+- **Thin community `Community 1155`** (1 nodes): `LoginForm.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1154`** (1 nodes): `LoginForm.tsx`
+- **Thin community `Community 1156`** (1 nodes): `LoginForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1155`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1157`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1156`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1158`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1157`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1159`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1158`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1160`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1159`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1161`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1160`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1162`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1161`** (1 nodes): `constants.ts`
+- **Thin community `Community 1163`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1162`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1164`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1163`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1165`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1164`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1166`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1165`** (1 nodes): `BulkOperationsPage.tsx`
+- **Thin community `Community 1167`** (1 nodes): `BulkOperationsPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1166`** (1 nodes): `CashControlsDashboard.auth.test.tsx`
+- **Thin community `Community 1168`** (1 nodes): `CashControlsDashboard.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1167`** (1 nodes): `CashControlsDashboard.test.tsx`
+- **Thin community `Community 1169`** (1 nodes): `CashControlsDashboard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1168`** (1 nodes): `CashControlsWorkspaceHeader.tsx`
+- **Thin community `Community 1170`** (1 nodes): `CashControlsWorkspaceHeader.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1169`** (1 nodes): `RegisterSessionView.auth.test.tsx`
+- **Thin community `Community 1171`** (1 nodes): `RegisterSessionView.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1170`** (1 nodes): `RegisterSessionView.test.tsx`
+- **Thin community `Community 1172`** (1 nodes): `RegisterSessionView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1171`** (1 nodes): `RegisterSessionsView.test.tsx`
+- **Thin community `Community 1173`** (1 nodes): `RegisterSessionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1172`** (1 nodes): `formatReviewReason.test.ts`
+- **Thin community `Community 1174`** (1 nodes): `formatReviewReason.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1173`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1175`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1174`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1176`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1175`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1177`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1176`** (1 nodes): `ListPagination.tsx`
+- **Thin community `Community 1178`** (1 nodes): `ListPagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1177`** (1 nodes): `PageLevelHeader.test.tsx`
+- **Thin community `Community 1179`** (1 nodes): `PageLevelHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1178`** (1 nodes): `PageLevelHeader.tsx`
+- **Thin community `Community 1180`** (1 nodes): `PageLevelHeader.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1179`** (1 nodes): `MetricCard.tsx`
+- **Thin community `Community 1181`** (1 nodes): `MetricCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1180`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 1182`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1181`** (1 nodes): `CommandApprovalDialog.test.tsx`
+- **Thin community `Community 1183`** (1 nodes): `CommandApprovalDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1182`** (1 nodes): `OperationReviewWorkspace.tsx`
+- **Thin community `Community 1184`** (1 nodes): `OperationReviewWorkspace.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1183`** (1 nodes): `OperationsQueueView.auth.test.tsx`
+- **Thin community `Community 1185`** (1 nodes): `OperationsQueueView.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1184`** (1 nodes): `useApprovedCommand.test.tsx`
+- **Thin community `Community 1186`** (1 nodes): `useApprovedCommand.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1185`** (1 nodes): `OrderStatus.test.tsx`
+- **Thin community `Community 1187`** (1 nodes): `OrderStatus.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1186`** (1 nodes): `OrderStatus.tsx`
+- **Thin community `Community 1188`** (1 nodes): `OrderStatus.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1187`** (1 nodes): `OrderSummary.tsx`
+- **Thin community `Community 1189`** (1 nodes): `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1188`** (1 nodes): `Orders.tsx`
+- **Thin community `Community 1190`** (1 nodes): `Orders.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1189`** (1 nodes): `RefundsView.test.tsx`
+- **Thin community `Community 1191`** (1 nodes): `RefundsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1190`** (1 nodes): `ReturnExchangeView.test.tsx`
+- **Thin community `Community 1192`** (1 nodes): `ReturnExchangeView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1191`** (1 nodes): `constants.ts`
+- **Thin community `Community 1193`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1192`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1194`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1193`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1195`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1194`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1196`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1195`** (1 nodes): `data.ts`
+- **Thin community `Community 1197`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1196`** (1 nodes): `refundUtils.test.ts`
+- **Thin community `Community 1198`** (1 nodes): `refundUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1197`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1199`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1198`** (1 nodes): `constants.ts`
+- **Thin community `Community 1200`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1199`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1201`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1200`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1202`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1201`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1203`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1202`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1204`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1203`** (1 nodes): `data.ts`
+- **Thin community `Community 1205`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1204`** (1 nodes): `inviteColumns.tsx`
+- **Thin community `Community 1206`** (1 nodes): `inviteColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1205`** (1 nodes): `constants.ts`
+- **Thin community `Community 1207`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1206`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1208`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1207`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1209`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1208`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1210`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1209`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1211`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1210`** (1 nodes): `data.ts`
+- **Thin community `Community 1212`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1211`** (1 nodes): `membersColumns.tsx`
+- **Thin community `Community 1213`** (1 nodes): `membersColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1212`** (1 nodes): `organization-switcher.test.tsx`
+- **Thin community `Community 1214`** (1 nodes): `organization-switcher.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1213`** (1 nodes): `CashierAuthDialog.test.tsx`
+- **Thin community `Community 1215`** (1 nodes): `CashierAuthDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1214`** (1 nodes): `CashierView.tsx`
+- **Thin community `Community 1216`** (1 nodes): `CashierView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1215`** (1 nodes): `POSRegisterView.tsx`
+- **Thin community `Community 1217`** (1 nodes): `POSRegisterView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1216`** (1 nodes): `PaymentView.test.tsx`
+- **Thin community `Community 1218`** (1 nodes): `PaymentView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1217`** (1 nodes): `PointOfSaleView.test.tsx`
+- **Thin community `Community 1219`** (1 nodes): `PointOfSaleView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1218`** (1 nodes): `PointOfSaleView.tsx`
+- **Thin community `Community 1220`** (1 nodes): `PointOfSaleView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1219`** (1 nodes): `ProductLookup.tsx`
+- **Thin community `Community 1221`** (1 nodes): `ProductLookup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1220`** (1 nodes): `RegisterActions.tsx`
+- **Thin community `Community 1222`** (1 nodes): `RegisterActions.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1221`** (1 nodes): `SessionManager.test.tsx`
+- **Thin community `Community 1223`** (1 nodes): `SessionManager.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1222`** (1 nodes): `SessionManager.tsx`
+- **Thin community `Community 1224`** (1 nodes): `SessionManager.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1223`** (1 nodes): `TotalsDisplay.test.tsx`
+- **Thin community `Community 1225`** (1 nodes): `TotalsDisplay.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1224`** (1 nodes): `TotalsDisplay.tsx`
+- **Thin community `Community 1226`** (1 nodes): `TotalsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1225`** (1 nodes): `ExpenseReportView.tsx`
+- **Thin community `Community 1227`** (1 nodes): `ExpenseReportView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1226`** (1 nodes): `ExpenseReportsView.test.ts`
+- **Thin community `Community 1228`** (1 nodes): `ExpenseReportsView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1227`** (1 nodes): `ExpenseReportsView.test.tsx`
+- **Thin community `Community 1229`** (1 nodes): `ExpenseReportsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1228`** (1 nodes): `expenseReportColumns.tsx`
+- **Thin community `Community 1230`** (1 nodes): `expenseReportColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1229`** (1 nodes): `PosReceiptShareControl.test.tsx`
+- **Thin community `Community 1231`** (1 nodes): `PosReceiptShareControl.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1230`** (1 nodes): `POSRegisterOpeningGuard.test.tsx`
+- **Thin community `Community 1232`** (1 nodes): `POSRegisterOpeningGuard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1231`** (1 nodes): `POSRegisterView.test.tsx`
+- **Thin community `Community 1233`** (1 nodes): `POSRegisterView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1232`** (1 nodes): `RegisterActionBar.test.tsx`
+- **Thin community `Community 1234`** (1 nodes): `RegisterActionBar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1233`** (1 nodes): `RegisterActionBar.tsx`
+- **Thin community `Community 1235`** (1 nodes): `RegisterActionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1234`** (1 nodes): `RegisterCheckoutPanel.tsx`
+- **Thin community `Community 1236`** (1 nodes): `RegisterCheckoutPanel.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1235`** (1 nodes): `HeldSessionsList.test.tsx`
+- **Thin community `Community 1237`** (1 nodes): `HeldSessionsList.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1236`** (1 nodes): `POSSessionsView.test.tsx`
+- **Thin community `Community 1238`** (1 nodes): `POSSessionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1237`** (1 nodes): `posSessionColumns.tsx`
+- **Thin community `Community 1239`** (1 nodes): `posSessionColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1238`** (1 nodes): `TransactionsView.test.tsx`
+- **Thin community `Community 1240`** (1 nodes): `TransactionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1239`** (1 nodes): `types.ts`
+- **Thin community `Community 1241`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1240`** (1 nodes): `ReceivingView.test.tsx`
+- **Thin community `Community 1242`** (1 nodes): `ReceivingView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1241`** (1 nodes): `AnalyticsInsights.tsx`
+- **Thin community `Community 1243`** (1 nodes): `AnalyticsInsights.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1242`** (1 nodes): `AttributesView.tsx`
+- **Thin community `Community 1244`** (1 nodes): `AttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1243`** (1 nodes): `DetailsView.tsx`
+- **Thin community `Community 1245`** (1 nodes): `DetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1244`** (1 nodes): `ProductDetailView.tsx`
+- **Thin community `Community 1246`** (1 nodes): `ProductDetailView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1245`** (1 nodes): `ArchivedProducts.tsx`
+- **Thin community `Community 1247`** (1 nodes): `ArchivedProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1246`** (1 nodes): `CategoryListView.tsx`
+- **Thin community `Community 1248`** (1 nodes): `CategoryListView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1247`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
+- **Thin community `Community 1249`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1248`** (1 nodes): `Products.tsx`
+- **Thin community `Community 1250`** (1 nodes): `Products.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1249`** (1 nodes): `StoreProducts.tsx`
+- **Thin community `Community 1251`** (1 nodes): `StoreProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1250`** (1 nodes): `UnresolvedProducts.tsx`
+- **Thin community `Community 1252`** (1 nodes): `UnresolvedProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1251`** (1 nodes): `ComplimentaryProducts.tsx`
+- **Thin community `Community 1253`** (1 nodes): `ComplimentaryProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1252`** (1 nodes): `complimentaryProductsColumn.tsx`
+- **Thin community `Community 1254`** (1 nodes): `complimentaryProductsColumn.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1253`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1255`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1254`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1256`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1255`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1257`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1256`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1258`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1257`** (1 nodes): `data.ts`
+- **Thin community `Community 1259`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1258`** (1 nodes): `productColumns.tsx`
+- **Thin community `Community 1260`** (1 nodes): `productColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1259`** (1 nodes): `PromoCodeHeader.test.tsx`
+- **Thin community `Community 1261`** (1 nodes): `PromoCodeHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1260`** (1 nodes): `PromoCodes.tsx`
+- **Thin community `Community 1262`** (1 nodes): `PromoCodes.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1261`** (1 nodes): `PromoCodeAnalytics.tsx`
+- **Thin community `Community 1263`** (1 nodes): `PromoCodeAnalytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1262`** (1 nodes): `captured-emails-columns.tsx`
+- **Thin community `Community 1264`** (1 nodes): `captured-emails-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1263`** (1 nodes): `promoCodeMoney.test.ts`
+- **Thin community `Community 1265`** (1 nodes): `promoCodeMoney.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1264`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1266`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1265`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1267`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1266`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1268`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1267`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1269`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1268`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1270`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1269`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1271`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1270`** (1 nodes): `constants.ts`
+- **Thin community `Community 1272`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1271`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1273`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1272`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1274`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1273`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1275`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1274`** (1 nodes): `data.ts`
+- **Thin community `Community 1276`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1275`** (1 nodes): `types.ts`
+- **Thin community `Community 1277`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1276`** (1 nodes): `welcome-offer-card.tsx`
+- **Thin community `Community 1278`** (1 nodes): `welcome-offer-card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1277`** (1 nodes): `RatingStars.tsx`
+- **Thin community `Community 1279`** (1 nodes): `RatingStars.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1278`** (1 nodes): `ReviewCard.tsx`
+- **Thin community `Community 1280`** (1 nodes): `ReviewCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1279`** (1 nodes): `ReviewMetadata.tsx`
+- **Thin community `Community 1281`** (1 nodes): `ReviewMetadata.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1280`** (1 nodes): `ServicesWorkspaceView.test.tsx`
+- **Thin community `Community 1282`** (1 nodes): `ServicesWorkspaceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1281`** (1 nodes): `index.tsx`
+- **Thin community `Community 1283`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1282`** (1 nodes): `StaffAuthenticationDialog.test.tsx`
+- **Thin community `Community 1284`** (1 nodes): `StaffAuthenticationDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1283`** (1 nodes): `FeesView.test.ts`
+- **Thin community `Community 1285`** (1 nodes): `FeesView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1284`** (1 nodes): `FulfillmentView.test.tsx`
+- **Thin community `Community 1286`** (1 nodes): `FulfillmentView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1285`** (1 nodes): `MaintenanceView.test.tsx`
+- **Thin community `Community 1287`** (1 nodes): `MaintenanceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1286`** (1 nodes): `MtnMomoView.test.tsx`
+- **Thin community `Community 1288`** (1 nodes): `MtnMomoView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1287`** (1 nodes): `useStoreConfigUpdate.test.tsx`
+- **Thin community `Community 1289`** (1 nodes): `useStoreConfigUpdate.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1288`** (1 nodes): `index.tsx`
+- **Thin community `Community 1290`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1289`** (1 nodes): `WorkflowTraceView.test.tsx`
+- **Thin community `Community 1291`** (1 nodes): `WorkflowTraceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1290`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 1292`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1291`** (1 nodes): `button.test.tsx`
+- **Thin community `Community 1293`** (1 nodes): `button.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1292`** (1 nodes): `button.tsx`
+- **Thin community `Community 1294`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1293`** (1 nodes): `calendar.test.tsx`
+- **Thin community `Community 1295`** (1 nodes): `calendar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1294`** (1 nodes): `card.tsx`
+- **Thin community `Community 1296`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1295`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 1297`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1296`** (1 nodes): `collapsible.tsx`
+- **Thin community `Community 1298`** (1 nodes): `collapsible.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1297`** (1 nodes): `command.tsx`
+- **Thin community `Community 1299`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1298`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 1300`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1299`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 1301`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1300`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 1302`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1301`** (1 nodes): `form.tsx`
+- **Thin community `Community 1303`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1302`** (1 nodes): `icons.tsx`
+- **Thin community `Community 1304`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1303`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 1305`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1304`** (1 nodes): `input.tsx`
+- **Thin community `Community 1306`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1305`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 1307`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1306`** (1 nodes): `panel-header.tsx`
+- **Thin community `Community 1308`** (1 nodes): `panel-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1307`** (1 nodes): `popover.tsx`
+- **Thin community `Community 1309`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1308`** (1 nodes): `primitives.test.tsx`
+- **Thin community `Community 1310`** (1 nodes): `primitives.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1309`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 1311`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1310`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 1312`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1311`** (1 nodes): `select.tsx`
+- **Thin community `Community 1313`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1312`** (1 nodes): `separator.tsx`
+- **Thin community `Community 1314`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1313`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 1315`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1314`** (1 nodes): `switch.tsx`
+- **Thin community `Community 1316`** (1 nodes): `switch.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1315`** (1 nodes): `table.tsx`
+- **Thin community `Community 1317`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1316`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 1318`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1317`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 1319`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1318`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 1320`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1319`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 1321`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1320`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 1322`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1321`** (1 nodes): `upload-button.tsx`
+- **Thin community `Community 1323`** (1 nodes): `upload-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1322`** (1 nodes): `BagView.tsx`
+- **Thin community `Community 1324`** (1 nodes): `BagView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1323`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1325`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1324`** (1 nodes): `constants.ts`
+- **Thin community `Community 1326`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1325`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1327`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1326`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1328`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1327`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1329`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1328`** (1 nodes): `data.ts`
+- **Thin community `Community 1330`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1329`** (1 nodes): `bag-columns.tsx`
+- **Thin community `Community 1331`** (1 nodes): `bag-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1330`** (1 nodes): `bags-table.tsx`
+- **Thin community `Community 1332`** (1 nodes): `bags-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1331`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1333`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1332`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1334`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1333`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1335`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1334`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1336`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1335`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1337`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1336`** (1 nodes): `LinkedAccounts.tsx`
+- **Thin community `Community 1338`** (1 nodes): `LinkedAccounts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1337`** (1 nodes): `TimelineEventCard.test.tsx`
+- **Thin community `Community 1339`** (1 nodes): `TimelineEventCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1338`** (1 nodes): `UserCheckoutSession.tsx`
+- **Thin community `Community 1340`** (1 nodes): `UserCheckoutSession.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1339`** (1 nodes): `UserInsightsSection.tsx`
+- **Thin community `Community 1341`** (1 nodes): `UserInsightsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1340`** (1 nodes): `UserBehaviorInsights.tsx`
+- **Thin community `Community 1342`** (1 nodes): `UserBehaviorInsights.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1341`** (1 nodes): `index.ts`
+- **Thin community `Community 1343`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1342`** (1 nodes): `config.test.ts`
+- **Thin community `Community 1344`** (1 nodes): `config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1343`** (1 nodes): `ThemeContext.tsx`
+- **Thin community `Community 1345`** (1 nodes): `ThemeContext.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1344`** (1 nodes): `design-system-build-config.test.ts`
+- **Thin community `Community 1346`** (1 nodes): `design-system-build-config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1345`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 1347`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1346`** (1 nodes): `useAuth.test.tsx`
+- **Thin community `Community 1348`** (1 nodes): `useAuth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1347`** (1 nodes): `useExpenseSessions.test.ts`
+- **Thin community `Community 1349`** (1 nodes): `useExpenseSessions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1348`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 1350`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1349`** (1 nodes): `useProtectedAdminPageState.test.tsx`
+- **Thin community `Community 1351`** (1 nodes): `useProtectedAdminPageState.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1350`** (1 nodes): `capabilities.test.ts`
+- **Thin community `Community 1352`** (1 nodes): `capabilities.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1351`** (1 nodes): `aws.ts`
+- **Thin community `Community 1353`** (1 nodes): `aws.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1352`** (1 nodes): `constants.ts`
+- **Thin community `Community 1354`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1353`** (1 nodes): `countries.ts`
+- **Thin community `Community 1355`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1354`** (1 nodes): `operatorMessages.test.ts`
+- **Thin community `Community 1356`** (1 nodes): `operatorMessages.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1355`** (1 nodes): `presentCommandToast.test.ts`
+- **Thin community `Community 1357`** (1 nodes): `presentCommandToast.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1356`** (1 nodes): `presentUnexpectedErrorToast.test.ts`
+- **Thin community `Community 1358`** (1 nodes): `presentUnexpectedErrorToast.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1357`** (1 nodes): `runCommand.test.ts`
+- **Thin community `Community 1359`** (1 nodes): `runCommand.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1358`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1360`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1359`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 1361`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1360`** (1 nodes): `dto.ts`
+- **Thin community `Community 1362`** (1 nodes): `dto.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1361`** (1 nodes): `ports.ts`
+- **Thin community `Community 1363`** (1 nodes): `ports.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1362`** (1 nodes): `constants.ts`
+- **Thin community `Community 1364`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1363`** (1 nodes): `displayAmounts.test.ts`
+- **Thin community `Community 1365`** (1 nodes): `displayAmounts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1364`** (1 nodes): `cart.test.ts`
+- **Thin community `Community 1366`** (1 nodes): `cart.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1365`** (1 nodes): `index.ts`
+- **Thin community `Community 1367`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1366`** (1 nodes): `session.test.ts`
+- **Thin community `Community 1368`** (1 nodes): `session.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1367`** (1 nodes): `types.ts`
+- **Thin community `Community 1369`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1368`** (1 nodes): `registerGateway.test.ts`
+- **Thin community `Community 1370`** (1 nodes): `registerGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1369`** (1 nodes): `sessionGateway.test.ts`
+- **Thin community `Community 1371`** (1 nodes): `sessionGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1370`** (1 nodes): `loggerGateway.ts`
+- **Thin community `Community 1372`** (1 nodes): `loggerGateway.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1371`** (1 nodes): `catalogSearch.test.ts`
+- **Thin community `Community 1373`** (1 nodes): `catalogSearch.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1372`** (1 nodes): `registerUiState.ts`
+- **Thin community `Community 1374`** (1 nodes): `registerUiState.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1373`** (1 nodes): `productUtils.test.ts`
+- **Thin community `Community 1375`** (1 nodes): `productUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1374`** (1 nodes): `category.ts`
+- **Thin community `Community 1376`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1375`** (1 nodes): `product.ts`
+- **Thin community `Community 1377`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1376`** (1 nodes): `store.ts`
+- **Thin community `Community 1378`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1377`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1379`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1378`** (1 nodes): `user.ts`
+- **Thin community `Community 1380`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1379`** (1 nodes): `storeConfig.test.ts`
+- **Thin community `Community 1381`** (1 nodes): `storeConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1380`** (1 nodes): `createWorkflowTraceId.test.ts`
+- **Thin community `Community 1382`** (1 nodes): `createWorkflowTraceId.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1381`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1383`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1382`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 1384`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1383`** (1 nodes): `__root.tsx`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1384`** (1 nodes): `index.tsx`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1385`** (1 nodes): `index.tsx`
+- **Thin community `Community 1385`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1386`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1387`** (1 nodes): `$storeUrlSlug.tsx`
+- **Thin community `Community 1387`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1388`** (1 nodes): `analytics.tsx`
+- **Thin community `Community 1388`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1389`** (1 nodes): `assets.index.tsx`
+- **Thin community `Community 1389`** (1 nodes): `$storeUrlSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1390`** (1 nodes): `bags.$bagId.tsx`
+- **Thin community `Community 1390`** (1 nodes): `analytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1391`** (1 nodes): `bags.index.tsx`
+- **Thin community `Community 1391`** (1 nodes): `assets.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1392`** (1 nodes): `index.tsx`
+- **Thin community `Community 1392`** (1 nodes): `bags.$bagId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1393`** (1 nodes): `checkout-sessions.index.tsx`
+- **Thin community `Community 1393`** (1 nodes): `bags.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1394`** (1 nodes): `configuration.index.tsx`
+- **Thin community `Community 1394`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1395`** (1 nodes): `dashboard.index.tsx`
+- **Thin community `Community 1395`** (1 nodes): `checkout-sessions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1396`** (1 nodes): `home.tsx`
+- **Thin community `Community 1396`** (1 nodes): `configuration.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1397`** (1 nodes): `logs.$logId.tsx`
+- **Thin community `Community 1397`** (1 nodes): `dashboard.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1398`** (1 nodes): `logs.index.tsx`
+- **Thin community `Community 1398`** (1 nodes): `home.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1399`** (1 nodes): `members.index.tsx`
+- **Thin community `Community 1399`** (1 nodes): `logs.$logId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1400`** (1 nodes): `index.tsx`
+- **Thin community `Community 1400`** (1 nodes): `logs.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1401`** (1 nodes): `index.tsx`
+- **Thin community `Community 1401`** (1 nodes): `members.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1402`** (1 nodes): `all.index.tsx`
+- **Thin community `Community 1402`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1403`** (1 nodes): `cancelled.index.tsx`
+- **Thin community `Community 1403`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1404`** (1 nodes): `completed.index.tsx`
+- **Thin community `Community 1404`** (1 nodes): `all.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1405`** (1 nodes): `index.tsx`
+- **Thin community `Community 1405`** (1 nodes): `cancelled.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1406`** (1 nodes): `open.index.tsx`
+- **Thin community `Community 1406`** (1 nodes): `completed.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1407`** (1 nodes): `out-for-delivery.index.tsx`
+- **Thin community `Community 1407`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1408`** (1 nodes): `ready.index.tsx`
+- **Thin community `Community 1408`** (1 nodes): `open.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1409`** (1 nodes): `refunded.index.tsx`
+- **Thin community `Community 1409`** (1 nodes): `out-for-delivery.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1410`** (1 nodes): `$reportId.tsx`
+- **Thin community `Community 1410`** (1 nodes): `ready.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1411`** (1 nodes): `expense-reports.index.tsx`
+- **Thin community `Community 1411`** (1 nodes): `refunded.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1412`** (1 nodes): `index.tsx`
+- **Thin community `Community 1412`** (1 nodes): `$reportId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1413`** (1 nodes): `register.index.tsx`
+- **Thin community `Community 1413`** (1 nodes): `expense-reports.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1414`** (1 nodes): `sessions.index.tsx`
+- **Thin community `Community 1414`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1415`** (1 nodes): `settings.index.tsx`
+- **Thin community `Community 1415`** (1 nodes): `register.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1416`** (1 nodes): `$transactionId.tsx`
+- **Thin community `Community 1416`** (1 nodes): `sessions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1417`** (1 nodes): `transactions.index.tsx`
+- **Thin community `Community 1417`** (1 nodes): `settings.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1418`** (1 nodes): `procurement.index.test.ts`
+- **Thin community `Community 1418`** (1 nodes): `$transactionId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1419`** (1 nodes): `edit.tsx`
+- **Thin community `Community 1419`** (1 nodes): `transactions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1420`** (1 nodes): `index.tsx`
+- **Thin community `Community 1420`** (1 nodes): `procurement.index.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1421`** (1 nodes): `archived.tsx`
+- **Thin community `Community 1421`** (1 nodes): `edit.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1422`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1423`** (1 nodes): `new.tsx`
+- **Thin community `Community 1423`** (1 nodes): `archived.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1424`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1425`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1426`** (1 nodes): `unresolved.tsx`
+- **Thin community `Community 1426`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1427`** (1 nodes): `$promoCodeSlug.tsx`
+- **Thin community `Community 1427`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1428`** (1 nodes): `index.tsx`
+- **Thin community `Community 1428`** (1 nodes): `unresolved.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1429`** (1 nodes): `new.tsx`
+- **Thin community `Community 1429`** (1 nodes): `$promoCodeSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1430`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1431`** (1 nodes): `new.index.tsx`
+- **Thin community `Community 1431`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1432`** (1 nodes): `active-cases.index.tsx`
+- **Thin community `Community 1432`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1433`** (1 nodes): `appointments.index.tsx`
+- **Thin community `Community 1433`** (1 nodes): `new.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1434`** (1 nodes): `catalog-management.index.tsx`
+- **Thin community `Community 1434`** (1 nodes): `active-cases.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1435`** (1 nodes): `index.tsx`
+- **Thin community `Community 1435`** (1 nodes): `appointments.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1436`** (1 nodes): `intake.index.tsx`
+- **Thin community `Community 1436`** (1 nodes): `catalog-management.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1437`** (1 nodes): `$traceId.test.tsx`
+- **Thin community `Community 1437`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1438`** (1 nodes): `users.$userId.tsx`
+- **Thin community `Community 1438`** (1 nodes): `intake.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1439`** (1 nodes): `index.tsx`
+- **Thin community `Community 1439`** (1 nodes): `$traceId.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1440`** (1 nodes): `_authed.test.tsx`
+- **Thin community `Community 1440`** (1 nodes): `users.$userId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1441`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 1441`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1442`** (1 nodes): `join-team.index.tsx`
+- **Thin community `Community 1442`** (1 nodes): `_authed.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1443`** (1 nodes): `landing.tsx`
+- **Thin community `Community 1443`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1444`** (1 nodes): `_layout.index.test.tsx`
+- **Thin community `Community 1444`** (1 nodes): `join-team.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1445`** (1 nodes): `_layout.test.tsx`
+- **Thin community `Community 1445`** (1 nodes): `landing.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1446`** (1 nodes): `StoresSettingsAccordion.tsx`
+- **Thin community `Community 1446`** (1 nodes): `_layout.index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1447`** (1 nodes): `expenseStore.ts`
+- **Thin community `Community 1447`** (1 nodes): `_layout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1448`** (1 nodes): `Overview.stories.tsx`
+- **Thin community `Community 1448`** (1 nodes): `StoresSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1449`** (1 nodes): `foundations-content.test.tsx`
+- **Thin community `Community 1449`** (1 nodes): `expenseStore.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1450`** (1 nodes): `Introduction.stories.tsx`
+- **Thin community `Community 1450`** (1 nodes): `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1451`** (1 nodes): `introduction-content.test.tsx`
+- **Thin community `Community 1451`** (1 nodes): `foundations-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1452`** (1 nodes): `introduction-content.tsx`
+- **Thin community `Community 1452`** (1 nodes): `Introduction.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1453`** (1 nodes): `AdminShell.stories.tsx`
+- **Thin community `Community 1453`** (1 nodes): `introduction-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1454`** (1 nodes): `View.stories.tsx`
+- **Thin community `Community 1454`** (1 nodes): `introduction-content.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1455`** (1 nodes): `admin-shell-patterns.test.tsx`
+- **Thin community `Community 1455`** (1 nodes): `AdminShell.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1456`** (1 nodes): `view-patterns.test.tsx`
+- **Thin community `Community 1456`** (1 nodes): `View.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1457`** (1 nodes): `Surfaces.stories.tsx`
+- **Thin community `Community 1457`** (1 nodes): `admin-shell-patterns.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1458`** (1 nodes): `DashboardWorkspace.stories.tsx`
+- **Thin community `Community 1458`** (1 nodes): `view-patterns.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1459`** (1 nodes): `DataWorkspace.stories.tsx`
+- **Thin community `Community 1459`** (1 nodes): `Surfaces.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1460`** (1 nodes): `SettingsWorkspace.stories.tsx`
+- **Thin community `Community 1460`** (1 nodes): `DashboardWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1461`** (1 nodes): `reference-fixtures.test.tsx`
+- **Thin community `Community 1461`** (1 nodes): `DataWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1462`** (1 nodes): `storybook-config.test.ts`
+- **Thin community `Community 1462`** (1 nodes): `SettingsWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1463`** (1 nodes): `storybook-theme-decorator.test.ts`
+- **Thin community `Community 1463`** (1 nodes): `reference-fixtures.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1464`** (1 nodes): `setup.ts`
+- **Thin community `Community 1464`** (1 nodes): `storybook-config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1465`** (1 nodes): `usePrint.test.ts`
+- **Thin community `Community 1465`** (1 nodes): `storybook-theme-decorator.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1466`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 1466`** (1 nodes): `setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1467`** (1 nodes): `types.ts`
+- **Thin community `Community 1467`** (1 nodes): `usePrint.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1468`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 1468`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1469`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 1469`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1470`** (1 nodes): `global.d.ts`
+- **Thin community `Community 1470`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1471`** (1 nodes): `playwright.config.ts`
+- **Thin community `Community 1471`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1472`** (1 nodes): `analytics.test.ts`
+- **Thin community `Community 1472`** (1 nodes): `global.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1473`** (1 nodes): `types.ts`
+- **Thin community `Community 1473`** (1 nodes): `playwright.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1474`** (1 nodes): `HeartIconFilled.tsx`
+- **Thin community `Community 1474`** (1 nodes): `analytics.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1475`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 1475`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1476`** (1 nodes): `HomePage.test.tsx`
+- **Thin community `Community 1476`** (1 nodes): `HeartIconFilled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1477`** (1 nodes): `ProductCard.test.tsx`
+- **Thin community `Community 1477`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1478`** (1 nodes): `ProductCard.tsx`
+- **Thin community `Community 1478`** (1 nodes): `HomePage.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1479`** (1 nodes): `Upsell.tsx`
+- **Thin community `Community 1479`** (1 nodes): `ProductCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1480`** (1 nodes): `Checkout.test.tsx`
+- **Thin community `Community 1480`** (1 nodes): `ProductCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1481`** (1 nodes): `Checkout.tsx`
+- **Thin community `Community 1481`** (1 nodes): `Upsell.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1482`** (1 nodes): `CustomerInfoSection.tsx`
+- **Thin community `Community 1482`** (1 nodes): `Checkout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1483`** (1 nodes): `schema.ts`
+- **Thin community `Community 1483`** (1 nodes): `Checkout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1484`** (1 nodes): `DeliveryDetailsSection.tsx`
+- **Thin community `Community 1484`** (1 nodes): `CustomerInfoSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1485`** (1 nodes): `checkoutStorage.test.ts`
+- **Thin community `Community 1485`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1486`** (1 nodes): `deliveryFees.test.ts`
+- **Thin community `Community 1486`** (1 nodes): `DeliveryDetailsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1487`** (1 nodes): `deriveCheckoutState.test.ts`
+- **Thin community `Community 1487`** (1 nodes): `checkoutStorage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1488`** (1 nodes): `billingDetailsSchema.ts`
+- **Thin community `Community 1488`** (1 nodes): `deliveryFees.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1489`** (1 nodes): `checkoutFormSchema.ts`
+- **Thin community `Community 1489`** (1 nodes): `deriveCheckoutState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1490`** (1 nodes): `customerDetailsSchema.ts`
+- **Thin community `Community 1490`** (1 nodes): `billingDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1491`** (1 nodes): `deliveryDetailsSchema.ts`
+- **Thin community `Community 1491`** (1 nodes): `checkoutFormSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1492`** (1 nodes): `webOrderSchema.ts`
+- **Thin community `Community 1492`** (1 nodes): `customerDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1493`** (1 nodes): `types.ts`
+- **Thin community `Community 1493`** (1 nodes): `deliveryDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1494`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1494`** (1 nodes): `webOrderSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1495`** (1 nodes): `ProductFilterBar.tsx`
+- **Thin community `Community 1495`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1496`** (1 nodes): `BestSellersSection.test.tsx`
+- **Thin community `Community 1496`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1497`** (1 nodes): `HomeHero.tsx`
+- **Thin community `Community 1497`** (1 nodes): `ProductFilterBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1498`** (1 nodes): `HomeHeroSection.tsx`
+- **Thin community `Community 1498`** (1 nodes): `BestSellersSection.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1499`** (1 nodes): `homePageContent.test.ts`
+- **Thin community `Community 1499`** (1 nodes): `HomeHero.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1500`** (1 nodes): `MobileMenu.tsx`
+- **Thin community `Community 1500`** (1 nodes): `HomeHeroSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1501`** (1 nodes): `constants.ts`
+- **Thin community `Community 1501`** (1 nodes): `homePageContent.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1502`** (1 nodes): `navBarConstants.ts`
+- **Thin community `Community 1502`** (1 nodes): `MobileMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1503`** (1 nodes): `About.tsx`
+- **Thin community `Community 1503`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1504`** (1 nodes): `AboutProduct.tsx`
+- **Thin community `Community 1504`** (1 nodes): `navBarConstants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1505`** (1 nodes): `ProductActions.test.tsx`
+- **Thin community `Community 1505`** (1 nodes): `About.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1506`** (1 nodes): `ProductInfo.tsx`
+- **Thin community `Community 1506`** (1 nodes): `AboutProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1507`** (1 nodes): `ProductReviews.tsx`
+- **Thin community `Community 1507`** (1 nodes): `ProductActions.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1508`** (1 nodes): `ProductsNavigationBar.tsx`
+- **Thin community `Community 1508`** (1 nodes): `ProductInfo.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1509`** (1 nodes): `ErrorMessage.tsx`
+- **Thin community `Community 1509`** (1 nodes): `ProductReviews.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1510`** (1 nodes): `ExistingReviewMessage.tsx`
+- **Thin community `Community 1510`** (1 nodes): `ProductsNavigationBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1511`** (1 nodes): `OrderItem.test.tsx`
+- **Thin community `Community 1511`** (1 nodes): `ErrorMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1512`** (1 nodes): `ReviewForm.tsx`
+- **Thin community `Community 1512`** (1 nodes): `ExistingReviewMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1513`** (1 nodes): `SuccessMessage.tsx`
+- **Thin community `Community 1513`** (1 nodes): `OrderItem.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1514`** (1 nodes): `types.ts`
+- **Thin community `Community 1514`** (1 nodes): `ReviewForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1515`** (1 nodes): `SavedBag.tsx`
+- **Thin community `Community 1515`** (1 nodes): `SuccessMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1516`** (1 nodes): `SavedIcon.tsx`
+- **Thin community `Community 1516`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1517`** (1 nodes): `CartIcon.tsx`
+- **Thin community `Community 1517`** (1 nodes): `SavedBag.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1518`** (1 nodes): `ShoppingBag.test.tsx`
+- **Thin community `Community 1518`** (1 nodes): `SavedIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1519`** (1 nodes): `empty-state.tsx`
+- **Thin community `Community 1519`** (1 nodes): `CartIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1520`** (1 nodes): `Maintenance.test.tsx`
+- **Thin community `Community 1520`** (1 nodes): `ShoppingBag.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1521`** (1 nodes): `Maintenance.tsx`
+- **Thin community `Community 1521`** (1 nodes): `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1522`** (1 nodes): `AnimatedCard.tsx`
+- **Thin community `Community 1522`** (1 nodes): `Maintenance.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1523`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 1523`** (1 nodes): `Maintenance.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1524`** (1 nodes): `alert.tsx`
+- **Thin community `Community 1524`** (1 nodes): `AnimatedCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1525`** (1 nodes): `breadcrumb.tsx`
+- **Thin community `Community 1525`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1526`** (1 nodes): `button.tsx`
+- **Thin community `Community 1526`** (1 nodes): `alert.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1527`** (1 nodes): `card.tsx`
+- **Thin community `Community 1527`** (1 nodes): `breadcrumb.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1528`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 1528`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1529`** (1 nodes): `command.tsx`
+- **Thin community `Community 1529`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1530`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 1530`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1531`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 1531`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1532`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 1532`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1533`** (1 nodes): `form.tsx`
+- **Thin community `Community 1533`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1534`** (1 nodes): `icons.tsx`
+- **Thin community `Community 1534`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1535`** (1 nodes): `image-with-fallback.tsx`
+- **Thin community `Community 1535`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1536`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 1536`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1537`** (1 nodes): `input-with-end-button.tsx`
+- **Thin community `Community 1537`** (1 nodes): `image-with-fallback.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1538`** (1 nodes): `input.tsx`
+- **Thin community `Community 1538`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1539`** (1 nodes): `label.tsx`
+- **Thin community `Community 1539`** (1 nodes): `input-with-end-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1540`** (1 nodes): `LeaveAReviewModalForm.tsx`
+- **Thin community `Community 1540`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1541`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 1541`** (1 nodes): `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1542`** (1 nodes): `welcomeBackModalAnimations.ts`
+- **Thin community `Community 1542`** (1 nodes): `LeaveAReviewModalForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1543`** (1 nodes): `index.ts`
+- **Thin community `Community 1543`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1544`** (1 nodes): `types.ts`
+- **Thin community `Community 1544`** (1 nodes): `welcomeBackModalAnimations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1545`** (1 nodes): `navigation-menu.tsx`
+- **Thin community `Community 1545`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1546`** (1 nodes): `popover.tsx`
+- **Thin community `Community 1546`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1547`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 1547`** (1 nodes): `navigation-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1548`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 1548`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1549`** (1 nodes): `select.tsx`
+- **Thin community `Community 1549`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1550`** (1 nodes): `separator.tsx`
+- **Thin community `Community 1550`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1551`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 1551`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1552`** (1 nodes): `table.tsx`
+- **Thin community `Community 1552`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1553`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 1553`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1554`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 1554`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1555`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 1555`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1556`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 1556`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1557`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 1557`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1558`** (1 nodes): `config.ts`
+- **Thin community `Community 1558`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1559`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 1559`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1560`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 1560`** (1 nodes): `config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1561`** (1 nodes): `useQueryEnabled.test.ts`
+- **Thin community `Community 1561`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1562`** (1 nodes): `useStorefrontObservability.ts`
+- **Thin community `Community 1562`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1563`** (1 nodes): `constants.ts`
+- **Thin community `Community 1563`** (1 nodes): `useQueryEnabled.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1564`** (1 nodes): `countries.ts`
+- **Thin community `Community 1564`** (1 nodes): `useStorefrontObservability.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1565`** (1 nodes): `feeUtils.test.ts`
+- **Thin community `Community 1565`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1566`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1566`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1567`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 1567`** (1 nodes): `feeUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1568`** (1 nodes): `maintenanceUtils.test.ts`
+- **Thin community `Community 1568`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1569`** (1 nodes): `index.ts`
+- **Thin community `Community 1569`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1570`** (1 nodes): `store.ts`
+- **Thin community `Community 1570`** (1 nodes): `maintenanceUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1571`** (1 nodes): `bag.ts`
+- **Thin community `Community 1571`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1572`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1572`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1573`** (1 nodes): `category.ts`
+- **Thin community `Community 1573`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1574`** (1 nodes): `organization.ts`
+- **Thin community `Community 1574`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1575`** (1 nodes): `product.ts`
+- **Thin community `Community 1575`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1576`** (1 nodes): `store.ts`
+- **Thin community `Community 1576`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1577`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1577`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1578`** (1 nodes): `user.ts`
+- **Thin community `Community 1578`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1579`** (1 nodes): `states.ts`
+- **Thin community `Community 1579`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1580`** (1 nodes): `storefrontFailureObservability.test.ts`
+- **Thin community `Community 1580`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1581`** (1 nodes): `storefrontJourneyEvents.test.ts`
+- **Thin community `Community 1581`** (1 nodes): `states.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1582`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1582`** (1 nodes): `storefrontFailureObservability.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1583`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 1583`** (1 nodes): `storefrontJourneyEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1584`** (1 nodes): `-homePageLoader.test.ts`
+- **Thin community `Community 1584`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1585`** (1 nodes): `__root.tsx`
+- **Thin community `Community 1585`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1586`** (1 nodes): `$orderItemId.review.tsx`
+- **Thin community `Community 1586`** (1 nodes): `-homePageLoader.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1587`** (1 nodes): `index.tsx`
+- **Thin community `Community 1587`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1588`** (1 nodes): `$subcategorySlug.tsx`
+- **Thin community `Community 1588`** (1 nodes): `$orderItemId.review.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1589`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1590`** (1 nodes): `rewards.index.tsx`
+- **Thin community `Community 1590`** (1 nodes): `$subcategorySlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1591`** (1 nodes): `shop.saved.index.tsx`
+- **Thin community `Community 1591`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1592`** (1 nodes): `bag.index.tsx`
+- **Thin community `Community 1592`** (1 nodes): `rewards.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1593`** (1 nodes): `complete.tsx`
+- **Thin community `Community 1593`** (1 nodes): `shop.saved.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1594`** (1 nodes): `incomplete.tsx`
+- **Thin community `Community 1594`** (1 nodes): `bag.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1595`** (1 nodes): `index.tsx`
+- **Thin community `Community 1595`** (1 nodes): `complete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1596`** (1 nodes): `pending.tsx`
+- **Thin community `Community 1596`** (1 nodes): `incomplete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1597`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 1597`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1598`** (1 nodes): `storefront-boot.e2e.ts`
+- **Thin community `Community 1598`** (1 nodes): `pending.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1599`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 1599`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1600`** (1 nodes): `vitest.setup.ts`
+- **Thin community `Community 1600`** (1 nodes): `storefront-boot.e2e.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1601`** (1 nodes): `index.js`
+- **Thin community `Community 1601`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1602`** (1 nodes): `harness-app-registry.test.ts`
+- **Thin community `Community 1602`** (1 nodes): `vitest.setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1603`** (1 nodes): `athena-runtime-app.test.ts`
+- **Thin community `Community 1603`** (1 nodes): `index.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1604`** (1 nodes): `storefront-runtime-api.test.ts`
+- **Thin community `Community 1604`** (1 nodes): `harness-app-registry.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1605`** (1 nodes): `valkey-runtime-app.test.ts`
+- **Thin community `Community 1605`** (1 nodes): `athena-runtime-app.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1606`** (1 nodes): `harness-behavior-scenarios.test.ts`
+- **Thin community `Community 1606`** (1 nodes): `storefront-runtime-api.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1607`** (1 nodes): `harness-repo-validation.test.ts`
+- **Thin community `Community 1607`** (1 nodes): `valkey-runtime-app.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1608`** (1 nodes): `harness-behavior-scenarios.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1609`** (1 nodes): `harness-repo-validation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -6712,6 +6712,18 @@
       "weight": 1
     },
     {
+      "_src": "github_workflows_check_runworkflowcheck",
+      "_tgt": "github_workflows_check_collectworkflowfiles",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "github_workflows_check_collectworkflowfiles",
+      "source_file": "scripts/github-workflows-check.ts",
+      "source_location": "L33",
+      "target": "github_workflows_check_runworkflowcheck",
+      "weight": 1
+    },
+    {
       "_src": "graphify_check_collectstalegraphifyartifacts",
       "_tgt": "graphify_check_fileexists",
       "confidence": "EXTRACTED",
@@ -9707,7 +9719,7 @@
       "relation": "calls",
       "source": "harness_repo_validation_sortuniquepaths",
       "source_file": "scripts/harness-repo-validation.ts",
-      "source_location": "L48",
+      "source_location": "L49",
       "target": "harness_repo_validation_collectharnessrepovalidationselection",
       "weight": 1
     },
@@ -9719,7 +9731,7 @@
       "relation": "calls",
       "source": "harness_repo_validation_normalizerepopath",
       "source_file": "scripts/harness-repo-validation.ts",
-      "source_location": "L40",
+      "source_location": "L41",
       "target": "harness_repo_validation_matchesharnessrepovalidationpath",
       "weight": 1
     },
@@ -9731,7 +9743,7 @@
       "relation": "calls",
       "source": "harness_review_fileexists",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L345",
+      "source_location": "L393",
       "target": "harness_review_collectcommandsforchangedfiles",
       "weight": 1
     },
@@ -9743,7 +9755,7 @@
       "relation": "calls",
       "source": "harness_review_rungitcommand",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L431",
+      "source_location": "L479",
       "target": "harness_review_getchangedfilesforharnessreview",
       "weight": 1
     },
@@ -9755,7 +9767,7 @@
       "relation": "calls",
       "source": "harness_review_sortuniquepaths",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L464",
+      "source_location": "L512",
       "target": "harness_review_getchangedfilesforharnessreview",
       "weight": 1
     },
@@ -9767,7 +9779,7 @@
       "relation": "calls",
       "source": "harness_review_fileexists",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L116",
+      "source_location": "L164",
       "target": "harness_review_hasanyharnessdocs",
       "weight": 1
     },
@@ -9779,7 +9791,7 @@
       "relation": "calls",
       "source": "harness_review_fileexists",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L141",
+      "source_location": "L189",
       "target": "harness_review_loadreviewtarget",
       "weight": 1
     },
@@ -9791,7 +9803,7 @@
       "relation": "calls",
       "source": "harness_review_formatmissingpathprefixerror",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L216",
+      "source_location": "L264",
       "target": "harness_review_loadreviewtarget",
       "weight": 1
     },
@@ -9803,7 +9815,7 @@
       "relation": "calls",
       "source": "harness_review_normalizebehaviorscenarioname",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L248",
+      "source_location": "L296",
       "target": "harness_review_loadreviewtarget",
       "weight": 1
     },
@@ -9815,7 +9827,7 @@
       "relation": "calls",
       "source": "harness_review_normalizerepopath",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L257",
+      "source_location": "L305",
       "target": "harness_review_loadreviewtarget",
       "weight": 1
     },
@@ -9827,7 +9839,7 @@
       "relation": "calls",
       "source": "harness_review_hasanyharnessdocs",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L283",
+      "source_location": "L331",
       "target": "harness_review_loadreviewtargets",
       "weight": 1
     },
@@ -9839,7 +9851,7 @@
       "relation": "calls",
       "source": "harness_review_loadreviewtarget",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L291",
+      "source_location": "L339",
       "target": "harness_review_loadreviewtargets",
       "weight": 1
     },
@@ -9851,7 +9863,7 @@
       "relation": "calls",
       "source": "harness_review_normalizerepopath",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L60",
+      "source_location": "L62",
       "target": "harness_review_matchespathprefix",
       "weight": 1
     },
@@ -9863,7 +9875,7 @@
       "relation": "calls",
       "source": "harness_review_fileexists",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L548",
+      "source_location": "L596",
       "target": "harness_review_resolveharnessreviewshell",
       "weight": 1
     },
@@ -9875,7 +9887,7 @@
       "relation": "calls",
       "source": "harness_review_rungitcommand",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L405",
+      "source_location": "L453",
       "target": "harness_review_buildgitprocessenv",
       "weight": 1
     },
@@ -9887,7 +9899,7 @@
       "relation": "calls",
       "source": "harness_review_collectcommandsforchangedfiles",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L606",
+      "source_location": "L654",
       "target": "harness_review_runharnessreview",
       "weight": 1
     },
@@ -9899,7 +9911,7 @@
       "relation": "calls",
       "source": "harness_review_loadreviewtargets",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L599",
+      "source_location": "L647",
       "target": "harness_review_runharnessreview",
       "weight": 1
     },
@@ -9911,7 +9923,7 @@
       "relation": "calls",
       "source": "harness_review_resolveharnessreviewshell",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L557",
+      "source_location": "L605",
       "target": "harness_review_runrawcommand",
       "weight": 1
     },
@@ -52036,6 +52048,54 @@
       "weight": 1
     },
     {
+      "_src": "scripts_github_workflows_check_test_ts",
+      "_tgt": "github_workflows_check_test_createfixtureroot",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "scripts_github_workflows_check_test_ts",
+      "source_file": "scripts/github-workflows-check.test.ts",
+      "source_location": "L10",
+      "target": "github_workflows_check_test_createfixtureroot",
+      "weight": 1
+    },
+    {
+      "_src": "scripts_github_workflows_check_test_ts",
+      "_tgt": "github_workflows_check_test_write",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "scripts_github_workflows_check_test_ts",
+      "source_file": "scripts/github-workflows-check.test.ts",
+      "source_location": "L16",
+      "target": "github_workflows_check_test_write",
+      "weight": 1
+    },
+    {
+      "_src": "scripts_github_workflows_check_ts",
+      "_tgt": "github_workflows_check_collectworkflowfiles",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "scripts_github_workflows_check_ts",
+      "source_file": "scripts/github-workflows-check.ts",
+      "source_location": "L19",
+      "target": "github_workflows_check_collectworkflowfiles",
+      "weight": 1
+    },
+    {
+      "_src": "scripts_github_workflows_check_ts",
+      "_tgt": "github_workflows_check_runworkflowcheck",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "scripts_github_workflows_check_ts",
+      "source_file": "scripts/github-workflows-check.ts",
+      "source_location": "L29",
+      "target": "github_workflows_check_runworkflowcheck",
+      "weight": 1
+    },
+    {
       "_src": "scripts_graphify_check_test_ts",
       "_tgt": "graphify_check_test_createfixtureroot",
       "confidence": "EXTRACTED",
@@ -55043,7 +55103,7 @@
       "relation": "contains",
       "source": "scripts_harness_repo_validation_ts",
       "source_file": "scripts/harness-repo-validation.ts",
-      "source_location": "L47",
+      "source_location": "L48",
       "target": "harness_repo_validation_collectharnessrepovalidationselection",
       "weight": 1
     },
@@ -55055,7 +55115,7 @@
       "relation": "contains",
       "source": "scripts_harness_repo_validation_ts",
       "source_file": "scripts/harness-repo-validation.ts",
-      "source_location": "L39",
+      "source_location": "L40",
       "target": "harness_repo_validation_matchesharnessrepovalidationpath",
       "weight": 1
     },
@@ -55067,7 +55127,7 @@
       "relation": "contains",
       "source": "scripts_harness_repo_validation_ts",
       "source_file": "scripts/harness-repo-validation.ts",
-      "source_location": "L29",
+      "source_location": "L30",
       "target": "harness_repo_validation_normalizerepopath",
       "weight": 1
     },
@@ -55079,7 +55139,7 @@
       "relation": "contains",
       "source": "scripts_harness_repo_validation_ts",
       "source_file": "scripts/harness-repo-validation.ts",
-      "source_location": "L33",
+      "source_location": "L34",
       "target": "harness_repo_validation_sortuniquepaths",
       "weight": 1
     },
@@ -55103,7 +55163,7 @@
       "relation": "contains",
       "source": "scripts_harness_review_test_ts",
       "source_file": "scripts/harness-review.test.ts",
-      "source_location": "L1040",
+      "source_location": "L1215",
       "target": "harness_review_test_error",
       "weight": 1
     },
@@ -55127,7 +55187,7 @@
       "relation": "contains",
       "source": "scripts_harness_review_test_ts",
       "source_file": "scripts/harness-review.test.ts",
-      "source_location": "L1039",
+      "source_location": "L1214",
       "target": "harness_review_test_log",
       "weight": 1
     },
@@ -55163,7 +55223,7 @@
       "relation": "contains",
       "source": "scripts_harness_review_ts",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L421",
+      "source_location": "L469",
       "target": "harness_review_buildgitprocessenv",
       "weight": 1
     },
@@ -55175,7 +55235,7 @@
       "relation": "contains",
       "source": "scripts_harness_review_ts",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L304",
+      "source_location": "L352",
       "target": "harness_review_collectcommandsforchangedfiles",
       "weight": 1
     },
@@ -55187,7 +55247,7 @@
       "relation": "contains",
       "source": "scripts_harness_review_ts",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L95",
+      "source_location": "L143",
       "target": "harness_review_fileexists",
       "weight": 1
     },
@@ -55199,7 +55259,7 @@
       "relation": "contains",
       "source": "scripts_harness_review_ts",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L85",
+      "source_location": "L133",
       "target": "harness_review_formatmissingpathprefixerror",
       "weight": 1
     },
@@ -55211,7 +55271,7 @@
       "relation": "contains",
       "source": "scripts_harness_review_ts",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L427",
+      "source_location": "L475",
       "target": "harness_review_getchangedfilesforharnessreview",
       "weight": 1
     },
@@ -55223,8 +55283,20 @@
       "relation": "contains",
       "source": "scripts_harness_review_ts",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L104",
+      "source_location": "L152",
       "target": "harness_review_hasanyharnessdocs",
+      "weight": 1
+    },
+    {
+      "_src": "scripts_harness_review_ts",
+      "_tgt": "harness_review_isathenaprtestsprovidedcommand",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "scripts_harness_review_ts",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L87",
+      "target": "harness_review_isathenaprtestsprovidedcommand",
       "weight": 1
     },
     {
@@ -55235,7 +55307,7 @@
       "relation": "contains",
       "source": "scripts_harness_review_ts",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L134",
+      "source_location": "L182",
       "target": "harness_review_loadreviewtarget",
       "weight": 1
     },
@@ -55247,7 +55319,7 @@
       "relation": "contains",
       "source": "scripts_harness_review_ts",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L271",
+      "source_location": "L319",
       "target": "harness_review_loadreviewtargets",
       "weight": 1
     },
@@ -55259,7 +55331,7 @@
       "relation": "contains",
       "source": "scripts_harness_review_ts",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L59",
+      "source_location": "L61",
       "target": "harness_review_matchespathprefix",
       "weight": 1
     },
@@ -55271,7 +55343,7 @@
       "relation": "contains",
       "source": "scripts_harness_review_ts",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L81",
+      "source_location": "L83",
       "target": "harness_review_normalizebehaviorscenarioname",
       "weight": 1
     },
@@ -55283,7 +55355,7 @@
       "relation": "contains",
       "source": "scripts_harness_review_ts",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L55",
+      "source_location": "L57",
       "target": "harness_review_normalizerepopath",
       "weight": 1
     },
@@ -55295,7 +55367,7 @@
       "relation": "contains",
       "source": "scripts_harness_review_ts",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L73",
+      "source_location": "L75",
       "target": "harness_review_normalizevalidationcommand",
       "weight": 1
     },
@@ -55307,7 +55379,7 @@
       "relation": "contains",
       "source": "scripts_harness_review_ts",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L679",
+      "source_location": "L742",
       "target": "harness_review_parseharnessreviewargs",
       "weight": 1
     },
@@ -55319,7 +55391,7 @@
       "relation": "contains",
       "source": "scripts_harness_review_ts",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L124",
+      "source_location": "L172",
       "target": "harness_review_readjsonfile",
       "weight": 1
     },
@@ -55331,7 +55403,7 @@
       "relation": "contains",
       "source": "scripts_harness_review_ts",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L535",
+      "source_location": "L583",
       "target": "harness_review_resolveharnessreviewshell",
       "weight": 1
     },
@@ -55343,7 +55415,7 @@
       "relation": "contains",
       "source": "scripts_harness_review_ts",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L400",
+      "source_location": "L448",
       "target": "harness_review_rungitcommand",
       "weight": 1
     },
@@ -55355,7 +55427,7 @@
       "relation": "contains",
       "source": "scripts_harness_review_ts",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L570",
+      "source_location": "L618",
       "target": "harness_review_runharnessbehaviorscenario",
       "weight": 1
     },
@@ -55367,7 +55439,7 @@
       "relation": "contains",
       "source": "scripts_harness_review_ts",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L584",
+      "source_location": "L632",
       "target": "harness_review_runharnessreview",
       "weight": 1
     },
@@ -55379,7 +55451,7 @@
       "relation": "contains",
       "source": "scripts_harness_review_ts",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L521",
+      "source_location": "L569",
       "target": "harness_review_runpackagescript",
       "weight": 1
     },
@@ -55391,7 +55463,7 @@
       "relation": "contains",
       "source": "scripts_harness_review_ts",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L556",
+      "source_location": "L604",
       "target": "harness_review_runrawcommand",
       "weight": 1
     },
@@ -55403,7 +55475,7 @@
       "relation": "contains",
       "source": "scripts_harness_review_ts",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L128",
+      "source_location": "L176",
       "target": "harness_review_sortuniquepaths",
       "weight": 1
     },
@@ -62259,6 +62331,24 @@
     {
       "community": 1000,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_inventory_complimentaryproduct_ts",
+      "label": "complimentaryProduct.ts",
+      "norm_label": "complimentaryproduct.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/inventory/complimentaryProduct.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1001,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_inventory_featureditem_ts",
+      "label": "featuredItem.ts",
+      "norm_label": "featureditem.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/inventory/featuredItem.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1002,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_index_ts",
       "label": "index.ts",
       "norm_label": "index.ts",
@@ -62266,7 +62356,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1001,
+      "community": 1003,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_inventoryhold_ts",
       "label": "inventoryHold.ts",
@@ -62275,7 +62365,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1002,
+      "community": 1004,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_invitecode_ts",
       "label": "inviteCode.ts",
@@ -62284,7 +62374,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1003,
+      "community": 1005,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_organization_ts",
       "label": "organization.ts",
@@ -62293,7 +62383,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1004,
+      "community": 1006,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_organizationmember_ts",
       "label": "organizationMember.ts",
@@ -62302,7 +62392,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1005,
+      "community": 1007,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_product_ts",
       "label": "product.ts",
@@ -62311,7 +62401,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1006,
+      "community": 1008,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_promocode_ts",
       "label": "promoCode.ts",
@@ -62320,30 +62410,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1007,
+      "community": 1009,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_redeemedpromocode_ts",
       "label": "redeemedPromoCode.ts",
       "norm_label": "redeemedpromocode.ts",
       "source_file": "packages/athena-webapp/convex/schemas/inventory/redeemedPromoCode.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1008,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_inventory_store_ts",
-      "label": "store.ts",
-      "norm_label": "store.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/inventory/store.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1009,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_inventory_subcategory_ts",
-      "label": "subcategory.ts",
-      "norm_label": "subcategory.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/inventory/subcategory.ts",
       "source_location": "L1"
     },
     {
@@ -62421,6 +62493,24 @@
     {
       "community": 1010,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_inventory_store_ts",
+      "label": "store.ts",
+      "norm_label": "store.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/inventory/store.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1011,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_inventory_subcategory_ts",
+      "label": "subcategory.ts",
+      "norm_label": "subcategory.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/inventory/subcategory.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1012,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_observability_index_ts",
       "label": "index.ts",
       "norm_label": "index.ts",
@@ -62428,7 +62518,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1011,
+      "community": 1013,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_observability_workflowtrace_ts",
       "label": "workflowTrace.ts",
@@ -62437,7 +62527,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1012,
+      "community": 1014,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_observability_workflowtraceevent_ts",
       "label": "workflowTraceEvent.ts",
@@ -62446,7 +62536,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1013,
+      "community": 1015,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_observability_workflowtracelookup_ts",
       "label": "workflowTraceLookup.ts",
@@ -62455,7 +62545,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1014,
+      "community": 1016,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_approvalrequest_ts",
       "label": "approvalRequest.ts",
@@ -62464,7 +62554,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1015,
+      "community": 1017,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_customerprofile_ts",
       "label": "customerProfile.ts",
@@ -62473,7 +62563,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1016,
+      "community": 1018,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_dailyclose_ts",
       "label": "dailyClose.ts",
@@ -62482,30 +62572,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1017,
+      "community": 1019,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_dailyopening_ts",
       "label": "dailyOpening.ts",
       "norm_label": "dailyopening.ts",
       "source_file": "packages/athena-webapp/convex/schemas/operations/dailyOpening.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1018,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_operations_index_ts",
-      "label": "index.ts",
-      "norm_label": "index.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/operations/index.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1019,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_operations_inventorymovement_ts",
-      "label": "inventoryMovement.ts",
-      "norm_label": "inventorymovement.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/operations/inventoryMovement.ts",
       "source_location": "L1"
     },
     {
@@ -62583,6 +62655,24 @@
     {
       "community": 1020,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_operations_index_ts",
+      "label": "index.ts",
+      "norm_label": "index.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/operations/index.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1021,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_operations_inventorymovement_ts",
+      "label": "inventoryMovement.ts",
+      "norm_label": "inventorymovement.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/operations/inventoryMovement.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1022,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_managerelevation_ts",
       "label": "managerElevation.ts",
       "norm_label": "managerelevation.ts",
@@ -62590,7 +62680,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1021,
+      "community": 1023,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_operationalevent_ts",
       "label": "operationalEvent.ts",
@@ -62599,7 +62689,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1022,
+      "community": 1024,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_operationalworkitem_ts",
       "label": "operationalWorkItem.ts",
@@ -62608,7 +62698,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1023,
+      "community": 1025,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_paymentallocation_ts",
       "label": "paymentAllocation.ts",
@@ -62617,7 +62707,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1024,
+      "community": 1026,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_registersession_ts",
       "label": "registerSession.ts",
@@ -62626,7 +62716,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1025,
+      "community": 1027,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_staffcredential_ts",
       "label": "staffCredential.ts",
@@ -62635,7 +62725,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1026,
+      "community": 1028,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_staffprofile_ts",
       "label": "staffProfile.ts",
@@ -62644,30 +62734,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1027,
+      "community": 1029,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_staffroleassignment_ts",
       "label": "staffRoleAssignment.ts",
       "norm_label": "staffroleassignment.ts",
       "source_file": "packages/athena-webapp/convex/schemas/operations/staffRoleAssignment.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1028,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_payments_mtncollections_ts",
-      "label": "mtnCollections.ts",
-      "norm_label": "mtncollections.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/payments/mtnCollections.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1029,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_pos_customer_ts",
-      "label": "customer.ts",
-      "norm_label": "customer.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/pos/customer.ts",
       "source_location": "L1"
     },
     {
@@ -62745,6 +62817,24 @@
     {
       "community": 1030,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_payments_mtncollections_ts",
+      "label": "mtnCollections.ts",
+      "norm_label": "mtncollections.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/payments/mtnCollections.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1031,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_pos_customer_ts",
+      "label": "customer.ts",
+      "norm_label": "customer.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/pos/customer.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1032,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_expensesession_ts",
       "label": "expenseSession.ts",
       "norm_label": "expensesession.ts",
@@ -62752,7 +62842,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1031,
+      "community": 1033,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_expensesessionitem_ts",
       "label": "expenseSessionItem.ts",
@@ -62761,7 +62851,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1032,
+      "community": 1034,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_expensetransaction_ts",
       "label": "expenseTransaction.ts",
@@ -62770,7 +62860,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1033,
+      "community": 1035,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_expensetransactionitem_ts",
       "label": "expenseTransactionItem.ts",
@@ -62779,7 +62869,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1034,
+      "community": 1036,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_index_ts",
       "label": "index.ts",
@@ -62788,7 +62878,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1035,
+      "community": 1037,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_possession_ts",
       "label": "posSession.ts",
@@ -62797,7 +62887,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1036,
+      "community": 1038,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_possessionitem_ts",
       "label": "posSessionItem.ts",
@@ -62806,30 +62896,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1037,
+      "community": 1039,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_posterminal_ts",
       "label": "posTerminal.ts",
       "norm_label": "posterminal.ts",
       "source_file": "packages/athena-webapp/convex/schemas/pos/posTerminal.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1038,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_pos_postransaction_ts",
-      "label": "posTransaction.ts",
-      "norm_label": "postransaction.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/pos/posTransaction.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1039,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_pos_postransactionitem_ts",
-      "label": "posTransactionItem.ts",
-      "norm_label": "postransactionitem.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/pos/posTransactionItem.ts",
       "source_location": "L1"
     },
     {
@@ -62907,6 +62979,24 @@
     {
       "community": 1040,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_pos_postransaction_ts",
+      "label": "posTransaction.ts",
+      "norm_label": "postransaction.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/pos/posTransaction.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1041,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_pos_postransactionitem_ts",
+      "label": "posTransactionItem.ts",
+      "norm_label": "postransactionitem.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/pos/posTransactionItem.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1042,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_index_ts",
       "label": "index.ts",
       "norm_label": "index.ts",
@@ -62914,7 +63004,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1041,
+      "community": 1043,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_serviceappointment_ts",
       "label": "serviceAppointment.ts",
@@ -62923,7 +63013,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1042,
+      "community": 1044,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_servicecase_ts",
       "label": "serviceCase.ts",
@@ -62932,7 +63022,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1043,
+      "community": 1045,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_servicecaselineitem_ts",
       "label": "serviceCaseLineItem.ts",
@@ -62941,7 +63031,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1044,
+      "community": 1046,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_servicecatalog_ts",
       "label": "serviceCatalog.ts",
@@ -62950,7 +63040,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1045,
+      "community": 1047,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_serviceinventoryusage_ts",
       "label": "serviceInventoryUsage.ts",
@@ -62959,7 +63049,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1046,
+      "community": 1048,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_stockops_cyclecountdraft_ts",
       "label": "cycleCountDraft.ts",
@@ -62968,30 +63058,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1047,
+      "community": 1049,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_stockops_index_ts",
       "label": "index.ts",
       "norm_label": "index.ts",
       "source_file": "packages/athena-webapp/convex/schemas/stockOps/index.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1048,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_stockops_purchaseorder_ts",
-      "label": "purchaseOrder.ts",
-      "norm_label": "purchaseorder.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/stockOps/purchaseOrder.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1049,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_stockops_purchaseorderlineitem_ts",
-      "label": "purchaseOrderLineItem.ts",
-      "norm_label": "purchaseorderlineitem.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/stockOps/purchaseOrderLineItem.ts",
       "source_location": "L1"
     },
     {
@@ -63069,6 +63141,24 @@
     {
       "community": 1050,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_stockops_purchaseorder_ts",
+      "label": "purchaseOrder.ts",
+      "norm_label": "purchaseorder.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/stockOps/purchaseOrder.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1051,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_stockops_purchaseorderlineitem_ts",
+      "label": "purchaseOrderLineItem.ts",
+      "norm_label": "purchaseorderlineitem.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/stockOps/purchaseOrderLineItem.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1052,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_stockops_receivingbatch_ts",
       "label": "receivingBatch.ts",
       "norm_label": "receivingbatch.ts",
@@ -63076,7 +63166,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1051,
+      "community": 1053,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_stockops_stockadjustmentbatch_ts",
       "label": "stockAdjustmentBatch.ts",
@@ -63085,7 +63175,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1052,
+      "community": 1054,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_stockops_vendor_ts",
       "label": "vendor.ts",
@@ -63094,7 +63184,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1053,
+      "community": 1055,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_analytics_ts",
       "label": "analytics.ts",
@@ -63103,7 +63193,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1054,
+      "community": 1056,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_bag_ts",
       "label": "bag.ts",
@@ -63112,7 +63202,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1055,
+      "community": 1057,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_bagitem_ts",
       "label": "bagItem.ts",
@@ -63121,7 +63211,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1056,
+      "community": 1058,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_checkoutsession_ts",
       "label": "checkoutSession.ts",
@@ -63130,30 +63220,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1057,
+      "community": 1059,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_checkoutsessionitem_ts",
       "label": "checkoutSessionItem.ts",
       "norm_label": "checkoutsessionitem.ts",
       "source_file": "packages/athena-webapp/convex/schemas/storeFront/checkoutSessionItem.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1058,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_storefront_guest_ts",
-      "label": "guest.ts",
-      "norm_label": "guest.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/storeFront/guest.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1059,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_storefront_index_ts",
-      "label": "index.ts",
-      "norm_label": "index.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/storeFront/index.ts",
       "source_location": "L1"
     },
     {
@@ -63231,6 +63303,24 @@
     {
       "community": 1060,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_storefront_guest_ts",
+      "label": "guest.ts",
+      "norm_label": "guest.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/storeFront/guest.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1061,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_storefront_index_ts",
+      "label": "index.ts",
+      "norm_label": "index.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/storeFront/index.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1062,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_offer_ts",
       "label": "offer.ts",
       "norm_label": "offer.ts",
@@ -63238,7 +63328,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1061,
+      "community": 1063,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_onlineorder_onlineorder_ts",
       "label": "onlineOrder.ts",
@@ -63247,7 +63337,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1062,
+      "community": 1064,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_onlineorder_onlineorderitem_ts",
       "label": "onlineOrderItem.ts",
@@ -63256,7 +63346,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1063,
+      "community": 1065,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_review_ts",
       "label": "review.ts",
@@ -63265,7 +63355,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1064,
+      "community": 1066,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_rewards_ts",
       "label": "rewards.ts",
@@ -63274,7 +63364,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1065,
+      "community": 1067,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_savedbag_ts",
       "label": "savedBag.ts",
@@ -63283,7 +63373,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1066,
+      "community": 1068,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_savedbagitem_ts",
       "label": "savedBagItem.ts",
@@ -63292,30 +63382,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1067,
+      "community": 1069,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_storefrontsession_ts",
       "label": "storeFrontSession.ts",
       "norm_label": "storefrontsession.ts",
       "source_file": "packages/athena-webapp/convex/schemas/storeFront/storeFrontSession.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1068,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_storefront_storefrontuser_ts",
-      "label": "storeFrontUser.ts",
-      "norm_label": "storefrontuser.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/storeFront/storeFrontUser.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1069,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_storefront_storefrontverificationcode_ts",
-      "label": "storeFrontVerificationCode.ts",
-      "norm_label": "storefrontverificationcode.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/storeFront/storeFrontVerificationCode.ts",
       "source_location": "L1"
     },
     {
@@ -63393,6 +63465,24 @@
     {
       "community": 1070,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_storefront_storefrontuser_ts",
+      "label": "storeFrontUser.ts",
+      "norm_label": "storefrontuser.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/storeFront/storeFrontUser.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1071,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_storefront_storefrontverificationcode_ts",
+      "label": "storeFrontVerificationCode.ts",
+      "norm_label": "storefrontverificationcode.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/storeFront/storeFrontVerificationCode.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1072,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_supportticket_ts",
       "label": "supportTicket.ts",
       "norm_label": "supportticket.ts",
@@ -63400,7 +63490,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1071,
+      "community": 1073,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_serviceops_catalogappointments_test_ts",
       "label": "catalogAppointments.test.ts",
@@ -63409,7 +63499,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1072,
+      "community": 1074,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_bag_ts",
       "label": "bag.ts",
@@ -63418,7 +63508,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1073,
+      "community": 1075,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_bagitem_ts",
       "label": "bagItem.ts",
@@ -63427,7 +63517,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1074,
+      "community": 1076,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_checkoutsession_test_ts",
       "label": "checkoutSession.test.ts",
@@ -63436,7 +63526,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1075,
+      "community": 1077,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_customer_ts",
       "label": "customer.ts",
@@ -63445,7 +63535,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1076,
+      "community": 1078,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_guest_ts",
       "label": "guest.ts",
@@ -63454,30 +63544,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1077,
+      "community": 1079,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_offers_test_ts",
       "label": "offers.test.ts",
       "norm_label": "offers.test.ts",
       "source_file": "packages/athena-webapp/convex/storeFront/offers.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1078,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_onlineorderutilfns_ts",
-      "label": "onlineOrderUtilFns.ts",
-      "norm_label": "onlineorderutilfns.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrderUtilFns.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1079,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_orderoperations_test_ts",
-      "label": "orderOperations.test.ts",
-      "norm_label": "orderoperations.test.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/orderOperations.test.ts",
       "source_location": "L1"
     },
     {
@@ -63555,6 +63627,24 @@
     {
       "community": 1080,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_onlineorderutilfns_ts",
+      "label": "onlineOrderUtilFns.ts",
+      "norm_label": "onlineorderutilfns.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrderUtilFns.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1081,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_orderoperations_test_ts",
+      "label": "orderOperations.test.ts",
+      "norm_label": "orderoperations.test.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/orderOperations.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1082,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_payment_test_ts",
       "label": "payment.test.ts",
       "norm_label": "payment.test.ts",
@@ -63562,7 +63652,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1081,
+      "community": 1083,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_payment_ts",
       "label": "payment.ts",
@@ -63571,7 +63661,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1082,
+      "community": 1084,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_paystackactions_ts",
       "label": "paystackActions.ts",
@@ -63580,7 +63670,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1083,
+      "community": 1085,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_savedbagitem_ts",
       "label": "savedBagItem.ts",
@@ -63589,7 +63679,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1084,
+      "community": 1086,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_supportticket_ts",
       "label": "supportTicket.ts",
@@ -63598,7 +63688,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1085,
+      "community": 1087,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_users_ts",
       "label": "users.ts",
@@ -63607,7 +63697,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1086,
+      "community": 1088,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_types_payment_ts",
       "label": "payment.ts",
@@ -63616,30 +63706,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1087,
+      "community": 1089,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_adapters_possession_test_ts",
       "label": "posSession.test.ts",
       "norm_label": "possession.test.ts",
       "source_file": "packages/athena-webapp/convex/workflowTraces/adapters/posSession.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1088,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_workflowtraces_adapters_registersession_test_ts",
-      "label": "registerSession.test.ts",
-      "norm_label": "registersession.test.ts",
-      "source_file": "packages/athena-webapp/convex/workflowTraces/adapters/registerSession.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1089,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_workflowtraces_presentation_test_ts",
-      "label": "presentation.test.ts",
-      "norm_label": "presentation.test.ts",
-      "source_file": "packages/athena-webapp/convex/workflowTraces/presentation.test.ts",
       "source_location": "L1"
     },
     {
@@ -63717,6 +63789,24 @@
     {
       "community": 1090,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_workflowtraces_adapters_registersession_test_ts",
+      "label": "registerSession.test.ts",
+      "norm_label": "registersession.test.ts",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/adapters/registerSession.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1091,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_workflowtraces_presentation_test_ts",
+      "label": "presentation.test.ts",
+      "norm_label": "presentation.test.ts",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/presentation.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1092,
+      "file_type": "code",
       "id": "packages_athena_webapp_eslint_config_js",
       "label": "eslint.config.js",
       "norm_label": "eslint.config.js",
@@ -63724,7 +63814,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1091,
+      "community": 1093,
       "file_type": "code",
       "id": "packages_athena_webapp_index_ts",
       "label": "index.ts",
@@ -63733,7 +63823,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1092,
+      "community": 1094,
       "file_type": "code",
       "id": "packages_athena_webapp_postcss_config_js",
       "label": "postcss.config.js",
@@ -63742,7 +63832,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1093,
+      "community": 1095,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_approvalpolicy_ts",
       "label": "approvalPolicy.ts",
@@ -63751,7 +63841,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1094,
+      "community": 1096,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_auth_ts",
       "label": "auth.ts",
@@ -63760,7 +63850,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1095,
+      "community": 1097,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_commandresult_test_ts",
       "label": "commandResult.test.ts",
@@ -63769,7 +63859,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1096,
+      "community": 1098,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_currencyformatter_test_ts",
       "label": "currencyFormatter.test.ts",
@@ -63778,30 +63868,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1097,
+      "community": 1099,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_registersessionstatus_test_ts",
       "label": "registerSessionStatus.test.ts",
       "norm_label": "registersessionstatus.test.ts",
       "source_file": "packages/athena-webapp/shared/registerSessionStatus.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1098,
-      "file_type": "code",
-      "id": "packages_athena_webapp_shared_staffdisplayname_test_ts",
-      "label": "staffDisplayName.test.ts",
-      "norm_label": "staffdisplayname.test.ts",
-      "source_file": "packages/athena-webapp/shared/staffDisplayName.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1099,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_genericcombobox_tsx",
-      "label": "GenericComboBox.tsx",
-      "norm_label": "genericcombobox.tsx",
-      "source_file": "packages/athena-webapp/src/components/GenericComboBox.tsx",
       "source_location": "L1"
     },
     {
@@ -64158,6 +64230,24 @@
     {
       "community": 1100,
       "file_type": "code",
+      "id": "packages_athena_webapp_shared_staffdisplayname_test_ts",
+      "label": "staffDisplayName.test.ts",
+      "norm_label": "staffdisplayname.test.ts",
+      "source_file": "packages/athena-webapp/shared/staffDisplayName.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1101,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_genericcombobox_tsx",
+      "label": "GenericComboBox.tsx",
+      "norm_label": "genericcombobox.tsx",
+      "source_file": "packages/athena-webapp/src/components/GenericComboBox.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1102,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_storeaccordion_tsx",
       "label": "StoreAccordion.tsx",
       "norm_label": "storeaccordion.tsx",
@@ -64165,7 +64255,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1101,
+      "community": 1103,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storesaccordion_tsx",
       "label": "StoresAccordion.tsx",
@@ -64174,7 +64264,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1102,
+      "community": 1104,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_themetoggle_tsx",
       "label": "ThemeToggle.tsx",
@@ -64183,7 +64273,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1103,
+      "community": 1105,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_defaultattributestogglegroup_tsx",
       "label": "DefaultAttributesToggleGroup.tsx",
@@ -64192,7 +64282,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1104,
+      "community": 1106,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productattributesview_tsx",
       "label": "ProductAttributesView.tsx",
@@ -64201,7 +64291,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1105,
+      "community": 1107,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productstock_test_ts",
       "label": "ProductStock.test.ts",
@@ -64210,7 +64300,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1106,
+      "community": 1108,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productview_test_tsx",
       "label": "ProductView.test.tsx",
@@ -64219,30 +64309,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1107,
+      "community": 1109,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_constants_ts",
       "label": "constants.ts",
       "norm_label": "constants.ts",
       "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/constants.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1108,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_faceted_filter_tsx",
-      "label": "data-table-faceted-filter.tsx",
-      "norm_label": "data-table-faceted-filter.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table-faceted-filter.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1109,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_pagination_tsx",
-      "label": "data-table-pagination.tsx",
-      "norm_label": "data-table-pagination.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table-pagination.tsx",
       "source_location": "L1"
     },
     {
@@ -64320,6 +64392,24 @@
     {
       "community": 1110,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_faceted_filter_tsx",
+      "label": "data-table-faceted-filter.tsx",
+      "norm_label": "data-table-faceted-filter.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table-faceted-filter.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1111,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_pagination_tsx",
+      "label": "data-table-pagination.tsx",
+      "norm_label": "data-table-pagination.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table-pagination.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1112,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_tsx",
       "label": "data-table.tsx",
       "norm_label": "data-table.tsx",
@@ -64327,7 +64417,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1111,
+      "community": 1113,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_types_ts",
       "label": "types.ts",
@@ -64336,7 +64426,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1112,
+      "community": 1114,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_conversionfunnelchart_tsx",
       "label": "ConversionFunnelChart.tsx",
@@ -64345,7 +64435,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1113,
+      "community": 1115,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_revenuechart_tsx",
       "label": "RevenueChart.tsx",
@@ -64354,7 +64444,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1114,
+      "community": 1116,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_analytics_columns_tsx",
       "label": "analytics-columns.tsx",
@@ -64363,7 +64453,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1115,
+      "community": 1117,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -64372,7 +64462,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1116,
+      "community": 1118,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -64381,30 +64471,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1117,
+      "community": 1119,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
       "norm_label": "data-table-toolbar.tsx",
       "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/data-table-toolbar.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1118,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_tsx",
-      "label": "data-table.tsx",
-      "norm_label": "data-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/data-table.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1119,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_columns_tsx",
-      "label": "columns.tsx",
-      "norm_label": "columns.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-products-table/columns.tsx",
       "source_location": "L1"
     },
     {
@@ -64482,6 +64554,24 @@
     {
       "community": 1120,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_tsx",
+      "label": "data-table.tsx",
+      "norm_label": "data-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/data-table.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1121,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_columns_tsx",
+      "label": "columns.tsx",
+      "norm_label": "columns.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-products-table/columns.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1122,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
       "norm_label": "data-table-faceted-filter.tsx",
@@ -64489,7 +64579,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1121,
+      "community": 1123,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -64498,7 +64588,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1122,
+      "community": 1124,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -64507,7 +64597,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1123,
+      "community": 1125,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -64516,7 +64606,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1124,
+      "community": 1126,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_users_table_columns_tsx",
       "label": "columns.tsx",
@@ -64525,7 +64615,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1125,
+      "community": 1127,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_users_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -64534,7 +64624,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1126,
+      "community": 1128,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_users_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -64543,30 +64633,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1127,
+      "community": 1129,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_chart_tsx",
       "label": "chart.tsx",
       "norm_label": "chart.tsx",
       "source_file": "packages/athena-webapp/src/components/analytics/chart.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1128,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_combined_users_table_columns_tsx",
-      "label": "columns.tsx",
-      "norm_label": "columns.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/combined-users-table/columns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1129,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_combined_users_table_data_table_pagination_tsx",
-      "label": "data-table-pagination.tsx",
-      "norm_label": "data-table-pagination.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/combined-users-table/data-table-pagination.tsx",
       "source_location": "L1"
     },
     {
@@ -64644,6 +64716,24 @@
     {
       "community": 1130,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_combined_users_table_columns_tsx",
+      "label": "columns.tsx",
+      "norm_label": "columns.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/combined-users-table/columns.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1131,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_combined_users_table_data_table_pagination_tsx",
+      "label": "data-table-pagination.tsx",
+      "norm_label": "data-table-pagination.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/combined-users-table/data-table-pagination.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1132,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_combined_users_table_data_table_tsx",
       "label": "data-table.tsx",
       "norm_label": "data-table.tsx",
@@ -64651,7 +64741,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1131,
+      "community": 1133,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_columns_tsx",
       "label": "columns.tsx",
@@ -64660,7 +64750,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1132,
+      "community": 1134,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_constants_ts",
       "label": "constants.ts",
@@ -64669,7 +64759,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1133,
+      "community": 1135,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -64678,7 +64768,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1134,
+      "community": 1136,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -64687,7 +64777,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1135,
+      "community": 1137,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -64696,7 +64786,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1136,
+      "community": 1138,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_data_ts",
       "label": "data.ts",
@@ -64705,30 +64795,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1137,
+      "community": 1139,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_users_table_columns_tsx",
       "label": "columns.tsx",
       "norm_label": "columns.tsx",
       "source_file": "packages/athena-webapp/src/components/analytics/users-table/columns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1138,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_users_table_data_table_pagination_tsx",
-      "label": "data-table-pagination.tsx",
-      "norm_label": "data-table-pagination.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/users-table/data-table-pagination.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1139,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_users_table_data_table_tsx",
-      "label": "data-table.tsx",
-      "norm_label": "data-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/users-table/data-table.tsx",
       "source_location": "L1"
     },
     {
@@ -64806,6 +64878,24 @@
     {
       "community": 1140,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_users_table_data_table_pagination_tsx",
+      "label": "data-table-pagination.tsx",
+      "norm_label": "data-table-pagination.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/users-table/data-table-pagination.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1141,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_users_table_data_table_tsx",
+      "label": "data-table.tsx",
+      "norm_label": "data-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/users-table/data-table.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1142,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_columns_tsx",
       "label": "columns.tsx",
       "norm_label": "columns.tsx",
@@ -64813,7 +64903,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1141,
+      "community": 1143,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -64822,7 +64912,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1142,
+      "community": 1144,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -64831,7 +64921,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1143,
+      "community": 1145,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -64840,7 +64930,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1144,
+      "community": 1146,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -64849,7 +64939,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1145,
+      "community": 1147,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_assetscolumns_tsx",
       "label": "assetsColumns.tsx",
@@ -64858,7 +64948,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1146,
+      "community": 1148,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_constants_ts",
       "label": "constants.ts",
@@ -64867,30 +64957,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1147,
+      "community": 1149,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
       "norm_label": "data-table-faceted-filter.tsx",
       "source_file": "packages/athena-webapp/src/components/assets/assets-table/data-table-faceted-filter.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1148,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_pagination_tsx",
-      "label": "data-table-pagination.tsx",
-      "norm_label": "data-table-pagination.tsx",
-      "source_file": "packages/athena-webapp/src/components/assets/assets-table/data-table-pagination.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1149,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_tsx",
-      "label": "data-table.tsx",
-      "norm_label": "data-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/assets/assets-table/data-table.tsx",
       "source_location": "L1"
     },
     {
@@ -64968,6 +65040,24 @@
     {
       "community": 1150,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_pagination_tsx",
+      "label": "data-table-pagination.tsx",
+      "norm_label": "data-table-pagination.tsx",
+      "source_file": "packages/athena-webapp/src/components/assets/assets-table/data-table-pagination.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1151,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_tsx",
+      "label": "data-table.tsx",
+      "norm_label": "data-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/assets/assets-table/data-table.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1152,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_data_ts",
       "label": "data.ts",
       "norm_label": "data.ts",
@@ -64975,7 +65065,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1151,
+      "community": 1153,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_defaultcatchboundary_test_tsx",
       "label": "DefaultCatchBoundary.test.tsx",
@@ -64984,7 +65074,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1152,
+      "community": 1154,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_defaultcatchboundary_tsx",
       "label": "DefaultCatchBoundary.tsx",
@@ -64993,7 +65083,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1153,
+      "community": 1155,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_login_loginform_test_tsx",
       "label": "LoginForm.test.tsx",
@@ -65002,7 +65092,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1154,
+      "community": 1156,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_login_loginform_tsx",
       "label": "LoginForm.tsx",
@@ -65011,7 +65101,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1155,
+      "community": 1157,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_columns_tsx",
       "label": "columns.tsx",
@@ -65020,7 +65110,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1156,
+      "community": 1158,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -65029,30 +65119,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1157,
+      "community": 1159,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
       "norm_label": "data-table-pagination.tsx",
       "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/data-table-pagination.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1158,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_toolbar_tsx",
-      "label": "data-table-toolbar.tsx",
-      "norm_label": "data-table-toolbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/data-table-toolbar.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1159,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_tsx",
-      "label": "data-table.tsx",
-      "norm_label": "data-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/data-table.tsx",
       "source_location": "L1"
     },
     {
@@ -65130,6 +65202,24 @@
     {
       "community": 1160,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_toolbar_tsx",
+      "label": "data-table-toolbar.tsx",
+      "norm_label": "data-table-toolbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/data-table-toolbar.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1161,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_tsx",
+      "label": "data-table.tsx",
+      "norm_label": "data-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/data-table.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1162,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_columns_tsx",
       "label": "columns.tsx",
       "norm_label": "columns.tsx",
@@ -65137,7 +65227,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1161,
+      "community": 1163,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_constants_ts",
       "label": "constants.ts",
@@ -65146,7 +65236,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1162,
+      "community": 1164,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -65155,7 +65245,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1163,
+      "community": 1165,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -65164,7 +65254,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1164,
+      "community": 1166,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -65173,7 +65263,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1165,
+      "community": 1167,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationspage_tsx",
       "label": "BulkOperationsPage.tsx",
@@ -65182,7 +65272,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1166,
+      "community": 1168,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_cashcontrolsdashboard_auth_test_tsx",
       "label": "CashControlsDashboard.auth.test.tsx",
@@ -65191,30 +65281,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1167,
+      "community": 1169,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_cashcontrolsdashboard_test_tsx",
       "label": "CashControlsDashboard.test.tsx",
       "norm_label": "cashcontrolsdashboard.test.tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1168,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_cash_controls_cashcontrolsworkspaceheader_tsx",
-      "label": "CashControlsWorkspaceHeader.tsx",
-      "norm_label": "cashcontrolsworkspaceheader.tsx",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsWorkspaceHeader.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1169,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_cash_controls_registersessionview_auth_test_tsx",
-      "label": "RegisterSessionView.auth.test.tsx",
-      "norm_label": "registersessionview.auth.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.auth.test.tsx",
       "source_location": "L1"
     },
     {
@@ -65292,6 +65364,24 @@
     {
       "community": 1170,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_cash_controls_cashcontrolsworkspaceheader_tsx",
+      "label": "CashControlsWorkspaceHeader.tsx",
+      "norm_label": "cashcontrolsworkspaceheader.tsx",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsWorkspaceHeader.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1171,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_cash_controls_registersessionview_auth_test_tsx",
+      "label": "RegisterSessionView.auth.test.tsx",
+      "norm_label": "registersessionview.auth.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.auth.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1172,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_registersessionview_test_tsx",
       "label": "RegisterSessionView.test.tsx",
       "norm_label": "registersessionview.test.tsx",
@@ -65299,7 +65389,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1171,
+      "community": 1173,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_registersessionsview_test_tsx",
       "label": "RegisterSessionsView.test.tsx",
@@ -65308,7 +65398,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1172,
+      "community": 1174,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_formatreviewreason_test_ts",
       "label": "formatReviewReason.test.ts",
@@ -65317,7 +65407,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1173,
+      "community": 1175,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkout_sessions_table_columns_tsx",
       "label": "columns.tsx",
@@ -65326,7 +65416,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1174,
+      "community": 1176,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkout_sessions_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -65335,7 +65425,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1175,
+      "community": 1177,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkout_sessions_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -65344,7 +65434,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1176,
+      "community": 1178,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_common_listpagination_tsx",
       "label": "ListPagination.tsx",
@@ -65353,30 +65443,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1177,
+      "community": 1179,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_common_pagelevelheader_test_tsx",
       "label": "PageLevelHeader.test.tsx",
       "norm_label": "pagelevelheader.test.tsx",
       "source_file": "packages/athena-webapp/src/components/common/PageLevelHeader.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1178,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_common_pagelevelheader_tsx",
-      "label": "PageLevelHeader.tsx",
-      "norm_label": "pagelevelheader.tsx",
-      "source_file": "packages/athena-webapp/src/components/common/PageLevelHeader.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1179,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_dashboard_metriccard_tsx",
-      "label": "MetricCard.tsx",
-      "norm_label": "metriccard.tsx",
-      "source_file": "packages/athena-webapp/src/components/dashboard/MetricCard.tsx",
       "source_location": "L1"
     },
     {
@@ -65454,6 +65526,24 @@
     {
       "community": 1180,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_common_pagelevelheader_tsx",
+      "label": "PageLevelHeader.tsx",
+      "norm_label": "pagelevelheader.tsx",
+      "source_file": "packages/athena-webapp/src/components/common/PageLevelHeader.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1181,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_dashboard_metriccard_tsx",
+      "label": "MetricCard.tsx",
+      "norm_label": "metriccard.tsx",
+      "source_file": "packages/athena-webapp/src/components/dashboard/MetricCard.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1182,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_join_team_index_test_tsx",
       "label": "index.test.tsx",
       "norm_label": "index.test.tsx",
@@ -65461,7 +65551,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1181,
+      "community": 1183,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_commandapprovaldialog_test_tsx",
       "label": "CommandApprovalDialog.test.tsx",
@@ -65470,7 +65560,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1182,
+      "community": 1184,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_operationreviewworkspace_tsx",
       "label": "OperationReviewWorkspace.tsx",
@@ -65479,7 +65569,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1183,
+      "community": 1185,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_operationsqueueview_auth_test_tsx",
       "label": "OperationsQueueView.auth.test.tsx",
@@ -65488,7 +65578,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1184,
+      "community": 1186,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_useapprovedcommand_test_tsx",
       "label": "useApprovedCommand.test.tsx",
@@ -65497,7 +65587,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1185,
+      "community": 1187,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orderstatus_test_tsx",
       "label": "OrderStatus.test.tsx",
@@ -65506,7 +65596,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1186,
+      "community": 1188,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orderstatus_tsx",
       "label": "OrderStatus.tsx",
@@ -65515,30 +65605,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1187,
+      "community": 1189,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_ordersummary_tsx",
       "label": "OrderSummary.tsx",
       "norm_label": "ordersummary.tsx",
       "source_file": "packages/athena-webapp/src/components/orders/OrderSummary.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1188,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_orders_tsx",
-      "label": "Orders.tsx",
-      "norm_label": "orders.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/Orders.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1189,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_refundsview_test_tsx",
-      "label": "RefundsView.test.tsx",
-      "norm_label": "refundsview.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/RefundsView.test.tsx",
       "source_location": "L1"
     },
     {
@@ -65616,6 +65688,24 @@
     {
       "community": 1190,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_orders_tsx",
+      "label": "Orders.tsx",
+      "norm_label": "orders.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/Orders.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1191,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_refundsview_test_tsx",
+      "label": "RefundsView.test.tsx",
+      "norm_label": "refundsview.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/RefundsView.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1192,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_returnexchangeview_test_tsx",
       "label": "ReturnExchangeView.test.tsx",
       "norm_label": "returnexchangeview.test.tsx",
@@ -65623,7 +65713,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1191,
+      "community": 1193,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_constants_ts",
       "label": "constants.ts",
@@ -65632,7 +65722,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1192,
+      "community": 1194,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -65641,7 +65731,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1193,
+      "community": 1195,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -65650,7 +65740,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1194,
+      "community": 1196,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_tsx",
       "label": "data-table.tsx",
@@ -65659,7 +65749,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1195,
+      "community": 1197,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_ts",
       "label": "data.ts",
@@ -65668,7 +65758,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1196,
+      "community": 1198,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_refundutils_test_ts",
       "label": "refundUtils.test.ts",
@@ -65677,30 +65767,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1197,
+      "community": 1199,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_utils_test_ts",
       "label": "utils.test.ts",
       "norm_label": "utils.test.ts",
       "source_file": "packages/athena-webapp/src/components/orders/utils.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1198,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_constants_ts",
-      "label": "constants.ts",
-      "norm_label": "constants.ts",
-      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/constants.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1199,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_faceted_filter_tsx",
-      "label": "data-table-faceted-filter.tsx",
-      "norm_label": "data-table-faceted-filter.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table-faceted-filter.tsx",
       "source_location": "L1"
     },
     {
@@ -66030,6 +66102,24 @@
     {
       "community": 1200,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_constants_ts",
+      "label": "constants.ts",
+      "norm_label": "constants.ts",
+      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/constants.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1201,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_faceted_filter_tsx",
+      "label": "data-table-faceted-filter.tsx",
+      "norm_label": "data-table-faceted-filter.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table-faceted-filter.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1202,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
       "norm_label": "data-table-pagination.tsx",
@@ -66037,7 +66127,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1201,
+      "community": 1203,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -66046,7 +66136,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1202,
+      "community": 1204,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_tsx",
       "label": "data-table.tsx",
@@ -66055,7 +66145,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1203,
+      "community": 1205,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_ts",
       "label": "data.ts",
@@ -66064,7 +66154,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1204,
+      "community": 1206,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_invitecolumns_tsx",
       "label": "inviteColumns.tsx",
@@ -66073,7 +66163,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1205,
+      "community": 1207,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_constants_ts",
       "label": "constants.ts",
@@ -66082,7 +66172,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1206,
+      "community": 1208,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -66091,30 +66181,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1207,
+      "community": 1209,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
       "norm_label": "data-table-pagination.tsx",
       "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data-table-pagination.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1208,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_toolbar_tsx",
-      "label": "data-table-toolbar.tsx",
-      "norm_label": "data-table-toolbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data-table-toolbar.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1209,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_tsx",
-      "label": "data-table.tsx",
-      "norm_label": "data-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data-table.tsx",
       "source_location": "L1"
     },
     {
@@ -66192,6 +66264,24 @@
     {
       "community": 1210,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_toolbar_tsx",
+      "label": "data-table-toolbar.tsx",
+      "norm_label": "data-table-toolbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data-table-toolbar.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1211,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_tsx",
+      "label": "data-table.tsx",
+      "norm_label": "data-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data-table.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1212,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_ts",
       "label": "data.ts",
       "norm_label": "data.ts",
@@ -66199,7 +66289,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1211,
+      "community": 1213,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_memberscolumns_tsx",
       "label": "membersColumns.tsx",
@@ -66208,7 +66298,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1212,
+      "community": 1214,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_switcher_test_tsx",
       "label": "organization-switcher.test.tsx",
@@ -66217,7 +66307,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1213,
+      "community": 1215,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_cashierauthdialog_test_tsx",
       "label": "CashierAuthDialog.test.tsx",
@@ -66226,7 +66316,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1214,
+      "community": 1216,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_cashierview_tsx",
       "label": "CashierView.tsx",
@@ -66235,7 +66325,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1215,
+      "community": 1217,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_posregisterview_tsx",
       "label": "POSRegisterView.tsx",
@@ -66244,7 +66334,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1216,
+      "community": 1218,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_paymentview_test_tsx",
       "label": "PaymentView.test.tsx",
@@ -66253,30 +66343,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1217,
+      "community": 1219,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_pointofsaleview_test_tsx",
       "label": "PointOfSaleView.test.tsx",
       "norm_label": "pointofsaleview.test.tsx",
       "source_file": "packages/athena-webapp/src/components/pos/PointOfSaleView.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1218,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_pointofsaleview_tsx",
-      "label": "PointOfSaleView.tsx",
-      "norm_label": "pointofsaleview.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/PointOfSaleView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1219,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_productlookup_tsx",
-      "label": "ProductLookup.tsx",
-      "norm_label": "productlookup.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/ProductLookup.tsx",
       "source_location": "L1"
     },
     {
@@ -66354,6 +66426,24 @@
     {
       "community": 1220,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_pointofsaleview_tsx",
+      "label": "PointOfSaleView.tsx",
+      "norm_label": "pointofsaleview.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/PointOfSaleView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1221,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_productlookup_tsx",
+      "label": "ProductLookup.tsx",
+      "norm_label": "productlookup.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/ProductLookup.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1222,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_registeractions_tsx",
       "label": "RegisterActions.tsx",
       "norm_label": "registeractions.tsx",
@@ -66361,7 +66451,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1221,
+      "community": 1223,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_sessionmanager_test_tsx",
       "label": "SessionManager.test.tsx",
@@ -66370,7 +66460,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1222,
+      "community": 1224,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_sessionmanager_tsx",
       "label": "SessionManager.tsx",
@@ -66379,7 +66469,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1223,
+      "community": 1225,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_totalsdisplay_test_tsx",
       "label": "TotalsDisplay.test.tsx",
@@ -66388,7 +66478,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1224,
+      "community": 1226,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_totalsdisplay_tsx",
       "label": "TotalsDisplay.tsx",
@@ -66397,7 +66487,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1225,
+      "community": 1227,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportview_tsx",
       "label": "ExpenseReportView.tsx",
@@ -66406,7 +66496,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1226,
+      "community": 1228,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportsview_test_ts",
       "label": "ExpenseReportsView.test.ts",
@@ -66415,30 +66505,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1227,
+      "community": 1229,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportsview_test_tsx",
       "label": "ExpenseReportsView.test.tsx",
       "norm_label": "expensereportsview.test.tsx",
       "source_file": "packages/athena-webapp/src/components/pos/expense-reports/ExpenseReportsView.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1228,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportcolumns_tsx",
-      "label": "expenseReportColumns.tsx",
-      "norm_label": "expensereportcolumns.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/expense-reports/expenseReportColumns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1229,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_receipt_posreceiptsharecontrol_test_tsx",
-      "label": "PosReceiptShareControl.test.tsx",
-      "norm_label": "posreceiptsharecontrol.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/receipt/PosReceiptShareControl.test.tsx",
       "source_location": "L1"
     },
     {
@@ -66507,6 +66579,24 @@
     {
       "community": 1230,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportcolumns_tsx",
+      "label": "expenseReportColumns.tsx",
+      "norm_label": "expensereportcolumns.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/expense-reports/expenseReportColumns.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1231,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_receipt_posreceiptsharecontrol_test_tsx",
+      "label": "PosReceiptShareControl.test.tsx",
+      "norm_label": "posreceiptsharecontrol.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/receipt/PosReceiptShareControl.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1232,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_posregisteropeningguard_test_tsx",
       "label": "POSRegisterOpeningGuard.test.tsx",
       "norm_label": "posregisteropeningguard.test.tsx",
@@ -66514,7 +66604,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1231,
+      "community": 1233,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_posregisterview_test_tsx",
       "label": "POSRegisterView.test.tsx",
@@ -66523,7 +66613,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1232,
+      "community": 1234,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_registeractionbar_test_tsx",
       "label": "RegisterActionBar.test.tsx",
@@ -66532,7 +66622,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1233,
+      "community": 1235,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_registeractionbar_tsx",
       "label": "RegisterActionBar.tsx",
@@ -66541,7 +66631,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1234,
+      "community": 1236,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_registercheckoutpanel_tsx",
       "label": "RegisterCheckoutPanel.tsx",
@@ -66550,7 +66640,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1235,
+      "community": 1237,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_session_heldsessionslist_test_tsx",
       "label": "HeldSessionsList.test.tsx",
@@ -66559,7 +66649,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1236,
+      "community": 1238,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_sessions_possessionsview_test_tsx",
       "label": "POSSessionsView.test.tsx",
@@ -66568,30 +66658,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1237,
+      "community": 1239,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_sessions_possessioncolumns_tsx",
       "label": "posSessionColumns.tsx",
       "norm_label": "possessioncolumns.tsx",
       "source_file": "packages/athena-webapp/src/components/pos/sessions/posSessionColumns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1238,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_transactions_transactionsview_test_tsx",
-      "label": "TransactionsView.test.tsx",
-      "norm_label": "transactionsview.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionsView.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1239,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_types_ts",
-      "label": "types.ts",
-      "norm_label": "types.ts",
-      "source_file": "packages/athena-webapp/src/components/pos/types.ts",
       "source_location": "L1"
     },
     {
@@ -66660,6 +66732,24 @@
     {
       "community": 1240,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_transactions_transactionsview_test_tsx",
+      "label": "TransactionsView.test.tsx",
+      "norm_label": "transactionsview.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionsView.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1241,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_types_ts",
+      "label": "types.ts",
+      "norm_label": "types.ts",
+      "source_file": "packages/athena-webapp/src/components/pos/types.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1242,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_procurement_receivingview_test_tsx",
       "label": "ReceivingView.test.tsx",
       "norm_label": "receivingview.test.tsx",
@@ -66667,7 +66757,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1241,
+      "community": 1243,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_analyticsinsights_tsx",
       "label": "AnalyticsInsights.tsx",
@@ -66676,7 +66766,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1242,
+      "community": 1244,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_attributesview_tsx",
       "label": "AttributesView.tsx",
@@ -66685,7 +66775,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1243,
+      "community": 1245,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_detailsview_tsx",
       "label": "DetailsView.tsx",
@@ -66694,7 +66784,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1244,
+      "community": 1246,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_productdetailview_tsx",
       "label": "ProductDetailView.tsx",
@@ -66703,7 +66793,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1245,
+      "community": 1247,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_archivedproducts_tsx",
       "label": "ArchivedProducts.tsx",
@@ -66712,7 +66802,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1246,
+      "community": 1248,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_categorylistview_tsx",
       "label": "CategoryListView.tsx",
@@ -66721,30 +66811,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1247,
+      "community": 1249,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_productsubcategorytogglegroup_tsx",
       "label": "ProductSubcategoryToggleGroup.tsx",
       "norm_label": "productsubcategorytogglegroup.tsx",
       "source_file": "packages/athena-webapp/src/components/products/ProductSubcategoryToggleGroup.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1248,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_products_tsx",
-      "label": "Products.tsx",
-      "norm_label": "products.tsx",
-      "source_file": "packages/athena-webapp/src/components/products/Products.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1249,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_storeproducts_tsx",
-      "label": "StoreProducts.tsx",
-      "norm_label": "storeproducts.tsx",
-      "source_file": "packages/athena-webapp/src/components/products/StoreProducts.tsx",
       "source_location": "L1"
     },
     {
@@ -66813,6 +66885,24 @@
     {
       "community": 1250,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_products_products_tsx",
+      "label": "Products.tsx",
+      "norm_label": "products.tsx",
+      "source_file": "packages/athena-webapp/src/components/products/Products.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1251,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_products_storeproducts_tsx",
+      "label": "StoreProducts.tsx",
+      "norm_label": "storeproducts.tsx",
+      "source_file": "packages/athena-webapp/src/components/products/StoreProducts.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1252,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_unresolvedproducts_tsx",
       "label": "UnresolvedProducts.tsx",
       "norm_label": "unresolvedproducts.tsx",
@@ -66820,7 +66910,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1251,
+      "community": 1253,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_complimentary_complimentaryproducts_tsx",
       "label": "ComplimentaryProducts.tsx",
@@ -66829,7 +66919,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1252,
+      "community": 1254,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_complimentary_complimentaryproductscolumn_tsx",
       "label": "complimentaryProductsColumn.tsx",
@@ -66838,7 +66928,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1253,
+      "community": 1255,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -66847,7 +66937,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1254,
+      "community": 1256,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -66856,7 +66946,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1255,
+      "community": 1257,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -66865,7 +66955,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1256,
+      "community": 1258,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_tsx",
       "label": "data-table.tsx",
@@ -66874,30 +66964,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1257,
+      "community": 1259,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_ts",
       "label": "data.ts",
       "norm_label": "data.ts",
       "source_file": "packages/athena-webapp/src/components/products/products-table/components/data.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1258,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_products_table_components_productcolumns_tsx",
-      "label": "productColumns.tsx",
-      "norm_label": "productcolumns.tsx",
-      "source_file": "packages/athena-webapp/src/components/products/products-table/components/productColumns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1259,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_promocodeheader_test_tsx",
-      "label": "PromoCodeHeader.test.tsx",
-      "norm_label": "promocodeheader.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeHeader.test.tsx",
       "source_location": "L1"
     },
     {
@@ -66966,6 +67038,24 @@
     {
       "community": 1260,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_products_products_table_components_productcolumns_tsx",
+      "label": "productColumns.tsx",
+      "norm_label": "productcolumns.tsx",
+      "source_file": "packages/athena-webapp/src/components/products/products-table/components/productColumns.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1261,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_promocodeheader_test_tsx",
+      "label": "PromoCodeHeader.test.tsx",
+      "norm_label": "promocodeheader.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeHeader.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1262,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodes_tsx",
       "label": "PromoCodes.tsx",
       "norm_label": "promocodes.tsx",
@@ -66973,7 +67063,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1261,
+      "community": 1263,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_analytics_promocodeanalytics_tsx",
       "label": "PromoCodeAnalytics.tsx",
@@ -66982,7 +67072,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1262,
+      "community": 1264,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_captured_captured_emails_columns_tsx",
       "label": "captured-emails-columns.tsx",
@@ -66991,7 +67081,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1263,
+      "community": 1265,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodemoney_test_ts",
       "label": "promoCodeMoney.test.ts",
@@ -67000,7 +67090,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1264,
+      "community": 1266,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_columns_tsx",
       "label": "columns.tsx",
@@ -67009,7 +67099,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1265,
+      "community": 1267,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -67018,7 +67108,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1266,
+      "community": 1268,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -67027,30 +67117,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1267,
+      "community": 1269,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
       "norm_label": "data-table-toolbar.tsx",
       "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/data-table-toolbar.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1268,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_tsx",
-      "label": "data-table.tsx",
-      "norm_label": "data-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/data-table.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1269,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_table_columns_tsx",
-      "label": "columns.tsx",
-      "norm_label": "columns.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/table/columns.tsx",
       "source_location": "L1"
     },
     {
@@ -67119,6 +67191,24 @@
     {
       "community": 1270,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_tsx",
+      "label": "data-table.tsx",
+      "norm_label": "data-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/data-table.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1271,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_table_columns_tsx",
+      "label": "columns.tsx",
+      "norm_label": "columns.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/table/columns.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1272,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_constants_ts",
       "label": "constants.ts",
       "norm_label": "constants.ts",
@@ -67126,7 +67216,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1271,
+      "community": 1273,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -67135,7 +67225,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1272,
+      "community": 1274,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -67144,7 +67234,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1273,
+      "community": 1275,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -67153,7 +67243,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1274,
+      "community": 1276,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_data_ts",
       "label": "data.ts",
@@ -67162,7 +67252,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1275,
+      "community": 1277,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_types_ts",
       "label": "types.ts",
@@ -67171,7 +67261,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1276,
+      "community": 1278,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_welcome_offer_card_tsx",
       "label": "welcome-offer-card.tsx",
@@ -67180,30 +67270,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1277,
+      "community": 1279,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reviews_ratingstars_tsx",
       "label": "RatingStars.tsx",
       "norm_label": "ratingstars.tsx",
       "source_file": "packages/athena-webapp/src/components/reviews/RatingStars.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1278,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_reviews_reviewcard_tsx",
-      "label": "ReviewCard.tsx",
-      "norm_label": "reviewcard.tsx",
-      "source_file": "packages/athena-webapp/src/components/reviews/ReviewCard.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1279,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_reviews_reviewmetadata_tsx",
-      "label": "ReviewMetadata.tsx",
-      "norm_label": "reviewmetadata.tsx",
-      "source_file": "packages/athena-webapp/src/components/reviews/ReviewMetadata.tsx",
       "source_location": "L1"
     },
     {
@@ -67272,6 +67344,24 @@
     {
       "community": 1280,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_reviews_reviewcard_tsx",
+      "label": "ReviewCard.tsx",
+      "norm_label": "reviewcard.tsx",
+      "source_file": "packages/athena-webapp/src/components/reviews/ReviewCard.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1281,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_reviews_reviewmetadata_tsx",
+      "label": "ReviewMetadata.tsx",
+      "norm_label": "reviewmetadata.tsx",
+      "source_file": "packages/athena-webapp/src/components/reviews/ReviewMetadata.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1282,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_servicesworkspaceview_test_tsx",
       "label": "ServicesWorkspaceView.test.tsx",
       "norm_label": "servicesworkspaceview.test.tsx",
@@ -67279,7 +67369,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1281,
+      "community": 1283,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_staff_index_tsx",
       "label": "index.tsx",
@@ -67288,7 +67378,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1282,
+      "community": 1284,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_staff_auth_staffauthenticationdialog_test_tsx",
       "label": "StaffAuthenticationDialog.test.tsx",
@@ -67297,7 +67387,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1283,
+      "community": 1285,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_feesview_test_ts",
       "label": "FeesView.test.ts",
@@ -67306,7 +67396,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1284,
+      "community": 1286,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_fulfillmentview_test_tsx",
       "label": "FulfillmentView.test.tsx",
@@ -67315,7 +67405,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1285,
+      "community": 1287,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_maintenanceview_test_tsx",
       "label": "MaintenanceView.test.tsx",
@@ -67324,7 +67414,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1286,
+      "community": 1288,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_mtnmomoview_test_tsx",
       "label": "MtnMomoView.test.tsx",
@@ -67333,30 +67423,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1287,
+      "community": 1289,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_hooks_usestoreconfigupdate_test_tsx",
       "label": "useStoreConfigUpdate.test.tsx",
       "norm_label": "usestoreconfigupdate.test.tsx",
       "source_file": "packages/athena-webapp/src/components/store-configuration/hooks/useStoreConfigUpdate.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1288,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_store_configuration_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1289,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_traces_workflowtraceview_test_tsx",
-      "label": "WorkflowTraceView.test.tsx",
-      "norm_label": "workflowtraceview.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/traces/WorkflowTraceView.test.tsx",
       "source_location": "L1"
     },
     {
@@ -67425,6 +67497,24 @@
     {
       "community": 1290,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_store_configuration_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1291,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_traces_workflowtraceview_test_tsx",
+      "label": "WorkflowTraceView.test.tsx",
+      "norm_label": "workflowtraceview.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/traces/WorkflowTraceView.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1292,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_accordion_tsx",
       "label": "accordion.tsx",
       "norm_label": "accordion.tsx",
@@ -67432,7 +67522,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1291,
+      "community": 1293,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_button_test_tsx",
       "label": "button.test.tsx",
@@ -67441,7 +67531,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1292,
+      "community": 1294,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_button_tsx",
       "label": "button.tsx",
@@ -67450,7 +67540,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1293,
+      "community": 1295,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_calendar_test_tsx",
       "label": "calendar.test.tsx",
@@ -67459,7 +67549,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1294,
+      "community": 1296,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_card_tsx",
       "label": "card.tsx",
@@ -67468,7 +67558,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1295,
+      "community": 1297,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_checkbox_tsx",
       "label": "checkbox.tsx",
@@ -67477,7 +67567,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1296,
+      "community": 1298,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_collapsible_tsx",
       "label": "collapsible.tsx",
@@ -67486,30 +67576,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1297,
+      "community": 1299,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_command_tsx",
       "label": "command.tsx",
       "norm_label": "command.tsx",
       "source_file": "packages/athena-webapp/src/components/ui/command.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1298,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_context_menu_tsx",
-      "label": "context-menu.tsx",
-      "norm_label": "context-menu.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/context-menu.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1299,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_dialog_tsx",
-      "label": "dialog.tsx",
-      "norm_label": "dialog.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/dialog.tsx",
       "source_location": "L1"
     },
     {
@@ -67830,6 +67902,24 @@
     {
       "community": 1300,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_context_menu_tsx",
+      "label": "context-menu.tsx",
+      "norm_label": "context-menu.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/context-menu.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1301,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_dialog_tsx",
+      "label": "dialog.tsx",
+      "norm_label": "dialog.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/dialog.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1302,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_dropdown_menu_tsx",
       "label": "dropdown-menu.tsx",
       "norm_label": "dropdown-menu.tsx",
@@ -67837,7 +67927,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1301,
+      "community": 1303,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_form_tsx",
       "label": "form.tsx",
@@ -67846,7 +67936,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1302,
+      "community": 1304,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_icons_tsx",
       "label": "icons.tsx",
@@ -67855,7 +67945,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1303,
+      "community": 1305,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_input_otp_tsx",
       "label": "input-otp.tsx",
@@ -67864,7 +67954,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1304,
+      "community": 1306,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_input_tsx",
       "label": "input.tsx",
@@ -67873,7 +67963,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1305,
+      "community": 1307,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_action_modal_tsx",
       "label": "action-modal.tsx",
@@ -67882,7 +67972,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1306,
+      "community": 1308,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_panel_header_tsx",
       "label": "panel-header.tsx",
@@ -67891,30 +67981,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1307,
+      "community": 1309,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_popover_tsx",
       "label": "popover.tsx",
       "norm_label": "popover.tsx",
       "source_file": "packages/athena-webapp/src/components/ui/popover.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1308,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_primitives_test_tsx",
-      "label": "primitives.test.tsx",
-      "norm_label": "primitives.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/primitives.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1309,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_radio_group_tsx",
-      "label": "radio-group.tsx",
-      "norm_label": "radio-group.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/radio-group.tsx",
       "source_location": "L1"
     },
     {
@@ -67983,6 +68055,24 @@
     {
       "community": 1310,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_primitives_test_tsx",
+      "label": "primitives.test.tsx",
+      "norm_label": "primitives.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/primitives.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1311,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_radio_group_tsx",
+      "label": "radio-group.tsx",
+      "norm_label": "radio-group.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/radio-group.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1312,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_scroll_area_tsx",
       "label": "scroll-area.tsx",
       "norm_label": "scroll-area.tsx",
@@ -67990,7 +68080,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1311,
+      "community": 1313,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_select_tsx",
       "label": "select.tsx",
@@ -67999,7 +68089,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1312,
+      "community": 1314,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_separator_tsx",
       "label": "separator.tsx",
@@ -68008,7 +68098,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1313,
+      "community": 1315,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_sheet_tsx",
       "label": "sheet.tsx",
@@ -68017,7 +68107,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1314,
+      "community": 1316,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_switch_tsx",
       "label": "switch.tsx",
@@ -68026,7 +68116,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1315,
+      "community": 1317,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_table_tsx",
       "label": "table.tsx",
@@ -68035,7 +68125,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1316,
+      "community": 1318,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_tabs_tsx",
       "label": "tabs.tsx",
@@ -68044,30 +68134,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1317,
+      "community": 1319,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_textarea_tsx",
       "label": "textarea.tsx",
       "norm_label": "textarea.tsx",
       "source_file": "packages/athena-webapp/src/components/ui/textarea.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1318,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_toggle_group_tsx",
-      "label": "toggle-group.tsx",
-      "norm_label": "toggle-group.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/toggle-group.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1319,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_toggle_tsx",
-      "label": "toggle.tsx",
-      "norm_label": "toggle.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/toggle.tsx",
       "source_location": "L1"
     },
     {
@@ -68136,6 +68208,24 @@
     {
       "community": 1320,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_toggle_group_tsx",
+      "label": "toggle-group.tsx",
+      "norm_label": "toggle-group.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/toggle-group.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1321,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_toggle_tsx",
+      "label": "toggle.tsx",
+      "norm_label": "toggle.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/toggle.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1322,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_tooltip_tsx",
       "label": "tooltip.tsx",
       "norm_label": "tooltip.tsx",
@@ -68143,7 +68233,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1321,
+      "community": 1323,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_upload_button_tsx",
       "label": "upload-button.tsx",
@@ -68152,7 +68242,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1322,
+      "community": 1324,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_bagview_tsx",
       "label": "BagView.tsx",
@@ -68161,7 +68251,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1323,
+      "community": 1325,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_columns_tsx",
       "label": "columns.tsx",
@@ -68170,7 +68260,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1324,
+      "community": 1326,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_constants_ts",
       "label": "constants.ts",
@@ -68179,7 +68269,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1325,
+      "community": 1327,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -68188,7 +68278,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1326,
+      "community": 1328,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -68197,30 +68287,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1327,
+      "community": 1329,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_data_table_tsx",
       "label": "data-table.tsx",
       "norm_label": "data-table.tsx",
       "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1328,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_table_data_ts",
-      "label": "data.ts",
-      "norm_label": "data.ts",
-      "source_file": "packages/athena-webapp/src/components/user-bags/table/data.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1329,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_bag_columns_tsx",
-      "label": "bag-columns.tsx",
-      "norm_label": "bag-columns.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/bag-columns.tsx",
       "source_location": "L1"
     },
     {
@@ -68289,6 +68361,24 @@
     {
       "community": 1330,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_table_data_ts",
+      "label": "data.ts",
+      "norm_label": "data.ts",
+      "source_file": "packages/athena-webapp/src/components/user-bags/table/data.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1331,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_bag_columns_tsx",
+      "label": "bag-columns.tsx",
+      "norm_label": "bag-columns.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/bag-columns.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1332,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_bags_table_tsx",
       "label": "bags-table.tsx",
       "norm_label": "bags-table.tsx",
@@ -68296,7 +68386,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1331,
+      "community": 1333,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_columns_tsx",
       "label": "columns.tsx",
@@ -68305,7 +68395,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1332,
+      "community": 1334,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -68314,7 +68404,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1333,
+      "community": 1335,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -68323,7 +68413,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1334,
+      "community": 1336,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -68332,7 +68422,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1335,
+      "community": 1337,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -68341,7 +68431,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1336,
+      "community": 1338,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_linkedaccounts_tsx",
       "label": "LinkedAccounts.tsx",
@@ -68350,30 +68440,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1337,
+      "community": 1339,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_timelineeventcard_test_tsx",
       "label": "TimelineEventCard.test.tsx",
       "norm_label": "timelineeventcard.test.tsx",
       "source_file": "packages/athena-webapp/src/components/users/TimelineEventCard.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1338,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_users_usercheckoutsession_tsx",
-      "label": "UserCheckoutSession.tsx",
-      "norm_label": "usercheckoutsession.tsx",
-      "source_file": "packages/athena-webapp/src/components/users/UserCheckoutSession.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1339,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_users_userinsightssection_tsx",
-      "label": "UserInsightsSection.tsx",
-      "norm_label": "userinsightssection.tsx",
-      "source_file": "packages/athena-webapp/src/components/users/UserInsightsSection.tsx",
       "source_location": "L1"
     },
     {
@@ -68442,6 +68514,24 @@
     {
       "community": 1340,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_users_usercheckoutsession_tsx",
+      "label": "UserCheckoutSession.tsx",
+      "norm_label": "usercheckoutsession.tsx",
+      "source_file": "packages/athena-webapp/src/components/users/UserCheckoutSession.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1341,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_users_userinsightssection_tsx",
+      "label": "UserInsightsSection.tsx",
+      "norm_label": "userinsightssection.tsx",
+      "source_file": "packages/athena-webapp/src/components/users/UserInsightsSection.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1342,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_userbehaviorinsights_tsx",
       "label": "UserBehaviorInsights.tsx",
       "norm_label": "userbehaviorinsights.tsx",
@@ -68449,7 +68539,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1341,
+      "community": 1343,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_index_ts",
       "label": "index.ts",
@@ -68458,7 +68548,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1342,
+      "community": 1344,
       "file_type": "code",
       "id": "packages_athena_webapp_src_config_test_ts",
       "label": "config.test.ts",
@@ -68467,7 +68557,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1343,
+      "community": 1345,
       "file_type": "code",
       "id": "packages_athena_webapp_src_contexts_themecontext_tsx",
       "label": "ThemeContext.tsx",
@@ -68476,7 +68566,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1344,
+      "community": 1346,
       "file_type": "code",
       "id": "packages_athena_webapp_src_design_system_build_config_test_ts",
       "label": "design-system-build-config.test.ts",
@@ -68485,7 +68575,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1345,
+      "community": 1347,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_store_modal_tsx",
       "label": "use-store-modal.tsx",
@@ -68494,7 +68584,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1346,
+      "community": 1348,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useauth_test_tsx",
       "label": "useAuth.test.tsx",
@@ -68503,30 +68593,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1347,
+      "community": 1349,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useexpensesessions_test_ts",
       "label": "useExpenseSessions.test.ts",
       "norm_label": "useexpensesessions.test.ts",
       "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1348,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_useorganizationmodal_tsx",
-      "label": "useOrganizationModal.tsx",
-      "norm_label": "useorganizationmodal.tsx",
-      "source_file": "packages/athena-webapp/src/hooks/useOrganizationModal.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1349,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_useprotectedadminpagestate_test_tsx",
-      "label": "useProtectedAdminPageState.test.tsx",
-      "norm_label": "useprotectedadminpagestate.test.tsx",
-      "source_file": "packages/athena-webapp/src/hooks/useProtectedAdminPageState.test.tsx",
       "source_location": "L1"
     },
     {
@@ -68595,6 +68667,24 @@
     {
       "community": 1350,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_useorganizationmodal_tsx",
+      "label": "useOrganizationModal.tsx",
+      "norm_label": "useorganizationmodal.tsx",
+      "source_file": "packages/athena-webapp/src/hooks/useOrganizationModal.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1351,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_useprotectedadminpagestate_test_tsx",
+      "label": "useProtectedAdminPageState.test.tsx",
+      "norm_label": "useprotectedadminpagestate.test.tsx",
+      "source_file": "packages/athena-webapp/src/hooks/useProtectedAdminPageState.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1352,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_lib_access_capabilities_test_ts",
       "label": "capabilities.test.ts",
       "norm_label": "capabilities.test.ts",
@@ -68602,7 +68692,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1351,
+      "community": 1353,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_aws_ts",
       "label": "aws.ts",
@@ -68611,7 +68701,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1352,
+      "community": 1354,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_constants_ts",
       "label": "constants.ts",
@@ -68620,7 +68710,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1353,
+      "community": 1355,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_countries_ts",
       "label": "countries.ts",
@@ -68629,7 +68719,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1354,
+      "community": 1356,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_operatormessages_test_ts",
       "label": "operatorMessages.test.ts",
@@ -68638,7 +68728,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1355,
+      "community": 1357,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_presentcommandtoast_test_ts",
       "label": "presentCommandToast.test.ts",
@@ -68647,7 +68737,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1356,
+      "community": 1358,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_presentunexpectederrortoast_test_ts",
       "label": "presentUnexpectedErrorToast.test.ts",
@@ -68656,30 +68746,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1357,
+      "community": 1359,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_runcommand_test_ts",
       "label": "runCommand.test.ts",
       "norm_label": "runcommand.test.ts",
       "source_file": "packages/athena-webapp/src/lib/errors/runCommand.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1358,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_ghana_ts",
-      "label": "ghana.ts",
-      "norm_label": "ghana.ts",
-      "source_file": "packages/athena-webapp/src/lib/ghana.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1359,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_ghanaregions_ts",
-      "label": "ghanaRegions.ts",
-      "norm_label": "ghanaregions.ts",
-      "source_file": "packages/athena-webapp/src/lib/ghanaRegions.ts",
       "source_location": "L1"
     },
     {
@@ -68748,6 +68820,24 @@
     {
       "community": 1360,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_ghana_ts",
+      "label": "ghana.ts",
+      "norm_label": "ghana.ts",
+      "source_file": "packages/athena-webapp/src/lib/ghana.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1361,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_ghanaregions_ts",
+      "label": "ghanaRegions.ts",
+      "norm_label": "ghanaregions.ts",
+      "source_file": "packages/athena-webapp/src/lib/ghanaRegions.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1362,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_dto_ts",
       "label": "dto.ts",
       "norm_label": "dto.ts",
@@ -68755,7 +68845,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1361,
+      "community": 1363,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_ports_ts",
       "label": "ports.ts",
@@ -68764,7 +68854,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1362,
+      "community": 1364,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_constants_ts",
       "label": "constants.ts",
@@ -68773,7 +68863,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1363,
+      "community": 1365,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_displayamounts_test_ts",
       "label": "displayAmounts.test.ts",
@@ -68782,7 +68872,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1364,
+      "community": 1366,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_domain_cart_test_ts",
       "label": "cart.test.ts",
@@ -68791,7 +68881,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1365,
+      "community": 1367,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_domain_index_ts",
       "label": "index.ts",
@@ -68800,7 +68890,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1366,
+      "community": 1368,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_domain_session_test_ts",
       "label": "session.test.ts",
@@ -68809,30 +68899,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1367,
+      "community": 1369,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_domain_types_ts",
       "label": "types.ts",
       "norm_label": "types.ts",
       "source_file": "packages/athena-webapp/src/lib/pos/domain/types.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1368,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_registergateway_test_ts",
-      "label": "registerGateway.test.ts",
-      "norm_label": "registergateway.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/registerGateway.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1369,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_sessiongateway_test_ts",
-      "label": "sessionGateway.test.ts",
-      "norm_label": "sessiongateway.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/sessionGateway.test.ts",
       "source_location": "L1"
     },
     {
@@ -68901,6 +68973,24 @@
     {
       "community": 1370,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_registergateway_test_ts",
+      "label": "registerGateway.test.ts",
+      "norm_label": "registergateway.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/registerGateway.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1371,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_sessiongateway_test_ts",
+      "label": "sessionGateway.test.ts",
+      "norm_label": "sessiongateway.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/sessionGateway.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1372,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_telemetry_loggergateway_ts",
       "label": "loggerGateway.ts",
       "norm_label": "loggergateway.ts",
@@ -68908,7 +68998,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1371,
+      "community": 1373,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_presentation_register_catalogsearch_test_ts",
       "label": "catalogSearch.test.ts",
@@ -68917,7 +69007,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1372,
+      "community": 1374,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_presentation_register_registeruistate_ts",
       "label": "registerUiState.ts",
@@ -68926,7 +69016,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1373,
+      "community": 1375,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_productutils_test_ts",
       "label": "productUtils.test.ts",
@@ -68935,7 +69025,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1374,
+      "community": 1376,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_schemas_category_ts",
       "label": "category.ts",
@@ -68944,7 +69034,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1375,
+      "community": 1377,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_schemas_product_ts",
       "label": "product.ts",
@@ -68953,7 +69043,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1376,
+      "community": 1378,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_schemas_store_ts",
       "label": "store.ts",
@@ -68962,30 +69052,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1377,
+      "community": 1379,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_schemas_subcategory_ts",
       "label": "subcategory.ts",
       "norm_label": "subcategory.ts",
       "source_file": "packages/athena-webapp/src/lib/schemas/subcategory.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1378,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_schemas_user_ts",
-      "label": "user.ts",
-      "norm_label": "user.ts",
-      "source_file": "packages/athena-webapp/src/lib/schemas/user.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1379,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_storeconfig_test_ts",
-      "label": "storeConfig.test.ts",
-      "norm_label": "storeconfig.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/storeConfig.test.ts",
       "source_location": "L1"
     },
     {
@@ -69054,6 +69126,24 @@
     {
       "community": 1380,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_schemas_user_ts",
+      "label": "user.ts",
+      "norm_label": "user.ts",
+      "source_file": "packages/athena-webapp/src/lib/schemas/user.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1381,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_storeconfig_test_ts",
+      "label": "storeConfig.test.ts",
+      "norm_label": "storeconfig.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/storeConfig.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1382,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_lib_traces_createworkflowtraceid_test_ts",
       "label": "createWorkflowTraceId.test.ts",
       "norm_label": "createworkflowtraceid.test.ts",
@@ -69061,7 +69151,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1381,
+      "community": 1383,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_utils_test_ts",
       "label": "utils.test.ts",
@@ -69070,7 +69160,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1382,
+      "community": 1384,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routetree_gen_ts",
       "label": "routeTree.gen.ts",
@@ -69079,7 +69169,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1383,
+      "community": 1385,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_root_tsx",
       "label": "__root.tsx",
@@ -69088,7 +69178,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1384,
+      "community": 1386,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_index_tsx",
       "label": "index.tsx",
@@ -69097,7 +69187,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1385,
+      "community": 1387,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_settings_index_tsx",
       "label": "index.tsx",
@@ -69106,7 +69196,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1386,
+      "community": 1388,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_settings_organization_index_tsx",
       "label": "index.tsx",
@@ -69115,30 +69205,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1387,
+      "community": 1389,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_settings_stores_storeurlslug_tsx",
       "label": "$storeUrlSlug.tsx",
       "norm_label": "$storeurlslug.tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/settings/stores/$storeUrlSlug.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1388,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_analytics_tsx",
-      "label": "analytics.tsx",
-      "norm_label": "analytics.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/analytics.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1389,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_assets_index_tsx",
-      "label": "assets.index.tsx",
-      "norm_label": "assets.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/assets.index.tsx",
       "source_location": "L1"
     },
     {
@@ -69207,6 +69279,24 @@
     {
       "community": 1390,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_analytics_tsx",
+      "label": "analytics.tsx",
+      "norm_label": "analytics.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/analytics.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1391,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_assets_index_tsx",
+      "label": "assets.index.tsx",
+      "norm_label": "assets.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/assets.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1392,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_bags_bagid_tsx",
       "label": "bags.$bagId.tsx",
       "norm_label": "bags.$bagid.tsx",
@@ -69214,7 +69304,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1391,
+      "community": 1393,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_bags_index_tsx",
       "label": "bags.index.tsx",
@@ -69223,7 +69313,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1392,
+      "community": 1394,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_bulk_operations_index_tsx",
       "label": "index.tsx",
@@ -69232,7 +69322,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1393,
+      "community": 1395,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_checkout_sessions_index_tsx",
       "label": "checkout-sessions.index.tsx",
@@ -69241,7 +69331,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1394,
+      "community": 1396,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_configuration_index_tsx",
       "label": "configuration.index.tsx",
@@ -69250,7 +69340,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1395,
+      "community": 1397,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_dashboard_index_tsx",
       "label": "dashboard.index.tsx",
@@ -69259,7 +69349,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1396,
+      "community": 1398,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_home_tsx",
       "label": "home.tsx",
@@ -69268,30 +69358,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1397,
+      "community": 1399,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_logs_logid_tsx",
       "label": "logs.$logId.tsx",
       "norm_label": "logs.$logid.tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/logs.$logId.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1398,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_logs_index_tsx",
-      "label": "logs.index.tsx",
-      "norm_label": "logs.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/logs.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1399,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_members_index_tsx",
-      "label": "members.index.tsx",
-      "norm_label": "members.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/members.index.tsx",
       "source_location": "L1"
     },
     {
@@ -69585,6 +69657,24 @@
     {
       "community": 1400,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_logs_index_tsx",
+      "label": "logs.index.tsx",
+      "norm_label": "logs.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/logs.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1401,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_members_index_tsx",
+      "label": "members.index.tsx",
+      "norm_label": "members.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/members.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1402,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_operations_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
@@ -69592,7 +69682,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1401,
+      "community": 1403,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_orderslug_index_tsx",
       "label": "index.tsx",
@@ -69601,7 +69691,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1402,
+      "community": 1404,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_all_index_tsx",
       "label": "all.index.tsx",
@@ -69610,7 +69700,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1403,
+      "community": 1405,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_cancelled_index_tsx",
       "label": "cancelled.index.tsx",
@@ -69619,7 +69709,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1404,
+      "community": 1406,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_completed_index_tsx",
       "label": "completed.index.tsx",
@@ -69628,7 +69718,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1405,
+      "community": 1407,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_index_tsx",
       "label": "index.tsx",
@@ -69637,7 +69727,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1406,
+      "community": 1408,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_open_index_tsx",
       "label": "open.index.tsx",
@@ -69646,30 +69736,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1407,
+      "community": 1409,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_out_for_delivery_index_tsx",
       "label": "out-for-delivery.index.tsx",
       "norm_label": "out-for-delivery.index.tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/out-for-delivery.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1408,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_ready_index_tsx",
-      "label": "ready.index.tsx",
-      "norm_label": "ready.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/ready.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1409,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_refunded_index_tsx",
-      "label": "refunded.index.tsx",
-      "norm_label": "refunded.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/refunded.index.tsx",
       "source_location": "L1"
     },
     {
@@ -69738,6 +69810,24 @@
     {
       "community": 1410,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_ready_index_tsx",
+      "label": "ready.index.tsx",
+      "norm_label": "ready.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/ready.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1411,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_refunded_index_tsx",
+      "label": "refunded.index.tsx",
+      "norm_label": "refunded.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/refunded.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1412,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_reports_reportid_tsx",
       "label": "$reportId.tsx",
       "norm_label": "$reportid.tsx",
@@ -69745,7 +69835,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1411,
+      "community": 1413,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_reports_index_tsx",
       "label": "expense-reports.index.tsx",
@@ -69754,7 +69844,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1412,
+      "community": 1414,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_index_tsx",
       "label": "index.tsx",
@@ -69763,7 +69853,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1413,
+      "community": 1415,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_register_index_tsx",
       "label": "register.index.tsx",
@@ -69772,7 +69862,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1414,
+      "community": 1416,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_sessions_index_tsx",
       "label": "sessions.index.tsx",
@@ -69781,7 +69871,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1415,
+      "community": 1417,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_settings_index_tsx",
       "label": "settings.index.tsx",
@@ -69790,7 +69880,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1416,
+      "community": 1418,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_transactions_transactionid_tsx",
       "label": "$transactionId.tsx",
@@ -69799,30 +69889,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1417,
+      "community": 1419,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_transactions_index_tsx",
       "label": "transactions.index.tsx",
       "norm_label": "transactions.index.tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/transactions.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1418,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_procurement_index_test_ts",
-      "label": "procurement.index.test.ts",
-      "norm_label": "procurement.index.test.ts",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/procurement.index.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1419,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_productslug_edit_tsx",
-      "label": "edit.tsx",
-      "norm_label": "edit.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/$productSlug/edit.tsx",
       "source_location": "L1"
     },
     {
@@ -69891,6 +69963,24 @@
     {
       "community": 1420,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_procurement_index_test_ts",
+      "label": "procurement.index.test.ts",
+      "norm_label": "procurement.index.test.ts",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/procurement.index.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1421,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_productslug_edit_tsx",
+      "label": "edit.tsx",
+      "norm_label": "edit.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/$productSlug/edit.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1422,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_productslug_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
@@ -69898,7 +69988,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1421,
+      "community": 1423,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_archived_tsx",
       "label": "archived.tsx",
@@ -69907,7 +69997,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1422,
+      "community": 1424,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_complimentary_index_tsx",
       "label": "index.tsx",
@@ -69916,7 +70006,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1423,
+      "community": 1425,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_complimentary_new_tsx",
       "label": "new.tsx",
@@ -69925,7 +70015,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1424,
+      "community": 1426,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_index_tsx",
       "label": "index.tsx",
@@ -69934,7 +70024,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1425,
+      "community": 1427,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_new_tsx",
       "label": "new.tsx",
@@ -69943,7 +70033,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1426,
+      "community": 1428,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_unresolved_tsx",
       "label": "unresolved.tsx",
@@ -69952,30 +70042,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1427,
+      "community": 1429,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_promocodeslug_tsx",
       "label": "$promoCodeSlug.tsx",
       "norm_label": "$promocodeslug.tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/promo-codes/$promoCodeSlug.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1428,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/promo-codes/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1429,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_new_tsx",
-      "label": "new.tsx",
-      "norm_label": "new.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/promo-codes/new.tsx",
       "source_location": "L1"
     },
     {
@@ -70044,6 +70116,24 @@
     {
       "community": 1430,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/promo-codes/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1431,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_new_tsx",
+      "label": "new.tsx",
+      "norm_label": "new.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/promo-codes/new.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1432,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reviews_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
@@ -70051,7 +70141,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1431,
+      "community": 1433,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reviews_new_index_tsx",
       "label": "new.index.tsx",
@@ -70060,7 +70150,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1432,
+      "community": 1434,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_active_cases_index_tsx",
       "label": "active-cases.index.tsx",
@@ -70069,7 +70159,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1433,
+      "community": 1435,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_appointments_index_tsx",
       "label": "appointments.index.tsx",
@@ -70078,7 +70168,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1434,
+      "community": 1436,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_catalog_management_index_tsx",
       "label": "catalog-management.index.tsx",
@@ -70087,7 +70177,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1435,
+      "community": 1437,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_index_tsx",
       "label": "index.tsx",
@@ -70096,7 +70186,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1436,
+      "community": 1438,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_intake_index_tsx",
       "label": "intake.index.tsx",
@@ -70105,30 +70195,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1437,
+      "community": 1439,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_traces_traceid_test_tsx",
       "label": "$traceId.test.tsx",
       "norm_label": "$traceid.test.tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1438,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_users_userid_tsx",
-      "label": "users.$userId.tsx",
-      "norm_label": "users.$userid.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/users.$userId.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1439,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/index.tsx",
       "source_location": "L1"
     },
     {
@@ -70197,6 +70269,24 @@
     {
       "community": 1440,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_users_userid_tsx",
+      "label": "users.$userId.tsx",
+      "norm_label": "users.$userid.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/users.$userId.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1441,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1442,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_test_tsx",
       "label": "_authed.test.tsx",
       "norm_label": "_authed.test.tsx",
@@ -70204,7 +70294,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1441,
+      "community": 1443,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_index_test_tsx",
       "label": "index.test.tsx",
@@ -70213,7 +70303,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1442,
+      "community": 1444,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_join_team_index_tsx",
       "label": "join-team.index.tsx",
@@ -70222,7 +70312,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1443,
+      "community": 1445,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_landing_tsx",
       "label": "landing.tsx",
@@ -70231,7 +70321,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1444,
+      "community": 1446,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_login_layout_index_test_tsx",
       "label": "_layout.index.test.tsx",
@@ -70240,7 +70330,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1445,
+      "community": 1447,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_login_layout_test_tsx",
       "label": "_layout.test.tsx",
@@ -70249,7 +70339,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1446,
+      "community": 1448,
       "file_type": "code",
       "id": "packages_athena_webapp_src_settings_store_storessettingsaccordion_tsx",
       "label": "StoresSettingsAccordion.tsx",
@@ -70258,30 +70348,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1447,
+      "community": 1449,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stores_expensestore_ts",
       "label": "expenseStore.ts",
       "norm_label": "expensestore.ts",
       "source_file": "packages/athena-webapp/src/stores/expenseStore.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1448,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_foundations_overview_stories_tsx",
-      "label": "Overview.stories.tsx",
-      "norm_label": "overview.stories.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/Overview.stories.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1449,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_foundations_foundations_content_test_tsx",
-      "label": "foundations-content.test.tsx",
-      "norm_label": "foundations-content.test.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.test.tsx",
       "source_location": "L1"
     },
     {
@@ -70350,6 +70422,24 @@
     {
       "community": 1450,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_foundations_overview_stories_tsx",
+      "label": "Overview.stories.tsx",
+      "norm_label": "overview.stories.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/Overview.stories.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1451,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_foundations_foundations_content_test_tsx",
+      "label": "foundations-content.test.tsx",
+      "norm_label": "foundations-content.test.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1452,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_stories_guidance_introduction_stories_tsx",
       "label": "Introduction.stories.tsx",
       "norm_label": "introduction.stories.tsx",
@@ -70357,7 +70447,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1451,
+      "community": 1453,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_guidance_introduction_content_test_tsx",
       "label": "introduction-content.test.tsx",
@@ -70366,7 +70456,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1452,
+      "community": 1454,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_guidance_introduction_content_tsx",
       "label": "introduction-content.tsx",
@@ -70375,7 +70465,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1453,
+      "community": 1455,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_patterns_adminshell_stories_tsx",
       "label": "AdminShell.stories.tsx",
@@ -70384,7 +70474,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1454,
+      "community": 1456,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_patterns_view_stories_tsx",
       "label": "View.stories.tsx",
@@ -70393,7 +70483,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1455,
+      "community": 1457,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_patterns_admin_shell_patterns_test_tsx",
       "label": "admin-shell-patterns.test.tsx",
@@ -70402,7 +70492,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1456,
+      "community": 1458,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_patterns_view_patterns_test_tsx",
       "label": "view-patterns.test.tsx",
@@ -70411,30 +70501,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1457,
+      "community": 1459,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_surfaces_stories_tsx",
       "label": "Surfaces.stories.tsx",
       "norm_label": "surfaces.stories.tsx",
       "source_file": "packages/athena-webapp/src/stories/Primitives/Surfaces.stories.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1458,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_templates_dashboardworkspace_stories_tsx",
-      "label": "DashboardWorkspace.stories.tsx",
-      "norm_label": "dashboardworkspace.stories.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Templates/DashboardWorkspace.stories.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1459,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_templates_dataworkspace_stories_tsx",
-      "label": "DataWorkspace.stories.tsx",
-      "norm_label": "dataworkspace.stories.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Templates/DataWorkspace.stories.tsx",
       "source_location": "L1"
     },
     {
@@ -70503,6 +70575,24 @@
     {
       "community": 1460,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_templates_dashboardworkspace_stories_tsx",
+      "label": "DashboardWorkspace.stories.tsx",
+      "norm_label": "dashboardworkspace.stories.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Templates/DashboardWorkspace.stories.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1461,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_templates_dataworkspace_stories_tsx",
+      "label": "DataWorkspace.stories.tsx",
+      "norm_label": "dataworkspace.stories.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Templates/DataWorkspace.stories.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1462,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_stories_templates_settingsworkspace_stories_tsx",
       "label": "SettingsWorkspace.stories.tsx",
       "norm_label": "settingsworkspace.stories.tsx",
@@ -70510,7 +70600,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1461,
+      "community": 1463,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_templates_reference_fixtures_test_tsx",
       "label": "reference-fixtures.test.tsx",
@@ -70519,7 +70609,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1462,
+      "community": 1464,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_storybook_config_test_ts",
       "label": "storybook-config.test.ts",
@@ -70528,7 +70618,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1463,
+      "community": 1465,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_storybook_theme_decorator_test_ts",
       "label": "storybook-theme-decorator.test.ts",
@@ -70537,7 +70627,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1464,
+      "community": 1466,
       "file_type": "code",
       "id": "packages_athena_webapp_src_test_setup_ts",
       "label": "setup.ts",
@@ -70546,7 +70636,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1465,
+      "community": 1467,
       "file_type": "code",
       "id": "packages_athena_webapp_src_tests_pos_useprint_test_ts",
       "label": "usePrint.test.ts",
@@ -70555,7 +70645,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1466,
+      "community": 1468,
       "file_type": "code",
       "id": "packages_athena_webapp_tailwind_config_js",
       "label": "tailwind.config.js",
@@ -70564,30 +70654,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1467,
+      "community": 1469,
       "file_type": "code",
       "id": "packages_athena_webapp_types_ts",
       "label": "types.ts",
       "norm_label": "types.ts",
       "source_file": "packages/athena-webapp/types.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1468,
-      "file_type": "code",
-      "id": "packages_athena_webapp_vitest_config_ts",
-      "label": "vitest.config.ts",
-      "norm_label": "vitest.config.ts",
-      "source_file": "packages/athena-webapp/vitest.config.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1469,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_eslint_config_js",
-      "label": "eslint.config.js",
-      "norm_label": "eslint.config.js",
-      "source_file": "packages/storefront-webapp/eslint.config.js",
       "source_location": "L1"
     },
     {
@@ -70656,6 +70728,24 @@
     {
       "community": 1470,
       "file_type": "code",
+      "id": "packages_athena_webapp_vitest_config_ts",
+      "label": "vitest.config.ts",
+      "norm_label": "vitest.config.ts",
+      "source_file": "packages/athena-webapp/vitest.config.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1471,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_eslint_config_js",
+      "label": "eslint.config.js",
+      "norm_label": "eslint.config.js",
+      "source_file": "packages/storefront-webapp/eslint.config.js",
+      "source_location": "L1"
+    },
+    {
+      "community": 1472,
+      "file_type": "code",
       "id": "packages_storefront_webapp_global_d_ts",
       "label": "global.d.ts",
       "norm_label": "global.d.ts",
@@ -70663,7 +70753,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1471,
+      "community": 1473,
       "file_type": "code",
       "id": "packages_storefront_webapp_playwright_config_ts",
       "label": "playwright.config.ts",
@@ -70672,7 +70762,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1472,
+      "community": 1474,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_analytics_test_ts",
       "label": "analytics.test.ts",
@@ -70681,7 +70771,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1473,
+      "community": 1475,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_types_ts",
       "label": "types.ts",
@@ -70690,7 +70780,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1474,
+      "community": 1476,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_assets_icons_hearticonfilled_tsx",
       "label": "HeartIconFilled.tsx",
@@ -70699,7 +70789,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1475,
+      "community": 1477,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_defaultcatchboundary_tsx",
       "label": "DefaultCatchBoundary.tsx",
@@ -70708,7 +70798,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1476,
+      "community": 1478,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_homepage_test_tsx",
       "label": "HomePage.test.tsx",
@@ -70717,30 +70807,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1477,
+      "community": 1479,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_productcard_test_tsx",
       "label": "ProductCard.test.tsx",
       "norm_label": "productcard.test.tsx",
       "source_file": "packages/storefront-webapp/src/components/ProductCard.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1478,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_productcard_tsx",
-      "label": "ProductCard.tsx",
-      "norm_label": "productcard.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ProductCard.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1479,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_upsell_tsx",
-      "label": "Upsell.tsx",
-      "norm_label": "upsell.tsx",
-      "source_file": "packages/storefront-webapp/src/components/Upsell.tsx",
       "source_location": "L1"
     },
     {
@@ -70809,6 +70881,24 @@
     {
       "community": 1480,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_productcard_tsx",
+      "label": "ProductCard.tsx",
+      "norm_label": "productcard.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ProductCard.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1481,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_upsell_tsx",
+      "label": "Upsell.tsx",
+      "norm_label": "upsell.tsx",
+      "source_file": "packages/storefront-webapp/src/components/Upsell.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1482,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkout_test_tsx",
       "label": "Checkout.test.tsx",
       "norm_label": "checkout.test.tsx",
@@ -70816,7 +70906,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1481,
+      "community": 1483,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkout_tsx",
       "label": "Checkout.tsx",
@@ -70825,7 +70915,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1482,
+      "community": 1484,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_customerinfosection_tsx",
       "label": "CustomerInfoSection.tsx",
@@ -70834,7 +70924,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1483,
+      "community": 1485,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_schema_ts",
       "label": "schema.ts",
@@ -70843,7 +70933,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1484,
+      "community": 1486,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliverydetailssection_tsx",
       "label": "DeliveryDetailsSection.tsx",
@@ -70852,7 +70942,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1485,
+      "community": 1487,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkoutstorage_test_ts",
       "label": "checkoutStorage.test.ts",
@@ -70861,7 +70951,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1486,
+      "community": 1488,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliveryfees_test_ts",
       "label": "deliveryFees.test.ts",
@@ -70870,30 +70960,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1487,
+      "community": 1489,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_derivecheckoutstate_test_ts",
       "label": "deriveCheckoutState.test.ts",
       "norm_label": "derivecheckoutstate.test.ts",
       "source_file": "packages/storefront-webapp/src/components/checkout/deriveCheckoutState.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1488,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_schemas_billingdetailsschema_ts",
-      "label": "billingDetailsSchema.ts",
-      "norm_label": "billingdetailsschema.ts",
-      "source_file": "packages/storefront-webapp/src/components/checkout/schemas/billingDetailsSchema.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1489,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_schemas_checkoutformschema_ts",
-      "label": "checkoutFormSchema.ts",
-      "norm_label": "checkoutformschema.ts",
-      "source_file": "packages/storefront-webapp/src/components/checkout/schemas/checkoutFormSchema.ts",
       "source_location": "L1"
     },
     {
@@ -70962,6 +71034,24 @@
     {
       "community": 1490,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_schemas_billingdetailsschema_ts",
+      "label": "billingDetailsSchema.ts",
+      "norm_label": "billingdetailsschema.ts",
+      "source_file": "packages/storefront-webapp/src/components/checkout/schemas/billingDetailsSchema.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1491,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_schemas_checkoutformschema_ts",
+      "label": "checkoutFormSchema.ts",
+      "norm_label": "checkoutformschema.ts",
+      "source_file": "packages/storefront-webapp/src/components/checkout/schemas/checkoutFormSchema.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1492,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_customerdetailsschema_ts",
       "label": "customerDetailsSchema.ts",
       "norm_label": "customerdetailsschema.ts",
@@ -70969,7 +71059,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1491,
+      "community": 1493,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_deliverydetailsschema_ts",
       "label": "deliveryDetailsSchema.ts",
@@ -70978,7 +71068,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1492,
+      "community": 1494,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_weborderschema_ts",
       "label": "webOrderSchema.ts",
@@ -70987,7 +71077,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1493,
+      "community": 1495,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_types_ts",
       "label": "types.ts",
@@ -70996,7 +71086,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1494,
+      "community": 1496,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_utils_test_ts",
       "label": "utils.test.ts",
@@ -71005,7 +71095,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1495,
+      "community": 1497,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_filter_productfilterbar_tsx",
       "label": "ProductFilterBar.tsx",
@@ -71014,7 +71104,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1496,
+      "community": 1498,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_bestsellerssection_test_tsx",
       "label": "BestSellersSection.test.tsx",
@@ -71023,30 +71113,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1497,
+      "community": 1499,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_homehero_tsx",
       "label": "HomeHero.tsx",
       "norm_label": "homehero.tsx",
       "source_file": "packages/storefront-webapp/src/components/home/HomeHero.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1498,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_home_homeherosection_tsx",
-      "label": "HomeHeroSection.tsx",
-      "norm_label": "homeherosection.tsx",
-      "source_file": "packages/storefront-webapp/src/components/home/HomeHeroSection.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1499,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_home_homepagecontent_test_ts",
-      "label": "homePageContent.test.ts",
-      "norm_label": "homepagecontent.test.ts",
-      "source_file": "packages/storefront-webapp/src/components/home/homePageContent.test.ts",
       "source_location": "L1"
     },
     {
@@ -71340,6 +71412,24 @@
     {
       "community": 1500,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_home_homeherosection_tsx",
+      "label": "HomeHeroSection.tsx",
+      "norm_label": "homeherosection.tsx",
+      "source_file": "packages/storefront-webapp/src/components/home/HomeHeroSection.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1501,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_home_homepagecontent_test_ts",
+      "label": "homePageContent.test.ts",
+      "norm_label": "homepagecontent.test.ts",
+      "source_file": "packages/storefront-webapp/src/components/home/homePageContent.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1502,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_mobilemenu_tsx",
       "label": "MobileMenu.tsx",
       "norm_label": "mobilemenu.tsx",
@@ -71347,7 +71437,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1501,
+      "community": 1503,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_constants_ts",
       "label": "constants.ts",
@@ -71356,7 +71446,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1502,
+      "community": 1504,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_navbarconstants_ts",
       "label": "navBarConstants.ts",
@@ -71365,7 +71455,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1503,
+      "community": 1505,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_about_tsx",
       "label": "About.tsx",
@@ -71374,7 +71464,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1504,
+      "community": 1506,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_aboutproduct_tsx",
       "label": "AboutProduct.tsx",
@@ -71383,7 +71473,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1505,
+      "community": 1507,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productactions_test_tsx",
       "label": "ProductActions.test.tsx",
@@ -71392,7 +71482,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1506,
+      "community": 1508,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productinfo_tsx",
       "label": "ProductInfo.tsx",
@@ -71401,30 +71491,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1507,
+      "community": 1509,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productreviews_tsx",
       "label": "ProductReviews.tsx",
       "norm_label": "productreviews.tsx",
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductReviews.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1508,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_page_productsnavigationbar_tsx",
-      "label": "ProductsNavigationBar.tsx",
-      "norm_label": "productsnavigationbar.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-page/ProductsNavigationBar.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1509,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_reviews_errormessage_tsx",
-      "label": "ErrorMessage.tsx",
-      "norm_label": "errormessage.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-reviews/ErrorMessage.tsx",
       "source_location": "L1"
     },
     {
@@ -71493,6 +71565,24 @@
     {
       "community": 1510,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_page_productsnavigationbar_tsx",
+      "label": "ProductsNavigationBar.tsx",
+      "norm_label": "productsnavigationbar.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-page/ProductsNavigationBar.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1511,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_reviews_errormessage_tsx",
+      "label": "ErrorMessage.tsx",
+      "norm_label": "errormessage.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-reviews/ErrorMessage.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1512,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_existingreviewmessage_tsx",
       "label": "ExistingReviewMessage.tsx",
       "norm_label": "existingreviewmessage.tsx",
@@ -71500,7 +71590,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1511,
+      "community": 1513,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_orderitem_test_tsx",
       "label": "OrderItem.test.tsx",
@@ -71509,7 +71599,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1512,
+      "community": 1514,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_reviewform_tsx",
       "label": "ReviewForm.tsx",
@@ -71518,7 +71608,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1513,
+      "community": 1515,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_successmessage_tsx",
       "label": "SuccessMessage.tsx",
@@ -71527,7 +71617,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1514,
+      "community": 1516,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_types_ts",
       "label": "types.ts",
@@ -71536,7 +71626,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1515,
+      "community": 1517,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_saved_items_savedbag_tsx",
       "label": "SavedBag.tsx",
@@ -71545,7 +71635,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1516,
+      "community": 1518,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_saved_items_savedicon_tsx",
       "label": "SavedIcon.tsx",
@@ -71554,30 +71644,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1517,
+      "community": 1519,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_shopping_bag_carticon_tsx",
       "label": "CartIcon.tsx",
       "norm_label": "carticon.tsx",
       "source_file": "packages/storefront-webapp/src/components/shopping-bag/CartIcon.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1518,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_shopping_bag_shoppingbag_test_tsx",
-      "label": "ShoppingBag.test.tsx",
-      "norm_label": "shoppingbag.test.tsx",
-      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1519,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_states_empty_empty_state_tsx",
-      "label": "empty-state.tsx",
-      "norm_label": "empty-state.tsx",
-      "source_file": "packages/storefront-webapp/src/components/states/empty/empty-state.tsx",
       "source_location": "L1"
     },
     {
@@ -71637,6 +71709,24 @@
     {
       "community": 1520,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_shopping_bag_shoppingbag_test_tsx",
+      "label": "ShoppingBag.test.tsx",
+      "norm_label": "shoppingbag.test.tsx",
+      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1521,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_states_empty_empty_state_tsx",
+      "label": "empty-state.tsx",
+      "norm_label": "empty-state.tsx",
+      "source_file": "packages/storefront-webapp/src/components/states/empty/empty-state.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1522,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_maintenance_maintenance_test_tsx",
       "label": "Maintenance.test.tsx",
       "norm_label": "maintenance.test.tsx",
@@ -71644,7 +71734,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1521,
+      "community": 1523,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_maintenance_maintenance_tsx",
       "label": "Maintenance.tsx",
@@ -71653,7 +71743,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1522,
+      "community": 1524,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_animatedcard_tsx",
       "label": "AnimatedCard.tsx",
@@ -71662,7 +71752,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1523,
+      "community": 1525,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_accordion_tsx",
       "label": "accordion.tsx",
@@ -71671,7 +71761,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1524,
+      "community": 1526,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_alert_tsx",
       "label": "alert.tsx",
@@ -71680,7 +71770,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1525,
+      "community": 1527,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_breadcrumb_tsx",
       "label": "breadcrumb.tsx",
@@ -71689,7 +71779,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1526,
+      "community": 1528,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_button_tsx",
       "label": "button.tsx",
@@ -71698,30 +71788,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1527,
+      "community": 1529,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_card_tsx",
       "label": "card.tsx",
       "norm_label": "card.tsx",
       "source_file": "packages/storefront-webapp/src/components/ui/card.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1528,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_checkbox_tsx",
-      "label": "checkbox.tsx",
-      "norm_label": "checkbox.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/checkbox.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1529,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_command_tsx",
-      "label": "command.tsx",
-      "norm_label": "command.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/command.tsx",
       "source_location": "L1"
     },
     {
@@ -71781,6 +71853,24 @@
     {
       "community": 1530,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_checkbox_tsx",
+      "label": "checkbox.tsx",
+      "norm_label": "checkbox.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/checkbox.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1531,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_command_tsx",
+      "label": "command.tsx",
+      "norm_label": "command.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/command.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1532,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_context_menu_tsx",
       "label": "context-menu.tsx",
       "norm_label": "context-menu.tsx",
@@ -71788,7 +71878,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1531,
+      "community": 1533,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_dialog_tsx",
       "label": "dialog.tsx",
@@ -71797,7 +71887,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1532,
+      "community": 1534,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_dropdown_menu_tsx",
       "label": "dropdown-menu.tsx",
@@ -71806,7 +71896,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1533,
+      "community": 1535,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_form_tsx",
       "label": "form.tsx",
@@ -71815,7 +71905,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1534,
+      "community": 1536,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_icons_tsx",
       "label": "icons.tsx",
@@ -71824,7 +71914,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1535,
+      "community": 1537,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_image_with_fallback_tsx",
       "label": "image-with-fallback.tsx",
@@ -71833,7 +71923,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1536,
+      "community": 1538,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_input_otp_tsx",
       "label": "input-otp.tsx",
@@ -71842,30 +71932,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1537,
+      "community": 1539,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_input_with_end_button_tsx",
       "label": "input-with-end-button.tsx",
       "norm_label": "input-with-end-button.tsx",
       "source_file": "packages/storefront-webapp/src/components/ui/input-with-end-button.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1538,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_input_tsx",
-      "label": "input.tsx",
-      "norm_label": "input.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/input.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1539,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_label_tsx",
-      "label": "label.tsx",
-      "norm_label": "label.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/label.tsx",
       "source_location": "L1"
     },
     {
@@ -71925,6 +71997,24 @@
     {
       "community": 1540,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_input_tsx",
+      "label": "input.tsx",
+      "norm_label": "input.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/input.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1541,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_label_tsx",
+      "label": "label.tsx",
+      "norm_label": "label.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/label.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1542,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_leaveareviewmodalform_tsx",
       "label": "LeaveAReviewModalForm.tsx",
       "norm_label": "leaveareviewmodalform.tsx",
@@ -71932,7 +72022,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1541,
+      "community": 1543,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_action_modal_tsx",
       "label": "action-modal.tsx",
@@ -71941,7 +72031,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1542,
+      "community": 1544,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_animations_welcomebackmodalanimations_ts",
       "label": "welcomeBackModalAnimations.ts",
@@ -71950,7 +72040,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1543,
+      "community": 1545,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_index_ts",
       "label": "index.ts",
@@ -71959,7 +72049,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1544,
+      "community": 1546,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_types_ts",
       "label": "types.ts",
@@ -71968,7 +72058,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1545,
+      "community": 1547,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_navigation_menu_tsx",
       "label": "navigation-menu.tsx",
@@ -71977,7 +72067,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1546,
+      "community": 1548,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_popover_tsx",
       "label": "popover.tsx",
@@ -71986,30 +72076,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1547,
+      "community": 1549,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_radio_group_tsx",
       "label": "radio-group.tsx",
       "norm_label": "radio-group.tsx",
       "source_file": "packages/storefront-webapp/src/components/ui/radio-group.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1548,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_scroll_area_tsx",
-      "label": "scroll-area.tsx",
-      "norm_label": "scroll-area.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/scroll-area.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1549,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_select_tsx",
-      "label": "select.tsx",
-      "norm_label": "select.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/select.tsx",
       "source_location": "L1"
     },
     {
@@ -72069,6 +72141,24 @@
     {
       "community": 1550,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_scroll_area_tsx",
+      "label": "scroll-area.tsx",
+      "norm_label": "scroll-area.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/scroll-area.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1551,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_select_tsx",
+      "label": "select.tsx",
+      "norm_label": "select.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/select.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1552,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_separator_tsx",
       "label": "separator.tsx",
       "norm_label": "separator.tsx",
@@ -72076,7 +72166,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1551,
+      "community": 1553,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_sheet_tsx",
       "label": "sheet.tsx",
@@ -72085,7 +72175,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1552,
+      "community": 1554,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_table_tsx",
       "label": "table.tsx",
@@ -72094,7 +72184,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1553,
+      "community": 1555,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_tabs_tsx",
       "label": "tabs.tsx",
@@ -72103,7 +72193,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1554,
+      "community": 1556,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_textarea_tsx",
       "label": "textarea.tsx",
@@ -72112,7 +72202,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1555,
+      "community": 1557,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_toggle_group_tsx",
       "label": "toggle-group.tsx",
@@ -72121,7 +72211,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1556,
+      "community": 1558,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_toggle_tsx",
       "label": "toggle.tsx",
@@ -72130,30 +72220,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1557,
+      "community": 1559,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_tooltip_tsx",
       "label": "tooltip.tsx",
       "norm_label": "tooltip.tsx",
       "source_file": "packages/storefront-webapp/src/components/ui/tooltip.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1558,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_config_ts",
-      "label": "config.ts",
-      "norm_label": "config.ts",
-      "source_file": "packages/storefront-webapp/src/config.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1559,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_use_store_modal_tsx",
-      "label": "use-store-modal.tsx",
-      "norm_label": "use-store-modal.tsx",
-      "source_file": "packages/storefront-webapp/src/hooks/use-store-modal.tsx",
       "source_location": "L1"
     },
     {
@@ -72213,6 +72285,24 @@
     {
       "community": 1560,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_config_ts",
+      "label": "config.ts",
+      "norm_label": "config.ts",
+      "source_file": "packages/storefront-webapp/src/config.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1561,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_use_store_modal_tsx",
+      "label": "use-store-modal.tsx",
+      "norm_label": "use-store-modal.tsx",
+      "source_file": "packages/storefront-webapp/src/hooks/use-store-modal.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1562,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useorganizationmodal_tsx",
       "label": "useOrganizationModal.tsx",
       "norm_label": "useorganizationmodal.tsx",
@@ -72220,7 +72310,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1561,
+      "community": 1563,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usequeryenabled_test_ts",
       "label": "useQueryEnabled.test.ts",
@@ -72229,7 +72319,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1562,
+      "community": 1564,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usestorefrontobservability_ts",
       "label": "useStorefrontObservability.ts",
@@ -72238,7 +72328,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1563,
+      "community": 1565,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_constants_ts",
       "label": "constants.ts",
@@ -72247,7 +72337,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1564,
+      "community": 1566,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_countries_ts",
       "label": "countries.ts",
@@ -72256,7 +72346,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1565,
+      "community": 1567,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_feeutils_test_ts",
       "label": "feeUtils.test.ts",
@@ -72265,7 +72355,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1566,
+      "community": 1568,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_ghana_ts",
       "label": "ghana.ts",
@@ -72274,30 +72364,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1567,
+      "community": 1569,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_ghanaregions_ts",
       "label": "ghanaRegions.ts",
       "norm_label": "ghanaregions.ts",
       "source_file": "packages/storefront-webapp/src/lib/ghanaRegions.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1568,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_maintenanceutils_test_ts",
-      "label": "maintenanceUtils.test.ts",
-      "norm_label": "maintenanceutils.test.ts",
-      "source_file": "packages/storefront-webapp/src/lib/maintenanceUtils.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1569,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_mutations_ts_index_ts",
-      "label": "index.ts",
-      "norm_label": "index.ts",
-      "source_file": "packages/storefront-webapp/src/lib/mutations.ts/index.ts",
       "source_location": "L1"
     },
     {
@@ -72357,6 +72429,24 @@
     {
       "community": 1570,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_maintenanceutils_test_ts",
+      "label": "maintenanceUtils.test.ts",
+      "norm_label": "maintenanceutils.test.ts",
+      "source_file": "packages/storefront-webapp/src/lib/maintenanceUtils.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1571,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_mutations_ts_index_ts",
+      "label": "index.ts",
+      "norm_label": "index.ts",
+      "source_file": "packages/storefront-webapp/src/lib/mutations.ts/index.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1572,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_store_ts",
       "label": "store.ts",
       "norm_label": "store.ts",
@@ -72364,7 +72454,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1571,
+      "community": 1573,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_bag_ts",
       "label": "bag.ts",
@@ -72373,7 +72463,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1572,
+      "community": 1574,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_bagitem_ts",
       "label": "bagItem.ts",
@@ -72382,7 +72472,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1573,
+      "community": 1575,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_category_ts",
       "label": "category.ts",
@@ -72391,7 +72481,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1574,
+      "community": 1576,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_organization_ts",
       "label": "organization.ts",
@@ -72400,7 +72490,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1575,
+      "community": 1577,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_product_ts",
       "label": "product.ts",
@@ -72409,7 +72499,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1576,
+      "community": 1578,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_store_ts",
       "label": "store.ts",
@@ -72418,30 +72508,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1577,
+      "community": 1579,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_subcategory_ts",
       "label": "subcategory.ts",
       "norm_label": "subcategory.ts",
       "source_file": "packages/storefront-webapp/src/lib/schemas/subcategory.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1578,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_schemas_user_ts",
-      "label": "user.ts",
-      "norm_label": "user.ts",
-      "source_file": "packages/storefront-webapp/src/lib/schemas/user.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1579,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_states_ts",
-      "label": "states.ts",
-      "norm_label": "states.ts",
-      "source_file": "packages/storefront-webapp/src/lib/states.ts",
       "source_location": "L1"
     },
     {
@@ -72501,6 +72573,24 @@
     {
       "community": 1580,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_schemas_user_ts",
+      "label": "user.ts",
+      "norm_label": "user.ts",
+      "source_file": "packages/storefront-webapp/src/lib/schemas/user.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1581,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_states_ts",
+      "label": "states.ts",
+      "norm_label": "states.ts",
+      "source_file": "packages/storefront-webapp/src/lib/states.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1582,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_storefrontfailureobservability_test_ts",
       "label": "storefrontFailureObservability.test.ts",
       "norm_label": "storefrontfailureobservability.test.ts",
@@ -72508,7 +72598,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1581,
+      "community": 1583,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_storefrontjourneyevents_test_ts",
       "label": "storefrontJourneyEvents.test.ts",
@@ -72517,7 +72607,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1582,
+      "community": 1584,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_utils_test_ts",
       "label": "utils.test.ts",
@@ -72526,7 +72616,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1583,
+      "community": 1585,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routetree_gen_ts",
       "label": "routeTree.gen.ts",
@@ -72535,7 +72625,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1584,
+      "community": 1586,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_homepageloader_test_ts",
       "label": "-homePageLoader.test.ts",
@@ -72544,7 +72634,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1585,
+      "community": 1587,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_root_tsx",
       "label": "__root.tsx",
@@ -72553,7 +72643,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1586,
+      "community": 1588,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_orderid_orderitemid_review_tsx",
       "label": "$orderItemId.review.tsx",
@@ -72562,30 +72652,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1587,
+      "community": 1589,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
       "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1588,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_layout_shoplayout_shop_categoryslug_subcategoryslug_tsx",
-      "label": "$subcategorySlug.tsx",
-      "norm_label": "$subcategoryslug.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/_shopLayout/shop/$categorySlug/$subcategorySlug.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1589,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_layout_shoplayout_shop_categoryslug_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/_shopLayout/shop/$categorySlug/index.tsx",
       "source_location": "L1"
     },
     {
@@ -72645,6 +72717,24 @@
     {
       "community": 1590,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_layout_shoplayout_shop_categoryslug_subcategoryslug_tsx",
+      "label": "$subcategorySlug.tsx",
+      "norm_label": "$subcategoryslug.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/_shopLayout/shop/$categorySlug/$subcategorySlug.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1591,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_layout_shoplayout_shop_categoryslug_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/_shopLayout/shop/$categorySlug/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1592,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_rewards_index_tsx",
       "label": "rewards.index.tsx",
       "norm_label": "rewards.index.tsx",
@@ -72652,7 +72742,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1591,
+      "community": 1593,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_shop_saved_index_tsx",
       "label": "shop.saved.index.tsx",
@@ -72661,7 +72751,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1592,
+      "community": 1594,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_bag_index_tsx",
       "label": "bag.index.tsx",
@@ -72670,7 +72760,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1593,
+      "community": 1595,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_complete_tsx",
       "label": "complete.tsx",
@@ -72679,7 +72769,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1594,
+      "community": 1596,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_incomplete_tsx",
       "label": "incomplete.tsx",
@@ -72688,7 +72778,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1595,
+      "community": 1597,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_index_tsx",
       "label": "index.tsx",
@@ -72697,7 +72787,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1596,
+      "community": 1598,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_pending_tsx",
       "label": "pending.tsx",
@@ -72706,30 +72796,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1597,
+      "community": 1599,
       "file_type": "code",
       "id": "packages_storefront_webapp_tailwind_config_js",
       "label": "tailwind.config.js",
       "norm_label": "tailwind.config.js",
       "source_file": "packages/storefront-webapp/tailwind.config.js",
-      "source_location": "L1"
-    },
-    {
-      "community": 1598,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_tests_e2e_storefront_boot_e2e_ts",
-      "label": "storefront-boot.e2e.ts",
-      "norm_label": "storefront-boot.e2e.ts",
-      "source_file": "packages/storefront-webapp/tests/e2e/storefront-boot.e2e.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1599,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_vitest_config_ts",
-      "label": "vitest.config.ts",
-      "norm_label": "vitest.config.ts",
-      "source_file": "packages/storefront-webapp/vitest.config.ts",
       "source_location": "L1"
     },
     {
@@ -73014,6 +73086,24 @@
     {
       "community": 1600,
       "file_type": "code",
+      "id": "packages_storefront_webapp_tests_e2e_storefront_boot_e2e_ts",
+      "label": "storefront-boot.e2e.ts",
+      "norm_label": "storefront-boot.e2e.ts",
+      "source_file": "packages/storefront-webapp/tests/e2e/storefront-boot.e2e.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1601,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_vitest_config_ts",
+      "label": "vitest.config.ts",
+      "norm_label": "vitest.config.ts",
+      "source_file": "packages/storefront-webapp/vitest.config.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1602,
+      "file_type": "code",
       "id": "packages_storefront_webapp_vitest_setup_ts",
       "label": "vitest.setup.ts",
       "norm_label": "vitest.setup.ts",
@@ -73021,7 +73111,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1601,
+      "community": 1603,
       "file_type": "code",
       "id": "packages_valkey_proxy_server_index_js",
       "label": "index.js",
@@ -73030,7 +73120,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1602,
+      "community": 1604,
       "file_type": "code",
       "id": "scripts_harness_app_registry_test_ts",
       "label": "harness-app-registry.test.ts",
@@ -73039,7 +73129,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1603,
+      "community": 1605,
       "file_type": "code",
       "id": "scripts_harness_behavior_fixtures_athena_runtime_app_test_ts",
       "label": "athena-runtime-app.test.ts",
@@ -73048,7 +73138,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1604,
+      "community": 1606,
       "file_type": "code",
       "id": "scripts_harness_behavior_fixtures_storefront_runtime_api_test_ts",
       "label": "storefront-runtime-api.test.ts",
@@ -73057,7 +73147,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1605,
+      "community": 1607,
       "file_type": "code",
       "id": "scripts_harness_behavior_fixtures_valkey_runtime_app_test_ts",
       "label": "valkey-runtime-app.test.ts",
@@ -73066,7 +73156,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1606,
+      "community": 1608,
       "file_type": "code",
       "id": "scripts_harness_behavior_scenarios_test_ts",
       "label": "harness-behavior-scenarios.test.ts",
@@ -73075,7 +73165,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1607,
+      "community": 1609,
       "file_type": "code",
       "id": "scripts_harness_repo_validation_test_ts",
       "label": "harness-repo-validation.test.ts",
@@ -73140,60 +73230,6 @@
     {
       "community": 162,
       "file_type": "code",
-      "id": "inputotp_formatrequestdelay",
-      "label": "formatRequestDelay()",
-      "norm_label": "formatrequestdelay()",
-      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
-      "source_location": "L46"
-    },
-    {
-      "community": 162,
-      "file_type": "code",
-      "id": "inputotp_handlepinchange",
-      "label": "handlePinChange()",
-      "norm_label": "handlepinchange()",
-      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
-      "source_location": "L95"
-    },
-    {
-      "community": 162,
-      "file_type": "code",
-      "id": "inputotp_handlerequestnewcode",
-      "label": "handleRequestNewCode()",
-      "norm_label": "handlerequestnewcode()",
-      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
-      "source_location": "L143"
-    },
-    {
-      "community": 162,
-      "file_type": "code",
-      "id": "inputotp_normalizeotpcode",
-      "label": "normalizeOtpCode()",
-      "norm_label": "normalizeotpcode()",
-      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
-      "source_location": "L30"
-    },
-    {
-      "community": 162,
-      "file_type": "code",
-      "id": "inputotp_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
-      "source_location": "L105"
-    },
-    {
-      "community": 162,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_auth_login_inputotp_tsx",
-      "label": "InputOTP.tsx",
-      "norm_label": "inputotp.tsx",
-      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 163,
-      "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_selectable_data_provider_tsx",
       "label": "selectable-data-provider.tsx",
       "norm_label": "selectable-data-provider.tsx",
@@ -73201,7 +73237,7 @@
       "source_location": "L1"
     },
     {
-      "community": 163,
+      "community": 162,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_selectable_data_provider_tsx",
       "label": "selectable-data-provider.tsx",
@@ -73210,7 +73246,7 @@
       "source_location": "L1"
     },
     {
-      "community": 163,
+      "community": 162,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_selectable_data_provider_tsx",
       "label": "selectable-data-provider.tsx",
@@ -73219,7 +73255,7 @@
       "source_location": "L1"
     },
     {
-      "community": 163,
+      "community": 162,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_selectable_data_provider_tsx",
       "label": "selectable-data-provider.tsx",
@@ -73228,7 +73264,7 @@
       "source_location": "L1"
     },
     {
-      "community": 163,
+      "community": 162,
       "file_type": "code",
       "id": "selectable_data_provider_selectedproductsprovider",
       "label": "SelectedProductsProvider()",
@@ -73237,13 +73273,67 @@
       "source_location": "L16"
     },
     {
-      "community": 163,
+      "community": 162,
       "file_type": "code",
       "id": "selectable_data_provider_useselectedproducts",
       "label": "useSelectedProducts()",
       "norm_label": "useselectedproducts()",
       "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/selectable-data-provider.tsx",
       "source_location": "L37"
+    },
+    {
+      "community": 163,
+      "file_type": "code",
+      "id": "inputotp_formatrequestdelay",
+      "label": "formatRequestDelay()",
+      "norm_label": "formatrequestdelay()",
+      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
+      "source_location": "L46"
+    },
+    {
+      "community": 163,
+      "file_type": "code",
+      "id": "inputotp_handlepinchange",
+      "label": "handlePinChange()",
+      "norm_label": "handlepinchange()",
+      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
+      "source_location": "L95"
+    },
+    {
+      "community": 163,
+      "file_type": "code",
+      "id": "inputotp_handlerequestnewcode",
+      "label": "handleRequestNewCode()",
+      "norm_label": "handlerequestnewcode()",
+      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
+      "source_location": "L143"
+    },
+    {
+      "community": 163,
+      "file_type": "code",
+      "id": "inputotp_normalizeotpcode",
+      "label": "normalizeOtpCode()",
+      "norm_label": "normalizeotpcode()",
+      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
+      "source_location": "L30"
+    },
+    {
+      "community": 163,
+      "file_type": "code",
+      "id": "inputotp_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
+      "source_location": "L105"
+    },
+    {
+      "community": 163,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_auth_login_inputotp_tsx",
+      "label": "InputOTP.tsx",
+      "norm_label": "inputotp.tsx",
+      "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
+      "source_location": "L1"
     },
     {
       "community": 164,
@@ -75084,199 +75174,208 @@
     {
       "community": 19,
       "file_type": "code",
-      "id": "dailyoperations_attentionseverity",
-      "label": "attentionSeverity()",
-      "norm_label": "attentionseverity()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
-      "source_location": "L286"
+      "id": "harness_review_buildgitprocessenv",
+      "label": "buildGitProcessEnv()",
+      "norm_label": "buildgitprocessenv()",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L469"
     },
     {
       "community": 19,
       "file_type": "code",
-      "id": "dailyoperations_builddailyoperationssnapshotwithctx",
-      "label": "buildDailyOperationsSnapshotWithCtx()",
-      "norm_label": "builddailyoperationssnapshotwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
-      "source_location": "L647"
+      "id": "harness_review_collectcommandsforchangedfiles",
+      "label": "collectCommandsForChangedFiles()",
+      "norm_label": "collectcommandsforchangedfiles()",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L352"
     },
     {
       "community": 19,
       "file_type": "code",
-      "id": "dailyoperations_buildlanes",
-      "label": "buildLanes()",
-      "norm_label": "buildlanes()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
-      "source_location": "L530"
+      "id": "harness_review_fileexists",
+      "label": "fileExists()",
+      "norm_label": "fileexists()",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L143"
     },
     {
       "community": 19,
       "file_type": "code",
-      "id": "dailyoperations_buildweekmetricfordate",
-      "label": "buildWeekMetricForDate()",
-      "norm_label": "buildweekmetricfordate()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
-      "source_location": "L186"
-    },
-    {
-      "community": 19,
-      "file_type": "code",
-      "id": "dailyoperations_buildweekmetrics",
-      "label": "buildWeekMetrics()",
-      "norm_label": "buildweekmetrics()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
-      "source_location": "L260"
-    },
-    {
-      "community": 19,
-      "file_type": "code",
-      "id": "dailyoperations_emptyclosesummary",
-      "label": "emptyCloseSummary()",
-      "norm_label": "emptyclosesummary()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
-      "source_location": "L155"
-    },
-    {
-      "community": 19,
-      "file_type": "code",
-      "id": "dailyoperations_getcloseitemcounts",
-      "label": "getCloseItemCounts()",
-      "norm_label": "getcloseitemcounts()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
-      "source_location": "L415"
-    },
-    {
-      "community": 19,
-      "file_type": "code",
-      "id": "dailyoperations_lifecyclecopy",
-      "label": "lifecycleCopy()",
-      "norm_label": "lifecyclecopy()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
-      "source_location": "L463"
-    },
-    {
-      "community": 19,
-      "file_type": "code",
-      "id": "dailyoperations_listopenqueuesnapshot",
-      "label": "listOpenQueueSnapshot()",
-      "norm_label": "listopenqueuesnapshot()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
-      "source_location": "L328"
-    },
-    {
-      "community": 19,
-      "file_type": "code",
-      "id": "dailyoperations_listtimelineevents",
-      "label": "listTimelineEvents()",
-      "norm_label": "listtimelineevents()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
-      "source_location": "L381"
-    },
-    {
-      "community": 19,
-      "file_type": "code",
-      "id": "dailyoperations_openingnotstartedattention",
-      "label": "openingNotStartedAttention()",
-      "norm_label": "openingnotstartedattention()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
-      "source_location": "L309"
-    },
-    {
-      "community": 19,
-      "file_type": "code",
-      "id": "dailyoperations_operatingdaterange",
-      "label": "operatingDateRange()",
-      "norm_label": "operatingdaterange()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
-      "source_location": "L105"
-    },
-    {
-      "community": 19,
-      "file_type": "code",
-      "id": "dailyoperations_pluralize",
-      "label": "pluralize()",
-      "norm_label": "pluralize()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
-      "source_location": "L170"
-    },
-    {
-      "community": 19,
-      "file_type": "code",
-      "id": "dailyoperations_primaryaction",
-      "label": "primaryAction()",
-      "norm_label": "primaryaction()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
-      "source_location": "L499"
-    },
-    {
-      "community": 19,
-      "file_type": "code",
-      "id": "dailyoperations_queueattentionitems",
-      "label": "queueAttentionItems()",
-      "norm_label": "queueattentionitems()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
-      "source_location": "L429"
-    },
-    {
-      "community": 19,
-      "file_type": "code",
-      "id": "dailyoperations_resolverange",
-      "label": "resolveRange()",
-      "norm_label": "resolverange()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
-      "source_location": "L137"
-    },
-    {
-      "community": 19,
-      "file_type": "code",
-      "id": "dailyoperations_saturdayweekendoperatingdate",
-      "label": "saturdayWeekEndOperatingDate()",
-      "norm_label": "saturdayweekendoperatingdate()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
+      "id": "harness_review_formatmissingpathprefixerror",
+      "label": "formatMissingPathPrefixError()",
+      "norm_label": "formatmissingpathprefixerror()",
+      "source_file": "scripts/harness-review.ts",
       "source_location": "L133"
     },
     {
       "community": 19,
       "file_type": "code",
-      "id": "dailyoperations_shiftoperatingdate",
-      "label": "shiftOperatingDate()",
-      "norm_label": "shiftoperatingdate()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
-      "source_location": "L115"
+      "id": "harness_review_getchangedfilesforharnessreview",
+      "label": "getChangedFilesForHarnessReview()",
+      "norm_label": "getchangedfilesforharnessreview()",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L475"
     },
     {
       "community": 19,
       "file_type": "code",
-      "id": "dailyoperations_sourceattentionitem",
-      "label": "sourceAttentionItem()",
-      "norm_label": "sourceattentionitem()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
-      "source_location": "L292"
+      "id": "harness_review_hasanyharnessdocs",
+      "label": "hasAnyHarnessDocs()",
+      "norm_label": "hasanyharnessdocs()",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L152"
     },
     {
       "community": 19,
       "file_type": "code",
-      "id": "dailyoperations_sundayweekstartoperatingdate",
-      "label": "sundayWeekStartOperatingDate()",
-      "norm_label": "sundayweekstartoperatingdate()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
-      "source_location": "L123"
+      "id": "harness_review_isathenaprtestsprovidedcommand",
+      "label": "isAthenaPrTestsProvidedCommand()",
+      "norm_label": "isathenaprtestsprovidedcommand()",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L87"
     },
     {
       "community": 19,
       "file_type": "code",
-      "id": "dailyoperations_transactioncashdelta",
-      "label": "transactionCashDelta()",
-      "norm_label": "transactioncashdelta()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
-      "source_location": "L175"
+      "id": "harness_review_loadreviewtarget",
+      "label": "loadReviewTarget()",
+      "norm_label": "loadreviewtarget()",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L182"
     },
     {
       "community": 19,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_dailyoperations_ts",
-      "label": "dailyOperations.ts",
-      "norm_label": "dailyoperations.ts",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
+      "id": "harness_review_loadreviewtargets",
+      "label": "loadReviewTargets()",
+      "norm_label": "loadreviewtargets()",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L319"
+    },
+    {
+      "community": 19,
+      "file_type": "code",
+      "id": "harness_review_matchespathprefix",
+      "label": "matchesPathPrefix()",
+      "norm_label": "matchespathprefix()",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L61"
+    },
+    {
+      "community": 19,
+      "file_type": "code",
+      "id": "harness_review_normalizebehaviorscenarioname",
+      "label": "normalizeBehaviorScenarioName()",
+      "norm_label": "normalizebehaviorscenarioname()",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L83"
+    },
+    {
+      "community": 19,
+      "file_type": "code",
+      "id": "harness_review_normalizerepopath",
+      "label": "normalizeRepoPath()",
+      "norm_label": "normalizerepopath()",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L57"
+    },
+    {
+      "community": 19,
+      "file_type": "code",
+      "id": "harness_review_normalizevalidationcommand",
+      "label": "normalizeValidationCommand()",
+      "norm_label": "normalizevalidationcommand()",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L75"
+    },
+    {
+      "community": 19,
+      "file_type": "code",
+      "id": "harness_review_parseharnessreviewargs",
+      "label": "parseHarnessReviewArgs()",
+      "norm_label": "parseharnessreviewargs()",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L742"
+    },
+    {
+      "community": 19,
+      "file_type": "code",
+      "id": "harness_review_readjsonfile",
+      "label": "readJsonFile()",
+      "norm_label": "readjsonfile()",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L172"
+    },
+    {
+      "community": 19,
+      "file_type": "code",
+      "id": "harness_review_resolveharnessreviewshell",
+      "label": "resolveHarnessReviewShell()",
+      "norm_label": "resolveharnessreviewshell()",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L583"
+    },
+    {
+      "community": 19,
+      "file_type": "code",
+      "id": "harness_review_rungitcommand",
+      "label": "runGitCommand()",
+      "norm_label": "rungitcommand()",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L448"
+    },
+    {
+      "community": 19,
+      "file_type": "code",
+      "id": "harness_review_runharnessbehaviorscenario",
+      "label": "runHarnessBehaviorScenario()",
+      "norm_label": "runharnessbehaviorscenario()",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L618"
+    },
+    {
+      "community": 19,
+      "file_type": "code",
+      "id": "harness_review_runharnessreview",
+      "label": "runHarnessReview()",
+      "norm_label": "runharnessreview()",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L632"
+    },
+    {
+      "community": 19,
+      "file_type": "code",
+      "id": "harness_review_runpackagescript",
+      "label": "runPackageScript()",
+      "norm_label": "runpackagescript()",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L569"
+    },
+    {
+      "community": 19,
+      "file_type": "code",
+      "id": "harness_review_runrawcommand",
+      "label": "runRawCommand()",
+      "norm_label": "runrawcommand()",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L604"
+    },
+    {
+      "community": 19,
+      "file_type": "code",
+      "id": "harness_review_sortuniquepaths",
+      "label": "sortUniquePaths()",
+      "norm_label": "sortuniquepaths()",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L176"
+    },
+    {
+      "community": 19,
+      "file_type": "code",
+      "id": "scripts_harness_review_ts",
+      "label": "harness-review.ts",
+      "norm_label": "harness-review.ts",
+      "source_file": "scripts/harness-review.ts",
       "source_location": "L1"
     },
     {
@@ -76209,199 +76308,199 @@
     {
       "community": 20,
       "file_type": "code",
-      "id": "cyclecountdrafts_buildactivecyclecountdraftssubmissionkey",
-      "label": "buildActiveCycleCountDraftsSubmissionKey()",
-      "norm_label": "buildactivecyclecountdraftssubmissionkey()",
-      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
-      "source_location": "L90"
+      "id": "dailyoperations_attentionseverity",
+      "label": "attentionSeverity()",
+      "norm_label": "attentionseverity()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
+      "source_location": "L286"
     },
     {
       "community": 20,
       "file_type": "code",
-      "id": "cyclecountdrafts_buildcyclecountdraftsubmissionkey",
-      "label": "buildCycleCountDraftSubmissionKey()",
-      "norm_label": "buildcyclecountdraftsubmissionkey()",
-      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
-      "source_location": "L75"
+      "id": "dailyoperations_builddailyoperationssnapshotwithctx",
+      "label": "buildDailyOperationsSnapshotWithCtx()",
+      "norm_label": "builddailyoperationssnapshotwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
+      "source_location": "L647"
     },
     {
       "community": 20,
       "file_type": "code",
-      "id": "cyclecountdrafts_createcyclecountdraftwithctx",
-      "label": "createCycleCountDraftWithCtx()",
-      "norm_label": "createcyclecountdraftwithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
-      "source_location": "L190"
-    },
-    {
-      "community": 20,
-      "file_type": "code",
-      "id": "cyclecountdrafts_discardcyclecountdraftcommandwithctx",
-      "label": "discardCycleCountDraftCommandWithCtx()",
-      "norm_label": "discardcyclecountdraftcommandwithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
-      "source_location": "L481"
-    },
-    {
-      "community": 20,
-      "file_type": "code",
-      "id": "cyclecountdrafts_ensurecyclecountdraftcommandwithctx",
-      "label": "ensureCycleCountDraftCommandWithCtx()",
-      "norm_label": "ensurecyclecountdraftcommandwithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
-      "source_location": "L347"
-    },
-    {
-      "community": 20,
-      "file_type": "code",
-      "id": "cyclecountdrafts_ensurecyclecountdraftwithctx",
-      "label": "ensureCycleCountDraftWithCtx()",
-      "norm_label": "ensurecyclecountdraftwithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
-      "source_location": "L235"
-    },
-    {
-      "community": 20,
-      "file_type": "code",
-      "id": "cyclecountdrafts_findopencyclecountdraftwithctx",
-      "label": "findOpenCycleCountDraftWithCtx()",
-      "norm_label": "findopencyclecountdraftwithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
-      "source_location": "L103"
-    },
-    {
-      "community": 20,
-      "file_type": "code",
-      "id": "cyclecountdrafts_getactivecyclecountdraftsummarywithctx",
-      "label": "getActiveCycleCountDraftSummaryWithCtx()",
-      "norm_label": "getactivecyclecountdraftsummarywithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
-      "source_location": "L289"
-    },
-    {
-      "community": 20,
-      "file_type": "code",
-      "id": "cyclecountdrafts_getactivecyclecountdraftwithctx",
-      "label": "getActiveCycleCountDraftWithCtx()",
-      "norm_label": "getactivecyclecountdraftwithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
-      "source_location": "L264"
-    },
-    {
-      "community": 20,
-      "file_type": "code",
-      "id": "cyclecountdrafts_getcyclecountdraftlinewithctx",
-      "label": "getCycleCountDraftLineWithCtx()",
-      "norm_label": "getcyclecountdraftlinewithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
-      "source_location": "L155"
-    },
-    {
-      "community": 20,
-      "file_type": "code",
-      "id": "cyclecountdrafts_listcyclecountdraftlineswithctx",
-      "label": "listCycleCountDraftLinesWithCtx()",
-      "norm_label": "listcyclecountdraftlineswithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
-      "source_location": "L144"
-    },
-    {
-      "community": 20,
-      "file_type": "code",
-      "id": "cyclecountdrafts_listopencyclecountdraftswithctx",
-      "label": "listOpenCycleCountDraftsWithCtx()",
-      "norm_label": "listopencyclecountdraftswithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
-      "source_location": "L123"
-    },
-    {
-      "community": 20,
-      "file_type": "code",
-      "id": "cyclecountdrafts_liststalecyclecountdraftlines",
-      "label": "listStaleCycleCountDraftLines()",
-      "norm_label": "liststalecyclecountdraftlines()",
-      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
-      "source_location": "L612"
-    },
-    {
-      "community": 20,
-      "file_type": "code",
-      "id": "cyclecountdrafts_mapcyclecountdrafterror",
-      "label": "mapCycleCountDraftError()",
-      "norm_label": "mapcyclecountdrafterror()",
-      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
-      "source_location": "L904"
-    },
-    {
-      "community": 20,
-      "file_type": "code",
-      "id": "cyclecountdrafts_refreshcyclecountdraftlinebaselinecommandwithctx",
-      "label": "refreshCycleCountDraftLineBaselineCommandWithCtx()",
-      "norm_label": "refreshcyclecountdraftlinebaselinecommandwithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
+      "id": "dailyoperations_buildlanes",
+      "label": "buildLanes()",
+      "norm_label": "buildlanes()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
       "source_location": "L530"
     },
     {
       "community": 20,
       "file_type": "code",
-      "id": "cyclecountdrafts_refreshcyclecountdraftsummarywithctx",
-      "label": "refreshCycleCountDraftSummaryWithCtx()",
-      "norm_label": "refreshcyclecountdraftsummarywithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
+      "id": "dailyoperations_buildweekmetricfordate",
+      "label": "buildWeekMetricForDate()",
+      "norm_label": "buildweekmetricfordate()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
+      "source_location": "L186"
+    },
+    {
+      "community": 20,
+      "file_type": "code",
+      "id": "dailyoperations_buildweekmetrics",
+      "label": "buildWeekMetrics()",
+      "norm_label": "buildweekmetrics()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
+      "source_location": "L260"
+    },
+    {
+      "community": 20,
+      "file_type": "code",
+      "id": "dailyoperations_emptyclosesummary",
+      "label": "emptyCloseSummary()",
+      "norm_label": "emptyclosesummary()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
+      "source_location": "L155"
+    },
+    {
+      "community": 20,
+      "file_type": "code",
+      "id": "dailyoperations_getcloseitemcounts",
+      "label": "getCloseItemCounts()",
+      "norm_label": "getcloseitemcounts()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
+      "source_location": "L415"
+    },
+    {
+      "community": 20,
+      "file_type": "code",
+      "id": "dailyoperations_lifecyclecopy",
+      "label": "lifecycleCopy()",
+      "norm_label": "lifecyclecopy()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
+      "source_location": "L463"
+    },
+    {
+      "community": 20,
+      "file_type": "code",
+      "id": "dailyoperations_listopenqueuesnapshot",
+      "label": "listOpenQueueSnapshot()",
+      "norm_label": "listopenqueuesnapshot()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
+      "source_location": "L328"
+    },
+    {
+      "community": 20,
+      "file_type": "code",
+      "id": "dailyoperations_listtimelineevents",
+      "label": "listTimelineEvents()",
+      "norm_label": "listtimelineevents()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
+      "source_location": "L381"
+    },
+    {
+      "community": 20,
+      "file_type": "code",
+      "id": "dailyoperations_openingnotstartedattention",
+      "label": "openingNotStartedAttention()",
+      "norm_label": "openingnotstartedattention()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
+      "source_location": "L309"
+    },
+    {
+      "community": 20,
+      "file_type": "code",
+      "id": "dailyoperations_operatingdaterange",
+      "label": "operatingDateRange()",
+      "norm_label": "operatingdaterange()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
+      "source_location": "L105"
+    },
+    {
+      "community": 20,
+      "file_type": "code",
+      "id": "dailyoperations_pluralize",
+      "label": "pluralize()",
+      "norm_label": "pluralize()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
       "source_location": "L170"
     },
     {
       "community": 20,
       "file_type": "code",
-      "id": "cyclecountdrafts_requirecyclecountdraftaccess",
-      "label": "requireCycleCountDraftAccess()",
-      "norm_label": "requirecyclecountdraftaccess()",
-      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
-      "source_location": "L43"
+      "id": "dailyoperations_primaryaction",
+      "label": "primaryAction()",
+      "norm_label": "primaryaction()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
+      "source_location": "L499"
     },
     {
       "community": 20,
       "file_type": "code",
-      "id": "cyclecountdrafts_savecyclecountdraftlinecommandwithctx",
-      "label": "saveCycleCountDraftLineCommandWithCtx()",
-      "norm_label": "savecyclecountdraftlinecommandwithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
-      "source_location": "L370"
+      "id": "dailyoperations_queueattentionitems",
+      "label": "queueAttentionItems()",
+      "norm_label": "queueattentionitems()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
+      "source_location": "L429"
     },
     {
       "community": 20,
       "file_type": "code",
-      "id": "cyclecountdrafts_submitactivecyclecountdraftscommandwithctx",
-      "label": "submitActiveCycleCountDraftsCommandWithCtx()",
-      "norm_label": "submitactivecyclecountdraftscommandwithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
-      "source_location": "L776"
+      "id": "dailyoperations_resolverange",
+      "label": "resolveRange()",
+      "norm_label": "resolverange()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
+      "source_location": "L137"
     },
     {
       "community": 20,
       "file_type": "code",
-      "id": "cyclecountdrafts_submitcyclecountdraftcommandwithctx",
-      "label": "submitCycleCountDraftCommandWithCtx()",
-      "norm_label": "submitcyclecountdraftcommandwithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
-      "source_location": "L645"
+      "id": "dailyoperations_saturdayweekendoperatingdate",
+      "label": "saturdayWeekEndOperatingDate()",
+      "norm_label": "saturdayweekendoperatingdate()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
+      "source_location": "L133"
     },
     {
       "community": 20,
       "file_type": "code",
-      "id": "cyclecountdrafts_trimrequiredscopekey",
-      "label": "trimRequiredScopeKey()",
-      "norm_label": "trimrequiredscopekey()",
-      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
-      "source_location": "L65"
+      "id": "dailyoperations_shiftoperatingdate",
+      "label": "shiftOperatingDate()",
+      "norm_label": "shiftoperatingdate()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
+      "source_location": "L115"
     },
     {
       "community": 20,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_stockops_cyclecountdrafts_ts",
-      "label": "cycleCountDrafts.ts",
-      "norm_label": "cyclecountdrafts.ts",
-      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
+      "id": "dailyoperations_sourceattentionitem",
+      "label": "sourceAttentionItem()",
+      "norm_label": "sourceattentionitem()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
+      "source_location": "L292"
+    },
+    {
+      "community": 20,
+      "file_type": "code",
+      "id": "dailyoperations_sundayweekstartoperatingdate",
+      "label": "sundayWeekStartOperatingDate()",
+      "norm_label": "sundayweekstartoperatingdate()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
+      "source_location": "L123"
+    },
+    {
+      "community": 20,
+      "file_type": "code",
+      "id": "dailyoperations_transactioncashdelta",
+      "label": "transactionCashDelta()",
+      "norm_label": "transactioncashdelta()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
+      "source_location": "L175"
+    },
+    {
+      "community": 20,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_dailyoperations_ts",
+      "label": "dailyOperations.ts",
+      "norm_label": "dailyoperations.ts",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
       "source_location": "L1"
     },
     {
@@ -76857,200 +76956,200 @@
     {
       "community": 21,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_storeconfig_ts",
-      "label": "storeConfig.ts",
-      "norm_label": "storeconfig.ts",
-      "source_file": "packages/athena-webapp/src/lib/storeConfig.ts",
-      "source_location": "L1"
+      "id": "cyclecountdrafts_buildactivecyclecountdraftssubmissionkey",
+      "label": "buildActiveCycleCountDraftsSubmissionKey()",
+      "norm_label": "buildactivecyclecountdraftssubmissionkey()",
+      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
+      "source_location": "L90"
     },
     {
       "community": 21,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_storeconfig_ts",
-      "label": "storeConfig.ts",
-      "norm_label": "storeconfig.ts",
-      "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
-      "source_location": "L1"
+      "id": "cyclecountdrafts_buildcyclecountdraftsubmissionkey",
+      "label": "buildCycleCountDraftSubmissionKey()",
+      "norm_label": "buildcyclecountdraftsubmissionkey()",
+      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
+      "source_location": "L75"
     },
     {
       "community": 21,
       "file_type": "code",
-      "id": "storeconfig_asboolean",
-      "label": "asBoolean()",
-      "norm_label": "asboolean()",
-      "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
-      "source_location": "L117"
+      "id": "cyclecountdrafts_createcyclecountdraftwithctx",
+      "label": "createCycleCountDraftWithCtx()",
+      "norm_label": "createcyclecountdraftwithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
+      "source_location": "L190"
     },
     {
       "community": 21,
       "file_type": "code",
-      "id": "storeconfig_asmtnmomosetupstatus",
-      "label": "asMtnMomoSetupStatus()",
-      "norm_label": "asmtnmomosetupstatus()",
-      "source_file": "packages/athena-webapp/src/lib/storeConfig.ts",
-      "source_location": "L80"
+      "id": "cyclecountdrafts_discardcyclecountdraftcommandwithctx",
+      "label": "discardCycleCountDraftCommandWithCtx()",
+      "norm_label": "discardcyclecountdraftcommandwithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
+      "source_location": "L481"
     },
     {
       "community": 21,
       "file_type": "code",
-      "id": "storeconfig_asnumber",
-      "label": "asNumber()",
-      "norm_label": "asnumber()",
-      "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
-      "source_location": "L114"
+      "id": "cyclecountdrafts_ensurecyclecountdraftcommandwithctx",
+      "label": "ensureCycleCountDraftCommandWithCtx()",
+      "norm_label": "ensurecyclecountdraftcommandwithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
+      "source_location": "L347"
     },
     {
       "community": 21,
       "file_type": "code",
-      "id": "storeconfig_asoptionalarray",
-      "label": "asOptionalArray()",
-      "norm_label": "asoptionalarray()",
-      "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
-      "source_location": "L132"
+      "id": "cyclecountdrafts_ensurecyclecountdraftwithctx",
+      "label": "ensureCycleCountDraftWithCtx()",
+      "norm_label": "ensurecyclecountdraftwithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
+      "source_location": "L235"
     },
     {
       "community": 21,
       "file_type": "code",
-      "id": "storeconfig_asrecord",
-      "label": "asRecord()",
-      "norm_label": "asrecord()",
-      "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
+      "id": "cyclecountdrafts_findopencyclecountdraftwithctx",
+      "label": "findOpenCycleCountDraftWithCtx()",
+      "norm_label": "findopencyclecountdraftwithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
       "source_location": "L103"
     },
     {
       "community": 21,
       "file_type": "code",
-      "id": "storeconfig_asstring",
-      "label": "asString()",
-      "norm_label": "asstring()",
-      "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
-      "source_location": "L111"
+      "id": "cyclecountdrafts_getactivecyclecountdraftsummarywithctx",
+      "label": "getActiveCycleCountDraftSummaryWithCtx()",
+      "norm_label": "getactivecyclecountdraftsummarywithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
+      "source_location": "L289"
     },
     {
       "community": 21,
       "file_type": "code",
-      "id": "storeconfig_cleanundefined",
-      "label": "cleanUndefined()",
-      "norm_label": "cleanundefined()",
-      "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
-      "source_location": "L143"
+      "id": "cyclecountdrafts_getactivecyclecountdraftwithctx",
+      "label": "getActiveCycleCountDraftWithCtx()",
+      "norm_label": "getactivecyclecountdraftwithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
+      "source_location": "L264"
     },
     {
       "community": 21,
       "file_type": "code",
-      "id": "storeconfig_firstdefined",
-      "label": "firstDefined()",
-      "norm_label": "firstdefined()",
-      "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
-      "source_location": "L120"
-    },
-    {
-      "community": 21,
-      "file_type": "code",
-      "id": "storeconfig_getrawconfig",
-      "label": "getRawConfig()",
-      "norm_label": "getrawconfig()",
-      "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
-      "source_location": "L196"
-    },
-    {
-      "community": 21,
-      "file_type": "code",
-      "id": "storeconfig_getstoreconfigv2",
-      "label": "getStoreConfigV2()",
-      "norm_label": "getstoreconfigv2()",
-      "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
-      "source_location": "L208"
-    },
-    {
-      "community": 21,
-      "file_type": "code",
-      "id": "storeconfig_getstorefallbackimageurl",
-      "label": "getStoreFallbackImageUrl()",
-      "norm_label": "getstorefallbackimageurl()",
-      "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
-      "source_location": "L479"
-    },
-    {
-      "community": 21,
-      "file_type": "code",
-      "id": "storeconfig_hasmtnmomoreceivingaccountdetails",
-      "label": "hasMtnMomoReceivingAccountDetails()",
-      "norm_label": "hasmtnmomoreceivingaccountdetails()",
-      "source_file": "packages/athena-webapp/src/lib/storeConfig.ts",
-      "source_location": "L93"
-    },
-    {
-      "community": 21,
-      "file_type": "code",
-      "id": "storeconfig_isstoremaintenancemode",
-      "label": "isStoreMaintenanceMode()",
-      "norm_label": "isstoremaintenancemode()",
-      "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
-      "source_location": "L465"
-    },
-    {
-      "community": 21,
-      "file_type": "code",
-      "id": "storeconfig_isstorereadonlymode",
-      "label": "isStoreReadOnlyMode()",
-      "norm_label": "isstorereadonlymode()",
-      "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
-      "source_location": "L461"
-    },
-    {
-      "community": 21,
-      "file_type": "code",
-      "id": "storeconfig_mapmtnmomoreceivingaccount",
-      "label": "mapMtnMomoReceivingAccount()",
-      "norm_label": "mapmtnmomoreceivingaccount()",
-      "source_file": "packages/athena-webapp/src/lib/storeConfig.ts",
-      "source_location": "L106"
-    },
-    {
-      "community": 21,
-      "file_type": "code",
-      "id": "storeconfig_mappromo",
-      "label": "mapPromo()",
-      "norm_label": "mappromo()",
-      "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
-      "source_location": "L172"
-    },
-    {
-      "community": 21,
-      "file_type": "code",
-      "id": "storeconfig_mappromotion",
-      "label": "mapPromotion()",
-      "norm_label": "mappromotion()",
-      "source_file": "packages/athena-webapp/src/lib/storeConfig.ts",
-      "source_location": "L172"
-    },
-    {
-      "community": 21,
-      "file_type": "code",
-      "id": "storeconfig_mapstreamreel",
-      "label": "mapStreamReel()",
-      "norm_label": "mapstreamreel()",
-      "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
+      "id": "cyclecountdrafts_getcyclecountdraftlinewithctx",
+      "label": "getCycleCountDraftLineWithCtx()",
+      "norm_label": "getcyclecountdraftlinewithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
       "source_location": "L155"
     },
     {
       "community": 21,
       "file_type": "code",
-      "id": "storeconfig_normalizemtnmomoreceivingaccounts",
-      "label": "normalizeMtnMomoReceivingAccounts()",
-      "norm_label": "normalizemtnmomoreceivingaccounts()",
-      "source_file": "packages/athena-webapp/src/lib/storeConfig.ts",
-      "source_location": "L126"
+      "id": "cyclecountdrafts_listcyclecountdraftlineswithctx",
+      "label": "listCycleCountDraftLinesWithCtx()",
+      "norm_label": "listcyclecountdraftlineswithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
+      "source_location": "L144"
     },
     {
       "community": 21,
       "file_type": "code",
-      "id": "storeconfig_normalizewaivedeliveryfees",
-      "label": "normalizeWaiveDeliveryFees()",
-      "norm_label": "normalizewaivedeliveryfees()",
-      "source_file": "packages/athena-webapp/src/lib/storeConfig.ts",
-      "source_location": "L177"
+      "id": "cyclecountdrafts_listopencyclecountdraftswithctx",
+      "label": "listOpenCycleCountDraftsWithCtx()",
+      "norm_label": "listopencyclecountdraftswithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
+      "source_location": "L123"
+    },
+    {
+      "community": 21,
+      "file_type": "code",
+      "id": "cyclecountdrafts_liststalecyclecountdraftlines",
+      "label": "listStaleCycleCountDraftLines()",
+      "norm_label": "liststalecyclecountdraftlines()",
+      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
+      "source_location": "L612"
+    },
+    {
+      "community": 21,
+      "file_type": "code",
+      "id": "cyclecountdrafts_mapcyclecountdrafterror",
+      "label": "mapCycleCountDraftError()",
+      "norm_label": "mapcyclecountdrafterror()",
+      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
+      "source_location": "L904"
+    },
+    {
+      "community": 21,
+      "file_type": "code",
+      "id": "cyclecountdrafts_refreshcyclecountdraftlinebaselinecommandwithctx",
+      "label": "refreshCycleCountDraftLineBaselineCommandWithCtx()",
+      "norm_label": "refreshcyclecountdraftlinebaselinecommandwithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
+      "source_location": "L530"
+    },
+    {
+      "community": 21,
+      "file_type": "code",
+      "id": "cyclecountdrafts_refreshcyclecountdraftsummarywithctx",
+      "label": "refreshCycleCountDraftSummaryWithCtx()",
+      "norm_label": "refreshcyclecountdraftsummarywithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
+      "source_location": "L170"
+    },
+    {
+      "community": 21,
+      "file_type": "code",
+      "id": "cyclecountdrafts_requirecyclecountdraftaccess",
+      "label": "requireCycleCountDraftAccess()",
+      "norm_label": "requirecyclecountdraftaccess()",
+      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
+      "source_location": "L43"
+    },
+    {
+      "community": 21,
+      "file_type": "code",
+      "id": "cyclecountdrafts_savecyclecountdraftlinecommandwithctx",
+      "label": "saveCycleCountDraftLineCommandWithCtx()",
+      "norm_label": "savecyclecountdraftlinecommandwithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
+      "source_location": "L370"
+    },
+    {
+      "community": 21,
+      "file_type": "code",
+      "id": "cyclecountdrafts_submitactivecyclecountdraftscommandwithctx",
+      "label": "submitActiveCycleCountDraftsCommandWithCtx()",
+      "norm_label": "submitactivecyclecountdraftscommandwithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
+      "source_location": "L776"
+    },
+    {
+      "community": 21,
+      "file_type": "code",
+      "id": "cyclecountdrafts_submitcyclecountdraftcommandwithctx",
+      "label": "submitCycleCountDraftCommandWithCtx()",
+      "norm_label": "submitcyclecountdraftcommandwithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
+      "source_location": "L645"
+    },
+    {
+      "community": 21,
+      "file_type": "code",
+      "id": "cyclecountdrafts_trimrequiredscopekey",
+      "label": "trimRequiredScopeKey()",
+      "norm_label": "trimrequiredscopekey()",
+      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
+      "source_location": "L65"
+    },
+    {
+      "community": 21,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_stockops_cyclecountdrafts_ts",
+      "label": "cycleCountDrafts.ts",
+      "norm_label": "cyclecountdrafts.ts",
+      "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.ts",
+      "source_location": "L1"
     },
     {
       "community": 210,
@@ -77505,200 +77604,200 @@
     {
       "community": 22,
       "file_type": "code",
-      "id": "harness_review_buildgitprocessenv",
-      "label": "buildGitProcessEnv()",
-      "norm_label": "buildgitprocessenv()",
-      "source_file": "scripts/harness-review.ts",
-      "source_location": "L421"
-    },
-    {
-      "community": 22,
-      "file_type": "code",
-      "id": "harness_review_collectcommandsforchangedfiles",
-      "label": "collectCommandsForChangedFiles()",
-      "norm_label": "collectcommandsforchangedfiles()",
-      "source_file": "scripts/harness-review.ts",
-      "source_location": "L304"
-    },
-    {
-      "community": 22,
-      "file_type": "code",
-      "id": "harness_review_fileexists",
-      "label": "fileExists()",
-      "norm_label": "fileexists()",
-      "source_file": "scripts/harness-review.ts",
-      "source_location": "L95"
-    },
-    {
-      "community": 22,
-      "file_type": "code",
-      "id": "harness_review_formatmissingpathprefixerror",
-      "label": "formatMissingPathPrefixError()",
-      "norm_label": "formatmissingpathprefixerror()",
-      "source_file": "scripts/harness-review.ts",
-      "source_location": "L85"
-    },
-    {
-      "community": 22,
-      "file_type": "code",
-      "id": "harness_review_getchangedfilesforharnessreview",
-      "label": "getChangedFilesForHarnessReview()",
-      "norm_label": "getchangedfilesforharnessreview()",
-      "source_file": "scripts/harness-review.ts",
-      "source_location": "L427"
-    },
-    {
-      "community": 22,
-      "file_type": "code",
-      "id": "harness_review_hasanyharnessdocs",
-      "label": "hasAnyHarnessDocs()",
-      "norm_label": "hasanyharnessdocs()",
-      "source_file": "scripts/harness-review.ts",
-      "source_location": "L104"
-    },
-    {
-      "community": 22,
-      "file_type": "code",
-      "id": "harness_review_loadreviewtarget",
-      "label": "loadReviewTarget()",
-      "norm_label": "loadreviewtarget()",
-      "source_file": "scripts/harness-review.ts",
-      "source_location": "L134"
-    },
-    {
-      "community": 22,
-      "file_type": "code",
-      "id": "harness_review_loadreviewtargets",
-      "label": "loadReviewTargets()",
-      "norm_label": "loadreviewtargets()",
-      "source_file": "scripts/harness-review.ts",
-      "source_location": "L271"
-    },
-    {
-      "community": 22,
-      "file_type": "code",
-      "id": "harness_review_matchespathprefix",
-      "label": "matchesPathPrefix()",
-      "norm_label": "matchespathprefix()",
-      "source_file": "scripts/harness-review.ts",
-      "source_location": "L59"
-    },
-    {
-      "community": 22,
-      "file_type": "code",
-      "id": "harness_review_normalizebehaviorscenarioname",
-      "label": "normalizeBehaviorScenarioName()",
-      "norm_label": "normalizebehaviorscenarioname()",
-      "source_file": "scripts/harness-review.ts",
-      "source_location": "L81"
-    },
-    {
-      "community": 22,
-      "file_type": "code",
-      "id": "harness_review_normalizerepopath",
-      "label": "normalizeRepoPath()",
-      "norm_label": "normalizerepopath()",
-      "source_file": "scripts/harness-review.ts",
-      "source_location": "L55"
-    },
-    {
-      "community": 22,
-      "file_type": "code",
-      "id": "harness_review_normalizevalidationcommand",
-      "label": "normalizeValidationCommand()",
-      "norm_label": "normalizevalidationcommand()",
-      "source_file": "scripts/harness-review.ts",
-      "source_location": "L73"
-    },
-    {
-      "community": 22,
-      "file_type": "code",
-      "id": "harness_review_parseharnessreviewargs",
-      "label": "parseHarnessReviewArgs()",
-      "norm_label": "parseharnessreviewargs()",
-      "source_file": "scripts/harness-review.ts",
-      "source_location": "L679"
-    },
-    {
-      "community": 22,
-      "file_type": "code",
-      "id": "harness_review_readjsonfile",
-      "label": "readJsonFile()",
-      "norm_label": "readjsonfile()",
-      "source_file": "scripts/harness-review.ts",
-      "source_location": "L124"
-    },
-    {
-      "community": 22,
-      "file_type": "code",
-      "id": "harness_review_resolveharnessreviewshell",
-      "label": "resolveHarnessReviewShell()",
-      "norm_label": "resolveharnessreviewshell()",
-      "source_file": "scripts/harness-review.ts",
-      "source_location": "L535"
-    },
-    {
-      "community": 22,
-      "file_type": "code",
-      "id": "harness_review_rungitcommand",
-      "label": "runGitCommand()",
-      "norm_label": "rungitcommand()",
-      "source_file": "scripts/harness-review.ts",
-      "source_location": "L400"
-    },
-    {
-      "community": 22,
-      "file_type": "code",
-      "id": "harness_review_runharnessbehaviorscenario",
-      "label": "runHarnessBehaviorScenario()",
-      "norm_label": "runharnessbehaviorscenario()",
-      "source_file": "scripts/harness-review.ts",
-      "source_location": "L570"
-    },
-    {
-      "community": 22,
-      "file_type": "code",
-      "id": "harness_review_runharnessreview",
-      "label": "runHarnessReview()",
-      "norm_label": "runharnessreview()",
-      "source_file": "scripts/harness-review.ts",
-      "source_location": "L584"
-    },
-    {
-      "community": 22,
-      "file_type": "code",
-      "id": "harness_review_runpackagescript",
-      "label": "runPackageScript()",
-      "norm_label": "runpackagescript()",
-      "source_file": "scripts/harness-review.ts",
-      "source_location": "L521"
-    },
-    {
-      "community": 22,
-      "file_type": "code",
-      "id": "harness_review_runrawcommand",
-      "label": "runRawCommand()",
-      "norm_label": "runrawcommand()",
-      "source_file": "scripts/harness-review.ts",
-      "source_location": "L556"
-    },
-    {
-      "community": 22,
-      "file_type": "code",
-      "id": "harness_review_sortuniquepaths",
-      "label": "sortUniquePaths()",
-      "norm_label": "sortuniquepaths()",
-      "source_file": "scripts/harness-review.ts",
-      "source_location": "L128"
-    },
-    {
-      "community": 22,
-      "file_type": "code",
-      "id": "scripts_harness_review_ts",
-      "label": "harness-review.ts",
-      "norm_label": "harness-review.ts",
-      "source_file": "scripts/harness-review.ts",
+      "id": "packages_athena_webapp_src_lib_storeconfig_ts",
+      "label": "storeConfig.ts",
+      "norm_label": "storeconfig.ts",
+      "source_file": "packages/athena-webapp/src/lib/storeConfig.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 22,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_storeconfig_ts",
+      "label": "storeConfig.ts",
+      "norm_label": "storeconfig.ts",
+      "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 22,
+      "file_type": "code",
+      "id": "storeconfig_asboolean",
+      "label": "asBoolean()",
+      "norm_label": "asboolean()",
+      "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
+      "source_location": "L117"
+    },
+    {
+      "community": 22,
+      "file_type": "code",
+      "id": "storeconfig_asmtnmomosetupstatus",
+      "label": "asMtnMomoSetupStatus()",
+      "norm_label": "asmtnmomosetupstatus()",
+      "source_file": "packages/athena-webapp/src/lib/storeConfig.ts",
+      "source_location": "L80"
+    },
+    {
+      "community": 22,
+      "file_type": "code",
+      "id": "storeconfig_asnumber",
+      "label": "asNumber()",
+      "norm_label": "asnumber()",
+      "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
+      "source_location": "L114"
+    },
+    {
+      "community": 22,
+      "file_type": "code",
+      "id": "storeconfig_asoptionalarray",
+      "label": "asOptionalArray()",
+      "norm_label": "asoptionalarray()",
+      "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
+      "source_location": "L132"
+    },
+    {
+      "community": 22,
+      "file_type": "code",
+      "id": "storeconfig_asrecord",
+      "label": "asRecord()",
+      "norm_label": "asrecord()",
+      "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
+      "source_location": "L103"
+    },
+    {
+      "community": 22,
+      "file_type": "code",
+      "id": "storeconfig_asstring",
+      "label": "asString()",
+      "norm_label": "asstring()",
+      "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
+      "source_location": "L111"
+    },
+    {
+      "community": 22,
+      "file_type": "code",
+      "id": "storeconfig_cleanundefined",
+      "label": "cleanUndefined()",
+      "norm_label": "cleanundefined()",
+      "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
+      "source_location": "L143"
+    },
+    {
+      "community": 22,
+      "file_type": "code",
+      "id": "storeconfig_firstdefined",
+      "label": "firstDefined()",
+      "norm_label": "firstdefined()",
+      "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
+      "source_location": "L120"
+    },
+    {
+      "community": 22,
+      "file_type": "code",
+      "id": "storeconfig_getrawconfig",
+      "label": "getRawConfig()",
+      "norm_label": "getrawconfig()",
+      "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
+      "source_location": "L196"
+    },
+    {
+      "community": 22,
+      "file_type": "code",
+      "id": "storeconfig_getstoreconfigv2",
+      "label": "getStoreConfigV2()",
+      "norm_label": "getstoreconfigv2()",
+      "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
+      "source_location": "L208"
+    },
+    {
+      "community": 22,
+      "file_type": "code",
+      "id": "storeconfig_getstorefallbackimageurl",
+      "label": "getStoreFallbackImageUrl()",
+      "norm_label": "getstorefallbackimageurl()",
+      "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
+      "source_location": "L479"
+    },
+    {
+      "community": 22,
+      "file_type": "code",
+      "id": "storeconfig_hasmtnmomoreceivingaccountdetails",
+      "label": "hasMtnMomoReceivingAccountDetails()",
+      "norm_label": "hasmtnmomoreceivingaccountdetails()",
+      "source_file": "packages/athena-webapp/src/lib/storeConfig.ts",
+      "source_location": "L93"
+    },
+    {
+      "community": 22,
+      "file_type": "code",
+      "id": "storeconfig_isstoremaintenancemode",
+      "label": "isStoreMaintenanceMode()",
+      "norm_label": "isstoremaintenancemode()",
+      "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
+      "source_location": "L465"
+    },
+    {
+      "community": 22,
+      "file_type": "code",
+      "id": "storeconfig_isstorereadonlymode",
+      "label": "isStoreReadOnlyMode()",
+      "norm_label": "isstorereadonlymode()",
+      "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
+      "source_location": "L461"
+    },
+    {
+      "community": 22,
+      "file_type": "code",
+      "id": "storeconfig_mapmtnmomoreceivingaccount",
+      "label": "mapMtnMomoReceivingAccount()",
+      "norm_label": "mapmtnmomoreceivingaccount()",
+      "source_file": "packages/athena-webapp/src/lib/storeConfig.ts",
+      "source_location": "L106"
+    },
+    {
+      "community": 22,
+      "file_type": "code",
+      "id": "storeconfig_mappromo",
+      "label": "mapPromo()",
+      "norm_label": "mappromo()",
+      "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
+      "source_location": "L172"
+    },
+    {
+      "community": 22,
+      "file_type": "code",
+      "id": "storeconfig_mappromotion",
+      "label": "mapPromotion()",
+      "norm_label": "mappromotion()",
+      "source_file": "packages/athena-webapp/src/lib/storeConfig.ts",
+      "source_location": "L172"
+    },
+    {
+      "community": 22,
+      "file_type": "code",
+      "id": "storeconfig_mapstreamreel",
+      "label": "mapStreamReel()",
+      "norm_label": "mapstreamreel()",
+      "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
+      "source_location": "L155"
+    },
+    {
+      "community": 22,
+      "file_type": "code",
+      "id": "storeconfig_normalizemtnmomoreceivingaccounts",
+      "label": "normalizeMtnMomoReceivingAccounts()",
+      "norm_label": "normalizemtnmomoreceivingaccounts()",
+      "source_file": "packages/athena-webapp/src/lib/storeConfig.ts",
+      "source_location": "L126"
+    },
+    {
+      "community": 22,
+      "file_type": "code",
+      "id": "storeconfig_normalizewaivedeliveryfees",
+      "label": "normalizeWaiveDeliveryFees()",
+      "norm_label": "normalizewaivedeliveryfees()",
+      "source_file": "packages/athena-webapp/src/lib/storeConfig.ts",
+      "source_location": "L177"
     },
     {
       "community": 220,
@@ -79255,7 +79354,7 @@
       "label": "collectHarnessRepoValidationSelection()",
       "norm_label": "collectharnessrepovalidationselection()",
       "source_file": "scripts/harness-repo-validation.ts",
-      "source_location": "L47"
+      "source_location": "L48"
     },
     {
       "community": 246,
@@ -79264,7 +79363,7 @@
       "label": "matchesHarnessRepoValidationPath()",
       "norm_label": "matchesharnessrepovalidationpath()",
       "source_file": "scripts/harness-repo-validation.ts",
-      "source_location": "L39"
+      "source_location": "L40"
     },
     {
       "community": 246,
@@ -79273,7 +79372,7 @@
       "label": "normalizeRepoPath()",
       "norm_label": "normalizerepopath()",
       "source_file": "scripts/harness-repo-validation.ts",
-      "source_location": "L29"
+      "source_location": "L30"
     },
     {
       "community": 246,
@@ -79282,7 +79381,7 @@
       "label": "sortUniquePaths()",
       "norm_label": "sortuniquepaths()",
       "source_file": "scripts/harness-repo-validation.ts",
-      "source_location": "L33"
+      "source_location": "L34"
     },
     {
       "community": 246,
@@ -91113,6 +91212,60 @@
     {
       "community": 481,
       "file_type": "code",
+      "id": "github_workflows_check_test_createfixtureroot",
+      "label": "createFixtureRoot()",
+      "norm_label": "createfixtureroot()",
+      "source_file": "scripts/github-workflows-check.test.ts",
+      "source_location": "L10"
+    },
+    {
+      "community": 481,
+      "file_type": "code",
+      "id": "github_workflows_check_test_write",
+      "label": "write()",
+      "norm_label": "write()",
+      "source_file": "scripts/github-workflows-check.test.ts",
+      "source_location": "L16"
+    },
+    {
+      "community": 481,
+      "file_type": "code",
+      "id": "scripts_github_workflows_check_test_ts",
+      "label": "github-workflows-check.test.ts",
+      "norm_label": "github-workflows-check.test.ts",
+      "source_file": "scripts/github-workflows-check.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 482,
+      "file_type": "code",
+      "id": "github_workflows_check_collectworkflowfiles",
+      "label": "collectWorkflowFiles()",
+      "norm_label": "collectworkflowfiles()",
+      "source_file": "scripts/github-workflows-check.ts",
+      "source_location": "L19"
+    },
+    {
+      "community": 482,
+      "file_type": "code",
+      "id": "github_workflows_check_runworkflowcheck",
+      "label": "runWorkflowCheck()",
+      "norm_label": "runworkflowcheck()",
+      "source_file": "scripts/github-workflows-check.ts",
+      "source_location": "L29"
+    },
+    {
+      "community": 482,
+      "file_type": "code",
+      "id": "scripts_github_workflows_check_ts",
+      "label": "github-workflows-check.ts",
+      "norm_label": "github-workflows-check.ts",
+      "source_file": "scripts/github-workflows-check.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 483,
+      "file_type": "code",
       "id": "graphify_wiki_test_createfixtureroot",
       "label": "createFixtureRoot()",
       "norm_label": "createfixtureroot()",
@@ -91120,7 +91273,7 @@
       "source_location": "L16"
     },
     {
-      "community": 481,
+      "community": 483,
       "file_type": "code",
       "id": "graphify_wiki_test_write",
       "label": "write()",
@@ -91129,7 +91282,7 @@
       "source_location": "L10"
     },
     {
-      "community": 481,
+      "community": 483,
       "file_type": "code",
       "id": "scripts_graphify_wiki_test_ts",
       "label": "graphify-wiki.test.ts",
@@ -91138,7 +91291,7 @@
       "source_location": "L1"
     },
     {
-      "community": 482,
+      "community": 484,
       "file_type": "code",
       "id": "harness_audit_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -91147,7 +91300,7 @@
       "source_location": "L17"
     },
     {
-      "community": 482,
+      "community": 484,
       "file_type": "code",
       "id": "harness_audit_test_write",
       "label": "write()",
@@ -91156,7 +91309,7 @@
       "source_location": "L11"
     },
     {
-      "community": 482,
+      "community": 484,
       "file_type": "code",
       "id": "scripts_harness_audit_test_ts",
       "label": "harness-audit.test.ts",
@@ -91165,7 +91318,7 @@
       "source_location": "L1"
     },
     {
-      "community": 483,
+      "community": 485,
       "file_type": "code",
       "id": "harness_check_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -91174,7 +91327,7 @@
       "source_location": "L48"
     },
     {
-      "community": 483,
+      "community": 485,
       "file_type": "code",
       "id": "harness_check_test_write",
       "label": "write()",
@@ -91183,7 +91336,7 @@
       "source_location": "L42"
     },
     {
-      "community": 483,
+      "community": 485,
       "file_type": "code",
       "id": "scripts_harness_check_test_ts",
       "label": "harness-check.test.ts",
@@ -91192,7 +91345,7 @@
       "source_location": "L1"
     },
     {
-      "community": 484,
+      "community": 486,
       "file_type": "code",
       "id": "harness_generate_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -91201,7 +91354,7 @@
       "source_location": "L16"
     },
     {
-      "community": 484,
+      "community": 486,
       "file_type": "code",
       "id": "harness_generate_test_write",
       "label": "write()",
@@ -91210,7 +91363,7 @@
       "source_location": "L10"
     },
     {
-      "community": 484,
+      "community": 486,
       "file_type": "code",
       "id": "scripts_harness_generate_test_ts",
       "label": "harness-generate.test.ts",
@@ -91219,7 +91372,7 @@
       "source_location": "L1"
     },
     {
-      "community": 485,
+      "community": 487,
       "file_type": "code",
       "id": "harness_inferential_review_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -91228,7 +91381,7 @@
       "source_location": "L19"
     },
     {
-      "community": 485,
+      "community": 487,
       "file_type": "code",
       "id": "harness_inferential_review_test_write",
       "label": "write()",
@@ -91237,7 +91390,7 @@
       "source_location": "L13"
     },
     {
-      "community": 485,
+      "community": 487,
       "file_type": "code",
       "id": "scripts_harness_inferential_review_test_ts",
       "label": "harness-inferential-review.test.ts",
@@ -91246,7 +91399,7 @@
       "source_location": "L1"
     },
     {
-      "community": 486,
+      "community": 488,
       "file_type": "code",
       "id": "harness_self_review_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -91255,7 +91408,7 @@
       "source_location": "L16"
     },
     {
-      "community": 486,
+      "community": 488,
       "file_type": "code",
       "id": "harness_self_review_test_write",
       "label": "write()",
@@ -91264,7 +91417,7 @@
       "source_location": "L10"
     },
     {
-      "community": 486,
+      "community": 488,
       "file_type": "code",
       "id": "scripts_harness_self_review_test_ts",
       "label": "harness-self-review.test.ts",
@@ -91273,7 +91426,7 @@
       "source_location": "L1"
     },
     {
-      "community": 487,
+      "community": 489,
       "file_type": "code",
       "id": "harness_test_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -91282,7 +91435,7 @@
       "source_location": "L20"
     },
     {
-      "community": 487,
+      "community": 489,
       "file_type": "code",
       "id": "harness_test_test_write",
       "label": "write()",
@@ -91291,66 +91444,12 @@
       "source_location": "L14"
     },
     {
-      "community": 487,
+      "community": 489,
       "file_type": "code",
       "id": "scripts_harness_test_test_ts",
       "label": "harness-test.test.ts",
       "norm_label": "harness-test.test.ts",
       "source_file": "scripts/harness-test.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 488,
-      "file_type": "code",
-      "id": "root_scripts_coverage_test_createfixtureroot",
-      "label": "createFixtureRoot()",
-      "norm_label": "createfixtureroot()",
-      "source_file": "scripts/root-scripts-coverage.test.ts",
-      "source_location": "L10"
-    },
-    {
-      "community": 488,
-      "file_type": "code",
-      "id": "root_scripts_coverage_test_write",
-      "label": "write()",
-      "norm_label": "write()",
-      "source_file": "scripts/root-scripts-coverage.test.ts",
-      "source_location": "L16"
-    },
-    {
-      "community": 488,
-      "file_type": "code",
-      "id": "scripts_root_scripts_coverage_test_ts",
-      "label": "root-scripts-coverage.test.ts",
-      "norm_label": "root-scripts-coverage.test.ts",
-      "source_file": "scripts/root-scripts-coverage.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 489,
-      "file_type": "code",
-      "id": "root_scripts_coverage_collectrootscripttestfiles",
-      "label": "collectRootScriptTestFiles()",
-      "norm_label": "collectrootscripttestfiles()",
-      "source_file": "scripts/root-scripts-coverage.ts",
-      "source_location": "L4"
-    },
-    {
-      "community": 489,
-      "file_type": "code",
-      "id": "root_scripts_coverage_runrootscriptscoverage",
-      "label": "runRootScriptsCoverage()",
-      "norm_label": "runrootscriptscoverage()",
-      "source_file": "scripts/root-scripts-coverage.ts",
-      "source_location": "L13"
-    },
-    {
-      "community": 489,
-      "file_type": "code",
-      "id": "scripts_root_scripts_coverage_ts",
-      "label": "root-scripts-coverage.ts",
-      "norm_label": "root-scripts-coverage.ts",
-      "source_file": "scripts/root-scripts-coverage.ts",
       "source_location": "L1"
     },
     {
@@ -91491,6 +91590,60 @@
     {
       "community": 490,
       "file_type": "code",
+      "id": "root_scripts_coverage_test_createfixtureroot",
+      "label": "createFixtureRoot()",
+      "norm_label": "createfixtureroot()",
+      "source_file": "scripts/root-scripts-coverage.test.ts",
+      "source_location": "L10"
+    },
+    {
+      "community": 490,
+      "file_type": "code",
+      "id": "root_scripts_coverage_test_write",
+      "label": "write()",
+      "norm_label": "write()",
+      "source_file": "scripts/root-scripts-coverage.test.ts",
+      "source_location": "L16"
+    },
+    {
+      "community": 490,
+      "file_type": "code",
+      "id": "scripts_root_scripts_coverage_test_ts",
+      "label": "root-scripts-coverage.test.ts",
+      "norm_label": "root-scripts-coverage.test.ts",
+      "source_file": "scripts/root-scripts-coverage.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 491,
+      "file_type": "code",
+      "id": "root_scripts_coverage_collectrootscripttestfiles",
+      "label": "collectRootScriptTestFiles()",
+      "norm_label": "collectrootscripttestfiles()",
+      "source_file": "scripts/root-scripts-coverage.ts",
+      "source_location": "L4"
+    },
+    {
+      "community": 491,
+      "file_type": "code",
+      "id": "root_scripts_coverage_runrootscriptscoverage",
+      "label": "runRootScriptsCoverage()",
+      "norm_label": "runrootscriptscoverage()",
+      "source_file": "scripts/root-scripts-coverage.ts",
+      "source_location": "L13"
+    },
+    {
+      "community": 491,
+      "file_type": "code",
+      "id": "scripts_root_scripts_coverage_ts",
+      "label": "root-scripts-coverage.ts",
+      "norm_label": "root-scripts-coverage.ts",
+      "source_file": "scripts/root-scripts-coverage.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 492,
+      "file_type": "code",
       "id": "deposits_test_getsource",
       "label": "getSource()",
       "norm_label": "getsource()",
@@ -91498,7 +91651,7 @@
       "source_location": "L9"
     },
     {
-      "community": 490,
+      "community": 492,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cashcontrols_deposits_test_ts",
       "label": "deposits.test.ts",
@@ -91507,7 +91660,7 @@
       "source_location": "L1"
     },
     {
-      "community": 491,
+      "community": 493,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cashcontrols_paymentallocationattribution_test_ts",
       "label": "paymentAllocationAttribution.test.ts",
@@ -91516,7 +91669,7 @@
       "source_location": "L1"
     },
     {
-      "community": 491,
+      "community": 493,
       "file_type": "code",
       "id": "paymentallocationattribution_test_readprojectfile",
       "label": "readProjectFile()",
@@ -91525,7 +91678,7 @@
       "source_location": "L12"
     },
     {
-      "community": 492,
+      "community": 494,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cloudflare_stream_ts",
       "label": "stream.ts",
@@ -91534,7 +91687,7 @@
       "source_location": "L1"
     },
     {
-      "community": 492,
+      "community": 494,
       "file_type": "code",
       "id": "stream_getcloudflareconfig",
       "label": "getCloudflareConfig()",
@@ -91543,7 +91696,7 @@
       "source_location": "L8"
     },
     {
-      "community": 493,
+      "community": 495,
       "file_type": "code",
       "id": "convexauditscript_test_createcommandshimbin",
       "label": "createCommandShimBin()",
@@ -91552,7 +91705,7 @@
       "source_location": "L10"
     },
     {
-      "community": 493,
+      "community": 495,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_convexauditscript_test_ts",
       "label": "convexAuditScript.test.ts",
@@ -91561,7 +91714,7 @@
       "source_location": "L1"
     },
     {
-      "community": 494,
+      "community": 496,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_customermessaging_policy_ts",
       "label": "policy.ts",
@@ -91570,7 +91723,7 @@
       "source_location": "L1"
     },
     {
-      "community": 494,
+      "community": 496,
       "file_type": "code",
       "id": "policy_assertsupportedcustomermessagepolicy",
       "label": "assertSupportedCustomerMessagePolicy()",
@@ -91579,7 +91732,7 @@
       "source_location": "L8"
     },
     {
-      "community": 495,
+      "community": 497,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_customermessaging_repository_test_ts",
       "label": "repository.test.ts",
@@ -91588,7 +91741,7 @@
       "source_location": "L1"
     },
     {
-      "community": 495,
+      "community": 497,
       "file_type": "code",
       "id": "repository_test_queryresult",
       "label": "queryResult()",
@@ -91597,7 +91750,7 @@
       "source_location": "L12"
     },
     {
-      "community": 496,
+      "community": 498,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_customermessaging_webhooksecurity_test_ts",
       "label": "webhookSecurity.test.ts",
@@ -91606,7 +91759,7 @@
       "source_location": "L1"
     },
     {
-      "community": 496,
+      "community": 498,
       "file_type": "code",
       "id": "webhooksecurity_test_sign",
       "label": "sign()",
@@ -91615,7 +91768,7 @@
       "source_location": "L5"
     },
     {
-      "community": 497,
+      "community": 499,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_verificationcode_tsx",
       "label": "VerificationCode.tsx",
@@ -91624,49 +91777,13 @@
       "source_location": "L1"
     },
     {
-      "community": 497,
+      "community": 499,
       "file_type": "code",
       "id": "verificationcode_verificationcode",
       "label": "VerificationCode()",
       "norm_label": "verificationcode()",
       "source_file": "packages/athena-webapp/convex/emails/VerificationCode.tsx",
       "source_location": "L18"
-    },
-    {
-      "community": 498,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_core_routes_subcategories_ts",
-      "label": "subcategories.ts",
-      "norm_label": "subcategories.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/core/routes/subcategories.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 498,
-      "file_type": "code",
-      "id": "subcategories_removestorefronthiddensubcategorylist",
-      "label": "removeStorefrontHiddenSubcategoryList()",
-      "norm_label": "removestorefronthiddensubcategorylist()",
-      "source_file": "packages/athena-webapp/convex/http/domains/core/routes/subcategories.ts",
-      "source_location": "L10"
-    },
-    {
-      "community": 499,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_storefrontcors_test_ts",
-      "label": "storefrontCors.test.ts",
-      "norm_label": "storefrontcors.test.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/storefrontCors.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 499,
-      "file_type": "code",
-      "id": "storefrontcors_test_readroutefile",
-      "label": "readRouteFile()",
-      "norm_label": "readroutefile()",
-      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/storefrontCors.test.ts",
-      "source_location": "L6"
     },
     {
       "community": 5,
@@ -92157,6 +92274,42 @@
     {
       "community": 500,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_core_routes_subcategories_ts",
+      "label": "subcategories.ts",
+      "norm_label": "subcategories.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/core/routes/subcategories.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 500,
+      "file_type": "code",
+      "id": "subcategories_removestorefronthiddensubcategorylist",
+      "label": "removeStorefrontHiddenSubcategoryList()",
+      "norm_label": "removestorefronthiddensubcategorylist()",
+      "source_file": "packages/athena-webapp/convex/http/domains/core/routes/subcategories.ts",
+      "source_location": "L10"
+    },
+    {
+      "community": 501,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_storefrontcors_test_ts",
+      "label": "storefrontCors.test.ts",
+      "norm_label": "storefrontcors.test.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/storefrontCors.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 501,
+      "file_type": "code",
+      "id": "storefrontcors_test_readroutefile",
+      "label": "readRouteFile()",
+      "norm_label": "readroutefile()",
+      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/storefrontCors.test.ts",
+      "source_location": "L6"
+    },
+    {
+      "community": 502,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customermessaging_routes_whatsapp_ts",
       "label": "whatsapp.ts",
       "norm_label": "whatsapp.ts",
@@ -92164,7 +92317,7 @@
       "source_location": "L1"
     },
     {
-      "community": 500,
+      "community": 502,
       "file_type": "code",
       "id": "whatsapp_mapwebhookstatus",
       "label": "mapWebhookStatus()",
@@ -92173,7 +92326,7 @@
       "source_location": "L15"
     },
     {
-      "community": 501,
+      "community": 503,
       "file_type": "code",
       "id": "mtnmomo_handlecollectionnotification",
       "label": "handleCollectionNotification()",
@@ -92182,7 +92335,7 @@
       "source_location": "L10"
     },
     {
-      "community": 501,
+      "community": 503,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_moneymovement_routes_mtnmomo_ts",
       "label": "mtnMomo.ts",
@@ -92191,7 +92344,7 @@
       "source_location": "L1"
     },
     {
-      "community": 502,
+      "community": 504,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_routercomposition_test_ts",
       "label": "routerComposition.test.ts",
@@ -92200,7 +92353,7 @@
       "source_location": "L1"
     },
     {
-      "community": 502,
+      "community": 504,
       "file_type": "code",
       "id": "routercomposition_test_readprojectfile",
       "label": "readProjectFile()",
@@ -92209,7 +92362,7 @@
       "source_location": "L6"
     },
     {
-      "community": 503,
+      "community": 505,
       "file_type": "code",
       "id": "auth_mapathenaauthsyncerror",
       "label": "mapAthenaAuthSyncError()",
@@ -92218,7 +92371,7 @@
       "source_location": "L110"
     },
     {
-      "community": 503,
+      "community": 505,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_auth_ts",
       "label": "auth.ts",
@@ -92227,7 +92380,7 @@
       "source_location": "L1"
     },
     {
-      "community": 504,
+      "community": 506,
       "file_type": "code",
       "id": "bestseller_test_gethandler",
       "label": "getHandler()",
@@ -92236,7 +92389,7 @@
       "source_location": "L6"
     },
     {
-      "community": 504,
+      "community": 506,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_bestseller_test_ts",
       "label": "bestSeller.test.ts",
@@ -92245,7 +92398,7 @@
       "source_location": "L1"
     },
     {
-      "community": 505,
+      "community": 507,
       "file_type": "code",
       "id": "expensesessionitems_usererrorfromexpenseitemcommandfailure",
       "label": "userErrorFromExpenseItemCommandFailure()",
@@ -92254,7 +92407,7 @@
       "source_location": "L14"
     },
     {
-      "community": 505,
+      "community": 507,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_expensesessionitems_ts",
       "label": "expenseSessionItems.ts",
@@ -92263,7 +92416,7 @@
       "source_location": "L1"
     },
     {
-      "community": 506,
+      "community": 508,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_posquerycleanup_test_ts",
       "label": "posQueryCleanup.test.ts",
@@ -92272,7 +92425,7 @@
       "source_location": "L1"
     },
     {
-      "community": 506,
+      "community": 508,
       "file_type": "code",
       "id": "posquerycleanup_test_readprojectfile",
       "label": "readProjectFile()",
@@ -92281,7 +92434,7 @@
       "source_location": "L8"
     },
     {
-      "community": 507,
+      "community": 509,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_possessionitems_ts",
       "label": "posSessionItems.ts",
@@ -92290,49 +92443,13 @@
       "source_location": "L1"
     },
     {
-      "community": 507,
+      "community": 509,
       "file_type": "code",
       "id": "possessionitems_usererrorfromsessionitemfailure",
       "label": "userErrorFromSessionItemFailure()",
       "norm_label": "usererrorfromsessionitemfailure()",
       "source_file": "packages/athena-webapp/convex/inventory/posSessionItems.ts",
       "source_location": "L22"
-    },
-    {
-      "community": 508,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_productutil_ts",
-      "label": "productUtil.ts",
-      "norm_label": "productutil.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/productUtil.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 508,
-      "file_type": "code",
-      "id": "productutil_buildallproductscachekey",
-      "label": "buildAllProductsCacheKey()",
-      "norm_label": "buildallproductscachekey()",
-      "source_file": "packages/athena-webapp/convex/inventory/productUtil.ts",
-      "source_location": "L8"
-    },
-    {
-      "community": 509,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_promocode_ts",
-      "label": "promoCode.ts",
-      "norm_label": "promocode.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/promoCode.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 509,
-      "file_type": "code",
-      "id": "promocode_calculateselectedproductpromodiscount",
-      "label": "calculateSelectedProductPromoDiscount()",
-      "norm_label": "calculateselectedproductpromodiscount()",
-      "source_file": "packages/athena-webapp/convex/inventory/promoCode.ts",
-      "source_location": "L14"
     },
     {
       "community": 51,
@@ -92472,6 +92589,42 @@
     {
       "community": 510,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_productutil_ts",
+      "label": "productUtil.ts",
+      "norm_label": "productutil.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/productUtil.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 510,
+      "file_type": "code",
+      "id": "productutil_buildallproductscachekey",
+      "label": "buildAllProductsCacheKey()",
+      "norm_label": "buildallproductscachekey()",
+      "source_file": "packages/athena-webapp/convex/inventory/productUtil.ts",
+      "source_location": "L8"
+    },
+    {
+      "community": 511,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_promocode_ts",
+      "label": "promoCode.ts",
+      "norm_label": "promocode.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/promoCode.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 511,
+      "file_type": "code",
+      "id": "promocode_calculateselectedproductpromodiscount",
+      "label": "calculateSelectedProductPromoDiscount()",
+      "norm_label": "calculateselectedproductpromodiscount()",
+      "source_file": "packages/athena-webapp/convex/inventory/promoCode.ts",
+      "source_location": "L14"
+    },
+    {
+      "community": 512,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_stores_ts",
       "label": "stores.ts",
       "norm_label": "stores.ts",
@@ -92479,7 +92632,7 @@
       "source_location": "L1"
     },
     {
-      "community": 510,
+      "community": 512,
       "file_type": "code",
       "id": "stores_tov2onlyconfig",
       "label": "toV2OnlyConfig()",
@@ -92488,7 +92641,7 @@
       "source_location": "L29"
     },
     {
-      "community": 511,
+      "community": 513,
       "file_type": "code",
       "id": "commandresultvalidators_commandresultvalidator",
       "label": "commandResultValidator()",
@@ -92497,7 +92650,7 @@
       "source_location": "L73"
     },
     {
-      "community": 511,
+      "community": 513,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_lib_commandresultvalidators_ts",
       "label": "commandResultValidators.ts",
@@ -92506,7 +92659,7 @@
       "source_location": "L1"
     },
     {
-      "community": 512,
+      "community": 514,
       "file_type": "code",
       "id": "callllmprovider_callllmprovider",
       "label": "callLlmProvider()",
@@ -92515,7 +92668,7 @@
       "source_location": "L4"
     },
     {
-      "community": 512,
+      "community": 514,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_callllmprovider_ts",
       "label": "callLlmProvider.ts",
@@ -92524,7 +92677,7 @@
       "source_location": "L1"
     },
     {
-      "community": 513,
+      "community": 515,
       "file_type": "code",
       "id": "anthropic_callanthropic",
       "label": "callAnthropic()",
@@ -92533,7 +92686,7 @@
       "source_location": "L3"
     },
     {
-      "community": 513,
+      "community": 515,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_providers_anthropic_ts",
       "label": "anthropic.ts",
@@ -92542,7 +92695,7 @@
       "source_location": "L1"
     },
     {
-      "community": 514,
+      "community": 516,
       "file_type": "code",
       "id": "openai_callopenai",
       "label": "callOpenAi()",
@@ -92551,7 +92704,7 @@
       "source_location": "L3"
     },
     {
-      "community": 514,
+      "community": 516,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_providers_openai_ts",
       "label": "openai.ts",
@@ -92560,7 +92713,7 @@
       "source_location": "L1"
     },
     {
-      "community": 515,
+      "community": 517,
       "file_type": "code",
       "id": "foundation_test_readprojectfile",
       "label": "readProjectFile()",
@@ -92569,7 +92722,7 @@
       "source_location": "L6"
     },
     {
-      "community": 515,
+      "community": 517,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_foundation_test_ts",
       "label": "foundation.test.ts",
@@ -92578,7 +92731,7 @@
       "source_location": "L1"
     },
     {
-      "community": 516,
+      "community": 518,
       "file_type": "code",
       "id": "approvalactions_consumecommandapprovalproofwithctx",
       "label": "consumeCommandApprovalProofWithCtx()",
@@ -92587,7 +92740,7 @@
       "source_location": "L46"
     },
     {
-      "community": 516,
+      "community": 518,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_approvalactions_ts",
       "label": "approvalActions.ts",
@@ -92596,7 +92749,7 @@
       "source_location": "L1"
     },
     {
-      "community": 517,
+      "community": 519,
       "file_type": "code",
       "id": "approvalauditevents_test_createoperationaleventctx",
       "label": "createOperationalEventCtx()",
@@ -92605,48 +92758,12 @@
       "source_location": "L11"
     },
     {
-      "community": 517,
+      "community": 519,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_approvalauditevents_test_ts",
       "label": "approvalAuditEvents.test.ts",
       "norm_label": "approvalauditevents.test.ts",
       "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 518,
-      "file_type": "code",
-      "id": "approvalproofs_test_createapprovalproofmutationctx",
-      "label": "createApprovalProofMutationCtx()",
-      "norm_label": "createapprovalproofmutationctx()",
-      "source_file": "packages/athena-webapp/convex/operations/approvalProofs.test.ts",
-      "source_location": "L11"
-    },
-    {
-      "community": 518,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_approvalproofs_test_ts",
-      "label": "approvalProofs.test.ts",
-      "norm_label": "approvalproofs.test.ts",
-      "source_file": "packages/athena-webapp/convex/operations/approvalProofs.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 519,
-      "file_type": "code",
-      "id": "approvalrequesthelpers_buildapprovalrequest",
-      "label": "buildApprovalRequest()",
-      "norm_label": "buildapprovalrequest()",
-      "source_file": "packages/athena-webapp/convex/operations/approvalRequestHelpers.ts",
-      "source_location": "L3"
-    },
-    {
-      "community": 519,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_approvalrequesthelpers_ts",
-      "label": "approvalRequestHelpers.ts",
-      "norm_label": "approvalrequesthelpers.ts",
-      "source_file": "packages/athena-webapp/convex/operations/approvalRequestHelpers.ts",
       "source_location": "L1"
     },
     {
@@ -92787,6 +92904,42 @@
     {
       "community": 520,
       "file_type": "code",
+      "id": "approvalproofs_test_createapprovalproofmutationctx",
+      "label": "createApprovalProofMutationCtx()",
+      "norm_label": "createapprovalproofmutationctx()",
+      "source_file": "packages/athena-webapp/convex/operations/approvalProofs.test.ts",
+      "source_location": "L11"
+    },
+    {
+      "community": 520,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_approvalproofs_test_ts",
+      "label": "approvalProofs.test.ts",
+      "norm_label": "approvalproofs.test.ts",
+      "source_file": "packages/athena-webapp/convex/operations/approvalProofs.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 521,
+      "file_type": "code",
+      "id": "approvalrequesthelpers_buildapprovalrequest",
+      "label": "buildApprovalRequest()",
+      "norm_label": "buildapprovalrequest()",
+      "source_file": "packages/athena-webapp/convex/operations/approvalRequestHelpers.ts",
+      "source_location": "L3"
+    },
+    {
+      "community": 521,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_approvalrequesthelpers_ts",
+      "label": "approvalRequestHelpers.ts",
+      "norm_label": "approvalrequesthelpers.ts",
+      "source_file": "packages/athena-webapp/convex/operations/approvalRequestHelpers.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 522,
+      "file_type": "code",
       "id": "approvalrequests_test_createapprovalrequestmutationctx",
       "label": "createApprovalRequestMutationCtx()",
       "norm_label": "createapprovalrequestmutationctx()",
@@ -92794,7 +92947,7 @@
       "source_location": "L19"
     },
     {
-      "community": 520,
+      "community": 522,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_approvalrequests_test_ts",
       "label": "approvalRequests.test.ts",
@@ -92803,7 +92956,7 @@
       "source_location": "L1"
     },
     {
-      "community": 521,
+      "community": 523,
       "file_type": "code",
       "id": "eventbuilders_buildoperationaleventmessage",
       "label": "buildOperationalEventMessage()",
@@ -92812,7 +92965,7 @@
       "source_location": "L1"
     },
     {
-      "community": 521,
+      "community": 523,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_helpers_eventbuilders_ts",
       "label": "eventBuilders.ts",
@@ -92821,7 +92974,7 @@
       "source_location": "L1"
     },
     {
-      "community": 522,
+      "community": 524,
       "file_type": "code",
       "id": "emailotp_formatvalidtime",
       "label": "formatValidTime()",
@@ -92830,7 +92983,7 @@
       "source_location": "L9"
     },
     {
-      "community": 522,
+      "community": 524,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_otp_emailotp_ts",
       "label": "EmailOTP.ts",
@@ -92839,7 +92992,7 @@
       "source_location": "L1"
     },
     {
-      "community": 523,
+      "community": 525,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_commands_quickaddcatalogitem_test_ts",
       "label": "quickAddCatalogItem.test.ts",
@@ -92848,7 +93001,7 @@
       "source_location": "L1"
     },
     {
-      "community": 523,
+      "community": 525,
       "file_type": "code",
       "id": "quickaddcatalogitem_test_createquickaddctx",
       "label": "createQuickAddCtx()",
@@ -92857,7 +93010,7 @@
       "source_location": "L17"
     },
     {
-      "community": 524,
+      "community": 526,
       "file_type": "code",
       "id": "completetransaction_test_expectnocompletionsideeffects",
       "label": "expectNoCompletionSideEffects()",
@@ -92866,7 +93019,7 @@
       "source_location": "L82"
     },
     {
-      "community": 524,
+      "community": 526,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_completetransaction_test_ts",
       "label": "completeTransaction.test.ts",
@@ -92875,7 +93028,7 @@
       "source_location": "L1"
     },
     {
-      "community": 525,
+      "community": 527,
       "file_type": "code",
       "id": "correcttransactionpaymentmethod_test_createmutationctx",
       "label": "createMutationCtx()",
@@ -92884,7 +93037,7 @@
       "source_location": "L44"
     },
     {
-      "community": 525,
+      "community": 527,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_correcttransactionpaymentmethod_test_ts",
       "label": "correctTransactionPaymentMethod.test.ts",
@@ -92893,7 +93046,7 @@
       "source_location": "L1"
     },
     {
-      "community": 526,
+      "community": 528,
       "file_type": "code",
       "id": "correctionevents_buildcorrectionoperationalevent",
       "label": "buildCorrectionOperationalEvent()",
@@ -92902,7 +93055,7 @@
       "source_location": "L35"
     },
     {
-      "community": 526,
+      "community": 528,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_corrections_correctionevents_ts",
       "label": "correctionEvents.ts",
@@ -92911,7 +93064,7 @@
       "source_location": "L1"
     },
     {
-      "community": 527,
+      "community": 529,
       "file_type": "code",
       "id": "gettransactions_test_mockcorrectionhistorydb",
       "label": "mockCorrectionHistoryDb()",
@@ -92920,48 +93073,12 @@
       "source_location": "L33"
     },
     {
-      "community": 527,
+      "community": 529,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_gettransactions_test_ts",
       "label": "getTransactions.test.ts",
       "norm_label": "gettransactions.test.ts",
       "source_file": "packages/athena-webapp/convex/pos/application/getTransactions.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 528,
-      "file_type": "code",
-      "id": "listregistercatalog_test_createregistercatalogctx",
-      "label": "createRegisterCatalogCtx()",
-      "norm_label": "createregistercatalogctx()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/listRegisterCatalog.test.ts",
-      "source_location": "L22"
-    },
-    {
-      "community": 528,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_queries_listregistercatalog_test_ts",
-      "label": "listRegisterCatalog.test.ts",
-      "norm_label": "listregistercatalog.test.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/listRegisterCatalog.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 529,
-      "file_type": "code",
-      "id": "cashierrepository_getcashierforregisterstate",
-      "label": "getCashierForRegisterState()",
-      "norm_label": "getcashierforregisterstate()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/cashierRepository.ts",
-      "source_location": "L7"
-    },
-    {
-      "community": 529,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_cashierrepository_ts",
-      "label": "cashierRepository.ts",
-      "norm_label": "cashierrepository.ts",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/cashierRepository.ts",
       "source_location": "L1"
     },
     {
@@ -93102,6 +93219,42 @@
     {
       "community": 530,
       "file_type": "code",
+      "id": "listregistercatalog_test_createregistercatalogctx",
+      "label": "createRegisterCatalogCtx()",
+      "norm_label": "createregistercatalogctx()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/listRegisterCatalog.test.ts",
+      "source_location": "L22"
+    },
+    {
+      "community": 530,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_queries_listregistercatalog_test_ts",
+      "label": "listRegisterCatalog.test.ts",
+      "norm_label": "listregistercatalog.test.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/listRegisterCatalog.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 531,
+      "file_type": "code",
+      "id": "cashierrepository_getcashierforregisterstate",
+      "label": "getCashierForRegisterState()",
+      "norm_label": "getcashierforregisterstate()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/cashierRepository.ts",
+      "source_location": "L7"
+    },
+    {
+      "community": 531,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_cashierrepository_ts",
+      "label": "cashierRepository.ts",
+      "norm_label": "cashierrepository.ts",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/cashierRepository.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 532,
+      "file_type": "code",
       "id": "expensesessioncommandrepository_createexpensesessioncommandrepository",
       "label": "createExpenseSessionCommandRepository()",
       "norm_label": "createexpensesessioncommandrepository()",
@@ -93109,7 +93262,7 @@
       "source_location": "L60"
     },
     {
-      "community": 530,
+      "community": 532,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_expensesessioncommandrepository_ts",
       "label": "expenseSessionCommandRepository.ts",
@@ -93118,7 +93271,7 @@
       "source_location": "L1"
     },
     {
-      "community": 531,
+      "community": 533,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_sessioncommandrepository_test_ts",
       "label": "sessionCommandRepository.test.ts",
@@ -93127,7 +93280,7 @@
       "source_location": "L1"
     },
     {
-      "community": 531,
+      "community": 533,
       "file_type": "code",
       "id": "sessioncommandrepository_test_readprojectfile",
       "label": "readProjectFile()",
@@ -93136,7 +93289,7 @@
       "source_location": "L9"
     },
     {
-      "community": 532,
+      "community": 534,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_sessionrepository_test_ts",
       "label": "sessionRepository.test.ts",
@@ -93145,7 +93298,7 @@
       "source_location": "L1"
     },
     {
-      "community": 532,
+      "community": 534,
       "file_type": "code",
       "id": "sessionrepository_test_buildsession",
       "label": "buildSession()",
@@ -93154,7 +93307,7 @@
       "source_location": "L88"
     },
     {
-      "community": 533,
+      "community": 535,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_transactions_ts",
       "label": "transactions.ts",
@@ -93163,7 +93316,7 @@
       "source_location": "L1"
     },
     {
-      "community": 533,
+      "community": 535,
       "file_type": "code",
       "id": "transactions_mapcorrectionerror",
       "label": "mapCorrectionError()",
@@ -93172,7 +93325,7 @@
       "source_location": "L60"
     },
     {
-      "community": 534,
+      "community": 536,
       "file_type": "code",
       "id": "modulewiring_test_getsource",
       "label": "getSource()",
@@ -93181,7 +93334,7 @@
       "source_location": "L4"
     },
     {
-      "community": 534,
+      "community": 536,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_serviceops_modulewiring_test_ts",
       "label": "moduleWiring.test.ts",
@@ -93190,7 +93343,7 @@
       "source_location": "L1"
     },
     {
-      "community": 535,
+      "community": 537,
       "file_type": "code",
       "id": "access_test_createstockopsaccessqueryctx",
       "label": "createStockOpsAccessQueryCtx()",
@@ -93199,7 +93352,7 @@
       "source_location": "L15"
     },
     {
-      "community": 535,
+      "community": 537,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_access_test_ts",
       "label": "access.test.ts",
@@ -93208,7 +93361,7 @@
       "source_location": "L1"
     },
     {
-      "community": 536,
+      "community": 538,
       "file_type": "code",
       "id": "access_requirestorefulladminaccess",
       "label": "requireStoreFullAdminAccess()",
@@ -93217,7 +93370,7 @@
       "source_location": "L7"
     },
     {
-      "community": 536,
+      "community": 538,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_access_ts",
       "label": "access.ts",
@@ -93226,7 +93379,7 @@
       "source_location": "L1"
     },
     {
-      "community": 537,
+      "community": 539,
       "file_type": "code",
       "id": "cyclecountdrafts_test_createcyclecountdraftctx",
       "label": "createCycleCountDraftCtx()",
@@ -93235,48 +93388,12 @@
       "source_location": "L22"
     },
     {
-      "community": 537,
+      "community": 539,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_cyclecountdrafts_test_ts",
       "label": "cycleCountDrafts.test.ts",
       "norm_label": "cyclecountdrafts.test.ts",
       "source_file": "packages/athena-webapp/convex/stockOps/cycleCountDrafts.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 538,
-      "file_type": "code",
-      "id": "auth_getstorefrontactorbyid",
-      "label": "getStoreFrontActorById()",
-      "norm_label": "getstorefrontactorbyid()",
-      "source_file": "packages/athena-webapp/convex/storeFront/auth.ts",
-      "source_location": "L15"
-    },
-    {
-      "community": 538,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_auth_ts",
-      "label": "auth.ts",
-      "norm_label": "auth.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/auth.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 539,
-      "file_type": "code",
-      "id": "customerbehaviortimeline_test_createqueryctx",
-      "label": "createQueryCtx()",
-      "norm_label": "createqueryctx()",
-      "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.test.ts",
-      "source_location": "L8"
-    },
-    {
-      "community": 539,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_customerbehaviortimeline_test_ts",
-      "label": "customerBehaviorTimeline.test.ts",
-      "norm_label": "customerbehaviortimeline.test.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.test.ts",
       "source_location": "L1"
     },
     {
@@ -93408,6 +93525,42 @@
     {
       "community": 540,
       "file_type": "code",
+      "id": "auth_getstorefrontactorbyid",
+      "label": "getStoreFrontActorById()",
+      "norm_label": "getstorefrontactorbyid()",
+      "source_file": "packages/athena-webapp/convex/storeFront/auth.ts",
+      "source_location": "L15"
+    },
+    {
+      "community": 540,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_auth_ts",
+      "label": "auth.ts",
+      "norm_label": "auth.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/auth.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 541,
+      "file_type": "code",
+      "id": "customerbehaviortimeline_test_createqueryctx",
+      "label": "createQueryCtx()",
+      "norm_label": "createqueryctx()",
+      "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.test.ts",
+      "source_location": "L8"
+    },
+    {
+      "community": 541,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_customerbehaviortimeline_test_ts",
+      "label": "customerBehaviorTimeline.test.ts",
+      "norm_label": "customerbehaviortimeline.test.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 542,
+      "file_type": "code",
       "id": "customerobservabilitytimeline_test_createanalyticsevent",
       "label": "createAnalyticsEvent()",
       "norm_label": "createanalyticsevent()",
@@ -93415,7 +93568,7 @@
       "source_location": "L17"
     },
     {
-      "community": 540,
+      "community": 542,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_customerobservabilitytimeline_test_ts",
       "label": "customerObservabilityTimeline.test.ts",
@@ -93424,7 +93577,7 @@
       "source_location": "L1"
     },
     {
-      "community": 541,
+      "community": 543,
       "file_type": "code",
       "id": "helperorchestration_test_readprojectfile",
       "label": "readProjectFile()",
@@ -93433,7 +93586,7 @@
       "source_location": "L6"
     },
     {
-      "community": 541,
+      "community": 543,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_helperorchestration_test_ts",
       "label": "helperOrchestration.test.ts",
@@ -93442,7 +93595,7 @@
       "source_location": "L1"
     },
     {
-      "community": 542,
+      "community": 544,
       "file_type": "code",
       "id": "customerengagementevents_test_createmutationctx",
       "label": "createMutationCtx()",
@@ -93451,7 +93604,7 @@
       "source_location": "L5"
     },
     {
-      "community": 542,
+      "community": 544,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_helpers_customerengagementevents_test_ts",
       "label": "customerEngagementEvents.test.ts",
@@ -93460,7 +93613,7 @@
       "source_location": "L1"
     },
     {
-      "community": 543,
+      "community": 545,
       "file_type": "code",
       "id": "onlineorder_test_getsource",
       "label": "getSource()",
@@ -93469,7 +93622,7 @@
       "source_location": "L4"
     },
     {
-      "community": 543,
+      "community": 545,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_onlineorder_test_ts",
       "label": "onlineOrder.test.ts",
@@ -93478,7 +93631,7 @@
       "source_location": "L1"
     },
     {
-      "community": 544,
+      "community": 546,
       "file_type": "code",
       "id": "onlineorderitem_updateonlineorderitem",
       "label": "updateOnlineOrderItem()",
@@ -93487,7 +93640,7 @@
       "source_location": "L25"
     },
     {
-      "community": 544,
+      "community": 546,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_onlineorderitem_ts",
       "label": "onlineOrderItem.ts",
@@ -93496,7 +93649,7 @@
       "source_location": "L1"
     },
     {
-      "community": 545,
+      "community": 547,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_reviews_ts",
       "label": "reviews.ts",
@@ -93505,7 +93658,7 @@
       "source_location": "L1"
     },
     {
-      "community": 545,
+      "community": 547,
       "file_type": "code",
       "id": "reviews_getstorefrontactorbyid",
       "label": "getStoreFrontActorById()",
@@ -93514,7 +93667,7 @@
       "source_location": "L19"
     },
     {
-      "community": 546,
+      "community": 548,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_rewards_ts",
       "label": "rewards.ts",
@@ -93523,7 +93676,7 @@
       "source_location": "L1"
     },
     {
-      "community": 546,
+      "community": 548,
       "file_type": "code",
       "id": "rewards_formatpointslabel",
       "label": "formatPointsLabel()",
@@ -93532,7 +93685,7 @@
       "source_location": "L7"
     },
     {
-      "community": 547,
+      "community": 549,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_savedbag_ts",
       "label": "savedBag.ts",
@@ -93541,49 +93694,13 @@
       "source_location": "L1"
     },
     {
-      "community": 547,
+      "community": 549,
       "file_type": "code",
       "id": "savedbag_listsavedbagitems",
       "label": "listSavedBagItems()",
       "norm_label": "listsavedbagitems()",
       "source_file": "packages/athena-webapp/convex/storeFront/savedBag.ts",
       "source_location": "L14"
-    },
-    {
-      "community": 548,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_storefrontobservabilityreport_test_ts",
-      "label": "storefrontObservabilityReport.test.ts",
-      "norm_label": "storefrontobservabilityreport.test.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/storefrontObservabilityReport.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 548,
-      "file_type": "code",
-      "id": "storefrontobservabilityreport_test_createanalyticsevent",
-      "label": "createAnalyticsEvent()",
-      "norm_label": "createanalyticsevent()",
-      "source_file": "packages/athena-webapp/convex/storeFront/storefrontObservabilityReport.test.ts",
-      "source_location": "L8"
-    },
-    {
-      "community": 549,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_syntheticmonitor_ts",
-      "label": "syntheticMonitor.ts",
-      "norm_label": "syntheticmonitor.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/syntheticMonitor.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 549,
-      "file_type": "code",
-      "id": "syntheticmonitor_issyntheticmonitororigin",
-      "label": "isSyntheticMonitorOrigin()",
-      "norm_label": "issyntheticmonitororigin()",
-      "source_file": "packages/athena-webapp/convex/storeFront/syntheticMonitor.ts",
-      "source_location": "L3"
     },
     {
       "community": 55,
@@ -93714,6 +93831,42 @@
     {
       "community": 550,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_storefrontobservabilityreport_test_ts",
+      "label": "storefrontObservabilityReport.test.ts",
+      "norm_label": "storefrontobservabilityreport.test.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/storefrontObservabilityReport.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 550,
+      "file_type": "code",
+      "id": "storefrontobservabilityreport_test_createanalyticsevent",
+      "label": "createAnalyticsEvent()",
+      "norm_label": "createanalyticsevent()",
+      "source_file": "packages/athena-webapp/convex/storeFront/storefrontObservabilityReport.test.ts",
+      "source_location": "L8"
+    },
+    {
+      "community": 551,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_syntheticmonitor_ts",
+      "label": "syntheticMonitor.ts",
+      "norm_label": "syntheticmonitor.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/syntheticMonitor.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 551,
+      "file_type": "code",
+      "id": "syntheticmonitor_issyntheticmonitororigin",
+      "label": "isSyntheticMonitorOrigin()",
+      "norm_label": "issyntheticmonitororigin()",
+      "source_file": "packages/athena-webapp/convex/storeFront/syntheticMonitor.ts",
+      "source_location": "L3"
+    },
+    {
+      "community": 552,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_timequeryrefactors_test_ts",
       "label": "timeQueryRefactors.test.ts",
       "norm_label": "timequeryrefactors.test.ts",
@@ -93721,7 +93874,7 @@
       "source_location": "L1"
     },
     {
-      "community": 550,
+      "community": 552,
       "file_type": "code",
       "id": "timequeryrefactors_test_readsource",
       "label": "readSource()",
@@ -93730,7 +93883,7 @@
       "source_location": "L5"
     },
     {
-      "community": 551,
+      "community": 553,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_user_ts",
       "label": "user.ts",
@@ -93739,7 +93892,7 @@
       "source_location": "L1"
     },
     {
-      "community": 551,
+      "community": 553,
       "file_type": "code",
       "id": "user_getstorefrontactorbyid",
       "label": "getStoreFrontActorById()",
@@ -93748,7 +93901,7 @@
       "source_location": "L16"
     },
     {
-      "community": 552,
+      "community": 554,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_useroffers_ts",
       "label": "userOffers.ts",
@@ -93757,7 +93910,7 @@
       "source_location": "L1"
     },
     {
-      "community": 552,
+      "community": 554,
       "file_type": "code",
       "id": "useroffers_determineoffereligibility",
       "label": "determineOfferEligibility()",
@@ -93766,7 +93919,7 @@
       "source_location": "L30"
     },
     {
-      "community": 553,
+      "community": 555,
       "file_type": "code",
       "id": "expensesession_buildexpensesessiontraceseed",
       "label": "buildExpenseSessionTraceSeed()",
@@ -93775,7 +93928,7 @@
       "source_location": "L42"
     },
     {
-      "community": 553,
+      "community": 555,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_adapters_expensesession_ts",
       "label": "expenseSession.ts",
@@ -93784,7 +93937,7 @@
       "source_location": "L1"
     },
     {
-      "community": 554,
+      "community": 556,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_adapters_possession_ts",
       "label": "posSession.ts",
@@ -93793,7 +93946,7 @@
       "source_location": "L1"
     },
     {
-      "community": 554,
+      "community": 556,
       "file_type": "code",
       "id": "possession_buildpossessiontraceseed",
       "label": "buildPosSessionTraceSeed()",
@@ -93802,7 +93955,7 @@
       "source_location": "L42"
     },
     {
-      "community": 555,
+      "community": 557,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_presentation_ts",
       "label": "presentation.ts",
@@ -93811,7 +93964,7 @@
       "source_location": "L1"
     },
     {
-      "community": 555,
+      "community": 557,
       "file_type": "code",
       "id": "presentation_buildworkflowtraceviewmodel",
       "label": "buildWorkflowTraceViewModel()",
@@ -93820,7 +93973,7 @@
       "source_location": "L31"
     },
     {
-      "community": 556,
+      "community": 558,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_schemaindexes_test_ts",
       "label": "schemaIndexes.test.ts",
@@ -93829,7 +93982,7 @@
       "source_location": "L1"
     },
     {
-      "community": 556,
+      "community": 558,
       "file_type": "code",
       "id": "schemaindexes_test_gettableindexes",
       "label": "getTableIndexes()",
@@ -93838,7 +93991,7 @@
       "source_location": "L5"
     },
     {
-      "community": 557,
+      "community": 559,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_serviceintake_ts",
       "label": "serviceIntake.ts",
@@ -93847,48 +94000,12 @@
       "source_location": "L1"
     },
     {
-      "community": 557,
+      "community": 559,
       "file_type": "code",
       "id": "serviceintake_validateserviceintakeinput",
       "label": "validateServiceIntakeInput()",
       "norm_label": "validateserviceintakeinput()",
       "source_file": "packages/athena-webapp/shared/serviceIntake.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 558,
-      "file_type": "code",
-      "id": "organizationview_navigation",
-      "label": "Navigation()",
-      "norm_label": "navigation()",
-      "source_file": "packages/athena-webapp/src/components/OrganizationView.tsx",
-      "source_location": "L7"
-    },
-    {
-      "community": 558,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organizationview_tsx",
-      "label": "OrganizationView.tsx",
-      "norm_label": "organizationview.tsx",
-      "source_file": "packages/athena-webapp/src/components/OrganizationView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 559,
-      "file_type": "code",
-      "id": "organizationsview_navigation",
-      "label": "Navigation()",
-      "norm_label": "navigation()",
-      "source_file": "packages/athena-webapp/src/components/OrganizationsView.tsx",
-      "source_location": "L12"
-    },
-    {
-      "community": 559,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organizationsview_tsx",
-      "label": "OrganizationsView.tsx",
-      "norm_label": "organizationsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/OrganizationsView.tsx",
       "source_location": "L1"
     },
     {
@@ -94020,6 +94137,42 @@
     {
       "community": 560,
       "file_type": "code",
+      "id": "organizationview_navigation",
+      "label": "Navigation()",
+      "norm_label": "navigation()",
+      "source_file": "packages/athena-webapp/src/components/OrganizationView.tsx",
+      "source_location": "L7"
+    },
+    {
+      "community": 560,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_organizationview_tsx",
+      "label": "OrganizationView.tsx",
+      "norm_label": "organizationview.tsx",
+      "source_file": "packages/athena-webapp/src/components/OrganizationView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 561,
+      "file_type": "code",
+      "id": "organizationsview_navigation",
+      "label": "Navigation()",
+      "norm_label": "navigation()",
+      "source_file": "packages/athena-webapp/src/components/OrganizationsView.tsx",
+      "source_location": "L12"
+    },
+    {
+      "community": 561,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_organizationsview_tsx",
+      "label": "OrganizationsView.tsx",
+      "norm_label": "organizationsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/OrganizationsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 562,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_permissiongate_tsx",
       "label": "PermissionGate.tsx",
       "norm_label": "permissiongate.tsx",
@@ -94027,7 +94180,7 @@
       "source_location": "L1"
     },
     {
-      "community": 560,
+      "community": 562,
       "file_type": "code",
       "id": "permissiongate_permissiongate",
       "label": "PermissionGate()",
@@ -94036,7 +94189,7 @@
       "source_location": "L11"
     },
     {
-      "community": 561,
+      "community": 563,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_protectedroute_tsx",
       "label": "ProtectedRoute.tsx",
@@ -94045,7 +94198,7 @@
       "source_location": "L1"
     },
     {
-      "community": 561,
+      "community": 563,
       "file_type": "code",
       "id": "protectedroute_protectedroute",
       "label": "ProtectedRoute()",
@@ -94054,7 +94207,7 @@
       "source_location": "L11"
     },
     {
-      "community": 562,
+      "community": 564,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_settingsview_tsx",
       "label": "SettingsView.tsx",
@@ -94063,7 +94216,7 @@
       "source_location": "L1"
     },
     {
-      "community": 562,
+      "community": 564,
       "file_type": "code",
       "id": "settingsview_settingsview",
       "label": "SettingsView()",
@@ -94072,7 +94225,7 @@
       "source_location": "L3"
     },
     {
-      "community": 563,
+      "community": 565,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storeactions_tsx",
       "label": "StoreActions.tsx",
@@ -94081,7 +94234,7 @@
       "source_location": "L1"
     },
     {
-      "community": 563,
+      "community": 565,
       "file_type": "code",
       "id": "storeactions_storeactions",
       "label": "StoreActions()",
@@ -94090,7 +94243,7 @@
       "source_location": "L12"
     },
     {
-      "community": 564,
+      "community": 566,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storedropdown_tsx",
       "label": "StoreDropdown.tsx",
@@ -94099,7 +94252,7 @@
       "source_location": "L1"
     },
     {
-      "community": 564,
+      "community": 566,
       "file_type": "code",
       "id": "storedropdown_storedropdown",
       "label": "StoreDropdown()",
@@ -94108,7 +94261,7 @@
       "source_location": "L42"
     },
     {
-      "community": 565,
+      "community": 567,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storeview_tsx",
       "label": "StoreView.tsx",
@@ -94117,7 +94270,7 @@
       "source_location": "L1"
     },
     {
-      "community": 565,
+      "community": 567,
       "file_type": "code",
       "id": "storeview_navigation",
       "label": "Navigation()",
@@ -94126,7 +94279,7 @@
       "source_location": "L13"
     },
     {
-      "community": 566,
+      "community": 568,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storesdropdown_tsx",
       "label": "StoresDropdown.tsx",
@@ -94135,7 +94288,7 @@
       "source_location": "L1"
     },
     {
-      "community": 566,
+      "community": 568,
       "file_type": "code",
       "id": "storesdropdown_storesdropdown",
       "label": "StoresDropdown()",
@@ -94144,7 +94297,7 @@
       "source_location": "L42"
     },
     {
-      "community": 567,
+      "community": 569,
       "file_type": "code",
       "id": "barcodeqrviewer_handleprint",
       "label": "handlePrint()",
@@ -94153,49 +94306,13 @@
       "source_location": "L31"
     },
     {
-      "community": 567,
+      "community": 569,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_barcodeqrviewer_tsx",
       "label": "BarcodeQRViewer.tsx",
       "norm_label": "barcodeqrviewer.tsx",
       "source_file": "packages/athena-webapp/src/components/add-product/BarcodeQRViewer.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 568,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_processingfees_tsx",
-      "label": "ProcessingFees.tsx",
-      "norm_label": "processingfees.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProcessingFees.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 568,
-      "file_type": "code",
-      "id": "processingfees_processingfeesview",
-      "label": "ProcessingFeesView()",
-      "norm_label": "processingfeesview()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProcessingFees.tsx",
-      "source_location": "L10"
-    },
-    {
-      "community": 569,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_productattributes_tsx",
-      "label": "ProductAttributes.tsx",
-      "norm_label": "productattributes.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductAttributes.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 569,
-      "file_type": "code",
-      "id": "productattributes_isallowedattribute",
-      "label": "isAllowedAttribute()",
-      "norm_label": "isallowedattribute()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductAttributes.tsx",
-      "source_location": "L14"
     },
     {
       "community": 57,
@@ -94326,6 +94443,42 @@
     {
       "community": 570,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_processingfees_tsx",
+      "label": "ProcessingFees.tsx",
+      "norm_label": "processingfees.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProcessingFees.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 570,
+      "file_type": "code",
+      "id": "processingfees_processingfeesview",
+      "label": "ProcessingFeesView()",
+      "norm_label": "processingfeesview()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProcessingFees.tsx",
+      "source_location": "L10"
+    },
+    {
+      "community": 571,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_productattributes_tsx",
+      "label": "ProductAttributes.tsx",
+      "norm_label": "productattributes.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductAttributes.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 571,
+      "file_type": "code",
+      "id": "productattributes_isallowedattribute",
+      "label": "isAllowedAttribute()",
+      "norm_label": "isallowedattribute()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductAttributes.tsx",
+      "source_location": "L14"
+    },
+    {
+      "community": 572,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productavailabilitytogglegroup_tsx",
       "label": "ProductAvailabilityToggleGroup.tsx",
       "norm_label": "productavailabilitytogglegroup.tsx",
@@ -94333,7 +94486,7 @@
       "source_location": "L1"
     },
     {
-      "community": 570,
+      "community": 572,
       "file_type": "code",
       "id": "productavailabilitytogglegroup_productavailabilitytogglegroup",
       "label": "ProductAvailabilityToggleGroup()",
@@ -94342,7 +94495,7 @@
       "source_location": "L5"
     },
     {
-      "community": 571,
+      "community": 573,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productdetails_tsx",
       "label": "ProductDetails.tsx",
@@ -94351,7 +94504,7 @@
       "source_location": "L1"
     },
     {
-      "community": 571,
+      "community": 573,
       "file_type": "code",
       "id": "productdetails_handlenamechange",
       "label": "handleNameChange()",
@@ -94360,7 +94513,7 @@
       "source_location": "L10"
     },
     {
-      "community": 572,
+      "community": 574,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productimages_tsx",
       "label": "ProductImages.tsx",
@@ -94369,7 +94522,7 @@
       "source_location": "L1"
     },
     {
-      "community": 572,
+      "community": 574,
       "file_type": "code",
       "id": "productimages_header",
       "label": "Header()",
@@ -94378,7 +94531,7 @@
       "source_location": "L15"
     },
     {
-      "community": 573,
+      "community": 575,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productpage_tsx",
       "label": "ProductPage.tsx",
@@ -94387,7 +94540,7 @@
       "source_location": "L1"
     },
     {
-      "community": 573,
+      "community": 575,
       "file_type": "code",
       "id": "productpage_productpage",
       "label": "ProductPage()",
@@ -94396,7 +94549,7 @@
       "source_location": "L13"
     },
     {
-      "community": 574,
+      "community": 576,
       "file_type": "code",
       "id": "copyimagesview_setisupdatingsku",
       "label": "setIsUpdatingSku()",
@@ -94405,7 +94558,7 @@
       "source_location": "L118"
     },
     {
-      "community": 574,
+      "community": 576,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_copyimagesview_tsx",
       "label": "CopyImagesView.tsx",
@@ -94414,7 +94567,7 @@
       "source_location": "L1"
     },
     {
-      "community": 575,
+      "community": 577,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_product_variant_columns_tsx",
       "label": "product-variant-columns.tsx",
@@ -94423,7 +94576,7 @@
       "source_location": "L1"
     },
     {
-      "community": 575,
+      "community": 577,
       "file_type": "code",
       "id": "product_variant_columns_setsourcevariant",
       "label": "setSourceVariant()",
@@ -94432,7 +94585,7 @@
       "source_location": "L47"
     },
     {
-      "community": 576,
+      "community": 578,
       "file_type": "code",
       "id": "activitytimeline_capitalizefirstletter",
       "label": "capitalizeFirstLetter()",
@@ -94441,7 +94594,7 @@
       "source_location": "L152"
     },
     {
-      "community": 576,
+      "community": 578,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_activitytimeline_tsx",
       "label": "ActivityTimeline.tsx",
@@ -94450,7 +94603,7 @@
       "source_location": "L1"
     },
     {
-      "community": 577,
+      "community": 579,
       "file_type": "code",
       "id": "analyticscombinedusers_analyticscombinedusers",
       "label": "AnalyticsCombinedUsers()",
@@ -94459,48 +94612,12 @@
       "source_location": "L5"
     },
     {
-      "community": 577,
+      "community": 579,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticscombinedusers_tsx",
       "label": "AnalyticsCombinedUsers.tsx",
       "norm_label": "analyticscombinedusers.tsx",
       "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsCombinedUsers.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 578,
-      "file_type": "code",
-      "id": "analyticsitems_analyticsitems",
-      "label": "AnalyticsItems()",
-      "norm_label": "analyticsitems()",
-      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsItems.tsx",
-      "source_location": "L6"
-    },
-    {
-      "community": 578,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analyticsitems_tsx",
-      "label": "AnalyticsItems.tsx",
-      "norm_label": "analyticsitems.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsItems.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 579,
-      "file_type": "code",
-      "id": "analyticsproducts_analyticsproducts",
-      "label": "AnalyticsProducts()",
-      "norm_label": "analyticsproducts()",
-      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsProducts.tsx",
-      "source_location": "L13"
-    },
-    {
-      "community": 579,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analyticsproducts_tsx",
-      "label": "AnalyticsProducts.tsx",
-      "norm_label": "analyticsproducts.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsProducts.tsx",
       "source_location": "L1"
     },
     {
@@ -94632,6 +94749,42 @@
     {
       "community": 580,
       "file_type": "code",
+      "id": "analyticsitems_analyticsitems",
+      "label": "AnalyticsItems()",
+      "norm_label": "analyticsitems()",
+      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsItems.tsx",
+      "source_location": "L6"
+    },
+    {
+      "community": 580,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_analyticsitems_tsx",
+      "label": "AnalyticsItems.tsx",
+      "norm_label": "analyticsitems.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsItems.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 581,
+      "file_type": "code",
+      "id": "analyticsproducts_analyticsproducts",
+      "label": "AnalyticsProducts()",
+      "norm_label": "analyticsproducts()",
+      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsProducts.tsx",
+      "source_location": "L13"
+    },
+    {
+      "community": 581,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_analyticsproducts_tsx",
+      "label": "AnalyticsProducts.tsx",
+      "norm_label": "analyticsproducts.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsProducts.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 582,
+      "file_type": "code",
       "id": "analyticsusers_analyticsusers",
       "label": "AnalyticsUsers()",
       "norm_label": "analyticsusers()",
@@ -94639,7 +94792,7 @@
       "source_location": "L7"
     },
     {
-      "community": 580,
+      "community": 582,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticsusers_tsx",
       "label": "AnalyticsUsers.tsx",
@@ -94648,7 +94801,7 @@
       "source_location": "L1"
     },
     {
-      "community": 581,
+      "community": 583,
       "file_type": "code",
       "id": "analyticsview_formatmetric",
       "label": "formatMetric()",
@@ -94657,7 +94810,7 @@
       "source_location": "L27"
     },
     {
-      "community": 581,
+      "community": 583,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticsview_tsx",
       "label": "AnalyticsView.tsx",
@@ -94666,7 +94819,7 @@
       "source_location": "L1"
     },
     {
-      "community": 582,
+      "community": 584,
       "file_type": "code",
       "id": "enhancedanalyticsview_getdaterangemilliseconds",
       "label": "getDateRangeMilliseconds()",
@@ -94675,7 +94828,7 @@
       "source_location": "L42"
     },
     {
-      "community": 582,
+      "community": 584,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_enhancedanalyticsview_tsx",
       "label": "EnhancedAnalyticsView.tsx",
@@ -94684,7 +94837,7 @@
       "source_location": "L1"
     },
     {
-      "community": 583,
+      "community": 585,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_storeinsights_tsx",
       "label": "StoreInsights.tsx",
@@ -94693,7 +94846,7 @@
       "source_location": "L1"
     },
     {
-      "community": 583,
+      "community": 585,
       "file_type": "code",
       "id": "storeinsights_gettrendicon",
       "label": "getTrendIcon()",
@@ -94702,7 +94855,7 @@
       "source_location": "L66"
     },
     {
-      "community": 584,
+      "community": 586,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_visitorchart_tsx",
       "label": "VisitorChart.tsx",
@@ -94711,7 +94864,7 @@
       "source_location": "L1"
     },
     {
-      "community": 584,
+      "community": 586,
       "file_type": "code",
       "id": "visitorchart_formathour",
       "label": "formatHour()",
@@ -94720,7 +94873,7 @@
       "source_location": "L18"
     },
     {
-      "community": 585,
+      "community": 587,
       "file_type": "code",
       "id": "analyticsworkspaceefficiency_test_readsource",
       "label": "readSource()",
@@ -94729,7 +94882,7 @@
       "source_location": "L5"
     },
     {
-      "community": 585,
+      "community": 587,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticsworkspaceefficiency_test_ts",
       "label": "analyticsWorkspaceEfficiency.test.ts",
@@ -94738,7 +94891,7 @@
       "source_location": "L1"
     },
     {
-      "community": 586,
+      "community": 588,
       "file_type": "code",
       "id": "logitems_logitems",
       "label": "LogItems()",
@@ -94747,7 +94900,7 @@
       "source_location": "L6"
     },
     {
-      "community": 586,
+      "community": 588,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_logitems_tsx",
       "label": "LogItems.tsx",
@@ -94756,7 +94909,7 @@
       "source_location": "L1"
     },
     {
-      "community": 587,
+      "community": 589,
       "file_type": "code",
       "id": "logview_header",
       "label": "Header()",
@@ -94765,49 +94918,13 @@
       "source_location": "L10"
     },
     {
-      "community": 587,
+      "community": 589,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_logview_tsx",
       "label": "LogView.tsx",
       "norm_label": "logview.tsx",
       "source_file": "packages/athena-webapp/src/components/app-logs/LogView.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 588,
-      "file_type": "code",
-      "id": "logsview_navigation",
-      "label": "Navigation()",
-      "norm_label": "navigation()",
-      "source_file": "packages/athena-webapp/src/components/app-logs/LogsView.tsx",
-      "source_location": "L27"
-    },
-    {
-      "community": 588,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_app_logs_logsview_tsx",
-      "label": "LogsView.tsx",
-      "norm_label": "logsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/app-logs/LogsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 589,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_app_logs_hooks_useloadlogitems_ts",
-      "label": "useLoadLogItems.ts",
-      "norm_label": "useloadlogitems.ts",
-      "source_file": "packages/athena-webapp/src/components/app-logs/hooks/useLoadLogItems.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 589,
-      "file_type": "code",
-      "id": "useloadlogitems_useloadlogitems",
-      "label": "useLoadLogItems()",
-      "norm_label": "useloadlogitems()",
-      "source_file": "packages/athena-webapp/src/components/app-logs/hooks/useLoadLogItems.ts",
-      "source_location": "L12"
     },
     {
       "community": 59,
@@ -94938,6 +95055,42 @@
     {
       "community": 590,
       "file_type": "code",
+      "id": "logsview_navigation",
+      "label": "Navigation()",
+      "norm_label": "navigation()",
+      "source_file": "packages/athena-webapp/src/components/app-logs/LogsView.tsx",
+      "source_location": "L27"
+    },
+    {
+      "community": 590,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_app_logs_logsview_tsx",
+      "label": "LogsView.tsx",
+      "norm_label": "logsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/app-logs/LogsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 591,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_app_logs_hooks_useloadlogitems_ts",
+      "label": "useLoadLogItems.ts",
+      "norm_label": "useloadlogitems.ts",
+      "source_file": "packages/athena-webapp/src/components/app-logs/hooks/useLoadLogItems.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 591,
+      "file_type": "code",
+      "id": "useloadlogitems_useloadlogitems",
+      "label": "useLoadLogItems()",
+      "norm_label": "useloadlogitems()",
+      "source_file": "packages/athena-webapp/src/components/app-logs/hooks/useLoadLogItems.ts",
+      "source_location": "L12"
+    },
+    {
+      "community": 592,
+      "file_type": "code",
       "id": "app_sidebar_test_passthrough",
       "label": "Passthrough()",
       "norm_label": "passthrough()",
@@ -94945,7 +95098,7 @@
       "source_location": "L70"
     },
     {
-      "community": 590,
+      "community": 592,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_sidebar_test_tsx",
       "label": "app-sidebar.test.tsx",
@@ -94954,7 +95107,7 @@
       "source_location": "L1"
     },
     {
-      "community": 591,
+      "community": 593,
       "file_type": "code",
       "id": "app_sidebar_sidebarmenucollapsible",
       "label": "SidebarMenuCollapsible()",
@@ -94963,7 +95116,7 @@
       "source_location": "L59"
     },
     {
-      "community": 591,
+      "community": 593,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_sidebar_tsx",
       "label": "app-sidebar.tsx",
@@ -94972,7 +95125,7 @@
       "source_location": "L1"
     },
     {
-      "community": 592,
+      "community": 594,
       "file_type": "code",
       "id": "auth_auth",
       "label": "Auth()",
@@ -94981,7 +95134,7 @@
       "source_location": "L3"
     },
     {
-      "community": 592,
+      "community": 594,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_auth_tsx",
       "label": "Auth.tsx",
@@ -94990,7 +95143,7 @@
       "source_location": "L1"
     },
     {
-      "community": 593,
+      "community": 595,
       "file_type": "code",
       "id": "inputotp_test_resolvesignin",
       "label": "resolveSignIn()",
@@ -94999,7 +95152,7 @@
       "source_location": "L102"
     },
     {
-      "community": 593,
+      "community": 595,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_login_inputotp_test_tsx",
       "label": "InputOTP.test.tsx",
@@ -95008,7 +95161,7 @@
       "source_location": "L1"
     },
     {
-      "community": 594,
+      "community": 596,
       "file_type": "code",
       "id": "index_login",
       "label": "Login()",
@@ -95017,7 +95170,7 @@
       "source_location": "L5"
     },
     {
-      "community": 594,
+      "community": 596,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_login_index_tsx",
       "label": "index.tsx",
@@ -95026,7 +95179,7 @@
       "source_location": "L1"
     },
     {
-      "community": 595,
+      "community": 597,
       "file_type": "code",
       "id": "data_table_column_header_datatablecolumnheader",
       "label": "DataTableColumnHeader()",
@@ -95035,7 +95188,7 @@
       "source_location": "L25"
     },
     {
-      "community": 595,
+      "community": 597,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_data_table_column_header_tsx",
       "label": "data-table-column-header.tsx",
@@ -95044,7 +95197,7 @@
       "source_location": "L1"
     },
     {
-      "community": 596,
+      "community": 598,
       "file_type": "code",
       "id": "bulkoperationsfilters_handleloadproducts",
       "label": "handleLoadProducts()",
@@ -95053,7 +95206,7 @@
       "source_location": "L49"
     },
     {
-      "community": 596,
+      "community": 598,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationsfilters_tsx",
       "label": "BulkOperationsFilters.tsx",
@@ -95062,7 +95215,7 @@
       "source_location": "L1"
     },
     {
-      "community": 597,
+      "community": 599,
       "file_type": "code",
       "id": "bulkoperationspreview_test_makerow",
       "label": "makeRow()",
@@ -95071,48 +95224,12 @@
       "source_location": "L23"
     },
     {
-      "community": 597,
+      "community": 599,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationspreview_test_tsx",
       "label": "BulkOperationsPreview.test.tsx",
       "norm_label": "bulkoperationspreview.test.tsx",
       "source_file": "packages/athena-webapp/src/components/bulk-operations/BulkOperationsPreview.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 598,
-      "file_type": "code",
-      "id": "bulkoperationspreview_formatprice",
-      "label": "formatPrice()",
-      "norm_label": "formatprice()",
-      "source_file": "packages/athena-webapp/src/components/bulk-operations/BulkOperationsPreview.tsx",
-      "source_location": "L50"
-    },
-    {
-      "community": 598,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationspreview_tsx",
-      "label": "BulkOperationsPreview.tsx",
-      "norm_label": "bulkoperationspreview.tsx",
-      "source_file": "packages/athena-webapp/src/components/bulk-operations/BulkOperationsPreview.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 599,
-      "file_type": "code",
-      "id": "formatreviewreason_formatreviewreason",
-      "label": "formatReviewReason()",
-      "norm_label": "formatreviewreason()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/formatReviewReason.ts",
-      "source_location": "L3"
-    },
-    {
-      "community": 599,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_cash_controls_formatreviewreason_ts",
-      "label": "formatReviewReason.ts",
-      "norm_label": "formatreviewreason.ts",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/formatReviewReason.ts",
       "source_location": "L1"
     },
     {
@@ -95532,6 +95649,42 @@
     {
       "community": 600,
       "file_type": "code",
+      "id": "bulkoperationspreview_formatprice",
+      "label": "formatPrice()",
+      "norm_label": "formatprice()",
+      "source_file": "packages/athena-webapp/src/components/bulk-operations/BulkOperationsPreview.tsx",
+      "source_location": "L50"
+    },
+    {
+      "community": 600,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationspreview_tsx",
+      "label": "BulkOperationsPreview.tsx",
+      "norm_label": "bulkoperationspreview.tsx",
+      "source_file": "packages/athena-webapp/src/components/bulk-operations/BulkOperationsPreview.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 601,
+      "file_type": "code",
+      "id": "formatreviewreason_formatreviewreason",
+      "label": "formatReviewReason()",
+      "norm_label": "formatreviewreason()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/formatReviewReason.ts",
+      "source_location": "L3"
+    },
+    {
+      "community": 601,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_cash_controls_formatreviewreason_ts",
+      "label": "formatReviewReason.ts",
+      "norm_label": "formatreviewreason.ts",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/formatReviewReason.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 602,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_registersessioncolumns_tsx",
       "label": "registerSessionColumns.tsx",
       "norm_label": "registersessioncolumns.tsx",
@@ -95539,7 +95692,7 @@
       "source_location": "L1"
     },
     {
-      "community": 600,
+      "community": 602,
       "file_type": "code",
       "id": "registersessioncolumns_registersessionlink",
       "label": "RegisterSessionLink()",
@@ -95548,7 +95701,7 @@
       "source_location": "L33"
     },
     {
-      "community": 601,
+      "community": 603,
       "file_type": "code",
       "id": "checkoutsessionstable_checkoutsessionstable",
       "label": "CheckoutSessionsTable()",
@@ -95557,7 +95710,7 @@
       "source_location": "L13"
     },
     {
-      "community": 601,
+      "community": 603,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkoutsessionstable_tsx",
       "label": "CheckoutSessionsTable.tsx",
@@ -95566,7 +95719,7 @@
       "source_location": "L1"
     },
     {
-      "community": 602,
+      "community": 604,
       "file_type": "code",
       "id": "checkoutsesssionsview_navigation",
       "label": "Navigation()",
@@ -95575,7 +95728,7 @@
       "source_location": "L11"
     },
     {
-      "community": 602,
+      "community": 604,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkoutsesssionsview_tsx",
       "label": "CheckoutSesssionsView.tsx",
@@ -95584,7 +95737,7 @@
       "source_location": "L1"
     },
     {
-      "community": 603,
+      "community": 605,
       "file_type": "code",
       "id": "expensecompletion_expensecompletion",
       "label": "ExpenseCompletion()",
@@ -95593,7 +95746,7 @@
       "source_location": "L24"
     },
     {
-      "community": 603,
+      "community": 605,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_expense_expensecompletion_tsx",
       "label": "ExpenseCompletion.tsx",
@@ -95602,7 +95755,7 @@
       "source_location": "L1"
     },
     {
-      "community": 604,
+      "community": 606,
       "file_type": "code",
       "id": "expenseview_expenseview",
       "label": "ExpenseView()",
@@ -95611,7 +95764,7 @@
       "source_location": "L4"
     },
     {
-      "community": 604,
+      "community": 606,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_expense_expenseview_tsx",
       "label": "ExpenseView.tsx",
@@ -95620,7 +95773,7 @@
       "source_location": "L1"
     },
     {
-      "community": 605,
+      "community": 607,
       "file_type": "code",
       "id": "bestsellersdialog_handleaddbestseller",
       "label": "handleAddBestSeller()",
@@ -95629,7 +95782,7 @@
       "source_location": "L29"
     },
     {
-      "community": 605,
+      "community": 607,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_bestsellersdialog_tsx",
       "label": "BestSellersDialog.tsx",
@@ -95638,7 +95791,7 @@
       "source_location": "L1"
     },
     {
-      "community": 606,
+      "community": 608,
       "file_type": "code",
       "id": "featuredsectiondialog_handleaddfeatureditem",
       "label": "handleAddFeaturedItem()",
@@ -95647,7 +95800,7 @@
       "source_location": "L37"
     },
     {
-      "community": 606,
+      "community": 608,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_featuredsectiondialog_tsx",
       "label": "FeaturedSectionDialog.tsx",
@@ -95656,7 +95809,7 @@
       "source_location": "L1"
     },
     {
-      "community": 607,
+      "community": 609,
       "file_type": "code",
       "id": "home_navigation",
       "label": "Navigation()",
@@ -95665,49 +95818,13 @@
       "source_location": "L25"
     },
     {
-      "community": 607,
+      "community": 609,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_home_tsx",
       "label": "Home.tsx",
       "norm_label": "home.tsx",
       "source_file": "packages/athena-webapp/src/components/homepage/Home.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 608,
-      "file_type": "code",
-      "id": "landingpagereelversion_handleupdateconfig",
-      "label": "handleUpdateConfig()",
-      "norm_label": "handleupdateconfig()",
-      "source_file": "packages/athena-webapp/src/components/homepage/LandingPageReelVersion.tsx",
-      "source_location": "L83"
-    },
-    {
-      "community": 608,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_homepage_landingpagereelversion_tsx",
-      "label": "LandingPageReelVersion.tsx",
-      "norm_label": "landingpagereelversion.tsx",
-      "source_file": "packages/athena-webapp/src/components/homepage/LandingPageReelVersion.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 609,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_homepage_shoplookdialog_tsx",
-      "label": "ShopLookDialog.tsx",
-      "norm_label": "shoplookdialog.tsx",
-      "source_file": "packages/athena-webapp/src/components/homepage/ShopLookDialog.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 609,
-      "file_type": "code",
-      "id": "shoplookdialog_handleaddfeatureditem",
-      "label": "handleAddFeaturedItem()",
-      "norm_label": "handleaddfeatureditem()",
-      "source_file": "packages/athena-webapp/src/components/homepage/ShopLookDialog.tsx",
-      "source_location": "L35"
     },
     {
       "community": 61,
@@ -95829,6 +95946,42 @@
     {
       "community": 610,
       "file_type": "code",
+      "id": "landingpagereelversion_handleupdateconfig",
+      "label": "handleUpdateConfig()",
+      "norm_label": "handleupdateconfig()",
+      "source_file": "packages/athena-webapp/src/components/homepage/LandingPageReelVersion.tsx",
+      "source_location": "L83"
+    },
+    {
+      "community": 610,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_homepage_landingpagereelversion_tsx",
+      "label": "LandingPageReelVersion.tsx",
+      "norm_label": "landingpagereelversion.tsx",
+      "source_file": "packages/athena-webapp/src/components/homepage/LandingPageReelVersion.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 611,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_homepage_shoplookdialog_tsx",
+      "label": "ShopLookDialog.tsx",
+      "norm_label": "shoplookdialog.tsx",
+      "source_file": "packages/athena-webapp/src/components/homepage/ShopLookDialog.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 611,
+      "file_type": "code",
+      "id": "shoplookdialog_handleaddfeatureditem",
+      "label": "handleAddFeaturedItem()",
+      "norm_label": "handleaddfeatureditem()",
+      "source_file": "packages/athena-webapp/src/components/homepage/ShopLookDialog.tsx",
+      "source_location": "L35"
+    },
+    {
+      "community": 612,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_shoplookimageuploader_tsx",
       "label": "ShopLookImageUploader.tsx",
       "norm_label": "shoplookimageuploader.tsx",
@@ -95836,7 +95989,7 @@
       "source_location": "L1"
     },
     {
-      "community": 610,
+      "community": 612,
       "file_type": "code",
       "id": "shoplookimageuploader_shoplookimageuploader",
       "label": "ShopLookImageUploader()",
@@ -95845,7 +95998,7 @@
       "source_location": "L28"
     },
     {
-      "community": 611,
+      "community": 613,
       "file_type": "code",
       "id": "index_jointeam",
       "label": "JoinTeam()",
@@ -95854,7 +96007,7 @@
       "source_location": "L12"
     },
     {
-      "community": 611,
+      "community": 613,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_join_team_index_tsx",
       "label": "index.tsx",
@@ -95863,7 +96016,7 @@
       "source_location": "L1"
     },
     {
-      "community": 612,
+      "community": 614,
       "file_type": "code",
       "id": "athenalandingpage_reveal",
       "label": "Reveal()",
@@ -95872,7 +96025,7 @@
       "source_location": "L88"
     },
     {
-      "community": 612,
+      "community": 614,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_landing_athenalandingpage_tsx",
       "label": "AthenaLandingPage.tsx",
@@ -95881,7 +96034,7 @@
       "source_location": "L1"
     },
     {
-      "community": 613,
+      "community": 615,
       "file_type": "code",
       "id": "operationreviewitemcard_cn",
       "label": "cn()",
@@ -95890,7 +96043,7 @@
       "source_location": "L82"
     },
     {
-      "community": 613,
+      "community": 615,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_operationreviewitemcard_tsx",
       "label": "OperationReviewItemCard.tsx",
@@ -95899,7 +96052,7 @@
       "source_location": "L1"
     },
     {
-      "community": 614,
+      "community": 616,
       "file_type": "code",
       "id": "operationssummarymetric_buildparams",
       "label": "buildParams()",
@@ -95908,7 +96061,7 @@
       "source_location": "L15"
     },
     {
-      "community": 614,
+      "community": 616,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_operationssummarymetric_tsx",
       "label": "OperationsSummaryMetric.tsx",
@@ -95917,7 +96070,7 @@
       "source_location": "L1"
     },
     {
-      "community": 615,
+      "community": 617,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_test_tsx",
       "label": "StockAdjustmentWorkspace.test.tsx",
@@ -95926,7 +96079,7 @@
       "source_location": "L1"
     },
     {
-      "community": 615,
+      "community": 617,
       "file_type": "code",
       "id": "stockadjustmentworkspace_test_renderstockadjustmentworkspace",
       "label": "renderStockAdjustmentWorkspace()",
@@ -95935,7 +96088,7 @@
       "source_location": "L88"
     },
     {
-      "community": 616,
+      "community": 618,
       "file_type": "code",
       "id": "customerdetailsview_customerdetailsview",
       "label": "CustomerDetailsView()",
@@ -95944,7 +96097,7 @@
       "source_location": "L13"
     },
     {
-      "community": 616,
+      "community": 618,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_customerdetailsview_tsx",
       "label": "CustomerDetailsView.tsx",
@@ -95953,7 +96106,7 @@
       "source_location": "L1"
     },
     {
-      "community": 617,
+      "community": 619,
       "file_type": "code",
       "id": "emailstatusview_handlesendorderemail",
       "label": "handleSendOrderEmail()",
@@ -95962,48 +96115,12 @@
       "source_location": "L43"
     },
     {
-      "community": 617,
+      "community": 619,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_emailstatusview_tsx",
       "label": "EmailStatusView.tsx",
       "norm_label": "emailstatusview.tsx",
       "source_file": "packages/athena-webapp/src/components/orders/EmailStatusView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 618,
-      "file_type": "code",
-      "id": "ordermetricspanel_handletimerangechange",
-      "label": "handleTimeRangeChange()",
-      "norm_label": "handletimerangechange()",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderMetricsPanel.tsx",
-      "source_location": "L33"
-    },
-    {
-      "community": 618,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_ordermetricspanel_tsx",
-      "label": "OrderMetricsPanel.tsx",
-      "norm_label": "ordermetricspanel.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderMetricsPanel.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 619,
-      "file_type": "code",
-      "id": "ordersview_gettimefilter",
-      "label": "getTimeFilter()",
-      "norm_label": "gettimefilter()",
-      "source_file": "packages/athena-webapp/src/components/orders/OrdersView.tsx",
-      "source_location": "L35"
-    },
-    {
-      "community": 619,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_ordersview_tsx",
-      "label": "OrdersView.tsx",
-      "norm_label": "ordersview.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/OrdersView.tsx",
       "source_location": "L1"
     },
     {
@@ -96126,6 +96243,42 @@
     {
       "community": 620,
       "file_type": "code",
+      "id": "ordermetricspanel_handletimerangechange",
+      "label": "handleTimeRangeChange()",
+      "norm_label": "handletimerangechange()",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderMetricsPanel.tsx",
+      "source_location": "L33"
+    },
+    {
+      "community": 620,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_ordermetricspanel_tsx",
+      "label": "OrderMetricsPanel.tsx",
+      "norm_label": "ordermetricspanel.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderMetricsPanel.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 621,
+      "file_type": "code",
+      "id": "ordersview_gettimefilter",
+      "label": "getTimeFilter()",
+      "norm_label": "gettimefilter()",
+      "source_file": "packages/athena-webapp/src/components/orders/OrdersView.tsx",
+      "source_location": "L35"
+    },
+    {
+      "community": 621,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_ordersview_tsx",
+      "label": "OrdersView.tsx",
+      "norm_label": "ordersview.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/OrdersView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 622,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_refundsview_tsx",
       "label": "RefundsView.tsx",
       "norm_label": "refundsview.tsx",
@@ -96133,7 +96286,7 @@
       "source_location": "L1"
     },
     {
-      "community": 620,
+      "community": 622,
       "file_type": "code",
       "id": "refundsview_handlerefundorder",
       "label": "handleRefundOrder()",
@@ -96142,7 +96295,7 @@
       "source_location": "L83"
     },
     {
-      "community": 621,
+      "community": 623,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_hooks_usegetactiveonlineorder_ts",
       "label": "useGetActiveOnlineOrder.ts",
@@ -96151,7 +96304,7 @@
       "source_location": "L1"
     },
     {
-      "community": 621,
+      "community": 623,
       "file_type": "code",
       "id": "usegetactiveonlineorder_usegetactiveonlineorder",
       "label": "useGetActiveOnlineOrder()",
@@ -96160,7 +96313,7 @@
       "source_location": "L6"
     },
     {
-      "community": 622,
+      "community": 624,
       "file_type": "code",
       "id": "data_table_toolbar_handleclearfilters",
       "label": "handleClearFilters()",
@@ -96169,7 +96322,7 @@
       "source_location": "L34"
     },
     {
-      "community": 622,
+      "community": 624,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -96178,7 +96331,7 @@
       "source_location": "L1"
     },
     {
-      "community": 623,
+      "community": 625,
       "file_type": "code",
       "id": "ordercolumns_if",
       "label": "if()",
@@ -96187,7 +96340,7 @@
       "source_location": "L89"
     },
     {
-      "community": 623,
+      "community": 625,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_ordercolumns_tsx",
       "label": "orderColumns.tsx",
@@ -96196,7 +96349,7 @@
       "source_location": "L1"
     },
     {
-      "community": 624,
+      "community": 626,
       "file_type": "code",
       "id": "organization_switcher_organizationswitcher",
       "label": "OrganizationSwitcher()",
@@ -96205,7 +96358,7 @@
       "source_location": "L37"
     },
     {
-      "community": 624,
+      "community": 626,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_switcher_tsx",
       "label": "organization-switcher.tsx",
@@ -96214,7 +96367,7 @@
       "source_location": "L1"
     },
     {
-      "community": 625,
+      "community": 627,
       "file_type": "code",
       "id": "cartitems_cn",
       "label": "cn()",
@@ -96223,7 +96376,7 @@
       "source_location": "L215"
     },
     {
-      "community": 625,
+      "community": 627,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_cartitems_tsx",
       "label": "CartItems.tsx",
@@ -96232,7 +96385,7 @@
       "source_location": "L1"
     },
     {
-      "community": 626,
+      "community": 628,
       "file_type": "code",
       "id": "debugproducts_debugproducts",
       "label": "DebugProducts()",
@@ -96241,7 +96394,7 @@
       "source_location": "L5"
     },
     {
-      "community": 626,
+      "community": 628,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_debugproducts_tsx",
       "label": "DebugProducts.tsx",
@@ -96250,7 +96403,7 @@
       "source_location": "L1"
     },
     {
-      "community": 627,
+      "community": 629,
       "file_type": "code",
       "id": "noresultsmessage_noresultsmessage",
       "label": "NoResultsMessage()",
@@ -96259,49 +96412,13 @@
       "source_location": "L7"
     },
     {
-      "community": 627,
+      "community": 629,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_noresultsmessage_tsx",
       "label": "NoResultsMessage.tsx",
       "norm_label": "noresultsmessage.tsx",
       "source_file": "packages/athena-webapp/src/components/pos/NoResultsMessage.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 628,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_pininput_tsx",
-      "label": "PinInput.tsx",
-      "norm_label": "pininput.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/PinInput.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 628,
-      "file_type": "code",
-      "id": "pininput_pininput",
-      "label": "PinInput()",
-      "norm_label": "pininput()",
-      "source_file": "packages/athena-webapp/src/components/pos/PinInput.tsx",
-      "source_location": "L13"
-    },
-    {
-      "community": 629,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_printinstructions_tsx",
-      "label": "PrintInstructions.tsx",
-      "norm_label": "printinstructions.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/PrintInstructions.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 629,
-      "file_type": "code",
-      "id": "printinstructions_printinstructions",
-      "label": "PrintInstructions()",
-      "norm_label": "printinstructions()",
-      "source_file": "packages/athena-webapp/src/components/pos/PrintInstructions.tsx",
-      "source_location": "L3"
     },
     {
       "community": 63,
@@ -96423,6 +96540,42 @@
     {
       "community": 630,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_pininput_tsx",
+      "label": "PinInput.tsx",
+      "norm_label": "pininput.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/PinInput.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 630,
+      "file_type": "code",
+      "id": "pininput_pininput",
+      "label": "PinInput()",
+      "norm_label": "pininput()",
+      "source_file": "packages/athena-webapp/src/components/pos/PinInput.tsx",
+      "source_location": "L13"
+    },
+    {
+      "community": 631,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_printinstructions_tsx",
+      "label": "PrintInstructions.tsx",
+      "norm_label": "printinstructions.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/PrintInstructions.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 631,
+      "file_type": "code",
+      "id": "printinstructions_printinstructions",
+      "label": "PrintInstructions()",
+      "norm_label": "printinstructions()",
+      "source_file": "packages/athena-webapp/src/components/pos/PrintInstructions.tsx",
+      "source_location": "L3"
+    },
+    {
+      "community": 632,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_productcard_tsx",
       "label": "ProductCard.tsx",
       "norm_label": "productcard.tsx",
@@ -96430,7 +96583,7 @@
       "source_location": "L1"
     },
     {
-      "community": 630,
+      "community": 632,
       "file_type": "code",
       "id": "productcard_productcard",
       "label": "ProductCard()",
@@ -96439,7 +96592,7 @@
       "source_location": "L14"
     },
     {
-      "community": 631,
+      "community": 633,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_searchresultssection_test_tsx",
       "label": "SearchResultsSection.test.tsx",
@@ -96448,7 +96601,7 @@
       "source_location": "L1"
     },
     {
-      "community": 631,
+      "community": 633,
       "file_type": "code",
       "id": "searchresultssection_test_buildproduct",
       "label": "buildProduct()",
@@ -96457,7 +96610,7 @@
       "source_location": "L12"
     },
     {
-      "community": 632,
+      "community": 634,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_sessiondemo_tsx",
       "label": "SessionDemo.tsx",
@@ -96466,7 +96619,7 @@
       "source_location": "L1"
     },
     {
-      "community": 632,
+      "community": 634,
       "file_type": "code",
       "id": "sessiondemo_sessiondemo",
       "label": "SessionDemo()",
@@ -96475,7 +96628,7 @@
       "source_location": "L15"
     },
     {
-      "community": 633,
+      "community": 635,
       "file_type": "code",
       "id": "expensereportsview_istoday",
       "label": "isToday()",
@@ -96484,7 +96637,7 @@
       "source_location": "L21"
     },
     {
-      "community": 633,
+      "community": 635,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportsview_tsx",
       "label": "ExpenseReportsView.tsx",
@@ -96493,7 +96646,7 @@
       "source_location": "L1"
     },
     {
-      "community": 634,
+      "community": 636,
       "file_type": "code",
       "id": "expensereportrows_toexpensereportrows",
       "label": "toExpenseReportRows()",
@@ -96502,7 +96655,7 @@
       "source_location": "L15"
     },
     {
-      "community": 634,
+      "community": 636,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportrows_ts",
       "label": "expenseReportRows.ts",
@@ -96511,7 +96664,7 @@
       "source_location": "L1"
     },
     {
-      "community": 635,
+      "community": 637,
       "file_type": "code",
       "id": "expensecompletionpanel_expensecompletionpanel",
       "label": "ExpenseCompletionPanel()",
@@ -96520,7 +96673,7 @@
       "source_location": "L9"
     },
     {
-      "community": 635,
+      "community": 637,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_expensecompletionpanel_tsx",
       "label": "ExpenseCompletionPanel.tsx",
@@ -96529,7 +96682,7 @@
       "source_location": "L1"
     },
     {
-      "community": 636,
+      "community": 638,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_registercustomerattribution_test_tsx",
       "label": "RegisterCustomerAttribution.test.tsx",
@@ -96538,7 +96691,7 @@
       "source_location": "L1"
     },
     {
-      "community": 636,
+      "community": 638,
       "file_type": "code",
       "id": "registercustomerattribution_test_makecustomer",
       "label": "makeCustomer()",
@@ -96547,7 +96700,7 @@
       "source_location": "L28"
     },
     {
-      "community": 637,
+      "community": 639,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_registercustomerpanel_tsx",
       "label": "RegisterCustomerPanel.tsx",
@@ -96556,48 +96709,12 @@
       "source_location": "L1"
     },
     {
-      "community": 637,
+      "community": 639,
       "file_type": "code",
       "id": "registercustomerpanel_registercustomerpanel",
       "label": "RegisterCustomerPanel()",
       "norm_label": "registercustomerpanel()",
       "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerPanel.tsx",
-      "source_location": "L9"
-    },
-    {
-      "community": 638,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_register_registerdrawergate_test_tsx",
-      "label": "RegisterDrawerGate.test.tsx",
-      "norm_label": "registerdrawergate.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 638,
-      "file_type": "code",
-      "id": "registerdrawergate_test_rendergate",
-      "label": "renderGate()",
-      "norm_label": "rendergate()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.test.tsx",
-      "source_location": "L23"
-    },
-    {
-      "community": 639,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_register_registersessionpanel_tsx",
-      "label": "RegisterSessionPanel.tsx",
-      "norm_label": "registersessionpanel.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterSessionPanel.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 639,
-      "file_type": "code",
-      "id": "registersessionpanel_registersessionpanel",
-      "label": "RegisterSessionPanel()",
-      "norm_label": "registersessionpanel()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterSessionPanel.tsx",
       "source_location": "L9"
     },
     {
@@ -96720,6 +96837,42 @@
     {
       "community": 640,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_register_registerdrawergate_test_tsx",
+      "label": "RegisterDrawerGate.test.tsx",
+      "norm_label": "registerdrawergate.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 640,
+      "file_type": "code",
+      "id": "registerdrawergate_test_rendergate",
+      "label": "renderGate()",
+      "norm_label": "rendergate()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.test.tsx",
+      "source_location": "L23"
+    },
+    {
+      "community": 641,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_register_registersessionpanel_tsx",
+      "label": "RegisterSessionPanel.tsx",
+      "norm_label": "registersessionpanel.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterSessionPanel.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 641,
+      "file_type": "code",
+      "id": "registersessionpanel_registersessionpanel",
+      "label": "RegisterSessionPanel()",
+      "norm_label": "registersessionpanel()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterSessionPanel.tsx",
+      "source_location": "L9"
+    },
+    {
+      "community": 642,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_transactions_transactioncolumns_test_tsx",
       "label": "transactionColumns.test.tsx",
       "norm_label": "transactioncolumns.test.tsx",
@@ -96727,7 +96880,7 @@
       "source_location": "L1"
     },
     {
-      "community": 640,
+      "community": 642,
       "file_type": "code",
       "id": "transactioncolumns_test_rendertransactioncell",
       "label": "renderTransactionCell()",
@@ -96736,7 +96889,7 @@
       "source_location": "L34"
     },
     {
-      "community": 641,
+      "community": 643,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_transactions_transactioncolumns_tsx",
       "label": "transactionColumns.tsx",
@@ -96745,7 +96898,7 @@
       "source_location": "L1"
     },
     {
-      "community": 641,
+      "community": 643,
       "file_type": "code",
       "id": "transactioncolumns_getpaymentmethodicon",
       "label": "getPaymentMethodIcon()",
@@ -96754,7 +96907,7 @@
       "source_location": "L27"
     },
     {
-      "community": 642,
+      "community": 644,
       "file_type": "code",
       "id": "barcodeview_barcodeview",
       "label": "BarcodeView()",
@@ -96763,7 +96916,7 @@
       "source_location": "L14"
     },
     {
-      "community": 642,
+      "community": 644,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_barcodeview_tsx",
       "label": "BarcodeView.tsx",
@@ -96772,7 +96925,7 @@
       "source_location": "L1"
     },
     {
-      "community": 643,
+      "community": 645,
       "file_type": "code",
       "id": "categorizationview_categorizationview",
       "label": "CategorizationView()",
@@ -96781,7 +96934,7 @@
       "source_location": "L6"
     },
     {
-      "community": 643,
+      "community": 645,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_categorizationview_tsx",
       "label": "CategorizationView.tsx",
@@ -96790,7 +96943,7 @@
       "source_location": "L1"
     },
     {
-      "community": 644,
+      "community": 646,
       "file_type": "code",
       "id": "imagesview_handlekeydown",
       "label": "handleKeyDown()",
@@ -96799,7 +96952,7 @@
       "source_location": "L37"
     },
     {
-      "community": 644,
+      "community": 646,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_imagesview_tsx",
       "label": "ImagesView.tsx",
@@ -96808,7 +96961,7 @@
       "source_location": "L1"
     },
     {
-      "community": 645,
+      "community": 647,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_productstatus_tsx",
       "label": "ProductStatus.tsx",
@@ -96817,7 +96970,7 @@
       "source_location": "L1"
     },
     {
-      "community": 645,
+      "community": 647,
       "file_type": "code",
       "id": "productstatus_productstatus",
       "label": "ProductStatus()",
@@ -96826,7 +96979,7 @@
       "source_location": "L11"
     },
     {
-      "community": 646,
+      "community": 648,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_skuselector_tsx",
       "label": "SKUSelector.tsx",
@@ -96835,7 +96988,7 @@
       "source_location": "L1"
     },
     {
-      "community": 646,
+      "community": 648,
       "file_type": "code",
       "id": "skuselector_skuselector",
       "label": "SKUSelector()",
@@ -96844,7 +96997,7 @@
       "source_location": "L10"
     },
     {
-      "community": 647,
+      "community": 649,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_actions_tsx",
       "label": "product-actions.tsx",
@@ -96853,49 +97006,13 @@
       "source_location": "L1"
     },
     {
-      "community": 647,
+      "community": 649,
       "file_type": "code",
       "id": "product_actions_usearchiveproduct",
       "label": "useArchiveProduct()",
       "norm_label": "usearchiveproduct()",
       "source_file": "packages/athena-webapp/src/components/product-actions.tsx",
       "source_location": "L6"
-    },
-    {
-      "community": 648,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_productsview_tsx",
-      "label": "ProductsView.tsx",
-      "norm_label": "productsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/products/ProductsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 648,
-      "file_type": "code",
-      "id": "productsview_productsview",
-      "label": "ProductsView()",
-      "norm_label": "productsview()",
-      "source_file": "packages/athena-webapp/src/components/products/ProductsView.tsx",
-      "source_location": "L5"
-    },
-    {
-      "community": 649,
-      "file_type": "code",
-      "id": "add_product_command_addproductcommand",
-      "label": "AddProductCommand()",
-      "norm_label": "addproductcommand()",
-      "source_file": "packages/athena-webapp/src/components/products/products-table/components/add-product-command.tsx",
-      "source_location": "L17"
-    },
-    {
-      "community": 649,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_products_table_components_add_product_command_tsx",
-      "label": "add-product-command.tsx",
-      "norm_label": "add-product-command.tsx",
-      "source_file": "packages/athena-webapp/src/components/products/products-table/components/add-product-command.tsx",
-      "source_location": "L1"
     },
     {
       "community": 65,
@@ -97017,6 +97134,42 @@
     {
       "community": 650,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_products_productsview_tsx",
+      "label": "ProductsView.tsx",
+      "norm_label": "productsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/products/ProductsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 650,
+      "file_type": "code",
+      "id": "productsview_productsview",
+      "label": "ProductsView()",
+      "norm_label": "productsview()",
+      "source_file": "packages/athena-webapp/src/components/products/ProductsView.tsx",
+      "source_location": "L5"
+    },
+    {
+      "community": 651,
+      "file_type": "code",
+      "id": "add_product_command_addproductcommand",
+      "label": "AddProductCommand()",
+      "norm_label": "addproductcommand()",
+      "source_file": "packages/athena-webapp/src/components/products/products-table/components/add-product-command.tsx",
+      "source_location": "L17"
+    },
+    {
+      "community": 651,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_products_products_table_components_add_product_command_tsx",
+      "label": "add-product-command.tsx",
+      "norm_label": "add-product-command.tsx",
+      "source_file": "packages/athena-webapp/src/components/products/products-table/components/add-product-command.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 652,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_products_tsx",
       "label": "Products.tsx",
       "norm_label": "products.tsx",
@@ -97024,7 +97177,7 @@
       "source_location": "L1"
     },
     {
-      "community": 650,
+      "community": 652,
       "file_type": "code",
       "id": "products_products",
       "label": "Products()",
@@ -97033,7 +97186,7 @@
       "source_location": "L4"
     },
     {
-      "community": 651,
+      "community": 653,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodeform_tsx",
       "label": "PromoCodeForm.tsx",
@@ -97042,7 +97195,7 @@
       "source_location": "L1"
     },
     {
-      "community": 651,
+      "community": 653,
       "file_type": "code",
       "id": "promocodeform_togglediscounttype",
       "label": "toggleDiscountType()",
@@ -97051,7 +97204,7 @@
       "source_location": "L82"
     },
     {
-      "community": 652,
+      "community": 654,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodeheader_tsx",
       "label": "PromoCodeHeader.tsx",
@@ -97060,7 +97213,7 @@
       "source_location": "L1"
     },
     {
-      "community": 652,
+      "community": 654,
       "file_type": "code",
       "id": "promocodeheader_handledeletepromocode",
       "label": "handleDeletePromoCode()",
@@ -97069,7 +97222,7 @@
       "source_location": "L23"
     },
     {
-      "community": 653,
+      "community": 655,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodepreview_tsx",
       "label": "PromoCodePreview.tsx",
@@ -97078,7 +97231,7 @@
       "source_location": "L1"
     },
     {
-      "community": 653,
+      "community": 655,
       "file_type": "code",
       "id": "promocodepreview_discount",
       "label": "Discount()",
@@ -97087,7 +97240,7 @@
       "source_location": "L37"
     },
     {
-      "community": 654,
+      "community": 656,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodesview_test_tsx",
       "label": "PromoCodesView.test.tsx",
@@ -97096,7 +97249,7 @@
       "source_location": "L1"
     },
     {
-      "community": 654,
+      "community": 656,
       "file_type": "code",
       "id": "promocodesview_test_readsource",
       "label": "readSource()",
@@ -97105,7 +97258,7 @@
       "source_location": "L5"
     },
     {
-      "community": 655,
+      "community": 657,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodesview_tsx",
       "label": "PromoCodesView.tsx",
@@ -97114,7 +97267,7 @@
       "source_location": "L1"
     },
     {
-      "community": 655,
+      "community": 657,
       "file_type": "code",
       "id": "promocodesview_promocodesview",
       "label": "PromoCodesView()",
@@ -97123,7 +97276,7 @@
       "source_location": "L10"
     },
     {
-      "community": 656,
+      "community": 658,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectablecategories_tsx",
       "label": "SelectableCategories.tsx",
@@ -97132,7 +97285,7 @@
       "source_location": "L1"
     },
     {
-      "community": 656,
+      "community": 658,
       "file_type": "code",
       "id": "selectablecategories_toggle",
       "label": "toggle()",
@@ -97141,7 +97294,7 @@
       "source_location": "L23"
     },
     {
-      "community": 657,
+      "community": 659,
       "file_type": "code",
       "id": "discounttypetogglegroup_discounttypetogglegroup",
       "label": "DiscountTypeToggleGroup()",
@@ -97150,48 +97303,12 @@
       "source_location": "L5"
     },
     {
-      "community": 657,
+      "community": 659,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_add_promo_code_discounttypetogglegroup_tsx",
       "label": "DiscountTypeToggleGroup.tsx",
       "norm_label": "discounttypetogglegroup.tsx",
       "source_file": "packages/athena-webapp/src/components/promo-codes/add-promo-code/DiscountTypeToggleGroup.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 658,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_add_promo_code_promocodespantogglegroup_tsx",
-      "label": "PromoCodeSpanToggleGroup.tsx",
-      "norm_label": "promocodespantogglegroup.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/add-promo-code/PromoCodeSpanToggleGroup.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 658,
-      "file_type": "code",
-      "id": "promocodespantogglegroup_promocodespantogglegroup",
-      "label": "PromoCodeSpanToggleGroup()",
-      "norm_label": "promocodespantogglegroup()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/add-promo-code/PromoCodeSpanToggleGroup.tsx",
-      "source_location": "L4"
-    },
-    {
-      "community": 659,
-      "file_type": "code",
-      "id": "capturedemails_capturedemails",
-      "label": "CapturedEmails()",
-      "norm_label": "capturedemails()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/captured/CapturedEmails.tsx",
-      "source_location": "L13"
-    },
-    {
-      "community": 659,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_captured_capturedemails_tsx",
-      "label": "CapturedEmails.tsx",
-      "norm_label": "capturedemails.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/captured/CapturedEmails.tsx",
       "source_location": "L1"
     },
     {
@@ -97314,6 +97431,42 @@
     {
       "community": 660,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_add_promo_code_promocodespantogglegroup_tsx",
+      "label": "PromoCodeSpanToggleGroup.tsx",
+      "norm_label": "promocodespantogglegroup.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/add-promo-code/PromoCodeSpanToggleGroup.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 660,
+      "file_type": "code",
+      "id": "promocodespantogglegroup_promocodespantogglegroup",
+      "label": "PromoCodeSpanToggleGroup()",
+      "norm_label": "promocodespantogglegroup()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/add-promo-code/PromoCodeSpanToggleGroup.tsx",
+      "source_location": "L4"
+    },
+    {
+      "community": 661,
+      "file_type": "code",
+      "id": "capturedemails_capturedemails",
+      "label": "CapturedEmails()",
+      "norm_label": "capturedemails()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/captured/CapturedEmails.tsx",
+      "source_location": "L13"
+    },
+    {
+      "community": 661,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_captured_capturedemails_tsx",
+      "label": "CapturedEmails.tsx",
+      "norm_label": "capturedemails.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/captured/CapturedEmails.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 662,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_modals_promo_code_modal_tsx",
       "label": "promo-code-modal.tsx",
       "norm_label": "promo-code-modal.tsx",
@@ -97321,7 +97474,7 @@
       "source_location": "L1"
     },
     {
-      "community": 660,
+      "community": 662,
       "file_type": "code",
       "id": "promo_code_modal_promocodemodal",
       "label": "PromoCodeModal()",
@@ -97330,7 +97483,7 @@
       "source_location": "L29"
     },
     {
-      "community": 661,
+      "community": 663,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reviews_reviewactions_tsx",
       "label": "ReviewActions.tsx",
@@ -97339,7 +97492,7 @@
       "source_location": "L1"
     },
     {
-      "community": 661,
+      "community": 663,
       "file_type": "code",
       "id": "reviewactions_reviewactions",
       "label": "ReviewActions()",
@@ -97348,7 +97501,7 @@
       "source_location": "L20"
     },
     {
-      "community": 662,
+      "community": 664,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_servicecasesview_test_tsx",
       "label": "ServiceCasesView.test.tsx",
@@ -97357,7 +97510,7 @@
       "source_location": "L1"
     },
     {
-      "community": 662,
+      "community": 664,
       "file_type": "code",
       "id": "servicecasesview_test_chooseselectoption",
       "label": "chooseSelectOption()",
@@ -97366,7 +97519,7 @@
       "source_location": "L63"
     },
     {
-      "community": 663,
+      "community": 665,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_servicecatalogview_test_tsx",
       "label": "ServiceCatalogView.test.tsx",
@@ -97375,7 +97528,7 @@
       "source_location": "L1"
     },
     {
-      "community": 663,
+      "community": 665,
       "file_type": "code",
       "id": "servicecatalogview_test_chooseselectoption",
       "label": "chooseSelectOption()",
@@ -97384,7 +97537,7 @@
       "source_location": "L60"
     },
     {
-      "community": 664,
+      "community": 666,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_serviceintakeform_tsx",
       "label": "ServiceIntakeForm.tsx",
@@ -97393,7 +97546,7 @@
       "source_location": "L1"
     },
     {
-      "community": 664,
+      "community": 666,
       "file_type": "code",
       "id": "serviceintakeform_serviceintakeform",
       "label": "ServiceIntakeForm()",
@@ -97402,7 +97555,7 @@
       "source_location": "L59"
     },
     {
-      "community": 665,
+      "community": 667,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_serviceintakeview_auth_test_tsx",
       "label": "ServiceIntakeView.auth.test.tsx",
@@ -97411,7 +97564,7 @@
       "source_location": "L1"
     },
     {
-      "community": 665,
+      "community": 667,
       "file_type": "code",
       "id": "serviceintakeview_auth_test_chooseselectoption",
       "label": "chooseSelectOption()",
@@ -97420,7 +97573,7 @@
       "source_location": "L45"
     },
     {
-      "community": 666,
+      "community": 668,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_serviceintakeview_test_tsx",
       "label": "ServiceIntakeView.test.tsx",
@@ -97429,7 +97582,7 @@
       "source_location": "L1"
     },
     {
-      "community": 666,
+      "community": 668,
       "file_type": "code",
       "id": "serviceintakeview_test_chooseselectoption",
       "label": "chooseSelectOption()",
@@ -97438,7 +97591,7 @@
       "source_location": "L47"
     },
     {
-      "community": 667,
+      "community": 669,
       "file_type": "code",
       "id": "empty_state_onclick",
       "label": "onClick()",
@@ -97447,48 +97600,12 @@
       "source_location": "L29"
     },
     {
-      "community": 667,
+      "community": 669,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_empty_empty_state_tsx",
       "label": "empty-state.tsx",
       "norm_label": "empty-state.tsx",
       "source_file": "packages/athena-webapp/src/components/states/empty/empty-state.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 668,
-      "file_type": "code",
-      "id": "nopermission_nopermission",
-      "label": "NoPermission()",
-      "norm_label": "nopermission()",
-      "source_file": "packages/athena-webapp/src/components/states/no-permission/NoPermission.tsx",
-      "source_location": "L3"
-    },
-    {
-      "community": 668,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_states_no_permission_nopermission_tsx",
-      "label": "NoPermission.tsx",
-      "norm_label": "nopermission.tsx",
-      "source_file": "packages/athena-webapp/src/components/states/no-permission/NoPermission.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 669,
-      "file_type": "code",
-      "id": "nopermissionview_nopermissionview",
-      "label": "NoPermissionView()",
-      "norm_label": "nopermissionview()",
-      "source_file": "packages/athena-webapp/src/components/states/no-permission/NoPermissionView.tsx",
-      "source_location": "L4"
-    },
-    {
-      "community": 669,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_states_no_permission_nopermissionview_tsx",
-      "label": "NoPermissionView.tsx",
-      "norm_label": "nopermissionview.tsx",
-      "source_file": "packages/athena-webapp/src/components/states/no-permission/NoPermissionView.tsx",
       "source_location": "L1"
     },
     {
@@ -97602,6 +97719,42 @@
     {
       "community": 670,
       "file_type": "code",
+      "id": "nopermission_nopermission",
+      "label": "NoPermission()",
+      "norm_label": "nopermission()",
+      "source_file": "packages/athena-webapp/src/components/states/no-permission/NoPermission.tsx",
+      "source_location": "L3"
+    },
+    {
+      "community": 670,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_states_no_permission_nopermission_tsx",
+      "label": "NoPermission.tsx",
+      "norm_label": "nopermission.tsx",
+      "source_file": "packages/athena-webapp/src/components/states/no-permission/NoPermission.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 671,
+      "file_type": "code",
+      "id": "nopermissionview_nopermissionview",
+      "label": "NoPermissionView()",
+      "norm_label": "nopermissionview()",
+      "source_file": "packages/athena-webapp/src/components/states/no-permission/NoPermissionView.tsx",
+      "source_location": "L4"
+    },
+    {
+      "community": 671,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_states_no_permission_nopermissionview_tsx",
+      "label": "NoPermissionView.tsx",
+      "norm_label": "nopermissionview.tsx",
+      "source_file": "packages/athena-webapp/src/components/states/no-permission/NoPermissionView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 672,
+      "file_type": "code",
       "id": "notfoundview_notfoundview",
       "label": "NotFoundView()",
       "norm_label": "notfoundview()",
@@ -97609,7 +97762,7 @@
       "source_location": "L4"
     },
     {
-      "community": 670,
+      "community": 672,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_not_found_notfoundview_tsx",
       "label": "NotFoundView.tsx",
@@ -97618,7 +97771,7 @@
       "source_location": "L1"
     },
     {
-      "community": 671,
+      "community": 673,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_signed_out_protectedadminsigninview_tsx",
       "label": "ProtectedAdminSignInView.tsx",
@@ -97627,7 +97780,7 @@
       "source_location": "L1"
     },
     {
-      "community": 671,
+      "community": 673,
       "file_type": "code",
       "id": "protectedadminsigninview_protectedadminsigninview",
       "label": "ProtectedAdminSignInView()",
@@ -97636,7 +97789,7 @@
       "source_location": "L9"
     },
     {
-      "community": 672,
+      "community": 674,
       "file_type": "code",
       "id": "contactview_contactview",
       "label": "ContactView()",
@@ -97645,7 +97798,7 @@
       "source_location": "L9"
     },
     {
-      "community": 672,
+      "community": 674,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_contactview_tsx",
       "label": "ContactView.tsx",
@@ -97654,7 +97807,7 @@
       "source_location": "L1"
     },
     {
-      "community": 673,
+      "community": 675,
       "file_type": "code",
       "id": "header_header",
       "label": "Header()",
@@ -97663,7 +97816,7 @@
       "source_location": "L1"
     },
     {
-      "community": 673,
+      "community": 675,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_header_tsx",
       "label": "Header.tsx",
@@ -97672,7 +97825,7 @@
       "source_location": "L1"
     },
     {
-      "community": 674,
+      "community": 676,
       "file_type": "code",
       "id": "maintenanceview_maintenanceview",
       "label": "MaintenanceView()",
@@ -97681,7 +97834,7 @@
       "source_location": "L11"
     },
     {
-      "community": 674,
+      "community": 676,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_maintenanceview_tsx",
       "label": "MaintenanceView.tsx",
@@ -97690,7 +97843,7 @@
       "source_location": "L1"
     },
     {
-      "community": 675,
+      "community": 677,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_taxview_tsx",
       "label": "TaxView.tsx",
@@ -97699,7 +97852,7 @@
       "source_location": "L1"
     },
     {
-      "community": 675,
+      "community": 677,
       "file_type": "code",
       "id": "taxview_handleupdatetaxsettings",
       "label": "handleUpdateTaxSettings()",
@@ -97708,7 +97861,7 @@
       "source_location": "L25"
     },
     {
-      "community": 676,
+      "community": 678,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_hooks_usestoreconfigupdate_ts",
       "label": "useStoreConfigUpdate.ts",
@@ -97717,7 +97870,7 @@
       "source_location": "L1"
     },
     {
-      "community": 676,
+      "community": 678,
       "file_type": "code",
       "id": "usestoreconfigupdate_usestoreconfigupdate",
       "label": "useStoreConfigUpdate()",
@@ -97726,7 +97879,7 @@
       "source_location": "L21"
     },
     {
-      "community": 677,
+      "community": 679,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_switcher_tsx",
       "label": "store-switcher.tsx",
@@ -97735,49 +97888,13 @@
       "source_location": "L1"
     },
     {
-      "community": 677,
+      "community": 679,
       "file_type": "code",
       "id": "store_switcher_onstoreselect",
       "label": "onStoreSelect()",
       "norm_label": "onstoreselect()",
       "source_file": "packages/athena-webapp/src/components/store-switcher.tsx",
       "source_location": "L63"
-    },
-    {
-      "community": 678,
-      "file_type": "code",
-      "id": "chart_usechart",
-      "label": "useChart()",
-      "norm_label": "usechart()",
-      "source_file": "packages/athena-webapp/src/components/ui/chart.tsx",
-      "source_location": "L25"
-    },
-    {
-      "community": 678,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_chart_tsx",
-      "label": "chart.tsx",
-      "norm_label": "chart.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/chart.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 679,
-      "file_type": "code",
-      "id": "copy_button_handlecopy",
-      "label": "handleCopy()",
-      "norm_label": "handlecopy()",
-      "source_file": "packages/athena-webapp/src/components/ui/copy-button.tsx",
-      "source_location": "L15"
-    },
-    {
-      "community": 679,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_copy_button_tsx",
-      "label": "copy-button.tsx",
-      "norm_label": "copy-button.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/copy-button.tsx",
-      "source_location": "L1"
     },
     {
       "community": 68,
@@ -97890,6 +98007,42 @@
     {
       "community": 680,
       "file_type": "code",
+      "id": "chart_usechart",
+      "label": "useChart()",
+      "norm_label": "usechart()",
+      "source_file": "packages/athena-webapp/src/components/ui/chart.tsx",
+      "source_location": "L25"
+    },
+    {
+      "community": 680,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_chart_tsx",
+      "label": "chart.tsx",
+      "norm_label": "chart.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/chart.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 681,
+      "file_type": "code",
+      "id": "copy_button_handlecopy",
+      "label": "handleCopy()",
+      "norm_label": "handlecopy()",
+      "source_file": "packages/athena-webapp/src/components/ui/copy-button.tsx",
+      "source_location": "L15"
+    },
+    {
+      "community": 681,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_copy_button_tsx",
+      "label": "copy-button.tsx",
+      "norm_label": "copy-button.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/copy-button.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 682,
+      "file_type": "code",
       "id": "copy_wrapper_handlecopy",
       "label": "handleCopy()",
       "norm_label": "handlecopy()",
@@ -97897,7 +98050,7 @@
       "source_location": "L21"
     },
     {
-      "community": 680,
+      "community": 682,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_copy_wrapper_tsx",
       "label": "copy-wrapper.tsx",
@@ -97906,7 +98059,7 @@
       "source_location": "L1"
     },
     {
-      "community": 681,
+      "community": 683,
       "file_type": "code",
       "id": "label_label",
       "label": "Label()",
@@ -97915,7 +98068,7 @@
       "source_location": "L6"
     },
     {
-      "community": 681,
+      "community": 683,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_label_tsx",
       "label": "label.tsx",
@@ -97924,7 +98077,7 @@
       "source_location": "L1"
     },
     {
-      "community": 682,
+      "community": 684,
       "file_type": "code",
       "id": "custom_modal_custommodal",
       "label": "CustomModal()",
@@ -97933,7 +98086,7 @@
       "source_location": "L25"
     },
     {
-      "community": 682,
+      "community": 684,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_custom_modal_tsx",
       "label": "custom-modal.tsx",
@@ -97942,7 +98095,7 @@
       "source_location": "L1"
     },
     {
-      "community": 683,
+      "community": 685,
       "file_type": "code",
       "id": "organization_modal_onsubmit",
       "label": "onSubmit()",
@@ -97951,7 +98104,7 @@
       "source_location": "L49"
     },
     {
-      "community": 683,
+      "community": 685,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_organization_modal_tsx",
       "label": "organization-modal.tsx",
@@ -97960,7 +98113,7 @@
       "source_location": "L1"
     },
     {
-      "community": 684,
+      "community": 686,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_store_modal_tsx",
       "label": "store-modal.tsx",
@@ -97969,7 +98122,7 @@
       "source_location": "L1"
     },
     {
-      "community": 684,
+      "community": 686,
       "file_type": "code",
       "id": "store_modal_onsubmit",
       "label": "onSubmit()",
@@ -97978,7 +98131,7 @@
       "source_location": "L63"
     },
     {
-      "community": 685,
+      "community": 687,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_welcome_back_modal_example_tsx",
       "label": "welcome-back-modal-example.tsx",
@@ -97987,7 +98140,7 @@
       "source_location": "L1"
     },
     {
-      "community": 685,
+      "community": 687,
       "file_type": "code",
       "id": "welcome_back_modal_example_welcomebackmodalexample",
       "label": "WelcomeBackModalExample()",
@@ -97996,7 +98149,7 @@
       "source_location": "L5"
     },
     {
-      "community": 686,
+      "community": 688,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_welcome_back_modal_tsx",
       "label": "welcome-back-modal.tsx",
@@ -98005,7 +98158,7 @@
       "source_location": "L1"
     },
     {
-      "community": 686,
+      "community": 688,
       "file_type": "code",
       "id": "welcome_back_modal_welcomebackmodal",
       "label": "WelcomeBackModal()",
@@ -98014,7 +98167,7 @@
       "source_location": "L12"
     },
     {
-      "community": 687,
+      "community": 689,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_select_native_tsx",
       "label": "select-native.tsx",
@@ -98023,49 +98176,13 @@
       "source_location": "L1"
     },
     {
-      "community": 687,
+      "community": 689,
       "file_type": "code",
       "id": "select_native_cn",
       "label": "cn()",
       "norm_label": "cn()",
       "source_file": "packages/athena-webapp/src/components/ui/select-native.tsx",
       "source_location": "L15"
-    },
-    {
-      "community": 688,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_timeline_item_tsx",
-      "label": "timeline-item.tsx",
-      "norm_label": "timeline-item.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/timeline-item.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 688,
-      "file_type": "code",
-      "id": "timeline_item_timelineitem",
-      "label": "TimelineItem()",
-      "norm_label": "timelineitem()",
-      "source_file": "packages/athena-webapp/src/components/ui/timeline-item.tsx",
-      "source_location": "L3"
-    },
-    {
-      "community": 689,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_webp_image_tsx",
-      "label": "webp-image.tsx",
-      "norm_label": "webp-image.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/webp-image.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 689,
-      "file_type": "code",
-      "id": "webp_image_webpimage",
-      "label": "WebpImage()",
-      "norm_label": "webpimage()",
-      "source_file": "packages/athena-webapp/src/components/ui/webp-image.tsx",
-      "source_location": "L1"
     },
     {
       "community": 69,
@@ -98178,6 +98295,42 @@
     {
       "community": 690,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_timeline_item_tsx",
+      "label": "timeline-item.tsx",
+      "norm_label": "timeline-item.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/timeline-item.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 690,
+      "file_type": "code",
+      "id": "timeline_item_timelineitem",
+      "label": "TimelineItem()",
+      "norm_label": "timelineitem()",
+      "source_file": "packages/athena-webapp/src/components/ui/timeline-item.tsx",
+      "source_location": "L3"
+    },
+    {
+      "community": 691,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_webp_image_tsx",
+      "label": "webp-image.tsx",
+      "norm_label": "webp-image.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/webp-image.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 691,
+      "file_type": "code",
+      "id": "webp_image_webpimage",
+      "label": "WebpImage()",
+      "norm_label": "webpimage()",
+      "source_file": "packages/athena-webapp/src/components/ui/webp-image.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 692,
+      "file_type": "code",
       "id": "bagitems_bagitems",
       "label": "BagItems()",
       "norm_label": "bagitems()",
@@ -98185,7 +98338,7 @@
       "source_location": "L5"
     },
     {
-      "community": 690,
+      "community": 692,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_bagitems_tsx",
       "label": "BagItems.tsx",
@@ -98194,7 +98347,7 @@
       "source_location": "L1"
     },
     {
-      "community": 691,
+      "community": 693,
       "file_type": "code",
       "id": "bagitemsview_bagitemsview",
       "label": "BagItemsView()",
@@ -98203,7 +98356,7 @@
       "source_location": "L11"
     },
     {
-      "community": 691,
+      "community": 693,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_bagitemsview_tsx",
       "label": "BagItemsView.tsx",
@@ -98212,7 +98365,7 @@
       "source_location": "L1"
     },
     {
-      "community": 692,
+      "community": 694,
       "file_type": "code",
       "id": "bags_bags",
       "label": "Bags()",
@@ -98221,7 +98374,7 @@
       "source_location": "L4"
     },
     {
-      "community": 692,
+      "community": 694,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_bags_tsx",
       "label": "Bags.tsx",
@@ -98230,7 +98383,7 @@
       "source_location": "L1"
     },
     {
-      "community": 693,
+      "community": 695,
       "file_type": "code",
       "id": "customerbehaviortimeline_string",
       "label": "String()",
@@ -98239,7 +98392,7 @@
       "source_location": "L102"
     },
     {
-      "community": 693,
+      "community": 695,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_customerbehaviortimeline_tsx",
       "label": "CustomerBehaviorTimeline.tsx",
@@ -98248,7 +98401,7 @@
       "source_location": "L1"
     },
     {
-      "community": 694,
+      "community": 696,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_useranalyticsname_tsx",
       "label": "UserAnalyticsName.tsx",
@@ -98257,7 +98410,7 @@
       "source_location": "L1"
     },
     {
-      "community": 694,
+      "community": 696,
       "file_type": "code",
       "id": "useranalyticsname_useranalyticsname",
       "label": "UserAnalyticsName()",
@@ -98266,7 +98419,7 @@
       "source_location": "L13"
     },
     {
-      "community": 695,
+      "community": 697,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_userbag_tsx",
       "label": "UserBag.tsx",
@@ -98275,7 +98428,7 @@
       "source_location": "L1"
     },
     {
-      "community": 695,
+      "community": 697,
       "file_type": "code",
       "id": "userbag_userbag",
       "label": "UserBag()",
@@ -98284,7 +98437,7 @@
       "source_location": "L7"
     },
     {
-      "community": 696,
+      "community": 698,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_useronlineorders_tsx",
       "label": "UserOnlineOrders.tsx",
@@ -98293,7 +98446,7 @@
       "source_location": "L1"
     },
     {
-      "community": 696,
+      "community": 698,
       "file_type": "code",
       "id": "useronlineorders_useronlineorders",
       "label": "UserOnlineOrders()",
@@ -98302,7 +98455,7 @@
       "source_location": "L11"
     },
     {
-      "community": 697,
+      "community": 699,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_userstatus_tsx",
       "label": "UserStatus.tsx",
@@ -98311,49 +98464,13 @@
       "source_location": "L1"
     },
     {
-      "community": 697,
+      "community": 699,
       "file_type": "code",
       "id": "userstatus_userstatus",
       "label": "UserStatus()",
       "norm_label": "userstatus()",
       "source_file": "packages/athena-webapp/src/components/users/UserStatus.tsx",
       "source_location": "L7"
-    },
-    {
-      "community": 698,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_users_userview_tsx",
-      "label": "UserView.tsx",
-      "norm_label": "userview.tsx",
-      "source_file": "packages/athena-webapp/src/components/users/UserView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 698,
-      "file_type": "code",
-      "id": "userview_useractions",
-      "label": "UserActions()",
-      "norm_label": "useractions()",
-      "source_file": "packages/athena-webapp/src/components/users/UserView.tsx",
-      "source_location": "L45"
-    },
-    {
-      "community": 699,
-      "file_type": "code",
-      "id": "customerjourneystage_customerjourneystagecard",
-      "label": "CustomerJourneyStageCard()",
-      "norm_label": "customerjourneystagecard()",
-      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/CustomerJourneyStage.tsx",
-      "source_location": "L13"
-    },
-    {
-      "community": 699,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_users_behavioral_insights_customerjourneystage_tsx",
-      "label": "CustomerJourneyStage.tsx",
-      "norm_label": "customerjourneystage.tsx",
-      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/CustomerJourneyStage.tsx",
-      "source_location": "L1"
     },
     {
       "community": 7,
@@ -98745,6 +98862,42 @@
     {
       "community": 700,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_users_userview_tsx",
+      "label": "UserView.tsx",
+      "norm_label": "userview.tsx",
+      "source_file": "packages/athena-webapp/src/components/users/UserView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 700,
+      "file_type": "code",
+      "id": "userview_useractions",
+      "label": "UserActions()",
+      "norm_label": "useractions()",
+      "source_file": "packages/athena-webapp/src/components/users/UserView.tsx",
+      "source_location": "L45"
+    },
+    {
+      "community": 701,
+      "file_type": "code",
+      "id": "customerjourneystage_customerjourneystagecard",
+      "label": "CustomerJourneyStageCard()",
+      "norm_label": "customerjourneystagecard()",
+      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/CustomerJourneyStage.tsx",
+      "source_location": "L13"
+    },
+    {
+      "community": 701,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_users_behavioral_insights_customerjourneystage_tsx",
+      "label": "CustomerJourneyStage.tsx",
+      "norm_label": "customerjourneystage.tsx",
+      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/CustomerJourneyStage.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 702,
+      "file_type": "code",
       "id": "managerelevationcontext_test_wrapper",
       "label": "wrapper()",
       "norm_label": "wrapper()",
@@ -98752,7 +98905,7 @@
       "source_location": "L64"
     },
     {
-      "community": 700,
+      "community": 702,
       "file_type": "code",
       "id": "packages_athena_webapp_src_contexts_managerelevationcontext_test_tsx",
       "label": "ManagerElevationContext.test.tsx",
@@ -98761,7 +98914,7 @@
       "source_location": "L1"
     },
     {
-      "community": 701,
+      "community": 703,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_image_upload_ts",
       "label": "use-image-upload.ts",
@@ -98770,7 +98923,7 @@
       "source_location": "L1"
     },
     {
-      "community": 701,
+      "community": 703,
       "file_type": "code",
       "id": "use_image_upload_useimageupload",
       "label": "useImageUpload()",
@@ -98779,7 +98932,7 @@
       "source_location": "L7"
     },
     {
-      "community": 702,
+      "community": 704,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_mobile_tsx",
       "label": "use-mobile.tsx",
@@ -98788,7 +98941,7 @@
       "source_location": "L1"
     },
     {
-      "community": 702,
+      "community": 704,
       "file_type": "code",
       "id": "use_mobile_useismobile",
       "label": "useIsMobile()",
@@ -98797,7 +98950,7 @@
       "source_location": "L5"
     },
     {
-      "community": 703,
+      "community": 705,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_navigate_back_ts",
       "label": "use-navigate-back.ts",
@@ -98806,7 +98959,7 @@
       "source_location": "L1"
     },
     {
-      "community": 703,
+      "community": 705,
       "file_type": "code",
       "id": "use_navigate_back_usenavigateback",
       "label": "useNavigateBack()",
@@ -98815,7 +98968,7 @@
       "source_location": "L5"
     },
     {
-      "community": 704,
+      "community": 706,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_navigation_keyboard_shortcuts_ts",
       "label": "use-navigation-keyboard-shortcuts.ts",
@@ -98824,7 +98977,7 @@
       "source_location": "L1"
     },
     {
-      "community": 704,
+      "community": 706,
       "file_type": "code",
       "id": "use_navigation_keyboard_shortcuts_usenavigationkeyboardshortcuts",
       "label": "useNavigationKeyboardShortcuts()",
@@ -98833,7 +98986,7 @@
       "source_location": "L7"
     },
     {
-      "community": 705,
+      "community": 707,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_pagination_persistence_ts",
       "label": "use-pagination-persistence.ts",
@@ -98842,7 +98995,7 @@
       "source_location": "L1"
     },
     {
-      "community": 705,
+      "community": 707,
       "file_type": "code",
       "id": "use_pagination_persistence_usepaginationpersistence",
       "label": "usePaginationPersistence()",
@@ -98851,7 +99004,7 @@
       "source_location": "L11"
     },
     {
-      "community": 706,
+      "community": 708,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_table_keyboard_pagination_ts",
       "label": "use-table-keyboard-pagination.ts",
@@ -98860,7 +99013,7 @@
       "source_location": "L1"
     },
     {
-      "community": 706,
+      "community": 708,
       "file_type": "code",
       "id": "use_table_keyboard_pagination_usetablekeyboardpagination",
       "label": "useTableKeyboardPagination()",
@@ -98869,7 +99022,7 @@
       "source_location": "L6"
     },
     {
-      "community": 707,
+      "community": 709,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usebulkoperations_test_ts",
       "label": "useBulkOperations.test.ts",
@@ -98878,49 +99031,13 @@
       "source_location": "L1"
     },
     {
-      "community": 707,
+      "community": 709,
       "file_type": "code",
       "id": "usebulkoperations_test_makesku",
       "label": "makeSku()",
       "norm_label": "makesku()",
       "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.test.ts",
       "source_location": "L189"
-    },
-    {
-      "community": 708,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_useconvexauthidentity_ts",
-      "label": "useConvexAuthIdentity.ts",
-      "norm_label": "useconvexauthidentity.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useConvexAuthIdentity.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 708,
-      "file_type": "code",
-      "id": "useconvexauthidentity_useconvexauthidentity",
-      "label": "useConvexAuthIdentity()",
-      "norm_label": "useconvexauthidentity()",
-      "source_file": "packages/athena-webapp/src/hooks/useConvexAuthIdentity.ts",
-      "source_location": "L5"
-    },
-    {
-      "community": 709,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_usecopytext_ts",
-      "label": "useCopyText.ts",
-      "norm_label": "usecopytext.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useCopyText.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 709,
-      "file_type": "code",
-      "id": "usecopytext_usecopytext",
-      "label": "useCopyText()",
-      "norm_label": "usecopytext()",
-      "source_file": "packages/athena-webapp/src/hooks/useCopyText.ts",
-      "source_location": "L1"
     },
     {
       "community": 71,
@@ -99024,6 +99141,42 @@
     {
       "community": 710,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_useconvexauthidentity_ts",
+      "label": "useConvexAuthIdentity.ts",
+      "norm_label": "useconvexauthidentity.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useConvexAuthIdentity.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 710,
+      "file_type": "code",
+      "id": "useconvexauthidentity_useconvexauthidentity",
+      "label": "useConvexAuthIdentity()",
+      "norm_label": "useconvexauthidentity()",
+      "source_file": "packages/athena-webapp/src/hooks/useConvexAuthIdentity.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 711,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_usecopytext_ts",
+      "label": "useCopyText.ts",
+      "norm_label": "usecopytext.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useCopyText.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 711,
+      "file_type": "code",
+      "id": "usecopytext_usecopytext",
+      "label": "useCopyText()",
+      "norm_label": "usecopytext()",
+      "source_file": "packages/athena-webapp/src/hooks/useCopyText.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 712,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usecreatecomplimentaryproduct_ts",
       "label": "useCreateComplimentaryProduct.ts",
       "norm_label": "usecreatecomplimentaryproduct.ts",
@@ -99031,7 +99184,7 @@
       "source_location": "L1"
     },
     {
-      "community": 710,
+      "community": 712,
       "file_type": "code",
       "id": "usecreatecomplimentaryproduct_usecreatecomplimentaryproduct",
       "label": "useCreateComplimentaryProduct()",
@@ -99040,7 +99193,7 @@
       "source_location": "L6"
     },
     {
-      "community": 711,
+      "community": 713,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usedebounce_ts",
       "label": "useDebounce.ts",
@@ -99049,7 +99202,7 @@
       "source_location": "L1"
     },
     {
-      "community": 711,
+      "community": 713,
       "file_type": "code",
       "id": "usedebounce_usedebounce",
       "label": "useDebounce()",
@@ -99058,7 +99211,7 @@
       "source_location": "L12"
     },
     {
-      "community": 712,
+      "community": 714,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetactiveproduct_ts",
       "label": "useGetActiveProduct.ts",
@@ -99067,7 +99220,7 @@
       "source_location": "L1"
     },
     {
-      "community": 712,
+      "community": 714,
       "file_type": "code",
       "id": "usegetactiveproduct_usegetactiveproduct",
       "label": "useGetActiveProduct()",
@@ -99076,7 +99229,7 @@
       "source_location": "L6"
     },
     {
-      "community": 713,
+      "community": 715,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetautheduser_ts",
       "label": "useGetAuthedUser.ts",
@@ -99085,7 +99238,7 @@
       "source_location": "L1"
     },
     {
-      "community": 713,
+      "community": 715,
       "file_type": "code",
       "id": "usegetautheduser_usegetautheduser",
       "label": "useGetAuthedUser()",
@@ -99094,7 +99247,7 @@
       "source_location": "L4"
     },
     {
-      "community": 714,
+      "community": 716,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetcategories_ts",
       "label": "useGetCategories.ts",
@@ -99103,7 +99256,7 @@
       "source_location": "L1"
     },
     {
-      "community": 714,
+      "community": 716,
       "file_type": "code",
       "id": "usegetcategories_usegetcategories",
       "label": "useGetCategories()",
@@ -99112,7 +99265,7 @@
       "source_location": "L5"
     },
     {
-      "community": 715,
+      "community": 717,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetcomplimentaryproducts_ts",
       "label": "useGetComplimentaryProducts.ts",
@@ -99121,7 +99274,7 @@
       "source_location": "L1"
     },
     {
-      "community": 715,
+      "community": 717,
       "file_type": "code",
       "id": "usegetcomplimentaryproducts_usegetcomplimentaryproducts",
       "label": "useGetComplimentaryProducts()",
@@ -99130,7 +99283,7 @@
       "source_location": "L5"
     },
     {
-      "community": 716,
+      "community": 718,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetcurrencyformatter_ts",
       "label": "useGetCurrencyFormatter.ts",
@@ -99139,7 +99292,7 @@
       "source_location": "L1"
     },
     {
-      "community": 716,
+      "community": 718,
       "file_type": "code",
       "id": "usegetcurrencyformatter_usegetcurrencyformatter",
       "label": "useGetCurrencyFormatter()",
@@ -99148,7 +99301,7 @@
       "source_location": "L4"
     },
     {
-      "community": 717,
+      "community": 719,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetsubcategories_ts",
       "label": "useGetSubcategories.ts",
@@ -99157,49 +99310,13 @@
       "source_location": "L1"
     },
     {
-      "community": 717,
+      "community": 719,
       "file_type": "code",
       "id": "usegetsubcategories_usegetsubcategories",
       "label": "useGetSubcategories()",
       "norm_label": "usegetsubcategories()",
       "source_file": "packages/athena-webapp/src/hooks/useGetSubcategories.ts",
       "source_location": "L5"
-    },
-    {
-      "community": 718,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_usegetterminal_ts",
-      "label": "useGetTerminal.ts",
-      "norm_label": "usegetterminal.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useGetTerminal.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 718,
-      "file_type": "code",
-      "id": "usegetterminal_usegetterminal",
-      "label": "useGetTerminal()",
-      "norm_label": "usegetterminal()",
-      "source_file": "packages/athena-webapp/src/hooks/useGetTerminal.ts",
-      "source_location": "L5"
-    },
-    {
-      "community": 719,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_usenewordernotification_ts",
-      "label": "useNewOrderNotification.ts",
-      "norm_label": "usenewordernotification.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useNewOrderNotification.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 719,
-      "file_type": "code",
-      "id": "usenewordernotification_usenewordernotification",
-      "label": "useNewOrderNotification()",
-      "norm_label": "usenewordernotification()",
-      "source_file": "packages/athena-webapp/src/hooks/useNewOrderNotification.ts",
-      "source_location": "L8"
     },
     {
       "community": 72,
@@ -99303,6 +99420,42 @@
     {
       "community": 720,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_usegetterminal_ts",
+      "label": "useGetTerminal.ts",
+      "norm_label": "usegetterminal.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useGetTerminal.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 720,
+      "file_type": "code",
+      "id": "usegetterminal_usegetterminal",
+      "label": "useGetTerminal()",
+      "norm_label": "usegetterminal()",
+      "source_file": "packages/athena-webapp/src/hooks/useGetTerminal.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 721,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_usenewordernotification_ts",
+      "label": "useNewOrderNotification.ts",
+      "norm_label": "usenewordernotification.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useNewOrderNotification.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 721,
+      "file_type": "code",
+      "id": "usenewordernotification_usenewordernotification",
+      "label": "useNewOrderNotification()",
+      "norm_label": "usenewordernotification()",
+      "source_file": "packages/athena-webapp/src/hooks/useNewOrderNotification.ts",
+      "source_location": "L8"
+    },
+    {
+      "community": 722,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usepermissions_ts",
       "label": "usePermissions.ts",
       "norm_label": "usepermissions.ts",
@@ -99310,7 +99463,7 @@
       "source_location": "L1"
     },
     {
-      "community": 720,
+      "community": 722,
       "file_type": "code",
       "id": "usepermissions_usepermissions",
       "label": "usePermissions()",
@@ -99319,7 +99472,7 @@
       "source_location": "L21"
     },
     {
-      "community": 721,
+      "community": 723,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useprint_ts",
       "label": "usePrint.ts",
@@ -99328,7 +99481,7 @@
       "source_location": "L1"
     },
     {
-      "community": 721,
+      "community": 723,
       "file_type": "code",
       "id": "useprint_useprint",
       "label": "usePrint()",
@@ -99337,7 +99490,7 @@
       "source_location": "L3"
     },
     {
-      "community": 722,
+      "community": 724,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useproductsearchresults_ts",
       "label": "useProductSearchResults.ts",
@@ -99346,7 +99499,7 @@
       "source_location": "L1"
     },
     {
-      "community": 722,
+      "community": 724,
       "file_type": "code",
       "id": "useproductsearchresults_useproductsearchresults",
       "label": "useProductSearchResults()",
@@ -99355,7 +99508,7 @@
       "source_location": "L27"
     },
     {
-      "community": 723,
+      "community": 725,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useproductwithnoimagesnotification_tsx",
       "label": "useProductWithNoImagesNotification.tsx",
@@ -99364,7 +99517,7 @@
       "source_location": "L1"
     },
     {
-      "community": 723,
+      "community": 725,
       "file_type": "code",
       "id": "useproductwithnoimagesnotification_useproductwithnoimagesnotification",
       "label": "useProductWithNoImagesNotification()",
@@ -99373,7 +99526,7 @@
       "source_location": "L7"
     },
     {
-      "community": 724,
+      "community": 726,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useprotectedadminpagestate_ts",
       "label": "useProtectedAdminPageState.ts",
@@ -99382,7 +99535,7 @@
       "source_location": "L1"
     },
     {
-      "community": 724,
+      "community": 726,
       "file_type": "code",
       "id": "useprotectedadminpagestate_useprotectedadminpagestate",
       "label": "useProtectedAdminPageState()",
@@ -99391,7 +99544,7 @@
       "source_location": "L7"
     },
     {
-      "community": 725,
+      "community": 727,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useskusreservedincheckout_ts",
       "label": "useSkusReservedInCheckout.ts",
@@ -99400,7 +99553,7 @@
       "source_location": "L1"
     },
     {
-      "community": 725,
+      "community": 727,
       "file_type": "code",
       "id": "useskusreservedincheckout_useskusreservedincheckout",
       "label": "useSkusReservedInCheckout()",
@@ -99409,7 +99562,7 @@
       "source_location": "L12"
     },
     {
-      "community": 726,
+      "community": 728,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useskusreservedinpossession_ts",
       "label": "useSkusReservedInPosSession.ts",
@@ -99418,7 +99571,7 @@
       "source_location": "L1"
     },
     {
-      "community": 726,
+      "community": 728,
       "file_type": "code",
       "id": "useskusreservedinpossession_useskusreservedinpossession",
       "label": "useSkusReservedInPosSession()",
@@ -99427,7 +99580,7 @@
       "source_location": "L12"
     },
     {
-      "community": 727,
+      "community": 729,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usetogglecomplimentaryproductactive_ts",
       "label": "useToggleComplimentaryProductActive.ts",
@@ -99436,49 +99589,13 @@
       "source_location": "L1"
     },
     {
-      "community": 727,
+      "community": 729,
       "file_type": "code",
       "id": "usetogglecomplimentaryproductactive_usetogglecomplimentaryproductactive",
       "label": "useToggleComplimentaryProductActive()",
       "norm_label": "usetogglecomplimentaryproductactive()",
       "source_file": "packages/athena-webapp/src/hooks/useToggleComplimentaryProductActive.ts",
       "source_location": "L5"
-    },
-    {
-      "community": 728,
-      "file_type": "code",
-      "id": "operatormessages_tooperatormessage",
-      "label": "toOperatorMessage()",
-      "norm_label": "tooperatormessage()",
-      "source_file": "packages/athena-webapp/src/lib/errors/operatorMessages.ts",
-      "source_location": "L48"
-    },
-    {
-      "community": 728,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_errors_operatormessages_ts",
-      "label": "operatorMessages.ts",
-      "norm_label": "operatormessages.ts",
-      "source_file": "packages/athena-webapp/src/lib/errors/operatorMessages.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 729,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_errors_presentunexpectederrortoast_ts",
-      "label": "presentUnexpectedErrorToast.ts",
-      "norm_label": "presentunexpectederrortoast.ts",
-      "source_file": "packages/athena-webapp/src/lib/errors/presentUnexpectedErrorToast.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 729,
-      "file_type": "code",
-      "id": "presentunexpectederrortoast_presentunexpectederrortoast",
-      "label": "presentUnexpectedErrorToast()",
-      "norm_label": "presentunexpectederrortoast()",
-      "source_file": "packages/athena-webapp/src/lib/errors/presentUnexpectedErrorToast.ts",
-      "source_location": "L7"
     },
     {
       "community": 73,
@@ -99582,6 +99699,42 @@
     {
       "community": 730,
       "file_type": "code",
+      "id": "operatormessages_tooperatormessage",
+      "label": "toOperatorMessage()",
+      "norm_label": "tooperatormessage()",
+      "source_file": "packages/athena-webapp/src/lib/errors/operatorMessages.ts",
+      "source_location": "L48"
+    },
+    {
+      "community": 730,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_errors_operatormessages_ts",
+      "label": "operatorMessages.ts",
+      "norm_label": "operatormessages.ts",
+      "source_file": "packages/athena-webapp/src/lib/errors/operatorMessages.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 731,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_errors_presentunexpectederrortoast_ts",
+      "label": "presentUnexpectedErrorToast.ts",
+      "norm_label": "presentunexpectederrortoast.ts",
+      "source_file": "packages/athena-webapp/src/lib/errors/presentUnexpectedErrorToast.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 731,
+      "file_type": "code",
+      "id": "presentunexpectederrortoast_presentunexpectederrortoast",
+      "label": "presentUnexpectedErrorToast()",
+      "norm_label": "presentunexpectederrortoast()",
+      "source_file": "packages/athena-webapp/src/lib/errors/presentUnexpectedErrorToast.ts",
+      "source_location": "L7"
+    },
+    {
+      "community": 732,
+      "file_type": "code",
       "id": "navigationutils_getorigin",
       "label": "getOrigin()",
       "norm_label": "getorigin()",
@@ -99589,7 +99742,7 @@
       "source_location": "L1"
     },
     {
-      "community": 730,
+      "community": 732,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_navigationutils_ts",
       "label": "navigationUtils.ts",
@@ -99598,7 +99751,7 @@
       "source_location": "L1"
     },
     {
-      "community": 731,
+      "community": 733,
       "file_type": "code",
       "id": "additem_additem",
       "label": "addItem()",
@@ -99607,7 +99760,7 @@
       "source_location": "L5"
     },
     {
-      "community": 731,
+      "community": 733,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_usecases_additem_ts",
       "label": "addItem.ts",
@@ -99616,7 +99769,7 @@
       "source_location": "L1"
     },
     {
-      "community": 732,
+      "community": 734,
       "file_type": "code",
       "id": "bootstrapregister_bootstrapregister",
       "label": "bootstrapRegister()",
@@ -99625,7 +99778,7 @@
       "source_location": "L6"
     },
     {
-      "community": 732,
+      "community": 734,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_usecases_bootstrapregister_ts",
       "label": "bootstrapRegister.ts",
@@ -99634,7 +99787,7 @@
       "source_location": "L1"
     },
     {
-      "community": 733,
+      "community": 735,
       "file_type": "code",
       "id": "holdsession_holdsession",
       "label": "holdSession()",
@@ -99643,7 +99796,7 @@
       "source_location": "L5"
     },
     {
-      "community": 733,
+      "community": 735,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_usecases_holdsession_ts",
       "label": "holdSession.ts",
@@ -99652,7 +99805,7 @@
       "source_location": "L1"
     },
     {
-      "community": 734,
+      "community": 736,
       "file_type": "code",
       "id": "opendrawer_opendrawer",
       "label": "openDrawer()",
@@ -99661,7 +99814,7 @@
       "source_location": "L5"
     },
     {
-      "community": 734,
+      "community": 736,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_usecases_opendrawer_ts",
       "label": "openDrawer.ts",
@@ -99670,7 +99823,7 @@
       "source_location": "L1"
     },
     {
-      "community": 735,
+      "community": 737,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_usecases_startsession_ts",
       "label": "startSession.ts",
@@ -99679,7 +99832,7 @@
       "source_location": "L1"
     },
     {
-      "community": 735,
+      "community": 737,
       "file_type": "code",
       "id": "startsession_startsession",
       "label": "startSession()",
@@ -99688,7 +99841,7 @@
       "source_location": "L5"
     },
     {
-      "community": 736,
+      "community": 738,
       "file_type": "code",
       "id": "calculations_calculatecarttotals",
       "label": "calculateCartTotals()",
@@ -99697,7 +99850,7 @@
       "source_location": "L10"
     },
     {
-      "community": 736,
+      "community": 738,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_calculations_ts",
       "label": "calculations.ts",
@@ -99706,7 +99859,7 @@
       "source_location": "L1"
     },
     {
-      "community": 737,
+      "community": 739,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_presentation_register_useregistercatalogindex_ts",
       "label": "useRegisterCatalogIndex.ts",
@@ -99715,49 +99868,13 @@
       "source_location": "L1"
     },
     {
-      "community": 737,
+      "community": 739,
       "file_type": "code",
       "id": "useregistercatalogindex_useregistercatalogindex",
       "label": "useRegisterCatalogIndex()",
       "norm_label": "useregistercatalogindex()",
       "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterCatalogIndex.ts",
       "source_location": "L8"
-    },
-    {
-      "community": 738,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_security_pinhash_ts",
-      "label": "pinHash.ts",
-      "norm_label": "pinhash.ts",
-      "source_file": "packages/athena-webapp/src/lib/security/pinHash.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 738,
-      "file_type": "code",
-      "id": "pinhash_hashpin",
-      "label": "hashPin()",
-      "norm_label": "hashpin()",
-      "source_file": "packages/athena-webapp/src/lib/security/pinHash.ts",
-      "source_location": "L12"
-    },
-    {
-      "community": 739,
-      "file_type": "code",
-      "id": "index_hasorgnotfoundpayload",
-      "label": "hasOrgNotFoundPayload()",
-      "norm_label": "hasorgnotfoundpayload()",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/cash-controls/index.tsx",
-      "source_location": "L6"
-    },
-    {
-      "community": 739,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_cash_controls_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/cash-controls/index.tsx",
-      "source_location": "L1"
     },
     {
       "community": 74,
@@ -99861,6 +99978,42 @@
     {
       "community": 740,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_security_pinhash_ts",
+      "label": "pinHash.ts",
+      "norm_label": "pinhash.ts",
+      "source_file": "packages/athena-webapp/src/lib/security/pinHash.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 740,
+      "file_type": "code",
+      "id": "pinhash_hashpin",
+      "label": "hashPin()",
+      "norm_label": "hashpin()",
+      "source_file": "packages/athena-webapp/src/lib/security/pinHash.ts",
+      "source_location": "L12"
+    },
+    {
+      "community": 741,
+      "file_type": "code",
+      "id": "index_hasorgnotfoundpayload",
+      "label": "hasOrgNotFoundPayload()",
+      "norm_label": "hasorgnotfoundpayload()",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/cash-controls/index.tsx",
+      "source_location": "L6"
+    },
+    {
+      "community": 741,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_cash_controls_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/cash-controls/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 742,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_cash_controls_registers_sessionid_tsx",
       "label": "$sessionId.tsx",
       "norm_label": "$sessionid.tsx",
@@ -99868,7 +100021,7 @@
       "source_location": "L1"
     },
     {
-      "community": 740,
+      "community": 742,
       "file_type": "code",
       "id": "sessionid_hasorgnotfoundpayload",
       "label": "hasOrgNotFoundPayload()",
@@ -99877,7 +100030,7 @@
       "source_location": "L6"
     },
     {
-      "community": 741,
+      "community": 743,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_cash_controls_registers_index_tsx",
       "label": "registers.index.tsx",
@@ -99886,7 +100039,7 @@
       "source_location": "L1"
     },
     {
-      "community": 741,
+      "community": 743,
       "file_type": "code",
       "id": "registers_index_hasorgnotfoundpayload",
       "label": "hasOrgNotFoundPayload()",
@@ -99895,7 +100048,7 @@
       "source_location": "L6"
     },
     {
-      "community": 742,
+      "community": 744,
       "file_type": "code",
       "id": "index_storerootredirect",
       "label": "StoreRootRedirect()",
@@ -99904,7 +100057,7 @@
       "source_location": "L7"
     },
     {
-      "community": 742,
+      "community": 744,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_index_tsx",
       "label": "index.tsx",
@@ -99913,7 +100066,7 @@
       "source_location": "L1"
     },
     {
-      "community": 743,
+      "community": 745,
       "file_type": "code",
       "id": "approvals_approvalsroute",
       "label": "ApprovalsRoute()",
@@ -99922,7 +100075,7 @@
       "source_location": "L11"
     },
     {
-      "community": 743,
+      "community": 745,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_operations_approvals_tsx",
       "label": "approvals.tsx",
@@ -99931,7 +100084,7 @@
       "source_location": "L1"
     },
     {
-      "community": 744,
+      "community": 746,
       "file_type": "code",
       "id": "daily_close_history_dailyclosehistoryroute",
       "label": "DailyCloseHistoryRoute()",
@@ -99940,7 +100093,7 @@
       "source_location": "L11"
     },
     {
-      "community": 744,
+      "community": 746,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_operations_daily_close_history_tsx",
       "label": "daily-close-history.tsx",
@@ -99949,7 +100102,7 @@
       "source_location": "L1"
     },
     {
-      "community": 745,
+      "community": 747,
       "file_type": "code",
       "id": "daily_close_dailycloseroute",
       "label": "DailyCloseRoute()",
@@ -99958,7 +100111,7 @@
       "source_location": "L19"
     },
     {
-      "community": 745,
+      "community": 747,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_operations_daily_close_tsx",
       "label": "daily-close.tsx",
@@ -99967,7 +100120,7 @@
       "source_location": "L1"
     },
     {
-      "community": 746,
+      "community": 748,
       "file_type": "code",
       "id": "open_work_openworkroute",
       "label": "OpenWorkRoute()",
@@ -99976,7 +100129,7 @@
       "source_location": "L11"
     },
     {
-      "community": 746,
+      "community": 748,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_operations_open_work_tsx",
       "label": "open-work.tsx",
@@ -99985,7 +100138,7 @@
       "source_location": "L1"
     },
     {
-      "community": 747,
+      "community": 749,
       "file_type": "code",
       "id": "opening_dailyopeningroute",
       "label": "DailyOpeningRoute()",
@@ -99994,48 +100147,12 @@
       "source_location": "L11"
     },
     {
-      "community": 747,
+      "community": 749,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_operations_opening_tsx",
       "label": "opening.tsx",
       "norm_label": "opening.tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/opening.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 748,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_operations_stock_adjustments_tsx",
-      "label": "stock-adjustments.tsx",
-      "norm_label": "stock-adjustments.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/stock-adjustments.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 748,
-      "file_type": "code",
-      "id": "stock_adjustments_stockadjustmentsroute",
-      "label": "StockAdjustmentsRoute()",
-      "norm_label": "stockadjustmentsroute()",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/stock-adjustments.tsx",
-      "source_location": "L25"
-    },
-    {
-      "community": 749,
-      "file_type": "code",
-      "id": "expense_index_expenseroutecomponent",
-      "label": "ExpenseRouteComponent()",
-      "norm_label": "expenseroutecomponent()",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/expense.index.tsx",
-      "source_location": "L6"
-    },
-    {
-      "community": 749,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_index_tsx",
-      "label": "expense.index.tsx",
-      "norm_label": "expense.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/expense.index.tsx",
       "source_location": "L1"
     },
     {
@@ -100140,6 +100257,42 @@
     {
       "community": 750,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_operations_stock_adjustments_tsx",
+      "label": "stock-adjustments.tsx",
+      "norm_label": "stock-adjustments.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/stock-adjustments.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 750,
+      "file_type": "code",
+      "id": "stock_adjustments_stockadjustmentsroute",
+      "label": "StockAdjustmentsRoute()",
+      "norm_label": "stockadjustmentsroute()",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/stock-adjustments.tsx",
+      "source_location": "L25"
+    },
+    {
+      "community": 751,
+      "file_type": "code",
+      "id": "expense_index_expenseroutecomponent",
+      "label": "ExpenseRouteComponent()",
+      "norm_label": "expenseroutecomponent()",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/expense.index.tsx",
+      "source_location": "L6"
+    },
+    {
+      "community": 751,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_index_tsx",
+      "label": "expense.index.tsx",
+      "norm_label": "expense.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/expense.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 752,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reviews_published_index_tsx",
       "label": "published.index.tsx",
       "norm_label": "published.index.tsx",
@@ -100147,7 +100300,7 @@
       "source_location": "L1"
     },
     {
-      "community": 750,
+      "community": 752,
       "file_type": "code",
       "id": "published_index_routecomponent",
       "label": "RouteComponent()",
@@ -100156,7 +100309,7 @@
       "source_location": "L9"
     },
     {
-      "community": 751,
+      "community": 753,
       "file_type": "code",
       "id": "index_index",
       "label": "Index()",
@@ -100165,7 +100318,7 @@
       "source_location": "L13"
     },
     {
-      "community": 751,
+      "community": 753,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_index_tsx",
       "label": "index.tsx",
@@ -100174,7 +100327,7 @@
       "source_location": "L1"
     },
     {
-      "community": 752,
+      "community": 754,
       "file_type": "code",
       "id": "layout_index_athenaloginreadyview",
       "label": "AthenaLoginReadyView()",
@@ -100183,7 +100336,7 @@
       "source_location": "L4"
     },
     {
-      "community": 752,
+      "community": 754,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_login_layout_index_tsx",
       "label": "_layout.index.tsx",
@@ -100192,7 +100345,7 @@
       "source_location": "L1"
     },
     {
-      "community": 753,
+      "community": 755,
       "file_type": "code",
       "id": "organizationssettingsaccordion_organizationsettingsaccordion",
       "label": "OrganizationSettingsAccordion()",
@@ -100201,7 +100354,7 @@
       "source_location": "L13"
     },
     {
-      "community": 753,
+      "community": 755,
       "file_type": "code",
       "id": "packages_athena_webapp_src_settings_organization_components_organizationssettingsaccordion_tsx",
       "label": "OrganizationsSettingsAccordion.tsx",
@@ -100210,7 +100363,7 @@
       "source_location": "L1"
     },
     {
-      "community": 754,
+      "community": 756,
       "file_type": "code",
       "id": "overview_stories_patternsoverview",
       "label": "PatternsOverview()",
@@ -100219,7 +100372,7 @@
       "source_location": "L5"
     },
     {
-      "community": 754,
+      "community": 756,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_patterns_overview_stories_tsx",
       "label": "Overview.stories.tsx",
@@ -100228,7 +100381,7 @@
       "source_location": "L1"
     },
     {
-      "community": 755,
+      "community": 757,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_patterns_view_patterns_tsx",
       "label": "view-patterns.tsx",
@@ -100237,7 +100390,7 @@
       "source_location": "L1"
     },
     {
-      "community": 755,
+      "community": 757,
       "file_type": "code",
       "id": "view_patterns_cn",
       "label": "cn()",
@@ -100246,7 +100399,7 @@
       "source_location": "L142"
     },
     {
-      "community": 756,
+      "community": 758,
       "file_type": "code",
       "id": "controls_stories_controlsshowcase",
       "label": "ControlsShowcase()",
@@ -100255,7 +100408,7 @@
       "source_location": "L17"
     },
     {
-      "community": 756,
+      "community": 758,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_controls_stories_tsx",
       "label": "Controls.stories.tsx",
@@ -100264,7 +100417,7 @@
       "source_location": "L1"
     },
     {
-      "community": 757,
+      "community": 759,
       "file_type": "code",
       "id": "dialog_stories_dialogshowcase",
       "label": "DialogShowcase()",
@@ -100273,48 +100426,12 @@
       "source_location": "L15"
     },
     {
-      "community": 757,
+      "community": 759,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_dialog_stories_tsx",
       "label": "Dialog.stories.tsx",
       "norm_label": "dialog.stories.tsx",
       "source_file": "packages/athena-webapp/src/stories/Primitives/Dialog.stories.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 758,
-      "file_type": "code",
-      "id": "feedback_stories_feedbackshowcase",
-      "label": "FeedbackShowcase()",
-      "norm_label": "feedbackshowcase()",
-      "source_file": "packages/athena-webapp/src/stories/Primitives/Feedback.stories.tsx",
-      "source_location": "L12"
-    },
-    {
-      "community": 758,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_primitives_feedback_stories_tsx",
-      "label": "Feedback.stories.tsx",
-      "norm_label": "feedback.stories.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Primitives/Feedback.stories.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 759,
-      "file_type": "code",
-      "id": "overview_stories_primitivesoverview",
-      "label": "PrimitivesOverview()",
-      "norm_label": "primitivesoverview()",
-      "source_file": "packages/athena-webapp/src/stories/Primitives/Overview.stories.tsx",
-      "source_location": "L5"
-    },
-    {
-      "community": 759,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_primitives_overview_stories_tsx",
-      "label": "Overview.stories.tsx",
-      "norm_label": "overview.stories.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Primitives/Overview.stories.tsx",
       "source_location": "L1"
     },
     {
@@ -100419,6 +100536,42 @@
     {
       "community": 760,
       "file_type": "code",
+      "id": "feedback_stories_feedbackshowcase",
+      "label": "FeedbackShowcase()",
+      "norm_label": "feedbackshowcase()",
+      "source_file": "packages/athena-webapp/src/stories/Primitives/Feedback.stories.tsx",
+      "source_location": "L12"
+    },
+    {
+      "community": 760,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_primitives_feedback_stories_tsx",
+      "label": "Feedback.stories.tsx",
+      "norm_label": "feedback.stories.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Primitives/Feedback.stories.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 761,
+      "file_type": "code",
+      "id": "overview_stories_primitivesoverview",
+      "label": "PrimitivesOverview()",
+      "norm_label": "primitivesoverview()",
+      "source_file": "packages/athena-webapp/src/stories/Primitives/Overview.stories.tsx",
+      "source_location": "L5"
+    },
+    {
+      "community": 761,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_primitives_overview_stories_tsx",
+      "label": "Overview.stories.tsx",
+      "norm_label": "overview.stories.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Primitives/Overview.stories.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 762,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_popover_stories_tsx",
       "label": "Popover.stories.tsx",
       "norm_label": "popover.stories.tsx",
@@ -100426,7 +100579,7 @@
       "source_location": "L1"
     },
     {
-      "community": 760,
+      "community": 762,
       "file_type": "code",
       "id": "popover_stories_popovershowcase",
       "label": "PopoverShowcase()",
@@ -100435,7 +100588,7 @@
       "source_location": "L13"
     },
     {
-      "community": 761,
+      "community": 763,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_sheet_stories_tsx",
       "label": "Sheet.stories.tsx",
@@ -100444,7 +100597,7 @@
       "source_location": "L1"
     },
     {
-      "community": 761,
+      "community": 763,
       "file_type": "code",
       "id": "sheet_stories_sheetshowcase",
       "label": "SheetShowcase()",
@@ -100453,7 +100606,7 @@
       "source_location": "L14"
     },
     {
-      "community": 762,
+      "community": 764,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_tooltip_stories_tsx",
       "label": "Tooltip.stories.tsx",
@@ -100462,7 +100615,7 @@
       "source_location": "L1"
     },
     {
-      "community": 762,
+      "community": 764,
       "file_type": "code",
       "id": "tooltip_stories_tooltipshowcase",
       "label": "TooltipShowcase()",
@@ -100471,7 +100624,7 @@
       "source_location": "L13"
     },
     {
-      "community": 763,
+      "community": 765,
       "file_type": "code",
       "id": "overview_stories_templatesoverview",
       "label": "TemplatesOverview()",
@@ -100480,7 +100633,7 @@
       "source_location": "L5"
     },
     {
-      "community": 763,
+      "community": 765,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_templates_overview_stories_tsx",
       "label": "Overview.stories.tsx",
@@ -100489,7 +100642,7 @@
       "source_location": "L1"
     },
     {
-      "community": 764,
+      "community": 766,
       "file_type": "code",
       "id": "formatnumber_formatnumber",
       "label": "formatNumber()",
@@ -100498,7 +100651,7 @@
       "source_location": "L1"
     },
     {
-      "community": 764,
+      "community": 766,
       "file_type": "code",
       "id": "packages_athena_webapp_src_utils_formatnumber_ts",
       "label": "formatNumber.ts",
@@ -100507,7 +100660,7 @@
       "source_location": "L1"
     },
     {
-      "community": 765,
+      "community": 767,
       "file_type": "code",
       "id": "bannermessage_getbannermessage",
       "label": "getBannerMessage()",
@@ -100516,7 +100669,7 @@
       "source_location": "L4"
     },
     {
-      "community": 765,
+      "community": 767,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_bannermessage_ts",
       "label": "bannerMessage.ts",
@@ -100525,7 +100678,7 @@
       "source_location": "L1"
     },
     {
-      "community": 766,
+      "community": 768,
       "file_type": "code",
       "id": "checkoutsession_test_jsonresponse",
       "label": "jsonResponse()",
@@ -100534,7 +100687,7 @@
       "source_location": "L27"
     },
     {
-      "community": 766,
+      "community": 768,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_checkoutsession_test_ts",
       "label": "checkoutSession.test.ts",
@@ -100543,7 +100696,7 @@
       "source_location": "L1"
     },
     {
-      "community": 767,
+      "community": 769,
       "file_type": "code",
       "id": "guest_updateguest",
       "label": "updateGuest()",
@@ -100552,49 +100705,13 @@
       "source_location": "L4"
     },
     {
-      "community": 767,
+      "community": 769,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_guest_ts",
       "label": "guest.ts",
       "norm_label": "guest.ts",
       "source_file": "packages/storefront-webapp/src/api/guest.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 768,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_postransaction_test_ts",
-      "label": "posTransaction.test.ts",
-      "norm_label": "postransaction.test.ts",
-      "source_file": "packages/storefront-webapp/src/api/posTransaction.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 768,
-      "file_type": "code",
-      "id": "postransaction_test_jsonresponse",
-      "label": "jsonResponse()",
-      "norm_label": "jsonresponse()",
-      "source_file": "packages/storefront-webapp/src/api/posTransaction.test.ts",
-      "source_location": "L10"
-    },
-    {
-      "community": 769,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_storefront_ts",
-      "label": "storefront.ts",
-      "norm_label": "storefront.ts",
-      "source_file": "packages/storefront-webapp/src/api/storefront.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 769,
-      "file_type": "code",
-      "id": "storefront_getstore",
-      "label": "getStore()",
-      "norm_label": "getstore()",
-      "source_file": "packages/storefront-webapp/src/api/storefront.ts",
-      "source_location": "L5"
     },
     {
       "community": 77,
@@ -100689,6 +100806,42 @@
     {
       "community": 770,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_api_postransaction_test_ts",
+      "label": "posTransaction.test.ts",
+      "norm_label": "postransaction.test.ts",
+      "source_file": "packages/storefront-webapp/src/api/posTransaction.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 770,
+      "file_type": "code",
+      "id": "postransaction_test_jsonresponse",
+      "label": "jsonResponse()",
+      "norm_label": "jsonresponse()",
+      "source_file": "packages/storefront-webapp/src/api/posTransaction.test.ts",
+      "source_location": "L10"
+    },
+    {
+      "community": 771,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_api_storefront_ts",
+      "label": "storefront.ts",
+      "norm_label": "storefront.ts",
+      "source_file": "packages/storefront-webapp/src/api/storefront.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 771,
+      "file_type": "code",
+      "id": "storefront_getstore",
+      "label": "getStore()",
+      "norm_label": "getstore()",
+      "source_file": "packages/storefront-webapp/src/api/storefront.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 772,
+      "file_type": "code",
       "id": "entitypage_entitypage",
       "label": "EntityPage()",
       "norm_label": "entitypage()",
@@ -100696,7 +100849,7 @@
       "source_location": "L10"
     },
     {
-      "community": 770,
+      "community": 772,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_entitypage_tsx",
       "label": "EntityPage.tsx",
@@ -100705,7 +100858,7 @@
       "source_location": "L1"
     },
     {
-      "community": 771,
+      "community": 773,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_productspage_tsx",
       "label": "ProductsPage.tsx",
@@ -100714,7 +100867,7 @@
       "source_location": "L1"
     },
     {
-      "community": 771,
+      "community": 773,
       "file_type": "code",
       "id": "productspage_productcardloadingskeleton",
       "label": "ProductCardLoadingSkeleton()",
@@ -100723,7 +100876,7 @@
       "source_location": "L10"
     },
     {
-      "community": 772,
+      "community": 774,
       "file_type": "code",
       "id": "auth_authcomponent",
       "label": "AuthComponent()",
@@ -100732,7 +100885,7 @@
       "source_location": "L4"
     },
     {
-      "community": 772,
+      "community": 774,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_auth_auth_tsx",
       "label": "Auth.tsx",
@@ -100741,7 +100894,7 @@
       "source_location": "L1"
     },
     {
-      "community": 773,
+      "community": 775,
       "file_type": "code",
       "id": "bagsummary_tobagsummaryitems",
       "label": "toBagSummaryItems()",
@@ -100750,7 +100903,7 @@
       "source_location": "L39"
     },
     {
-      "community": 773,
+      "community": 775,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_bagsummary_tsx",
       "label": "BagSummary.tsx",
@@ -100759,7 +100912,7 @@
       "source_location": "L1"
     },
     {
-      "community": 774,
+      "community": 776,
       "file_type": "code",
       "id": "checkoutform_checkoutform",
       "label": "CheckoutForm()",
@@ -100768,7 +100921,7 @@
       "source_location": "L18"
     },
     {
-      "community": 774,
+      "community": 776,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkoutform_tsx",
       "label": "CheckoutForm.tsx",
@@ -100777,7 +100930,7 @@
       "source_location": "L1"
     },
     {
-      "community": 775,
+      "community": 777,
       "file_type": "code",
       "id": "checkoutprovider_checkoutprovider",
       "label": "CheckoutProvider()",
@@ -100786,7 +100939,7 @@
       "source_location": "L71"
     },
     {
-      "community": 775,
+      "community": 777,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkoutprovider_tsx",
       "label": "CheckoutProvider.tsx",
@@ -100795,7 +100948,7 @@
       "source_location": "L1"
     },
     {
-      "community": 776,
+      "community": 778,
       "file_type": "code",
       "id": "enteredbillingaddressdetails_enteredbillingaddressdetails",
       "label": "EnteredBillingAddressDetails()",
@@ -100804,7 +100957,7 @@
       "source_location": "L6"
     },
     {
-      "community": 776,
+      "community": 778,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_enteredbillingaddressdetails_tsx",
       "label": "EnteredBillingAddressDetails.tsx",
@@ -100813,7 +100966,7 @@
       "source_location": "L1"
     },
     {
-      "community": 777,
+      "community": 779,
       "file_type": "code",
       "id": "ordersummary_ordersummary",
       "label": "OrderSummary()",
@@ -100822,49 +100975,13 @@
       "source_location": "L18"
     },
     {
-      "community": 777,
+      "community": 779,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_orderdetails_ordersummary_tsx",
       "label": "OrderSummary.tsx",
       "norm_label": "ordersummary.tsx",
       "source_file": "packages/storefront-webapp/src/components/checkout/OrderDetails/OrderSummary.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 778,
-      "file_type": "code",
-      "id": "index_pickupdetails",
-      "label": "PickupDetails()",
-      "norm_label": "pickupdetails()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/OrderDetails/index.tsx",
-      "source_location": "L11"
-    },
-    {
-      "community": 778,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_orderdetails_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/storefront-webapp/src/components/checkout/OrderDetails/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 779,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_paymentmethodsection_tsx",
-      "label": "PaymentMethodSection.tsx",
-      "norm_label": "paymentmethodsection.tsx",
-      "source_file": "packages/storefront-webapp/src/components/checkout/PaymentMethodSection.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 779,
-      "file_type": "code",
-      "id": "paymentmethodsection_paymentmethodsection",
-      "label": "PaymentMethodSection()",
-      "norm_label": "paymentmethodsection()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/PaymentMethodSection.tsx",
-      "source_location": "L8"
     },
     {
       "community": 78,
@@ -100959,6 +101076,42 @@
     {
       "community": 780,
       "file_type": "code",
+      "id": "index_pickupdetails",
+      "label": "PickupDetails()",
+      "norm_label": "pickupdetails()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/OrderDetails/index.tsx",
+      "source_location": "L11"
+    },
+    {
+      "community": 780,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_orderdetails_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/storefront-webapp/src/components/checkout/OrderDetails/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 781,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_paymentmethodsection_tsx",
+      "label": "PaymentMethodSection.tsx",
+      "norm_label": "paymentmethodsection.tsx",
+      "source_file": "packages/storefront-webapp/src/components/checkout/PaymentMethodSection.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 781,
+      "file_type": "code",
+      "id": "paymentmethodsection_paymentmethodsection",
+      "label": "PaymentMethodSection()",
+      "norm_label": "paymentmethodsection()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/PaymentMethodSection.tsx",
+      "source_location": "L8"
+    },
+    {
+      "community": 782,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_paymentsection_tsx",
       "label": "PaymentSection.tsx",
       "norm_label": "paymentsection.tsx",
@@ -100966,7 +101119,7 @@
       "source_location": "L1"
     },
     {
-      "community": 780,
+      "community": 782,
       "file_type": "code",
       "id": "paymentsection_paymentsection",
       "label": "PaymentSection()",
@@ -100975,7 +101128,7 @@
       "source_location": "L27"
     },
     {
-      "community": 781,
+      "community": 783,
       "file_type": "code",
       "id": "deliveryfees_calculatedeliveryfee",
       "label": "calculateDeliveryFee()",
@@ -100984,7 +101137,7 @@
       "source_location": "L40"
     },
     {
-      "community": 781,
+      "community": 783,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliveryfees_ts",
       "label": "deliveryFees.ts",
@@ -100993,7 +101146,7 @@
       "source_location": "L1"
     },
     {
-      "community": 782,
+      "community": 784,
       "file_type": "code",
       "id": "derivecheckoutstate_derivecheckoutstate",
       "label": "deriveCheckoutState()",
@@ -101002,7 +101155,7 @@
       "source_location": "L3"
     },
     {
-      "community": 782,
+      "community": 784,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_derivecheckoutstate_ts",
       "label": "deriveCheckoutState.ts",
@@ -101011,7 +101164,7 @@
       "source_location": "L1"
     },
     {
-      "community": 783,
+      "community": 785,
       "file_type": "code",
       "id": "checkoutschemas_test_getissuemap",
       "label": "getIssueMap()",
@@ -101020,7 +101173,7 @@
       "source_location": "L8"
     },
     {
-      "community": 783,
+      "community": 785,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_checkoutschemas_test_ts",
       "label": "checkoutSchemas.test.ts",
@@ -101029,7 +101182,7 @@
       "source_location": "L1"
     },
     {
-      "community": 784,
+      "community": 786,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_weborderschema_test_ts",
       "label": "webOrderSchema.test.ts",
@@ -101038,7 +101191,7 @@
       "source_location": "L1"
     },
     {
-      "community": 784,
+      "community": 786,
       "file_type": "code",
       "id": "weborderschema_test_getissuemap",
       "label": "getIssueMap()",
@@ -101047,7 +101200,7 @@
       "source_location": "L12"
     },
     {
-      "community": 785,
+      "community": 787,
       "file_type": "code",
       "id": "customerdetailsform_onsubmit",
       "label": "onSubmit()",
@@ -101056,7 +101209,7 @@
       "source_location": "L77"
     },
     {
-      "community": 785,
+      "community": 787,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_common_forms_customerdetailsform_tsx",
       "label": "CustomerDetailsForm.tsx",
@@ -101065,7 +101218,7 @@
       "source_location": "L1"
     },
     {
-      "community": 786,
+      "community": 788,
       "file_type": "code",
       "id": "deliverydetailsform_onsubmit",
       "label": "onSubmit()",
@@ -101074,7 +101227,7 @@
       "source_location": "L161"
     },
     {
-      "community": 786,
+      "community": 788,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_common_forms_deliverydetailsform_tsx",
       "label": "DeliveryDetailsForm.tsx",
@@ -101083,7 +101236,7 @@
       "source_location": "L1"
     },
     {
-      "community": 787,
+      "community": 789,
       "file_type": "code",
       "id": "hooks_usecountdown",
       "label": "useCountdown()",
@@ -101092,49 +101245,13 @@
       "source_location": "L3"
     },
     {
-      "community": 787,
+      "community": 789,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_common_hooks_ts",
       "label": "hooks.ts",
       "norm_label": "hooks.ts",
       "source_file": "packages/storefront-webapp/src/components/common/hooks.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 788,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_communication_trustsignals_tsx",
-      "label": "TrustSignals.tsx",
-      "norm_label": "trustsignals.tsx",
-      "source_file": "packages/storefront-webapp/src/components/communication/TrustSignals.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 788,
-      "file_type": "code",
-      "id": "trustsignals_trustsignals",
-      "label": "TrustSignals()",
-      "norm_label": "trustsignals()",
-      "source_file": "packages/storefront-webapp/src/components/communication/TrustSignals.tsx",
-      "source_location": "L4"
-    },
-    {
-      "community": 789,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_filter_productfilter_tsx",
-      "label": "ProductFilter.tsx",
-      "norm_label": "productfilter.tsx",
-      "source_file": "packages/storefront-webapp/src/components/filter/ProductFilter.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 789,
-      "file_type": "code",
-      "id": "productfilter_productfilter",
-      "label": "ProductFilter()",
-      "norm_label": "productfilter()",
-      "source_file": "packages/storefront-webapp/src/components/filter/ProductFilter.tsx",
-      "source_location": "L14"
     },
     {
       "community": 79,
@@ -101229,6 +101346,42 @@
     {
       "community": 790,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_communication_trustsignals_tsx",
+      "label": "TrustSignals.tsx",
+      "norm_label": "trustsignals.tsx",
+      "source_file": "packages/storefront-webapp/src/components/communication/TrustSignals.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 790,
+      "file_type": "code",
+      "id": "trustsignals_trustsignals",
+      "label": "TrustSignals()",
+      "norm_label": "trustsignals()",
+      "source_file": "packages/storefront-webapp/src/components/communication/TrustSignals.tsx",
+      "source_location": "L4"
+    },
+    {
+      "community": 791,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_filter_productfilter_tsx",
+      "label": "ProductFilter.tsx",
+      "norm_label": "productfilter.tsx",
+      "source_file": "packages/storefront-webapp/src/components/filter/ProductFilter.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 791,
+      "file_type": "code",
+      "id": "productfilter_productfilter",
+      "label": "ProductFilter()",
+      "norm_label": "productfilter()",
+      "source_file": "packages/storefront-webapp/src/components/filter/ProductFilter.tsx",
+      "source_location": "L14"
+    },
+    {
+      "community": 792,
+      "file_type": "code",
       "id": "filter_handlecheckboxchange",
       "label": "handleCheckboxChange()",
       "norm_label": "handlecheckboxchange()",
@@ -101236,7 +101389,7 @@
       "source_location": "L27"
     },
     {
-      "community": 790,
+      "community": 792,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_footer_filter_tsx",
       "label": "Filter.tsx",
@@ -101245,7 +101398,7 @@
       "source_location": "L1"
     },
     {
-      "community": 791,
+      "community": 793,
       "file_type": "code",
       "id": "bestsellerssection_bestsellerssection",
       "label": "BestSellersSection()",
@@ -101254,7 +101407,7 @@
       "source_location": "L17"
     },
     {
-      "community": 791,
+      "community": 793,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_bestsellerssection_tsx",
       "label": "BestSellersSection.tsx",
@@ -101263,7 +101416,7 @@
       "source_location": "L1"
     },
     {
-      "community": 792,
+      "community": 794,
       "file_type": "code",
       "id": "homepagecontent_resolvehomepagecontent",
       "label": "resolveHomepageContent()",
@@ -101272,7 +101425,7 @@
       "source_location": "L13"
     },
     {
-      "community": 792,
+      "community": 794,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_homepagecontent_ts",
       "label": "homePageContent.ts",
@@ -101281,7 +101434,7 @@
       "source_location": "L1"
     },
     {
-      "community": 793,
+      "community": 795,
       "file_type": "code",
       "id": "bagmenu_handleonlinkclick",
       "label": "handleOnLinkClick()",
@@ -101290,7 +101443,7 @@
       "source_location": "L47"
     },
     {
-      "community": 793,
+      "community": 795,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_bagmenu_tsx",
       "label": "BagMenu.tsx",
@@ -101299,7 +101452,7 @@
       "source_location": "L1"
     },
     {
-      "community": 794,
+      "community": 796,
       "file_type": "code",
       "id": "mobilebagmenu_mobilebagmenu",
       "label": "MobileBagMenu()",
@@ -101308,7 +101461,7 @@
       "source_location": "L7"
     },
     {
-      "community": 794,
+      "community": 796,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_mobilebagmenu_tsx",
       "label": "MobileBagMenu.tsx",
@@ -101317,7 +101470,7 @@
       "source_location": "L1"
     },
     {
-      "community": 795,
+      "community": 797,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_sitebanner_tsx",
       "label": "SiteBanner.tsx",
@@ -101326,7 +101479,7 @@
       "source_location": "L1"
     },
     {
-      "community": 795,
+      "community": 797,
       "file_type": "code",
       "id": "sitebanner_sitebanner",
       "label": "SiteBanner()",
@@ -101335,7 +101488,7 @@
       "source_location": "L18"
     },
     {
-      "community": 796,
+      "community": 798,
       "file_type": "code",
       "id": "notificationpill_notificationpill",
       "label": "NotificationPill()",
@@ -101344,7 +101497,7 @@
       "source_location": "L1"
     },
     {
-      "community": 796,
+      "community": 798,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_notification_notificationpill_tsx",
       "label": "NotificationPill.tsx",
@@ -101353,7 +101506,7 @@
       "source_location": "L1"
     },
     {
-      "community": 797,
+      "community": 799,
       "file_type": "code",
       "id": "dimensionbar_mapvaluetolabelindex",
       "label": "mapValueToLabelIndex()",
@@ -101362,48 +101515,12 @@
       "source_location": "L12"
     },
     {
-      "community": 797,
+      "community": 799,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_dimensionbar_tsx",
       "label": "DimensionBar.tsx",
       "norm_label": "dimensionbar.tsx",
       "source_file": "packages/storefront-webapp/src/components/product-page/DimensionBar.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 798,
-      "file_type": "code",
-      "id": "discountbadge_discountbadge",
-      "label": "DiscountBadge()",
-      "norm_label": "discountbadge()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/DiscountBadge.tsx",
-      "source_location": "L8"
-    },
-    {
-      "community": 798,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_page_discountbadge_tsx",
-      "label": "DiscountBadge.tsx",
-      "norm_label": "discountbadge.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-page/DiscountBadge.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 799,
-      "file_type": "code",
-      "id": "galleryviewer_handleclickonpreview",
-      "label": "handleClickOnPreview()",
-      "norm_label": "handleclickonpreview()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/GalleryViewer.tsx",
-      "source_location": "L45"
-    },
-    {
-      "community": 799,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_page_galleryviewer_tsx",
-      "label": "GalleryViewer.tsx",
-      "norm_label": "galleryviewer.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-page/GalleryViewer.tsx",
       "source_location": "L1"
     },
     {
@@ -101787,6 +101904,42 @@
     {
       "community": 800,
       "file_type": "code",
+      "id": "discountbadge_discountbadge",
+      "label": "DiscountBadge()",
+      "norm_label": "discountbadge()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/DiscountBadge.tsx",
+      "source_location": "L8"
+    },
+    {
+      "community": 800,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_page_discountbadge_tsx",
+      "label": "DiscountBadge.tsx",
+      "norm_label": "discountbadge.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-page/DiscountBadge.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 801,
+      "file_type": "code",
+      "id": "galleryviewer_handleclickonpreview",
+      "label": "handleClickOnPreview()",
+      "norm_label": "handleclickonpreview()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/GalleryViewer.tsx",
+      "source_location": "L45"
+    },
+    {
+      "community": 801,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_page_galleryviewer_tsx",
+      "label": "GalleryViewer.tsx",
+      "norm_label": "galleryviewer.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-page/GalleryViewer.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 802,
+      "file_type": "code",
       "id": "onsaleproduct_onsaleproduct",
       "label": "OnsaleProduct()",
       "norm_label": "onsaleproduct()",
@@ -101794,7 +101947,7 @@
       "source_location": "L5"
     },
     {
-      "community": 800,
+      "community": 802,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_onsaleproduct_tsx",
       "label": "OnSaleProduct.tsx",
@@ -101803,7 +101956,7 @@
       "source_location": "L1"
     },
     {
-      "community": 801,
+      "community": 803,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productactions_tsx",
       "label": "ProductActions.tsx",
@@ -101812,7 +101965,7 @@
       "source_location": "L1"
     },
     {
-      "community": 801,
+      "community": 803,
       "file_type": "code",
       "id": "productactions_productactions",
       "label": "ProductActions()",
@@ -101821,7 +101974,7 @@
       "source_location": "L17"
     },
     {
-      "community": 802,
+      "community": 804,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productattributes_tsx",
       "label": "ProductAttributes.tsx",
@@ -101830,7 +101983,7 @@
       "source_location": "L1"
     },
     {
-      "community": 802,
+      "community": 804,
       "file_type": "code",
       "id": "productattributes_productattributes",
       "label": "ProductAttributes()",
@@ -101839,7 +101992,7 @@
       "source_location": "L3"
     },
     {
-      "community": 803,
+      "community": 805,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productpage_test_tsx",
       "label": "ProductPage.test.tsx",
@@ -101848,7 +102001,7 @@
       "source_location": "L1"
     },
     {
-      "community": 803,
+      "community": 805,
       "file_type": "code",
       "id": "productpage_test_makepagestate",
       "label": "makePageState()",
@@ -101857,7 +102010,7 @@
       "source_location": "L37"
     },
     {
-      "community": 804,
+      "community": 806,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productpage_tsx",
       "label": "ProductPage.tsx",
@@ -101866,7 +102019,7 @@
       "source_location": "L1"
     },
     {
-      "community": 804,
+      "community": 806,
       "file_type": "code",
       "id": "productpage_showshippingpolicy",
       "label": "showShippingPolicy()",
@@ -101875,7 +102028,7 @@
       "source_location": "L79"
     },
     {
-      "community": 805,
+      "community": 807,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productreview_tsx",
       "label": "ProductReview.tsx",
@@ -101884,7 +102037,7 @@
       "source_location": "L1"
     },
     {
-      "community": 805,
+      "community": 807,
       "file_type": "code",
       "id": "productreview_handlehelpful",
       "label": "handleHelpful()",
@@ -101893,7 +102046,7 @@
       "source_location": "L87"
     },
     {
-      "community": 806,
+      "community": 808,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_reviewsummary_tsx",
       "label": "ReviewSummary.tsx",
@@ -101902,7 +102055,7 @@
       "source_location": "L1"
     },
     {
-      "community": 806,
+      "community": 808,
       "file_type": "code",
       "id": "reviewsummary_reviewsummary",
       "label": "ReviewSummary()",
@@ -101911,7 +102064,7 @@
       "source_location": "L8"
     },
     {
-      "community": 807,
+      "community": 809,
       "file_type": "code",
       "id": "orderitem_orderitem",
       "label": "OrderItem()",
@@ -101920,48 +102073,12 @@
       "source_location": "L13"
     },
     {
-      "community": 807,
+      "community": 809,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_orderitem_tsx",
       "label": "OrderItem.tsx",
       "norm_label": "orderitem.tsx",
       "source_file": "packages/storefront-webapp/src/components/product-reviews/OrderItem.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 808,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_reviews_ratingselector_tsx",
-      "label": "RatingSelector.tsx",
-      "norm_label": "ratingselector.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-reviews/RatingSelector.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 808,
-      "file_type": "code",
-      "id": "ratingselector_ratingselector",
-      "label": "RatingSelector()",
-      "norm_label": "ratingselector()",
-      "source_file": "packages/storefront-webapp/src/components/product-reviews/RatingSelector.tsx",
-      "source_location": "L18"
-    },
-    {
-      "community": 809,
-      "file_type": "code",
-      "id": "guestrewardsprompt_guestrewardsprompt",
-      "label": "GuestRewardsPrompt()",
-      "norm_label": "guestrewardsprompt()",
-      "source_file": "packages/storefront-webapp/src/components/rewards/GuestRewardsPrompt.tsx",
-      "source_location": "L10"
-    },
-    {
-      "community": 809,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_rewards_guestrewardsprompt_tsx",
-      "label": "GuestRewardsPrompt.tsx",
-      "norm_label": "guestrewardsprompt.tsx",
-      "source_file": "packages/storefront-webapp/src/components/rewards/GuestRewardsPrompt.tsx",
       "source_location": "L1"
     },
     {
@@ -102057,6 +102174,42 @@
     {
       "community": 810,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_reviews_ratingselector_tsx",
+      "label": "RatingSelector.tsx",
+      "norm_label": "ratingselector.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-reviews/RatingSelector.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 810,
+      "file_type": "code",
+      "id": "ratingselector_ratingselector",
+      "label": "RatingSelector()",
+      "norm_label": "ratingselector()",
+      "source_file": "packages/storefront-webapp/src/components/product-reviews/RatingSelector.tsx",
+      "source_location": "L18"
+    },
+    {
+      "community": 811,
+      "file_type": "code",
+      "id": "guestrewardsprompt_guestrewardsprompt",
+      "label": "GuestRewardsPrompt()",
+      "norm_label": "guestrewardsprompt()",
+      "source_file": "packages/storefront-webapp/src/components/rewards/GuestRewardsPrompt.tsx",
+      "source_location": "L10"
+    },
+    {
+      "community": 811,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_rewards_guestrewardsprompt_tsx",
+      "label": "GuestRewardsPrompt.tsx",
+      "norm_label": "guestrewardsprompt.tsx",
+      "source_file": "packages/storefront-webapp/src/components/rewards/GuestRewardsPrompt.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 812,
+      "file_type": "code",
       "id": "orderpointsdisplay_orderpointsdisplay",
       "label": "OrderPointsDisplay()",
       "norm_label": "orderpointsdisplay()",
@@ -102064,7 +102217,7 @@
       "source_location": "L11"
     },
     {
-      "community": 810,
+      "community": 812,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_rewards_orderpointsdisplay_tsx",
       "label": "OrderPointsDisplay.tsx",
@@ -102073,7 +102226,7 @@
       "source_location": "L1"
     },
     {
-      "community": 811,
+      "community": 813,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_rewards_pastordersrewards_tsx",
       "label": "PastOrdersRewards.tsx",
@@ -102082,7 +102235,7 @@
       "source_location": "L1"
     },
     {
-      "community": 811,
+      "community": 813,
       "file_type": "code",
       "id": "pastordersrewards_handleclaimpoints",
       "label": "handleClaimPoints()",
@@ -102091,7 +102244,7 @@
       "source_location": "L60"
     },
     {
-      "community": 812,
+      "community": 814,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_rewards_rewardspanel_tsx",
       "label": "RewardsPanel.tsx",
@@ -102100,7 +102253,7 @@
       "source_location": "L1"
     },
     {
-      "community": 812,
+      "community": 814,
       "file_type": "code",
       "id": "rewardspanel_handleredeemreward",
       "label": "handleRedeemReward()",
@@ -102109,7 +102262,7 @@
       "source_location": "L33"
     },
     {
-      "community": 813,
+      "community": 815,
       "file_type": "code",
       "id": "bagitem_bagitem",
       "label": "BagItem()",
@@ -102118,7 +102271,7 @@
       "source_location": "L20"
     },
     {
-      "community": 813,
+      "community": 815,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_shopping_bag_bagitem_tsx",
       "label": "BagItem.tsx",
@@ -102127,7 +102280,7 @@
       "source_location": "L1"
     },
     {
-      "community": 814,
+      "community": 816,
       "file_type": "code",
       "id": "checkoutunavailable_checkoutunavailable",
       "label": "CheckoutUnavailable()",
@@ -102136,7 +102289,7 @@
       "source_location": "L4"
     },
     {
-      "community": 814,
+      "community": 816,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_checkout_unavailable_checkoutunavailable_tsx",
       "label": "CheckoutUnavailable.tsx",
@@ -102145,7 +102298,7 @@
       "source_location": "L1"
     },
     {
-      "community": 815,
+      "community": 817,
       "file_type": "code",
       "id": "errorboundary_errorboundary",
       "label": "ErrorBoundary()",
@@ -102154,7 +102307,7 @@
       "source_location": "L22"
     },
     {
-      "community": 815,
+      "community": 817,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_error_errorboundary_tsx",
       "label": "ErrorBoundary.tsx",
@@ -102163,7 +102316,7 @@
       "source_location": "L1"
     },
     {
-      "community": 816,
+      "community": 818,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_scrolldownbutton_tsx",
       "label": "ScrollDownButton.tsx",
@@ -102172,7 +102325,7 @@
       "source_location": "L1"
     },
     {
-      "community": 816,
+      "community": 818,
       "file_type": "code",
       "id": "scrolldownbutton_scrolldownbutton",
       "label": "ScrollDownButton()",
@@ -102181,7 +102334,7 @@
       "source_location": "L11"
     },
     {
-      "community": 817,
+      "community": 819,
       "file_type": "code",
       "id": "country_select_countryselect",
       "label": "CountrySelect()",
@@ -102190,48 +102343,12 @@
       "source_location": "L3"
     },
     {
-      "community": 817,
+      "community": 819,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_country_select_tsx",
       "label": "country-select.tsx",
       "norm_label": "country-select.tsx",
       "source_file": "packages/storefront-webapp/src/components/ui/country-select.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 818,
-      "file_type": "code",
-      "id": "ghana_region_select_ghanaregionselect",
-      "label": "GhanaRegionSelect()",
-      "norm_label": "ghanaregionselect()",
-      "source_file": "packages/storefront-webapp/src/components/ui/ghana-region-select.tsx",
-      "source_location": "L3"
-    },
-    {
-      "community": 818,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_ghana_region_select_tsx",
-      "label": "ghana-region-select.tsx",
-      "norm_label": "ghana-region-select.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/ghana-region-select.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 819,
-      "file_type": "code",
-      "id": "ghost_button_ghostbutton",
-      "label": "GhostButton()",
-      "norm_label": "ghostbutton()",
-      "source_file": "packages/storefront-webapp/src/components/ui/ghost-button.tsx",
-      "source_location": "L9"
-    },
-    {
-      "community": 819,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_ghost_button_tsx",
-      "label": "ghost-button.tsx",
-      "norm_label": "ghost-button.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/ghost-button.tsx",
       "source_location": "L1"
     },
     {
@@ -102327,6 +102444,42 @@
     {
       "community": 820,
       "file_type": "code",
+      "id": "ghana_region_select_ghanaregionselect",
+      "label": "GhanaRegionSelect()",
+      "norm_label": "ghanaregionselect()",
+      "source_file": "packages/storefront-webapp/src/components/ui/ghana-region-select.tsx",
+      "source_location": "L3"
+    },
+    {
+      "community": 820,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_ghana_region_select_tsx",
+      "label": "ghana-region-select.tsx",
+      "norm_label": "ghana-region-select.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/ghana-region-select.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 821,
+      "file_type": "code",
+      "id": "ghost_button_ghostbutton",
+      "label": "GhostButton()",
+      "norm_label": "ghostbutton()",
+      "source_file": "packages/storefront-webapp/src/components/ui/ghost-button.tsx",
+      "source_location": "L9"
+    },
+    {
+      "community": 821,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_ghost_button_tsx",
+      "label": "ghost-button.tsx",
+      "norm_label": "ghost-button.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/ghost-button.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 822,
+      "file_type": "code",
       "id": "leaveareviewmodal_handleclose",
       "label": "handleClose()",
       "norm_label": "handleclose()",
@@ -102334,7 +102487,7 @@
       "source_location": "L66"
     },
     {
-      "community": 820,
+      "community": 822,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_leaveareviewmodal_tsx",
       "label": "LeaveAReviewModal.tsx",
@@ -102343,7 +102496,7 @@
       "source_location": "L1"
     },
     {
-      "community": 821,
+      "community": 823,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_upsellmodalsuccess_tsx",
       "label": "UpsellModalSuccess.tsx",
@@ -102352,7 +102505,7 @@
       "source_location": "L1"
     },
     {
-      "community": 821,
+      "community": 823,
       "file_type": "code",
       "id": "upsellmodalsuccess_upsellmodalsuccess",
       "label": "UpsellModalSuccess()",
@@ -102361,7 +102514,7 @@
       "source_location": "L19"
     },
     {
-      "community": 822,
+      "community": 824,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_welcomebackmodalsuccess_tsx",
       "label": "WelcomeBackModalSuccess.tsx",
@@ -102370,7 +102523,7 @@
       "source_location": "L1"
     },
     {
-      "community": 822,
+      "community": 824,
       "file_type": "code",
       "id": "welcomebackmodalsuccess_welcomebackmodalsuccess",
       "label": "WelcomeBackModalSuccess()",
@@ -102379,7 +102532,7 @@
       "source_location": "L13"
     },
     {
-      "community": 823,
+      "community": 825,
       "file_type": "code",
       "id": "leavereviewmodalconfig_getmodalconfig",
       "label": "getModalConfig()",
@@ -102388,7 +102541,7 @@
       "source_location": "L46"
     },
     {
-      "community": 823,
+      "community": 825,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_config_leavereviewmodalconfig_tsx",
       "label": "leaveReviewModalConfig.tsx",
@@ -102397,7 +102550,7 @@
       "source_location": "L1"
     },
     {
-      "community": 824,
+      "community": 826,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_config_welcomebackmodalconfig_tsx",
       "label": "welcomeBackModalConfig.tsx",
@@ -102406,7 +102559,7 @@
       "source_location": "L1"
     },
     {
-      "community": 824,
+      "community": 826,
       "file_type": "code",
       "id": "welcomebackmodalconfig_getmodalconfig",
       "label": "getModalConfig()",
@@ -102415,7 +102568,7 @@
       "source_location": "L46"
     },
     {
-      "community": 825,
+      "community": 827,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_webp_jpg_tsx",
       "label": "webp-jpg.tsx",
@@ -102424,7 +102577,7 @@
       "source_location": "L1"
     },
     {
-      "community": 825,
+      "community": 827,
       "file_type": "code",
       "id": "webp_jpg_webpimage",
       "label": "WebpImage()",
@@ -102433,7 +102586,7 @@
       "source_location": "L1"
     },
     {
-      "community": 826,
+      "community": 828,
       "file_type": "code",
       "id": "formsubmissionprovider_useformsubmission",
       "label": "useFormSubmission()",
@@ -102442,7 +102595,7 @@
       "source_location": "L15"
     },
     {
-      "community": 826,
+      "community": 828,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_contexts_formsubmissionprovider_tsx",
       "label": "FormSubmissionProvider.tsx",
@@ -102451,7 +102604,7 @@
       "source_location": "L1"
     },
     {
-      "community": 827,
+      "community": 829,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usecheckout_ts",
       "label": "useCheckout.ts",
@@ -102460,49 +102613,13 @@
       "source_location": "L1"
     },
     {
-      "community": 827,
+      "community": 829,
       "file_type": "code",
       "id": "usecheckout_usecheckout",
       "label": "useCheckout()",
       "norm_label": "usecheckout()",
       "source_file": "packages/storefront-webapp/src/hooks/useCheckout.ts",
       "source_location": "L5"
-    },
-    {
-      "community": 828,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_usediscountcodealert_tsx",
-      "label": "useDiscountCodeAlert.tsx",
-      "norm_label": "usediscountcodealert.tsx",
-      "source_file": "packages/storefront-webapp/src/hooks/useDiscountCodeAlert.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 828,
-      "file_type": "code",
-      "id": "usediscountcodealert_usediscountcodealert",
-      "label": "useDiscountCodeAlert()",
-      "norm_label": "usediscountcodealert()",
-      "source_file": "packages/storefront-webapp/src/hooks/useDiscountCodeAlert.tsx",
-      "source_location": "L14"
-    },
-    {
-      "community": 829,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_useenhancedtracking_ts",
-      "label": "useEnhancedTracking.ts",
-      "norm_label": "useenhancedtracking.ts",
-      "source_file": "packages/storefront-webapp/src/hooks/useEnhancedTracking.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 829,
-      "file_type": "code",
-      "id": "useenhancedtracking_useenhancedtracking",
-      "label": "useEnhancedTracking()",
-      "norm_label": "useenhancedtracking()",
-      "source_file": "packages/storefront-webapp/src/hooks/useEnhancedTracking.ts",
-      "source_location": "L29"
     },
     {
       "community": 83,
@@ -102597,6 +102714,42 @@
     {
       "community": 830,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_usediscountcodealert_tsx",
+      "label": "useDiscountCodeAlert.tsx",
+      "norm_label": "usediscountcodealert.tsx",
+      "source_file": "packages/storefront-webapp/src/hooks/useDiscountCodeAlert.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 830,
+      "file_type": "code",
+      "id": "usediscountcodealert_usediscountcodealert",
+      "label": "useDiscountCodeAlert()",
+      "norm_label": "usediscountcodealert()",
+      "source_file": "packages/storefront-webapp/src/hooks/useDiscountCodeAlert.tsx",
+      "source_location": "L14"
+    },
+    {
+      "community": 831,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_useenhancedtracking_ts",
+      "label": "useEnhancedTracking.ts",
+      "norm_label": "useenhancedtracking.ts",
+      "source_file": "packages/storefront-webapp/src/hooks/useEnhancedTracking.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 831,
+      "file_type": "code",
+      "id": "useenhancedtracking_useenhancedtracking",
+      "label": "useEnhancedTracking()",
+      "norm_label": "useenhancedtracking()",
+      "source_file": "packages/storefront-webapp/src/hooks/useEnhancedTracking.ts",
+      "source_location": "L29"
+    },
+    {
+      "community": 832,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usegetactivecheckoutsession_tsx",
       "label": "useGetActiveCheckoutSession.tsx",
       "norm_label": "usegetactivecheckoutsession.tsx",
@@ -102604,7 +102757,7 @@
       "source_location": "L1"
     },
     {
-      "community": 830,
+      "community": 832,
       "file_type": "code",
       "id": "usegetactivecheckoutsession_usegetactivecheckoutsession",
       "label": "useGetActiveCheckoutSession()",
@@ -102613,7 +102766,7 @@
       "source_location": "L5"
     },
     {
-      "community": 831,
+      "community": 833,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usegetproduct_tsx",
       "label": "useGetProduct.tsx",
@@ -102622,7 +102775,7 @@
       "source_location": "L1"
     },
     {
-      "community": 831,
+      "community": 833,
       "file_type": "code",
       "id": "usegetproduct_usegetproductquery",
       "label": "useGetProductQuery()",
@@ -102631,7 +102784,7 @@
       "source_location": "L5"
     },
     {
-      "community": 832,
+      "community": 834,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usegetproductfilters_ts",
       "label": "useGetProductFilters.ts",
@@ -102640,7 +102793,7 @@
       "source_location": "L1"
     },
     {
-      "community": 832,
+      "community": 834,
       "file_type": "code",
       "id": "usegetproductfilters_usegetproductfilters",
       "label": "useGetProductFilters()",
@@ -102649,7 +102802,7 @@
       "source_location": "L3"
     },
     {
-      "community": 833,
+      "community": 835,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usegetproductreviews_ts",
       "label": "useGetProductReviews.ts",
@@ -102658,7 +102811,7 @@
       "source_location": "L1"
     },
     {
-      "community": 833,
+      "community": 835,
       "file_type": "code",
       "id": "usegetproductreviews_usegetproductreviewsquery",
       "label": "useGetProductReviewsQuery()",
@@ -102667,7 +102820,7 @@
       "source_location": "L4"
     },
     {
-      "community": 834,
+      "community": 836,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usegetstore_ts",
       "label": "useGetStore.ts",
@@ -102676,7 +102829,7 @@
       "source_location": "L1"
     },
     {
-      "community": 834,
+      "community": 836,
       "file_type": "code",
       "id": "usegetstore_usegetstore",
       "label": "useGetStore()",
@@ -102685,7 +102838,7 @@
       "source_location": "L4"
     },
     {
-      "community": 835,
+      "community": 837,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useinventorystatus_ts",
       "label": "useInventoryStatus.ts",
@@ -102694,7 +102847,7 @@
       "source_location": "L1"
     },
     {
-      "community": 835,
+      "community": 837,
       "file_type": "code",
       "id": "useinventorystatus_useinventorystatus",
       "label": "useInventoryStatus()",
@@ -102703,7 +102856,7 @@
       "source_location": "L9"
     },
     {
-      "community": 836,
+      "community": 838,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useleaveareviewmodal_tsx",
       "label": "useLeaveAReviewModal.tsx",
@@ -102712,7 +102865,7 @@
       "source_location": "L1"
     },
     {
-      "community": 836,
+      "community": 838,
       "file_type": "code",
       "id": "useleaveareviewmodal_useleaveareviewmodal",
       "label": "useLeaveAReviewModal()",
@@ -102721,7 +102874,7 @@
       "source_location": "L17"
     },
     {
-      "community": 837,
+      "community": 839,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_uselogout_ts",
       "label": "useLogout.ts",
@@ -102730,49 +102883,13 @@
       "source_location": "L1"
     },
     {
-      "community": 837,
+      "community": 839,
       "file_type": "code",
       "id": "uselogout_uselogout",
       "label": "useLogout()",
       "norm_label": "uselogout()",
       "source_file": "packages/storefront-webapp/src/hooks/useLogout.ts",
       "source_location": "L5"
-    },
-    {
-      "community": 838,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_usemodalstate_tsx",
-      "label": "useModalState.tsx",
-      "norm_label": "usemodalstate.tsx",
-      "source_file": "packages/storefront-webapp/src/hooks/useModalState.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 838,
-      "file_type": "code",
-      "id": "usemodalstate_usemodalstate",
-      "label": "useModalState()",
-      "norm_label": "usemodalstate()",
-      "source_file": "packages/storefront-webapp/src/hooks/useModalState.tsx",
-      "source_location": "L15"
-    },
-    {
-      "community": 839,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_useproductpagelogic_ts",
-      "label": "useProductPageLogic.ts",
-      "norm_label": "useproductpagelogic.ts",
-      "source_file": "packages/storefront-webapp/src/hooks/useProductPageLogic.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 839,
-      "file_type": "code",
-      "id": "useproductpagelogic_useproductpagelogic",
-      "label": "useProductPageLogic()",
-      "norm_label": "useproductpagelogic()",
-      "source_file": "packages/storefront-webapp/src/hooks/useProductPageLogic.ts",
-      "source_location": "L18"
     },
     {
       "community": 84,
@@ -102867,6 +102984,42 @@
     {
       "community": 840,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_usemodalstate_tsx",
+      "label": "useModalState.tsx",
+      "norm_label": "usemodalstate.tsx",
+      "source_file": "packages/storefront-webapp/src/hooks/useModalState.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 840,
+      "file_type": "code",
+      "id": "usemodalstate_usemodalstate",
+      "label": "useModalState()",
+      "norm_label": "usemodalstate()",
+      "source_file": "packages/storefront-webapp/src/hooks/useModalState.tsx",
+      "source_location": "L15"
+    },
+    {
+      "community": 841,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_useproductpagelogic_ts",
+      "label": "useProductPageLogic.ts",
+      "norm_label": "useproductpagelogic.ts",
+      "source_file": "packages/storefront-webapp/src/hooks/useProductPageLogic.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 841,
+      "file_type": "code",
+      "id": "useproductpagelogic_useproductpagelogic",
+      "label": "useProductPageLogic()",
+      "norm_label": "useproductpagelogic()",
+      "source_file": "packages/storefront-webapp/src/hooks/useProductPageLogic.ts",
+      "source_location": "L18"
+    },
+    {
+      "community": 842,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useproductreminder_tsx",
       "label": "useProductReminder.tsx",
       "norm_label": "useproductreminder.tsx",
@@ -102874,7 +103027,7 @@
       "source_location": "L1"
     },
     {
-      "community": 840,
+      "community": 842,
       "file_type": "code",
       "id": "useproductreminder_useproductreminder",
       "label": "useProductReminder()",
@@ -102883,7 +103036,7 @@
       "source_location": "L9"
     },
     {
-      "community": 841,
+      "community": 843,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usepromoalert_tsx",
       "label": "usePromoAlert.tsx",
@@ -102892,7 +103045,7 @@
       "source_location": "L1"
     },
     {
-      "community": 841,
+      "community": 843,
       "file_type": "code",
       "id": "usepromoalert_usepromoalert",
       "label": "usePromoAlert()",
@@ -102901,7 +103054,7 @@
       "source_location": "L16"
     },
     {
-      "community": 842,
+      "community": 844,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usequeryenabled_ts",
       "label": "useQueryEnabled.ts",
@@ -102910,7 +103063,7 @@
       "source_location": "L1"
     },
     {
-      "community": 842,
+      "community": 844,
       "file_type": "code",
       "id": "usequeryenabled_usequeryenabled",
       "label": "useQueryEnabled()",
@@ -102919,7 +103072,7 @@
       "source_location": "L3"
     },
     {
-      "community": 843,
+      "community": 845,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_userewardsalert_tsx",
       "label": "useRewardsAlert.tsx",
@@ -102928,7 +103081,7 @@
       "source_location": "L1"
     },
     {
-      "community": 843,
+      "community": 845,
       "file_type": "code",
       "id": "userewardsalert_userewardsalert",
       "label": "useRewardsAlert()",
@@ -102937,7 +103090,7 @@
       "source_location": "L11"
     },
     {
-      "community": 844,
+      "community": 846,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usescrolltotop_ts",
       "label": "useScrollToTop.ts",
@@ -102946,7 +103099,7 @@
       "source_location": "L1"
     },
     {
-      "community": 844,
+      "community": 846,
       "file_type": "code",
       "id": "usescrolltotop_usescrolltotop",
       "label": "useScrollToTop()",
@@ -102955,7 +103108,7 @@
       "source_location": "L3"
     },
     {
-      "community": 845,
+      "community": 847,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usetrackaction_ts",
       "label": "useTrackAction.ts",
@@ -102964,7 +103117,7 @@
       "source_location": "L1"
     },
     {
-      "community": 845,
+      "community": 847,
       "file_type": "code",
       "id": "usetrackaction_usetrackaction",
       "label": "useTrackAction()",
@@ -102973,7 +103126,7 @@
       "source_location": "L7"
     },
     {
-      "community": 846,
+      "community": 848,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usetrackevent_ts",
       "label": "useTrackEvent.ts",
@@ -102982,7 +103135,7 @@
       "source_location": "L1"
     },
     {
-      "community": 846,
+      "community": 848,
       "file_type": "code",
       "id": "usetrackevent_usetrackevent",
       "label": "useTrackEvent()",
@@ -102991,7 +103144,7 @@
       "source_location": "L4"
     },
     {
-      "community": 847,
+      "community": 849,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useupsellmodal_tsx",
       "label": "useUpsellModal.tsx",
@@ -103000,49 +103153,13 @@
       "source_location": "L1"
     },
     {
-      "community": 847,
+      "community": 849,
       "file_type": "code",
       "id": "useupsellmodal_useupsellmodal",
       "label": "useUpsellModal()",
       "norm_label": "useupsellmodal()",
       "source_file": "packages/storefront-webapp/src/hooks/useUpsellModal.tsx",
       "source_location": "L14"
-    },
-    {
-      "community": 848,
-      "file_type": "code",
-      "id": "analytics_usepostanalytics",
-      "label": "usePostAnalytics()",
-      "norm_label": "usepostanalytics()",
-      "source_file": "packages/storefront-webapp/src/lib/mutations.ts/analytics.ts",
-      "source_location": "L4"
-    },
-    {
-      "community": 848,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_mutations_ts_analytics_ts",
-      "label": "analytics.ts",
-      "norm_label": "analytics.ts",
-      "source_file": "packages/storefront-webapp/src/lib/mutations.ts/analytics.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 849,
-      "file_type": "code",
-      "id": "bag_usebagqueries",
-      "label": "useBagQueries()",
-      "norm_label": "usebagqueries()",
-      "source_file": "packages/storefront-webapp/src/lib/queries/bag.ts",
-      "source_location": "L7"
-    },
-    {
-      "community": 849,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_queries_bag_ts",
-      "label": "bag.ts",
-      "norm_label": "bag.ts",
-      "source_file": "packages/storefront-webapp/src/lib/queries/bag.ts",
-      "source_location": "L1"
     },
     {
       "community": 85,
@@ -103137,6 +103254,42 @@
     {
       "community": 850,
       "file_type": "code",
+      "id": "analytics_usepostanalytics",
+      "label": "usePostAnalytics()",
+      "norm_label": "usepostanalytics()",
+      "source_file": "packages/storefront-webapp/src/lib/mutations.ts/analytics.ts",
+      "source_location": "L4"
+    },
+    {
+      "community": 850,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_mutations_ts_analytics_ts",
+      "label": "analytics.ts",
+      "norm_label": "analytics.ts",
+      "source_file": "packages/storefront-webapp/src/lib/mutations.ts/analytics.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 851,
+      "file_type": "code",
+      "id": "bag_usebagqueries",
+      "label": "useBagQueries()",
+      "norm_label": "usebagqueries()",
+      "source_file": "packages/storefront-webapp/src/lib/queries/bag.ts",
+      "source_location": "L7"
+    },
+    {
+      "community": 851,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_queries_bag_ts",
+      "label": "bag.ts",
+      "norm_label": "bag.ts",
+      "source_file": "packages/storefront-webapp/src/lib/queries/bag.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 852,
+      "file_type": "code",
       "id": "bannermessage_usebannermessagequeries",
       "label": "useBannerMessageQueries()",
       "norm_label": "usebannermessagequeries()",
@@ -103144,7 +103297,7 @@
       "source_location": "L6"
     },
     {
-      "community": 850,
+      "community": 852,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_bannermessage_ts",
       "label": "bannerMessage.ts",
@@ -103153,7 +103306,7 @@
       "source_location": "L1"
     },
     {
-      "community": 851,
+      "community": 853,
       "file_type": "code",
       "id": "checkout_usecheckoutsessionqueries",
       "label": "useCheckoutSessionQueries()",
@@ -103162,7 +103315,7 @@
       "source_location": "L10"
     },
     {
-      "community": 851,
+      "community": 853,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_checkout_ts",
       "label": "checkout.ts",
@@ -103171,7 +103324,7 @@
       "source_location": "L1"
     },
     {
-      "community": 852,
+      "community": 854,
       "file_type": "code",
       "id": "inventory_useinventoryqueries",
       "label": "useInventoryQueries()",
@@ -103180,7 +103333,7 @@
       "source_location": "L6"
     },
     {
-      "community": 852,
+      "community": 854,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_inventory_ts",
       "label": "inventory.ts",
@@ -103189,7 +103342,7 @@
       "source_location": "L1"
     },
     {
-      "community": 853,
+      "community": 855,
       "file_type": "code",
       "id": "onlineorder_useonlineorderqueries",
       "label": "useOnlineOrderQueries()",
@@ -103198,7 +103351,7 @@
       "source_location": "L5"
     },
     {
-      "community": 853,
+      "community": 855,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_onlineorder_ts",
       "label": "onlineOrder.ts",
@@ -103207,7 +103360,7 @@
       "source_location": "L1"
     },
     {
-      "community": 854,
+      "community": 856,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_postransaction_ts",
       "label": "posTransaction.ts",
@@ -103216,7 +103369,7 @@
       "source_location": "L1"
     },
     {
-      "community": 854,
+      "community": 856,
       "file_type": "code",
       "id": "postransaction_usepostransactionqueries",
       "label": "usePosTransactionQueries()",
@@ -103225,7 +103378,7 @@
       "source_location": "L5"
     },
     {
-      "community": 855,
+      "community": 857,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_product_ts",
       "label": "product.ts",
@@ -103234,7 +103387,7 @@
       "source_location": "L1"
     },
     {
-      "community": 855,
+      "community": 857,
       "file_type": "code",
       "id": "product_useproductqueries",
       "label": "useProductQueries()",
@@ -103243,7 +103396,7 @@
       "source_location": "L14"
     },
     {
-      "community": 856,
+      "community": 858,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_promocode_ts",
       "label": "promoCode.ts",
@@ -103252,7 +103405,7 @@
       "source_location": "L1"
     },
     {
-      "community": 856,
+      "community": 858,
       "file_type": "code",
       "id": "promocode_usepromocodesqueries",
       "label": "usePromoCodesQueries()",
@@ -103261,7 +103414,7 @@
       "source_location": "L9"
     },
     {
-      "community": 857,
+      "community": 859,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_reviews_ts",
       "label": "reviews.ts",
@@ -103270,49 +103423,13 @@
       "source_location": "L1"
     },
     {
-      "community": 857,
+      "community": 859,
       "file_type": "code",
       "id": "reviews_usereviewqueries",
       "label": "useReviewQueries()",
       "norm_label": "usereviewqueries()",
       "source_file": "packages/storefront-webapp/src/lib/queries/reviews.ts",
       "source_location": "L10"
-    },
-    {
-      "community": 858,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_queries_rewards_ts",
-      "label": "rewards.ts",
-      "norm_label": "rewards.ts",
-      "source_file": "packages/storefront-webapp/src/lib/queries/rewards.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 858,
-      "file_type": "code",
-      "id": "rewards_userewardsqueries",
-      "label": "useRewardsQueries()",
-      "norm_label": "userewardsqueries()",
-      "source_file": "packages/storefront-webapp/src/lib/queries/rewards.ts",
-      "source_location": "L11"
-    },
-    {
-      "community": 859,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_queries_upsells_ts",
-      "label": "upsells.ts",
-      "norm_label": "upsells.ts",
-      "source_file": "packages/storefront-webapp/src/lib/queries/upsells.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 859,
-      "file_type": "code",
-      "id": "upsells_useupsellsqueries",
-      "label": "useUpsellsQueries()",
-      "norm_label": "useupsellsqueries()",
-      "source_file": "packages/storefront-webapp/src/lib/queries/upsells.ts",
-      "source_location": "L6"
     },
     {
       "community": 86,
@@ -103407,6 +103524,42 @@
     {
       "community": 860,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_queries_rewards_ts",
+      "label": "rewards.ts",
+      "norm_label": "rewards.ts",
+      "source_file": "packages/storefront-webapp/src/lib/queries/rewards.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 860,
+      "file_type": "code",
+      "id": "rewards_userewardsqueries",
+      "label": "useRewardsQueries()",
+      "norm_label": "userewardsqueries()",
+      "source_file": "packages/storefront-webapp/src/lib/queries/rewards.ts",
+      "source_location": "L11"
+    },
+    {
+      "community": 861,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_queries_upsells_ts",
+      "label": "upsells.ts",
+      "norm_label": "upsells.ts",
+      "source_file": "packages/storefront-webapp/src/lib/queries/upsells.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 861,
+      "file_type": "code",
+      "id": "upsells_useupsellsqueries",
+      "label": "useUpsellsQueries()",
+      "norm_label": "useupsellsqueries()",
+      "source_file": "packages/storefront-webapp/src/lib/queries/upsells.ts",
+      "source_location": "L6"
+    },
+    {
+      "community": 862,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_user_ts",
       "label": "user.ts",
       "norm_label": "user.ts",
@@ -103414,7 +103567,7 @@
       "source_location": "L1"
     },
     {
-      "community": 860,
+      "community": 862,
       "file_type": "code",
       "id": "user_useuserqueries",
       "label": "useUserQueries()",
@@ -103423,7 +103576,7 @@
       "source_location": "L5"
     },
     {
-      "community": 861,
+      "community": 863,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_useroffers_ts",
       "label": "userOffers.ts",
@@ -103432,7 +103585,7 @@
       "source_location": "L1"
     },
     {
-      "community": 861,
+      "community": 863,
       "file_type": "code",
       "id": "useroffers_useuseroffersqueries",
       "label": "useUserOffersQueries()",
@@ -103441,7 +103594,7 @@
       "source_location": "L6"
     },
     {
-      "community": 862,
+      "community": 864,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_storeconfig_test_ts",
       "label": "storeConfig.test.ts",
@@ -103450,7 +103603,7 @@
       "source_location": "L1"
     },
     {
-      "community": 862,
+      "community": 864,
       "file_type": "code",
       "id": "storeconfig_test_buildv2config",
       "label": "buildV2Config()",
@@ -103459,7 +103612,7 @@
       "source_location": "L10"
     },
     {
-      "community": 863,
+      "community": 865,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_storefrontobservability_test_ts",
       "label": "storefrontObservability.test.ts",
@@ -103468,7 +103621,7 @@
       "source_location": "L1"
     },
     {
-      "community": 863,
+      "community": 865,
       "file_type": "code",
       "id": "storefrontobservability_test_creatememorystorage",
       "label": "createMemoryStorage()",
@@ -103477,7 +103630,7 @@
       "source_location": "L15"
     },
     {
-      "community": 864,
+      "community": 866,
       "file_type": "code",
       "id": "email_validateemail",
       "label": "validateEmail()",
@@ -103486,7 +103639,7 @@
       "source_location": "L14"
     },
     {
-      "community": 864,
+      "community": 866,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_validations_email_ts",
       "label": "email.ts",
@@ -103495,7 +103648,7 @@
       "source_location": "L1"
     },
     {
-      "community": 865,
+      "community": 867,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_router_tsx",
       "label": "router.tsx",
@@ -103504,7 +103657,7 @@
       "source_location": "L1"
     },
     {
-      "community": 865,
+      "community": 867,
       "file_type": "code",
       "id": "router_createrouter",
       "label": "createRouter()",
@@ -103513,7 +103666,7 @@
       "source_location": "L6"
     },
     {
-      "community": 866,
+      "community": 868,
       "file_type": "code",
       "id": "homepageloader_loadhomepagedata",
       "label": "loadHomePageData()",
@@ -103522,7 +103675,7 @@
       "source_location": "L14"
     },
     {
-      "community": 866,
+      "community": 868,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_homepageloader_ts",
       "label": "-homePageLoader.ts",
@@ -103531,7 +103684,7 @@
       "source_location": "L1"
     },
     {
-      "community": 867,
+      "community": 869,
       "file_type": "code",
       "id": "orderslayout_layoutcomponent",
       "label": "LayoutComponent()",
@@ -103540,48 +103693,12 @@
       "source_location": "L8"
     },
     {
-      "community": 867,
+      "community": 869,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_tsx",
       "label": "_ordersLayout.tsx",
       "norm_label": "_orderslayout.tsx",
       "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 868,
-      "file_type": "code",
-      "id": "contact_us_contactus",
-      "label": "ContactUs()",
-      "norm_label": "contactus()",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/contact-us.tsx",
-      "source_location": "L14"
-    },
-    {
-      "community": 868,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_layout_contact_us_tsx",
-      "label": "contact-us.tsx",
-      "norm_label": "contact-us.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/contact-us.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 869,
-      "file_type": "code",
-      "id": "delivery_returns_exchanges_index_onlineorderpolicy",
-      "label": "OnlineOrderPolicy()",
-      "norm_label": "onlineorderpolicy()",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/policies/delivery-returns-exchanges.index.tsx",
-      "source_location": "L13"
-    },
-    {
-      "community": 869,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_layout_policies_delivery_returns_exchanges_index_tsx",
-      "label": "delivery-returns-exchanges.index.tsx",
-      "norm_label": "delivery-returns-exchanges.index.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/policies/delivery-returns-exchanges.index.tsx",
       "source_location": "L1"
     },
     {
@@ -103677,6 +103794,42 @@
     {
       "community": 870,
       "file_type": "code",
+      "id": "contact_us_contactus",
+      "label": "ContactUs()",
+      "norm_label": "contactus()",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/contact-us.tsx",
+      "source_location": "L14"
+    },
+    {
+      "community": 870,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_layout_contact_us_tsx",
+      "label": "contact-us.tsx",
+      "norm_label": "contact-us.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/contact-us.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 871,
+      "file_type": "code",
+      "id": "delivery_returns_exchanges_index_onlineorderpolicy",
+      "label": "OnlineOrderPolicy()",
+      "norm_label": "onlineorderpolicy()",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/policies/delivery-returns-exchanges.index.tsx",
+      "source_location": "L13"
+    },
+    {
+      "community": 871,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_layout_policies_delivery_returns_exchanges_index_tsx",
+      "label": "delivery-returns-exchanges.index.tsx",
+      "norm_label": "delivery-returns-exchanges.index.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/policies/delivery-returns-exchanges.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 872,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_policies_privacy_index_tsx",
       "label": "privacy.index.tsx",
       "norm_label": "privacy.index.tsx",
@@ -103684,7 +103837,7 @@
       "source_location": "L1"
     },
     {
-      "community": 870,
+      "community": 872,
       "file_type": "code",
       "id": "privacy_index_privacypolicy",
       "label": "PrivacyPolicy()",
@@ -103693,7 +103846,7 @@
       "source_location": "L9"
     },
     {
-      "community": 871,
+      "community": 873,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_policies_tos_index_tsx",
       "label": "tos.index.tsx",
@@ -103702,7 +103855,7 @@
       "source_location": "L1"
     },
     {
-      "community": 871,
+      "community": 873,
       "file_type": "code",
       "id": "tos_index_tossection",
       "label": "TosSection()",
@@ -103711,7 +103864,7 @@
       "source_location": "L15"
     },
     {
-      "community": 872,
+      "community": 874,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_shop_product_productslug_tsx",
       "label": "shop.product.$productSlug.tsx",
@@ -103720,7 +103873,7 @@
       "source_location": "L1"
     },
     {
-      "community": 872,
+      "community": 874,
       "file_type": "code",
       "id": "shop_product_productslug_component",
       "label": "Component()",
@@ -103729,7 +103882,7 @@
       "source_location": "L16"
     },
     {
-      "community": 873,
+      "community": 875,
       "file_type": "code",
       "id": "layout_layoutcomponent",
       "label": "LayoutComponent()",
@@ -103738,7 +103891,7 @@
       "source_location": "L6"
     },
     {
-      "community": 873,
+      "community": 875,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_tsx",
       "label": "_layout.tsx",
@@ -103747,7 +103900,7 @@
       "source_location": "L1"
     },
     {
-      "community": 874,
+      "community": 876,
       "file_type": "code",
       "id": "index_homeroute",
       "label": "HomeRoute()",
@@ -103756,7 +103909,7 @@
       "source_location": "L10"
     },
     {
-      "community": 874,
+      "community": 876,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_index_tsx",
       "label": "index.tsx",
@@ -103765,7 +103918,7 @@
       "source_location": "L1"
     },
     {
-      "community": 875,
+      "community": 877,
       "file_type": "code",
       "id": "canceled_checkoutcanceledview",
       "label": "CheckoutCanceledView()",
@@ -103774,7 +103927,7 @@
       "source_location": "L21"
     },
     {
-      "community": 875,
+      "community": 877,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_canceled_tsx",
       "label": "canceled.tsx",
@@ -103783,7 +103936,7 @@
       "source_location": "L1"
     },
     {
-      "community": 876,
+      "community": 878,
       "file_type": "code",
       "id": "complete_index_checkoutcomplete",
       "label": "CheckoutComplete()",
@@ -103792,7 +103945,7 @@
       "source_location": "L33"
     },
     {
-      "community": 876,
+      "community": 878,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_complete_index_tsx",
       "label": "complete.index.tsx",
@@ -103801,7 +103954,7 @@
       "source_location": "L1"
     },
     {
-      "community": 877,
+      "community": 879,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_pod_confirmation_tsx",
       "label": "pod-confirmation.tsx",
@@ -103810,49 +103963,13 @@
       "source_location": "L1"
     },
     {
-      "community": 877,
+      "community": 879,
       "file_type": "code",
       "id": "pod_confirmation_completepodcheckoutsession",
       "label": "completePODCheckoutSession()",
       "norm_label": "completepodcheckoutsession()",
       "source_file": "packages/storefront-webapp/src/routes/shop/checkout/pod-confirmation.tsx",
       "source_location": "L196"
-    },
-    {
-      "community": 878,
-      "file_type": "code",
-      "id": "index_receiptshareroute",
-      "label": "ReceiptShareRoute()",
-      "norm_label": "receiptshareroute()",
-      "source_file": "packages/storefront-webapp/src/routes/shop/receipt/s/$token/index.tsx",
-      "source_location": "L9"
-    },
-    {
-      "community": 878,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_shop_receipt_s_token_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/shop/receipt/s/$token/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 879,
-      "file_type": "code",
-      "id": "packages_valkey_proxy_server_test_connection_js",
-      "label": "test-connection.js",
-      "norm_label": "test-connection.js",
-      "source_file": "packages/valkey-proxy-server/test-connection.js",
-      "source_location": "L1"
-    },
-    {
-      "community": 879,
-      "file_type": "code",
-      "id": "test_connection_main",
-      "label": "main()",
-      "norm_label": "main()",
-      "source_file": "packages/valkey-proxy-server/test-connection.js",
-      "source_location": "L7"
     },
     {
       "community": 88,
@@ -103938,6 +104055,42 @@
     {
       "community": 880,
       "file_type": "code",
+      "id": "index_receiptshareroute",
+      "label": "ReceiptShareRoute()",
+      "norm_label": "receiptshareroute()",
+      "source_file": "packages/storefront-webapp/src/routes/shop/receipt/s/$token/index.tsx",
+      "source_location": "L9"
+    },
+    {
+      "community": 880,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_shop_receipt_s_token_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/shop/receipt/s/$token/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 881,
+      "file_type": "code",
+      "id": "packages_valkey_proxy_server_test_connection_js",
+      "label": "test-connection.js",
+      "norm_label": "test-connection.js",
+      "source_file": "packages/valkey-proxy-server/test-connection.js",
+      "source_location": "L1"
+    },
+    {
+      "community": 881,
+      "file_type": "code",
+      "id": "test_connection_main",
+      "label": "main()",
+      "norm_label": "main()",
+      "source_file": "packages/valkey-proxy-server/test-connection.js",
+      "source_location": "L7"
+    },
+    {
+      "community": 882,
+      "file_type": "code",
       "id": "architecture_boundaries_test_createsnippetlinter",
       "label": "createSnippetLinter()",
       "norm_label": "createsnippetlinter()",
@@ -103945,7 +104098,7 @@
       "source_location": "L10"
     },
     {
-      "community": 880,
+      "community": 882,
       "file_type": "code",
       "id": "scripts_architecture_boundaries_test_ts",
       "label": "architecture-boundaries.test.ts",
@@ -103954,7 +104107,7 @@
       "source_location": "L1"
     },
     {
-      "community": 881,
+      "community": 883,
       "file_type": "code",
       "id": "architecture_boundary_check_run",
       "label": "run()",
@@ -103963,7 +104116,7 @@
       "source_location": "L32"
     },
     {
-      "community": 881,
+      "community": 883,
       "file_type": "code",
       "id": "scripts_architecture_boundary_check_ts",
       "label": "architecture-boundary-check.ts",
@@ -103972,7 +104125,7 @@
       "source_location": "L1"
     },
     {
-      "community": 882,
+      "community": 884,
       "file_type": "code",
       "id": "deploy_qa_vps_test_readrepofile",
       "label": "readRepoFile()",
@@ -103981,7 +104134,7 @@
       "source_location": "L7"
     },
     {
-      "community": 882,
+      "community": 884,
       "file_type": "code",
       "id": "scripts_deploy_qa_vps_test_ts",
       "label": "deploy-qa-vps.test.ts",
@@ -103990,7 +104143,7 @@
       "source_location": "L1"
     },
     {
-      "community": 883,
+      "community": 885,
       "file_type": "code",
       "id": "github_pr_merge_test_runcommand",
       "label": "runCommand()",
@@ -103999,7 +104152,7 @@
       "source_location": "L16"
     },
     {
-      "community": 883,
+      "community": 885,
       "file_type": "code",
       "id": "scripts_github_pr_merge_test_ts",
       "label": "github-pr-merge.test.ts",
@@ -104008,7 +104161,7 @@
       "source_location": "L1"
     },
     {
-      "community": 884,
+      "community": 886,
       "file_type": "code",
       "id": "athena_runtime_app_shutdown",
       "label": "shutdown()",
@@ -104017,7 +104170,7 @@
       "source_location": "L211"
     },
     {
-      "community": 884,
+      "community": 886,
       "file_type": "code",
       "id": "scripts_harness_behavior_fixtures_athena_runtime_app_ts",
       "label": "athena-runtime-app.ts",
@@ -104026,7 +104179,7 @@
       "source_location": "L1"
     },
     {
-      "community": 885,
+      "community": 887,
       "file_type": "code",
       "id": "sample_app_shutdown",
       "label": "shutdown()",
@@ -104035,7 +104188,7 @@
       "source_location": "L85"
     },
     {
-      "community": 885,
+      "community": 887,
       "file_type": "code",
       "id": "scripts_harness_behavior_fixtures_sample_app_ts",
       "label": "sample-app.ts",
@@ -104044,7 +104197,7 @@
       "source_location": "L1"
     },
     {
-      "community": 886,
+      "community": 888,
       "file_type": "code",
       "id": "harness_runtime_trends_test_buildreportline",
       "label": "buildReportLine()",
@@ -104053,7 +104206,7 @@
       "source_location": "L15"
     },
     {
-      "community": 886,
+      "community": 888,
       "file_type": "code",
       "id": "scripts_harness_runtime_trends_test_ts",
       "label": "harness-runtime-trends.test.ts",
@@ -104062,30 +104215,12 @@
       "source_location": "L1"
     },
     {
-      "community": 887,
+      "community": 889,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_generated_api_d_ts",
       "label": "api.d.ts",
       "norm_label": "api.d.ts",
       "source_file": "packages/athena-webapp/convex/_generated/api.d.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 888,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_generated_api_js",
-      "label": "api.js",
-      "norm_label": "api.js",
-      "source_file": "packages/athena-webapp/convex/_generated/api.js",
-      "source_location": "L1"
-    },
-    {
-      "community": 889,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_generated_datamodel_d_ts",
-      "label": "dataModel.d.ts",
-      "norm_label": "datamodel.d.ts",
-      "source_file": "packages/athena-webapp/convex/_generated/dataModel.d.ts",
       "source_location": "L1"
     },
     {
@@ -104172,6 +104307,24 @@
     {
       "community": 890,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_generated_api_js",
+      "label": "api.js",
+      "norm_label": "api.js",
+      "source_file": "packages/athena-webapp/convex/_generated/api.js",
+      "source_location": "L1"
+    },
+    {
+      "community": 891,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_generated_datamodel_d_ts",
+      "label": "dataModel.d.ts",
+      "norm_label": "datamodel.d.ts",
+      "source_file": "packages/athena-webapp/convex/_generated/dataModel.d.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 892,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_generated_server_d_ts",
       "label": "server.d.ts",
       "norm_label": "server.d.ts",
@@ -104179,7 +104332,7 @@
       "source_location": "L1"
     },
     {
-      "community": 891,
+      "community": 893,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_generated_server_js",
       "label": "server.js",
@@ -104188,7 +104341,7 @@
       "source_location": "L1"
     },
     {
-      "community": 892,
+      "community": 894,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_app_ts",
       "label": "app.ts",
@@ -104197,7 +104350,7 @@
       "source_location": "L1"
     },
     {
-      "community": 893,
+      "community": 895,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_auth_config_js",
       "label": "auth.config.js",
@@ -104206,7 +104359,7 @@
       "source_location": "L1"
     },
     {
-      "community": 894,
+      "community": 896,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_auth_ts",
       "label": "auth.ts",
@@ -104215,7 +104368,7 @@
       "source_location": "L1"
     },
     {
-      "community": 895,
+      "community": 897,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cashcontrols_registersessions_test_ts",
       "label": "registerSessions.test.ts",
@@ -104224,7 +104377,7 @@
       "source_location": "L1"
     },
     {
-      "community": 896,
+      "community": 898,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cloudflare_r2_test_ts",
       "label": "r2.test.ts",
@@ -104233,30 +104386,12 @@
       "source_location": "L1"
     },
     {
-      "community": 897,
+      "community": 899,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_constants_countries_ts",
       "label": "countries.ts",
       "norm_label": "countries.ts",
       "source_file": "packages/athena-webapp/convex/constants/countries.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 898,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_constants_email_ts",
-      "label": "email.ts",
-      "norm_label": "email.ts",
-      "source_file": "packages/athena-webapp/convex/constants/email.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 899,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_constants_ghana_ts",
-      "label": "ghana.ts",
-      "norm_label": "ghana.ts",
-      "source_file": "packages/athena-webapp/convex/constants/ghana.ts",
       "source_location": "L1"
     },
     {
@@ -104622,6 +104757,24 @@
     {
       "community": 900,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_constants_email_ts",
+      "label": "email.ts",
+      "norm_label": "email.ts",
+      "source_file": "packages/athena-webapp/convex/constants/email.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 901,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_constants_ghana_ts",
+      "label": "ghana.ts",
+      "norm_label": "ghana.ts",
+      "source_file": "packages/athena-webapp/convex/constants/ghana.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 902,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_constants_payment_ts",
       "label": "payment.ts",
       "norm_label": "payment.ts",
@@ -104629,7 +104782,7 @@
       "source_location": "L1"
     },
     {
-      "community": 901,
+      "community": 903,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_crons_ts",
       "label": "crons.ts",
@@ -104638,7 +104791,7 @@
       "source_location": "L1"
     },
     {
-      "community": 902,
+      "community": 904,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_customermessaging_domain_test_ts",
       "label": "domain.test.ts",
@@ -104647,7 +104800,7 @@
       "source_location": "L1"
     },
     {
-      "community": 903,
+      "community": 905,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_customermessaging_internal_ts",
       "label": "internal.ts",
@@ -104656,7 +104809,7 @@
       "source_location": "L1"
     },
     {
-      "community": 904,
+      "community": 906,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_customermessaging_public_test_ts",
       "label": "public.test.ts",
@@ -104665,7 +104818,7 @@
       "source_location": "L1"
     },
     {
-      "community": 905,
+      "community": 907,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_customermessaging_token_test_ts",
       "label": "token.test.ts",
@@ -104674,7 +104827,7 @@
       "source_location": "L1"
     },
     {
-      "community": 906,
+      "community": 908,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_customermessaging_whatsappclient_test_ts",
       "label": "whatsappClient.test.ts",
@@ -104683,30 +104836,12 @@
       "source_location": "L1"
     },
     {
-      "community": 907,
+      "community": 909,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_customermessaging_whatsappconfig_test_ts",
       "label": "whatsappConfig.test.ts",
       "norm_label": "whatsappconfig.test.ts",
       "source_file": "packages/athena-webapp/convex/customerMessaging/whatsappConfig.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 908,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_devpatchbadtransaction_ts",
-      "label": "devPatchBadTransaction.ts",
-      "norm_label": "devpatchbadtransaction.ts",
-      "source_file": "packages/athena-webapp/convex/devPatchBadTransaction.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 909,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_emails_feedbackrequest_tsx",
-      "label": "FeedbackRequest.tsx",
-      "norm_label": "feedbackrequest.tsx",
-      "source_file": "packages/athena-webapp/convex/emails/FeedbackRequest.tsx",
       "source_location": "L1"
     },
     {
@@ -104793,6 +104928,24 @@
     {
       "community": 910,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_devpatchbadtransaction_ts",
+      "label": "devPatchBadTransaction.ts",
+      "norm_label": "devpatchbadtransaction.ts",
+      "source_file": "packages/athena-webapp/convex/devPatchBadTransaction.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 911,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_emails_feedbackrequest_tsx",
+      "label": "FeedbackRequest.tsx",
+      "norm_label": "feedbackrequest.tsx",
+      "source_file": "packages/athena-webapp/convex/emails/FeedbackRequest.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 912,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_neworderadmin_tsx",
       "label": "NewOrderAdmin.tsx",
       "norm_label": "neworderadmin.tsx",
@@ -104800,7 +104953,7 @@
       "source_location": "L1"
     },
     {
-      "community": 911,
+      "community": 913,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_orderemail_tsx",
       "label": "OrderEmail.tsx",
@@ -104809,7 +104962,7 @@
       "source_location": "L1"
     },
     {
-      "community": 912,
+      "community": 914,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_posreceiptemail_tsx",
       "label": "PosReceiptEmail.tsx",
@@ -104818,7 +104971,7 @@
       "source_location": "L1"
     },
     {
-      "community": 913,
+      "community": 915,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_env_ts",
       "label": "env.ts",
@@ -104827,7 +104980,7 @@
       "source_location": "L1"
     },
     {
-      "community": 914,
+      "community": 916,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_core_routes_analytics_ts",
       "label": "analytics.ts",
@@ -104836,7 +104989,7 @@
       "source_location": "L1"
     },
     {
-      "community": 915,
+      "community": 917,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_core_routes_auth_ts",
       "label": "auth.ts",
@@ -104845,7 +104998,7 @@
       "source_location": "L1"
     },
     {
-      "community": 916,
+      "community": 918,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_core_routes_bannermessage_ts",
       "label": "bannerMessage.ts",
@@ -104854,30 +105007,12 @@
       "source_location": "L1"
     },
     {
-      "community": 917,
+      "community": 919,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_core_routes_colors_ts",
       "label": "colors.ts",
       "norm_label": "colors.ts",
       "source_file": "packages/athena-webapp/convex/http/domains/core/routes/colors.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 918,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_core_routes_index_ts",
-      "label": "index.ts",
-      "norm_label": "index.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/core/routes/index.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 919,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_core_routes_organizations_ts",
-      "label": "organizations.ts",
-      "norm_label": "organizations.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/core/routes/organizations.ts",
       "source_location": "L1"
     },
     {
@@ -104964,6 +105099,24 @@
     {
       "community": 920,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_core_routes_index_ts",
+      "label": "index.ts",
+      "norm_label": "index.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/core/routes/index.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 921,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_core_routes_organizations_ts",
+      "label": "organizations.ts",
+      "norm_label": "organizations.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/core/routes/organizations.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 922,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_core_routes_products_ts",
       "label": "products.ts",
       "norm_label": "products.ts",
@@ -104971,7 +105124,7 @@
       "source_location": "L1"
     },
     {
-      "community": 921,
+      "community": 923,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_core_routes_storefronthidden_test_ts",
       "label": "storefrontHidden.test.ts",
@@ -104980,7 +105133,7 @@
       "source_location": "L1"
     },
     {
-      "community": 922,
+      "community": 924,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_core_routes_stores_ts",
       "label": "stores.ts",
@@ -104989,7 +105142,7 @@
       "source_location": "L1"
     },
     {
-      "community": 923,
+      "community": 925,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_bag_ts",
       "label": "bag.ts",
@@ -104998,7 +105151,7 @@
       "source_location": "L1"
     },
     {
-      "community": 924,
+      "community": 926,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_guest_ts",
       "label": "guest.ts",
@@ -105007,7 +105160,7 @@
       "source_location": "L1"
     },
     {
-      "community": 925,
+      "community": 927,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_index_ts",
       "label": "index.ts",
@@ -105016,7 +105169,7 @@
       "source_location": "L1"
     },
     {
-      "community": 926,
+      "community": 928,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_me_ts",
       "label": "me.ts",
@@ -105025,30 +105178,12 @@
       "source_location": "L1"
     },
     {
-      "community": 927,
+      "community": 929,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_offers_ts",
       "label": "offers.ts",
       "norm_label": "offers.ts",
       "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/offers.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 928,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_onlineorder_ts",
-      "label": "onlineOrder.ts",
-      "norm_label": "onlineorder.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/onlineOrder.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 929,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_paystack_ts",
-      "label": "paystack.ts",
-      "norm_label": "paystack.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/paystack.ts",
       "source_location": "L1"
     },
     {
@@ -105135,6 +105270,24 @@
     {
       "community": 930,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_onlineorder_ts",
+      "label": "onlineOrder.ts",
+      "norm_label": "onlineorder.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/onlineOrder.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 931,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_paystack_ts",
+      "label": "paystack.ts",
+      "norm_label": "paystack.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/paystack.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 932,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_postransaction_ts",
       "label": "posTransaction.ts",
       "norm_label": "postransaction.ts",
@@ -105142,7 +105295,7 @@
       "source_location": "L1"
     },
     {
-      "community": 931,
+      "community": 933,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_reviews_ts",
       "label": "reviews.ts",
@@ -105151,7 +105304,7 @@
       "source_location": "L1"
     },
     {
-      "community": 932,
+      "community": 934,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_rewards_ts",
       "label": "rewards.ts",
@@ -105160,7 +105313,7 @@
       "source_location": "L1"
     },
     {
-      "community": 933,
+      "community": 935,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_savedbag_ts",
       "label": "savedBag.ts",
@@ -105169,7 +105322,7 @@
       "source_location": "L1"
     },
     {
-      "community": 934,
+      "community": 936,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_security_test_ts",
       "label": "security.test.ts",
@@ -105178,7 +105331,7 @@
       "source_location": "L1"
     },
     {
-      "community": 935,
+      "community": 937,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_storefront_ts",
       "label": "storefront.ts",
@@ -105187,7 +105340,7 @@
       "source_location": "L1"
     },
     {
-      "community": 936,
+      "community": 938,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_upsells_ts",
       "label": "upsells.ts",
@@ -105196,30 +105349,12 @@
       "source_location": "L1"
     },
     {
-      "community": 937,
+      "community": 939,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_user_ts",
       "label": "user.ts",
       "norm_label": "user.ts",
       "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/user.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 938,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_useroffers_ts",
-      "label": "userOffers.ts",
-      "norm_label": "useroffers.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/userOffers.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 939,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_moneymovement_routes_index_ts",
-      "label": "index.ts",
-      "norm_label": "index.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/moneyMovement/routes/index.ts",
       "source_location": "L1"
     },
     {
@@ -105306,6 +105441,24 @@
     {
       "community": 940,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_useroffers_ts",
+      "label": "userOffers.ts",
+      "norm_label": "useroffers.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/userOffers.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 941,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_moneymovement_routes_index_ts",
+      "label": "index.ts",
+      "norm_label": "index.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/moneyMovement/routes/index.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 942,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_http_health_test_ts",
       "label": "health.test.ts",
       "norm_label": "health.test.ts",
@@ -105313,7 +105466,7 @@
       "source_location": "L1"
     },
     {
-      "community": 941,
+      "community": 943,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_ts",
       "label": "http.ts",
@@ -105322,7 +105475,7 @@
       "source_location": "L1"
     },
     {
-      "community": 942,
+      "community": 944,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_athenauser_ts",
       "label": "athenaUser.ts",
@@ -105331,7 +105484,7 @@
       "source_location": "L1"
     },
     {
-      "community": 943,
+      "community": 945,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_bannermessage_ts",
       "label": "bannerMessage.ts",
@@ -105340,7 +105493,7 @@
       "source_location": "L1"
     },
     {
-      "community": 944,
+      "community": 946,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_bestseller_ts",
       "label": "bestSeller.ts",
@@ -105349,7 +105502,7 @@
       "source_location": "L1"
     },
     {
-      "community": 945,
+      "community": 947,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_categories_ts",
       "label": "categories.ts",
@@ -105358,7 +105511,7 @@
       "source_location": "L1"
     },
     {
-      "community": 946,
+      "community": 948,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_colors_ts",
       "label": "colors.ts",
@@ -105367,30 +105520,12 @@
       "source_location": "L1"
     },
     {
-      "community": 947,
+      "community": 949,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_complimentaryproduct_ts",
       "label": "complimentaryProduct.ts",
       "norm_label": "complimentaryproduct.ts",
       "source_file": "packages/athena-webapp/convex/inventory/complimentaryProduct.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 948,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_expensetransactions_test_ts",
-      "label": "expenseTransactions.test.ts",
-      "norm_label": "expensetransactions.test.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/expenseTransactions.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 949,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_featureditem_ts",
-      "label": "featuredItem.ts",
-      "norm_label": "featureditem.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/featuredItem.ts",
       "source_location": "L1"
     },
     {
@@ -105477,6 +105612,24 @@
     {
       "community": 950,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_expensetransactions_test_ts",
+      "label": "expenseTransactions.test.ts",
+      "norm_label": "expensetransactions.test.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/expenseTransactions.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 951,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_featureditem_ts",
+      "label": "featuredItem.ts",
+      "norm_label": "featureditem.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/featuredItem.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 952,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_invitecode_ts",
       "label": "inviteCode.ts",
       "norm_label": "invitecode.ts",
@@ -105484,7 +105637,7 @@
       "source_location": "L1"
     },
     {
-      "community": 951,
+      "community": 953,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_organizationmembers_ts",
       "label": "organizationMembers.ts",
@@ -105493,7 +105646,7 @@
       "source_location": "L1"
     },
     {
-      "community": 952,
+      "community": 954,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_organizations_ts",
       "label": "organizations.ts",
@@ -105502,7 +105655,7 @@
       "source_location": "L1"
     },
     {
-      "community": 953,
+      "community": 955,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_pos_ts",
       "label": "pos.ts",
@@ -105511,7 +105664,7 @@
       "source_location": "L1"
     },
     {
-      "community": 954,
+      "community": 956,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_poscustomers_ts",
       "label": "posCustomers.ts",
@@ -105520,7 +105673,7 @@
       "source_location": "L1"
     },
     {
-      "community": 955,
+      "community": 957,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_posterminal_ts",
       "label": "posTerminal.ts",
@@ -105529,7 +105682,7 @@
       "source_location": "L1"
     },
     {
-      "community": 956,
+      "community": 958,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_productsku_ts",
       "label": "productSku.ts",
@@ -105538,30 +105691,12 @@
       "source_location": "L1"
     },
     {
-      "community": 957,
+      "community": 959,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_productutil_test_ts",
       "label": "productUtil.test.ts",
       "norm_label": "productutil.test.ts",
       "source_file": "packages/athena-webapp/convex/inventory/productUtil.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 958,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_promocode_test_ts",
-      "label": "promoCode.test.ts",
-      "norm_label": "promocode.test.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/promoCode.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 959,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_stockvalidation_ts",
-      "label": "stockValidation.ts",
-      "norm_label": "stockvalidation.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/stockValidation.ts",
       "source_location": "L1"
     },
     {
@@ -105639,6 +105774,24 @@
     {
       "community": 960,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_promocode_test_ts",
+      "label": "promoCode.test.ts",
+      "norm_label": "promocode.test.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/promoCode.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 961,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_stockvalidation_ts",
+      "label": "stockValidation.ts",
+      "norm_label": "stockvalidation.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/stockValidation.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 962,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_storeconfigv2_test_ts",
       "label": "storeConfigV2.test.ts",
       "norm_label": "storeconfigv2.test.ts",
@@ -105646,7 +105799,7 @@
       "source_location": "L1"
     },
     {
-      "community": 961,
+      "community": 963,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_subcategories_ts",
       "label": "subcategories.ts",
@@ -105655,7 +105808,7 @@
       "source_location": "L1"
     },
     {
-      "community": 962,
+      "community": 964,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_lib_commandresultvalidators_test_ts",
       "label": "commandResultValidators.test.ts",
@@ -105664,7 +105817,7 @@
       "source_location": "L1"
     },
     {
-      "community": 963,
+      "community": 965,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_lib_currency_test_ts",
       "label": "currency.test.ts",
@@ -105673,7 +105826,7 @@
       "source_location": "L1"
     },
     {
-      "community": 964,
+      "community": 966,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_storeinsights_ts",
       "label": "storeInsights.ts",
@@ -105682,7 +105835,7 @@
       "source_location": "L1"
     },
     {
-      "community": 965,
+      "community": 967,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_userinsights_ts",
       "label": "userInsights.ts",
@@ -105691,7 +105844,7 @@
       "source_location": "L1"
     },
     {
-      "community": 966,
+      "community": 968,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_migrations_migrateamountstopesewas_ts",
       "label": "migrateAmountsToPesewas.ts",
@@ -105700,30 +105853,12 @@
       "source_location": "L1"
     },
     {
-      "community": 967,
+      "community": 969,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_client_test_ts",
       "label": "client.test.ts",
       "norm_label": "client.test.ts",
       "source_file": "packages/athena-webapp/convex/mtn/client.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 968,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_mtn_config_test_ts",
-      "label": "config.test.ts",
-      "norm_label": "config.test.ts",
-      "source_file": "packages/athena-webapp/convex/mtn/config.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 969,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_mtn_normalize_test_ts",
-      "label": "normalize.test.ts",
-      "norm_label": "normalize.test.ts",
-      "source_file": "packages/athena-webapp/convex/mtn/normalize.test.ts",
       "source_location": "L1"
     },
     {
@@ -105801,6 +105936,24 @@
     {
       "community": 970,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_mtn_config_test_ts",
+      "label": "config.test.ts",
+      "norm_label": "config.test.ts",
+      "source_file": "packages/athena-webapp/convex/mtn/config.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 971,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_mtn_normalize_test_ts",
+      "label": "normalize.test.ts",
+      "norm_label": "normalize.test.ts",
+      "source_file": "packages/athena-webapp/convex/mtn/normalize.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 972,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_types_ts",
       "label": "types.ts",
       "norm_label": "types.ts",
@@ -105808,7 +105961,7 @@
       "source_location": "L1"
     },
     {
-      "community": 971,
+      "community": 973,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_customerprofiles_test_ts",
       "label": "customerProfiles.test.ts",
@@ -105817,7 +105970,7 @@
       "source_location": "L1"
     },
     {
-      "community": 972,
+      "community": 974,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_inventorymovements_test_ts",
       "label": "inventoryMovements.test.ts",
@@ -105826,7 +105979,7 @@
       "source_location": "L1"
     },
     {
-      "community": 973,
+      "community": 975,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_paymentallocations_test_ts",
       "label": "paymentAllocations.test.ts",
@@ -105835,7 +105988,7 @@
       "source_location": "L1"
     },
     {
-      "community": 974,
+      "community": 976,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_otp_emailotp_test_ts",
       "label": "EmailOTP.test.ts",
@@ -105844,7 +105997,7 @@
       "source_location": "L1"
     },
     {
-      "community": 975,
+      "community": 977,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_correcttransactioncustomer_test_ts",
       "label": "correctTransactionCustomer.test.ts",
@@ -105853,7 +106006,7 @@
       "source_location": "L1"
     },
     {
-      "community": 976,
+      "community": 978,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_corrections_correctionevents_test_ts",
       "label": "correctionEvents.test.ts",
@@ -105862,30 +106015,12 @@
       "source_location": "L1"
     },
     {
-      "community": 977,
+      "community": 979,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_corrections_correctionpolicy_test_ts",
       "label": "correctionPolicy.test.ts",
       "norm_label": "correctionpolicy.test.ts",
       "source_file": "packages/athena-webapp/convex/pos/application/corrections/correctionPolicy.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 978,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_dto_ts",
-      "label": "dto.ts",
-      "norm_label": "dto.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/dto.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 979,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_getregisterstate_test_ts",
-      "label": "getRegisterState.test.ts",
-      "norm_label": "getregisterstate.test.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/getRegisterState.test.ts",
       "source_location": "L1"
     },
     {
@@ -105963,6 +106098,24 @@
     {
       "community": 980,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_dto_ts",
+      "label": "dto.ts",
+      "norm_label": "dto.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/dto.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 981,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_getregisterstate_test_ts",
+      "label": "getRegisterState.test.ts",
+      "norm_label": "getregisterstate.test.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/getRegisterState.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 982,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_possessiontracing_test_ts",
       "label": "posSessionTracing.test.ts",
       "norm_label": "possessiontracing.test.ts",
@@ -105970,7 +106123,7 @@
       "source_location": "L1"
     },
     {
-      "community": 981,
+      "community": 983,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_terminals_test_ts",
       "label": "terminals.test.ts",
@@ -105979,7 +106132,7 @@
       "source_location": "L1"
     },
     {
-      "community": 982,
+      "community": 984,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_domain_types_ts",
       "label": "types.ts",
@@ -105988,7 +106141,7 @@
       "source_location": "L1"
     },
     {
-      "community": 983,
+      "community": 985,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_registersessionrepository_test_ts",
       "label": "registerSessionRepository.test.ts",
@@ -105997,7 +106150,7 @@
       "source_location": "L1"
     },
     {
-      "community": 984,
+      "community": 986,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_catalog_ts",
       "label": "catalog.ts",
@@ -106006,7 +106159,7 @@
       "source_location": "L1"
     },
     {
-      "community": 985,
+      "community": 987,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_customers_ts",
       "label": "customers.ts",
@@ -106015,7 +106168,7 @@
       "source_location": "L1"
     },
     {
-      "community": 986,
+      "community": 988,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_register_ts",
       "label": "register.ts",
@@ -106024,30 +106177,12 @@
       "source_location": "L1"
     },
     {
-      "community": 987,
+      "community": 989,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_terminals_ts",
       "label": "terminals.ts",
       "norm_label": "terminals.ts",
       "source_file": "packages/athena-webapp/convex/pos/public/terminals.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 988,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schema_ts",
-      "label": "schema.ts",
-      "norm_label": "schema.ts",
-      "source_file": "packages/athena-webapp/convex/schema.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 989,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_customermessaging_customermessagedelivery_ts",
-      "label": "customerMessageDelivery.ts",
-      "norm_label": "customermessagedelivery.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/customerMessaging/customerMessageDelivery.ts",
       "source_location": "L1"
     },
     {
@@ -106125,6 +106260,24 @@
     {
       "community": 990,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schema_ts",
+      "label": "schema.ts",
+      "norm_label": "schema.ts",
+      "source_file": "packages/athena-webapp/convex/schema.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 991,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_customermessaging_customermessagedelivery_ts",
+      "label": "customerMessageDelivery.ts",
+      "norm_label": "customermessagedelivery.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/customerMessaging/customerMessageDelivery.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 992,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_customermessaging_index_ts",
       "label": "index.ts",
       "norm_label": "index.ts",
@@ -106132,7 +106285,7 @@
       "source_location": "L1"
     },
     {
-      "community": 991,
+      "community": 993,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_customermessaging_receiptsharetoken_ts",
       "label": "receiptShareToken.ts",
@@ -106141,7 +106294,7 @@
       "source_location": "L1"
     },
     {
-      "community": 992,
+      "community": 994,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_appverificationcode_ts",
       "label": "appVerificationCode.ts",
@@ -106150,7 +106303,7 @@
       "source_location": "L1"
     },
     {
-      "community": 993,
+      "community": 995,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_athenauser_ts",
       "label": "athenaUser.ts",
@@ -106159,7 +106312,7 @@
       "source_location": "L1"
     },
     {
-      "community": 994,
+      "community": 996,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_bannermessage_ts",
       "label": "bannerMessage.ts",
@@ -106168,7 +106321,7 @@
       "source_location": "L1"
     },
     {
-      "community": 995,
+      "community": 997,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_bestseller_ts",
       "label": "bestSeller.ts",
@@ -106177,7 +106330,7 @@
       "source_location": "L1"
     },
     {
-      "community": 996,
+      "community": 998,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_category_ts",
       "label": "category.ts",
@@ -106186,30 +106339,12 @@
       "source_location": "L1"
     },
     {
-      "community": 997,
+      "community": 999,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_color_ts",
       "label": "color.ts",
       "norm_label": "color.ts",
       "source_file": "packages/athena-webapp/convex/schemas/inventory/color.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 998,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_inventory_complimentaryproduct_ts",
-      "label": "complimentaryProduct.ts",
-      "norm_label": "complimentaryproduct.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/inventory/complimentaryProduct.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 999,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_inventory_featureditem_ts",
-      "label": "featuredItem.ts",
-      "norm_label": "featureditem.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/inventory/featuredItem.ts",
       "source_location": "L1"
     }
   ]

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -7,10 +7,10 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 - [packages/AGENTS.md](../../packages/AGENTS.md) - package router plus the operational guides for each harnessed package
 
 ## Repo Summary
-- Code files discovered: 1679
-- Graph nodes: 5054
-- Graph edges: 5060
-- Communities: 1608
+- Code files discovered: 1681
+- Graph nodes: 5061
+- Graph edges: 5066
+- Communities: 1610
 
 ## Graph Hotspots
 - `DailyCloseView.tsx` (74 edges, Community 0) - [`packages/athena-webapp/src/components/operations/DailyCloseView.tsx`](../../packages/athena-webapp/src/components/operations/DailyCloseView.tsx)

--- a/graphify-out/wiki/packages/storefront-webapp.md
+++ b/graphify-out/wiki/packages/storefront-webapp.md
@@ -19,9 +19,9 @@ Landing page for packages/storefront-webapp. Use this page to orient around grap
 ## Graph Hotspots
 - `storefrontJourneyEvents.ts` (45 edges, Community 3) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
 - `createJourneyEvent()` (40 edges, Community 3) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
-- `getStoreConfigV2()` (17 edges, Community 21) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)
+- `getStoreConfigV2()` (17 edges, Community 22) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)
 - `checkoutSession.ts` (14 edges, Community 47) - [`packages/storefront-webapp/src/api/checkoutSession.ts`](../../../packages/storefront-webapp/src/api/checkoutSession.ts)
-- `storeConfig.ts` (14 edges, Community 21) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)
+- `storeConfig.ts` (14 edges, Community 22) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)
 
 ## Navigation
 - [wiki index](../index.md) - back to the wiki index

--- a/package.json
+++ b/package.json
@@ -20,9 +20,10 @@
     "harness:review": "bun scripts/harness-review.ts",
     "harness:test": "bun scripts/harness-test.ts",
     "github:pr-merge": "bun scripts/github-pr-merge.ts",
+    "workflow:check": "bun scripts/github-workflows-check.ts",
     "pre-commit:generated-artifacts": "bun scripts/pre-commit-generated-artifacts.ts",
     "pre-push:review": "bun scripts/pre-push-review.ts",
-    "pr:athena": "bun run pre-commit:generated-artifacts && bun run compound:check && bun run --filter '@athena/webapp' audit:convex && bun run --filter '@athena/webapp' lint:convex:changed && bun run --filter '@athena/webapp' lint:frontend:changed && bun run architecture:check && bun run test:coverage && bun run harness:test && bun run harness:check && bun run harness:review --base origin/main --repo-validation-provided-by pr:athena && bun run harness:inferential-review && bun run harness:audit && bun run harness:scorecard && bun run graphify:check && bun scripts/pre-push-validation-proof.ts record-pr-athena",
+    "pr:athena": "bun run pre-commit:generated-artifacts && bun run compound:check && bun run workflow:check && bun run --filter '@athena/webapp' audit:convex && bun run --filter '@athena/webapp' lint:convex:changed && bun run --filter '@athena/webapp' lint:frontend:changed && bun run architecture:check && bun run test:coverage && bun run harness:test && bun run harness:check && bun run harness:review --base origin/main --repo-validation-provided-by pr:athena && bun run harness:inferential-review && bun run harness:audit && bun run harness:scorecard && bun run graphify:check && bun scripts/pre-push-validation-proof.ts record-pr-athena",
     "test": "bun run --filter '@athena/webapp' test && bun run --filter '@athena/storefront-webapp' test",
     "test:coverage:scripts": "bun scripts/root-scripts-coverage.ts",
     "test:coverage": "bun scripts/coverage-toolchain-parity.ts --repair && bun run --filter '@athena/webapp' test:coverage && bun run --filter '@athena/storefront-webapp' test:coverage && bun run test:coverage:scripts && bun scripts/coverage-summary.ts"

--- a/packages/athena-webapp/src/components/operations/DailyOperationsView.test.tsx
+++ b/packages/athena-webapp/src/components/operations/DailyOperationsView.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen, within } from "@testing-library/react";
 import type { AnchorHTMLAttributes, ReactNode } from "react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
   DailyOperationsView,
@@ -386,10 +386,16 @@ function renderContent(
 
 describe("DailyOperationsViewContent", () => {
   beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 4, 10, 12));
     window.scrollTo = vi.fn();
     window.history.pushState({}, "", "/wigclub/store/osu/operations");
     mockedHooks.navigate.mockReset();
     mockedHooks.useSearch.mockReturnValue({});
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it("renders historical metrics with view-only workflow messaging", () => {

--- a/scripts/github-workflows-check.test.ts
+++ b/scripts/github-workflows-check.test.ts
@@ -1,0 +1,93 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { collectWorkflowFiles, runWorkflowCheck } from "./github-workflows-check";
+
+const tempRoots: string[] = [];
+
+async function createFixtureRoot() {
+  const rootDir = await mkdtemp(path.join(tmpdir(), "athena-workflow-check-"));
+  tempRoots.push(rootDir);
+  return rootDir;
+}
+
+async function write(relativePath: string, contents: string, rootDir: string) {
+  const filePath = path.join(rootDir, relativePath);
+  await mkdir(path.dirname(filePath), { recursive: true });
+  await writeFile(filePath, contents);
+}
+
+afterEach(async () => {
+  await Promise.all(
+    tempRoots.splice(0).map((rootDir) =>
+      rm(rootDir, { recursive: true, force: true })
+    )
+  );
+});
+
+describe("collectWorkflowFiles", () => {
+  it("collects only root GitHub workflow YAML files", async () => {
+    const rootDir = await createFixtureRoot();
+    await write(".github/workflows/athena-pr-tests.yml", "name: Test\n", rootDir);
+    await write(".github/workflows/qa.yaml", "name: QA\n", rootDir);
+    await write(".github/workflows/notes.md", "# ignored\n", rootDir);
+    await write(".github/workflows/nested/ignored.yml", "name: nested\n", rootDir);
+
+    await expect(collectWorkflowFiles(rootDir)).resolves.toEqual([
+      ".github/workflows/athena-pr-tests.yml",
+      ".github/workflows/qa.yaml",
+    ]);
+  });
+});
+
+describe("runWorkflowCheck", () => {
+  it("parses workflows with Ruby YAML instead of depending on PyYAML", async () => {
+    const rootDir = await createFixtureRoot();
+    await write(".github/workflows/athena-pr-tests.yml", "name: Test\non: pull_request\n", rootDir);
+
+    const spawnedCommands: string[][] = [];
+    const logLines: string[] = [];
+
+    await runWorkflowCheck(rootDir, {
+      logger: { log: (line) => logLines.push(line) },
+      spawn: (command) => {
+        spawnedCommands.push(command);
+        return { exited: Promise.resolve(0) };
+      },
+    });
+
+    expect(spawnedCommands).toEqual([
+      [
+        "ruby",
+        "-ryaml",
+        "-e",
+        "YAML.load_file(ARGV.fetch(0)); puts \"[workflow:check] parsed #{ARGV.fetch(0)}\"",
+        ".github/workflows/athena-pr-tests.yml",
+      ],
+    ]);
+    expect(logLines).toEqual([
+      "GitHub workflow YAML check passed for 1 workflow file(s).",
+    ]);
+  });
+
+  it("fails with the workflow path when YAML parsing fails", async () => {
+    const rootDir = await createFixtureRoot();
+    await write(".github/workflows/athena-pr-tests.yml", "name: [broken\n", rootDir);
+
+    await expect(
+      runWorkflowCheck(rootDir, {
+        spawn: () => ({ exited: Promise.resolve(1) }),
+      })
+    ).rejects.toThrow(
+      "GitHub workflow YAML check failed for .github/workflows/athena-pr-tests.yml"
+    );
+  });
+
+  it("parses the current repo workflows", async () => {
+    await expect(
+      runWorkflowCheck(path.resolve(import.meta.dirname, ".."))
+    ).resolves.toBeUndefined();
+  });
+});

--- a/scripts/github-workflows-check.ts
+++ b/scripts/github-workflows-check.ts
@@ -1,0 +1,76 @@
+import { readdir } from "node:fs/promises";
+import path from "node:path";
+
+type SpawnedProcess = {
+  exited: Promise<number>;
+};
+
+type WorkflowCheckOptions = {
+  spawn?: (
+    command: string[],
+    options: { cwd: string; stdout: "inherit"; stderr: "inherit" }
+  ) => SpawnedProcess;
+  logger?: Pick<Console, "log">;
+};
+
+const WORKFLOW_DIRECTORY = ".github/workflows";
+const WORKFLOW_FILE_PATTERN = /\.ya?ml$/i;
+
+export async function collectWorkflowFiles(rootDir: string) {
+  const workflowDir = path.join(rootDir, WORKFLOW_DIRECTORY);
+  const entries = await readdir(workflowDir, { withFileTypes: true });
+
+  return entries
+    .filter((entry) => entry.isFile() && WORKFLOW_FILE_PATTERN.test(entry.name))
+    .map((entry) => path.join(WORKFLOW_DIRECTORY, entry.name))
+    .sort((left, right) => left.localeCompare(right));
+}
+
+export async function runWorkflowCheck(
+  rootDir: string,
+  options: WorkflowCheckOptions = {}
+) {
+  const workflowFiles = await collectWorkflowFiles(rootDir);
+  const spawn = options.spawn ?? Bun.spawn;
+  const logger = options.logger ?? console;
+
+  if (workflowFiles.length === 0) {
+    throw new Error(`No GitHub workflow YAML files found in ${WORKFLOW_DIRECTORY}.`);
+  }
+
+  for (const workflowFile of workflowFiles) {
+    const proc = spawn(
+      [
+        "ruby",
+        "-ryaml",
+        "-e",
+        "YAML.load_file(ARGV.fetch(0)); puts \"[workflow:check] parsed #{ARGV.fetch(0)}\"",
+        workflowFile,
+      ],
+      {
+        cwd: rootDir,
+        stdout: "inherit",
+        stderr: "inherit",
+      }
+    );
+
+    const exitCode = await proc.exited;
+    if (exitCode !== 0) {
+      throw new Error(
+        `GitHub workflow YAML check failed for ${workflowFile} (exit ${exitCode}).`
+      );
+    }
+  }
+
+  logger.log(`GitHub workflow YAML check passed for ${workflowFiles.length} workflow file(s).`);
+}
+
+if (import.meta.main) {
+  try {
+    await runWorkflowCheck(path.resolve(import.meta.dirname, ".."));
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(message);
+    process.exit(1);
+  }
+}

--- a/scripts/harness-inferential-review.test.ts
+++ b/scripts/harness-inferential-review.test.ts
@@ -472,6 +472,41 @@ describe("runHarnessInferentialReview", () => {
     expect(result.machine.findings).toEqual([]);
   });
 
+  it("accepts the athena-pr-tests validation provider flag in the PR workflow", async () => {
+    const rootDir = await createFixtureRepo();
+    await write(
+      ".github/workflows/athena-pr-tests.yml",
+      [
+        "name: Athena PR Tests",
+        "jobs:",
+        "  harness-validation:",
+        "    steps:",
+        "      - name: Harness check",
+        "        run: bun run harness:check",
+        "      - name: Targeted harness review",
+        "        run: bun run harness:review --base origin/main --validation-provided-by athena-pr-tests",
+        "      - name: Inferential harness review",
+        "        env:",
+        "          HARNESS_INFERENTIAL_SEMANTIC_MODE: shadow",
+        "        run: bun run harness:inferential-review",
+        "      - name: Harness audit",
+        "        run: bun run harness:audit",
+        "      - name: Graphify check",
+        "        run: bun run graphify:check",
+      ].join("\n"),
+      rootDir
+    );
+
+    const result = await runHarnessInferentialReview(rootDir, {
+      getChangedFiles: async () => [".github/workflows/athena-pr-tests.yml"],
+      nowIso: () => "2026-04-12T05:00:00.000Z",
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.machine.status).toBe("pass");
+    expect(result.machine.findings).toEqual([]);
+  });
+
   it("does not treat commented harness review text as a real workflow gate", async () => {
     const rootDir = await createFixtureRepo();
     await write(

--- a/scripts/harness-inferential-review.ts
+++ b/scripts/harness-inferential-review.ts
@@ -289,7 +289,7 @@ function buildShellCommandPattern(commandBody: string) {
 
 function hasHarnessReviewCommand(value: string, baseRef: string) {
   const pattern = buildShellCommandPattern(
-    `bun\\s+run\\s+harness:review\\s+--base(?:\\s+|=)${escapeRegExp(baseRef)}(?:\\s+--repo-validation-provided-by\\s+pr:athena)?`
+    `bun\\s+run\\s+harness:review\\s+--base(?:\\s+|=)${escapeRegExp(baseRef)}(?:\\s+--repo-validation-provided-by\\s+pr:athena)?(?:\\s+--validation-provided-by\\s+athena-pr-tests)?`
   );
   return pattern.test(value);
 }

--- a/scripts/harness-repo-validation.test.ts
+++ b/scripts/harness-repo-validation.test.ts
@@ -50,6 +50,7 @@ describe("collectHarnessRepoValidationSelection", () => {
       },
     ]);
     expect(selection.selectedCommands).toEqual([
+      "bun run workflow:check",
       "bun run harness:test",
       "bun run compound:check",
       "bun run test:coverage",

--- a/scripts/harness-repo-validation.ts
+++ b/scripts/harness-repo-validation.ts
@@ -12,6 +12,7 @@ const HARNESS_REPO_VALIDATION_PATTERNS = [
 ] as const;
 
 const HARNESS_REPO_VALIDATION_COMMANDS = [
+  "bun run workflow:check",
   "bun run harness:test",
   "bun run compound:check",
   "bun run test:coverage",

--- a/scripts/harness-review.test.ts
+++ b/scripts/harness-review.test.ts
@@ -440,6 +440,7 @@ describe("runHarnessReview", () => {
 
     expect(steps).toEqual([
       "harness:check",
+      "bun run workflow:check",
       "bun run harness:test",
       "bun run compound:check",
       "bun run test:coverage",
@@ -667,6 +668,7 @@ describe("runHarnessReview", () => {
 
     expect(steps).toEqual([
       "harness:check",
+      "raw:bun run workflow:check",
       "raw:bun run harness:test",
       "raw:bun run compound:check",
       "raw:bun run test:coverage",
@@ -677,6 +679,7 @@ describe("runHarnessReview", () => {
   it("does not rerun repo-level validations when pr:athena already provides them", async () => {
     const rootDir = await createFixtureRepo();
     const steps: string[] = [
+      "raw:bun run workflow:check",
       "raw:bun run compound:check",
       "raw:bun run test:coverage",
       "raw:bun run harness:test",
@@ -700,11 +703,182 @@ describe("runHarnessReview", () => {
     steps.push("raw:bun run harness:inferential-review");
 
     expect(steps).toEqual([
+      "raw:bun run workflow:check",
       "raw:bun run compound:check",
       "raw:bun run test:coverage",
       "raw:bun run harness:test",
       "harness:check",
       "raw:bun run harness:inferential-review",
+    ]);
+  });
+
+  it("lets athena-pr-tests provide broad package commands while still running selected behavior", async () => {
+    const rootDir = await createFixtureRepo();
+    const steps: string[] = [];
+
+    await write(
+      "packages/athena-webapp/package.json",
+      JSON.stringify(
+        {
+          name: "@athena/webapp",
+          scripts: {
+            "audit:convex": "echo audit",
+            build: "echo build",
+            "lint:architecture": "echo architecture",
+            "lint:convex:changed": "echo lint convex",
+            "lint:frontend:changed": "echo lint frontend",
+            test: "echo test",
+          },
+        },
+        null,
+        2
+      ),
+      rootDir
+    );
+    await write(
+      "packages/athena-webapp/docs/agent/validation-map.json",
+      JSON.stringify(
+        {
+          workspace: "@athena/webapp",
+          packageDir: "packages/athena-webapp",
+          surfaces: [
+            {
+              name: "daily-store-operations-lifecycle-edits",
+              pathPrefixes: [
+                "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
+              ],
+              commands: [
+                {
+                  kind: "raw",
+                  command:
+                    "bun run --filter '@athena/webapp' test -- src/components/operations/DailyCloseView.test.tsx",
+                },
+                { kind: "script", script: "audit:convex" },
+                { kind: "script", script: "lint:convex:changed" },
+                { kind: "script", script: "lint:frontend:changed" },
+                {
+                  kind: "raw",
+                  command:
+                    "bunx tsc --noEmit -p packages/athena-webapp/tsconfig.json",
+                },
+                { kind: "script", script: "build" },
+              ],
+              behaviorScenarios: ["athena-admin-shell-boot"],
+            },
+          ],
+        },
+        null,
+        2
+      ),
+      rootDir
+    );
+    await write(
+      "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
+      "export const dailyClose = true;\n",
+      rootDir
+    );
+
+    await runHarnessReview(rootDir, {
+      getChangedFiles: async () => [
+        "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
+      ],
+      validationProvidedBy: "athena-pr-tests",
+      runHarnessCheck: async () => {
+        steps.push("harness:check");
+      },
+      runPackageScript: async (workspace, script) => {
+        steps.push(`${workspace}:${script}`);
+      },
+      runRawCommand: async (command) => {
+        steps.push(`raw:${command}`);
+      },
+      runHarnessBehaviorScenario: async (scenario) => {
+        steps.push(`behavior:${scenario}`);
+      },
+      logger: {
+        log() {},
+        error() {},
+      },
+    });
+
+    expect(steps).toEqual([
+      "harness:check",
+      "behavior:athena-admin-shell-boot",
+    ]);
+  });
+
+  it("does not skip package commands that athena-pr-tests does not provide", async () => {
+    const rootDir = await createFixtureRepo();
+    const steps: string[] = [];
+
+    await write(
+      "packages/storefront-webapp/package.json",
+      JSON.stringify(
+        {
+          name: "@athena/storefront-webapp",
+          scripts: {
+            test: "echo test",
+            "test:e2e": "echo e2e",
+          },
+        },
+        null,
+        2
+      ),
+      rootDir
+    );
+    await write(
+      "packages/storefront-webapp/docs/agent/validation-map.json",
+      JSON.stringify(
+        {
+          workspace: "@athena/storefront-webapp",
+          packageDir: "packages/storefront-webapp",
+          surfaces: [
+            {
+              name: "full-browser-journeys-and-payment-redirects",
+              pathPrefixes: ["packages/storefront-webapp/tests/e2e"],
+              commands: [
+                { kind: "script", script: "test" },
+                { kind: "script", script: "test:e2e" },
+              ],
+              behaviorScenarios: ["storefront-checkout-bootstrap"],
+            },
+          ],
+        },
+        null,
+        2
+      ),
+      rootDir
+    );
+    await write(
+      "packages/storefront-webapp/tests/e2e/checkout.spec.ts",
+      "export const checkout = true;\n",
+      rootDir
+    );
+
+    await runHarnessReview(rootDir, {
+      getChangedFiles: async () => [
+        "packages/storefront-webapp/tests/e2e/checkout.spec.ts",
+      ],
+      validationProvidedBy: "athena-pr-tests",
+      runHarnessCheck: async () => {
+        steps.push("harness:check");
+      },
+      runPackageScript: async (workspace, script) => {
+        steps.push(`${workspace}:${script}`);
+      },
+      runHarnessBehaviorScenario: async (scenario) => {
+        steps.push(`behavior:${scenario}`);
+      },
+      logger: {
+        log() {},
+        error() {},
+      },
+    });
+
+    expect(steps).toEqual([
+      "harness:check",
+      "@athena/storefront-webapp:test:e2e",
+      "behavior:storefront-checkout-bootstrap",
     ]);
   });
 
@@ -1011,6 +1185,7 @@ describe("runHarnessReview", () => {
 
     expect(steps).toEqual([
       "harness:check",
+      "raw:bun run workflow:check",
       "raw:bun run harness:test",
       "raw:bun run compound:check",
       "raw:bun run test:coverage",
@@ -1078,6 +1253,19 @@ describe("parseHarnessReviewArgs", () => {
     });
   });
 
+  it("accepts athena-pr-tests as the workflow validation provider", () => {
+    expect(
+      parseHarnessReviewArgs([
+        "--base=origin/main",
+        "--validation-provided-by",
+        "athena-pr-tests",
+      ])
+    ).toEqual({
+      baseRef: "origin/main",
+      validationProvidedBy: "athena-pr-tests",
+    });
+  });
+
   it("rejects missing --base values", () => {
     expect(() => parseHarnessReviewArgs(["--base"])).toThrow(
       "Missing value for --base. Usage: bun run harness:review --base origin/main"
@@ -1089,6 +1277,14 @@ describe("parseHarnessReviewArgs", () => {
       parseHarnessReviewArgs(["--repo-validation-provided-by", "custom"])
     ).toThrow(
       "Missing or invalid value for --repo-validation-provided-by. Supported value: pr:athena"
+    );
+  });
+
+  it("rejects unknown workflow validation providers", () => {
+    expect(() =>
+      parseHarnessReviewArgs(["--validation-provided-by", "custom"])
+    ).toThrow(
+      "Missing or invalid value for --validation-provided-by. Supported value: athena-pr-tests"
     );
   });
 });

--- a/scripts/harness-review.ts
+++ b/scripts/harness-review.ts
@@ -39,6 +39,7 @@ type HarnessReviewLogger = Pick<Console, "log" | "error">;
 type ParsedHarnessReviewArgs = {
   baseRef?: string;
   repoValidationProvidedBy?: "pr:athena";
+  validationProvidedBy?: "athena-pr-tests";
 };
 
 type HarnessReviewOptions = {
@@ -50,6 +51,7 @@ type HarnessReviewOptions = {
   runRawCommand?: (command: string) => Promise<void>;
   runHarnessBehaviorScenario?: (scenario: string) => Promise<void>;
   repoValidationProvidedBy?: "pr:athena";
+  validationProvidedBy?: "athena-pr-tests";
 };
 
 function normalizeRepoPath(repoPath: string) {
@@ -80,6 +82,52 @@ function normalizeValidationCommand(
 
 function normalizeBehaviorScenarioName(scenario: string) {
   return scenario.trim();
+}
+
+function isAthenaPrTestsProvidedCommand(
+  command:
+    | { kind: "script"; workspace: string; script: string }
+    | { kind: "raw"; command: string }
+) {
+  if (command.kind === "script") {
+    if (command.workspace === "@athena/webapp") {
+      return new Set([
+        "audit:convex",
+        "build",
+        "lint:architecture",
+        "lint:convex:changed",
+        "lint:frontend:changed",
+        "test",
+      ]).has(command.script);
+    }
+
+    if (command.workspace === "@athena/storefront-webapp") {
+      return new Set(["build", "lint:architecture", "test"]).has(
+        command.script
+      );
+    }
+
+    return false;
+  }
+
+  const rawCommand = command.command.trim();
+
+  if (
+    rawCommand.startsWith("bun run --filter '@athena/webapp' test ") ||
+    rawCommand === "bunx tsc --noEmit -p packages/athena-webapp/tsconfig.json"
+  ) {
+    return true;
+  }
+
+  if (
+    rawCommand.startsWith("bun run --filter '@athena/storefront-webapp' test ") ||
+    rawCommand ===
+      "bunx tsc --noEmit -p packages/storefront-webapp/tsconfig.json"
+  ) {
+    return true;
+  }
+
+  return false;
 }
 
 function formatMissingPathPrefixError(
@@ -626,21 +674,36 @@ export async function runHarnessReview(
   }
 
   const combinedCommands = [
-    ...(options.repoValidationProvidedBy === "pr:athena"
+    ...(options.repoValidationProvidedBy === "pr:athena" ||
+    options.validationProvidedBy === "athena-pr-tests"
       ? []
       : repoValidation.selectedCommands.map((command) => ({
           kind: "raw" as const,
           command,
         }))),
     ...selectedCommands,
-  ];
+  ].filter(
+    (command) =>
+      options.validationProvidedBy !== "athena-pr-tests" ||
+      !isAthenaPrTestsProvidedCommand(command)
+  );
 
   if (
-    options.repoValidationProvidedBy === "pr:athena" &&
+    (options.repoValidationProvidedBy === "pr:athena" ||
+      options.validationProvidedBy === "athena-pr-tests") &&
     repoValidation.selectedCommands.length > 0
   ) {
     logger.log(
-      `Repo validation commands provided by pr:athena for ${repoValidation.matchedFiles.length} repo-owned changed file(s).`
+      `Repo validation commands provided by ${options.validationProvidedBy ?? options.repoValidationProvidedBy} for ${repoValidation.matchedFiles.length} repo-owned changed file(s).`
+    );
+  }
+
+  if (
+    options.validationProvidedBy === "athena-pr-tests" &&
+    selectedCommands.length > combinedCommands.length
+  ) {
+    logger.log(
+      `Package validation commands provided by athena-pr-tests for ${selectedCommands.length - combinedCommands.length} selected command(s).`
     );
   }
 
@@ -681,6 +744,7 @@ export function parseHarnessReviewArgs(
 ): ParsedHarnessReviewArgs {
   let baseRef: string | undefined;
   let repoValidationProvidedBy: "pr:athena" | undefined;
+  let validationProvidedBy: "athena-pr-tests" | undefined;
 
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index];
@@ -731,14 +795,38 @@ export function parseHarnessReviewArgs(
       continue;
     }
 
+    if (arg === "--validation-provided-by") {
+      const value = argv[index + 1]?.trim();
+      if (value !== "athena-pr-tests") {
+        throw new Error(
+          "Missing or invalid value for --validation-provided-by. Supported value: athena-pr-tests"
+        );
+      }
+      validationProvidedBy = value;
+      index += 1;
+      continue;
+    }
+
+    if (arg.startsWith("--validation-provided-by=")) {
+      const value = arg.slice("--validation-provided-by=".length).trim();
+      if (value !== "athena-pr-tests") {
+        throw new Error(
+          "Missing or invalid value for --validation-provided-by. Supported value: athena-pr-tests"
+        );
+      }
+      validationProvidedBy = value;
+      continue;
+    }
+
     throw new Error(
-      `Unknown argument: ${arg}. Usage: bun run harness:review [--base <ref>] [--repo-validation-provided-by pr:athena]`
+      `Unknown argument: ${arg}. Usage: bun run harness:review [--base <ref>] [--repo-validation-provided-by pr:athena] [--validation-provided-by athena-pr-tests]`
     );
   }
 
   return {
     baseRef,
     repoValidationProvidedBy,
+    validationProvidedBy,
   };
 }
 
@@ -748,6 +836,7 @@ if (import.meta.main) {
     await runHarnessReview(process.cwd(), {
       baseRef: parsed.baseRef,
       repoValidationProvidedBy: parsed.repoValidationProvidedBy,
+      validationProvidedBy: parsed.validationProvidedBy,
     });
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);

--- a/scripts/pre-push-review.test.ts
+++ b/scripts/pre-push-review.test.ts
@@ -792,9 +792,30 @@ describe("repo harness ergonomics", () => {
     expect(workflow).toContain("workflow_dispatch:");
     expect(workflow).toContain("harness-implementation-tests:");
     expect(workflow).toContain("fetch-depth: 0");
+    expect(workflow).toContain("run: bun run workflow:check");
+    expect(workflow).toContain("run: bun run compound:check");
     expect(workflow).toContain("run: bun run harness:self-review --base origin/main");
-    expect(workflow).toContain("run: bun run harness:review --base origin/main");
+    expect(workflow).toContain(
+      "run: bun run harness:review --base origin/main --validation-provided-by athena-pr-tests"
+    );
     expect(workflow).toContain("run: bun run harness:test");
+    expect(workflow).toContain("name: Athena and Storefront Webapp Validation");
+    expect(workflow).toContain("name: Storefront Webapp Validation Context");
+    expect(workflow).toContain("athena-webapp-validation:");
+    expect(workflow).toContain("storefront-webapp-validation-context:");
+    expect(workflow).toContain("needs: athena-webapp-validation");
+    expect(workflow).toContain("Confirm consolidated storefront validation coverage");
+    expect(workflow).toContain("run: bun run test:coverage");
+    expect(workflow).toContain("run: bun run --filter '@athena/webapp' build");
+    expect(workflow).toContain(
+      "run: bun run --filter '@athena/storefront-webapp' build"
+    );
+    expect(workflow).toContain(
+      "run: bun run --filter '@athena/webapp' lint:frontend:changed"
+    );
+    expect(workflow).not.toContain("run: bun run --filter '@athena/webapp' test");
+    expect(workflow).not.toContain("test-storefront-webapp:");
+    expect(workflow).not.toContain("cargo install ripgrep");
     expect(workflow).toContain(
       "run: python3 -m pip install -r .graphify-requirements.txt"
     );
@@ -820,6 +841,7 @@ describe("repo harness ergonomics", () => {
       "bun run pre-commit:generated-artifacts"
     );
     expect(packageJson.scripts?.["pr:athena"]).toContain("bun run compound:check");
+    expect(packageJson.scripts?.["pr:athena"]).toContain("bun run workflow:check");
     expect(packageJson.scripts?.["pr:athena"]).toContain("bun run harness:test");
     expect(packageJson.scripts?.["pr:athena"]).toContain(
       "bun run harness:review --base origin/main --repo-validation-provided-by pr:athena"


### PR DESCRIPTION
## Summary

Athena PR CI now avoids rerunning the same package validation through multiple jobs. The workflow keeps coverage as the package test authority, moves build and changed-file lint ownership into the webapp validation lane, and lets `harness:review` skip commands already provided by `athena-pr-tests` while preserving validation-map and runtime-scenario checks.

## What Changed

- Added `bun run workflow:check`, backed by Ruby YAML parsing, and wired it into `pr:athena`, CI, and repo-owned harness validation selection.
- Removed duplicate no-coverage Athena/storefront package test execution from the PR workflow.
- Added `--validation-provided-by athena-pr-tests` for CI `harness:review` so package commands covered elsewhere in the workflow are not rerun inside the harness job.
- Kept standalone `harness:review --base origin/main` fail-closed for local and agent usage.
- Documented the CI provider mode and added tests around provider parsing, command skipping, and inferential review acceptance.

## Validation

- `bun run pr:athena`
- Pre-push hook reused the recorded `pr:athena` proof and passed