### PR TITLE
[V26-544 V26-545 V26-546 V26-547 V26-548]: Add daily close reopen lifecycle

### DIFF
--- a/docs/plans/2026-05-11-001-feat-daily-close-reopen-lifecycle-plan.md
+++ b/docs/plans/2026-05-11-001-feat-daily-close-reopen-lifecycle-plan.md
@@ -1,0 +1,386 @@
+---
+title: "feat: Add Daily Close reopen lifecycle"
+type: feat
+status: active
+date: 2026-05-11
+origin: docs/brainstorms/2026-05-07-daily-operations-lifecycle-requirements.md
+---
+
+# feat: Add Daily Close reopen lifecycle
+
+## Summary
+
+Add an explicit, manager-approved reopen lifecycle for completed End-of-Day Reviews. The completed Daily Close report snapshot remains immutable audit evidence; reopening records a new lifecycle event, restores POS access for the operating date, and allows a later revised close to produce a new completed snapshot.
+
+---
+
+## Problem Frame
+
+Daily Close now persists the store-day report that operators and owners use as the trustworthy record of what was reviewed at close time. When a closed operating day needs additional action, Athena needs a way to reopen work without rewriting that completed report or letting POS ignore the closed-day boundary.
+
+---
+
+## Requirements
+
+- R1. Completed Daily Close report snapshots must remain immutable after completion.
+- R2. Reopening a completed operating day must be a manager-approved command at the operations layer.
+- R3. Reopening must record who reopened the day, when, why, and which completed close was reopened.
+- R4. Reopened activity must not mutate the original completed close snapshot; any later close must create or persist a distinct revised close record/snapshot.
+- R5. POS entry must follow the active store-day lifecycle state: closed days are blocked, reopened days are allowed if Opening Handoff is started.
+- R6. Daily Operations, End-of-Day Review, and Daily Close History must show reopened/superseded close state clearly without turning history into an edit surface.
+- R7. The reopen lifecycle must preserve existing Daily Opening, carry-forward, approval, and operational event boundaries.
+
+**Origin actors:** A1 Operator, A2 Owner or manager, A3 Staff member, A4 Athena
+**Origin flows:** F1 Daily close readiness review, F2 Exception review and carry-forward, F3 Close completion and daily summary, F4 Future opening handoff
+**Origin acceptance examples:** AE1, AE2, AE3, AE4
+
+---
+
+## Scope Boundaries
+
+- Do not edit or delete `dailyClose.reportSnapshot` for a completed close.
+- Do not implement a historical report editor.
+- Do not reopen from POS; POS only consumes the store-day lifecycle gate.
+- Do not close or resolve carry-forward work automatically during reopen.
+- Do not replace Cash Controls closeout reopen behavior; register-session reopen remains drawer/session scoped.
+- Do not add a generic audit-log explorer or analytics report.
+
+### Deferred to Follow-Up Work
+
+- Rich diffing between the original completed close and the revised close can follow after the core lifecycle exists.
+- Notifications for reopened days can follow once the operational event shape is proven.
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `packages/athena-webapp/convex/operations/dailyClose.ts` owns `buildDailyCloseSnapshotWithCtx`, `completeDailyCloseWithCtx`, stored report snapshot normalization, history queries, `isCurrent`, and completion operational events.
+- `packages/athena-webapp/convex/schemas/operations/dailyClose.ts` stores `status`, `isCurrent`, completion metadata, `reportSnapshot`, carry-forward IDs, reviewed keys, and summary data.
+- `packages/athena-webapp/convex/operations/dailyOpening.ts` starts the store day by re-reading server readiness, persisting `dailyOpening`, and recording an operational event.
+- `packages/athena-webapp/convex/operations/approvalActions.ts` centralizes approval action identities, including Daily Close completion and register-session reopen.
+- `packages/athena-webapp/src/components/operations/DailyCloseView.tsx` is the End-of-Day Review workspace and command surface for completion.
+- `packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx` lists completed close records and renders stored snapshots read-only.
+- `packages/athena-webapp/src/components/operations/DailyOperationsView.tsx` presents current and historical store-day lifecycle state.
+- `packages/athena-webapp/src/components/pos/register/POSRegisterOpeningGuard.tsx` gates POS entry using Opening Handoff and End-of-Day Review state.
+
+### Institutional Learnings
+
+- `docs/solutions/logic-errors/athena-daily-close-store-day-boundary-2026-05-07.md`: Daily Close is store-day scoped, revalidates command-time readiness, requires manager approval, and preserves completed summaries.
+- `docs/solutions/logic-errors/athena-daily-close-history-snapshots-2026-05-09.md`: completed Daily Close history must serve stored report snapshots rather than recomputing historical reports from live state.
+- `docs/solutions/logic-errors/athena-store-ops-workspace-state-boundaries-2026-05-09.md`: terminal store operations states are presentation boundaries; completed views should not let stale live blockers drive primary UI.
+- `docs/solutions/logic-errors/athena-daily-opening-readiness-gate-2026-05-08.md`: Opening is a store-day acknowledgement record and should not mutate drawers, register sessions, or carry-forward work.
+
+### External References
+
+- None. The work extends Athena's existing Convex, command-result, approval, operational event, Daily Close, Daily Opening, and POS gate patterns.
+
+---
+
+## Key Technical Decisions
+
+- **Snapshot immutability:** Treat `dailyClose.reportSnapshot` as frozen audit payload once the close is completed. Reopen state may be represented by lifecycle fields or related records, but not by editing the stored report content.
+- **Reopen is a new lifecycle transition:** Add a manager-approved reopen command that records an operational event and advances the active lifecycle state for the operating date.
+- **Prefer explicit lifecycle state over absence checks:** POS and operations surfaces should ask whether the current close is actively completed, reopened, or superseded rather than treating any completed close for the date as a hard block forever.
+- **Revised close creates a new audit point:** After reopen and additional action, completing End-of-Day Review again should produce a new completed snapshot. The original completed snapshot remains available in history as superseded/reopened evidence.
+- **Operations owns reopen:** The End-of-Day Review workspace owns the reopen command. POS, history, and Daily Operations consume the resulting state.
+
+---
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Should reopening mutate the recorded close?** No. The completed report snapshot remains immutable.
+- **Should POS be allowed to reopen a day implicitly?** No. POS only respects the lifecycle state written by End-of-Day Review.
+- **Should register-session closeout reopen be reused?** No. That command is drawer/session scoped; this plan adds store-day reopen.
+
+### Deferred to Implementation
+
+- Exact schema shape can be either additional lifecycle fields on `dailyClose` or a small related reopen record. The implementation should choose the smaller shape that preserves immutable snapshots and query simplicity.
+- Exact labels for reopened and superseded close records should be finalized with existing operator copy patterns.
+- Whether a second completion updates `isCurrent` on the original close or creates a new current close row should be finalized in backend tests before UI work.
+
+---
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+```mermaid
+stateDiagram-v2
+  [*] --> Open: End-of-Day Review not completed
+  Open --> Completed: completeDailyClose
+  Completed --> Reopened: manager-approved reopenDailyClose
+  Reopened --> CompletedAgain: completeDailyClose after reopened activity
+  CompletedAgain --> Reopened: manager-approved reopenDailyClose
+
+  note right of Completed
+    Stored reportSnapshot is immutable.
+    Reopen records lifecycle metadata/event.
+  end note
+```
+
+```mermaid
+flowchart TD
+  A[Completed Daily Close] --> B[Reopen command in End-of-Day Review]
+  B --> C[Manager approval proof]
+  C --> D[Lifecycle state: reopened/superseded]
+  D --> E[Operational event recorded]
+  D --> F[POS gate allows entry for operating date]
+  F --> G[Additional POS or operational action]
+  G --> H[Complete End-of-Day Review again]
+  H --> I[New completed report snapshot]
+  A --> J[History shows original immutable close]
+  I --> K[History shows revised close]
+```
+
+---
+
+## Implementation Units
+
+- U1. **Model immutable reopen lifecycle**
+
+**Goal:** Add the durable backend state needed to represent reopened/superseded Daily Close records without editing completed report snapshots.
+
+**Requirements:** R1, R3, R4, R7
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `packages/athena-webapp/convex/schemas/operations/dailyClose.ts`
+- Modify: `packages/athena-webapp/convex/schema.ts`
+- Modify: `packages/athena-webapp/convex/operations/dailyClose.ts`
+- Test: `packages/athena-webapp/convex/operations/dailyClose.test.ts`
+- Test: `packages/athena-webapp/convex/operations/operationsQueryIndexes.test.ts`
+
+**Approach:**
+- Extend the Daily Close lifecycle so a completed close can be marked reopened or superseded while its `reportSnapshot` stays unchanged.
+- Preserve store/date/current lookup semantics for the active close state.
+- Make the active close state queryable without scanning all completed historical records.
+- Ensure historical completed records remain listable and distinguishable from the active reopened state.
+
+**Execution note:** Characterization-first. Capture current behavior where a completed close with `reportSnapshot` is served as completed before changing lifecycle semantics.
+
+**Patterns to follow:**
+- `packages/athena-webapp/convex/operations/dailyClose.ts`
+- `packages/athena-webapp/convex/operations/operationsQueryIndexes.test.ts`
+- `docs/solutions/logic-errors/athena-daily-close-history-snapshots-2026-05-09.md`
+
+**Test scenarios:**
+- Happy path: a completed close keeps the exact stored `reportSnapshot` after it is marked reopened or superseded.
+- Happy path: active close lookup returns a reopened lifecycle state for the operating date instead of treating the old completed snapshot as the only current state.
+- Edge case: a store with multiple completed closes for one operating date identifies the current/revised close deterministically.
+- Error path: lifecycle state cannot be changed for a close belonging to another store.
+- Index coverage: schema exposes any new lookup needed for current active lifecycle state.
+
+**Verification:**
+- Daily Close backend tests prove immutable snapshot behavior, active-state lookup, and index coverage.
+
+---
+
+- U2. **Add manager-approved reopen command**
+
+**Goal:** Add the command boundary that reopens a completed End-of-Day Review with manager approval, reason capture, idempotency, and operational audit.
+
+**Requirements:** R2, R3, R4, R7
+
+**Dependencies:** U1
+
+**Files:**
+- Modify: `packages/athena-webapp/convex/operations/approvalActions.ts`
+- Modify: `packages/athena-webapp/convex/operations/dailyClose.ts`
+- Modify: `packages/athena-webapp/shared/commandResult.ts` if existing result typing needs extension
+- Test: `packages/athena-webapp/convex/operations/dailyClose.test.ts`
+- Test: `packages/athena-webapp/convex/operations/approvalRequests.test.ts` if approval subject coverage changes
+
+**Approach:**
+- Add a `dailyCloseReopen` approval action identity.
+- Add a `reopenDailyClose` command that validates store ownership, operating date, completed-close state, manager approval proof, and a required reason/note.
+- Consume approval proof server-side and record `daily_close_reopened` as an operational event with close id, operating date, approved manager staff profile, reason, and prior completion metadata.
+- Make repeated reopen attempts idempotent when the day is already reopened, while rejecting attempts for missing, open, or unrelated close records.
+
+**Execution note:** Test-first for the new command behavior.
+
+**Patterns to follow:**
+- `completeDailyCloseWithCtx` in `packages/athena-webapp/convex/operations/dailyClose.ts`
+- `startStoreDayWithCtx` in `packages/athena-webapp/convex/operations/dailyOpening.ts`
+- `consumeCommandApprovalProofWithCtx` in `packages/athena-webapp/convex/operations/approvalActions.ts`
+
+**Test scenarios:**
+- Happy path: completed close plus valid manager approval proof reopens the day, records lifecycle metadata, and emits an operational event.
+- Approval path: missing proof returns `approval_required` with a Daily Close reopen subject.
+- Error path: invalid proof or insufficient manager role fails without changing close state.
+- Error path: reopening an open, missing, or other-store close returns a user error without side effects.
+- Idempotency: repeating reopen after success returns already-reopened state without duplicating audit events.
+- Audit path: operational event metadata includes close id, operating date, reason, actor, and approval proof id.
+
+**Verification:**
+- Backend command tests prove approval enforcement, idempotency, immutable snapshot preservation, and audit event creation.
+
+---
+
+- U3. **Update store-day read models and POS gate**
+
+**Goal:** Teach Daily Close, Daily Operations, Daily Opening context, and POS entry to consume the reopened lifecycle state correctly.
+
+**Requirements:** R4, R5, R6, R7
+
+**Dependencies:** U1, U2
+
+**Files:**
+- Modify: `packages/athena-webapp/convex/operations/dailyClose.ts`
+- Modify: `packages/athena-webapp/convex/operations/dailyOperations.ts`
+- Modify: `packages/athena-webapp/convex/operations/dailyOpening.ts`
+- Modify: `packages/athena-webapp/src/components/pos/register/POSRegisterOpeningGuard.tsx`
+- Test: `packages/athena-webapp/convex/operations/dailyClose.test.ts`
+- Test: `packages/athena-webapp/convex/operations/dailyOperations.test.ts`
+- Test: `packages/athena-webapp/convex/operations/dailyOpening.test.ts`
+- Test: `packages/athena-webapp/src/components/pos/register/POSRegisterOpeningGuard.test.tsx`
+
+**Approach:**
+- Return a clear reopened lifecycle state from `getDailyCloseSnapshot` for the active operating date.
+- Keep completed/superseded stored snapshots available for history, but do not use superseded completion alone to block POS.
+- Update Daily Operations lifecycle cards and timeline inputs so reopened days communicate that End-of-Day Review was reopened and needs a revised close.
+- Ensure Opening Handoff does not treat a reopened prior close as an ordinary clean prior close unless the active lifecycle has completed again.
+- Update the POS gate so `completed` blocks entry, `reopened` allows entry when Opening Handoff has started, and loading states wait for both opening and close snapshots.
+
+**Execution note:** Characterization-first around current completed-close snapshot behavior and POS closed-day gating.
+
+**Patterns to follow:**
+- `packages/athena-webapp/src/components/pos/register/POSRegisterOpeningGuard.tsx`
+- `packages/athena-webapp/convex/operations/dailyOperations.ts`
+- `docs/solutions/logic-errors/athena-store-ops-workspace-state-boundaries-2026-05-09.md`
+
+**Test scenarios:**
+- Happy path: completed active close still blocks POS entry.
+- Happy path: reopened active close allows POS entry after Opening Handoff is started.
+- Edge case: superseded historical close does not block POS when a reopened active state exists.
+- Integration: Daily Operations shows the reopened day as requiring revised End-of-Day Review rather than as cleanly completed.
+- Opening context: next-day Opening does not treat a reopened prior close as clean unless a revised close completed.
+- Loading: POS gate waits for both opening and close state before rendering or redirecting.
+
+**Verification:**
+- Backend and component tests prove lifecycle state is consumed consistently across operations and POS.
+
+---
+
+- U4. **Add End-of-Day Review reopen UI**
+
+**Goal:** Expose the reopen action from End-of-Day Review with approval, reason capture, clear operator copy, and no history mutation affordance.
+
+**Requirements:** R2, R3, R5, R6
+
+**Dependencies:** U2, U3
+
+**Files:**
+- Modify: `packages/athena-webapp/src/components/operations/DailyCloseView.tsx`
+- Modify: `packages/athena-webapp/src/components/operations/DailyCloseView.test.tsx`
+- Modify: `packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx`
+- Modify: `packages/athena-webapp/src/components/operations/DailyCloseHistoryView.test.tsx`
+
+**Approach:**
+- Add a reopen action only on the active/current End-of-Day Review surface when the active lifecycle is completed.
+- Use the existing `useApprovedCommand` / `CommandApprovalDialog` path for manager approval.
+- Require a concise reopen reason before calling the command.
+- After successful reopen, show the reopened status and guide the operator to take needed POS or operations action before completing End-of-Day Review again.
+- Keep Daily Close History read-only. It may show reopened/superseded status and audit metadata, but it must not offer reopen actions.
+
+**Execution note:** Test-first for the action visibility and command-result paths.
+
+**Patterns to follow:**
+- `packages/athena-webapp/src/components/operations/DailyCloseView.tsx`
+- `packages/athena-webapp/src/components/operations/DailyOpeningView.tsx`
+- `packages/athena-webapp/src/components/operations/CommandApprovalDialog.tsx`
+- `docs/product-copy-tone.md`
+
+**Test scenarios:**
+- Happy path: completed current End-of-Day Review shows a reopen action that requires reason and manager approval.
+- Approval path: `approval_required` opens the shared manager approval dialog and retries with proof.
+- Success path: successful reopen updates the surface to reopened state and removes completed-day POS-blocking copy.
+- Error path: backend user errors are shown with normalized operator-facing copy.
+- Boundary: historical Daily Close detail remains read-only and does not show the reopen action.
+- Accessibility: reopen reason and approval controls have accessible labels and disabled states.
+
+**Verification:**
+- Component tests prove action visibility, approval flow, reason requirement, and read-only history boundaries.
+
+---
+
+- U5. **Refresh lifecycle docs and sensors**
+
+**Goal:** Keep repo guidance, generated graph artifacts, and reusable learnings aligned with the new reopened Daily Close behavior.
+
+**Requirements:** R1, R6, R7
+
+**Dependencies:** U1, U2, U3, U4
+
+**Files:**
+- Modify: `docs/solutions/logic-errors/athena-daily-close-store-day-boundary-2026-05-07.md`
+- Modify: `docs/solutions/logic-errors/athena-daily-close-history-snapshots-2026-05-09.md`
+- Modify: `docs/solutions/logic-errors/athena-store-ops-workspace-state-boundaries-2026-05-09.md`
+- Modify: `graphify-out/GRAPH_REPORT.md`
+- Modify: `graphify-out/graph.json`
+- Modify: `graphify-out/wiki/index.md`
+
+**Approach:**
+- Document the immutable-close plus reopen-lifecycle pattern after implementation proves the final shape.
+- Update solution docs so future agents do not treat `reportSnapshot` mutation as an acceptable reopen shortcut.
+- Rebuild Graphify once after the integrated code changes land.
+
+**Execution note:** Sensor-only after feature behavior is implemented and validated.
+
+**Patterns to follow:**
+- Existing `docs/solutions/logic-errors/athena-daily-close-*.md` entries.
+- Repo AGENTS guidance for `bun run graphify:rebuild`.
+
+**Test scenarios:**
+- Test expectation: none -- documentation and generated artifacts only. Behavior is covered in U1-U4.
+
+**Verification:**
+- Graphify artifacts are regenerated and solution docs describe immutable snapshots, reopen lifecycle, and read-only history boundaries.
+
+---
+
+## System-Wide Impact
+
+- **Interaction graph:** End-of-Day Review gains a reopen command; POSRegisterOpeningGuard, Daily Operations, Daily Opening, and Daily Close History consume the new lifecycle state.
+- **Error propagation:** Reopen follows command-result conventions: `approval_required`, user errors for invalid state/ownership, and normalized UI copy.
+- **State lifecycle risks:** The main risk is accidentally editing or hiding the original completed snapshot. Tests must assert snapshot payload preservation and historical visibility.
+- **API surface parity:** Convex generated API updates are expected for the new reopen mutation and any changed snapshot status union.
+- **Integration coverage:** Backend command tests plus component tests are needed; UI-only gating is insufficient because the command mutates durable lifecycle state.
+- **Unchanged invariants:** Cash Controls register-session reopen remains drawer/session scoped. Daily Opening remains a start-day acknowledgement and does not reopen closes. Daily Close History remains read-only.
+
+---
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Reopen accidentally rewrites historical close evidence | Assert `reportSnapshot` immutability in backend tests and keep history served from stored snapshots |
+| POS gate allows sales on a truly closed day | Keep closed vs reopened status explicit and test POS gate states |
+| Reopen becomes a hidden approval bypass | Require `approval_required` and consume manager proof server-side |
+| Multiple close records for one operating date become ambiguous | Define current/revised state lookup semantics in U1 before UI work |
+| History becomes an editing workspace | Keep reopen action only on active End-of-Day Review and test history read-only boundaries |
+
+---
+
+## Documentation / Operational Notes
+
+- Reopen should be visible in operational events so owners can audit why the business record changed after close.
+- The final implementation should update solution docs after the actual schema/command shape is known.
+- Multiple tickets will touch `graphify-out/*`; execution should regenerate Graphify once on the integration branch rather than in every parallel ticket PR.
+
+---
+
+## Sources & References
+
+- **Origin document:** [docs/brainstorms/2026-05-07-daily-operations-lifecycle-requirements.md](../brainstorms/2026-05-07-daily-operations-lifecycle-requirements.md)
+- Related requirements: [docs/brainstorms/2026-05-09-historical-daily-close-records-requirements.md](../brainstorms/2026-05-09-historical-daily-close-records-requirements.md)
+- Related plan: [docs/plans/2026-05-07-001-feat-daily-operations-lifecycle-plan.md](2026-05-07-001-feat-daily-operations-lifecycle-plan.md)
+- Related plan: [docs/plans/2026-05-08-001-feat-opening-mvp-store-readiness-gate-plan.md](2026-05-08-001-feat-opening-mvp-store-readiness-gate-plan.md)
+- Related code: `packages/athena-webapp/convex/operations/dailyClose.ts`
+- Related code: `packages/athena-webapp/convex/operations/dailyOpening.ts`
+- Related code: `packages/athena-webapp/src/components/operations/DailyCloseView.tsx`
+- Related code: `packages/athena-webapp/src/components/pos/register/POSRegisterOpeningGuard.tsx`

--- a/docs/solutions/logic-errors/athena-daily-close-history-snapshots-2026-05-09.md
+++ b/docs/solutions/logic-errors/athena-daily-close-history-snapshots-2026-05-09.md
@@ -36,6 +36,12 @@ command succeeds, then serve history from that stored snapshot. The historical
 view should list completed close records only, load details by store and
 `dailyCloseId`, and render the same report sections in read-only mode.
 
+When a completed close is reopened, the stored `reportSnapshot` remains the
+historical record. Reopen metadata can be displayed on that historical record,
+but the history surface stays read-only and does not expose the reopen command.
+If the reopened operating day is closed again, the revised completion produces a
+separate completed snapshot and marks the earlier record as superseded.
+
 This is the going-forward behavior. There is no legacy fallback requirement for
 older completed close rows without `reportSnapshot`; the detail query should
 return no historical report for those rows instead of rebuilding one from live
@@ -49,5 +55,9 @@ state.
 - Sort history newest-first by operating date.
 - Do not expose incomplete days in this first history version.
 - Do not recompute historical reports from live operational tables.
+- Do not edit a stored historical snapshot when the close is reopened or
+  superseded; use lifecycle metadata to explain the state.
+- Keep reopen actions out of Daily Close History. Reopen belongs to the active
+  End-of-Day Review workspace.
 - Add harness coverage for the history component, route, backend queries, and
   generated API surface whenever Daily Close history changes.

--- a/docs/solutions/logic-errors/athena-daily-close-store-day-boundary-2026-05-07.md
+++ b/docs/solutions/logic-errors/athena-daily-close-store-day-boundary-2026-05-07.md
@@ -63,6 +63,13 @@ dialog through `useApprovedCommand`, and the mutation consumes the one-use
 approval proof before persisting the close record. Do not rely on a
 screen-local manager prompt as the enforcement boundary.
 
+Reopening a completed Daily Close is also a store-day lifecycle mutation, not a
+history edit. Require the same manager approval boundary plus a human reason,
+record a `daily_close_reopened` operational event, and create or select an
+active open lifecycle record for the operating date. The original completed
+record remains audit evidence; a later revised completion supersedes it instead
+of rewriting its stored report.
+
 An all-zero store day is allowed to close when the server snapshot has no
 blockers, review items, carry-forward work, ready inputs, sales, cash activity,
 expenses, or variances. Treat that as an explicit zero-activity close in the UI
@@ -102,6 +109,11 @@ server-side item totals, not from stale client cart state.
   close instead of reusing ordinary completed-work copy.
 - Preserve carry-forward work as operational work items so the later opening
   workflow has a durable handoff.
+- Do not mutate `dailyClose.reportSnapshot` when reopening. Mark lifecycle state
+  explicitly and let a revised completion create the next completed snapshot.
+- POS and Opening should consume the active lifecycle state: completed blocks
+  POS, reopened permits continued work after Opening Handoff has started, and a
+  reopened prior day is not a clean close until a revised close completes.
 - Keep the snapshot query and completion mutation on the same validated
   operating-day range so the operator does not close against a different window
   than the UI displayed.

--- a/docs/solutions/logic-errors/athena-store-ops-workspace-state-boundaries-2026-05-09.md
+++ b/docs/solutions/logic-errors/athena-store-ops-workspace-state-boundaries-2026-05-09.md
@@ -57,6 +57,12 @@ Keep the raw snapshot for command submission and audit data. Presentation normal
 
 - Treat terminal states as presentation boundaries. If a workflow is completed or started, stale blocker/review details should not drive the primary UI.
 - Completed End-of-Day Review pages must render the persisted `dailyClose.reportSnapshot` instead of recomputing blockers from live register, approval, POS session, transaction, or work-item tables.
+- Reopened End-of-Day Review pages are active workflow state. Present them as
+  needing revised close work, while preserving the original completed snapshot
+  as read-only history.
+- Store-day gates should distinguish completed, reopened, and superseded close
+  records. A superseded historical close is audit context, not the active POS
+  gate for the operating date.
 - Live End-of-Day Review blocker sources must be scoped to the selected operating date. Approval blockers should follow their linked transaction or register session when available; unresolved POS sessions should intersect the operating-day range instead of using store-wide active/held state.
 - Keep current-day and historical operating-date copy separate. Historical reports should say "Net sales" and "Cash"; current-day operational views can say "Today's net sales" and "Today's cash".
 - Omit default current-day filters from navigation links. Include an operating date only when the target needs a historical date.

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 5072 nodes · 5082 edges · 1610 communities detected
+- 5084 nodes · 5104 edges · 1610 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -1624,14 +1624,14 @@
 ## God Nodes (most connected - your core abstractions)
 1. `createJourneyEvent()` - 40 edges
 2. `buildDailyCloseSnapshotWithCtx()` - 26 edges
-3. `getStoreConfigV2()` - 17 edges
-4. `DataTableViewOptions()` - 16 edges
-5. `buildDailyOpeningSnapshotWithCtx()` - 15 edges
+3. `buildDailyOpeningSnapshotWithCtx()` - 17 edges
+4. `getStoreConfigV2()` - 17 edges
+5. `DataTableViewOptions()` - 16 edges
 6. `toV2Config()` - 13 edges
 7. `validateHarnessDocs()` - 13 edges
 8. `runHarnessInferentialReview()` - 13 edges
-9. `getBaseUrl()` - 12 edges
-10. `fileExists()` - 12 edges
+9. `buildDailyOperationsSnapshotWithCtx()` - 12 edges
+10. `getBaseUrl()` - 12 edges
 
 ## Surprising Connections (you probably didn't know these)
 - `getAmountPaidForOrder()` --calls--> `getDiscountValue()`  [EXTRACTED]
@@ -1648,12 +1648,12 @@
 ## Communities
 
 ### Community 0 - "Community 0"
-Cohesion: 0.05
-Nodes (46): buildDailyCloseTransactionSearch(), cn(), formatCarriedOverRegisterCount(), formatDailyCloseMoney(), formatExpenseTransactionCount(), formatMetadataDisplayValue(), formatMetadataValue(), formatTimestampMetadata() (+38 more)
+Cohesion: 0.04
+Nodes (48): buildDailyCloseTransactionSearch(), canReopenDailyClose(), cn(), formatCarriedOverRegisterCount(), formatDailyCloseMoney(), formatExpenseTransactionCount(), formatMetadataDisplayValue(), formatMetadataValue() (+40 more)
 
 ### Community 1 - "Community 1"
 Cohesion: 0.07
-Nodes (48): approvalBelongsToRange(), approvalRequestTypeLabel(), buildDailyCloseApprovalSubject(), buildDailyCloseCompletionApprovalRequirement(), buildDailyCloseReportSnapshot(), buildDailyCloseSnapshotWithCtx(), buildExpenseSessionsById(), buildPaymentTotals() (+40 more)
+Nodes (50): approvalBelongsToRange(), approvalRequestTypeLabel(), buildDailyCloseApprovalSubject(), buildDailyCloseCompletionApprovalRequirement(), buildDailyCloseReopenApprovalRequirement(), buildDailyCloseReportSnapshot(), buildDailyCloseSnapshotWithCtx(), buildExpenseSessionsById() (+42 more)
 
 ### Community 2 - "Community 2"
 Cohesion: 0.1
@@ -1672,12 +1672,12 @@ Cohesion: 0.08
 Nodes (20): cn(), formatMetadataDisplayValue(), formatMetadataValue(), formatOperatingDate(), formatTimestamp(), getAcknowledgementKey(), getArrayMetadataStringValue(), getBucketConfigs() (+12 more)
 
 ### Community 6 - "Community 6"
-Cohesion: 0.15
-Nodes (31): collectHarnessOnboardingErrors(), collectMarkdownLinkErrors(), collectMissingRequiredLinkErrors(), collectPackageGuideLinkErrors(), collectPackagesRouterLinkErrors(), collectReadmeLinkErrors(), collectReferencedPathErrors(), collectRuntimeScenarioDocSyncErrors() (+23 more)
+Cohesion: 0.12
+Nodes (31): approvalMetadataEntries(), approvalRequestTypeLabel(), buildDailyOpeningSnapshotWithCtx(), buildReadiness(), compactMetadataEntries(), formatPaymentMethodLabel(), getDailyOpeningForDate(), getMissingCarryForwardItems() (+23 more)
 
 ### Community 7 - "Community 7"
-Cohesion: 0.12
-Nodes (29): approvalMetadataEntries(), approvalRequestTypeLabel(), buildDailyOpeningSnapshotWithCtx(), buildReadiness(), compactMetadataEntries(), formatPaymentMethodLabel(), getDailyOpeningForDate(), getMissingCarryForwardItems() (+21 more)
+Cohesion: 0.15
+Nodes (31): collectHarnessOnboardingErrors(), collectMarkdownLinkErrors(), collectMissingRequiredLinkErrors(), collectPackageGuideLinkErrors(), collectPackagesRouterLinkErrors(), collectReadmeLinkErrors(), collectReferencedPathErrors(), collectRuntimeScenarioDocSyncErrors() (+23 more)
 
 ### Community 8 - "Community 8"
 Cohesion: 0.12
@@ -1724,12 +1724,12 @@ Cohesion: 0.15
 Nodes (19): acquireExpenseQuantityPatchHold(), adjustExpenseQuantityPatchHold(), createDefaultExpenseSessionCommandService(), createExpenseInventoryHoldGateway(), createExpenseSessionCommandService(), failure(), isActiveRegisterSession(), isSessionExpired() (+11 more)
 
 ### Community 19 - "Community 19"
-Cohesion: 0.15
-Nodes (16): buildGitProcessEnv(), collectCommandsForChangedFiles(), fileExists(), formatMissingPathPrefixError(), getChangedFilesForHarnessReview(), hasAnyHarnessDocs(), loadReviewTarget(), loadReviewTargets() (+8 more)
+Cohesion: 0.17
+Nodes (21): attentionSeverity(), buildDailyOperationsSnapshotWithCtx(), buildLanes(), buildWeekMetricForDate(), buildWeekMetrics(), emptyCloseSummary(), getCloseItemCounts(), getDailyCloseRecordForDate() (+13 more)
 
 ### Community 20 - "Community 20"
-Cohesion: 0.18
-Nodes (20): attentionSeverity(), buildDailyOperationsSnapshotWithCtx(), buildLanes(), buildWeekMetricForDate(), buildWeekMetrics(), emptyCloseSummary(), getCloseItemCounts(), lifecycleCopy() (+12 more)
+Cohesion: 0.15
+Nodes (16): buildGitProcessEnv(), collectCommandsForChangedFiles(), fileExists(), formatMissingPathPrefixError(), getChangedFilesForHarnessReview(), hasAnyHarnessDocs(), loadReviewTarget(), loadReviewTargets() (+8 more)
 
 ### Community 21 - "Community 21"
 Cohesion: 0.25
@@ -1808,12 +1808,12 @@ Cohesion: 0.22
 Nodes (16): buildDegreeIndex(), buildHotspotLines(), buildPackagePage(), buildRootIndexPage(), collectRepoCodeFiles(), compareHotspots(), countCommunities(), fileExists() (+8 more)
 
 ### Community 40 - "Community 40"
-Cohesion: 0.25
-Nodes (14): buildCompleteTransactionResult(), calculateCanonicalTransactionTotals(), calculateTotalPaid(), completeTransaction(), createTransactionFromSessionHandler(), isUsableRegisterSession(), recordRegisterSessionSale(), recordRegisterSessionVoid() (+6 more)
-
-### Community 41 - "Community 41"
 Cohesion: 0.12
 Nodes (1): DataTableViewOptions()
+
+### Community 41 - "Community 41"
+Cohesion: 0.25
+Nodes (14): buildCompleteTransactionResult(), calculateCanonicalTransactionTotals(), calculateTotalPaid(), completeTransaction(), createTransactionFromSessionHandler(), isUsableRegisterSession(), recordRegisterSessionSale(), recordRegisterSessionVoid() (+6 more)
 
 ### Community 42 - "Community 42"
 Cohesion: 0.19
@@ -1836,28 +1836,28 @@ Cohesion: 0.27
 Nodes (15): assertValidOnlineOrderStatusTransition(), getOnlineOrderPaymentAmount(), getOnlineOrderPaymentMethodLabel(), getOnlineOrderStatusEventType(), getStoreOrganizationId(), isPaymentOnDeliveryOrder(), recordOnlineOrderCreatedEvent(), recordOnlineOrderFulfillmentMovement() (+7 more)
 
 ### Community 47 - "Community 47"
+Cohesion: 0.14
+Nodes (4): DailyCloseHistoryView(), getDailyCloseHistoryApi(), getHistoryRecordSnapshot(), normalizeHistorySnapshot()
+
+### Community 48 - "Community 48"
 Cohesion: 0.17
 Nodes (9): exitCorrectionWorkflow(), formatCorrectionEventType(), formatCorrectionHistoryChange(), formatCorrectionHistoryTitle(), formatPaymentMethodLabel(), getCorrectionHistoryChangeParts(), isManagerStaff(), runCustomerCorrection() (+1 more)
 
-### Community 48 - "Community 48"
+### Community 49 - "Community 49"
 Cohesion: 0.21
 Nodes (14): CheckoutSessionError, createCheckoutSession(), defaultCheckoutActionMessage(), getActiveCheckoutSession(), getBaseUrl(), getCheckoutActionErrorMessage(), getCheckoutErrorMessageFromPayload(), getCheckoutSession() (+6 more)
 
-### Community 49 - "Community 49"
+### Community 50 - "Community 50"
 Cohesion: 0.26
 Nodes (13): addGroupedError(), collectLiveSurfaceEntries(), fileExists(), formatGroupedErrors(), formatMissingValidationPathError(), hasAnyHarnessDocs(), inferGroupFromError(), loadAuditTarget() (+5 more)
 
-### Community 50 - "Community 50"
+### Community 51 - "Community 51"
 Cohesion: 0.33
 Nodes (14): adjustRegisterSessionExpectedCashForPaymentCorrection(), applyPaymentMethodCorrection(), buildPaymentMethodCorrectionApprovalRequirement(), consumePaymentMethodCorrectionApprovalProof(), correctTransactionCustomer(), correctTransactionPaymentMethod(), createPaymentMethodCorrectionApprovalRequest(), getPaymentMethodCashContribution() (+6 more)
 
-### Community 51 - "Community 51"
+### Community 52 - "Community 52"
 Cohesion: 0.17
 Nodes (6): buildServerPricedCheckoutProducts(), calculateItemsSubtotal(), deriveDeliveryOptionFromAddress(), isDeliveryFeeWaived(), normalizeDeliveryOption(), resolveServerDeliveryFee()
-
-### Community 52 - "Community 52"
-Cohesion: 0.15
-Nodes (4): DailyCloseHistoryView(), getDailyCloseHistoryApi(), getHistoryRecordSnapshot(), normalizeHistorySnapshot()
 
 ### Community 53 - "Community 53"
 Cohesion: 0.24
@@ -1932,24 +1932,24 @@ Cohesion: 0.18
 Nodes (2): formatBlockerList(), runPrePushReview()
 
 ### Community 71 - "Community 71"
-Cohesion: 0.29
-Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
-
-### Community 72 - "Community 72"
 Cohesion: 0.33
 Nodes (2): OrdersTableToolbarProvider(), useOrdersTableToolbar()
 
-### Community 73 - "Community 73"
+### Community 72 - "Community 72"
 Cohesion: 0.31
 Nodes (7): buildCustomerCreateInput(), cancelPendingAdd(), commitCustomer(), handleAddFromSearch(), handleClearCustomer(), handleSelectCustomer(), toCustomerInfo()
 
-### Community 74 - "Community 74"
+### Community 73 - "Community 73"
 Cohesion: 0.25
 Nodes (6): handleEdit(), handleReset(), handleSubmit(), itemToFormState(), parseServiceCatalogForm(), validateServiceCatalogForm()
 
-### Community 75 - "Community 75"
+### Community 74 - "Community 74"
 Cohesion: 0.18
 Nodes (0):
+
+### Community 75 - "Community 75"
+Cohesion: 0.29
+Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
 
 ### Community 76 - "Community 76"
 Cohesion: 0.18
@@ -2156,176 +2156,176 @@ Cohesion: 0.57
 Nodes (6): buildHeaders(), createCollectionsAccessToken(), encodeBasicAuth(), getRequestToPayStatus(), requestToPay(), toError()
 
 ### Community 127 - "Community 127"
+Cohesion: 0.33
+Nodes (2): completedDailyCloseRow(), completedDailyCloseSnapshot()
+
+### Community 128 - "Community 128"
 Cohesion: 0.52
 Nodes (6): buildCustomerProfileDraft(), buildFullName(), findMatchingCustomerProfile(), normalizeLookupValue(), normalizePhoneNumber(), splitFullName()
 
-### Community 128 - "Community 128"
+### Community 129 - "Community 129"
 Cohesion: 0.48
 Nodes (5): buildExpenseSessionTraceEvent(), buildExpenseSessionTraceRecord(), buildTraceSummary(), recordExpenseSessionTraceBestEffort(), safeTraceWrite()
 
-### Community 129 - "Community 129"
+### Community 130 - "Community 130"
 Cohesion: 0.43
 Nodes (4): assertRegisterNumberIsAvailable(), mapRegisterTerminalError(), normalizeRegisterNumber(), registerTerminal()
 
-### Community 130 - "Community 130"
-Cohesion: 0.29
-Nodes (0):
-
 ### Community 131 - "Community 131"
-Cohesion: 0.48
-Nodes (5): getActiveSessionForRegisterState(), listHeldSessionsForRegisterState(), querySessionsByStatus(), selectRegisterStateLookupStrategy(), summarizeRegisterStateSessions()
+Cohesion: 0.52
+Nodes (5): getRegisterCatalogPrice(), listRegisterCatalog(), mapSkuToRegisterCatalogRow(), readCategoryName(), readColorName()
 
 ### Community 132 - "Community 132"
 Cohesion: 0.29
 Nodes (0):
 
 ### Community 133 - "Community 133"
+Cohesion: 0.48
+Nodes (5): getActiveSessionForRegisterState(), listHeldSessionsForRegisterState(), querySessionsByStatus(), selectRegisterStateLookupStrategy(), summarizeRegisterStateSessions()
+
+### Community 134 - "Community 134"
+Cohesion: 0.29
+Nodes (0):
+
+### Community 135 - "Community 135"
 Cohesion: 0.33
 Nodes (2): getCustomerOperationalTimelineEvents(), resolveCustomerProfileIdForTimeline()
 
-### Community 134 - "Community 134"
+### Community 136 - "Community 136"
 Cohesion: 0.38
 Nodes (3): clearBagItems(), createOrderFromCheckoutSession(), generateOrderNumber()
 
-### Community 135 - "Community 135"
+### Community 137 - "Community 137"
 Cohesion: 0.57
 Nodes (5): getDeliveryAddress(), getLocationDetails(), getPickupLocation(), handleOrderStatusUpdate(), processOrderUpdateEmail()
 
-### Community 136 - "Community 136"
+### Community 138 - "Community 138"
 Cohesion: 0.33
 Nodes (2): appendTransition(), applyOnlineOrderUpdate()
 
-### Community 137 - "Community 137"
+### Community 139 - "Community 139"
 Cohesion: 0.38
 Nodes (3): createWorkflowTraceWithCtx(), getWorkflowTraceByIdWithCtx(), getWorkflowTraceByLookupWithCtx()
 
-### Community 138 - "Community 138"
+### Community 140 - "Community 140"
 Cohesion: 0.38
 Nodes (4): calculateCycleCountQuantityDelta(), hasHighStockAdjustmentVariance(), requiresStockAdjustmentApproval(), resolveStockAdjustmentQuantityDelta()
 
-### Community 139 - "Community 139"
+### Community 141 - "Community 141"
 Cohesion: 0.33
 Nodes (2): handleKeypadPress(), setAmountFromTouch()
 
-### Community 140 - "Community 140"
+### Community 142 - "Community 142"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 141 - "Community 141"
+### Community 143 - "Community 143"
 Cohesion: 0.48
 Nodes (4): applyCommandResult(), async(), handleSubmit(), parseDateTimeLocal()
 
-### Community 142 - "Community 142"
+### Community 144 - "Community 144"
 Cohesion: 0.38
 Nodes (3): formatDeposit(), formatMoney(), summarizeService()
 
-### Community 143 - "Community 143"
+### Community 145 - "Community 145"
 Cohesion: 0.52
 Nodes (6): deriveRegisterPhase(), hasActiveRegisterSession(), hasResumableRegisterSession(), isRegisterReadyToStart(), requiresCashier(), requiresTerminal()
 
-### Community 144 - "Community 144"
-Cohesion: 0.29
-Nodes (0):
-
-### Community 145 - "Community 145"
-Cohesion: 0.29
-Nodes (0):
-
 ### Community 146 - "Community 146"
-Cohesion: 0.33
-Nodes (2): getProductName(), sortProduct()
+Cohesion: 0.29
+Nodes (0):
 
 ### Community 147 - "Community 147"
 Cohesion: 0.29
 Nodes (0):
 
 ### Community 148 - "Community 148"
+Cohesion: 0.29
+Nodes (0):
+
+### Community 149 - "Community 149"
 Cohesion: 0.52
 Nodes (6): addItemToSavedBag(), getActiveSavedBag(), getBaseUrl(), removeItemFromSavedBag(), updateSavedBagItem(), updateSavedBagOwner()
 
-### Community 149 - "Community 149"
+### Community 150 - "Community 150"
+Cohesion: 0.33
+Nodes (2): getProductName(), sortProduct()
+
+### Community 151 - "Community 151"
 Cohesion: 0.43
 Nodes (4): createFixtureRepo(), gitEnv(), runGit(), write()
 
-### Community 150 - "Community 150"
+### Community 152 - "Community 152"
 Cohesion: 0.52
 Nodes (5): emitSignal(), handleCheckoutSessionFetch(), handleCheckoutSessionUpdate(), jsonResponse(), withCorsHeaders()
 
-### Community 151 - "Community 151"
+### Community 153 - "Community 153"
 Cohesion: 0.33
 Nodes (2): overwriteFreshGraphifyArtifacts(), write()
 
-### Community 152 - "Community 152"
+### Community 154 - "Community 154"
 Cohesion: 0.38
 Nodes (4): createFixtureRepo(), initializeGitHistory(), runGit(), write()
 
-### Community 153 - "Community 153"
+### Community 155 - "Community 155"
 Cohesion: 0.33
 Nodes (1): ValkeyClient
 
-### Community 154 - "Community 154"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 155 - "Community 155"
-Cohesion: 0.33
-Nodes (0):
-
 ### Community 156 - "Community 156"
-Cohesion: 0.53
-Nodes (4): listRegisterCatalog(), mapSkuToRegisterCatalogRow(), readCategoryName(), readColorName()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 157 - "Community 157"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 158 - "Community 158"
 Cohesion: 0.73
 Nodes (5): buildOrderStatusMessage(), buildPickupDetails(), sendPaymentVerificationEmails(), sendPODOrderEmails(), shouldSendToAdmins()
 
-### Community 158 - "Community 158"
+### Community 159 - "Community 159"
 Cohesion: 0.6
 Nodes (5): createVendorCommandWithCtx(), createVendorWithCtx(), mapCreateVendorError(), normalizeVendorLookupKey(), trimOptional()
 
-### Community 159 - "Community 159"
+### Community 160 - "Community 160"
 Cohesion: 0.6
 Nodes (5): find_block_end(), list_convex_files(), main(), scan_file(), strip_code()
 
-### Community 160 - "Community 160"
+### Community 161 - "Community 161"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 161 - "Community 161"
+### Community 162 - "Community 162"
 Cohesion: 0.53
 Nodes (4): includesRegisterSessionStatus(), isCashControlVisibleRegisterSessionStatus(), isPosUsableRegisterSessionStatus(), isRegisterSessionConflictBlockingStatus()
 
-### Community 162 - "Community 162"
+### Community 163 - "Community 163"
 Cohesion: 0.33
 Nodes (1): DataTableToolbar()
 
-### Community 163 - "Community 163"
+### Community 164 - "Community 164"
 Cohesion: 0.53
 Nodes (2): SelectedProductsProvider(), useSelectedProducts()
 
-### Community 164 - "Community 164"
+### Community 165 - "Community 165"
 Cohesion: 0.4
 Nodes (2): handlePinChange(), normalizeOtpCode()
 
-### Community 165 - "Community 165"
+### Community 166 - "Community 166"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 166 - "Community 166"
+### Community 167 - "Community 167"
 Cohesion: 0.47
 Nodes (3): historyRecord(), snapshot(), storedReportSnapshot()
 
-### Community 167 - "Community 167"
+### Community 168 - "Community 168"
 Cohesion: 0.33
 Nodes (0):
-
-### Community 168 - "Community 168"
-Cohesion: 0.4
-Nodes (2): buildApprovalRetryArgs(), getAsyncApprovalRequestId()
 
 ### Community 169 - "Community 169"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.4
+Nodes (2): buildApprovalRetryArgs(), getAsyncApprovalRequestId()
 
 ### Community 170 - "Community 170"
 Cohesion: 0.33
@@ -2336,16 +2336,16 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 172 - "Community 172"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 173 - "Community 173"
 Cohesion: 0.53
 Nodes (3): handleUpdateFees(), parseDeliveryFeeInputs(), parseOptionalDeliveryFeeInput()
 
-### Community 173 - "Community 173"
+### Community 174 - "Community 174"
 Cohesion: 0.47
 Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
-
-### Community 174 - "Community 174"
-Cohesion: 0.33
-Nodes (0):
 
 ### Community 175 - "Community 175"
 Cohesion: 0.33
@@ -2368,124 +2368,124 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 180 - "Community 180"
-Cohesion: 0.53
-Nodes (4): calculatePosChange(), calculatePosRemainingDue(), calculatePosTotalPaid(), roundPosAmount()
-
-### Community 181 - "Community 181"
 Cohesion: 0.33
 Nodes (0):
+
+### Community 181 - "Community 181"
+Cohesion: 0.53
+Nodes (4): calculatePosChange(), calculatePosRemainingDue(), calculatePosTotalPaid(), roundPosAmount()
 
 ### Community 182 - "Community 182"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 183 - "Community 183"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 184 - "Community 184"
 Cohesion: 0.4
 Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 185 - "Community 185"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 186 - "Community 186"
-Cohesion: 0.47
-Nodes (4): fetchPosTransaction(), getBaseUrl(), getPosTransactionByReceiptToken(), PosTransactionReceiptError
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 187 - "Community 187"
 Cohesion: 0.47
-Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
+Nodes (4): fetchPosTransaction(), getBaseUrl(), getPosTransactionByReceiptToken(), PosTransactionReceiptError
 
 ### Community 188 - "Community 188"
+Cohesion: 0.47
+Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
+
+### Community 189 - "Community 189"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 189 - "Community 189"
+### Community 190 - "Community 190"
 Cohesion: 0.4
 Nodes (2): handleConfirm(), handlePrimaryAction()
 
-### Community 190 - "Community 190"
+### Community 191 - "Community 191"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 191 - "Community 191"
+### Community 192 - "Community 192"
 Cohesion: 0.53
 Nodes (5): getRemainingForFreeDelivery(), hasWaiverConfigured(), isAnyFeeWaived(), isFeeWaived(), meetsThreshold()
 
-### Community 192 - "Community 192"
+### Community 193 - "Community 193"
 Cohesion: 0.47
 Nodes (3): onSubmit(), reportAuthFailure(), resendVerificationCode()
 
-### Community 193 - "Community 193"
+### Community 194 - "Community 194"
 Cohesion: 0.53
 Nodes (4): coverageSummary(), write(), writePackageSummaries(), writeRealBaselineSummaries()
 
-### Community 194 - "Community 194"
+### Community 195 - "Community 195"
 Cohesion: 0.67
 Nodes (5): collectRepoCodeFiles(), collectStaleGraphifyArtifacts(), copyGraphifyCheckInputs(), fileExists(), runGraphifyCheck()
 
-### Community 195 - "Community 195"
+### Community 196 - "Community 196"
 Cohesion: 0.4
 Nodes (2): createFixtureRoot(), write()
 
-### Community 196 - "Community 196"
+### Community 197 - "Community 197"
 Cohesion: 0.6
 Nodes (4): buildInStorePaymentAllocations(), normalizeInStorePayments(), resolveRegisterSessionForInStoreCollectionWithCtx(), selectRegisterSessionForAttribution()
-
-### Community 197 - "Community 197"
-Cohesion: 0.4
-Nodes (0):
 
 ### Community 198 - "Community 198"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 199 - "Community 199"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 200 - "Community 200"
 Cohesion: 0.6
 Nodes (3): formatStoredAmount(), toDisplayAmount(), toPesewas()
 
-### Community 200 - "Community 200"
+### Community 201 - "Community 201"
 Cohesion: 0.7
 Nodes (4): compactRecord(), ensureCustomerProfileFromSourcesWithCtx(), findExistingProfile(), loadCustomerSources()
 
-### Community 201 - "Community 201"
+### Community 202 - "Community 202"
 Cohesion: 0.5
 Nodes (2): buildInventoryMovement(), recordInventoryMovementWithCtx()
-
-### Community 202 - "Community 202"
-Cohesion: 0.4
-Nodes (0):
 
 ### Community 203 - "Community 203"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 204 - "Community 204"
-Cohesion: 0.7
-Nodes (4): buildDecision(), classifyCorrectionIntent(), isSupportedCorrectionIntent(), isUnsupportedHighRiskCorrectionIntent()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 205 - "Community 205"
 Cohesion: 0.7
-Nodes (4): getPaystackHeaders(), initializeTransaction(), initiateRefund(), verifyTransaction()
+Nodes (4): buildDecision(), classifyCorrectionIntent(), isSupportedCorrectionIntent(), isUnsupportedHighRiskCorrectionIntent()
 
 ### Community 206 - "Community 206"
+Cohesion: 0.7
+Nodes (4): getPaystackHeaders(), initializeTransaction(), initiateRefund(), verifyTransaction()
+
+### Community 207 - "Community 207"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 207 - "Community 207"
+### Community 208 - "Community 208"
 Cohesion: 0.6
 Nodes (3): buildOnlineOrderReturnExchangePlan(), getApprovalReason(), getKind()
 
-### Community 208 - "Community 208"
+### Community 209 - "Community 209"
 Cohesion: 0.5
 Nodes (2): getNonEmptyString(), normalizeStorefrontObservabilityEvent()
-
-### Community 209 - "Community 209"
-Cohesion: 0.4
-Nodes (0):
 
 ### Community 210 - "Community 210"
 Cohesion: 0.4
@@ -2504,12 +2504,12 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 214 - "Community 214"
-Cohesion: 0.5
-Nodes (2): handleFileSelect(), validateFile()
-
-### Community 215 - "Community 215"
 Cohesion: 0.4
 Nodes (0):
+
+### Community 215 - "Community 215"
+Cohesion: 0.5
+Nodes (2): handleFileSelect(), validateFile()
 
 ### Community 216 - "Community 216"
 Cohesion: 0.4
@@ -2524,20 +2524,20 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 219 - "Community 219"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 220 - "Community 220"
 Cohesion: 0.5
 Nodes (2): getBalanceDueLabel(), getBalanceDuePanel()
 
-### Community 220 - "Community 220"
+### Community 221 - "Community 221"
 Cohesion: 0.6
 Nodes (3): getSummaryAmount(), getSummaryLabel(), getSummaryPanel()
 
-### Community 221 - "Community 221"
+### Community 222 - "Community 222"
 Cohesion: 0.6
 Nodes (3): handleClearSearch(), handleQuickAddSubmit(), resetQuickAddForm()
-
-### Community 222 - "Community 222"
-Cohesion: 0.4
-Nodes (0):
 
 ### Community 223 - "Community 223"
 Cohesion: 0.4
@@ -2552,32 +2552,32 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 226 - "Community 226"
-Cohesion: 0.7
-Nodes (4): getRuntimeOrigin(), isLocalHost(), resolveStoreFrontUrl(), trimTrailingSlash()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 227 - "Community 227"
 Cohesion: 0.7
-Nodes (4): bufferToHex(), collectBrowserInfo(), generateBrowserFingerprint(), hashFingerprintSource()
+Nodes (4): getRuntimeOrigin(), isLocalHost(), resolveStoreFrontUrl(), trimTrailingSlash()
 
 ### Community 228 - "Community 228"
-Cohesion: 0.4
-Nodes (1): MockImage
+Cohesion: 0.7
+Nodes (4): bufferToHex(), collectBrowserInfo(), generateBrowserFingerprint(), hashFingerprintSource()
 
 ### Community 229 - "Community 229"
 Cohesion: 0.4
-Nodes (0):
+Nodes (1): MockImage
 
 ### Community 230 - "Community 230"
-Cohesion: 0.6
-Nodes (3): calculatePosCartTotals(), calculatePosItemTotal(), roundPosAmount()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 231 - "Community 231"
 Cohesion: 0.6
-Nodes (4): mapRegisterStateDto(), mapTerminalDto(), useConvexRegisterState(), useConvexTerminalByFingerprint()
+Nodes (3): calculatePosCartTotals(), calculatePosItemTotal(), roundPosAmount()
 
 ### Community 232 - "Community 232"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.6
+Nodes (4): mapRegisterStateDto(), mapTerminalDto(), useConvexRegisterState(), useConvexTerminalByFingerprint()
 
 ### Community 233 - "Community 233"
 Cohesion: 0.4
@@ -2592,88 +2592,88 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 236 - "Community 236"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 237 - "Community 237"
 Cohesion: 0.5
 Nodes (2): completePendingAuthSync(), sleep()
 
-### Community 237 - "Community 237"
+### Community 238 - "Community 238"
 Cohesion: 0.4
 Nodes (0):
-
-### Community 238 - "Community 238"
-Cohesion: 0.7
-Nodes (4): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory()
 
 ### Community 239 - "Community 239"
 Cohesion: 0.7
-Nodes (4): getBaseUrl(), getOrder(), getOrders(), updateOrdersOwner()
+Nodes (4): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory()
 
 ### Community 240 - "Community 240"
 Cohesion: 0.7
-Nodes (4): getActiveUser(), getBaseUrl(), getGuest(), updateUser()
+Nodes (4): getBaseUrl(), getOrder(), getOrders(), updateOrdersOwner()
 
 ### Community 241 - "Community 241"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.7
+Nodes (4): getActiveUser(), getBaseUrl(), getGuest(), updateUser()
 
 ### Community 242 - "Community 242"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 243 - "Community 243"
-Cohesion: 0.7
-Nodes (4): createStorefrontFailureEvent(), emitStorefrontFailure(), inferStorefrontJourneyFromRoute(), normalizeStorefrontError()
-
-### Community 244 - "Community 244"
 Cohesion: 0.4
 Nodes (0):
+
+### Community 244 - "Community 244"
+Cohesion: 0.7
+Nodes (4): createStorefrontFailureEvent(), emitStorefrontFailure(), inferStorefrontJourneyFromRoute(), normalizeStorefrontError()
 
 ### Community 245 - "Community 245"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 246 - "Community 246"
-Cohesion: 0.6
-Nodes (4): collectHarnessRepoValidationSelection(), matchesHarnessRepoValidationPath(), normalizeRepoPath(), sortUniquePaths()
-
-### Community 247 - "Community 247"
 Cohesion: 0.4
 Nodes (0):
 
+### Community 247 - "Community 247"
+Cohesion: 0.6
+Nodes (4): collectHarnessRepoValidationSelection(), matchesHarnessRepoValidationPath(), normalizeRepoPath(), sortUniquePaths()
+
 ### Community 248 - "Community 248"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 249 - "Community 249"
 Cohesion: 0.7
 Nodes (4): createFixtureRepo(), fixtureEnv(), runGit(), runWorktreeManager()
 
-### Community 249 - "Community 249"
+### Community 250 - "Community 250"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 250 - "Community 250"
+### Community 251 - "Community 251"
 Cohesion: 0.67
 Nodes (2): maskReceiptPhone(), normalizeReceiptPhone()
 
-### Community 251 - "Community 251"
+### Community 252 - "Community 252"
 Cohesion: 0.83
 Nodes (3): createReceiptShareToken(), hashReceiptShareToken(), toHex()
 
-### Community 252 - "Community 252"
+### Community 253 - "Community 253"
 Cohesion: 0.83
 Nodes (3): timingSafeEqual(), toHex(), verifyMetaWebhookSignature()
-
-### Community 253 - "Community 253"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 254 - "Community 254"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 255 - "Community 255"
-Cohesion: 0.67
-Nodes (2): createExpenseTransactionFromSessionHandler(), expenseTransactionError()
-
-### Community 256 - "Community 256"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 256 - "Community 256"
+Cohesion: 0.67
+Nodes (2): createExpenseTransactionFromSessionHandler(), expenseTransactionError()
 
 ### Community 257 - "Community 257"
 Cohesion: 0.5
@@ -2684,24 +2684,24 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 259 - "Community 259"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 260 - "Community 260"
 Cohesion: 0.67
 Nodes (2): createProductsQueryCtx(), createSkuMutationCtx()
 
-### Community 260 - "Community 260"
+### Community 261 - "Community 261"
 Cohesion: 0.83
 Nodes (3): getCachedTokenRecord(), resolveAccessTokenForStore(), resolveConfigForStore()
 
-### Community 261 - "Community 261"
+### Community 262 - "Community 262"
 Cohesion: 0.67
 Nodes (2): maskMtnPartyId(), normalizeCollectionsTransaction()
 
-### Community 262 - "Community 262"
+### Community 263 - "Community 263"
 Cohesion: 0.67
 Nodes (2): consumeApprovalProofWithCtx(), invalidApprovalProofResult()
-
-### Community 263 - "Community 263"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 264 - "Community 264"
 Cohesion: 0.67
@@ -10331,7 +10331,7 @@ _Questions this graph is uniquely positioned to answer:_
 - **What connects `HelpRequested` to the rest of the system?**
   _1 weakly-connected nodes found - possible documentation gaps or missing edges._
 - **Should `Community 0` be split into smaller, more focused modules?**
-  _Cohesion score 0.05 - nodes in this community are weakly interconnected._
+  _Cohesion score 0.04 - nodes in this community are weakly interconnected._
 - **Should `Community 1` be split into smaller, more focused modules?**
   _Cohesion score 0.07 - nodes in this community are weakly interconnected._
 - **Should `Community 2` be split into smaller, more focused modules?**

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -3695,7 +3695,7 @@
       "relation": "calls",
       "source": "dailyclose_isinrange",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L664",
+      "source_location": "L743",
       "target": "dailyclose_approvalbelongstorange",
       "weight": 1
     },
@@ -3707,7 +3707,7 @@
       "relation": "calls",
       "source": "dailyclose_registersessionbelongstorange",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L681",
+      "source_location": "L760",
       "target": "dailyclose_approvalbelongstorange",
       "weight": 1
     },
@@ -3719,7 +3719,7 @@
       "relation": "calls",
       "source": "dailyclose_formatpaymentmethodlabel",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L415",
+      "source_location": "L466",
       "target": "dailyclose_approvalrequesttypelabel",
       "weight": 1
     },
@@ -3731,7 +3731,7 @@
       "relation": "calls",
       "source": "dailyclose_builddailycloseapprovalsubject",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L265",
+      "source_location": "L282",
       "target": "dailyclose_builddailyclosecompletionapprovalrequirement",
       "weight": 1
     },
@@ -3743,7 +3743,7 @@
       "relation": "calls",
       "source": "dailyclose_builddailyclosereportsnapshot",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L940",
+      "source_location": "L1019",
       "target": "dailyclose_snapshotrevieweditems",
       "weight": 1
     },
@@ -3755,7 +3755,7 @@
       "relation": "calls",
       "source": "dailyclose_uniquedailycloseitems",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L941",
+      "source_location": "L1020",
       "target": "dailyclose_builddailyclosereportsnapshot",
       "weight": 1
     },
@@ -3767,7 +3767,7 @@
       "relation": "calls",
       "source": "dailyclose_buildexpensesessionsbyid",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1162",
+      "source_location": "L1244",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -3779,7 +3779,7 @@
       "relation": "calls",
       "source": "dailyclose_buildpaymenttotals",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1692",
+      "source_location": "L1779",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -3791,7 +3791,7 @@
       "relation": "calls",
       "source": "dailyclose_buildreadiness",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1695",
+      "source_location": "L1782",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -3803,7 +3803,7 @@
       "relation": "calls",
       "source": "dailyclose_buildregistersessionsbyid",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1155",
+      "source_location": "L1237",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -3815,7 +3815,7 @@
       "relation": "calls",
       "source": "dailyclose_buildstaffnamesbyid",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1094",
+      "source_location": "L1176",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -3827,7 +3827,7 @@
       "relation": "calls",
       "source": "dailyclose_buildterminallabelsbyid",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1177",
+      "source_location": "L1259",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -3839,7 +3839,7 @@
       "relation": "calls",
       "source": "dailyclose_cashdeltasbyregistersessionid",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1152",
+      "source_location": "L1234",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -3851,7 +3851,7 @@
       "relation": "calls",
       "source": "dailyclose_emptysummary",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1080",
+      "source_location": "L1162",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -3863,7 +3863,7 @@
       "relation": "calls",
       "source": "dailyclose_getdailyclosecompletioneventstaffprofileid",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1090",
+      "source_location": "L1172",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -3875,7 +3875,7 @@
       "relation": "calls",
       "source": "dailyclose_getdailyclosefordate",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1085",
+      "source_location": "L1167",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -3887,7 +3887,7 @@
       "relation": "calls",
       "source": "dailyclose_getpriorcompleteddailyclose",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1139",
+      "source_location": "L1221",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -3899,7 +3899,7 @@
       "relation": "calls",
       "source": "dailyclose_getstore",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1044",
+      "source_location": "L1125",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -3911,7 +3911,7 @@
       "relation": "calls",
       "source": "dailyclose_listactiveregistersessions",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1122",
+      "source_location": "L1204",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -3923,7 +3923,7 @@
       "relation": "calls",
       "source": "dailyclose_listclosedregistersessionsforday",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1123",
+      "source_location": "L1205",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -3935,7 +3935,7 @@
       "relation": "calls",
       "source": "dailyclose_listdepositsforday",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1138",
+      "source_location": "L1220",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -3947,7 +3947,7 @@
       "relation": "calls",
       "source": "dailyclose_listexpensesforday",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1137",
+      "source_location": "L1219",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -3959,7 +3959,7 @@
       "relation": "calls",
       "source": "dailyclose_listopenoperationalworkitems",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1126",
+      "source_location": "L1208",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -3971,7 +3971,7 @@
       "relation": "calls",
       "source": "dailyclose_listopenpossessions",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1125",
+      "source_location": "L1207",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -3983,7 +3983,7 @@
       "relation": "calls",
       "source": "dailyclose_listpendingcloseoutapprovals",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1124",
+      "source_location": "L1206",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -3995,7 +3995,7 @@
       "relation": "calls",
       "source": "dailyclose_listtransactionsforday",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1127",
+      "source_location": "L1209",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -4007,7 +4007,7 @@
       "relation": "calls",
       "source": "dailyclose_normalizecompleteddailyclosesnapshot",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1097",
+      "source_location": "L1179",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -4019,7 +4019,7 @@
       "relation": "calls",
       "source": "dailyclose_resolveoperatingdaterange",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1043",
+      "source_location": "L1124",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -4031,7 +4031,7 @@
       "relation": "calls",
       "source": "dailyclose_sortdailycloseblockers",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1694",
+      "source_location": "L1781",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -4043,7 +4043,7 @@
       "relation": "calls",
       "source": "dailyclose_uniquesourcesubjects",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1741",
+      "source_location": "L1828",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -4055,7 +4055,7 @@
       "relation": "calls",
       "source": "dailyclose_builddailycloseapprovalsubject",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1956",
+      "source_location": "L2043",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -4067,7 +4067,7 @@
       "relation": "calls",
       "source": "dailyclose_builddailyclosecompletionapprovalrequirement",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1943",
+      "source_location": "L2030",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -4079,7 +4079,7 @@
       "relation": "calls",
       "source": "dailyclose_builddailyclosereportsnapshot",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2009",
+      "source_location": "L2097",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -4091,7 +4091,7 @@
       "relation": "calls",
       "source": "dailyclose_builddailyclosesnapshotwithctx",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1878",
+      "source_location": "L1965",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -4103,7 +4103,7 @@
       "relation": "calls",
       "source": "dailyclose_createcarryforwardworkitems",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1966",
+      "source_location": "L2053",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -4115,7 +4115,7 @@
       "relation": "calls",
       "source": "dailyclose_getstore",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1853",
+      "source_location": "L1940",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -4127,7 +4127,7 @@
       "relation": "calls",
       "source": "dailyclose_markotherdailyclosesnotcurrent",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2041",
+      "source_location": "L2129",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -4139,7 +4139,7 @@
       "relation": "calls",
       "source": "dailyclose_resolveoperatingdaterange",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1869",
+      "source_location": "L1956",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -4151,7 +4151,7 @@
       "relation": "calls",
       "source": "dailyclose_trimoptional",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1991",
+      "source_location": "L2078",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -4163,7 +4163,7 @@
       "relation": "calls",
       "source": "dailyclose_validatecarryforwardworkitemids",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1929",
+      "source_location": "L2016",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -4175,7 +4175,7 @@
       "relation": "calls",
       "source": "dailyclose_trimoptional",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1787",
+      "source_location": "L1874",
       "target": "dailyclose_createcarryforwardworkitems",
       "weight": 1
     },
@@ -4187,7 +4187,7 @@
       "relation": "calls",
       "source": "dailyclose_buildstaffnamesbyid",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2210",
+      "source_location": "L2501",
       "target": "dailyclose_getcompleteddailyclosehistorydetailwithctx",
       "weight": 1
     },
@@ -4199,7 +4199,7 @@
       "relation": "calls",
       "source": "dailyclose_getdailyclosecompletioneventstaffprofileid",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2206",
+      "source_location": "L2497",
       "target": "dailyclose_getcompleteddailyclosehistorydetailwithctx",
       "weight": 1
     },
@@ -4211,7 +4211,7 @@
       "relation": "calls",
       "source": "dailyclose_getpriorcompleteddailyclose",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2108",
+      "source_location": "L2399",
       "target": "dailyclose_getdailycloseopeningcontextwithctx",
       "weight": 1
     },
@@ -4223,7 +4223,7 @@
       "relation": "calls",
       "source": "dailyclose_buildstaffnamesbyid",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2168",
+      "source_location": "L2459",
       "target": "dailyclose_listcompleteddailyclosehistorywithctx",
       "weight": 1
     },
@@ -4235,7 +4235,7 @@
       "relation": "calls",
       "source": "dailyclose_isinrange",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L626",
+      "source_location": "L705",
       "target": "dailyclose_registersessionbelongstorange",
       "weight": 1
     },
@@ -4247,7 +4247,7 @@
       "relation": "calls",
       "source": "dailyclose_registersessioncloseoutoperatingat",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L623",
+      "source_location": "L702",
       "target": "dailyclose_registersessionbelongstorange",
       "weight": 1
     },
@@ -4259,8 +4259,44 @@
       "relation": "calls",
       "source": "dailyclose_registersessionintersectsrange",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L629",
+      "source_location": "L708",
       "target": "dailyclose_registersessionbelongstorange",
+      "weight": 1
+    },
+    {
+      "_src": "dailyclose_reopendailyclosewithctx",
+      "_tgt": "dailyclose_builddailyclosereopenapprovalrequirement",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "dailyclose_builddailyclosereopenapprovalrequirement",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
+      "source_location": "L2284",
+      "target": "dailyclose_reopendailyclosewithctx",
+      "weight": 1
+    },
+    {
+      "_src": "dailyclose_reopendailyclosewithctx",
+      "_tgt": "dailyclose_markotherdailyclosesnotcurrent",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "dailyclose_markotherdailyclosesnotcurrent",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
+      "source_location": "L2344",
+      "target": "dailyclose_reopendailyclosewithctx",
+      "weight": 1
+    },
+    {
+      "_src": "dailyclose_reopendailyclosewithctx",
+      "_tgt": "dailyclose_trimoptional",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "dailyclose_trimoptional",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
+      "source_location": "L2202",
+      "target": "dailyclose_reopendailyclosewithctx",
       "weight": 1
     },
     {
@@ -4271,7 +4307,7 @@
       "relation": "calls",
       "source": "dailyclose_isvalidoperatingdaterange",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L328",
+      "source_location": "L379",
       "target": "dailyclose_resolveoperatingdaterange",
       "weight": 1
     },
@@ -4283,8 +4319,20 @@
       "relation": "calls",
       "source": "dailyclose_safeoperatingdaterange",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L322",
+      "source_location": "L373",
       "target": "dailyclose_resolveoperatingdaterange",
+      "weight": 1
+    },
+    {
+      "_src": "dailyclose_test_completeddailycloserow",
+      "_tgt": "dailyclose_test_completeddailyclosesnapshot",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "dailyclose_test_completeddailyclosesnapshot",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
+      "source_location": "L332",
+      "target": "dailyclose_test_completeddailycloserow",
       "weight": 1
     },
     {
@@ -4295,7 +4343,7 @@
       "relation": "calls",
       "source": "dailyclose_formatpaymentmethodlabel",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L394",
+      "source_location": "L445",
       "target": "dailyclose_transactionpaymentsummary",
       "weight": 1
     },
@@ -4307,7 +4355,7 @@
       "relation": "calls",
       "source": "dailyclosehistoryview_getdailyclosehistoryapi",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx",
-      "source_location": "L229",
+      "source_location": "L244",
       "target": "dailyclosehistoryview_dailyclosehistoryview",
       "weight": 1
     },
@@ -4319,7 +4367,7 @@
       "relation": "calls",
       "source": "dailyclosehistoryview_normalizehistorysnapshot",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx",
-      "source_location": "L182",
+      "source_location": "L197",
       "target": "dailyclosehistoryview_gethistoryrecordsnapshot",
       "weight": 1
     },
@@ -4355,8 +4403,20 @@
       "relation": "calls",
       "source": "dailycloseview_getlocaloperatingdate",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L529",
+      "source_location": "L550",
       "target": "dailycloseview_builddailyclosetransactionsearch",
+      "weight": 1
+    },
+    {
+      "_src": "dailycloseview_canreopendailyclose",
+      "_tgt": "dailycloseview_getdailyclosestatus",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "dailycloseview_getdailyclosestatus",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
+      "source_location": "L631",
+      "target": "dailycloseview_canreopendailyclose",
       "weight": 1
     },
     {
@@ -4367,7 +4427,7 @@
       "relation": "calls",
       "source": "dailycloseview_formatcarriedoverregistercount",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L2837",
+      "source_location": "L2976",
       "target": "dailycloseview_formatdailyclosemoney",
       "weight": 1
     },
@@ -4379,7 +4439,7 @@
       "relation": "calls",
       "source": "dailycloseview_formatdailyclosemoney",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L2838",
+      "source_location": "L2977",
       "target": "dailycloseview_getsummarycount",
       "weight": 1
     },
@@ -4391,7 +4451,7 @@
       "relation": "calls",
       "source": "dailycloseview_formatmetadatavalue",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L961",
+      "source_location": "L998",
       "target": "dailycloseview_formatmetadatadisplayvalue",
       "weight": 1
     },
@@ -4403,7 +4463,7 @@
       "relation": "calls",
       "source": "dailycloseview_getmetadatastringvalue",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L963",
+      "source_location": "L1000",
       "target": "dailycloseview_formatmetadatadisplayvalue",
       "weight": 1
     },
@@ -4415,7 +4475,7 @@
       "relation": "calls",
       "source": "dailycloseview_getnumericmetadatavalue",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1012",
+      "source_location": "L1049",
       "target": "dailycloseview_formatmetadatadisplayvalue",
       "weight": 1
     },
@@ -4427,7 +4487,7 @@
       "relation": "calls",
       "source": "dailycloseview_getvariancetone",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1017",
+      "source_location": "L1054",
       "target": "dailycloseview_formatmetadatadisplayvalue",
       "weight": 1
     },
@@ -4439,7 +4499,7 @@
       "relation": "calls",
       "source": "dailycloseview_normalizemetadatalabel",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L971",
+      "source_location": "L1008",
       "target": "dailycloseview_formatmetadatadisplayvalue",
       "weight": 1
     },
@@ -4451,7 +4511,7 @@
       "relation": "calls",
       "source": "dailycloseview_formatdailyclosemoney",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L905",
+      "source_location": "L942",
       "target": "dailycloseview_formatmetadatavalue",
       "weight": 1
     },
@@ -4463,7 +4523,7 @@
       "relation": "calls",
       "source": "dailycloseview_formattimestampmetadata",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L901",
+      "source_location": "L938",
       "target": "dailycloseview_formatmetadatavalue",
       "weight": 1
     },
@@ -4475,7 +4535,7 @@
       "relation": "calls",
       "source": "dailycloseview_humanizemetadatalabel",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L933",
+      "source_location": "L970",
       "target": "dailycloseview_formatmetadatavalue",
       "weight": 1
     },
@@ -4487,7 +4547,7 @@
       "relation": "calls",
       "source": "dailycloseview_ismoneymetadatalabel",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L904",
+      "source_location": "L941",
       "target": "dailycloseview_formatmetadatavalue",
       "weight": 1
     },
@@ -4499,7 +4559,7 @@
       "relation": "calls",
       "source": "dailycloseview_istimestampmetadatalabel",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L900",
+      "source_location": "L937",
       "target": "dailycloseview_formatmetadatavalue",
       "weight": 1
     },
@@ -4511,7 +4571,7 @@
       "relation": "calls",
       "source": "dailycloseview_normalizemetadatalabel",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L893",
+      "source_location": "L930",
       "target": "dailycloseview_formatmetadatavalue",
       "weight": 1
     },
@@ -4523,7 +4583,7 @@
       "relation": "calls",
       "source": "dailycloseview_iszeroactivitydailyclose",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1433",
+      "source_location": "L1475",
       "target": "dailycloseview_getbucketconfigs",
       "weight": 1
     },
@@ -4535,7 +4595,7 @@
       "relation": "calls",
       "source": "dailycloseview_getbucketcountclassname",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L422",
+      "source_location": "L443",
       "target": "dailycloseview_cn",
       "weight": 1
     },
@@ -4547,7 +4607,7 @@
       "relation": "calls",
       "source": "dailycloseview_getitemid",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L616",
+      "source_location": "L653",
       "target": "dailycloseview_getcarryforwardworkitemid",
       "weight": 1
     },
@@ -4559,7 +4619,7 @@
       "relation": "calls",
       "source": "dailycloseview_getlocaloperatingdate",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L535",
+      "source_location": "L556",
       "target": "dailycloseview_getdailyclosesalesmetriclabels",
       "weight": 1
     },
@@ -4571,7 +4631,7 @@
       "relation": "calls",
       "source": "dailycloseview_humanizemetadatalabel",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L858",
+      "source_location": "L895",
       "target": "dailycloseview_getdisplaymetadatalabel",
       "weight": 1
     },
@@ -4583,7 +4643,7 @@
       "relation": "calls",
       "source": "dailycloseview_normalizemetadatalabel",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L846",
+      "source_location": "L883",
       "target": "dailycloseview_getdisplaymetadatalabel",
       "weight": 1
     },
@@ -4595,7 +4655,7 @@
       "relation": "calls",
       "source": "dailycloseview_getitemcontextlabel",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L635",
+      "source_location": "L672",
       "target": "dailycloseview_humanizemetadatalabel",
       "weight": 1
     },
@@ -4607,7 +4667,7 @@
       "relation": "calls",
       "source": "dailycloseview_getlocaloperatingdate",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L556",
+      "source_location": "L577",
       "target": "dailycloseview_getlocaloperatingdaterange",
       "weight": 1
     },
@@ -4619,7 +4679,7 @@
       "relation": "calls",
       "source": "dailycloseview_getlocaldatefromoperatingdate",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L564",
+      "source_location": "L585",
       "target": "dailycloseview_getlocaloperatingdaterangefromsearch",
       "weight": 1
     },
@@ -4631,7 +4691,7 @@
       "relation": "calls",
       "source": "dailycloseview_getlocaloperatingdaterange",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L567",
+      "source_location": "L588",
       "target": "dailycloseview_getlocaloperatingdaterangefromsearch",
       "weight": 1
     },
@@ -4643,7 +4703,7 @@
       "relation": "calls",
       "source": "dailycloseview_normalizemetadatalabel",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1036",
+      "source_location": "L1073",
       "target": "dailycloseview_getmetadataentries",
       "weight": 1
     },
@@ -4655,7 +4715,7 @@
       "relation": "calls",
       "source": "dailycloseview_getmetadatavalue",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1505",
+      "source_location": "L1547",
       "target": "dailycloseview_getmetadatastringornumber",
       "weight": 1
     },
@@ -4667,7 +4727,7 @@
       "relation": "calls",
       "source": "dailycloseview_normalizemetadatalabel",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L883",
+      "source_location": "L920",
       "target": "dailycloseview_getmetadatavalue",
       "weight": 1
     },
@@ -4679,7 +4739,7 @@
       "relation": "calls",
       "source": "dailycloseview_iszeroactivitydailyclose",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1359",
+      "source_location": "L1396",
       "target": "dailycloseview_getstatusdisplaycopy",
       "weight": 1
     },
@@ -4691,7 +4751,7 @@
       "relation": "calls",
       "source": "dailycloseview_getstatuslabelclassname",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L351",
+      "source_location": "L372",
       "target": "dailycloseview_cn",
       "weight": 1
     },
@@ -4703,7 +4763,7 @@
       "relation": "calls",
       "source": "dailycloseview_getstatusrailbadgeclassname",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L413",
+      "source_location": "L434",
       "target": "dailycloseview_cn",
       "weight": 1
     },
@@ -4715,7 +4775,7 @@
       "relation": "calls",
       "source": "dailycloseview_getstatusrailiconclassname",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L363",
+      "source_location": "L384",
       "target": "dailycloseview_cn",
       "weight": 1
     },
@@ -4727,7 +4787,7 @@
       "relation": "calls",
       "source": "dailycloseview_formatexpensetransactioncount",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L2855",
+      "source_location": "L2994",
       "target": "dailycloseview_getsummaryamount",
       "weight": 1
     },
@@ -4739,7 +4799,7 @@
       "relation": "calls",
       "source": "dailycloseview_getsummaryamount",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L2856",
+      "source_location": "L2995",
       "target": "dailycloseview_getexpensetransactioncount",
       "weight": 1
     },
@@ -4751,7 +4811,7 @@
       "relation": "calls",
       "source": "dailycloseview_getsummaryamount",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1282",
+      "source_location": "L1319",
       "target": "dailycloseview_getsummaryregistervariancecount",
       "weight": 1
     },
@@ -4763,7 +4823,7 @@
       "relation": "calls",
       "source": "dailycloseview_formatdailyclosemoney",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1524",
+      "source_location": "L1566",
       "target": "dailycloseview_gettransactionreportamount",
       "weight": 1
     },
@@ -4775,7 +4835,7 @@
       "relation": "calls",
       "source": "dailycloseview_getmetadatastringornumber",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1521",
+      "source_location": "L1563",
       "target": "dailycloseview_gettransactionreportamount",
       "weight": 1
     },
@@ -4787,7 +4847,7 @@
       "relation": "calls",
       "source": "dailycloseview_getnumericmetadatavalue",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1520",
+      "source_location": "L1562",
       "target": "dailycloseview_gettransactionreportamount",
       "weight": 1
     },
@@ -4799,7 +4859,7 @@
       "relation": "calls",
       "source": "dailycloseview_getmetadatastringornumber",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1511",
+      "source_location": "L1553",
       "target": "dailycloseview_gettransactionreportidentifier",
       "weight": 1
     },
@@ -4811,7 +4871,7 @@
       "relation": "calls",
       "source": "dailycloseview_getmetadatastringornumber",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1533",
+      "source_location": "L1575",
       "target": "dailycloseview_gettransactionreportpayment",
       "weight": 1
     },
@@ -4823,7 +4883,7 @@
       "relation": "calls",
       "source": "dailycloseview_getmetadatastringornumber",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1528",
+      "source_location": "L1570",
       "target": "dailycloseview_gettransactionreportstaff",
       "weight": 1
     },
@@ -4835,7 +4895,7 @@
       "relation": "calls",
       "source": "dailycloseview_formattimestampmetadata",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1586",
+      "source_location": "L1628",
       "target": "dailycloseview_gettransactionreporttime",
       "weight": 1
     },
@@ -4847,7 +4907,7 @@
       "relation": "calls",
       "source": "dailycloseview_getmetadatastringornumber",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1582",
+      "source_location": "L1624",
       "target": "dailycloseview_gettransactionreporttime",
       "weight": 1
     },
@@ -4859,7 +4919,7 @@
       "relation": "calls",
       "source": "dailycloseview_getnumericmetadatavalue",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1581",
+      "source_location": "L1623",
       "target": "dailycloseview_gettransactionreporttime",
       "weight": 1
     },
@@ -4871,7 +4931,7 @@
       "relation": "calls",
       "source": "dailycloseview_normalizemetadatalabel",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L792",
+      "source_location": "L829",
       "target": "dailycloseview_ismoneymetadatalabel",
       "weight": 1
     },
@@ -4883,7 +4943,7 @@
       "relation": "calls",
       "source": "dailycloseview_normalizemetadatalabel",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L796",
+      "source_location": "L833",
       "target": "dailycloseview_istimestampmetadatalabel",
       "weight": 1
     },
@@ -4895,7 +4955,7 @@
       "relation": "calls",
       "source": "dailycloseview_getmetadatastringvalue",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L876",
+      "source_location": "L913",
       "target": "dailycloseview_isvarianceapprovalitem",
       "weight": 1
     },
@@ -4907,7 +4967,7 @@
       "relation": "calls",
       "source": "dailycloseview_normalizemetadatalabel",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L872",
+      "source_location": "L909",
       "target": "dailycloseview_isvarianceapprovalitem",
       "weight": 1
     },
@@ -4919,7 +4979,7 @@
       "relation": "calls",
       "source": "dailycloseview_getexpensestaffcount",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1337",
+      "source_location": "L1374",
       "target": "dailycloseview_iszeroactivitydailyclose",
       "weight": 1
     },
@@ -4931,7 +4991,7 @@
       "relation": "calls",
       "source": "dailycloseview_getsummaryamount",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1339",
+      "source_location": "L1376",
       "target": "dailycloseview_iszeroactivitydailyclose",
       "weight": 1
     },
@@ -4943,7 +5003,7 @@
       "relation": "calls",
       "source": "dailycloseview_getsummarycount",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1322",
+      "source_location": "L1359",
       "target": "dailycloseview_iszeroactivitydailyclose",
       "weight": 1
     },
@@ -4955,7 +5015,7 @@
       "relation": "calls",
       "source": "dailycloseview_getsummaryregistervariancecount",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1338",
+      "source_location": "L1375",
       "target": "dailycloseview_iszeroactivitydailyclose",
       "weight": 1
     },
@@ -4967,7 +5027,7 @@
       "relation": "calls",
       "source": "dailycloseview_getnumericmetadatavalue",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L828",
+      "source_location": "L865",
       "target": "dailycloseview_shouldshowmetadataentry",
       "weight": 1
     },
@@ -4979,7 +5039,7 @@
       "relation": "calls",
       "source": "dailycloseview_normalizemetadatalabel",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L821",
+      "source_location": "L858",
       "target": "dailycloseview_shouldshowmetadataentry",
       "weight": 1
     },
@@ -4991,7 +5051,7 @@
       "relation": "calls",
       "source": "dailyopening_approvalmetadataentries",
       "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L283",
+      "source_location": "L305",
       "target": "dailyopening_compactmetadataentries",
       "weight": 1
     },
@@ -5003,7 +5063,7 @@
       "relation": "calls",
       "source": "dailyopening_approvalmetadataentries",
       "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L305",
+      "source_location": "L327",
       "target": "dailyopening_getnumbermetadata",
       "weight": 1
     },
@@ -5015,7 +5075,7 @@
       "relation": "calls",
       "source": "dailyopening_approvalmetadataentries",
       "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L294",
+      "source_location": "L316",
       "target": "dailyopening_getpaymentmethodmetadata",
       "weight": 1
     },
@@ -5027,7 +5087,7 @@
       "relation": "calls",
       "source": "dailyopening_approvalmetadataentries",
       "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L286",
+      "source_location": "L308",
       "target": "dailyopening_getstringmetadata",
       "weight": 1
     },
@@ -5039,7 +5099,7 @@
       "relation": "calls",
       "source": "dailyopening_buildreadiness",
       "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L695",
+      "source_location": "L752",
       "target": "dailyopening_builddailyopeningsnapshotwithctx",
       "weight": 1
     },
@@ -5051,7 +5111,7 @@
       "relation": "calls",
       "source": "dailyopening_getdailyopeningfordate",
       "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L629",
+      "source_location": "L679",
       "target": "dailyopening_builddailyopeningsnapshotwithctx",
       "weight": 1
     },
@@ -5063,7 +5123,19 @@
       "relation": "calls",
       "source": "dailyopening_getmissingcarryforwarditems",
       "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L673",
+      "source_location": "L726",
+      "target": "dailyopening_builddailyopeningsnapshotwithctx",
+      "weight": 1
+    },
+    {
+      "_src": "dailyopening_builddailyopeningsnapshotwithctx",
+      "_tgt": "dailyopening_getpriordailycloseforopeningreview",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "dailyopening_getpriordailycloseforopeningreview",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
+      "source_location": "L723",
       "target": "dailyopening_builddailyopeningsnapshotwithctx",
       "weight": 1
     },
@@ -5075,7 +5147,7 @@
       "relation": "calls",
       "source": "dailyopening_getstore",
       "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L628",
+      "source_location": "L678",
       "target": "dailyopening_builddailyopeningsnapshotwithctx",
       "weight": 1
     },
@@ -5087,7 +5159,7 @@
       "relation": "calls",
       "source": "dailyopening_hydratestartedopening",
       "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L630",
+      "source_location": "L680",
       "target": "dailyopening_builddailyopeningsnapshotwithctx",
       "weight": 1
     },
@@ -5099,7 +5171,7 @@
       "relation": "calls",
       "source": "dailyopening_invalidoperatingdateitem",
       "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L634",
+      "source_location": "L684",
       "target": "dailyopening_builddailyopeningsnapshotwithctx",
       "weight": 1
     },
@@ -5111,7 +5183,7 @@
       "relation": "calls",
       "source": "dailyopening_isvalidoperatingdate",
       "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L633",
+      "source_location": "L683",
       "target": "dailyopening_builddailyopeningsnapshotwithctx",
       "weight": 1
     },
@@ -5123,7 +5195,7 @@
       "relation": "calls",
       "source": "dailyopening_listpendingopeningblockerapprovals",
       "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L669",
+      "source_location": "L719",
       "target": "dailyopening_builddailyopeningsnapshotwithctx",
       "weight": 1
     },
@@ -5135,7 +5207,7 @@
       "relation": "calls",
       "source": "dailyopening_missingpriorclosereviewitem",
       "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L690",
+      "source_location": "L747",
       "target": "dailyopening_builddailyopeningsnapshotwithctx",
       "weight": 1
     },
@@ -5147,7 +5219,7 @@
       "relation": "calls",
       "source": "dailyopening_priorclosenotesitem",
       "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L684",
+      "source_location": "L741",
       "target": "dailyopening_builddailyopeningsnapshotwithctx",
       "weight": 1
     },
@@ -5159,7 +5231,19 @@
       "relation": "calls",
       "source": "dailyopening_priorclosereadyitem",
       "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L682",
+      "source_location": "L738",
+      "target": "dailyopening_builddailyopeningsnapshotwithctx",
+      "weight": 1
+    },
+    {
+      "_src": "dailyopening_builddailyopeningsnapshotwithctx",
+      "_tgt": "dailyopening_priorclosereopeneditem",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "dailyopening_priorclosereopeneditem",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
+      "source_location": "L736",
       "target": "dailyopening_builddailyopeningsnapshotwithctx",
       "weight": 1
     },
@@ -5171,7 +5255,7 @@
       "relation": "calls",
       "source": "dailyopening_resolveoperatingdaterange",
       "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L631",
+      "source_location": "L681",
       "target": "dailyopening_builddailyopeningsnapshotwithctx",
       "weight": 1
     },
@@ -5183,7 +5267,7 @@
       "relation": "calls",
       "source": "dailyopening_uniquesourcesubjects",
       "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L723",
+      "source_location": "L780",
       "target": "dailyopening_builddailyopeningsnapshotwithctx",
       "weight": 1
     },
@@ -5195,7 +5279,7 @@
       "relation": "calls",
       "source": "dailyopening_getpaymentmethodmetadata",
       "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L355",
+      "source_location": "L377",
       "target": "dailyopening_formatpaymentmethodlabel",
       "weight": 1
     },
@@ -5207,7 +5291,7 @@
       "relation": "calls",
       "source": "dailyopening_getpaymentmethodmetadata",
       "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L354",
+      "source_location": "L376",
       "target": "dailyopening_getstringmetadata",
       "weight": 1
     },
@@ -5219,7 +5303,7 @@
       "relation": "calls",
       "source": "dailyopening_getstaffdisplayname",
       "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L217",
+      "source_location": "L239",
       "target": "dailyopening_hydratestartedopening",
       "weight": 1
     },
@@ -5231,7 +5315,7 @@
       "relation": "calls",
       "source": "dailyopening_pendingapprovalitem",
       "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L245",
+      "source_location": "L267",
       "target": "dailyopening_approvalmetadataentries",
       "weight": 1
     },
@@ -5243,7 +5327,7 @@
       "relation": "calls",
       "source": "dailyopening_pendingapprovalitem",
       "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L243",
+      "source_location": "L265",
       "target": "dailyopening_approvalrequesttypelabel",
       "weight": 1
     },
@@ -5255,7 +5339,7 @@
       "relation": "calls",
       "source": "dailyopening_trimoptional",
       "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L465",
+      "source_location": "L515",
       "target": "dailyopening_priorclosenotesitem",
       "weight": 1
     },
@@ -5303,7 +5387,7 @@
       "relation": "calls",
       "source": "dailyopening_builddailyopeningsnapshotwithctx",
       "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L762",
+      "source_location": "L819",
       "target": "dailyopening_startstoredaywithctx",
       "weight": 1
     },
@@ -5315,7 +5399,7 @@
       "relation": "calls",
       "source": "dailyopening_getstarteddailyopeningfordate",
       "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L753",
+      "source_location": "L810",
       "target": "dailyopening_startstoredaywithctx",
       "weight": 1
     },
@@ -5327,7 +5411,7 @@
       "relation": "calls",
       "source": "dailyopening_getstore",
       "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L737",
+      "source_location": "L794",
       "target": "dailyopening_startstoredaywithctx",
       "weight": 1
     },
@@ -5339,7 +5423,7 @@
       "relation": "calls",
       "source": "dailyopening_resolveopeningactor",
       "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L794",
+      "source_location": "L851",
       "target": "dailyopening_startstoredaywithctx",
       "weight": 1
     },
@@ -5351,7 +5435,7 @@
       "relation": "calls",
       "source": "dailyopening_trimoptional",
       "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L816",
+      "source_location": "L873",
       "target": "dailyopening_startstoredaywithctx",
       "weight": 1
     },
@@ -5531,7 +5615,7 @@
       "relation": "calls",
       "source": "dailyoperations_buildlanes",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
-      "source_location": "L731",
+      "source_location": "L800",
       "target": "dailyoperations_builddailyoperationssnapshotwithctx",
       "weight": 1
     },
@@ -5543,7 +5627,7 @@
       "relation": "calls",
       "source": "dailyoperations_buildweekmetrics",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
-      "source_location": "L665",
+      "source_location": "L710",
       "target": "dailyoperations_builddailyoperationssnapshotwithctx",
       "weight": 1
     },
@@ -5555,7 +5639,19 @@
       "relation": "calls",
       "source": "dailyoperations_getcloseitemcounts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
-      "source_location": "L712",
+      "source_location": "L781",
+      "target": "dailyoperations_builddailyoperationssnapshotwithctx",
+      "weight": 1
+    },
+    {
+      "_src": "dailyoperations_builddailyoperationssnapshotwithctx",
+      "_tgt": "dailyoperations_getdailycloserecordfordate",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "dailyoperations_getdailycloserecordfordate",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
+      "source_location": "L706",
       "target": "dailyoperations_builddailyoperationssnapshotwithctx",
       "weight": 1
     },
@@ -5567,7 +5663,7 @@
       "relation": "calls",
       "source": "dailyoperations_lifecyclecopy",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
-      "source_location": "L710",
+      "source_location": "L779",
       "target": "dailyoperations_builddailyoperationssnapshotwithctx",
       "weight": 1
     },
@@ -5579,7 +5675,7 @@
       "relation": "calls",
       "source": "dailyoperations_listopenqueuesnapshot",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
-      "source_location": "L662",
+      "source_location": "L707",
       "target": "dailyoperations_builddailyoperationssnapshotwithctx",
       "weight": 1
     },
@@ -5591,7 +5687,7 @@
       "relation": "calls",
       "source": "dailyoperations_listtimelineevents",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
-      "source_location": "L663",
+      "source_location": "L708",
       "target": "dailyoperations_builddailyoperationssnapshotwithctx",
       "weight": 1
     },
@@ -5603,7 +5699,7 @@
       "relation": "calls",
       "source": "dailyoperations_openingnotstartedattention",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
-      "source_location": "L679",
+      "source_location": "L727",
       "target": "dailyoperations_builddailyoperationssnapshotwithctx",
       "weight": 1
     },
@@ -5615,7 +5711,7 @@
       "relation": "calls",
       "source": "dailyoperations_primaryaction",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
-      "source_location": "L745",
+      "source_location": "L815",
       "target": "dailyoperations_builddailyoperationssnapshotwithctx",
       "weight": 1
     },
@@ -5627,7 +5723,7 @@
       "relation": "calls",
       "source": "dailyoperations_queueattentionitems",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
-      "source_location": "L692",
+      "source_location": "L759",
       "target": "dailyoperations_builddailyoperationssnapshotwithctx",
       "weight": 1
     },
@@ -5639,7 +5735,7 @@
       "relation": "calls",
       "source": "dailyoperations_resolverange",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
-      "source_location": "L657",
+      "source_location": "L693",
       "target": "dailyoperations_builddailyoperationssnapshotwithctx",
       "weight": 1
     },
@@ -5651,7 +5747,7 @@
       "relation": "calls",
       "source": "dailyoperations_pluralize",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
-      "source_location": "L615",
+      "source_location": "L651",
       "target": "dailyoperations_buildlanes",
       "weight": 1
     },
@@ -5663,7 +5759,7 @@
       "relation": "calls",
       "source": "dailyoperations_emptyclosesummary",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
-      "source_location": "L198",
+      "source_location": "L199",
       "target": "dailyoperations_buildweekmetricfordate",
       "weight": 1
     },
@@ -5675,7 +5771,7 @@
       "relation": "calls",
       "source": "dailyoperations_operatingdaterange",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
-      "source_location": "L194",
+      "source_location": "L195",
       "target": "dailyoperations_buildweekmetricfordate",
       "weight": 1
     },
@@ -5687,7 +5783,7 @@
       "relation": "calls",
       "source": "dailyoperations_saturdayweekendoperatingdate",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
-      "source_location": "L268",
+      "source_location": "L269",
       "target": "dailyoperations_buildweekmetrics",
       "weight": 1
     },
@@ -5699,7 +5795,7 @@
       "relation": "calls",
       "source": "dailyoperations_operatingdaterange",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
-      "source_location": "L152",
+      "source_location": "L153",
       "target": "dailyoperations_resolverange",
       "weight": 1
     },
@@ -5711,7 +5807,7 @@
       "relation": "calls",
       "source": "dailyoperations_shiftoperatingdate",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
-      "source_location": "L134",
+      "source_location": "L135",
       "target": "dailyoperations_saturdayweekendoperatingdate",
       "weight": 1
     },
@@ -5723,7 +5819,7 @@
       "relation": "calls",
       "source": "dailyoperations_sundayweekstartoperatingdate",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
-      "source_location": "L134",
+      "source_location": "L135",
       "target": "dailyoperations_saturdayweekendoperatingdate",
       "weight": 1
     },
@@ -5735,7 +5831,7 @@
       "relation": "calls",
       "source": "dailyoperations_operatingdaterange",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
-      "source_location": "L116",
+      "source_location": "L117",
       "target": "dailyoperations_shiftoperatingdate",
       "weight": 1
     },
@@ -5747,7 +5843,7 @@
       "relation": "calls",
       "source": "dailyoperations_attentionseverity",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
-      "source_location": "L303",
+      "source_location": "L304",
       "target": "dailyoperations_sourceattentionitem",
       "weight": 1
     },
@@ -5759,7 +5855,7 @@
       "relation": "calls",
       "source": "dailyoperations_operatingdaterange",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
-      "source_location": "L124",
+      "source_location": "L125",
       "target": "dailyoperations_sundayweekstartoperatingdate",
       "weight": 1
     },
@@ -11249,13 +11345,25 @@
     },
     {
       "_src": "listregistercatalog_listregistercatalog",
+      "_tgt": "listregistercatalog_getregistercatalogprice",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "listregistercatalog_getregistercatalogprice",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/listRegisterCatalog.ts",
+      "source_location": "L128",
+      "target": "listregistercatalog_listregistercatalog",
+      "weight": 1
+    },
+    {
+      "_src": "listregistercatalog_listregistercatalog",
       "_tgt": "listregistercatalog_mapskutoregistercatalogrow",
       "confidence": "EXTRACTED",
       "confidence_score": 1,
       "relation": "calls",
       "source": "listregistercatalog_mapskutoregistercatalogrow",
       "source_file": "packages/athena-webapp/convex/pos/application/queries/listRegisterCatalog.ts",
-      "source_location": "L125",
+      "source_location": "L133",
       "target": "listregistercatalog_listregistercatalog",
       "weight": 1
     },
@@ -11267,7 +11375,7 @@
       "relation": "calls",
       "source": "listregistercatalog_readcategoryname",
       "source_file": "packages/athena-webapp/convex/pos/application/queries/listRegisterCatalog.ts",
-      "source_location": "L128",
+      "source_location": "L136",
       "target": "listregistercatalog_listregistercatalog",
       "weight": 1
     },
@@ -11279,8 +11387,20 @@
       "relation": "calls",
       "source": "listregistercatalog_readcolorname",
       "source_file": "packages/athena-webapp/convex/pos/application/queries/listRegisterCatalog.ts",
-      "source_location": "L129",
+      "source_location": "L137",
       "target": "listregistercatalog_listregistercatalog",
+      "weight": 1
+    },
+    {
+      "_src": "listregistercatalog_mapskutoregistercatalogrow",
+      "_tgt": "listregistercatalog_getregistercatalogprice",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "listregistercatalog_mapskutoregistercatalogrow",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/listRegisterCatalog.ts",
+      "source_location": "L84",
+      "target": "listregistercatalog_getregistercatalogprice",
       "weight": 1
     },
     {
@@ -15779,7 +15899,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_approvalactions_ts",
       "source_file": "packages/athena-webapp/convex/operations/approvalActions.ts",
-      "source_location": "L46",
+      "source_location": "L50",
       "target": "approvalactions_consumecommandapprovalproofwithctx",
       "weight": 1
     },
@@ -16085,13 +16205,37 @@
     },
     {
       "_src": "packages_athena_webapp_convex_operations_dailyclose_test_ts",
+      "_tgt": "dailyclose_test_completeddailycloserow",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_convex_operations_dailyclose_test_ts",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
+      "source_location": "L331",
+      "target": "dailyclose_test_completeddailycloserow",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_convex_operations_dailyclose_test_ts",
+      "_tgt": "dailyclose_test_completeddailyclosesnapshot",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_convex_operations_dailyclose_test_ts",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
+      "source_location": "L277",
+      "target": "dailyclose_test_completeddailyclosesnapshot",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_convex_operations_dailyclose_test_ts",
       "_tgt": "dailyclose_test_createdb",
       "confidence": "EXTRACTED",
       "confidence_score": 1,
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_test_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
-      "source_location": "L30",
+      "source_location": "L31",
       "target": "dailyclose_test_createdb",
       "weight": 1
     },
@@ -16103,8 +16247,20 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_test_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
-      "source_location": "L240",
+      "source_location": "L241",
       "target": "dailyclose_test_dailycloseapprovalproof",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_convex_operations_dailyclose_test_ts",
+      "_tgt": "dailyclose_test_dailyclosereopenapprovalproof",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_convex_operations_dailyclose_test_ts",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
+      "source_location": "L259",
+      "target": "dailyclose_test_dailyclosereopenapprovalproof",
       "weight": 1
     },
     {
@@ -16115,7 +16271,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_test_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
-      "source_location": "L215",
+      "source_location": "L216",
       "target": "dailyclose_test_dailyclosesummary",
       "weight": 1
     },
@@ -16127,7 +16283,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L648",
+      "source_location": "L727",
       "target": "dailyclose_approvalbelongstorange",
       "weight": 1
     },
@@ -16139,7 +16295,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L402",
+      "source_location": "L453",
       "target": "dailyclose_approvalrequesttypelabel",
       "weight": 1
     },
@@ -16151,7 +16307,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L498",
+      "source_location": "L549",
       "target": "dailyclose_ascarryforwarditem",
       "weight": 1
     },
@@ -16163,7 +16319,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L245",
+      "source_location": "L262",
       "target": "dailyclose_builddailycloseapprovalsubject",
       "weight": 1
     },
@@ -16175,8 +16331,20 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L256",
+      "source_location": "L273",
       "target": "dailyclose_builddailyclosecompletionapprovalrequirement",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_convex_operations_dailyclose_ts",
+      "_tgt": "dailyclose_builddailyclosereopenapprovalrequirement",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
+      "source_location": "L301",
+      "target": "dailyclose_builddailyclosereopenapprovalrequirement",
       "weight": 1
     },
     {
@@ -16187,7 +16355,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L912",
+      "source_location": "L991",
       "target": "dailyclose_builddailyclosereportsnapshot",
       "weight": 1
     },
@@ -16199,7 +16367,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1034",
+      "source_location": "L1115",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -16211,7 +16379,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L478",
+      "source_location": "L529",
       "target": "dailyclose_buildexpensesessionsbyid",
       "weight": 1
     },
@@ -16223,7 +16391,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L827",
+      "source_location": "L906",
       "target": "dailyclose_buildpaymenttotals",
       "weight": 1
     },
@@ -16235,7 +16403,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L874",
+      "source_location": "L953",
       "target": "dailyclose_buildreadiness",
       "weight": 1
     },
@@ -16247,7 +16415,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L458",
+      "source_location": "L509",
       "target": "dailyclose_buildregistersessionsbyid",
       "weight": 1
     },
@@ -16259,7 +16427,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L438",
+      "source_location": "L489",
       "target": "dailyclose_buildstaffnamesbyid",
       "weight": 1
     },
@@ -16271,7 +16439,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L418",
+      "source_location": "L469",
       "target": "dailyclose_buildterminallabelsbyid",
       "weight": 1
     },
@@ -16283,7 +16451,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L856",
+      "source_location": "L935",
       "target": "dailyclose_cashdeltasbyregistersessionid",
       "weight": 1
     },
@@ -16295,7 +16463,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1849",
+      "source_location": "L1936",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -16307,7 +16475,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1773",
+      "source_location": "L1860",
       "target": "dailyclose_createcarryforwardworkitems",
       "weight": 1
     },
@@ -16319,7 +16487,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1010",
+      "source_location": "L1091",
       "target": "dailyclose_emptysummary",
       "weight": 1
     },
@@ -16331,7 +16499,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L374",
+      "source_location": "L425",
       "target": "dailyclose_formatpaymentmethodlabel",
       "weight": 1
     },
@@ -16343,7 +16511,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2186",
+      "source_location": "L2477",
       "target": "dailyclose_getcompleteddailyclosehistorydetailwithctx",
       "weight": 1
     },
@@ -16355,7 +16523,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L983",
+      "source_location": "L1064",
       "target": "dailyclose_getdailyclosecompletioneventstaffprofileid",
       "weight": 1
     },
@@ -16367,7 +16535,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L527",
+      "source_location": "L579",
       "target": "dailyclose_getdailyclosefordate",
       "weight": 1
     },
@@ -16379,7 +16547,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2101",
+      "source_location": "L2392",
       "target": "dailyclose_getdailycloseopeningcontextwithctx",
       "weight": 1
     },
@@ -16391,7 +16559,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L542",
+      "source_location": "L618",
       "target": "dailyclose_getpriorcompleteddailyclose",
       "weight": 1
     },
@@ -16403,7 +16571,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L520",
+      "source_location": "L572",
       "target": "dailyclose_getstore",
       "weight": 1
     },
@@ -16415,7 +16583,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L338",
+      "source_location": "L389",
       "target": "dailyclose_isinrange",
       "weight": 1
     },
@@ -16427,7 +16595,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L306",
+      "source_location": "L357",
       "target": "dailyclose_isvalidoperatingdaterange",
       "weight": 1
     },
@@ -16439,7 +16607,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L564",
+      "source_location": "L643",
       "target": "dailyclose_listactiveregistersessions",
       "weight": 1
     },
@@ -16451,7 +16619,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L582",
+      "source_location": "L661",
       "target": "dailyclose_listclosedregistersessionsforday",
       "weight": 1
     },
@@ -16463,7 +16631,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2137",
+      "source_location": "L2428",
       "target": "dailyclose_listcompleteddailyclosehistorywithctx",
       "weight": 1
     },
@@ -16475,7 +16643,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L805",
+      "source_location": "L884",
       "target": "dailyclose_listdepositsforday",
       "weight": 1
     },
@@ -16487,7 +16655,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L785",
+      "source_location": "L864",
       "target": "dailyclose_listexpensesforday",
       "weight": 1
     },
@@ -16499,7 +16667,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L750",
+      "source_location": "L829",
       "target": "dailyclose_listopenoperationalworkitems",
       "weight": 1
     },
@@ -16511,7 +16679,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L722",
+      "source_location": "L801",
       "target": "dailyclose_listopenpossessions",
       "weight": 1
     },
@@ -16523,7 +16691,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L688",
+      "source_location": "L767",
       "target": "dailyclose_listpendingcloseoutapprovals",
       "weight": 1
     },
@@ -16535,7 +16703,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L764",
+      "source_location": "L843",
       "target": "dailyclose_listtransactionsforday",
       "weight": 1
     },
@@ -16547,7 +16715,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1826",
+      "source_location": "L1913",
       "target": "dailyclose_markotherdailyclosesnotcurrent",
       "weight": 1
     },
@@ -16559,7 +16727,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L398",
+      "source_location": "L449",
       "target": "dailyclose_nonzerovariancemetadata",
       "weight": 1
     },
@@ -16571,7 +16739,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L163",
+      "source_location": "L164",
       "target": "dailyclose_normalizecompleteddailyclosesnapshot",
       "weight": 1
     },
@@ -16583,7 +16751,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L632",
+      "source_location": "L711",
       "target": "dailyclose_possessionintersectsrange",
       "weight": 1
     },
@@ -16595,7 +16763,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L361",
+      "source_location": "L412",
       "target": "dailyclose_registermetadatalabel",
       "weight": 1
     },
@@ -16607,7 +16775,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L616",
+      "source_location": "L695",
       "target": "dailyclose_registersessionbelongstorange",
       "weight": 1
     },
@@ -16619,7 +16787,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L342",
+      "source_location": "L393",
       "target": "dailyclose_registersessioncloseoutoperatingat",
       "weight": 1
     },
@@ -16631,7 +16799,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L606",
+      "source_location": "L685",
       "target": "dailyclose_registersessionintersectsrange",
       "weight": 1
     },
@@ -16643,8 +16811,20 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L353",
+      "source_location": "L404",
       "target": "dailyclose_registersessionlabel",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_convex_operations_dailyclose_ts",
+      "_tgt": "dailyclose_reopendailyclosewithctx",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
+      "source_location": "L2198",
+      "target": "dailyclose_reopendailyclosewithctx",
       "weight": 1
     },
     {
@@ -16655,7 +16835,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L317",
+      "source_location": "L368",
       "target": "dailyclose_resolveoperatingdaterange",
       "weight": 1
     },
@@ -16667,7 +16847,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L289",
+      "source_location": "L340",
       "target": "dailyclose_safeoperatingdaterange",
       "weight": 1
     },
@@ -16679,7 +16859,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L950",
+      "source_location": "L1029",
       "target": "dailyclose_snapshotrevieweditems",
       "weight": 1
     },
@@ -16691,7 +16871,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L126",
+      "source_location": "L127",
       "target": "dailyclose_sortdailycloseblockers",
       "weight": 1
     },
@@ -16703,7 +16883,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L962",
+      "source_location": "L1043",
       "target": "dailyclose_todailyclosehistorylistitem",
       "weight": 1
     },
@@ -16715,7 +16895,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L845",
+      "source_location": "L924",
       "target": "dailyclose_transactioncashdelta",
       "weight": 1
     },
@@ -16727,7 +16907,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L380",
+      "source_location": "L431",
       "target": "dailyclose_transactionpaymentsummary",
       "weight": 1
     },
@@ -16739,7 +16919,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L284",
+      "source_location": "L335",
       "target": "dailyclose_trimoptional",
       "weight": 1
     },
@@ -16751,7 +16931,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L904",
+      "source_location": "L983",
       "target": "dailyclose_uniquedailycloseitems",
       "weight": 1
     },
@@ -16763,7 +16943,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L894",
+      "source_location": "L973",
       "target": "dailyclose_uniquesourcesubjects",
       "weight": 1
     },
@@ -16775,7 +16955,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1745",
+      "source_location": "L1832",
       "target": "dailyclose_validatecarryforwardworkitemids",
       "weight": 1
     },
@@ -16811,7 +16991,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyopening_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L281",
+      "source_location": "L303",
       "target": "dailyopening_approvalmetadataentries",
       "weight": 1
     },
@@ -16823,7 +17003,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyopening_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L313",
+      "source_location": "L335",
       "target": "dailyopening_approvalrequesttypelabel",
       "weight": 1
     },
@@ -16835,7 +17015,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyopening_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L619",
+      "source_location": "L669",
       "target": "dailyopening_builddailyopeningsnapshotwithctx",
       "weight": 1
     },
@@ -16847,7 +17027,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyopening_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L516",
+      "source_location": "L566",
       "target": "dailyopening_buildreadiness",
       "weight": 1
     },
@@ -16859,7 +17039,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyopening_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L489",
+      "source_location": "L539",
       "target": "dailyopening_carryforwarditem",
       "weight": 1
     },
@@ -16871,7 +17051,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyopening_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L333",
+      "source_location": "L355",
       "target": "dailyopening_compactmetadataentries",
       "weight": 1
     },
@@ -16883,7 +17063,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyopening_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L366",
+      "source_location": "L388",
       "target": "dailyopening_formatpaymentmethodlabel",
       "weight": 1
     },
@@ -16907,7 +17087,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyopening_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L546",
+      "source_location": "L596",
       "target": "dailyopening_getmissingcarryforwarditems",
       "weight": 1
     },
@@ -16919,7 +17099,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyopening_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L342",
+      "source_location": "L364",
       "target": "dailyopening_getnumbermetadata",
       "weight": 1
     },
@@ -16931,8 +17111,20 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyopening_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L350",
+      "source_location": "L372",
       "target": "dailyopening_getpaymentmethodmetadata",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_convex_operations_dailyopening_ts",
+      "_tgt": "dailyopening_getpriordailycloseforopeningreview",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_convex_operations_dailyopening_ts",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
+      "source_location": "L195",
+      "target": "dailyopening_getpriordailycloseforopeningreview",
       "weight": 1
     },
     {
@@ -16943,7 +17135,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyopening_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L195",
+      "source_location": "L217",
       "target": "dailyopening_getstaffdisplayname",
       "weight": 1
     },
@@ -16979,7 +17171,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyopening_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L358",
+      "source_location": "L380",
       "target": "dailyopening_getstringmetadata",
       "weight": 1
     },
@@ -16991,7 +17183,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyopening_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L205",
+      "source_location": "L227",
       "target": "dailyopening_hydratestartedopening",
       "weight": 1
     },
@@ -17003,7 +17195,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyopening_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L401",
+      "source_location": "L423",
       "target": "dailyopening_invalidoperatingdateitem",
       "weight": 1
     },
@@ -17039,7 +17231,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyopening_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L221",
+      "source_location": "L243",
       "target": "dailyopening_listpendingopeningblockerapprovals",
       "weight": 1
     },
@@ -17051,7 +17243,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyopening_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L415",
+      "source_location": "L437",
       "target": "dailyopening_missingcarryforwarditem",
       "weight": 1
     },
@@ -17063,7 +17255,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyopening_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L372",
+      "source_location": "L394",
       "target": "dailyopening_missingpriorclosereviewitem",
       "weight": 1
     },
@@ -17075,7 +17267,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyopening_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L240",
+      "source_location": "L262",
       "target": "dailyopening_pendingapprovalitem",
       "weight": 1
     },
@@ -17087,7 +17279,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyopening_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L464",
+      "source_location": "L514",
       "target": "dailyopening_priorclosenotesitem",
       "weight": 1
     },
@@ -17099,8 +17291,20 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyopening_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L438",
+      "source_location": "L460",
       "target": "dailyopening_priorclosereadyitem",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_convex_operations_dailyopening_ts",
+      "_tgt": "dailyopening_priorclosereopeneditem",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_convex_operations_dailyopening_ts",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
+      "source_location": "L486",
+      "target": "dailyopening_priorclosereopeneditem",
       "weight": 1
     },
     {
@@ -17111,7 +17315,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyopening_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L562",
+      "source_location": "L612",
       "target": "dailyopening_resolveopeningactor",
       "weight": 1
     },
@@ -17147,7 +17351,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyopening_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L733",
+      "source_location": "L790",
       "target": "dailyopening_startstoredaywithctx",
       "weight": 1
     },
@@ -17171,7 +17375,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyopening_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L536",
+      "source_location": "L586",
       "target": "dailyopening_uniquesourcesubjects",
       "weight": 1
     },
@@ -17207,7 +17411,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyoperations_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
-      "source_location": "L286",
+      "source_location": "L287",
       "target": "dailyoperations_attentionseverity",
       "weight": 1
     },
@@ -17219,7 +17423,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyoperations_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
-      "source_location": "L647",
+      "source_location": "L683",
       "target": "dailyoperations_builddailyoperationssnapshotwithctx",
       "weight": 1
     },
@@ -17231,7 +17435,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyoperations_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
-      "source_location": "L530",
+      "source_location": "L561",
       "target": "dailyoperations_buildlanes",
       "weight": 1
     },
@@ -17243,7 +17447,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyoperations_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
-      "source_location": "L186",
+      "source_location": "L187",
       "target": "dailyoperations_buildweekmetricfordate",
       "weight": 1
     },
@@ -17255,7 +17459,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyoperations_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
-      "source_location": "L260",
+      "source_location": "L261",
       "target": "dailyoperations_buildweekmetrics",
       "weight": 1
     },
@@ -17267,7 +17471,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyoperations_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
-      "source_location": "L155",
+      "source_location": "L156",
       "target": "dailyoperations_emptyclosesummary",
       "weight": 1
     },
@@ -17279,8 +17483,20 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyoperations_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
-      "source_location": "L415",
+      "source_location": "L431",
       "target": "dailyoperations_getcloseitemcounts",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_convex_operations_dailyoperations_ts",
+      "_tgt": "dailyoperations_getdailycloserecordfordate",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_convex_operations_dailyoperations_ts",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
+      "source_location": "L416",
+      "target": "dailyoperations_getdailycloserecordfordate",
       "weight": 1
     },
     {
@@ -17291,7 +17507,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyoperations_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
-      "source_location": "L463",
+      "source_location": "L479",
       "target": "dailyoperations_lifecyclecopy",
       "weight": 1
     },
@@ -17303,7 +17519,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyoperations_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
-      "source_location": "L328",
+      "source_location": "L329",
       "target": "dailyoperations_listopenqueuesnapshot",
       "weight": 1
     },
@@ -17315,7 +17531,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyoperations_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
-      "source_location": "L381",
+      "source_location": "L382",
       "target": "dailyoperations_listtimelineevents",
       "weight": 1
     },
@@ -17327,7 +17543,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyoperations_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
-      "source_location": "L309",
+      "source_location": "L310",
       "target": "dailyoperations_openingnotstartedattention",
       "weight": 1
     },
@@ -17339,7 +17555,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyoperations_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
-      "source_location": "L105",
+      "source_location": "L106",
       "target": "dailyoperations_operatingdaterange",
       "weight": 1
     },
@@ -17351,7 +17567,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyoperations_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
-      "source_location": "L170",
+      "source_location": "L171",
       "target": "dailyoperations_pluralize",
       "weight": 1
     },
@@ -17363,7 +17579,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyoperations_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
-      "source_location": "L499",
+      "source_location": "L523",
       "target": "dailyoperations_primaryaction",
       "weight": 1
     },
@@ -17375,7 +17591,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyoperations_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
-      "source_location": "L429",
+      "source_location": "L445",
       "target": "dailyoperations_queueattentionitems",
       "weight": 1
     },
@@ -17387,7 +17603,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyoperations_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
-      "source_location": "L137",
+      "source_location": "L138",
       "target": "dailyoperations_resolverange",
       "weight": 1
     },
@@ -17399,7 +17615,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyoperations_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
-      "source_location": "L133",
+      "source_location": "L134",
       "target": "dailyoperations_saturdayweekendoperatingdate",
       "weight": 1
     },
@@ -17411,7 +17627,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyoperations_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
-      "source_location": "L115",
+      "source_location": "L116",
       "target": "dailyoperations_shiftoperatingdate",
       "weight": 1
     },
@@ -17423,7 +17639,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyoperations_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
-      "source_location": "L292",
+      "source_location": "L293",
       "target": "dailyoperations_sourceattentionitem",
       "weight": 1
     },
@@ -17435,7 +17651,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyoperations_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
-      "source_location": "L123",
+      "source_location": "L124",
       "target": "dailyoperations_sundayweekstartoperatingdate",
       "weight": 1
     },
@@ -17447,7 +17663,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyoperations_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
-      "source_location": "L175",
+      "source_location": "L176",
       "target": "dailyoperations_transactioncashdelta",
       "weight": 1
     },
@@ -20657,13 +20873,25 @@
     },
     {
       "_src": "packages_athena_webapp_convex_pos_application_queries_listregistercatalog_ts",
-      "_tgt": "listregistercatalog_listregistercatalog",
+      "_tgt": "listregistercatalog_getregistercatalogprice",
       "confidence": "EXTRACTED",
       "confidence_score": 1,
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_queries_listregistercatalog_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/queries/listRegisterCatalog.ts",
       "source_location": "L95",
+      "target": "listregistercatalog_getregistercatalogprice",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_convex_pos_application_queries_listregistercatalog_ts",
+      "_tgt": "listregistercatalog_listregistercatalog",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_convex_pos_application_queries_listregistercatalog_ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/listRegisterCatalog.ts",
+      "source_location": "L99",
       "target": "listregistercatalog_listregistercatalog",
       "weight": 1
     },
@@ -20675,7 +20903,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_pos_application_queries_listregistercatalog_ts",
       "source_file": "packages/athena-webapp/convex/pos/application/queries/listRegisterCatalog.ts",
-      "source_location": "L137",
+      "source_location": "L145",
       "target": "listregistercatalog_listregistercatalogavailability",
       "weight": 1
     },
@@ -28751,7 +28979,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailyclosehistoryview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx",
-      "source_location": "L373",
+      "source_location": "L388",
       "target": "dailyclosehistoryview_cn",
       "weight": 1
     },
@@ -28763,7 +28991,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailyclosehistoryview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx",
-      "source_location": "L208",
+      "source_location": "L223",
       "target": "dailyclosehistoryview_dailyclosehistoryapipendingview",
       "weight": 1
     },
@@ -28775,7 +29003,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailyclosehistoryview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx",
-      "source_location": "L228",
+      "source_location": "L243",
       "target": "dailyclosehistoryview_dailyclosehistoryview",
       "weight": 1
     },
@@ -28787,7 +29015,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailyclosehistoryview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx",
-      "source_location": "L195",
+      "source_location": "L210",
       "target": "dailyclosehistoryview_formatcount",
       "weight": 1
     },
@@ -28799,8 +29027,20 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailyclosehistoryview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx",
-      "source_location": "L96",
+      "source_location": "L99",
       "target": "dailyclosehistoryview_getdailyclosehistoryapi",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_components_operations_dailyclosehistoryview_tsx",
+      "_tgt": "dailyclosehistoryview_gethistorylifecyclelabel",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_components_operations_dailyclosehistoryview_tsx",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx",
+      "source_location": "L148",
+      "target": "dailyclosehistoryview_gethistorylifecyclelabel",
       "weight": 1
     },
     {
@@ -28811,7 +29051,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailyclosehistoryview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx",
-      "source_location": "L129",
+      "source_location": "L132",
       "target": "dailyclosehistoryview_gethistoryrecordcompletedat",
       "weight": 1
     },
@@ -28823,7 +29063,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailyclosehistoryview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx",
-      "source_location": "L133",
+      "source_location": "L136",
       "target": "dailyclosehistoryview_gethistoryrecordcompletedby",
       "weight": 1
     },
@@ -28835,7 +29075,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailyclosehistoryview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx",
-      "source_location": "L117",
+      "source_location": "L120",
       "target": "dailyclosehistoryview_gethistoryrecordid",
       "weight": 1
     },
@@ -28847,7 +29087,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailyclosehistoryview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx",
-      "source_location": "L106",
+      "source_location": "L109",
       "target": "dailyclosehistoryview_gethistoryrecords",
       "weight": 1
     },
@@ -28859,7 +29099,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailyclosehistoryview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx",
-      "source_location": "L177",
+      "source_location": "L192",
       "target": "dailyclosehistoryview_gethistoryrecordsnapshot",
       "weight": 1
     },
@@ -28871,7 +29111,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailyclosehistoryview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx",
-      "source_location": "L141",
+      "source_location": "L144",
       "target": "dailyclosehistoryview_gethistoryrecordsummary",
       "weight": 1
     },
@@ -28883,7 +29123,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailyclosehistoryview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx",
-      "source_location": "L123",
+      "source_location": "L126",
       "target": "dailyclosehistoryview_iscompletedhistoryrecord",
       "weight": 1
     },
@@ -28895,7 +29135,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailyclosehistoryview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx",
-      "source_location": "L145",
+      "source_location": "L160",
       "target": "dailyclosehistoryview_normalizehistorysnapshot",
       "weight": 1
     },
@@ -28907,7 +29147,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailyclosehistoryview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx",
-      "source_location": "L201",
+      "source_location": "L216",
       "target": "dailyclosehistoryview_sortnewestfirst",
       "weight": 1
     },
@@ -28955,8 +29195,20 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L520",
+      "source_location": "L541",
       "target": "dailycloseview_builddailyclosetransactionsearch",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
+      "_tgt": "dailycloseview_canreopendailyclose",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
+      "source_location": "L629",
+      "target": "dailycloseview_canreopendailyclose",
       "weight": 1
     },
     {
@@ -28967,7 +29219,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L2475",
+      "source_location": "L2525",
       "target": "dailycloseview_cn",
       "weight": 1
     },
@@ -28979,7 +29231,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L373",
+      "source_location": "L394",
       "target": "dailycloseview_dailyclosestatustitle",
       "weight": 1
     },
@@ -28991,7 +29243,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L338",
+      "source_location": "L359",
       "target": "dailycloseview_formatcarriedoverregistercount",
       "weight": 1
     },
@@ -29003,7 +29255,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L321",
+      "source_location": "L342",
       "target": "dailycloseview_formatchecklistcount",
       "weight": 1
     },
@@ -29015,7 +29267,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L500",
+      "source_location": "L521",
       "target": "dailycloseview_formatdailyclosecompletedat",
       "weight": 1
     },
@@ -29027,7 +29279,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L2827",
+      "source_location": "L2966",
       "target": "dailycloseview_formatdailyclosemoney",
       "weight": 1
     },
@@ -29039,7 +29291,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L466",
+      "source_location": "L487",
       "target": "dailycloseview_formatdailycloseoperatingdate",
       "weight": 1
     },
@@ -29051,7 +29303,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L311",
+      "source_location": "L332",
       "target": "dailycloseview_formatentitycount",
       "weight": 1
     },
@@ -29063,7 +29315,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L433",
+      "source_location": "L454",
       "target": "dailycloseview_formatexpensetransactioncount",
       "weight": 1
     },
@@ -29075,7 +29327,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L946",
+      "source_location": "L983",
       "target": "dailycloseview_formatmetadatadisplayvalue",
       "weight": 1
     },
@@ -29087,7 +29339,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L890",
+      "source_location": "L927",
       "target": "dailycloseview_formatmetadatavalue",
       "weight": 1
     },
@@ -29099,7 +29351,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L439",
+      "source_location": "L460",
       "target": "dailycloseview_formatpossalecount",
       "weight": 1
     },
@@ -29111,7 +29363,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L344",
+      "source_location": "L365",
       "target": "dailycloseview_formatregistervariancecount",
       "weight": 1
     },
@@ -29123,7 +29375,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L835",
+      "source_location": "L872",
       "target": "dailycloseview_formattimestampmetadata",
       "weight": 1
     },
@@ -29135,7 +29387,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L332",
+      "source_location": "L353",
       "target": "dailycloseview_formattodaycashtransactioncount",
       "weight": 1
     },
@@ -29147,7 +29399,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L445",
+      "source_location": "L466",
       "target": "dailycloseview_formatvoidedsalecount",
       "weight": 1
     },
@@ -29159,7 +29411,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1432",
+      "source_location": "L1474",
       "target": "dailycloseview_getbucketconfigs",
       "weight": 1
     },
@@ -29171,7 +29423,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L421",
+      "source_location": "L442",
       "target": "dailycloseview_getbucketcountclassname",
       "weight": 1
     },
@@ -29183,7 +29435,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L613",
+      "source_location": "L650",
       "target": "dailycloseview_getcarryforwardworkitemid",
       "weight": 1
     },
@@ -29195,7 +29447,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L619",
+      "source_location": "L656",
       "target": "dailycloseview_getcarryforwardworkitemids",
       "weight": 1
     },
@@ -29207,7 +29459,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1221",
+      "source_location": "L1258",
       "target": "dailycloseview_getcollapsedmetadataentries",
       "weight": 1
     },
@@ -29219,7 +29471,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L301",
+      "source_location": "L322",
       "target": "dailycloseview_getdailycloseapi",
       "weight": 1
     },
@@ -29231,7 +29483,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L534",
+      "source_location": "L555",
       "target": "dailycloseview_getdailyclosesalesmetriclabels",
       "weight": 1
     },
@@ -29243,7 +29495,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L587",
+      "source_location": "L608",
       "target": "dailycloseview_getdailyclosestatus",
       "weight": 1
     },
@@ -29255,7 +29507,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1409",
+      "source_location": "L1451",
       "target": "dailycloseview_getdefaultbucketvalue",
       "weight": 1
     },
@@ -29267,7 +29519,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L845",
+      "source_location": "L882",
       "target": "dailycloseview_getdisplaymetadatalabel",
       "weight": 1
     },
@@ -29279,7 +29531,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1290",
+      "source_location": "L1327",
       "target": "dailycloseview_getexpensestaffcount",
       "weight": 1
     },
@@ -29291,7 +29543,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1302",
+      "source_location": "L1339",
       "target": "dailycloseview_getexpensetransactioncount",
       "weight": 1
     },
@@ -29303,7 +29555,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L633",
+      "source_location": "L670",
       "target": "dailycloseview_getitemcontextlabel",
       "weight": 1
     },
@@ -29315,7 +29567,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L623",
+      "source_location": "L660",
       "target": "dailycloseview_getitemdescription",
       "weight": 1
     },
@@ -29327,7 +29579,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L601",
+      "source_location": "L638",
       "target": "dailycloseview_getitemid",
       "weight": 1
     },
@@ -29339,7 +29591,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L481",
+      "source_location": "L502",
       "target": "dailycloseview_getlocaldatefromoperatingdate",
       "weight": 1
     },
@@ -29351,7 +29603,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L512",
+      "source_location": "L533",
       "target": "dailycloseview_getlocaloperatingdate",
       "weight": 1
     },
@@ -29363,7 +29615,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L543",
+      "source_location": "L564",
       "target": "dailycloseview_getlocaloperatingdaterange",
       "weight": 1
     },
@@ -29375,7 +29627,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L562",
+      "source_location": "L583",
       "target": "dailycloseview_getlocaloperatingdaterangefromsearch",
       "weight": 1
     },
@@ -29387,7 +29639,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1028",
+      "source_location": "L1065",
       "target": "dailycloseview_getmetadataentries",
       "weight": 1
     },
@@ -29399,7 +29651,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1499",
+      "source_location": "L1541",
       "target": "dailycloseview_getmetadatastringornumber",
       "weight": 1
     },
@@ -29411,7 +29663,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L861",
+      "source_location": "L898",
       "target": "dailycloseview_getmetadatastringvalue",
       "weight": 1
     },
@@ -29423,7 +29675,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L882",
+      "source_location": "L919",
       "target": "dailycloseview_getmetadatavalue",
       "weight": 1
     },
@@ -29435,7 +29687,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L807",
+      "source_location": "L844",
       "target": "dailycloseview_getnumericmetadatavalue",
       "weight": 1
     },
@@ -29447,7 +29699,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L609",
+      "source_location": "L646",
       "target": "dailycloseview_getrevieweditemkeys",
       "weight": 1
     },
@@ -29459,7 +29711,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1355",
+      "source_location": "L1392",
       "target": "dailycloseview_getstatusdisplaycopy",
       "weight": 1
     },
@@ -29471,7 +29723,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L350",
+      "source_location": "L371",
       "target": "dailycloseview_getstatuslabelclassname",
       "weight": 1
     },
@@ -29483,7 +29735,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L412",
+      "source_location": "L433",
       "target": "dailycloseview_getstatusrailbadgeclassname",
       "weight": 1
     },
@@ -29495,7 +29747,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L362",
+      "source_location": "L383",
       "target": "dailycloseview_getstatusrailiconclassname",
       "weight": 1
     },
@@ -29507,7 +29759,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L2847",
+      "source_location": "L2986",
       "target": "dailycloseview_getsummaryamount",
       "weight": 1
     },
@@ -29519,7 +29771,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1260",
+      "source_location": "L1297",
       "target": "dailycloseview_getsummarycount",
       "weight": 1
     },
@@ -29531,7 +29783,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1275",
+      "source_location": "L1312",
       "target": "dailycloseview_getsummaryregistervariancecount",
       "weight": 1
     },
@@ -29543,7 +29795,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1519",
+      "source_location": "L1561",
       "target": "dailycloseview_gettransactionreportamount",
       "weight": 1
     },
@@ -29555,7 +29807,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1509",
+      "source_location": "L1551",
       "target": "dailycloseview_gettransactionreportidentifier",
       "weight": 1
     },
@@ -29567,7 +29819,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1480",
+      "source_location": "L1522",
       "target": "dailycloseview_gettransactionreportitems",
       "weight": 1
     },
@@ -29579,7 +29831,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1589",
+      "source_location": "L1631",
       "target": "dailycloseview_gettransactionreportlink",
       "weight": 1
     },
@@ -29591,7 +29843,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1532",
+      "source_location": "L1574",
       "target": "dailycloseview_gettransactionreportpayment",
       "weight": 1
     },
@@ -29603,7 +29855,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1527",
+      "source_location": "L1569",
       "target": "dailycloseview_gettransactionreportstaff",
       "weight": 1
     },
@@ -29615,7 +29867,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1580",
+      "source_location": "L1622",
       "target": "dailycloseview_gettransactionreporttime",
       "weight": 1
     },
@@ -29627,7 +29879,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L799",
+      "source_location": "L836",
       "target": "dailycloseview_getvariancetone",
       "weight": 1
     },
@@ -29639,7 +29891,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1830",
+      "source_location": "L1872",
       "target": "dailycloseview_handlepagechange",
       "weight": 1
     },
@@ -29651,8 +29903,20 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L641",
+      "source_location": "L678",
       "target": "dailycloseview_humanizemetadatalabel",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
+      "_tgt": "dailycloseview_if",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
+      "source_location": "L3152",
+      "target": "dailycloseview_if",
       "weight": 1
     },
     {
@@ -29663,7 +29927,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L791",
+      "source_location": "L828",
       "target": "dailycloseview_ismoneymetadatalabel",
       "weight": 1
     },
@@ -29675,7 +29939,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L795",
+      "source_location": "L832",
       "target": "dailycloseview_istimestampmetadatalabel",
       "weight": 1
     },
@@ -29687,7 +29951,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L871",
+      "source_location": "L908",
       "target": "dailycloseview_isvarianceapprovalitem",
       "weight": 1
     },
@@ -29699,7 +29963,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1316",
+      "source_location": "L1353",
       "target": "dailycloseview_iszeroactivitydailyclose",
       "weight": 1
     },
@@ -29711,7 +29975,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1419",
+      "source_location": "L1461",
       "target": "dailycloseview_normalizebuckettab",
       "weight": 1
     },
@@ -29723,7 +29987,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L574",
+      "source_location": "L595",
       "target": "dailycloseview_normalizecommandmessage",
       "weight": 1
     },
@@ -29735,7 +29999,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1371",
+      "source_location": "L1408",
       "target": "dailycloseview_normalizecompletedreportsnapshot",
       "weight": 1
     },
@@ -29747,7 +30011,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L787",
+      "source_location": "L824",
       "target": "dailycloseview_normalizemetadatalabel",
       "weight": 1
     },
@@ -29759,7 +30023,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1426",
+      "source_location": "L1468",
       "target": "dailycloseview_normalizepage",
       "weight": 1
     },
@@ -29771,7 +30035,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1545",
+      "source_location": "L1587",
       "target": "dailycloseview_normalizetransactionreportpaymentmethod",
       "weight": 1
     },
@@ -29783,7 +30047,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L451",
+      "source_location": "L472",
       "target": "dailycloseview_sentencefragment",
       "weight": 1
     },
@@ -29795,7 +30059,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L627",
+      "source_location": "L664",
       "target": "dailycloseview_shouldshowcollapseddescription",
       "weight": 1
     },
@@ -29807,7 +30071,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L820",
+      "source_location": "L857",
       "target": "dailycloseview_shouldshowmetadataentry",
       "weight": 1
     },
@@ -29819,7 +30083,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L390",
+      "source_location": "L411",
       "target": "dailycloseview_successcheckicon",
       "weight": 1
     },
@@ -29831,7 +30095,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1552",
+      "source_location": "L1594",
       "target": "dailycloseview_transactionreportpaymenticon",
       "weight": 1
     },
@@ -32783,7 +33047,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_register_posregisteropeningguard_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterOpeningGuard.tsx",
-      "source_location": "L17",
+      "source_location": "L24",
       "target": "posregisteropeningguard_getlocaloperatingdate",
       "weight": 1
     },
@@ -32795,7 +33059,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_register_posregisteropeningguard_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterOpeningGuard.tsx",
-      "source_location": "L25",
+      "source_location": "L32",
       "target": "posregisteropeningguard_getlocaloperatingdaterange",
       "weight": 1
     },
@@ -48275,7 +48539,7 @@
       "relation": "calls",
       "source": "posregisteropeningguard_getlocaloperatingdate",
       "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterOpeningGuard.tsx",
-      "source_location": "L39",
+      "source_location": "L46",
       "target": "posregisteropeningguard_getlocaloperatingdaterange",
       "weight": 1
     },
@@ -60997,7 +61261,16 @@
       "label": "buildDailyCloseTransactionSearch()",
       "norm_label": "builddailyclosetransactionsearch()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L520"
+      "source_location": "L541"
+    },
+    {
+      "community": 0,
+      "file_type": "code",
+      "id": "dailycloseview_canreopendailyclose",
+      "label": "canReopenDailyClose()",
+      "norm_label": "canreopendailyclose()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
+      "source_location": "L629"
     },
     {
       "community": 0,
@@ -61006,7 +61279,7 @@
       "label": "cn()",
       "norm_label": "cn()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1952"
+      "source_location": "L1994"
     },
     {
       "community": 0,
@@ -61015,7 +61288,7 @@
       "label": "DailyCloseStatusTitle()",
       "norm_label": "dailyclosestatustitle()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L373"
+      "source_location": "L394"
     },
     {
       "community": 0,
@@ -61024,7 +61297,7 @@
       "label": "formatCarriedOverRegisterCount()",
       "norm_label": "formatcarriedoverregistercount()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L338"
+      "source_location": "L359"
     },
     {
       "community": 0,
@@ -61033,7 +61306,7 @@
       "label": "formatChecklistCount()",
       "norm_label": "formatchecklistcount()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L321"
+      "source_location": "L342"
     },
     {
       "community": 0,
@@ -61042,7 +61315,7 @@
       "label": "formatDailyCloseCompletedAt()",
       "norm_label": "formatdailyclosecompletedat()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L500"
+      "source_location": "L521"
     },
     {
       "community": 0,
@@ -61051,7 +61324,7 @@
       "label": "formatDailyCloseMoney()",
       "norm_label": "formatdailyclosemoney()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L455"
+      "source_location": "L476"
     },
     {
       "community": 0,
@@ -61060,7 +61333,7 @@
       "label": "formatDailyCloseOperatingDate()",
       "norm_label": "formatdailycloseoperatingdate()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L466"
+      "source_location": "L487"
     },
     {
       "community": 0,
@@ -61069,7 +61342,7 @@
       "label": "formatEntityCount()",
       "norm_label": "formatentitycount()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L311"
+      "source_location": "L332"
     },
     {
       "community": 0,
@@ -61078,7 +61351,7 @@
       "label": "formatExpenseTransactionCount()",
       "norm_label": "formatexpensetransactioncount()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L433"
+      "source_location": "L454"
     },
     {
       "community": 0,
@@ -61087,7 +61360,7 @@
       "label": "formatMetadataDisplayValue()",
       "norm_label": "formatmetadatadisplayvalue()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L946"
+      "source_location": "L983"
     },
     {
       "community": 0,
@@ -61096,7 +61369,7 @@
       "label": "formatMetadataValue()",
       "norm_label": "formatmetadatavalue()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L890"
+      "source_location": "L927"
     },
     {
       "community": 0,
@@ -61105,7 +61378,7 @@
       "label": "formatPosSaleCount()",
       "norm_label": "formatpossalecount()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L439"
+      "source_location": "L460"
     },
     {
       "community": 0,
@@ -61114,7 +61387,7 @@
       "label": "formatRegisterVarianceCount()",
       "norm_label": "formatregistervariancecount()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L344"
+      "source_location": "L365"
     },
     {
       "community": 0,
@@ -61123,7 +61396,7 @@
       "label": "formatTimestampMetadata()",
       "norm_label": "formattimestampmetadata()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L835"
+      "source_location": "L872"
     },
     {
       "community": 0,
@@ -61132,7 +61405,7 @@
       "label": "formatTodayCashTransactionCount()",
       "norm_label": "formattodaycashtransactioncount()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L332"
+      "source_location": "L353"
     },
     {
       "community": 0,
@@ -61141,7 +61414,7 @@
       "label": "formatVoidedSaleCount()",
       "norm_label": "formatvoidedsalecount()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L445"
+      "source_location": "L466"
     },
     {
       "community": 0,
@@ -61150,7 +61423,7 @@
       "label": "getBucketConfigs()",
       "norm_label": "getbucketconfigs()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1432"
+      "source_location": "L1474"
     },
     {
       "community": 0,
@@ -61159,7 +61432,7 @@
       "label": "getBucketCountClassName()",
       "norm_label": "getbucketcountclassname()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L421"
+      "source_location": "L442"
     },
     {
       "community": 0,
@@ -61168,7 +61441,7 @@
       "label": "getCarryForwardWorkItemId()",
       "norm_label": "getcarryforwardworkitemid()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L613"
+      "source_location": "L650"
     },
     {
       "community": 0,
@@ -61177,7 +61450,7 @@
       "label": "getCarryForwardWorkItemIds()",
       "norm_label": "getcarryforwardworkitemids()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L619"
+      "source_location": "L656"
     },
     {
       "community": 0,
@@ -61186,7 +61459,7 @@
       "label": "getCollapsedMetadataEntries()",
       "norm_label": "getcollapsedmetadataentries()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1221"
+      "source_location": "L1258"
     },
     {
       "community": 0,
@@ -61195,7 +61468,7 @@
       "label": "getDailyCloseApi()",
       "norm_label": "getdailycloseapi()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L301"
+      "source_location": "L322"
     },
     {
       "community": 0,
@@ -61204,7 +61477,7 @@
       "label": "getDailyCloseSalesMetricLabels()",
       "norm_label": "getdailyclosesalesmetriclabels()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L534"
+      "source_location": "L555"
     },
     {
       "community": 0,
@@ -61213,7 +61486,7 @@
       "label": "getDailyCloseStatus()",
       "norm_label": "getdailyclosestatus()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L587"
+      "source_location": "L608"
     },
     {
       "community": 0,
@@ -61222,7 +61495,7 @@
       "label": "getDefaultBucketValue()",
       "norm_label": "getdefaultbucketvalue()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1409"
+      "source_location": "L1451"
     },
     {
       "community": 0,
@@ -61231,7 +61504,7 @@
       "label": "getDisplayMetadataLabel()",
       "norm_label": "getdisplaymetadatalabel()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L845"
+      "source_location": "L882"
     },
     {
       "community": 0,
@@ -61240,7 +61513,7 @@
       "label": "getExpenseStaffCount()",
       "norm_label": "getexpensestaffcount()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1290"
+      "source_location": "L1327"
     },
     {
       "community": 0,
@@ -61249,7 +61522,7 @@
       "label": "getExpenseTransactionCount()",
       "norm_label": "getexpensetransactioncount()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1302"
+      "source_location": "L1339"
     },
     {
       "community": 0,
@@ -61258,7 +61531,7 @@
       "label": "getItemContextLabel()",
       "norm_label": "getitemcontextlabel()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L633"
+      "source_location": "L670"
     },
     {
       "community": 0,
@@ -61267,7 +61540,7 @@
       "label": "getItemDescription()",
       "norm_label": "getitemdescription()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L623"
+      "source_location": "L660"
     },
     {
       "community": 0,
@@ -61276,7 +61549,7 @@
       "label": "getItemId()",
       "norm_label": "getitemid()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L601"
+      "source_location": "L638"
     },
     {
       "community": 0,
@@ -61285,7 +61558,7 @@
       "label": "getLocalDateFromOperatingDate()",
       "norm_label": "getlocaldatefromoperatingdate()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L481"
+      "source_location": "L502"
     },
     {
       "community": 0,
@@ -61294,7 +61567,7 @@
       "label": "getLocalOperatingDate()",
       "norm_label": "getlocaloperatingdate()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L512"
+      "source_location": "L533"
     },
     {
       "community": 0,
@@ -61303,7 +61576,7 @@
       "label": "getLocalOperatingDateRange()",
       "norm_label": "getlocaloperatingdaterange()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L543"
+      "source_location": "L564"
     },
     {
       "community": 0,
@@ -61312,7 +61585,7 @@
       "label": "getLocalOperatingDateRangeFromSearch()",
       "norm_label": "getlocaloperatingdaterangefromsearch()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L562"
+      "source_location": "L583"
     },
     {
       "community": 0,
@@ -61321,7 +61594,7 @@
       "label": "getMetadataEntries()",
       "norm_label": "getmetadataentries()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1028"
+      "source_location": "L1065"
     },
     {
       "community": 0,
@@ -61330,7 +61603,7 @@
       "label": "getMetadataStringOrNumber()",
       "norm_label": "getmetadatastringornumber()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1499"
+      "source_location": "L1541"
     },
     {
       "community": 0,
@@ -61339,7 +61612,7 @@
       "label": "getMetadataStringValue()",
       "norm_label": "getmetadatastringvalue()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L861"
+      "source_location": "L898"
     },
     {
       "community": 0,
@@ -61348,7 +61621,7 @@
       "label": "getMetadataValue()",
       "norm_label": "getmetadatavalue()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L882"
+      "source_location": "L919"
     },
     {
       "community": 0,
@@ -61357,7 +61630,7 @@
       "label": "getNumericMetadataValue()",
       "norm_label": "getnumericmetadatavalue()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L807"
+      "source_location": "L844"
     },
     {
       "community": 0,
@@ -61366,7 +61639,7 @@
       "label": "getReviewedItemKeys()",
       "norm_label": "getrevieweditemkeys()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L609"
+      "source_location": "L646"
     },
     {
       "community": 0,
@@ -61375,7 +61648,7 @@
       "label": "getStatusDisplayCopy()",
       "norm_label": "getstatusdisplaycopy()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1355"
+      "source_location": "L1392"
     },
     {
       "community": 0,
@@ -61384,7 +61657,7 @@
       "label": "getStatusLabelClassName()",
       "norm_label": "getstatuslabelclassname()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L350"
+      "source_location": "L371"
     },
     {
       "community": 0,
@@ -61393,7 +61666,7 @@
       "label": "getStatusRailBadgeClassName()",
       "norm_label": "getstatusrailbadgeclassname()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L412"
+      "source_location": "L433"
     },
     {
       "community": 0,
@@ -61402,7 +61675,7 @@
       "label": "getStatusRailIconClassName()",
       "norm_label": "getstatusrailiconclassname()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L362"
+      "source_location": "L383"
     },
     {
       "community": 0,
@@ -61411,7 +61684,7 @@
       "label": "getSummaryAmount()",
       "norm_label": "getsummaryamount()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1245"
+      "source_location": "L1282"
     },
     {
       "community": 0,
@@ -61420,7 +61693,7 @@
       "label": "getSummaryCount()",
       "norm_label": "getsummarycount()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1260"
+      "source_location": "L1297"
     },
     {
       "community": 0,
@@ -61429,7 +61702,7 @@
       "label": "getSummaryRegisterVarianceCount()",
       "norm_label": "getsummaryregistervariancecount()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1275"
+      "source_location": "L1312"
     },
     {
       "community": 0,
@@ -61438,7 +61711,7 @@
       "label": "getTransactionReportAmount()",
       "norm_label": "gettransactionreportamount()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1519"
+      "source_location": "L1561"
     },
     {
       "community": 0,
@@ -61447,7 +61720,7 @@
       "label": "getTransactionReportIdentifier()",
       "norm_label": "gettransactionreportidentifier()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1509"
+      "source_location": "L1551"
     },
     {
       "community": 0,
@@ -61456,7 +61729,7 @@
       "label": "getTransactionReportItems()",
       "norm_label": "gettransactionreportitems()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1480"
+      "source_location": "L1522"
     },
     {
       "community": 0,
@@ -61465,7 +61738,7 @@
       "label": "getTransactionReportLink()",
       "norm_label": "gettransactionreportlink()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1589"
+      "source_location": "L1631"
     },
     {
       "community": 0,
@@ -61474,7 +61747,7 @@
       "label": "getTransactionReportPayment()",
       "norm_label": "gettransactionreportpayment()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1532"
+      "source_location": "L1574"
     },
     {
       "community": 0,
@@ -61483,7 +61756,7 @@
       "label": "getTransactionReportStaff()",
       "norm_label": "gettransactionreportstaff()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1527"
+      "source_location": "L1569"
     },
     {
       "community": 0,
@@ -61492,7 +61765,7 @@
       "label": "getTransactionReportTime()",
       "norm_label": "gettransactionreporttime()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1580"
+      "source_location": "L1622"
     },
     {
       "community": 0,
@@ -61501,7 +61774,7 @@
       "label": "getVarianceTone()",
       "norm_label": "getvariancetone()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L799"
+      "source_location": "L836"
     },
     {
       "community": 0,
@@ -61510,7 +61783,7 @@
       "label": "handlePageChange()",
       "norm_label": "handlepagechange()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1830"
+      "source_location": "L1872"
     },
     {
       "community": 0,
@@ -61519,7 +61792,16 @@
       "label": "humanizeMetadataLabel()",
       "norm_label": "humanizemetadatalabel()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L641"
+      "source_location": "L678"
+    },
+    {
+      "community": 0,
+      "file_type": "code",
+      "id": "dailycloseview_if",
+      "label": "if()",
+      "norm_label": "if()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
+      "source_location": "L3152"
     },
     {
       "community": 0,
@@ -61528,7 +61810,7 @@
       "label": "isMoneyMetadataLabel()",
       "norm_label": "ismoneymetadatalabel()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L791"
+      "source_location": "L828"
     },
     {
       "community": 0,
@@ -61537,7 +61819,7 @@
       "label": "isTimestampMetadataLabel()",
       "norm_label": "istimestampmetadatalabel()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L795"
+      "source_location": "L832"
     },
     {
       "community": 0,
@@ -61546,7 +61828,7 @@
       "label": "isVarianceApprovalItem()",
       "norm_label": "isvarianceapprovalitem()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L871"
+      "source_location": "L908"
     },
     {
       "community": 0,
@@ -61555,7 +61837,7 @@
       "label": "isZeroActivityDailyClose()",
       "norm_label": "iszeroactivitydailyclose()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1316"
+      "source_location": "L1353"
     },
     {
       "community": 0,
@@ -61564,7 +61846,7 @@
       "label": "normalizeBucketTab()",
       "norm_label": "normalizebuckettab()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1419"
+      "source_location": "L1461"
     },
     {
       "community": 0,
@@ -61573,7 +61855,7 @@
       "label": "normalizeCommandMessage()",
       "norm_label": "normalizecommandmessage()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L574"
+      "source_location": "L595"
     },
     {
       "community": 0,
@@ -61582,7 +61864,7 @@
       "label": "normalizeCompletedReportSnapshot()",
       "norm_label": "normalizecompletedreportsnapshot()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1371"
+      "source_location": "L1408"
     },
     {
       "community": 0,
@@ -61591,7 +61873,7 @@
       "label": "normalizeMetadataLabel()",
       "norm_label": "normalizemetadatalabel()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L787"
+      "source_location": "L824"
     },
     {
       "community": 0,
@@ -61600,7 +61882,7 @@
       "label": "normalizePage()",
       "norm_label": "normalizepage()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1426"
+      "source_location": "L1468"
     },
     {
       "community": 0,
@@ -61609,7 +61891,7 @@
       "label": "normalizeTransactionReportPaymentMethod()",
       "norm_label": "normalizetransactionreportpaymentmethod()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1545"
+      "source_location": "L1587"
     },
     {
       "community": 0,
@@ -61618,7 +61900,7 @@
       "label": "sentenceFragment()",
       "norm_label": "sentencefragment()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L451"
+      "source_location": "L472"
     },
     {
       "community": 0,
@@ -61627,7 +61909,7 @@
       "label": "shouldShowCollapsedDescription()",
       "norm_label": "shouldshowcollapseddescription()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L627"
+      "source_location": "L664"
     },
     {
       "community": 0,
@@ -61636,7 +61918,7 @@
       "label": "shouldShowMetadataEntry()",
       "norm_label": "shouldshowmetadataentry()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L820"
+      "source_location": "L857"
     },
     {
       "community": 0,
@@ -61645,7 +61927,7 @@
       "label": "SuccessCheckIcon()",
       "norm_label": "successcheckicon()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L390"
+      "source_location": "L411"
     },
     {
       "community": 0,
@@ -61654,7 +61936,7 @@
       "label": "TransactionReportPaymentIcon()",
       "norm_label": "transactionreportpaymenticon()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1552"
+      "source_location": "L1594"
     },
     {
       "community": 0,
@@ -61672,7 +61954,7 @@
       "label": "approvalBelongsToRange()",
       "norm_label": "approvalbelongstorange()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L648"
+      "source_location": "L727"
     },
     {
       "community": 1,
@@ -61681,7 +61963,7 @@
       "label": "approvalRequestTypeLabel()",
       "norm_label": "approvalrequesttypelabel()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L402"
+      "source_location": "L453"
     },
     {
       "community": 1,
@@ -61690,7 +61972,7 @@
       "label": "asCarryForwardItem()",
       "norm_label": "ascarryforwarditem()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L498"
+      "source_location": "L549"
     },
     {
       "community": 1,
@@ -61699,7 +61981,7 @@
       "label": "buildDailyCloseApprovalSubject()",
       "norm_label": "builddailycloseapprovalsubject()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L245"
+      "source_location": "L262"
     },
     {
       "community": 1,
@@ -61708,7 +61990,16 @@
       "label": "buildDailyCloseCompletionApprovalRequirement()",
       "norm_label": "builddailyclosecompletionapprovalrequirement()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L256"
+      "source_location": "L273"
+    },
+    {
+      "community": 1,
+      "file_type": "code",
+      "id": "dailyclose_builddailyclosereopenapprovalrequirement",
+      "label": "buildDailyCloseReopenApprovalRequirement()",
+      "norm_label": "builddailyclosereopenapprovalrequirement()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
+      "source_location": "L301"
     },
     {
       "community": 1,
@@ -61717,7 +62008,7 @@
       "label": "buildDailyCloseReportSnapshot()",
       "norm_label": "builddailyclosereportsnapshot()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L912"
+      "source_location": "L991"
     },
     {
       "community": 1,
@@ -61726,7 +62017,7 @@
       "label": "buildDailyCloseSnapshotWithCtx()",
       "norm_label": "builddailyclosesnapshotwithctx()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1034"
+      "source_location": "L1115"
     },
     {
       "community": 1,
@@ -61735,7 +62026,7 @@
       "label": "buildExpenseSessionsById()",
       "norm_label": "buildexpensesessionsbyid()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L478"
+      "source_location": "L529"
     },
     {
       "community": 1,
@@ -61744,7 +62035,7 @@
       "label": "buildPaymentTotals()",
       "norm_label": "buildpaymenttotals()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L827"
+      "source_location": "L906"
     },
     {
       "community": 1,
@@ -61753,7 +62044,7 @@
       "label": "buildReadiness()",
       "norm_label": "buildreadiness()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L874"
+      "source_location": "L953"
     },
     {
       "community": 1,
@@ -61762,7 +62053,7 @@
       "label": "buildRegisterSessionsById()",
       "norm_label": "buildregistersessionsbyid()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L458"
+      "source_location": "L509"
     },
     {
       "community": 1,
@@ -61771,7 +62062,7 @@
       "label": "buildStaffNamesById()",
       "norm_label": "buildstaffnamesbyid()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L438"
+      "source_location": "L489"
     },
     {
       "community": 1,
@@ -61780,7 +62071,7 @@
       "label": "buildTerminalLabelsById()",
       "norm_label": "buildterminallabelsbyid()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L418"
+      "source_location": "L469"
     },
     {
       "community": 1,
@@ -61789,7 +62080,7 @@
       "label": "cashDeltasByRegisterSessionId()",
       "norm_label": "cashdeltasbyregistersessionid()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L856"
+      "source_location": "L935"
     },
     {
       "community": 1,
@@ -61798,7 +62089,7 @@
       "label": "completeDailyCloseWithCtx()",
       "norm_label": "completedailyclosewithctx()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1849"
+      "source_location": "L1936"
     },
     {
       "community": 1,
@@ -61807,7 +62098,7 @@
       "label": "createCarryForwardWorkItems()",
       "norm_label": "createcarryforwardworkitems()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1773"
+      "source_location": "L1860"
     },
     {
       "community": 1,
@@ -61816,7 +62107,7 @@
       "label": "emptySummary()",
       "norm_label": "emptysummary()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1010"
+      "source_location": "L1091"
     },
     {
       "community": 1,
@@ -61825,7 +62116,7 @@
       "label": "formatPaymentMethodLabel()",
       "norm_label": "formatpaymentmethodlabel()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L374"
+      "source_location": "L425"
     },
     {
       "community": 1,
@@ -61834,7 +62125,7 @@
       "label": "getCompletedDailyCloseHistoryDetailWithCtx()",
       "norm_label": "getcompleteddailyclosehistorydetailwithctx()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2186"
+      "source_location": "L2477"
     },
     {
       "community": 1,
@@ -61843,7 +62134,7 @@
       "label": "getDailyCloseCompletionEventStaffProfileId()",
       "norm_label": "getdailyclosecompletioneventstaffprofileid()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L983"
+      "source_location": "L1064"
     },
     {
       "community": 1,
@@ -61852,7 +62143,7 @@
       "label": "getDailyCloseForDate()",
       "norm_label": "getdailyclosefordate()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L527"
+      "source_location": "L579"
     },
     {
       "community": 1,
@@ -61861,7 +62152,7 @@
       "label": "getDailyCloseOpeningContextWithCtx()",
       "norm_label": "getdailycloseopeningcontextwithctx()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2101"
+      "source_location": "L2392"
     },
     {
       "community": 1,
@@ -61870,7 +62161,7 @@
       "label": "getPriorCompletedDailyClose()",
       "norm_label": "getpriorcompleteddailyclose()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L542"
+      "source_location": "L618"
     },
     {
       "community": 1,
@@ -61879,7 +62170,7 @@
       "label": "getStore()",
       "norm_label": "getstore()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L520"
+      "source_location": "L572"
     },
     {
       "community": 1,
@@ -61888,7 +62179,7 @@
       "label": "isInRange()",
       "norm_label": "isinrange()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L338"
+      "source_location": "L389"
     },
     {
       "community": 1,
@@ -61897,7 +62188,7 @@
       "label": "isValidOperatingDateRange()",
       "norm_label": "isvalidoperatingdaterange()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L306"
+      "source_location": "L357"
     },
     {
       "community": 1,
@@ -61906,7 +62197,7 @@
       "label": "listActiveRegisterSessions()",
       "norm_label": "listactiveregistersessions()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L564"
+      "source_location": "L643"
     },
     {
       "community": 1,
@@ -61915,7 +62206,7 @@
       "label": "listClosedRegisterSessionsForDay()",
       "norm_label": "listclosedregistersessionsforday()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L582"
+      "source_location": "L661"
     },
     {
       "community": 1,
@@ -61924,7 +62215,7 @@
       "label": "listCompletedDailyCloseHistoryWithCtx()",
       "norm_label": "listcompleteddailyclosehistorywithctx()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2137"
+      "source_location": "L2428"
     },
     {
       "community": 1,
@@ -61933,7 +62224,7 @@
       "label": "listDepositsForDay()",
       "norm_label": "listdepositsforday()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L805"
+      "source_location": "L884"
     },
     {
       "community": 1,
@@ -61942,7 +62233,7 @@
       "label": "listExpensesForDay()",
       "norm_label": "listexpensesforday()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L785"
+      "source_location": "L864"
     },
     {
       "community": 1,
@@ -61951,7 +62242,7 @@
       "label": "listOpenOperationalWorkItems()",
       "norm_label": "listopenoperationalworkitems()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L750"
+      "source_location": "L829"
     },
     {
       "community": 1,
@@ -61960,7 +62251,7 @@
       "label": "listOpenPosSessions()",
       "norm_label": "listopenpossessions()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L722"
+      "source_location": "L801"
     },
     {
       "community": 1,
@@ -61969,7 +62260,7 @@
       "label": "listPendingCloseoutApprovals()",
       "norm_label": "listpendingcloseoutapprovals()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L688"
+      "source_location": "L767"
     },
     {
       "community": 1,
@@ -61978,7 +62269,7 @@
       "label": "listTransactionsForDay()",
       "norm_label": "listtransactionsforday()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L764"
+      "source_location": "L843"
     },
     {
       "community": 1,
@@ -61987,7 +62278,7 @@
       "label": "markOtherDailyClosesNotCurrent()",
       "norm_label": "markotherdailyclosesnotcurrent()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1826"
+      "source_location": "L1913"
     },
     {
       "community": 1,
@@ -61996,7 +62287,7 @@
       "label": "nonZeroVarianceMetadata()",
       "norm_label": "nonzerovariancemetadata()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L398"
+      "source_location": "L449"
     },
     {
       "community": 1,
@@ -62005,7 +62296,7 @@
       "label": "normalizeCompletedDailyCloseSnapshot()",
       "norm_label": "normalizecompleteddailyclosesnapshot()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L163"
+      "source_location": "L164"
     },
     {
       "community": 1,
@@ -62014,7 +62305,7 @@
       "label": "posSessionIntersectsRange()",
       "norm_label": "possessionintersectsrange()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L632"
+      "source_location": "L711"
     },
     {
       "community": 1,
@@ -62023,7 +62314,7 @@
       "label": "registerMetadataLabel()",
       "norm_label": "registermetadatalabel()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L361"
+      "source_location": "L412"
     },
     {
       "community": 1,
@@ -62032,7 +62323,7 @@
       "label": "registerSessionBelongsToRange()",
       "norm_label": "registersessionbelongstorange()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L616"
+      "source_location": "L695"
     },
     {
       "community": 1,
@@ -62041,7 +62332,7 @@
       "label": "registerSessionCloseoutOperatingAt()",
       "norm_label": "registersessioncloseoutoperatingat()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L342"
+      "source_location": "L393"
     },
     {
       "community": 1,
@@ -62050,7 +62341,7 @@
       "label": "registerSessionIntersectsRange()",
       "norm_label": "registersessionintersectsrange()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L606"
+      "source_location": "L685"
     },
     {
       "community": 1,
@@ -62059,7 +62350,16 @@
       "label": "registerSessionLabel()",
       "norm_label": "registersessionlabel()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L353"
+      "source_location": "L404"
+    },
+    {
+      "community": 1,
+      "file_type": "code",
+      "id": "dailyclose_reopendailyclosewithctx",
+      "label": "reopenDailyCloseWithCtx()",
+      "norm_label": "reopendailyclosewithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
+      "source_location": "L2198"
     },
     {
       "community": 1,
@@ -62068,7 +62368,7 @@
       "label": "resolveOperatingDateRange()",
       "norm_label": "resolveoperatingdaterange()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L317"
+      "source_location": "L368"
     },
     {
       "community": 1,
@@ -62077,7 +62377,7 @@
       "label": "safeOperatingDateRange()",
       "norm_label": "safeoperatingdaterange()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L289"
+      "source_location": "L340"
     },
     {
       "community": 1,
@@ -62086,7 +62386,7 @@
       "label": "snapshotReviewedItems()",
       "norm_label": "snapshotrevieweditems()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L950"
+      "source_location": "L1029"
     },
     {
       "community": 1,
@@ -62095,7 +62395,7 @@
       "label": "sortDailyCloseBlockers()",
       "norm_label": "sortdailycloseblockers()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L126"
+      "source_location": "L127"
     },
     {
       "community": 1,
@@ -62104,7 +62404,7 @@
       "label": "toDailyCloseHistoryListItem()",
       "norm_label": "todailyclosehistorylistitem()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L962"
+      "source_location": "L1043"
     },
     {
       "community": 1,
@@ -62113,7 +62413,7 @@
       "label": "transactionCashDelta()",
       "norm_label": "transactioncashdelta()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L845"
+      "source_location": "L924"
     },
     {
       "community": 1,
@@ -62122,7 +62422,7 @@
       "label": "transactionPaymentSummary()",
       "norm_label": "transactionpaymentsummary()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L380"
+      "source_location": "L431"
     },
     {
       "community": 1,
@@ -62131,7 +62431,7 @@
       "label": "trimOptional()",
       "norm_label": "trimoptional()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L284"
+      "source_location": "L335"
     },
     {
       "community": 1,
@@ -62140,7 +62440,7 @@
       "label": "uniqueDailyCloseItems()",
       "norm_label": "uniquedailycloseitems()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L904"
+      "source_location": "L983"
     },
     {
       "community": 1,
@@ -62149,7 +62449,7 @@
       "label": "uniqueSourceSubjects()",
       "norm_label": "uniquesourcesubjects()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L894"
+      "source_location": "L973"
     },
     {
       "community": 1,
@@ -62158,7 +62458,7 @@
       "label": "validateCarryForwardWorkItemIds()",
       "norm_label": "validatecarryforwardworkitemids()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1745"
+      "source_location": "L1832"
     },
     {
       "community": 1,
@@ -67329,64 +67629,64 @@
     {
       "community": 127,
       "file_type": "code",
-      "id": "linking_buildcustomerprofiledraft",
-      "label": "buildCustomerProfileDraft()",
-      "norm_label": "buildcustomerprofiledraft()",
-      "source_file": "packages/athena-webapp/convex/operations/helpers/linking.ts",
-      "source_location": "L110"
+      "id": "dailyclose_test_completeddailycloserow",
+      "label": "completedDailyCloseRow()",
+      "norm_label": "completeddailycloserow()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
+      "source_location": "L331"
     },
     {
       "community": 127,
       "file_type": "code",
-      "id": "linking_buildfullname",
-      "label": "buildFullName()",
-      "norm_label": "buildfullname()",
-      "source_file": "packages/athena-webapp/convex/operations/helpers/linking.ts",
-      "source_location": "L85"
+      "id": "dailyclose_test_completeddailyclosesnapshot",
+      "label": "completedDailyCloseSnapshot()",
+      "norm_label": "completeddailyclosesnapshot()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
+      "source_location": "L277"
     },
     {
       "community": 127,
       "file_type": "code",
-      "id": "linking_findmatchingcustomerprofile",
-      "label": "findMatchingCustomerProfile()",
-      "norm_label": "findmatchingcustomerprofile()",
-      "source_file": "packages/athena-webapp/convex/operations/helpers/linking.ts",
-      "source_location": "L172"
+      "id": "dailyclose_test_createdb",
+      "label": "createDb()",
+      "norm_label": "createdb()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
+      "source_location": "L31"
     },
     {
       "community": 127,
       "file_type": "code",
-      "id": "linking_normalizelookupvalue",
-      "label": "normalizeLookupValue()",
-      "norm_label": "normalizelookupvalue()",
-      "source_file": "packages/athena-webapp/convex/operations/helpers/linking.ts",
-      "source_location": "L58"
+      "id": "dailyclose_test_dailycloseapprovalproof",
+      "label": "dailyCloseApprovalProof()",
+      "norm_label": "dailycloseapprovalproof()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
+      "source_location": "L241"
     },
     {
       "community": 127,
       "file_type": "code",
-      "id": "linking_normalizephonenumber",
-      "label": "normalizePhoneNumber()",
-      "norm_label": "normalizephonenumber()",
-      "source_file": "packages/athena-webapp/convex/operations/helpers/linking.ts",
-      "source_location": "L62"
+      "id": "dailyclose_test_dailyclosereopenapprovalproof",
+      "label": "dailyCloseReopenApprovalProof()",
+      "norm_label": "dailyclosereopenapprovalproof()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
+      "source_location": "L259"
     },
     {
       "community": 127,
       "file_type": "code",
-      "id": "linking_splitfullname",
-      "label": "splitFullName()",
-      "norm_label": "splitfullname()",
-      "source_file": "packages/athena-webapp/convex/operations/helpers/linking.ts",
-      "source_location": "L66"
+      "id": "dailyclose_test_dailyclosesummary",
+      "label": "dailyCloseSummary()",
+      "norm_label": "dailyclosesummary()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
+      "source_location": "L216"
     },
     {
       "community": 127,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_helpers_linking_ts",
-      "label": "linking.ts",
-      "norm_label": "linking.ts",
-      "source_file": "packages/athena-webapp/convex/operations/helpers/linking.ts",
+      "id": "packages_athena_webapp_convex_operations_dailyclose_test_ts",
+      "label": "dailyClose.test.ts",
+      "norm_label": "dailyclose.test.ts",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
       "source_location": "L1"
     },
     {
@@ -67482,64 +67782,64 @@
     {
       "community": 128,
       "file_type": "code",
-      "id": "expensesessiontracing_buildexpensesessiontraceevent",
-      "label": "buildExpenseSessionTraceEvent()",
-      "norm_label": "buildexpensesessiontraceevent()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionTracing.ts",
-      "source_location": "L150"
+      "id": "linking_buildcustomerprofiledraft",
+      "label": "buildCustomerProfileDraft()",
+      "norm_label": "buildcustomerprofiledraft()",
+      "source_file": "packages/athena-webapp/convex/operations/helpers/linking.ts",
+      "source_location": "L110"
     },
     {
       "community": 128,
       "file_type": "code",
-      "id": "expensesessiontracing_buildexpensesessiontracerecord",
-      "label": "buildExpenseSessionTraceRecord()",
-      "norm_label": "buildexpensesessiontracerecord()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionTracing.ts",
-      "source_location": "L101"
+      "id": "linking_buildfullname",
+      "label": "buildFullName()",
+      "norm_label": "buildfullname()",
+      "source_file": "packages/athena-webapp/convex/operations/helpers/linking.ts",
+      "source_location": "L85"
     },
     {
       "community": 128,
       "file_type": "code",
-      "id": "expensesessiontracing_buildtracesummary",
-      "label": "buildTraceSummary()",
-      "norm_label": "buildtracesummary()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionTracing.ts",
-      "source_location": "L71"
+      "id": "linking_findmatchingcustomerprofile",
+      "label": "findMatchingCustomerProfile()",
+      "norm_label": "findmatchingcustomerprofile()",
+      "source_file": "packages/athena-webapp/convex/operations/helpers/linking.ts",
+      "source_location": "L172"
     },
     {
       "community": 128,
       "file_type": "code",
-      "id": "expensesessiontracing_createexpensesessiontracerecorder",
-      "label": "createExpenseSessionTraceRecorder()",
-      "norm_label": "createexpensesessiontracerecorder()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionTracing.ts",
-      "source_location": "L293"
+      "id": "linking_normalizelookupvalue",
+      "label": "normalizeLookupValue()",
+      "norm_label": "normalizelookupvalue()",
+      "source_file": "packages/athena-webapp/convex/operations/helpers/linking.ts",
+      "source_location": "L58"
     },
     {
       "community": 128,
       "file_type": "code",
-      "id": "expensesessiontracing_recordexpensesessiontracebesteffort",
-      "label": "recordExpenseSessionTraceBestEffort()",
-      "norm_label": "recordexpensesessiontracebesteffort()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionTracing.ts",
-      "source_location": "L266"
+      "id": "linking_normalizephonenumber",
+      "label": "normalizePhoneNumber()",
+      "norm_label": "normalizephonenumber()",
+      "source_file": "packages/athena-webapp/convex/operations/helpers/linking.ts",
+      "source_location": "L62"
     },
     {
       "community": 128,
       "file_type": "code",
-      "id": "expensesessiontracing_safetracewrite",
-      "label": "safeTraceWrite()",
-      "norm_label": "safetracewrite()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionTracing.ts",
-      "source_location": "L258"
+      "id": "linking_splitfullname",
+      "label": "splitFullName()",
+      "norm_label": "splitfullname()",
+      "source_file": "packages/athena-webapp/convex/operations/helpers/linking.ts",
+      "source_location": "L66"
     },
     {
       "community": 128,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_commands_expensesessiontracing_ts",
-      "label": "expenseSessionTracing.ts",
-      "norm_label": "expensesessiontracing.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionTracing.ts",
+      "id": "packages_athena_webapp_convex_operations_helpers_linking_ts",
+      "label": "linking.ts",
+      "norm_label": "linking.ts",
+      "source_file": "packages/athena-webapp/convex/operations/helpers/linking.ts",
       "source_location": "L1"
     },
     {
@@ -67635,65 +67935,65 @@
     {
       "community": 129,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_commands_terminals_ts",
-      "label": "terminals.ts",
-      "norm_label": "terminals.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/terminals.ts",
-      "source_location": "L1"
+      "id": "expensesessiontracing_buildexpensesessiontraceevent",
+      "label": "buildExpenseSessionTraceEvent()",
+      "norm_label": "buildexpensesessiontraceevent()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionTracing.ts",
+      "source_location": "L150"
     },
     {
       "community": 129,
       "file_type": "code",
-      "id": "terminals_assertregisternumberisavailable",
-      "label": "assertRegisterNumberIsAvailable()",
-      "norm_label": "assertregisternumberisavailable()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/terminals.ts",
-      "source_location": "L47"
+      "id": "expensesessiontracing_buildexpensesessiontracerecord",
+      "label": "buildExpenseSessionTraceRecord()",
+      "norm_label": "buildexpensesessiontracerecord()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionTracing.ts",
+      "source_location": "L101"
     },
     {
       "community": 129,
       "file_type": "code",
-      "id": "terminals_deleteterminal",
-      "label": "deleteTerminal()",
-      "norm_label": "deleteterminal()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/terminals.ts",
-      "source_location": "L169"
-    },
-    {
-      "community": 129,
-      "file_type": "code",
-      "id": "terminals_mapregisterterminalerror",
-      "label": "mapRegisterTerminalError()",
-      "norm_label": "mapregisterterminalerror()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/terminals.ts",
-      "source_location": "L30"
-    },
-    {
-      "community": 129,
-      "file_type": "code",
-      "id": "terminals_normalizeregisternumber",
-      "label": "normalizeRegisterNumber()",
-      "norm_label": "normalizeregisternumber()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/terminals.ts",
-      "source_location": "L25"
-    },
-    {
-      "community": 129,
-      "file_type": "code",
-      "id": "terminals_registerterminal",
-      "label": "registerTerminal()",
-      "norm_label": "registerterminal()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/terminals.ts",
+      "id": "expensesessiontracing_buildtracesummary",
+      "label": "buildTraceSummary()",
+      "norm_label": "buildtracesummary()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionTracing.ts",
       "source_location": "L71"
     },
     {
       "community": 129,
       "file_type": "code",
-      "id": "terminals_updateterminal",
-      "label": "updateTerminal()",
-      "norm_label": "updateterminal()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/terminals.ts",
-      "source_location": "L134"
+      "id": "expensesessiontracing_createexpensesessiontracerecorder",
+      "label": "createExpenseSessionTraceRecorder()",
+      "norm_label": "createexpensesessiontracerecorder()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionTracing.ts",
+      "source_location": "L293"
+    },
+    {
+      "community": 129,
+      "file_type": "code",
+      "id": "expensesessiontracing_recordexpensesessiontracebesteffort",
+      "label": "recordExpenseSessionTraceBestEffort()",
+      "norm_label": "recordexpensesessiontracebesteffort()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionTracing.ts",
+      "source_location": "L266"
+    },
+    {
+      "community": 129,
+      "file_type": "code",
+      "id": "expensesessiontracing_safetracewrite",
+      "label": "safeTraceWrite()",
+      "norm_label": "safetracewrite()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionTracing.ts",
+      "source_location": "L258"
+    },
+    {
+      "community": 129,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_commands_expensesessiontracing_ts",
+      "label": "expenseSessionTracing.ts",
+      "norm_label": "expensesessiontracing.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionTracing.ts",
+      "source_location": "L1"
     },
     {
       "community": 1290,
@@ -68040,65 +68340,65 @@
     {
       "community": 130,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_queries_searchcustomers_ts",
-      "label": "searchCustomers.ts",
-      "norm_label": "searchcustomers.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCustomers.ts",
+      "id": "packages_athena_webapp_convex_pos_application_commands_terminals_ts",
+      "label": "terminals.ts",
+      "norm_label": "terminals.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/terminals.ts",
       "source_location": "L1"
     },
     {
       "community": 130,
       "file_type": "code",
-      "id": "searchcustomers_findbystorefrontuser",
-      "label": "findByStoreFrontUser()",
-      "norm_label": "findbystorefrontuser()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCustomers.ts",
-      "source_location": "L95"
+      "id": "terminals_assertregisternumberisavailable",
+      "label": "assertRegisterNumberIsAvailable()",
+      "norm_label": "assertregisternumberisavailable()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/terminals.ts",
+      "source_location": "L47"
     },
     {
       "community": 130,
       "file_type": "code",
-      "id": "searchcustomers_findpotentialmatches",
-      "label": "findPotentialMatches()",
-      "norm_label": "findpotentialmatches()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCustomers.ts",
-      "source_location": "L122"
+      "id": "terminals_deleteterminal",
+      "label": "deleteTerminal()",
+      "norm_label": "deleteterminal()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/terminals.ts",
+      "source_location": "L169"
     },
     {
       "community": 130,
       "file_type": "code",
-      "id": "searchcustomers_getcustomerbyid",
-      "label": "getCustomerById()",
-      "norm_label": "getcustomerbyid()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCustomers.ts",
-      "source_location": "L66"
+      "id": "terminals_mapregisterterminalerror",
+      "label": "mapRegisterTerminalError()",
+      "norm_label": "mapregisterterminalerror()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/terminals.ts",
+      "source_location": "L30"
     },
     {
       "community": 130,
       "file_type": "code",
-      "id": "searchcustomers_getcustomerprofileidforposcustomer",
-      "label": "getCustomerProfileIdForPosCustomer()",
-      "norm_label": "getcustomerprofileidforposcustomer()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCustomers.ts",
-      "source_location": "L15"
+      "id": "terminals_normalizeregisternumber",
+      "label": "normalizeRegisterNumber()",
+      "norm_label": "normalizeregisternumber()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/terminals.ts",
+      "source_location": "L25"
     },
     {
       "community": 130,
       "file_type": "code",
-      "id": "searchcustomers_getcustomertransactions",
-      "label": "getCustomerTransactions()",
-      "norm_label": "getcustomertransactions()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCustomers.ts",
-      "source_location": "L75"
+      "id": "terminals_registerterminal",
+      "label": "registerTerminal()",
+      "norm_label": "registerterminal()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/terminals.ts",
+      "source_location": "L71"
     },
     {
       "community": 130,
       "file_type": "code",
-      "id": "searchcustomers_searchcustomers",
-      "label": "searchCustomers()",
-      "norm_label": "searchcustomers()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCustomers.ts",
-      "source_location": "L27"
+      "id": "terminals_updateterminal",
+      "label": "updateTerminal()",
+      "norm_label": "updateterminal()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/terminals.ts",
+      "source_location": "L134"
     },
     {
       "community": 1300,
@@ -68193,65 +68493,65 @@
     {
       "community": 131,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_sessionrepository_ts",
-      "label": "sessionRepository.ts",
-      "norm_label": "sessionrepository.ts",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionRepository.ts",
+      "id": "listregistercatalog_getregistercatalogprice",
+      "label": "getRegisterCatalogPrice()",
+      "norm_label": "getregistercatalogprice()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/listRegisterCatalog.ts",
+      "source_location": "L95"
+    },
+    {
+      "community": 131,
+      "file_type": "code",
+      "id": "listregistercatalog_listregistercatalog",
+      "label": "listRegisterCatalog()",
+      "norm_label": "listregistercatalog()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/listRegisterCatalog.ts",
+      "source_location": "L99"
+    },
+    {
+      "community": 131,
+      "file_type": "code",
+      "id": "listregistercatalog_listregistercatalogavailability",
+      "label": "listRegisterCatalogAvailability()",
+      "norm_label": "listregistercatalogavailability()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/listRegisterCatalog.ts",
+      "source_location": "L145"
+    },
+    {
+      "community": 131,
+      "file_type": "code",
+      "id": "listregistercatalog_mapskutoregistercatalogrow",
+      "label": "mapSkuToRegisterCatalogRow()",
+      "norm_label": "mapskutoregistercatalogrow()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/listRegisterCatalog.ts",
+      "source_location": "L70"
+    },
+    {
+      "community": 131,
+      "file_type": "code",
+      "id": "listregistercatalog_readcategoryname",
+      "label": "readCategoryName()",
+      "norm_label": "readcategoryname()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/listRegisterCatalog.ts",
+      "source_location": "L32"
+    },
+    {
+      "community": 131,
+      "file_type": "code",
+      "id": "listregistercatalog_readcolorname",
+      "label": "readColorName()",
+      "norm_label": "readcolorname()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/listRegisterCatalog.ts",
+      "source_location": "L49"
+    },
+    {
+      "community": 131,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_queries_listregistercatalog_ts",
+      "label": "listRegisterCatalog.ts",
+      "norm_label": "listregistercatalog.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/listRegisterCatalog.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 131,
-      "file_type": "code",
-      "id": "sessionrepository_getactivesessionforregisterstate",
-      "label": "getActiveSessionForRegisterState()",
-      "norm_label": "getactivesessionforregisterstate()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionRepository.ts",
-      "source_location": "L18"
-    },
-    {
-      "community": 131,
-      "file_type": "code",
-      "id": "sessionrepository_listheldsessionsforregisterstate",
-      "label": "listHeldSessionsForRegisterState()",
-      "norm_label": "listheldsessionsforregisterstate()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionRepository.ts",
-      "source_location": "L26"
-    },
-    {
-      "community": 131,
-      "file_type": "code",
-      "id": "sessionrepository_matchesregisteridentity",
-      "label": "matchesRegisterIdentity()",
-      "norm_label": "matchesregisteridentity()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionRepository.ts",
-      "source_location": "L119"
-    },
-    {
-      "community": 131,
-      "file_type": "code",
-      "id": "sessionrepository_querysessionsbystatus",
-      "label": "querySessionsByStatus()",
-      "norm_label": "querysessionsbystatus()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionRepository.ts",
-      "source_location": "L33"
-    },
-    {
-      "community": 131,
-      "file_type": "code",
-      "id": "sessionrepository_selectregisterstatelookupstrategy",
-      "label": "selectRegisterStateLookupStrategy()",
-      "norm_label": "selectregisterstatelookupstrategy()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionRepository.ts",
-      "source_location": "L83"
-    },
-    {
-      "community": 131,
-      "file_type": "code",
-      "id": "sessionrepository_summarizeregisterstatesessions",
-      "label": "summarizeRegisterStateSessions()",
-      "norm_label": "summarizeregisterstatesessions()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionRepository.ts",
-      "source_location": "L97"
     },
     {
       "community": 1310,
@@ -68346,65 +68646,65 @@
     {
       "community": 132,
       "file_type": "code",
-      "id": "analytics_extractpromocodeid",
-      "label": "extractPromoCodeId()",
-      "norm_label": "extractpromocodeid()",
-      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
-      "source_location": "L48"
-    },
-    {
-      "community": 132,
-      "file_type": "code",
-      "id": "analytics_getanalyticsbystoreandactionquery",
-      "label": "getAnalyticsByStoreAndActionQuery()",
-      "norm_label": "getanalyticsbystoreandactionquery()",
-      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
-      "source_location": "L153"
-    },
-    {
-      "community": 132,
-      "file_type": "code",
-      "id": "analytics_getanalyticsbystorequery",
-      "label": "getAnalyticsByStoreQuery()",
-      "norm_label": "getanalyticsbystorequery()",
-      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
-      "source_location": "L58"
-    },
-    {
-      "community": 132,
-      "file_type": "code",
-      "id": "analytics_getcompletedordersquery",
-      "label": "getCompletedOrdersQuery()",
-      "norm_label": "getcompletedordersquery()",
-      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
-      "source_location": "L106"
-    },
-    {
-      "community": 132,
-      "file_type": "code",
-      "id": "analytics_getskumapforproducts",
-      "label": "getSkuMapForProducts()",
-      "norm_label": "getskumapforproducts()",
-      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
-      "source_location": "L211"
-    },
-    {
-      "community": 132,
-      "file_type": "code",
-      "id": "analytics_getstorefrontactor",
-      "label": "getStoreFrontActor()",
-      "norm_label": "getstorefrontactor()",
-      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
-      "source_location": "L29"
-    },
-    {
-      "community": 132,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_analytics_ts",
-      "label": "analytics.ts",
-      "norm_label": "analytics.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
+      "id": "packages_athena_webapp_convex_pos_application_queries_searchcustomers_ts",
+      "label": "searchCustomers.ts",
+      "norm_label": "searchcustomers.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCustomers.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 132,
+      "file_type": "code",
+      "id": "searchcustomers_findbystorefrontuser",
+      "label": "findByStoreFrontUser()",
+      "norm_label": "findbystorefrontuser()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCustomers.ts",
+      "source_location": "L95"
+    },
+    {
+      "community": 132,
+      "file_type": "code",
+      "id": "searchcustomers_findpotentialmatches",
+      "label": "findPotentialMatches()",
+      "norm_label": "findpotentialmatches()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCustomers.ts",
+      "source_location": "L122"
+    },
+    {
+      "community": 132,
+      "file_type": "code",
+      "id": "searchcustomers_getcustomerbyid",
+      "label": "getCustomerById()",
+      "norm_label": "getcustomerbyid()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCustomers.ts",
+      "source_location": "L66"
+    },
+    {
+      "community": 132,
+      "file_type": "code",
+      "id": "searchcustomers_getcustomerprofileidforposcustomer",
+      "label": "getCustomerProfileIdForPosCustomer()",
+      "norm_label": "getcustomerprofileidforposcustomer()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCustomers.ts",
+      "source_location": "L15"
+    },
+    {
+      "community": 132,
+      "file_type": "code",
+      "id": "searchcustomers_getcustomertransactions",
+      "label": "getCustomerTransactions()",
+      "norm_label": "getcustomertransactions()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCustomers.ts",
+      "source_location": "L75"
+    },
+    {
+      "community": 132,
+      "file_type": "code",
+      "id": "searchcustomers_searchcustomers",
+      "label": "searchCustomers()",
+      "norm_label": "searchcustomers()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCustomers.ts",
+      "source_location": "L27"
     },
     {
       "community": 1320,
@@ -68499,65 +68799,65 @@
     {
       "community": 133,
       "file_type": "code",
-      "id": "customerbehaviortimeline_getcustomeranalyticsquery",
-      "label": "getCustomerAnalyticsQuery()",
-      "norm_label": "getcustomeranalyticsquery()",
-      "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
-      "source_location": "L27"
-    },
-    {
-      "community": 133,
-      "file_type": "code",
-      "id": "customerbehaviortimeline_getcustomeroperationaltimelineevents",
-      "label": "getCustomerOperationalTimelineEvents()",
-      "norm_label": "getcustomeroperationaltimelineevents()",
-      "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
-      "source_location": "L153"
-    },
-    {
-      "community": 133,
-      "file_type": "code",
-      "id": "customerbehaviortimeline_getproductinfomaps",
-      "label": "getProductInfoMaps()",
-      "norm_label": "getproductinfomaps()",
-      "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
-      "source_location": "L71"
-    },
-    {
-      "community": 133,
-      "file_type": "code",
-      "id": "customerbehaviortimeline_gettimefilterforrange",
-      "label": "getTimeFilterForRange()",
-      "norm_label": "gettimefilterforrange()",
-      "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
-      "source_location": "L12"
-    },
-    {
-      "community": 133,
-      "file_type": "code",
-      "id": "customerbehaviortimeline_gettimelineuserdata",
-      "label": "getTimelineUserData()",
-      "norm_label": "gettimelineuserdata()",
-      "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
-      "source_location": "L47"
-    },
-    {
-      "community": 133,
-      "file_type": "code",
-      "id": "customerbehaviortimeline_resolvecustomerprofileidfortimeline",
-      "label": "resolveCustomerProfileIdForTimeline()",
-      "norm_label": "resolvecustomerprofileidfortimeline()",
-      "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
-      "source_location": "L115"
-    },
-    {
-      "community": 133,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_customerbehaviortimeline_ts",
-      "label": "customerBehaviorTimeline.ts",
-      "norm_label": "customerbehaviortimeline.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
+      "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_sessionrepository_ts",
+      "label": "sessionRepository.ts",
+      "norm_label": "sessionrepository.ts",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionRepository.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 133,
+      "file_type": "code",
+      "id": "sessionrepository_getactivesessionforregisterstate",
+      "label": "getActiveSessionForRegisterState()",
+      "norm_label": "getactivesessionforregisterstate()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionRepository.ts",
+      "source_location": "L18"
+    },
+    {
+      "community": 133,
+      "file_type": "code",
+      "id": "sessionrepository_listheldsessionsforregisterstate",
+      "label": "listHeldSessionsForRegisterState()",
+      "norm_label": "listheldsessionsforregisterstate()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionRepository.ts",
+      "source_location": "L26"
+    },
+    {
+      "community": 133,
+      "file_type": "code",
+      "id": "sessionrepository_matchesregisteridentity",
+      "label": "matchesRegisterIdentity()",
+      "norm_label": "matchesregisteridentity()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionRepository.ts",
+      "source_location": "L119"
+    },
+    {
+      "community": 133,
+      "file_type": "code",
+      "id": "sessionrepository_querysessionsbystatus",
+      "label": "querySessionsByStatus()",
+      "norm_label": "querysessionsbystatus()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionRepository.ts",
+      "source_location": "L33"
+    },
+    {
+      "community": 133,
+      "file_type": "code",
+      "id": "sessionrepository_selectregisterstatelookupstrategy",
+      "label": "selectRegisterStateLookupStrategy()",
+      "norm_label": "selectregisterstatelookupstrategy()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionRepository.ts",
+      "source_location": "L83"
+    },
+    {
+      "community": 133,
+      "file_type": "code",
+      "id": "sessionrepository_summarizeregisterstatesessions",
+      "label": "summarizeRegisterStateSessions()",
+      "norm_label": "summarizeregisterstatesessions()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionRepository.ts",
+      "source_location": "L97"
     },
     {
       "community": 1330,
@@ -68652,64 +68952,64 @@
     {
       "community": 134,
       "file_type": "code",
-      "id": "onlineorder_clearbagitems",
-      "label": "clearBagItems()",
-      "norm_label": "clearbagitems()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
-      "source_location": "L49"
+      "id": "analytics_extractpromocodeid",
+      "label": "extractPromoCodeId()",
+      "norm_label": "extractpromocodeid()",
+      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
+      "source_location": "L48"
     },
     {
       "community": 134,
       "file_type": "code",
-      "id": "onlineorder_createorderfromcheckoutsession",
-      "label": "createOrderFromCheckoutSession()",
-      "norm_label": "createorderfromcheckoutsession()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
-      "source_location": "L108"
+      "id": "analytics_getanalyticsbystoreandactionquery",
+      "label": "getAnalyticsByStoreAndActionQuery()",
+      "norm_label": "getanalyticsbystoreandactionquery()",
+      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
+      "source_location": "L153"
     },
     {
       "community": 134,
       "file_type": "code",
-      "id": "onlineorder_findorderbyexternalreference",
-      "label": "findOrderByExternalReference()",
-      "norm_label": "findorderbyexternalreference()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
-      "source_location": "L25"
+      "id": "analytics_getanalyticsbystorequery",
+      "label": "getAnalyticsByStoreQuery()",
+      "norm_label": "getanalyticsbystorequery()",
+      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
+      "source_location": "L58"
     },
     {
       "community": 134,
       "file_type": "code",
-      "id": "onlineorder_findorderbyexternaltransactionid",
-      "label": "findOrderByExternalTransactionId()",
-      "norm_label": "findorderbyexternaltransactionid()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
-      "source_location": "L37"
+      "id": "analytics_getcompletedordersquery",
+      "label": "getCompletedOrdersQuery()",
+      "norm_label": "getcompletedordersquery()",
+      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
+      "source_location": "L106"
     },
     {
       "community": 134,
       "file_type": "code",
-      "id": "onlineorder_generateordernumber",
-      "label": "generateOrderNumber()",
-      "norm_label": "generateordernumber()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
-      "source_location": "L18"
+      "id": "analytics_getskumapforproducts",
+      "label": "getSkuMapForProducts()",
+      "norm_label": "getskumapforproducts()",
+      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
+      "source_location": "L211"
     },
     {
       "community": 134,
       "file_type": "code",
-      "id": "onlineorder_returnorderitemstostock",
-      "label": "returnOrderItemsToStock()",
-      "norm_label": "returnorderitemstostock()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
-      "source_location": "L61"
+      "id": "analytics_getstorefrontactor",
+      "label": "getStoreFrontActor()",
+      "norm_label": "getstorefrontactor()",
+      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
+      "source_location": "L29"
     },
     {
       "community": 134,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_helpers_onlineorder_ts",
-      "label": "onlineOrder.ts",
-      "norm_label": "onlineorder.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
+      "id": "packages_athena_webapp_convex_storefront_analytics_ts",
+      "label": "analytics.ts",
+      "norm_label": "analytics.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
       "source_location": "L1"
     },
     {
@@ -68805,64 +69105,64 @@
     {
       "community": 135,
       "file_type": "code",
-      "id": "orderupdateemails_formatorderitems",
-      "label": "formatOrderItems()",
-      "norm_label": "formatorderitems()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
-      "source_location": "L64"
+      "id": "customerbehaviortimeline_getcustomeranalyticsquery",
+      "label": "getCustomerAnalyticsQuery()",
+      "norm_label": "getcustomeranalyticsquery()",
+      "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
+      "source_location": "L27"
     },
     {
       "community": 135,
       "file_type": "code",
-      "id": "orderupdateemails_getdeliveryaddress",
-      "label": "getDeliveryAddress()",
-      "norm_label": "getdeliveryaddress()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
-      "source_location": "L55"
+      "id": "customerbehaviortimeline_getcustomeroperationaltimelineevents",
+      "label": "getCustomerOperationalTimelineEvents()",
+      "norm_label": "getcustomeroperationaltimelineevents()",
+      "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
+      "source_location": "L153"
     },
     {
       "community": 135,
       "file_type": "code",
-      "id": "orderupdateemails_getlocationdetails",
-      "label": "getLocationDetails()",
-      "norm_label": "getlocationdetails()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
-      "source_location": "L58"
+      "id": "customerbehaviortimeline_getproductinfomaps",
+      "label": "getProductInfoMaps()",
+      "norm_label": "getproductinfomaps()",
+      "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
+      "source_location": "L71"
     },
     {
       "community": 135,
       "file_type": "code",
-      "id": "orderupdateemails_getpickuplocation",
-      "label": "getPickupLocation()",
-      "norm_label": "getpickuplocation()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
-      "source_location": "L52"
+      "id": "customerbehaviortimeline_gettimefilterforrange",
+      "label": "getTimeFilterForRange()",
+      "norm_label": "gettimefilterforrange()",
+      "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
+      "source_location": "L12"
     },
     {
       "community": 135,
       "file_type": "code",
-      "id": "orderupdateemails_handleorderstatusupdate",
-      "label": "handleOrderStatusUpdate()",
-      "norm_label": "handleorderstatusupdate()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
-      "source_location": "L118"
+      "id": "customerbehaviortimeline_gettimelineuserdata",
+      "label": "getTimelineUserData()",
+      "norm_label": "gettimelineuserdata()",
+      "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
+      "source_location": "L47"
     },
     {
       "community": 135,
       "file_type": "code",
-      "id": "orderupdateemails_processorderupdateemail",
-      "label": "processOrderUpdateEmail()",
-      "norm_label": "processorderupdateemail()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
-      "source_location": "L293"
+      "id": "customerbehaviortimeline_resolvecustomerprofileidfortimeline",
+      "label": "resolveCustomerProfileIdForTimeline()",
+      "norm_label": "resolvecustomerprofileidfortimeline()",
+      "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
+      "source_location": "L115"
     },
     {
       "community": 135,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_helpers_orderupdateemails_ts",
-      "label": "orderUpdateEmails.ts",
-      "norm_label": "orderupdateemails.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
+      "id": "packages_athena_webapp_convex_storefront_customerbehaviortimeline_ts",
+      "label": "customerBehaviorTimeline.ts",
+      "norm_label": "customerbehaviortimeline.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
       "source_location": "L1"
     },
     {
@@ -68958,64 +69258,64 @@
     {
       "community": 136,
       "file_type": "code",
-      "id": "onlineorder_appendtransition",
-      "label": "appendTransition()",
-      "norm_label": "appendtransition()",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
-      "source_location": "L65"
+      "id": "onlineorder_clearbagitems",
+      "label": "clearBagItems()",
+      "norm_label": "clearbagitems()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
+      "source_location": "L49"
     },
     {
       "community": 136,
       "file_type": "code",
-      "id": "onlineorder_applyonlineorderupdate",
-      "label": "applyOnlineOrderUpdate()",
-      "norm_label": "applyonlineorderupdate()",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
-      "source_location": "L89"
+      "id": "onlineorder_createorderfromcheckoutsession",
+      "label": "createOrderFromCheckoutSession()",
+      "norm_label": "createorderfromcheckoutsession()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
+      "source_location": "L108"
     },
     {
       "community": 136,
       "file_type": "code",
-      "id": "onlineorder_buildreturnexchangereplacementsourceid",
-      "label": "buildReturnExchangeReplacementSourceId()",
-      "norm_label": "buildreturnexchangereplacementsourceid()",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
-      "source_location": "L210"
+      "id": "onlineorder_findorderbyexternalreference",
+      "label": "findOrderByExternalReference()",
+      "norm_label": "findorderbyexternalreference()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
+      "source_location": "L25"
     },
     {
       "community": 136,
       "file_type": "code",
-      "id": "onlineorder_buildreturnexchangereturnsourceid",
-      "label": "buildReturnExchangeReturnSourceId()",
-      "norm_label": "buildreturnexchangereturnsourceid()",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
-      "source_location": "L218"
+      "id": "onlineorder_findorderbyexternaltransactionid",
+      "label": "findOrderByExternalTransactionId()",
+      "norm_label": "findorderbyexternaltransactionid()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
+      "source_location": "L37"
     },
     {
       "community": 136,
       "file_type": "code",
-      "id": "onlineorder_listorderitems",
-      "label": "listOrderItems()",
-      "norm_label": "listorderitems()",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
-      "source_location": "L55"
+      "id": "onlineorder_generateordernumber",
+      "label": "generateOrderNumber()",
+      "norm_label": "generateordernumber()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
+      "source_location": "L18"
     },
     {
       "community": 136,
       "file_type": "code",
-      "id": "onlineorder_mapupdateordererror",
-      "label": "mapUpdateOrderError()",
-      "norm_label": "mapupdateordererror()",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
-      "source_location": "L225"
+      "id": "onlineorder_returnorderitemstostock",
+      "label": "returnOrderItemsToStock()",
+      "norm_label": "returnorderitemstostock()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
+      "source_location": "L61"
     },
     {
       "community": 136,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_onlineorder_ts",
+      "id": "packages_athena_webapp_convex_storefront_helpers_onlineorder_ts",
       "label": "onlineOrder.ts",
       "norm_label": "onlineorder.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
       "source_location": "L1"
     },
     {
@@ -69111,64 +69411,64 @@
     {
       "community": 137,
       "file_type": "code",
-      "id": "core_appendworkflowtraceeventwithctx",
-      "label": "appendWorkflowTraceEventWithCtx()",
-      "norm_label": "appendworkflowtraceeventwithctx()",
-      "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
-      "source_location": "L134"
+      "id": "orderupdateemails_formatorderitems",
+      "label": "formatOrderItems()",
+      "norm_label": "formatorderitems()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
+      "source_location": "L64"
     },
     {
       "community": 137,
       "file_type": "code",
-      "id": "core_createworkflowtracewithctx",
-      "label": "createWorkflowTraceWithCtx()",
-      "norm_label": "createworkflowtracewithctx()",
-      "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
-      "source_location": "L81"
+      "id": "orderupdateemails_getdeliveryaddress",
+      "label": "getDeliveryAddress()",
+      "norm_label": "getdeliveryaddress()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
+      "source_location": "L55"
     },
     {
       "community": 137,
       "file_type": "code",
-      "id": "core_getworkflowtracebyidwithctx",
-      "label": "getWorkflowTraceByIdWithCtx()",
-      "norm_label": "getworkflowtracebyidwithctx()",
-      "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
-      "source_location": "L17"
+      "id": "orderupdateemails_getlocationdetails",
+      "label": "getLocationDetails()",
+      "norm_label": "getlocationdetails()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
+      "source_location": "L58"
     },
     {
       "community": 137,
       "file_type": "code",
-      "id": "core_getworkflowtracebylookupwithctx",
-      "label": "getWorkflowTraceByLookupWithCtx()",
-      "norm_label": "getworkflowtracebylookupwithctx()",
-      "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
-      "source_location": "L32"
+      "id": "orderupdateemails_getpickuplocation",
+      "label": "getPickupLocation()",
+      "norm_label": "getpickuplocation()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
+      "source_location": "L52"
     },
     {
       "community": 137,
       "file_type": "code",
-      "id": "core_listworkflowtraceeventswithctx",
-      "label": "listWorkflowTraceEventsWithCtx()",
-      "norm_label": "listworkflowtraceeventswithctx()",
-      "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
-      "source_location": "L65"
+      "id": "orderupdateemails_handleorderstatusupdate",
+      "label": "handleOrderStatusUpdate()",
+      "norm_label": "handleorderstatusupdate()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
+      "source_location": "L118"
     },
     {
       "community": 137,
       "file_type": "code",
-      "id": "core_registerworkflowtracelookupwithctx",
-      "label": "registerWorkflowTraceLookupWithCtx()",
-      "norm_label": "registerworkflowtracelookupwithctx()",
-      "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
-      "source_location": "L104"
+      "id": "orderupdateemails_processorderupdateemail",
+      "label": "processOrderUpdateEmail()",
+      "norm_label": "processorderupdateemail()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
+      "source_location": "L293"
     },
     {
       "community": 137,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_workflowtraces_core_ts",
-      "label": "core.ts",
-      "norm_label": "core.ts",
-      "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
+      "id": "packages_athena_webapp_convex_storefront_helpers_orderupdateemails_ts",
+      "label": "orderUpdateEmails.ts",
+      "norm_label": "orderupdateemails.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
       "source_location": "L1"
     },
     {
@@ -69264,65 +69564,65 @@
     {
       "community": 138,
       "file_type": "code",
-      "id": "packages_athena_webapp_shared_stockadjustment_ts",
-      "label": "stockAdjustment.ts",
-      "norm_label": "stockadjustment.ts",
-      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
+      "id": "onlineorder_appendtransition",
+      "label": "appendTransition()",
+      "norm_label": "appendtransition()",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
+      "source_location": "L65"
+    },
+    {
+      "community": 138,
+      "file_type": "code",
+      "id": "onlineorder_applyonlineorderupdate",
+      "label": "applyOnlineOrderUpdate()",
+      "norm_label": "applyonlineorderupdate()",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
+      "source_location": "L89"
+    },
+    {
+      "community": 138,
+      "file_type": "code",
+      "id": "onlineorder_buildreturnexchangereplacementsourceid",
+      "label": "buildReturnExchangeReplacementSourceId()",
+      "norm_label": "buildreturnexchangereplacementsourceid()",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
+      "source_location": "L210"
+    },
+    {
+      "community": 138,
+      "file_type": "code",
+      "id": "onlineorder_buildreturnexchangereturnsourceid",
+      "label": "buildReturnExchangeReturnSourceId()",
+      "norm_label": "buildreturnexchangereturnsourceid()",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
+      "source_location": "L218"
+    },
+    {
+      "community": 138,
+      "file_type": "code",
+      "id": "onlineorder_listorderitems",
+      "label": "listOrderItems()",
+      "norm_label": "listorderitems()",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
+      "source_location": "L55"
+    },
+    {
+      "community": 138,
+      "file_type": "code",
+      "id": "onlineorder_mapupdateordererror",
+      "label": "mapUpdateOrderError()",
+      "norm_label": "mapupdateordererror()",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
+      "source_location": "L225"
+    },
+    {
+      "community": 138,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_onlineorder_ts",
+      "label": "onlineOrder.ts",
+      "norm_label": "onlineorder.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 138,
-      "file_type": "code",
-      "id": "stockadjustment_assertstockadjustmentreasoncode",
-      "label": "assertStockAdjustmentReasonCode()",
-      "norm_label": "assertstockadjustmentreasoncode()",
-      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
-      "source_location": "L25"
-    },
-    {
-      "community": 138,
-      "file_type": "code",
-      "id": "stockadjustment_calculatecyclecountquantitydelta",
-      "label": "calculateCycleCountQuantityDelta()",
-      "norm_label": "calculatecyclecountquantitydelta()",
-      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
-      "source_location": "L14"
-    },
-    {
-      "community": 138,
-      "file_type": "code",
-      "id": "stockadjustment_hashighstockadjustmentvariance",
-      "label": "hasHighStockAdjustmentVariance()",
-      "norm_label": "hashighstockadjustmentvariance()",
-      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
-      "source_location": "L96"
-    },
-    {
-      "community": 138,
-      "file_type": "code",
-      "id": "stockadjustment_requiresstockadjustmentapproval",
-      "label": "requiresStockAdjustmentApproval()",
-      "norm_label": "requiresstockadjustmentapproval()",
-      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
-      "source_location": "L102"
-    },
-    {
-      "community": 138,
-      "file_type": "code",
-      "id": "stockadjustment_resolvestockadjustmentquantitydelta",
-      "label": "resolveStockAdjustmentQuantityDelta()",
-      "norm_label": "resolvestockadjustmentquantitydelta()",
-      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
-      "source_location": "L45"
-    },
-    {
-      "community": 138,
-      "file_type": "code",
-      "id": "stockadjustment_summarizestockadjustmentlineitems",
-      "label": "summarizeStockAdjustmentLineItems()",
-      "norm_label": "summarizestockadjustmentlineitems()",
-      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
-      "source_location": "L76"
     },
     {
       "community": 1380,
@@ -69417,65 +69717,65 @@
     {
       "community": 139,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_paymentview_tsx",
-      "label": "PaymentView.tsx",
-      "norm_label": "paymentview.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
+      "id": "core_appendworkflowtraceeventwithctx",
+      "label": "appendWorkflowTraceEventWithCtx()",
+      "norm_label": "appendworkflowtraceeventwithctx()",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
+      "source_location": "L134"
+    },
+    {
+      "community": 139,
+      "file_type": "code",
+      "id": "core_createworkflowtracewithctx",
+      "label": "createWorkflowTraceWithCtx()",
+      "norm_label": "createworkflowtracewithctx()",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
+      "source_location": "L81"
+    },
+    {
+      "community": 139,
+      "file_type": "code",
+      "id": "core_getworkflowtracebyidwithctx",
+      "label": "getWorkflowTraceByIdWithCtx()",
+      "norm_label": "getworkflowtracebyidwithctx()",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
+      "source_location": "L17"
+    },
+    {
+      "community": 139,
+      "file_type": "code",
+      "id": "core_getworkflowtracebylookupwithctx",
+      "label": "getWorkflowTraceByLookupWithCtx()",
+      "norm_label": "getworkflowtracebylookupwithctx()",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
+      "source_location": "L32"
+    },
+    {
+      "community": 139,
+      "file_type": "code",
+      "id": "core_listworkflowtraceeventswithctx",
+      "label": "listWorkflowTraceEventsWithCtx()",
+      "norm_label": "listworkflowtraceeventswithctx()",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
+      "source_location": "L65"
+    },
+    {
+      "community": 139,
+      "file_type": "code",
+      "id": "core_registerworkflowtracelookupwithctx",
+      "label": "registerWorkflowTraceLookupWithCtx()",
+      "norm_label": "registerworkflowtracelookupwithctx()",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
+      "source_location": "L104"
+    },
+    {
+      "community": 139,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_workflowtraces_core_ts",
+      "label": "core.ts",
+      "norm_label": "core.ts",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/core.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 139,
-      "file_type": "code",
-      "id": "paymentview_cn",
-      "label": "cn()",
-      "norm_label": "cn()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
-      "source_location": "L404"
-    },
-    {
-      "community": 139,
-      "file_type": "code",
-      "id": "paymentview_handleaddpayment",
-      "label": "handleAddPayment()",
-      "norm_label": "handleaddpayment()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
-      "source_location": "L181"
-    },
-    {
-      "community": 139,
-      "file_type": "code",
-      "id": "paymentview_handleamountblur",
-      "label": "handleAmountBlur()",
-      "norm_label": "handleamountblur()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
-      "source_location": "L253"
-    },
-    {
-      "community": 139,
-      "file_type": "code",
-      "id": "paymentview_handleamountchange",
-      "label": "handleAmountChange()",
-      "norm_label": "handleamountchange()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
-      "source_location": "L231"
-    },
-    {
-      "community": 139,
-      "file_type": "code",
-      "id": "paymentview_handlekeypadpress",
-      "label": "handleKeypadPress()",
-      "norm_label": "handlekeypadpress()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
-      "source_location": "L275"
-    },
-    {
-      "community": 139,
-      "file_type": "code",
-      "id": "paymentview_setamountfromtouch",
-      "label": "setAmountFromTouch()",
-      "norm_label": "setamountfromtouch()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
-      "source_location": "L259"
     },
     {
       "community": 1390,
@@ -69795,65 +70095,65 @@
     {
       "community": 140,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_register_posregisterview_tsx",
-      "label": "POSRegisterView.tsx",
-      "norm_label": "posregisterview.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
+      "id": "packages_athena_webapp_shared_stockadjustment_ts",
+      "label": "stockAdjustment.ts",
+      "norm_label": "stockadjustment.ts",
+      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
       "source_location": "L1"
     },
     {
       "community": 140,
       "file_type": "code",
-      "id": "posregisterview_cartcountsummary",
-      "label": "CartCountSummary()",
-      "norm_label": "cartcountsummary()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
-      "source_location": "L152"
+      "id": "stockadjustment_assertstockadjustmentreasoncode",
+      "label": "assertStockAdjustmentReasonCode()",
+      "norm_label": "assertstockadjustmentreasoncode()",
+      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
+      "source_location": "L25"
     },
     {
       "community": 140,
       "file_type": "code",
-      "id": "posregisterview_cashierauthworkspace",
-      "label": "CashierAuthWorkspace()",
-      "norm_label": "cashierauthworkspace()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
-      "source_location": "L114"
+      "id": "stockadjustment_calculatecyclecountquantitydelta",
+      "label": "calculateCycleCountQuantityDelta()",
+      "norm_label": "calculatecyclecountquantitydelta()",
+      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
+      "source_location": "L14"
     },
     {
       "community": 140,
       "file_type": "code",
-      "id": "posregisterview_handlecmdk",
-      "label": "handleCmdK()",
-      "norm_label": "handlecmdk()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
-      "source_location": "L431"
+      "id": "stockadjustment_hashighstockadjustmentvariance",
+      "label": "hasHighStockAdjustmentVariance()",
+      "norm_label": "hashighstockadjustmentvariance()",
+      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
+      "source_location": "L96"
     },
     {
       "community": 140,
       "file_type": "code",
-      "id": "posregisterview_productlookupemptystate",
-      "label": "ProductLookupEmptyState()",
-      "norm_label": "productlookupemptystate()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
-      "source_location": "L73"
+      "id": "stockadjustment_requiresstockadjustmentapproval",
+      "label": "requiresStockAdjustmentApproval()",
+      "norm_label": "requiresstockadjustmentapproval()",
+      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
+      "source_location": "L102"
     },
     {
       "community": 140,
       "file_type": "code",
-      "id": "posregisterview_registersetupresolvingworkspace",
-      "label": "RegisterSetupResolvingWorkspace()",
-      "norm_label": "registersetupresolvingworkspace()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
-      "source_location": "L146"
+      "id": "stockadjustment_resolvestockadjustmentquantitydelta",
+      "label": "resolveStockAdjustmentQuantityDelta()",
+      "norm_label": "resolvestockadjustmentquantitydelta()",
+      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
+      "source_location": "L45"
     },
     {
       "community": 140,
       "file_type": "code",
-      "id": "posregisterview_usecollapsesidebarforposflow",
-      "label": "useCollapseSidebarForPosFlow()",
-      "norm_label": "usecollapsesidebarforposflow()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
-      "source_location": "L41"
+      "id": "stockadjustment_summarizestockadjustmentlineitems",
+      "label": "summarizeStockAdjustmentLineItems()",
+      "norm_label": "summarizestockadjustmentlineitems()",
+      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
+      "source_location": "L76"
     },
     {
       "community": 1400,
@@ -69948,65 +70248,65 @@
     {
       "community": 141,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_services_serviceappointmentsview_tsx",
-      "label": "ServiceAppointmentsView.tsx",
-      "norm_label": "serviceappointmentsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
+      "id": "packages_athena_webapp_src_components_pos_paymentview_tsx",
+      "label": "PaymentView.tsx",
+      "norm_label": "paymentview.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
       "source_location": "L1"
     },
     {
       "community": 141,
       "file_type": "code",
-      "id": "serviceappointmentsview_applycommandresult",
-      "label": "applyCommandResult()",
-      "norm_label": "applycommandresult()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
-      "source_location": "L139"
+      "id": "paymentview_cn",
+      "label": "cn()",
+      "norm_label": "cn()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
+      "source_location": "L404"
     },
     {
       "community": 141,
       "file_type": "code",
-      "id": "serviceappointmentsview_async",
-      "label": "async()",
-      "norm_label": "async()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
-      "source_location": "L432"
+      "id": "paymentview_handleaddpayment",
+      "label": "handleAddPayment()",
+      "norm_label": "handleaddpayment()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
+      "source_location": "L181"
     },
     {
       "community": 141,
       "file_type": "code",
-      "id": "serviceappointmentsview_formatdatetimelocal",
-      "label": "formatDateTimeLocal()",
-      "norm_label": "formatdatetimelocal()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
-      "source_location": "L110"
+      "id": "paymentview_handleamountblur",
+      "label": "handleAmountBlur()",
+      "norm_label": "handleamountblur()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
+      "source_location": "L253"
     },
     {
       "community": 141,
       "file_type": "code",
-      "id": "serviceappointmentsview_handlesubmit",
-      "label": "handleSubmit()",
-      "norm_label": "handlesubmit()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
-      "source_location": "L157"
+      "id": "paymentview_handleamountchange",
+      "label": "handleAmountChange()",
+      "norm_label": "handleamountchange()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
+      "source_location": "L231"
     },
     {
       "community": 141,
       "file_type": "code",
-      "id": "serviceappointmentsview_parsedatetimelocal",
-      "label": "parseDateTimeLocal()",
-      "norm_label": "parsedatetimelocal()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
-      "source_location": "L105"
+      "id": "paymentview_handlekeypadpress",
+      "label": "handleKeypadPress()",
+      "norm_label": "handlekeypadpress()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
+      "source_location": "L275"
     },
     {
       "community": 141,
       "file_type": "code",
-      "id": "serviceappointmentsview_withsavestate",
-      "label": "withSaveState()",
-      "norm_label": "withsavestate()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
-      "source_location": "L568"
+      "id": "paymentview_setamountfromtouch",
+      "label": "setAmountFromTouch()",
+      "norm_label": "setamountfromtouch()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
+      "source_location": "L259"
     },
     {
       "community": 1410,
@@ -70101,65 +70401,65 @@
     {
       "community": 142,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_services_servicesworkspaceview_tsx",
-      "label": "ServicesWorkspaceView.tsx",
-      "norm_label": "servicesworkspaceview.tsx",
-      "source_file": "packages/athena-webapp/src/components/services/ServicesWorkspaceView.tsx",
+      "id": "packages_athena_webapp_src_components_pos_register_posregisterview_tsx",
+      "label": "POSRegisterView.tsx",
+      "norm_label": "posregisterview.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
       "source_location": "L1"
     },
     {
       "community": 142,
       "file_type": "code",
-      "id": "servicesworkspaceview_detailrow",
-      "label": "DetailRow()",
-      "norm_label": "detailrow()",
-      "source_file": "packages/athena-webapp/src/components/services/ServicesWorkspaceView.tsx",
-      "source_location": "L120"
+      "id": "posregisterview_cartcountsummary",
+      "label": "CartCountSummary()",
+      "norm_label": "cartcountsummary()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
+      "source_location": "L152"
     },
     {
       "community": 142,
       "file_type": "code",
-      "id": "servicesworkspaceview_formatdeposit",
-      "label": "formatDeposit()",
-      "norm_label": "formatdeposit()",
-      "source_file": "packages/athena-webapp/src/components/services/ServicesWorkspaceView.tsx",
-      "source_location": "L91"
+      "id": "posregisterview_cashierauthworkspace",
+      "label": "CashierAuthWorkspace()",
+      "norm_label": "cashierauthworkspace()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
+      "source_location": "L114"
     },
     {
       "community": 142,
       "file_type": "code",
-      "id": "servicesworkspaceview_formatmoney",
-      "label": "formatMoney()",
-      "norm_label": "formatmoney()",
-      "source_file": "packages/athena-webapp/src/components/services/ServicesWorkspaceView.tsx",
-      "source_location": "L81"
+      "id": "posregisterview_handlecmdk",
+      "label": "handleCmdK()",
+      "norm_label": "handlecmdk()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
+      "source_location": "L431"
     },
     {
       "community": 142,
       "file_type": "code",
-      "id": "servicesworkspaceview_formatservicecatalogname",
-      "label": "formatServiceCatalogName()",
-      "norm_label": "formatservicecatalogname()",
-      "source_file": "packages/athena-webapp/src/components/services/ServicesWorkspaceView.tsx",
-      "source_location": "L71"
+      "id": "posregisterview_productlookupemptystate",
+      "label": "ProductLookupEmptyState()",
+      "norm_label": "productlookupemptystate()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
+      "source_location": "L73"
     },
     {
       "community": 142,
       "file_type": "code",
-      "id": "servicesworkspaceview_sortservices",
-      "label": "sortServices()",
-      "norm_label": "sortservices()",
-      "source_file": "packages/athena-webapp/src/components/services/ServicesWorkspaceView.tsx",
-      "source_location": "L112"
+      "id": "posregisterview_registersetupresolvingworkspace",
+      "label": "RegisterSetupResolvingWorkspace()",
+      "norm_label": "registersetupresolvingworkspace()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
+      "source_location": "L146"
     },
     {
       "community": 142,
       "file_type": "code",
-      "id": "servicesworkspaceview_summarizeservice",
-      "label": "summarizeService()",
-      "norm_label": "summarizeservice()",
-      "source_file": "packages/athena-webapp/src/components/services/ServicesWorkspaceView.tsx",
-      "source_location": "L103"
+      "id": "posregisterview_usecollapsesidebarforposflow",
+      "label": "useCollapseSidebarForPosFlow()",
+      "norm_label": "usecollapsesidebarforposflow()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
+      "source_location": "L41"
     },
     {
       "community": 1420,
@@ -70254,65 +70554,65 @@
     {
       "community": 143,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_domain_session_ts",
-      "label": "session.ts",
-      "norm_label": "session.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
+      "id": "packages_athena_webapp_src_components_services_serviceappointmentsview_tsx",
+      "label": "ServiceAppointmentsView.tsx",
+      "norm_label": "serviceappointmentsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
       "source_location": "L1"
     },
     {
       "community": 143,
       "file_type": "code",
-      "id": "session_deriveregisterphase",
-      "label": "deriveRegisterPhase()",
-      "norm_label": "deriveregisterphase()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
-      "source_location": "L3"
+      "id": "serviceappointmentsview_applycommandresult",
+      "label": "applyCommandResult()",
+      "norm_label": "applycommandresult()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
+      "source_location": "L139"
     },
     {
       "community": 143,
       "file_type": "code",
-      "id": "session_hasactiveregistersession",
-      "label": "hasActiveRegisterSession()",
-      "norm_label": "hasactiveregistersession()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
-      "source_location": "L33"
+      "id": "serviceappointmentsview_async",
+      "label": "async()",
+      "norm_label": "async()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
+      "source_location": "L432"
     },
     {
       "community": 143,
       "file_type": "code",
-      "id": "session_hasresumableregistersession",
-      "label": "hasResumableRegisterSession()",
-      "norm_label": "hasresumableregistersession()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
-      "source_location": "L39"
+      "id": "serviceappointmentsview_formatdatetimelocal",
+      "label": "formatDateTimeLocal()",
+      "norm_label": "formatdatetimelocal()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
+      "source_location": "L110"
     },
     {
       "community": 143,
       "file_type": "code",
-      "id": "session_isregisterreadytostart",
-      "label": "isRegisterReadyToStart()",
-      "norm_label": "isregisterreadytostart()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
-      "source_location": "L45"
+      "id": "serviceappointmentsview_handlesubmit",
+      "label": "handleSubmit()",
+      "norm_label": "handlesubmit()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
+      "source_location": "L157"
     },
     {
       "community": 143,
       "file_type": "code",
-      "id": "session_requirescashier",
-      "label": "requiresCashier()",
-      "norm_label": "requirescashier()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
-      "source_location": "L29"
+      "id": "serviceappointmentsview_parsedatetimelocal",
+      "label": "parseDateTimeLocal()",
+      "norm_label": "parsedatetimelocal()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
+      "source_location": "L105"
     },
     {
       "community": 143,
       "file_type": "code",
-      "id": "session_requiresterminal",
-      "label": "requiresTerminal()",
-      "norm_label": "requiresterminal()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
-      "source_location": "L25"
+      "id": "serviceappointmentsview_withsavestate",
+      "label": "withSaveState()",
+      "norm_label": "withsavestate()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx",
+      "source_location": "L568"
     },
     {
       "community": 1430,
@@ -70407,65 +70707,65 @@
     {
       "community": 144,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_presentation_register_useregisterviewmodel_test_ts",
-      "label": "useRegisterViewModel.test.ts",
-      "norm_label": "useregisterviewmodel.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts",
+      "id": "packages_athena_webapp_src_components_services_servicesworkspaceview_tsx",
+      "label": "ServicesWorkspaceView.tsx",
+      "norm_label": "servicesworkspaceview.tsx",
+      "source_file": "packages/athena-webapp/src/components/services/ServicesWorkspaceView.tsx",
       "source_location": "L1"
     },
     {
       "community": 144,
       "file_type": "code",
-      "id": "useregisterviewmodel_test_buildregistercatalogavailabilityrow",
-      "label": "buildRegisterCatalogAvailabilityRow()",
-      "norm_label": "buildregistercatalogavailabilityrow()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts",
-      "source_location": "L254"
+      "id": "servicesworkspaceview_detailrow",
+      "label": "DetailRow()",
+      "norm_label": "detailrow()",
+      "source_file": "packages/athena-webapp/src/components/services/ServicesWorkspaceView.tsx",
+      "source_location": "L120"
     },
     {
       "community": 144,
       "file_type": "code",
-      "id": "useregisterviewmodel_test_buildregistercatalogrow",
-      "label": "buildRegisterCatalogRow()",
-      "norm_label": "buildregistercatalogrow()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts",
-      "source_location": "L231"
+      "id": "servicesworkspaceview_formatdeposit",
+      "label": "formatDeposit()",
+      "norm_label": "formatdeposit()",
+      "source_file": "packages/athena-webapp/src/components/services/ServicesWorkspaceView.tsx",
+      "source_location": "L91"
     },
     {
       "community": 144,
       "file_type": "code",
-      "id": "useregisterviewmodel_test_deferred",
-      "label": "deferred()",
-      "norm_label": "deferred()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts",
-      "source_location": "L222"
+      "id": "servicesworkspaceview_formatmoney",
+      "label": "formatMoney()",
+      "norm_label": "formatmoney()",
+      "source_file": "packages/athena-webapp/src/components/services/ServicesWorkspaceView.tsx",
+      "source_location": "L81"
     },
     {
       "community": 144,
       "file_type": "code",
-      "id": "useregisterviewmodel_test_resolveadditem",
-      "label": "resolveAddItem()",
-      "norm_label": "resolveadditem()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts",
-      "source_location": "L2232"
+      "id": "servicesworkspaceview_formatservicecatalogname",
+      "label": "formatServiceCatalogName()",
+      "norm_label": "formatservicecatalogname()",
+      "source_file": "packages/athena-webapp/src/components/services/ServicesWorkspaceView.tsx",
+      "source_location": "L71"
     },
     {
       "community": 144,
       "file_type": "code",
-      "id": "useregisterviewmodel_test_resolveclearcart",
-      "label": "resolveClearCart()",
-      "norm_label": "resolveclearcart()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts",
-      "source_location": "L2680"
+      "id": "servicesworkspaceview_sortservices",
+      "label": "sortServices()",
+      "norm_label": "sortservices()",
+      "source_file": "packages/athena-webapp/src/components/services/ServicesWorkspaceView.tsx",
+      "source_location": "L112"
     },
     {
       "community": 144,
       "file_type": "code",
-      "id": "useregisterviewmodel_test_resolveremoveitem",
-      "label": "resolveRemoveItem()",
-      "norm_label": "resolveremoveitem()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts",
-      "source_location": "L2553"
+      "id": "servicesworkspaceview_summarizeservice",
+      "label": "summarizeService()",
+      "norm_label": "summarizeservice()",
+      "source_file": "packages/athena-webapp/src/components/services/ServicesWorkspaceView.tsx",
+      "source_location": "L103"
     },
     {
       "community": 1440,
@@ -70560,65 +70860,65 @@
     {
       "community": 145,
       "file_type": "code",
-      "id": "calculationservice_calculatecarttotals",
-      "label": "calculateCartTotals()",
-      "norm_label": "calculatecarttotals()",
-      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
-      "source_location": "L28"
-    },
-    {
-      "community": 145,
-      "file_type": "code",
-      "id": "calculationservice_calculatechange",
-      "label": "calculateChange()",
-      "norm_label": "calculatechange()",
-      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
-      "source_location": "L42"
-    },
-    {
-      "community": 145,
-      "file_type": "code",
-      "id": "calculationservice_calculateitemtotal",
-      "label": "calculateItemTotal()",
-      "norm_label": "calculateitemtotal()",
-      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
-      "source_location": "L35"
-    },
-    {
-      "community": 145,
-      "file_type": "code",
-      "id": "calculationservice_formatcurrency",
-      "label": "formatCurrency()",
-      "norm_label": "formatcurrency()",
-      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
-      "source_location": "L49"
-    },
-    {
-      "community": 145,
-      "file_type": "code",
-      "id": "calculationservice_geteffectiveprice",
-      "label": "getEffectivePrice()",
-      "norm_label": "geteffectiveprice()",
-      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
-      "source_location": "L70"
-    },
-    {
-      "community": 145,
-      "file_type": "code",
-      "id": "calculationservice_ispaymentsufficient",
-      "label": "isPaymentSufficient()",
-      "norm_label": "ispaymentsufficient()",
-      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
-      "source_location": "L59"
-    },
-    {
-      "community": 145,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_services_calculationservice_ts",
-      "label": "calculationService.ts",
-      "norm_label": "calculationservice.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
+      "id": "packages_athena_webapp_src_lib_pos_domain_session_ts",
+      "label": "session.ts",
+      "norm_label": "session.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 145,
+      "file_type": "code",
+      "id": "session_deriveregisterphase",
+      "label": "deriveRegisterPhase()",
+      "norm_label": "deriveregisterphase()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
+      "source_location": "L3"
+    },
+    {
+      "community": 145,
+      "file_type": "code",
+      "id": "session_hasactiveregistersession",
+      "label": "hasActiveRegisterSession()",
+      "norm_label": "hasactiveregistersession()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
+      "source_location": "L33"
+    },
+    {
+      "community": 145,
+      "file_type": "code",
+      "id": "session_hasresumableregistersession",
+      "label": "hasResumableRegisterSession()",
+      "norm_label": "hasresumableregistersession()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
+      "source_location": "L39"
+    },
+    {
+      "community": 145,
+      "file_type": "code",
+      "id": "session_isregisterreadytostart",
+      "label": "isRegisterReadyToStart()",
+      "norm_label": "isregisterreadytostart()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
+      "source_location": "L45"
+    },
+    {
+      "community": 145,
+      "file_type": "code",
+      "id": "session_requirescashier",
+      "label": "requiresCashier()",
+      "norm_label": "requirescashier()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
+      "source_location": "L29"
+    },
+    {
+      "community": 145,
+      "file_type": "code",
+      "id": "session_requiresterminal",
+      "label": "requiresTerminal()",
+      "norm_label": "requiresterminal()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/session.ts",
+      "source_location": "L25"
     },
     {
       "community": 1450,
@@ -70713,65 +71013,65 @@
     {
       "community": 146,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_productutils_ts",
-      "label": "productUtils.ts",
-      "norm_label": "productutils.ts",
-      "source_file": "packages/athena-webapp/src/lib/productUtils.ts",
+      "id": "packages_athena_webapp_src_lib_pos_presentation_register_useregisterviewmodel_test_ts",
+      "label": "useRegisterViewModel.test.ts",
+      "norm_label": "useregisterviewmodel.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts",
       "source_location": "L1"
     },
     {
       "community": 146,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_productutils_ts",
-      "label": "productUtils.ts",
-      "norm_label": "productutils.ts",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L1"
+      "id": "useregisterviewmodel_test_buildregistercatalogavailabilityrow",
+      "label": "buildRegisterCatalogAvailabilityRow()",
+      "norm_label": "buildregistercatalogavailabilityrow()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts",
+      "source_location": "L254"
     },
     {
       "community": 146,
       "file_type": "code",
-      "id": "productutils_getproductname",
-      "label": "getProductName()",
-      "norm_label": "getproductname()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L18"
+      "id": "useregisterviewmodel_test_buildregistercatalogrow",
+      "label": "buildRegisterCatalogRow()",
+      "norm_label": "buildregistercatalogrow()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts",
+      "source_location": "L231"
     },
     {
       "community": 146,
       "file_type": "code",
-      "id": "productutils_haslowstock",
-      "label": "hasLowStock()",
-      "norm_label": "haslowstock()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L52"
+      "id": "useregisterviewmodel_test_deferred",
+      "label": "deferred()",
+      "norm_label": "deferred()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts",
+      "source_location": "L222"
     },
     {
       "community": 146,
       "file_type": "code",
-      "id": "productutils_issoldout",
-      "label": "isSoldOut()",
-      "norm_label": "issoldout()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L45"
+      "id": "useregisterviewmodel_test_resolveadditem",
+      "label": "resolveAddItem()",
+      "norm_label": "resolveadditem()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts",
+      "source_location": "L2232"
     },
     {
       "community": 146,
       "file_type": "code",
-      "id": "productutils_sortproduct",
-      "label": "sortProduct()",
-      "norm_label": "sortproduct()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L66"
+      "id": "useregisterviewmodel_test_resolveclearcart",
+      "label": "resolveClearCart()",
+      "norm_label": "resolveclearcart()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts",
+      "source_location": "L2680"
     },
     {
       "community": 146,
       "file_type": "code",
-      "id": "productutils_sortskusbylength",
-      "label": "sortSkusByLength()",
-      "norm_label": "sortskusbylength()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L62"
+      "id": "useregisterviewmodel_test_resolveremoveitem",
+      "label": "resolveRemoveItem()",
+      "norm_label": "resolveremoveitem()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts",
+      "source_location": "L2553"
     },
     {
       "community": 1460,
@@ -70866,65 +71166,65 @@
     {
       "community": 147,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_templates_reference_fixtures_tsx",
-      "label": "reference-fixtures.tsx",
-      "norm_label": "reference-fixtures.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "id": "calculationservice_calculatecarttotals",
+      "label": "calculateCartTotals()",
+      "norm_label": "calculatecarttotals()",
+      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
+      "source_location": "L28"
+    },
+    {
+      "community": 147,
+      "file_type": "code",
+      "id": "calculationservice_calculatechange",
+      "label": "calculateChange()",
+      "norm_label": "calculatechange()",
+      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
+      "source_location": "L42"
+    },
+    {
+      "community": 147,
+      "file_type": "code",
+      "id": "calculationservice_calculateitemtotal",
+      "label": "calculateItemTotal()",
+      "norm_label": "calculateitemtotal()",
+      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
+      "source_location": "L35"
+    },
+    {
+      "community": 147,
+      "file_type": "code",
+      "id": "calculationservice_formatcurrency",
+      "label": "formatCurrency()",
+      "norm_label": "formatcurrency()",
+      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
+      "source_location": "L49"
+    },
+    {
+      "community": 147,
+      "file_type": "code",
+      "id": "calculationservice_geteffectiveprice",
+      "label": "getEffectivePrice()",
+      "norm_label": "geteffectiveprice()",
+      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
+      "source_location": "L70"
+    },
+    {
+      "community": 147,
+      "file_type": "code",
+      "id": "calculationservice_ispaymentsufficient",
+      "label": "isPaymentSufficient()",
+      "norm_label": "ispaymentsufficient()",
+      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
+      "source_location": "L59"
+    },
+    {
+      "community": 147,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_services_calculationservice_ts",
+      "label": "calculationService.ts",
+      "norm_label": "calculationservice.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 147,
-      "file_type": "code",
-      "id": "reference_fixtures_compacttable",
-      "label": "CompactTable()",
-      "norm_label": "compacttable()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L263"
-    },
-    {
-      "community": 147,
-      "file_type": "code",
-      "id": "reference_fixtures_framecard",
-      "label": "FrameCard()",
-      "norm_label": "framecard()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L163"
-    },
-    {
-      "community": 147,
-      "file_type": "code",
-      "id": "reference_fixtures_lanecard",
-      "label": "LaneCard()",
-      "norm_label": "lanecard()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L213"
-    },
-    {
-      "community": 147,
-      "file_type": "code",
-      "id": "reference_fixtures_metrictile",
-      "label": "MetricTile()",
-      "norm_label": "metrictile()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L194"
-    },
-    {
-      "community": 147,
-      "file_type": "code",
-      "id": "reference_fixtures_minitrendchart",
-      "label": "MiniTrendChart()",
-      "norm_label": "minitrendchart()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L240"
-    },
-    {
-      "community": 147,
-      "file_type": "code",
-      "id": "reference_fixtures_referencepageshell",
-      "label": "ReferencePageShell()",
-      "norm_label": "referencepageshell()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L145"
     },
     {
       "community": 1470,
@@ -71019,65 +71319,65 @@
     {
       "community": 148,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_savedbag_ts",
-      "label": "savedBag.ts",
-      "norm_label": "savedbag.ts",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "id": "packages_athena_webapp_src_stories_templates_reference_fixtures_tsx",
+      "label": "reference-fixtures.tsx",
+      "norm_label": "reference-fixtures.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
       "source_location": "L1"
     },
     {
       "community": 148,
       "file_type": "code",
-      "id": "savedbag_additemtosavedbag",
-      "label": "addItemToSavedBag()",
-      "norm_label": "additemtosavedbag()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L25"
+      "id": "reference_fixtures_compacttable",
+      "label": "CompactTable()",
+      "norm_label": "compacttable()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L263"
     },
     {
       "community": 148,
       "file_type": "code",
-      "id": "savedbag_getactivesavedbag",
-      "label": "getActiveSavedBag()",
-      "norm_label": "getactivesavedbag()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L10"
+      "id": "reference_fixtures_framecard",
+      "label": "FrameCard()",
+      "norm_label": "framecard()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L163"
     },
     {
       "community": 148,
       "file_type": "code",
-      "id": "savedbag_getbaseurl",
-      "label": "getBaseUrl()",
-      "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L8"
+      "id": "reference_fixtures_lanecard",
+      "label": "LaneCard()",
+      "norm_label": "lanecard()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L213"
     },
     {
       "community": 148,
       "file_type": "code",
-      "id": "savedbag_removeitemfromsavedbag",
-      "label": "removeItemFromSavedBag()",
-      "norm_label": "removeitemfromsavedbag()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L91"
+      "id": "reference_fixtures_metrictile",
+      "label": "MetricTile()",
+      "norm_label": "metrictile()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L194"
     },
     {
       "community": 148,
       "file_type": "code",
-      "id": "savedbag_updatesavedbagitem",
-      "label": "updateSavedBagItem()",
-      "norm_label": "updatesavedbagitem()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L61"
+      "id": "reference_fixtures_minitrendchart",
+      "label": "MiniTrendChart()",
+      "norm_label": "minitrendchart()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L240"
     },
     {
       "community": 148,
       "file_type": "code",
-      "id": "savedbag_updatesavedbagowner",
-      "label": "updateSavedBagOwner()",
-      "norm_label": "updatesavedbagowner()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L109"
+      "id": "reference_fixtures_referencepageshell",
+      "label": "ReferencePageShell()",
+      "norm_label": "referencepageshell()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L145"
     },
     {
       "community": 1480,
@@ -71172,65 +71472,65 @@
     {
       "community": 149,
       "file_type": "code",
-      "id": "compound_solution_check_test_createfixturerepo",
-      "label": "createFixtureRepo()",
-      "norm_label": "createfixturerepo()",
-      "source_file": "scripts/compound-solution-check.test.ts",
-      "source_location": "L15"
-    },
-    {
-      "community": 149,
-      "file_type": "code",
-      "id": "compound_solution_check_test_gitenv",
-      "label": "gitEnv()",
-      "norm_label": "gitenv()",
-      "source_file": "scripts/compound-solution-check.test.ts",
-      "source_location": "L50"
-    },
-    {
-      "community": 149,
-      "file_type": "code",
-      "id": "compound_solution_check_test_linechanges",
-      "label": "lineChanges()",
-      "norm_label": "linechanges()",
-      "source_file": "scripts/compound-solution-check.test.ts",
-      "source_location": "L66"
-    },
-    {
-      "community": 149,
-      "file_type": "code",
-      "id": "compound_solution_check_test_rungit",
-      "label": "runGit()",
-      "norm_label": "rungit()",
-      "source_file": "scripts/compound-solution-check.test.ts",
-      "source_location": "L35"
-    },
-    {
-      "community": 149,
-      "file_type": "code",
-      "id": "compound_solution_check_test_solutionnote",
-      "label": "solutionNote()",
-      "norm_label": "solutionnote()",
-      "source_file": "scripts/compound-solution-check.test.ts",
-      "source_location": "L75"
-    },
-    {
-      "community": 149,
-      "file_type": "code",
-      "id": "compound_solution_check_test_write",
-      "label": "write()",
-      "norm_label": "write()",
-      "source_file": "scripts/compound-solution-check.test.ts",
-      "source_location": "L29"
-    },
-    {
-      "community": 149,
-      "file_type": "code",
-      "id": "scripts_compound_solution_check_test_ts",
-      "label": "compound-solution-check.test.ts",
-      "norm_label": "compound-solution-check.test.ts",
-      "source_file": "scripts/compound-solution-check.test.ts",
+      "id": "packages_storefront_webapp_src_api_savedbag_ts",
+      "label": "savedBag.ts",
+      "norm_label": "savedbag.ts",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 149,
+      "file_type": "code",
+      "id": "savedbag_additemtosavedbag",
+      "label": "addItemToSavedBag()",
+      "norm_label": "additemtosavedbag()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L25"
+    },
+    {
+      "community": 149,
+      "file_type": "code",
+      "id": "savedbag_getactivesavedbag",
+      "label": "getActiveSavedBag()",
+      "norm_label": "getactivesavedbag()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L10"
+    },
+    {
+      "community": 149,
+      "file_type": "code",
+      "id": "savedbag_getbaseurl",
+      "label": "getBaseUrl()",
+      "norm_label": "getbaseurl()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L8"
+    },
+    {
+      "community": 149,
+      "file_type": "code",
+      "id": "savedbag_removeitemfromsavedbag",
+      "label": "removeItemFromSavedBag()",
+      "norm_label": "removeitemfromsavedbag()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L91"
+    },
+    {
+      "community": 149,
+      "file_type": "code",
+      "id": "savedbag_updatesavedbagitem",
+      "label": "updateSavedBagItem()",
+      "norm_label": "updatesavedbagitem()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L61"
+    },
+    {
+      "community": 149,
+      "file_type": "code",
+      "id": "savedbag_updatesavedbagowner",
+      "label": "updateSavedBagOwner()",
+      "norm_label": "updatesavedbagowner()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L109"
     },
     {
       "community": 1490,
@@ -71550,65 +71850,65 @@
     {
       "community": 150,
       "file_type": "code",
-      "id": "scripts_harness_behavior_fixtures_storefront_runtime_api_ts",
-      "label": "storefront-runtime-api.ts",
-      "norm_label": "storefront-runtime-api.ts",
-      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
+      "id": "packages_athena_webapp_src_lib_productutils_ts",
+      "label": "productUtils.ts",
+      "norm_label": "productutils.ts",
+      "source_file": "packages/athena-webapp/src/lib/productUtils.ts",
       "source_location": "L1"
     },
     {
       "community": 150,
       "file_type": "code",
-      "id": "storefront_runtime_api_emitsignal",
-      "label": "emitSignal()",
-      "norm_label": "emitsignal()",
-      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
-      "source_location": "L210"
+      "id": "packages_storefront_webapp_src_lib_productutils_ts",
+      "label": "productUtils.ts",
+      "norm_label": "productutils.ts",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L1"
     },
     {
       "community": 150,
       "file_type": "code",
-      "id": "storefront_runtime_api_handlecheckoutsessionfetch",
-      "label": "handleCheckoutSessionFetch()",
-      "norm_label": "handlecheckoutsessionfetch()",
-      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
-      "source_location": "L214"
+      "id": "productutils_getproductname",
+      "label": "getProductName()",
+      "norm_label": "getproductname()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L18"
     },
     {
       "community": 150,
       "file_type": "code",
-      "id": "storefront_runtime_api_handlecheckoutsessionupdate",
-      "label": "handleCheckoutSessionUpdate()",
-      "norm_label": "handlecheckoutsessionupdate()",
-      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
-      "source_location": "L236"
+      "id": "productutils_haslowstock",
+      "label": "hasLowStock()",
+      "norm_label": "haslowstock()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L52"
     },
     {
       "community": 150,
       "file_type": "code",
-      "id": "storefront_runtime_api_jsonresponse",
-      "label": "jsonResponse()",
-      "norm_label": "jsonresponse()",
-      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
-      "source_location": "L201"
+      "id": "productutils_issoldout",
+      "label": "isSoldOut()",
+      "norm_label": "issoldout()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L45"
     },
     {
       "community": 150,
       "file_type": "code",
-      "id": "storefront_runtime_api_shutdown",
-      "label": "shutdown()",
-      "norm_label": "shutdown()",
-      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
-      "source_location": "L421"
+      "id": "productutils_sortproduct",
+      "label": "sortProduct()",
+      "norm_label": "sortproduct()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L66"
     },
     {
       "community": 150,
       "file_type": "code",
-      "id": "storefront_runtime_api_withcorsheaders",
-      "label": "withCorsHeaders()",
-      "norm_label": "withcorsheaders()",
-      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
-      "source_location": "L186"
+      "id": "productutils_sortskusbylength",
+      "label": "sortSkusByLength()",
+      "norm_label": "sortskusbylength()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L62"
     },
     {
       "community": 1500,
@@ -71703,64 +72003,64 @@
     {
       "community": 151,
       "file_type": "code",
-      "id": "harness_janitor_test_createfixtureroot",
-      "label": "createFixtureRoot()",
-      "norm_label": "createfixtureroot()",
-      "source_file": "scripts/harness-janitor.test.ts",
-      "source_location": "L29"
+      "id": "compound_solution_check_test_createfixturerepo",
+      "label": "createFixtureRepo()",
+      "norm_label": "createfixturerepo()",
+      "source_file": "scripts/compound-solution-check.test.ts",
+      "source_location": "L15"
     },
     {
       "community": 151,
       "file_type": "code",
-      "id": "harness_janitor_test_overwritefreshgenerateddocs",
-      "label": "overwriteFreshGeneratedDocs()",
-      "norm_label": "overwritefreshgenerateddocs()",
-      "source_file": "scripts/harness-janitor.test.ts",
-      "source_location": "L46"
+      "id": "compound_solution_check_test_gitenv",
+      "label": "gitEnv()",
+      "norm_label": "gitenv()",
+      "source_file": "scripts/compound-solution-check.test.ts",
+      "source_location": "L50"
     },
     {
       "community": 151,
       "file_type": "code",
-      "id": "harness_janitor_test_overwritefreshgraphifyartifacts",
-      "label": "overwriteFreshGraphifyArtifacts()",
-      "norm_label": "overwritefreshgraphifyartifacts()",
-      "source_file": "scripts/harness-janitor.test.ts",
-      "source_location": "L54"
+      "id": "compound_solution_check_test_linechanges",
+      "label": "lineChanges()",
+      "norm_label": "linechanges()",
+      "source_file": "scripts/compound-solution-check.test.ts",
+      "source_location": "L66"
     },
     {
       "community": 151,
       "file_type": "code",
-      "id": "harness_janitor_test_seedartifacts",
-      "label": "seedArtifacts()",
-      "norm_label": "seedartifacts()",
-      "source_file": "scripts/harness-janitor.test.ts",
+      "id": "compound_solution_check_test_rungit",
+      "label": "runGit()",
+      "norm_label": "rungit()",
+      "source_file": "scripts/compound-solution-check.test.ts",
       "source_location": "L35"
     },
     {
       "community": 151,
       "file_type": "code",
-      "id": "harness_janitor_test_sortpaths",
-      "label": "sortPaths()",
-      "norm_label": "sortpaths()",
-      "source_file": "scripts/harness-janitor.test.ts",
-      "source_location": "L61"
+      "id": "compound_solution_check_test_solutionnote",
+      "label": "solutionNote()",
+      "norm_label": "solutionnote()",
+      "source_file": "scripts/compound-solution-check.test.ts",
+      "source_location": "L75"
     },
     {
       "community": 151,
       "file_type": "code",
-      "id": "harness_janitor_test_write",
+      "id": "compound_solution_check_test_write",
       "label": "write()",
       "norm_label": "write()",
-      "source_file": "scripts/harness-janitor.test.ts",
-      "source_location": "L23"
+      "source_file": "scripts/compound-solution-check.test.ts",
+      "source_location": "L29"
     },
     {
       "community": 151,
       "file_type": "code",
-      "id": "scripts_harness_janitor_test_ts",
-      "label": "harness-janitor.test.ts",
-      "norm_label": "harness-janitor.test.ts",
-      "source_file": "scripts/harness-janitor.test.ts",
+      "id": "scripts_compound_solution_check_test_ts",
+      "label": "compound-solution-check.test.ts",
+      "norm_label": "compound-solution-check.test.ts",
+      "source_file": "scripts/compound-solution-check.test.ts",
       "source_location": "L1"
     },
     {
@@ -71856,65 +72156,65 @@
     {
       "community": 152,
       "file_type": "code",
-      "id": "harness_review_test_createfixturerepo",
-      "label": "createFixtureRepo()",
-      "norm_label": "createfixturerepo()",
-      "source_file": "scripts/harness-review.test.ts",
-      "source_location": "L23"
-    },
-    {
-      "community": 152,
-      "file_type": "code",
-      "id": "harness_review_test_error",
-      "label": "error()",
-      "norm_label": "error()",
-      "source_file": "scripts/harness-review.test.ts",
-      "source_location": "L291"
-    },
-    {
-      "community": 152,
-      "file_type": "code",
-      "id": "harness_review_test_initializegithistory",
-      "label": "initializeGitHistory()",
-      "norm_label": "initializegithistory()",
-      "source_file": "scripts/harness-review.test.ts",
-      "source_location": "L260"
-    },
-    {
-      "community": 152,
-      "file_type": "code",
-      "id": "harness_review_test_log",
-      "label": "log()",
-      "norm_label": "log()",
-      "source_file": "scripts/harness-review.test.ts",
-      "source_location": "L290"
-    },
-    {
-      "community": 152,
-      "file_type": "code",
-      "id": "harness_review_test_rungit",
-      "label": "runGit()",
-      "norm_label": "rungit()",
-      "source_file": "scripts/harness-review.test.ts",
-      "source_location": "L246"
-    },
-    {
-      "community": 152,
-      "file_type": "code",
-      "id": "harness_review_test_write",
-      "label": "write()",
-      "norm_label": "write()",
-      "source_file": "scripts/harness-review.test.ts",
-      "source_location": "L17"
-    },
-    {
-      "community": 152,
-      "file_type": "code",
-      "id": "scripts_harness_review_test_ts",
-      "label": "harness-review.test.ts",
-      "norm_label": "harness-review.test.ts",
-      "source_file": "scripts/harness-review.test.ts",
+      "id": "scripts_harness_behavior_fixtures_storefront_runtime_api_ts",
+      "label": "storefront-runtime-api.ts",
+      "norm_label": "storefront-runtime-api.ts",
+      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 152,
+      "file_type": "code",
+      "id": "storefront_runtime_api_emitsignal",
+      "label": "emitSignal()",
+      "norm_label": "emitsignal()",
+      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
+      "source_location": "L210"
+    },
+    {
+      "community": 152,
+      "file_type": "code",
+      "id": "storefront_runtime_api_handlecheckoutsessionfetch",
+      "label": "handleCheckoutSessionFetch()",
+      "norm_label": "handlecheckoutsessionfetch()",
+      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
+      "source_location": "L214"
+    },
+    {
+      "community": 152,
+      "file_type": "code",
+      "id": "storefront_runtime_api_handlecheckoutsessionupdate",
+      "label": "handleCheckoutSessionUpdate()",
+      "norm_label": "handlecheckoutsessionupdate()",
+      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
+      "source_location": "L236"
+    },
+    {
+      "community": 152,
+      "file_type": "code",
+      "id": "storefront_runtime_api_jsonresponse",
+      "label": "jsonResponse()",
+      "norm_label": "jsonresponse()",
+      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
+      "source_location": "L201"
+    },
+    {
+      "community": 152,
+      "file_type": "code",
+      "id": "storefront_runtime_api_shutdown",
+      "label": "shutdown()",
+      "norm_label": "shutdown()",
+      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
+      "source_location": "L421"
+    },
+    {
+      "community": 152,
+      "file_type": "code",
+      "id": "storefront_runtime_api_withcorsheaders",
+      "label": "withCorsHeaders()",
+      "norm_label": "withcorsheaders()",
+      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
+      "source_location": "L186"
     },
     {
       "community": 1520,
@@ -72009,55 +72309,64 @@
     {
       "community": 153,
       "file_type": "code",
-      "id": "index_valkeyclient",
-      "label": "ValkeyClient",
-      "norm_label": "valkeyclient",
-      "source_file": "packages/athena-webapp/convex/cache/index.ts",
-      "source_location": "L4"
+      "id": "harness_janitor_test_createfixtureroot",
+      "label": "createFixtureRoot()",
+      "norm_label": "createfixtureroot()",
+      "source_file": "scripts/harness-janitor.test.ts",
+      "source_location": "L29"
     },
     {
       "community": 153,
       "file_type": "code",
-      "id": "index_valkeyclient_constructor",
-      "label": ".constructor()",
-      "norm_label": ".constructor()",
-      "source_file": "packages/athena-webapp/convex/cache/index.ts",
-      "source_location": "L11"
+      "id": "harness_janitor_test_overwritefreshgenerateddocs",
+      "label": "overwriteFreshGeneratedDocs()",
+      "norm_label": "overwritefreshgenerateddocs()",
+      "source_file": "scripts/harness-janitor.test.ts",
+      "source_location": "L46"
     },
     {
       "community": 153,
       "file_type": "code",
-      "id": "index_valkeyclient_get",
-      "label": ".get()",
-      "norm_label": ".get()",
-      "source_file": "packages/athena-webapp/convex/cache/index.ts",
-      "source_location": "L20"
+      "id": "harness_janitor_test_overwritefreshgraphifyartifacts",
+      "label": "overwriteFreshGraphifyArtifacts()",
+      "norm_label": "overwritefreshgraphifyartifacts()",
+      "source_file": "scripts/harness-janitor.test.ts",
+      "source_location": "L54"
     },
     {
       "community": 153,
       "file_type": "code",
-      "id": "index_valkeyclient_invalidate",
-      "label": ".invalidate()",
-      "norm_label": ".invalidate()",
-      "source_file": "packages/athena-webapp/convex/cache/index.ts",
-      "source_location": "L75"
+      "id": "harness_janitor_test_seedartifacts",
+      "label": "seedArtifacts()",
+      "norm_label": "seedartifacts()",
+      "source_file": "scripts/harness-janitor.test.ts",
+      "source_location": "L35"
     },
     {
       "community": 153,
       "file_type": "code",
-      "id": "index_valkeyclient_set",
-      "label": ".set()",
-      "norm_label": ".set()",
-      "source_file": "packages/athena-webapp/convex/cache/index.ts",
-      "source_location": "L48"
+      "id": "harness_janitor_test_sortpaths",
+      "label": "sortPaths()",
+      "norm_label": "sortpaths()",
+      "source_file": "scripts/harness-janitor.test.ts",
+      "source_location": "L61"
     },
     {
       "community": 153,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_cache_index_ts",
-      "label": "index.ts",
-      "norm_label": "index.ts",
-      "source_file": "packages/athena-webapp/convex/cache/index.ts",
+      "id": "harness_janitor_test_write",
+      "label": "write()",
+      "norm_label": "write()",
+      "source_file": "scripts/harness-janitor.test.ts",
+      "source_location": "L23"
+    },
+    {
+      "community": 153,
+      "file_type": "code",
+      "id": "scripts_harness_janitor_test_ts",
+      "label": "harness-janitor.test.ts",
+      "norm_label": "harness-janitor.test.ts",
+      "source_file": "scripts/harness-janitor.test.ts",
       "source_location": "L1"
     },
     {
@@ -72153,56 +72462,65 @@
     {
       "community": 154,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_security_ts",
-      "label": "security.ts",
-      "norm_label": "security.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/security.ts",
+      "id": "harness_review_test_createfixturerepo",
+      "label": "createFixtureRepo()",
+      "norm_label": "createfixturerepo()",
+      "source_file": "scripts/harness-review.test.ts",
+      "source_location": "L23"
+    },
+    {
+      "community": 154,
+      "file_type": "code",
+      "id": "harness_review_test_error",
+      "label": "error()",
+      "norm_label": "error()",
+      "source_file": "scripts/harness-review.test.ts",
+      "source_location": "L291"
+    },
+    {
+      "community": 154,
+      "file_type": "code",
+      "id": "harness_review_test_initializegithistory",
+      "label": "initializeGitHistory()",
+      "norm_label": "initializegithistory()",
+      "source_file": "scripts/harness-review.test.ts",
+      "source_location": "L260"
+    },
+    {
+      "community": 154,
+      "file_type": "code",
+      "id": "harness_review_test_log",
+      "label": "log()",
+      "norm_label": "log()",
+      "source_file": "scripts/harness-review.test.ts",
+      "source_location": "L290"
+    },
+    {
+      "community": 154,
+      "file_type": "code",
+      "id": "harness_review_test_rungit",
+      "label": "runGit()",
+      "norm_label": "rungit()",
+      "source_file": "scripts/harness-review.test.ts",
+      "source_location": "L246"
+    },
+    {
+      "community": 154,
+      "file_type": "code",
+      "id": "harness_review_test_write",
+      "label": "write()",
+      "norm_label": "write()",
+      "source_file": "scripts/harness-review.test.ts",
+      "source_location": "L17"
+    },
+    {
+      "community": 154,
+      "file_type": "code",
+      "id": "scripts_harness_review_test_ts",
+      "label": "harness-review.test.ts",
+      "norm_label": "harness-review.test.ts",
+      "source_file": "scripts/harness-review.test.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 154,
-      "file_type": "code",
-      "id": "security_buildcanonicalcheckoutproducts",
-      "label": "buildCanonicalCheckoutProducts()",
-      "norm_label": "buildcanonicalcheckoutproducts()",
-      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/security.ts",
-      "source_location": "L42"
-    },
-    {
-      "community": 154,
-      "file_type": "code",
-      "id": "security_hasvalidpositivequantity",
-      "label": "hasValidPositiveQuantity()",
-      "norm_label": "hasvalidpositivequantity()",
-      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/security.ts",
-      "source_location": "L27"
-    },
-    {
-      "community": 154,
-      "file_type": "code",
-      "id": "security_isamounttampered",
-      "label": "isAmountTampered()",
-      "norm_label": "isamounttampered()",
-      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/security.ts",
-      "source_location": "L65"
-    },
-    {
-      "community": 154,
-      "file_type": "code",
-      "id": "security_isauthorizedresourceowner",
-      "label": "isAuthorizedResourceOwner()",
-      "norm_label": "isauthorizedresourceowner()",
-      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/security.ts",
-      "source_location": "L31"
-    },
-    {
-      "community": 154,
-      "file_type": "code",
-      "id": "security_isduplicatechargesuccess",
-      "label": "isDuplicateChargeSuccess()",
-      "norm_label": "isduplicatechargesuccess()",
-      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/security.ts",
-      "source_location": "L76"
     },
     {
       "community": 1540,
@@ -72297,56 +72615,56 @@
     {
       "community": 155,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_products_ts",
-      "label": "products.ts",
-      "norm_label": "products.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/products.ts",
+      "id": "index_valkeyclient",
+      "label": "ValkeyClient",
+      "norm_label": "valkeyclient",
+      "source_file": "packages/athena-webapp/convex/cache/index.ts",
+      "source_location": "L4"
+    },
+    {
+      "community": 155,
+      "file_type": "code",
+      "id": "index_valkeyclient_constructor",
+      "label": ".constructor()",
+      "norm_label": ".constructor()",
+      "source_file": "packages/athena-webapp/convex/cache/index.ts",
+      "source_location": "L11"
+    },
+    {
+      "community": 155,
+      "file_type": "code",
+      "id": "index_valkeyclient_get",
+      "label": ".get()",
+      "norm_label": ".get()",
+      "source_file": "packages/athena-webapp/convex/cache/index.ts",
+      "source_location": "L20"
+    },
+    {
+      "community": 155,
+      "file_type": "code",
+      "id": "index_valkeyclient_invalidate",
+      "label": ".invalidate()",
+      "norm_label": ".invalidate()",
+      "source_file": "packages/athena-webapp/convex/cache/index.ts",
+      "source_location": "L75"
+    },
+    {
+      "community": 155,
+      "file_type": "code",
+      "id": "index_valkeyclient_set",
+      "label": ".set()",
+      "norm_label": ".set()",
+      "source_file": "packages/athena-webapp/convex/cache/index.ts",
+      "source_location": "L48"
+    },
+    {
+      "community": 155,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_cache_index_ts",
+      "label": "index.ts",
+      "norm_label": "index.ts",
+      "source_file": "packages/athena-webapp/convex/cache/index.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 155,
-      "file_type": "code",
-      "id": "products_adjustskuavailabilityforactiveholds",
-      "label": "adjustSkuAvailabilityForActiveHolds()",
-      "norm_label": "adjustskuavailabilityforactiveholds()",
-      "source_file": "packages/athena-webapp/convex/inventory/products.ts",
-      "source_location": "L78"
-    },
-    {
-      "community": 155,
-      "file_type": "code",
-      "id": "products_calculatetotalavailablecount",
-      "label": "calculateTotalAvailableCount()",
-      "norm_label": "calculatetotalavailablecount()",
-      "source_file": "packages/athena-webapp/convex/inventory/products.ts",
-      "source_location": "L73"
-    },
-    {
-      "community": 155,
-      "file_type": "code",
-      "id": "products_calculatetotalinventorycount",
-      "label": "calculateTotalInventoryCount()",
-      "norm_label": "calculatetotalinventorycount()",
-      "source_file": "packages/athena-webapp/convex/inventory/products.ts",
-      "source_location": "L68"
-    },
-    {
-      "community": 155,
-      "file_type": "code",
-      "id": "products_generatebarcode",
-      "label": "generateBarcode()",
-      "norm_label": "generatebarcode()",
-      "source_file": "packages/athena-webapp/convex/inventory/products.ts",
-      "source_location": "L45"
-    },
-    {
-      "community": 155,
-      "file_type": "code",
-      "id": "products_generatesku",
-      "label": "generateSKU()",
-      "norm_label": "generatesku()",
-      "source_file": "packages/athena-webapp/convex/inventory/products.ts",
-      "source_location": "L21"
     },
     {
       "community": 1550,
@@ -72441,56 +72759,56 @@
     {
       "community": 156,
       "file_type": "code",
-      "id": "listregistercatalog_listregistercatalog",
-      "label": "listRegisterCatalog()",
-      "norm_label": "listregistercatalog()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/listRegisterCatalog.ts",
-      "source_location": "L95"
-    },
-    {
-      "community": 156,
-      "file_type": "code",
-      "id": "listregistercatalog_listregistercatalogavailability",
-      "label": "listRegisterCatalogAvailability()",
-      "norm_label": "listregistercatalogavailability()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/listRegisterCatalog.ts",
-      "source_location": "L137"
-    },
-    {
-      "community": 156,
-      "file_type": "code",
-      "id": "listregistercatalog_mapskutoregistercatalogrow",
-      "label": "mapSkuToRegisterCatalogRow()",
-      "norm_label": "mapskutoregistercatalogrow()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/listRegisterCatalog.ts",
-      "source_location": "L70"
-    },
-    {
-      "community": 156,
-      "file_type": "code",
-      "id": "listregistercatalog_readcategoryname",
-      "label": "readCategoryName()",
-      "norm_label": "readcategoryname()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/listRegisterCatalog.ts",
-      "source_location": "L32"
-    },
-    {
-      "community": 156,
-      "file_type": "code",
-      "id": "listregistercatalog_readcolorname",
-      "label": "readColorName()",
-      "norm_label": "readcolorname()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/listRegisterCatalog.ts",
-      "source_location": "L49"
-    },
-    {
-      "community": 156,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_queries_listregistercatalog_ts",
-      "label": "listRegisterCatalog.ts",
-      "norm_label": "listregistercatalog.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/listRegisterCatalog.ts",
+      "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_security_ts",
+      "label": "security.ts",
+      "norm_label": "security.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/security.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 156,
+      "file_type": "code",
+      "id": "security_buildcanonicalcheckoutproducts",
+      "label": "buildCanonicalCheckoutProducts()",
+      "norm_label": "buildcanonicalcheckoutproducts()",
+      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/security.ts",
+      "source_location": "L42"
+    },
+    {
+      "community": 156,
+      "file_type": "code",
+      "id": "security_hasvalidpositivequantity",
+      "label": "hasValidPositiveQuantity()",
+      "norm_label": "hasvalidpositivequantity()",
+      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/security.ts",
+      "source_location": "L27"
+    },
+    {
+      "community": 156,
+      "file_type": "code",
+      "id": "security_isamounttampered",
+      "label": "isAmountTampered()",
+      "norm_label": "isamounttampered()",
+      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/security.ts",
+      "source_location": "L65"
+    },
+    {
+      "community": 156,
+      "file_type": "code",
+      "id": "security_isauthorizedresourceowner",
+      "label": "isAuthorizedResourceOwner()",
+      "norm_label": "isauthorizedresourceowner()",
+      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/security.ts",
+      "source_location": "L31"
+    },
+    {
+      "community": 156,
+      "file_type": "code",
+      "id": "security_isduplicatechargesuccess",
+      "label": "isDuplicateChargeSuccess()",
+      "norm_label": "isduplicatechargesuccess()",
+      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/security.ts",
+      "source_location": "L76"
     },
     {
       "community": 1560,
@@ -72585,56 +72903,56 @@
     {
       "community": 157,
       "file_type": "code",
-      "id": "orderemailservice_buildorderstatusmessage",
-      "label": "buildOrderStatusMessage()",
-      "norm_label": "buildorderstatusmessage()",
-      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
-      "source_location": "L49"
-    },
-    {
-      "community": 157,
-      "file_type": "code",
-      "id": "orderemailservice_buildpickupdetails",
-      "label": "buildPickupDetails()",
-      "norm_label": "buildpickupdetails()",
-      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
-      "source_location": "L77"
-    },
-    {
-      "community": 157,
-      "file_type": "code",
-      "id": "orderemailservice_sendpaymentverificationemails",
-      "label": "sendPaymentVerificationEmails()",
-      "norm_label": "sendpaymentverificationemails()",
-      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
-      "source_location": "L217"
-    },
-    {
-      "community": 157,
-      "file_type": "code",
-      "id": "orderemailservice_sendpodorderemails",
-      "label": "sendPODOrderEmails()",
-      "norm_label": "sendpodorderemails()",
-      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
-      "source_location": "L96"
-    },
-    {
-      "community": 157,
-      "file_type": "code",
-      "id": "orderemailservice_shouldsendtoadmins",
-      "label": "shouldSendToAdmins()",
-      "norm_label": "shouldsendtoadmins()",
-      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
-      "source_location": "L42"
-    },
-    {
-      "community": 157,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_services_orderemailservice_ts",
-      "label": "orderEmailService.ts",
-      "norm_label": "orderemailservice.ts",
-      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
+      "id": "packages_athena_webapp_convex_inventory_products_ts",
+      "label": "products.ts",
+      "norm_label": "products.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/products.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 157,
+      "file_type": "code",
+      "id": "products_adjustskuavailabilityforactiveholds",
+      "label": "adjustSkuAvailabilityForActiveHolds()",
+      "norm_label": "adjustskuavailabilityforactiveholds()",
+      "source_file": "packages/athena-webapp/convex/inventory/products.ts",
+      "source_location": "L78"
+    },
+    {
+      "community": 157,
+      "file_type": "code",
+      "id": "products_calculatetotalavailablecount",
+      "label": "calculateTotalAvailableCount()",
+      "norm_label": "calculatetotalavailablecount()",
+      "source_file": "packages/athena-webapp/convex/inventory/products.ts",
+      "source_location": "L73"
+    },
+    {
+      "community": 157,
+      "file_type": "code",
+      "id": "products_calculatetotalinventorycount",
+      "label": "calculateTotalInventoryCount()",
+      "norm_label": "calculatetotalinventorycount()",
+      "source_file": "packages/athena-webapp/convex/inventory/products.ts",
+      "source_location": "L68"
+    },
+    {
+      "community": 157,
+      "file_type": "code",
+      "id": "products_generatebarcode",
+      "label": "generateBarcode()",
+      "norm_label": "generatebarcode()",
+      "source_file": "packages/athena-webapp/convex/inventory/products.ts",
+      "source_location": "L45"
+    },
+    {
+      "community": 157,
+      "file_type": "code",
+      "id": "products_generatesku",
+      "label": "generateSKU()",
+      "norm_label": "generatesku()",
+      "source_file": "packages/athena-webapp/convex/inventory/products.ts",
+      "source_location": "L21"
     },
     {
       "community": 1570,
@@ -72729,56 +73047,56 @@
     {
       "community": 158,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_stockops_vendors_ts",
-      "label": "vendors.ts",
-      "norm_label": "vendors.ts",
-      "source_file": "packages/athena-webapp/convex/stockOps/vendors.ts",
+      "id": "orderemailservice_buildorderstatusmessage",
+      "label": "buildOrderStatusMessage()",
+      "norm_label": "buildorderstatusmessage()",
+      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
+      "source_location": "L49"
+    },
+    {
+      "community": 158,
+      "file_type": "code",
+      "id": "orderemailservice_buildpickupdetails",
+      "label": "buildPickupDetails()",
+      "norm_label": "buildpickupdetails()",
+      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
+      "source_location": "L77"
+    },
+    {
+      "community": 158,
+      "file_type": "code",
+      "id": "orderemailservice_sendpaymentverificationemails",
+      "label": "sendPaymentVerificationEmails()",
+      "norm_label": "sendpaymentverificationemails()",
+      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
+      "source_location": "L217"
+    },
+    {
+      "community": 158,
+      "file_type": "code",
+      "id": "orderemailservice_sendpodorderemails",
+      "label": "sendPODOrderEmails()",
+      "norm_label": "sendpodorderemails()",
+      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
+      "source_location": "L96"
+    },
+    {
+      "community": 158,
+      "file_type": "code",
+      "id": "orderemailservice_shouldsendtoadmins",
+      "label": "shouldSendToAdmins()",
+      "norm_label": "shouldsendtoadmins()",
+      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
+      "source_location": "L42"
+    },
+    {
+      "community": 158,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_services_orderemailservice_ts",
+      "label": "orderEmailService.ts",
+      "norm_label": "orderemailservice.ts",
+      "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 158,
-      "file_type": "code",
-      "id": "vendors_createvendorcommandwithctx",
-      "label": "createVendorCommandWithCtx()",
-      "norm_label": "createvendorcommandwithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/vendors.ts",
-      "source_location": "L118"
-    },
-    {
-      "community": 158,
-      "file_type": "code",
-      "id": "vendors_createvendorwithctx",
-      "label": "createVendorWithCtx()",
-      "norm_label": "createvendorwithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/vendors.ts",
-      "source_location": "L74"
-    },
-    {
-      "community": 158,
-      "file_type": "code",
-      "id": "vendors_mapcreatevendorerror",
-      "label": "mapCreateVendorError()",
-      "norm_label": "mapcreatevendorerror()",
-      "source_file": "packages/athena-webapp/convex/stockOps/vendors.ts",
-      "source_location": "L45"
-    },
-    {
-      "community": 158,
-      "file_type": "code",
-      "id": "vendors_normalizevendorlookupkey",
-      "label": "normalizeVendorLookupKey()",
-      "norm_label": "normalizevendorlookupkey()",
-      "source_file": "packages/athena-webapp/convex/stockOps/vendors.ts",
-      "source_location": "L37"
-    },
-    {
-      "community": 158,
-      "file_type": "code",
-      "id": "vendors_trimoptional",
-      "label": "trimOptional()",
-      "norm_label": "trimoptional()",
-      "source_file": "packages/athena-webapp/convex/stockOps/vendors.ts",
-      "source_location": "L32"
     },
     {
       "community": 1580,
@@ -72873,56 +73191,56 @@
     {
       "community": 159,
       "file_type": "code",
-      "id": "convexpaginationantipatterncheck_find_block_end",
-      "label": "find_block_end()",
-      "norm_label": "find_block_end()",
-      "source_file": "packages/athena-webapp/scripts/convexPaginationAntiPatternCheck.py",
-      "source_location": "L123"
-    },
-    {
-      "community": 159,
-      "file_type": "code",
-      "id": "convexpaginationantipatterncheck_list_convex_files",
-      "label": "list_convex_files()",
-      "norm_label": "list_convex_files()",
-      "source_file": "packages/athena-webapp/scripts/convexPaginationAntiPatternCheck.py",
-      "source_location": "L187"
-    },
-    {
-      "community": 159,
-      "file_type": "code",
-      "id": "convexpaginationantipatterncheck_main",
-      "label": "main()",
-      "norm_label": "main()",
-      "source_file": "packages/athena-webapp/scripts/convexPaginationAntiPatternCheck.py",
-      "source_location": "L207"
-    },
-    {
-      "community": 159,
-      "file_type": "code",
-      "id": "convexpaginationantipatterncheck_scan_file",
-      "label": "scan_file()",
-      "norm_label": "scan_file()",
-      "source_file": "packages/athena-webapp/scripts/convexPaginationAntiPatternCheck.py",
-      "source_location": "L137"
-    },
-    {
-      "community": 159,
-      "file_type": "code",
-      "id": "convexpaginationantipatterncheck_strip_code",
-      "label": "strip_code()",
-      "norm_label": "strip_code()",
-      "source_file": "packages/athena-webapp/scripts/convexPaginationAntiPatternCheck.py",
-      "source_location": "L9"
-    },
-    {
-      "community": 159,
-      "file_type": "code",
-      "id": "packages_athena_webapp_scripts_convexpaginationantipatterncheck_py",
-      "label": "convexPaginationAntiPatternCheck.py",
-      "norm_label": "convexpaginationantipatterncheck.py",
-      "source_file": "packages/athena-webapp/scripts/convexPaginationAntiPatternCheck.py",
+      "id": "packages_athena_webapp_convex_stockops_vendors_ts",
+      "label": "vendors.ts",
+      "norm_label": "vendors.ts",
+      "source_file": "packages/athena-webapp/convex/stockOps/vendors.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 159,
+      "file_type": "code",
+      "id": "vendors_createvendorcommandwithctx",
+      "label": "createVendorCommandWithCtx()",
+      "norm_label": "createvendorcommandwithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/vendors.ts",
+      "source_location": "L118"
+    },
+    {
+      "community": 159,
+      "file_type": "code",
+      "id": "vendors_createvendorwithctx",
+      "label": "createVendorWithCtx()",
+      "norm_label": "createvendorwithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/vendors.ts",
+      "source_location": "L74"
+    },
+    {
+      "community": 159,
+      "file_type": "code",
+      "id": "vendors_mapcreatevendorerror",
+      "label": "mapCreateVendorError()",
+      "norm_label": "mapcreatevendorerror()",
+      "source_file": "packages/athena-webapp/convex/stockOps/vendors.ts",
+      "source_location": "L45"
+    },
+    {
+      "community": 159,
+      "file_type": "code",
+      "id": "vendors_normalizevendorlookupkey",
+      "label": "normalizeVendorLookupKey()",
+      "norm_label": "normalizevendorlookupkey()",
+      "source_file": "packages/athena-webapp/convex/stockOps/vendors.ts",
+      "source_location": "L37"
+    },
+    {
+      "community": 159,
+      "file_type": "code",
+      "id": "vendors_trimoptional",
+      "label": "trimOptional()",
+      "norm_label": "trimoptional()",
+      "source_file": "packages/athena-webapp/convex/stockOps/vendors.ts",
+      "source_location": "L32"
     },
     {
       "community": 1590,
@@ -73242,55 +73560,55 @@
     {
       "community": 160,
       "file_type": "code",
-      "id": "commandresult_approvalrequired",
-      "label": "approvalRequired()",
-      "norm_label": "approvalrequired()",
-      "source_file": "packages/athena-webapp/shared/commandResult.ts",
-      "source_location": "L62"
+      "id": "convexpaginationantipatterncheck_find_block_end",
+      "label": "find_block_end()",
+      "norm_label": "find_block_end()",
+      "source_file": "packages/athena-webapp/scripts/convexPaginationAntiPatternCheck.py",
+      "source_location": "L123"
     },
     {
       "community": 160,
       "file_type": "code",
-      "id": "commandresult_isapprovalrequiredresult",
-      "label": "isApprovalRequiredResult()",
-      "norm_label": "isapprovalrequiredresult()",
-      "source_file": "packages/athena-webapp/shared/commandResult.ts",
-      "source_location": "L77"
+      "id": "convexpaginationantipatterncheck_list_convex_files",
+      "label": "list_convex_files()",
+      "norm_label": "list_convex_files()",
+      "source_file": "packages/athena-webapp/scripts/convexPaginationAntiPatternCheck.py",
+      "source_location": "L187"
     },
     {
       "community": 160,
       "file_type": "code",
-      "id": "commandresult_isusererrorresult",
-      "label": "isUserErrorResult()",
-      "norm_label": "isusererrorresult()",
-      "source_file": "packages/athena-webapp/shared/commandResult.ts",
-      "source_location": "L71"
+      "id": "convexpaginationantipatterncheck_main",
+      "label": "main()",
+      "norm_label": "main()",
+      "source_file": "packages/athena-webapp/scripts/convexPaginationAntiPatternCheck.py",
+      "source_location": "L207"
     },
     {
       "community": 160,
       "file_type": "code",
-      "id": "commandresult_ok",
-      "label": "ok()",
-      "norm_label": "ok()",
-      "source_file": "packages/athena-webapp/shared/commandResult.ts",
-      "source_location": "L48"
+      "id": "convexpaginationantipatterncheck_scan_file",
+      "label": "scan_file()",
+      "norm_label": "scan_file()",
+      "source_file": "packages/athena-webapp/scripts/convexPaginationAntiPatternCheck.py",
+      "source_location": "L137"
     },
     {
       "community": 160,
       "file_type": "code",
-      "id": "commandresult_usererror",
-      "label": "userError()",
-      "norm_label": "usererror()",
-      "source_file": "packages/athena-webapp/shared/commandResult.ts",
-      "source_location": "L55"
+      "id": "convexpaginationantipatterncheck_strip_code",
+      "label": "strip_code()",
+      "norm_label": "strip_code()",
+      "source_file": "packages/athena-webapp/scripts/convexPaginationAntiPatternCheck.py",
+      "source_location": "L9"
     },
     {
       "community": 160,
       "file_type": "code",
-      "id": "packages_athena_webapp_shared_commandresult_ts",
-      "label": "commandResult.ts",
-      "norm_label": "commandresult.ts",
-      "source_file": "packages/athena-webapp/shared/commandResult.ts",
+      "id": "packages_athena_webapp_scripts_convexpaginationantipatterncheck_py",
+      "label": "convexPaginationAntiPatternCheck.py",
+      "norm_label": "convexpaginationantipatterncheck.py",
+      "source_file": "packages/athena-webapp/scripts/convexPaginationAntiPatternCheck.py",
       "source_location": "L1"
     },
     {
@@ -73386,6 +73704,60 @@
     {
       "community": 161,
       "file_type": "code",
+      "id": "commandresult_approvalrequired",
+      "label": "approvalRequired()",
+      "norm_label": "approvalrequired()",
+      "source_file": "packages/athena-webapp/shared/commandResult.ts",
+      "source_location": "L62"
+    },
+    {
+      "community": 161,
+      "file_type": "code",
+      "id": "commandresult_isapprovalrequiredresult",
+      "label": "isApprovalRequiredResult()",
+      "norm_label": "isapprovalrequiredresult()",
+      "source_file": "packages/athena-webapp/shared/commandResult.ts",
+      "source_location": "L77"
+    },
+    {
+      "community": 161,
+      "file_type": "code",
+      "id": "commandresult_isusererrorresult",
+      "label": "isUserErrorResult()",
+      "norm_label": "isusererrorresult()",
+      "source_file": "packages/athena-webapp/shared/commandResult.ts",
+      "source_location": "L71"
+    },
+    {
+      "community": 161,
+      "file_type": "code",
+      "id": "commandresult_ok",
+      "label": "ok()",
+      "norm_label": "ok()",
+      "source_file": "packages/athena-webapp/shared/commandResult.ts",
+      "source_location": "L48"
+    },
+    {
+      "community": 161,
+      "file_type": "code",
+      "id": "commandresult_usererror",
+      "label": "userError()",
+      "norm_label": "usererror()",
+      "source_file": "packages/athena-webapp/shared/commandResult.ts",
+      "source_location": "L55"
+    },
+    {
+      "community": 161,
+      "file_type": "code",
+      "id": "packages_athena_webapp_shared_commandresult_ts",
+      "label": "commandResult.ts",
+      "norm_label": "commandresult.ts",
+      "source_file": "packages/athena-webapp/shared/commandResult.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 162,
+      "file_type": "code",
       "id": "packages_athena_webapp_shared_registersessionstatus_ts",
       "label": "registerSessionStatus.ts",
       "norm_label": "registersessionstatus.ts",
@@ -73393,7 +73765,7 @@
       "source_location": "L1"
     },
     {
-      "community": 161,
+      "community": 162,
       "file_type": "code",
       "id": "registersessionstatus_includesregistersessionstatus",
       "label": "includesRegisterSessionStatus()",
@@ -73402,7 +73774,7 @@
       "source_location": "L33"
     },
     {
-      "community": 161,
+      "community": 162,
       "file_type": "code",
       "id": "registersessionstatus_iscashcontrolvisibleregistersessionstatus",
       "label": "isCashControlVisibleRegisterSessionStatus()",
@@ -73411,7 +73783,7 @@
       "source_location": "L57"
     },
     {
-      "community": 161,
+      "community": 162,
       "file_type": "code",
       "id": "registersessionstatus_isposusableregistersessionstatus",
       "label": "isPosUsableRegisterSessionStatus()",
@@ -73420,7 +73792,7 @@
       "source_location": "L43"
     },
     {
-      "community": 161,
+      "community": 162,
       "file_type": "code",
       "id": "registersessionstatus_isregistersessionconflictblockingstatus",
       "label": "isRegisterSessionConflictBlockingStatus()",
@@ -73429,7 +73801,7 @@
       "source_location": "L50"
     },
     {
-      "community": 161,
+      "community": 162,
       "file_type": "code",
       "id": "registersessionstatus_isregistersessionstatus",
       "label": "isRegisterSessionStatus()",
@@ -73438,7 +73810,7 @@
       "source_location": "L24"
     },
     {
-      "community": 162,
+      "community": 163,
       "file_type": "code",
       "id": "data_table_toolbar_datatabletoolbar",
       "label": "DataTableToolbar()",
@@ -73447,7 +73819,7 @@
       "source_location": "L23"
     },
     {
-      "community": 162,
+      "community": 163,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -73456,7 +73828,7 @@
       "source_location": "L1"
     },
     {
-      "community": 162,
+      "community": 163,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -73465,7 +73837,7 @@
       "source_location": "L1"
     },
     {
-      "community": 162,
+      "community": 163,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -73474,7 +73846,7 @@
       "source_location": "L1"
     },
     {
-      "community": 162,
+      "community": 163,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -73483,7 +73855,7 @@
       "source_location": "L1"
     },
     {
-      "community": 162,
+      "community": 163,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -73492,7 +73864,7 @@
       "source_location": "L1"
     },
     {
-      "community": 163,
+      "community": 164,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_selectable_data_provider_tsx",
       "label": "selectable-data-provider.tsx",
@@ -73501,7 +73873,7 @@
       "source_location": "L1"
     },
     {
-      "community": 163,
+      "community": 164,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_selectable_data_provider_tsx",
       "label": "selectable-data-provider.tsx",
@@ -73510,7 +73882,7 @@
       "source_location": "L1"
     },
     {
-      "community": 163,
+      "community": 164,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_selectable_data_provider_tsx",
       "label": "selectable-data-provider.tsx",
@@ -73519,7 +73891,7 @@
       "source_location": "L1"
     },
     {
-      "community": 163,
+      "community": 164,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_selectable_data_provider_tsx",
       "label": "selectable-data-provider.tsx",
@@ -73528,7 +73900,7 @@
       "source_location": "L1"
     },
     {
-      "community": 163,
+      "community": 164,
       "file_type": "code",
       "id": "selectable_data_provider_selectedproductsprovider",
       "label": "SelectedProductsProvider()",
@@ -73537,7 +73909,7 @@
       "source_location": "L16"
     },
     {
-      "community": 163,
+      "community": 164,
       "file_type": "code",
       "id": "selectable_data_provider_useselectedproducts",
       "label": "useSelectedProducts()",
@@ -73546,7 +73918,7 @@
       "source_location": "L37"
     },
     {
-      "community": 164,
+      "community": 165,
       "file_type": "code",
       "id": "inputotp_formatrequestdelay",
       "label": "formatRequestDelay()",
@@ -73555,7 +73927,7 @@
       "source_location": "L46"
     },
     {
-      "community": 164,
+      "community": 165,
       "file_type": "code",
       "id": "inputotp_handlepinchange",
       "label": "handlePinChange()",
@@ -73564,7 +73936,7 @@
       "source_location": "L95"
     },
     {
-      "community": 164,
+      "community": 165,
       "file_type": "code",
       "id": "inputotp_handlerequestnewcode",
       "label": "handleRequestNewCode()",
@@ -73573,7 +73945,7 @@
       "source_location": "L143"
     },
     {
-      "community": 164,
+      "community": 165,
       "file_type": "code",
       "id": "inputotp_normalizeotpcode",
       "label": "normalizeOtpCode()",
@@ -73582,7 +73954,7 @@
       "source_location": "L30"
     },
     {
-      "community": 164,
+      "community": 165,
       "file_type": "code",
       "id": "inputotp_onsubmit",
       "label": "onSubmit()",
@@ -73591,7 +73963,7 @@
       "source_location": "L105"
     },
     {
-      "community": 164,
+      "community": 165,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_login_inputotp_tsx",
       "label": "InputOTP.tsx",
@@ -73600,7 +73972,7 @@
       "source_location": "L1"
     },
     {
-      "community": 165,
+      "community": 166,
       "file_type": "code",
       "id": "bannermessageeditor_getcountdownstatus",
       "label": "getCountdownStatus()",
@@ -73609,7 +73981,7 @@
       "source_location": "L123"
     },
     {
-      "community": 165,
+      "community": 166,
       "file_type": "code",
       "id": "bannermessageeditor_handleactivetoggle",
       "label": "handleActiveToggle()",
@@ -73618,7 +73990,7 @@
       "source_location": "L91"
     },
     {
-      "community": 165,
+      "community": 166,
       "file_type": "code",
       "id": "bannermessageeditor_handleclear",
       "label": "handleClear()",
@@ -73627,7 +73999,7 @@
       "source_location": "L66"
     },
     {
-      "community": 165,
+      "community": 166,
       "file_type": "code",
       "id": "bannermessageeditor_handlecountdownchange",
       "label": "handleCountdownChange()",
@@ -73636,7 +74008,7 @@
       "source_location": "L113"
     },
     {
-      "community": 165,
+      "community": 166,
       "file_type": "code",
       "id": "bannermessageeditor_handlesave",
       "label": "handleSave()",
@@ -73645,7 +74017,7 @@
       "source_location": "L46"
     },
     {
-      "community": 165,
+      "community": 166,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_bannermessageeditor_tsx",
       "label": "BannerMessageEditor.tsx",
@@ -73654,7 +74026,7 @@
       "source_location": "L1"
     },
     {
-      "community": 166,
+      "community": 167,
       "file_type": "code",
       "id": "dailyclosehistoryview_test_historyrecord",
       "label": "historyRecord()",
@@ -73663,7 +74035,7 @@
       "source_location": "L178"
     },
     {
-      "community": 166,
+      "community": 167,
       "file_type": "code",
       "id": "dailyclosehistoryview_test_mockprotectedstate",
       "label": "mockProtectedState()",
@@ -73672,7 +74044,7 @@
       "source_location": "L229"
     },
     {
-      "community": 166,
+      "community": 167,
       "file_type": "code",
       "id": "dailyclosehistoryview_test_mockqueries",
       "label": "mockQueries()",
@@ -73681,7 +74053,7 @@
       "source_location": "L243"
     },
     {
-      "community": 166,
+      "community": 167,
       "file_type": "code",
       "id": "dailyclosehistoryview_test_snapshot",
       "label": "snapshot()",
@@ -73690,7 +74062,7 @@
       "source_location": "L92"
     },
     {
-      "community": 166,
+      "community": 167,
       "file_type": "code",
       "id": "dailyclosehistoryview_test_storedreportsnapshot",
       "label": "storedReportSnapshot()",
@@ -73699,7 +74071,7 @@
       "source_location": "L159"
     },
     {
-      "community": 166,
+      "community": 167,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_dailyclosehistoryview_test_tsx",
       "label": "DailyCloseHistoryView.test.tsx",
@@ -73708,7 +74080,7 @@
       "source_location": "L1"
     },
     {
-      "community": 167,
+      "community": 168,
       "file_type": "code",
       "id": "dailyopeningview_test_async",
       "label": "async()",
@@ -73717,7 +74089,7 @@
       "source_location": "L123"
     },
     {
-      "community": 167,
+      "community": 168,
       "file_type": "code",
       "id": "dailyopeningview_test_disconnect",
       "label": "disconnect()",
@@ -73726,7 +74098,7 @@
       "source_location": "L302"
     },
     {
-      "community": 167,
+      "community": 168,
       "file_type": "code",
       "id": "dailyopeningview_test_formatexpectedtimestamp",
       "label": "formatExpectedTimestamp()",
@@ -73735,7 +74107,7 @@
       "source_location": "L201"
     },
     {
-      "community": 167,
+      "community": 168,
       "file_type": "code",
       "id": "dailyopeningview_test_observe",
       "label": "observe()",
@@ -73744,7 +74116,7 @@
       "source_location": "L303"
     },
     {
-      "community": 167,
+      "community": 168,
       "file_type": "code",
       "id": "dailyopeningview_test_unobserve",
       "label": "unobserve()",
@@ -73753,7 +74125,7 @@
       "source_location": "L304"
     },
     {
-      "community": 167,
+      "community": 168,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_dailyopeningview_test_tsx",
       "label": "DailyOpeningView.test.tsx",
@@ -73762,7 +74134,7 @@
       "source_location": "L1"
     },
     {
-      "community": 168,
+      "community": 169,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_useapprovedcommand_tsx",
       "label": "useApprovedCommand.tsx",
@@ -73771,7 +74143,7 @@
       "source_location": "L1"
     },
     {
-      "community": 168,
+      "community": 169,
       "file_type": "code",
       "id": "useapprovedcommand_buildapprovalretryargs",
       "label": "buildApprovalRetryArgs()",
@@ -73780,7 +74152,7 @@
       "source_location": "L86"
     },
     {
-      "community": 168,
+      "community": 169,
       "file_type": "code",
       "id": "useapprovedcommand_getasyncapprovalrequestid",
       "label": "getAsyncApprovalRequestId()",
@@ -73789,7 +74161,7 @@
       "source_location": "L74"
     },
     {
-      "community": 168,
+      "community": 169,
       "file_type": "code",
       "id": "useapprovedcommand_hasasyncapprovalrequest",
       "label": "hasAsyncApprovalRequest()",
@@ -73798,7 +74170,7 @@
       "source_location": "L68"
     },
     {
-      "community": 168,
+      "community": 169,
       "file_type": "code",
       "id": "useapprovedcommand_hasinlinemanagerproof",
       "label": "hasInlineManagerProof()",
@@ -73807,67 +74179,13 @@
       "source_location": "L62"
     },
     {
-      "community": 168,
+      "community": 169,
       "file_type": "code",
       "id": "useapprovedcommand_useapprovedcommand",
       "label": "useApprovedCommand()",
       "norm_label": "useapprovedcommand()",
       "source_file": "packages/athena-webapp/src/components/operations/useApprovedCommand.tsx",
       "source_location": "L98"
-    },
-    {
-      "community": 169,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_transactions_transactionsview_tsx",
-      "label": "TransactionsView.tsx",
-      "norm_label": "transactionsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 169,
-      "file_type": "code",
-      "id": "transactionsview_formatoperatingdatefilterlabel",
-      "label": "formatOperatingDateFilterLabel()",
-      "norm_label": "formatoperatingdatefilterlabel()",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionsView.tsx",
-      "source_location": "L58"
-    },
-    {
-      "community": 169,
-      "file_type": "code",
-      "id": "transactionsview_formatpaymentmethod",
-      "label": "formatPaymentMethod()",
-      "norm_label": "formatpaymentmethod()",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionsView.tsx",
-      "source_location": "L25"
-    },
-    {
-      "community": 169,
-      "file_type": "code",
-      "id": "transactionsview_formatregisterfilterlabel",
-      "label": "formatRegisterFilterLabel()",
-      "norm_label": "formatregisterfilterlabel()",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionsView.tsx",
-      "source_location": "L30"
-    },
-    {
-      "community": 169,
-      "file_type": "code",
-      "id": "transactionsview_getstartofoperatingdate",
-      "label": "getStartOfOperatingDate()",
-      "norm_label": "getstartofoperatingdate()",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionsView.tsx",
-      "source_location": "L49"
-    },
-    {
-      "community": 169,
-      "file_type": "code",
-      "id": "transactionsview_istoday",
-      "label": "isToday()",
-      "norm_label": "istoday()",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionsView.tsx",
-      "source_location": "L43"
     },
     {
       "community": 17,
@@ -74088,6 +74406,60 @@
     {
       "community": 170,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_transactions_transactionsview_tsx",
+      "label": "TransactionsView.tsx",
+      "norm_label": "transactionsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 170,
+      "file_type": "code",
+      "id": "transactionsview_formatoperatingdatefilterlabel",
+      "label": "formatOperatingDateFilterLabel()",
+      "norm_label": "formatoperatingdatefilterlabel()",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionsView.tsx",
+      "source_location": "L58"
+    },
+    {
+      "community": 170,
+      "file_type": "code",
+      "id": "transactionsview_formatpaymentmethod",
+      "label": "formatPaymentMethod()",
+      "norm_label": "formatpaymentmethod()",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionsView.tsx",
+      "source_location": "L25"
+    },
+    {
+      "community": 170,
+      "file_type": "code",
+      "id": "transactionsview_formatregisterfilterlabel",
+      "label": "formatRegisterFilterLabel()",
+      "norm_label": "formatregisterfilterlabel()",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionsView.tsx",
+      "source_location": "L30"
+    },
+    {
+      "community": 170,
+      "file_type": "code",
+      "id": "transactionsview_getstartofoperatingdate",
+      "label": "getStartOfOperatingDate()",
+      "norm_label": "getstartofoperatingdate()",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionsView.tsx",
+      "source_location": "L49"
+    },
+    {
+      "community": 170,
+      "file_type": "code",
+      "id": "transactionsview_istoday",
+      "label": "isToday()",
+      "norm_label": "istoday()",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionsView.tsx",
+      "source_location": "L43"
+    },
+    {
+      "community": 171,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_procurement_receivingview_tsx",
       "label": "ReceivingView.tsx",
       "norm_label": "receivingview.tsx",
@@ -74095,7 +74467,7 @@
       "source_location": "L1"
     },
     {
-      "community": 170,
+      "community": 171,
       "file_type": "code",
       "id": "receivingview_builddefaultreceivedquantities",
       "label": "buildDefaultReceivedQuantities()",
@@ -74104,7 +74476,7 @@
       "source_location": "L50"
     },
     {
-      "community": 170,
+      "community": 171,
       "file_type": "code",
       "id": "receivingview_buildreceivedquantitiesaftersubmission",
       "label": "buildReceivedQuantitiesAfterSubmission()",
@@ -74113,7 +74485,7 @@
       "source_location": "L59"
     },
     {
-      "community": 170,
+      "community": 171,
       "file_type": "code",
       "id": "receivingview_buildsubmissionkey",
       "label": "buildSubmissionKey()",
@@ -74122,7 +74494,7 @@
       "source_location": "L32"
     },
     {
-      "community": 170,
+      "community": 171,
       "file_type": "code",
       "id": "receivingview_parselineitemdescription",
       "label": "parseLineItemDescription()",
@@ -74131,7 +74503,7 @@
       "source_location": "L36"
     },
     {
-      "community": 170,
+      "community": 171,
       "file_type": "code",
       "id": "receivingview_receivingview",
       "label": "ReceivingView()",
@@ -74140,7 +74512,7 @@
       "source_location": "L85"
     },
     {
-      "community": 171,
+      "community": 172,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reviews_reviewsview_tsx",
       "label": "ReviewsView.tsx",
@@ -74149,7 +74521,7 @@
       "source_location": "L1"
     },
     {
-      "community": 171,
+      "community": 172,
       "file_type": "code",
       "id": "reviewsview_handleapprove",
       "label": "handleApprove()",
@@ -74158,7 +74530,7 @@
       "source_location": "L44"
     },
     {
-      "community": 171,
+      "community": 172,
       "file_type": "code",
       "id": "reviewsview_handlepublish",
       "label": "handlePublish()",
@@ -74167,7 +74539,7 @@
       "source_location": "L80"
     },
     {
-      "community": 171,
+      "community": 172,
       "file_type": "code",
       "id": "reviewsview_handlereject",
       "label": "handleReject()",
@@ -74176,7 +74548,7 @@
       "source_location": "L62"
     },
     {
-      "community": 171,
+      "community": 172,
       "file_type": "code",
       "id": "reviewsview_handleunpublish",
       "label": "handleUnpublish()",
@@ -74185,7 +74557,7 @@
       "source_location": "L98"
     },
     {
-      "community": 171,
+      "community": 172,
       "file_type": "code",
       "id": "reviewsview_header",
       "label": "Header()",
@@ -74194,7 +74566,7 @@
       "source_location": "L15"
     },
     {
-      "community": 172,
+      "community": 173,
       "file_type": "code",
       "id": "feesview_formatdeliveryfeeinput",
       "label": "formatDeliveryFeeInput()",
@@ -74203,7 +74575,7 @@
       "source_location": "L31"
     },
     {
-      "community": 172,
+      "community": 173,
       "file_type": "code",
       "id": "feesview_handletoggleallfees",
       "label": "handleToggleAllFees()",
@@ -74212,7 +74584,7 @@
       "source_location": "L162"
     },
     {
-      "community": 172,
+      "community": 173,
       "file_type": "code",
       "id": "feesview_handleupdatefees",
       "label": "handleUpdateFees()",
@@ -74221,7 +74593,7 @@
       "source_location": "L88"
     },
     {
-      "community": 172,
+      "community": 173,
       "file_type": "code",
       "id": "feesview_parsedeliveryfeeinputs",
       "label": "parseDeliveryFeeInputs()",
@@ -74230,7 +74602,7 @@
       "source_location": "L45"
     },
     {
-      "community": 172,
+      "community": 173,
       "file_type": "code",
       "id": "feesview_parseoptionaldeliveryfeeinput",
       "label": "parseOptionalDeliveryFeeInput()",
@@ -74239,7 +74611,7 @@
       "source_location": "L35"
     },
     {
-      "community": 172,
+      "community": 173,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_feesview_tsx",
       "label": "FeesView.tsx",
@@ -74248,7 +74620,7 @@
       "source_location": "L1"
     },
     {
-      "community": 173,
+      "community": 174,
       "file_type": "code",
       "id": "image_uploader_ondragend",
       "label": "onDragEnd()",
@@ -74257,7 +74629,7 @@
       "source_location": "L100"
     },
     {
-      "community": 173,
+      "community": 174,
       "file_type": "code",
       "id": "image_uploader_ondrop",
       "label": "onDrop()",
@@ -74266,7 +74638,7 @@
       "source_location": "L20"
     },
     {
-      "community": 173,
+      "community": 174,
       "file_type": "code",
       "id": "image_uploader_removeimage",
       "label": "removeImage()",
@@ -74275,7 +74647,7 @@
       "source_location": "L31"
     },
     {
-      "community": 173,
+      "community": 174,
       "file_type": "code",
       "id": "image_uploader_unmarkfordeletion",
       "label": "unmarkForDeletion()",
@@ -74284,7 +74656,7 @@
       "source_location": "L46"
     },
     {
-      "community": 173,
+      "community": 174,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_image_uploader_tsx",
       "label": "image-uploader.tsx",
@@ -74293,7 +74665,7 @@
       "source_location": "L1"
     },
     {
-      "community": 173,
+      "community": 174,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_image_uploader_tsx",
       "label": "image-uploader.tsx",
@@ -74302,7 +74674,7 @@
       "source_location": "L1"
     },
     {
-      "community": 174,
+      "community": 175,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_sidebar_tsx",
       "label": "sidebar.tsx",
@@ -74311,7 +74683,7 @@
       "source_location": "L1"
     },
     {
-      "community": 174,
+      "community": 175,
       "file_type": "code",
       "id": "sidebar_cn",
       "label": "cn()",
@@ -74320,7 +74692,7 @@
       "source_location": "L146"
     },
     {
-      "community": 174,
+      "community": 175,
       "file_type": "code",
       "id": "sidebar_handlekeydown",
       "label": "handleKeyDown()",
@@ -74329,7 +74701,7 @@
       "source_location": "L104"
     },
     {
-      "community": 174,
+      "community": 175,
       "file_type": "code",
       "id": "sidebar_handleonhover",
       "label": "handleOnHover()",
@@ -74338,7 +74710,7 @@
       "source_location": "L222"
     },
     {
-      "community": 174,
+      "community": 175,
       "file_type": "code",
       "id": "sidebar_handleonmouseleave",
       "label": "handleOnMouseLeave()",
@@ -74347,7 +74719,7 @@
       "source_location": "L226"
     },
     {
-      "community": 174,
+      "community": 175,
       "file_type": "code",
       "id": "sidebar_usesidebar",
       "label": "useSidebar()",
@@ -74356,7 +74728,7 @@
       "source_location": "L44"
     },
     {
-      "community": 175,
+      "community": 176,
       "file_type": "code",
       "id": "managerelevationcontext_getstaffdisplayname",
       "label": "getStaffDisplayName()",
@@ -74365,7 +74737,7 @@
       "source_location": "L48"
     },
     {
-      "community": 175,
+      "community": 176,
       "file_type": "code",
       "id": "managerelevationcontext_managerelevationprovider",
       "label": "ManagerElevationProvider()",
@@ -74374,7 +74746,7 @@
       "source_location": "L71"
     },
     {
-      "community": 175,
+      "community": 176,
       "file_type": "code",
       "id": "managerelevationcontext_tostaffauthenticationresult",
       "label": "toStaffAuthenticationResult()",
@@ -74383,7 +74755,7 @@
       "source_location": "L58"
     },
     {
-      "community": 175,
+      "community": 176,
       "file_type": "code",
       "id": "managerelevationcontext_usemanagerelevation",
       "label": "useManagerElevation()",
@@ -74392,7 +74764,7 @@
       "source_location": "L224"
     },
     {
-      "community": 175,
+      "community": 176,
       "file_type": "code",
       "id": "managerelevationcontext_useoptionalmanagerelevation",
       "label": "useOptionalManagerElevation()",
@@ -74401,7 +74773,7 @@
       "source_location": "L236"
     },
     {
-      "community": 175,
+      "community": 176,
       "file_type": "code",
       "id": "packages_athena_webapp_src_contexts_managerelevationcontext_tsx",
       "label": "ManagerElevationContext.tsx",
@@ -74410,7 +74782,7 @@
       "source_location": "L1"
     },
     {
-      "community": 176,
+      "community": 177,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useexpensesessions_ts",
       "label": "useExpenseSessions.ts",
@@ -74419,7 +74791,7 @@
       "source_location": "L1"
     },
     {
-      "community": 176,
+      "community": 177,
       "file_type": "code",
       "id": "useexpensesessions_useexpenseactivesession",
       "label": "useExpenseActiveSession()",
@@ -74428,7 +74800,7 @@
       "source_location": "L42"
     },
     {
-      "community": 176,
+      "community": 177,
       "file_type": "code",
       "id": "useexpensesessions_useexpensesession",
       "label": "useExpenseSession()",
@@ -74437,7 +74809,7 @@
       "source_location": "L32"
     },
     {
-      "community": 176,
+      "community": 177,
       "file_type": "code",
       "id": "useexpensesessions_useexpensesessioncreate",
       "label": "useExpenseSessionCreate()",
@@ -74446,7 +74818,7 @@
       "source_location": "L62"
     },
     {
-      "community": 176,
+      "community": 177,
       "file_type": "code",
       "id": "useexpensesessions_useexpensesessionupdate",
       "label": "useExpenseSessionUpdate()",
@@ -74455,7 +74827,7 @@
       "source_location": "L101"
     },
     {
-      "community": 176,
+      "community": 177,
       "file_type": "code",
       "id": "useexpensesessions_useexpensestoresessions",
       "label": "useExpenseStoreSessions()",
@@ -74464,7 +74836,7 @@
       "source_location": "L10"
     },
     {
-      "community": 177,
+      "community": 178,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useposproducts_ts",
       "label": "usePOSProducts.ts",
@@ -74473,7 +74845,7 @@
       "source_location": "L1"
     },
     {
-      "community": 177,
+      "community": 178,
       "file_type": "code",
       "id": "useposproducts_useposbarcodesearch",
       "label": "usePOSBarcodeSearch()",
@@ -74482,7 +74854,7 @@
       "source_location": "L17"
     },
     {
-      "community": 177,
+      "community": 178,
       "file_type": "code",
       "id": "useposproducts_useposproductidsearch",
       "label": "usePOSProductIdSearch()",
@@ -74491,7 +74863,7 @@
       "source_location": "L24"
     },
     {
-      "community": 177,
+      "community": 178,
       "file_type": "code",
       "id": "useposproducts_useposproductsearch",
       "label": "usePOSProductSearch()",
@@ -74500,7 +74872,7 @@
       "source_location": "L10"
     },
     {
-      "community": 177,
+      "community": 178,
       "file_type": "code",
       "id": "useposproducts_useposquickaddproductsku",
       "label": "usePOSQuickAddProductSku()",
@@ -74509,7 +74881,7 @@
       "source_location": "L33"
     },
     {
-      "community": 177,
+      "community": 178,
       "file_type": "code",
       "id": "useposproducts_usepostransactioncomplete",
       "label": "usePOSTransactionComplete()",
@@ -74518,7 +74890,7 @@
       "source_location": "L31"
     },
     {
-      "community": 178,
+      "community": 179,
       "file_type": "code",
       "id": "behaviorutils_calculateengagementmetrics",
       "label": "calculateEngagementMetrics()",
@@ -74527,7 +74899,7 @@
       "source_location": "L173"
     },
     {
-      "community": 178,
+      "community": 179,
       "file_type": "code",
       "id": "behaviorutils_calculateriskindicators",
       "label": "calculateRiskIndicators()",
@@ -74536,7 +74908,7 @@
       "source_location": "L71"
     },
     {
-      "community": 178,
+      "community": 179,
       "file_type": "code",
       "id": "behaviorutils_getactivitypriority",
       "label": "getActivityPriority()",
@@ -74545,7 +74917,7 @@
       "source_location": "L251"
     },
     {
-      "community": 178,
+      "community": 179,
       "file_type": "code",
       "id": "behaviorutils_getcustomerjourneystage",
       "label": "getCustomerJourneyStage()",
@@ -74554,7 +74926,7 @@
       "source_location": "L36"
     },
     {
-      "community": 178,
+      "community": 179,
       "file_type": "code",
       "id": "behaviorutils_getjourneystageinfo",
       "label": "getJourneyStageInfo()",
@@ -74563,67 +74935,13 @@
       "source_location": "L277"
     },
     {
-      "community": 178,
+      "community": 179,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_behaviorutils_ts",
       "label": "behaviorUtils.ts",
       "norm_label": "behaviorutils.ts",
       "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 179,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_application_results_ts",
-      "label": "results.ts",
-      "norm_label": "results.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 179,
-      "file_type": "code",
-      "id": "results_isposusecasesuccess",
-      "label": "isPosUseCaseSuccess()",
-      "norm_label": "isposusecasesuccess()",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
-      "source_location": "L122"
-    },
-    {
-      "community": 179,
-      "file_type": "code",
-      "id": "results_mapcommandoutcome",
-      "label": "mapCommandOutcome()",
-      "norm_label": "mapcommandoutcome()",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
-      "source_location": "L68"
-    },
-    {
-      "community": 179,
-      "file_type": "code",
-      "id": "results_mapcommandresult",
-      "label": "mapCommandResult()",
-      "norm_label": "mapcommandresult()",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
-      "source_location": "L85"
-    },
-    {
-      "community": 179,
-      "file_type": "code",
-      "id": "results_maplegacymutationresult",
-      "label": "mapLegacyMutationResult()",
-      "norm_label": "maplegacymutationresult()",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
-      "source_location": "L51"
-    },
-    {
-      "community": 179,
-      "file_type": "code",
-      "id": "results_mapthrownerror",
-      "label": "mapThrownError()",
-      "norm_label": "mapthrownerror()",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
-      "source_location": "L102"
     },
     {
       "community": 18,
@@ -74844,6 +75162,60 @@
     {
       "community": 180,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_application_results_ts",
+      "label": "results.ts",
+      "norm_label": "results.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 180,
+      "file_type": "code",
+      "id": "results_isposusecasesuccess",
+      "label": "isPosUseCaseSuccess()",
+      "norm_label": "isposusecasesuccess()",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
+      "source_location": "L122"
+    },
+    {
+      "community": 180,
+      "file_type": "code",
+      "id": "results_mapcommandoutcome",
+      "label": "mapCommandOutcome()",
+      "norm_label": "mapcommandoutcome()",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
+      "source_location": "L68"
+    },
+    {
+      "community": 180,
+      "file_type": "code",
+      "id": "results_mapcommandresult",
+      "label": "mapCommandResult()",
+      "norm_label": "mapcommandresult()",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
+      "source_location": "L85"
+    },
+    {
+      "community": 180,
+      "file_type": "code",
+      "id": "results_maplegacymutationresult",
+      "label": "mapLegacyMutationResult()",
+      "norm_label": "maplegacymutationresult()",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
+      "source_location": "L51"
+    },
+    {
+      "community": 180,
+      "file_type": "code",
+      "id": "results_mapthrownerror",
+      "label": "mapThrownError()",
+      "norm_label": "mapthrownerror()",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/results.ts",
+      "source_location": "L102"
+    },
+    {
+      "community": 181,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_domain_payments_ts",
       "label": "payments.ts",
       "norm_label": "payments.ts",
@@ -74851,7 +75223,7 @@
       "source_location": "L1"
     },
     {
-      "community": 180,
+      "community": 181,
       "file_type": "code",
       "id": "payments_calculateposchange",
       "label": "calculatePosChange()",
@@ -74860,7 +75232,7 @@
       "source_location": "L3"
     },
     {
-      "community": 180,
+      "community": 181,
       "file_type": "code",
       "id": "payments_calculateposremainingdue",
       "label": "calculatePosRemainingDue()",
@@ -74869,7 +75241,7 @@
       "source_location": "L20"
     },
     {
-      "community": 180,
+      "community": 181,
       "file_type": "code",
       "id": "payments_calculatepostotalpaid",
       "label": "calculatePosTotalPaid()",
@@ -74878,7 +75250,7 @@
       "source_location": "L14"
     },
     {
-      "community": 180,
+      "community": 181,
       "file_type": "code",
       "id": "payments_ispospaymentsufficient",
       "label": "isPosPaymentSufficient()",
@@ -74887,7 +75259,7 @@
       "source_location": "L7"
     },
     {
-      "community": 180,
+      "community": 181,
       "file_type": "code",
       "id": "payments_roundposamount",
       "label": "roundPosAmount()",
@@ -74896,7 +75268,7 @@
       "source_location": "L27"
     },
     {
-      "community": 181,
+      "community": 182,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_presentation_register_selectors_ts",
       "label": "selectors.ts",
@@ -74905,7 +75277,7 @@
       "source_location": "L1"
     },
     {
-      "community": 181,
+      "community": 182,
       "file_type": "code",
       "id": "selectors_buildregisterheaderstate",
       "label": "buildRegisterHeaderState()",
@@ -74914,7 +75286,7 @@
       "source_location": "L28"
     },
     {
-      "community": 181,
+      "community": 182,
       "file_type": "code",
       "id": "selectors_buildregisterinfostate",
       "label": "buildRegisterInfoState()",
@@ -74923,7 +75295,7 @@
       "source_location": "L37"
     },
     {
-      "community": 181,
+      "community": 182,
       "file_type": "code",
       "id": "selectors_getcashierdisplayname",
       "label": "getCashierDisplayName()",
@@ -74932,7 +75304,7 @@
       "source_location": "L12"
     },
     {
-      "community": 181,
+      "community": 182,
       "file_type": "code",
       "id": "selectors_getregistercustomerinfo",
       "label": "getRegisterCustomerInfo()",
@@ -74941,7 +75313,7 @@
       "source_location": "L6"
     },
     {
-      "community": 181,
+      "community": 182,
       "file_type": "code",
       "id": "selectors_isregistersessionactive",
       "label": "isRegisterSessionActive()",
@@ -74950,7 +75322,7 @@
       "source_location": "L49"
     },
     {
-      "community": 182,
+      "community": 183,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_toastservice_ts",
       "label": "toastService.ts",
@@ -74959,7 +75331,7 @@
       "source_location": "L1"
     },
     {
-      "community": 182,
+      "community": 183,
       "file_type": "code",
       "id": "toastservice_handleposoperation",
       "label": "handlePOSOperation()",
@@ -74968,7 +75340,7 @@
       "source_location": "L171"
     },
     {
-      "community": 182,
+      "community": 183,
       "file_type": "code",
       "id": "toastservice_showinventoryerror",
       "label": "showInventoryError()",
@@ -74977,7 +75349,7 @@
       "source_location": "L302"
     },
     {
-      "community": 182,
+      "community": 183,
       "file_type": "code",
       "id": "toastservice_shownoactivesessionerror",
       "label": "showNoActiveSessionError()",
@@ -74986,7 +75358,7 @@
       "source_location": "L319"
     },
     {
-      "community": 182,
+      "community": 183,
       "file_type": "code",
       "id": "toastservice_showsessionexpirederror",
       "label": "showSessionExpiredError()",
@@ -74995,7 +75367,7 @@
       "source_location": "L312"
     },
     {
-      "community": 182,
+      "community": 183,
       "file_type": "code",
       "id": "toastservice_showvalidationerror",
       "label": "showValidationError()",
@@ -75004,7 +75376,7 @@
       "source_location": "L293"
     },
     {
-      "community": 183,
+      "community": 184,
       "file_type": "code",
       "id": "organizationsettingsview_handledeletestore",
       "label": "handleDeleteStore()",
@@ -75013,7 +75385,7 @@
       "source_location": "L155"
     },
     {
-      "community": 183,
+      "community": 184,
       "file_type": "code",
       "id": "organizationsettingsview_navigation",
       "label": "Navigation()",
@@ -75022,7 +75394,7 @@
       "source_location": "L197"
     },
     {
-      "community": 183,
+      "community": 184,
       "file_type": "code",
       "id": "organizationsettingsview_onsubmit",
       "label": "onSubmit()",
@@ -75031,7 +75403,7 @@
       "source_location": "L104"
     },
     {
-      "community": 183,
+      "community": 184,
       "file_type": "code",
       "id": "organizationsettingsview_organizationsettings",
       "label": "OrganizationSettings()",
@@ -75040,7 +75412,7 @@
       "source_location": "L25"
     },
     {
-      "community": 183,
+      "community": 184,
       "file_type": "code",
       "id": "organizationsettingsview_savestorechanges",
       "label": "saveStoreChanges()",
@@ -75049,7 +75421,7 @@
       "source_location": "L72"
     },
     {
-      "community": 183,
+      "community": 184,
       "file_type": "code",
       "id": "packages_athena_webapp_src_settings_organization_components_organizationsettingsview_tsx",
       "label": "OrganizationSettingsView.tsx",
@@ -75058,7 +75430,7 @@
       "source_location": "L1"
     },
     {
-      "community": 184,
+      "community": 185,
       "file_type": "code",
       "id": "packages_athena_webapp_src_settings_store_storesettingsview_tsx",
       "label": "StoreSettingsView.tsx",
@@ -75067,7 +75439,7 @@
       "source_location": "L1"
     },
     {
-      "community": 184,
+      "community": 185,
       "file_type": "code",
       "id": "storesettingsview_handledeleteallproductsinstore",
       "label": "handleDeleteAllProductsInStore()",
@@ -75076,7 +75448,7 @@
       "source_location": "L231"
     },
     {
-      "community": 184,
+      "community": 185,
       "file_type": "code",
       "id": "storesettingsview_handledeletestore",
       "label": "handleDeleteStore()",
@@ -75085,7 +75457,7 @@
       "source_location": "L167"
     },
     {
-      "community": 184,
+      "community": 185,
       "file_type": "code",
       "id": "storesettingsview_onsubmit",
       "label": "onSubmit()",
@@ -75094,7 +75466,7 @@
       "source_location": "L116"
     },
     {
-      "community": 184,
+      "community": 185,
       "file_type": "code",
       "id": "storesettingsview_savestorechanges",
       "label": "saveStoreChanges()",
@@ -75103,7 +75475,7 @@
       "source_location": "L83"
     },
     {
-      "community": 184,
+      "community": 185,
       "file_type": "code",
       "id": "storesettingsview_storesettings",
       "label": "StoreSettings()",
@@ -75112,7 +75484,7 @@
       "source_location": "L29"
     },
     {
-      "community": 185,
+      "community": 186,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_storybook_shell_tsx",
       "label": "storybook-shell.tsx",
@@ -75121,7 +75493,7 @@
       "source_location": "L1"
     },
     {
-      "community": 185,
+      "community": 186,
       "file_type": "code",
       "id": "storybook_shell_storybookcallout",
       "label": "StorybookCallout()",
@@ -75130,7 +75502,7 @@
       "source_location": "L76"
     },
     {
-      "community": 185,
+      "community": 186,
       "file_type": "code",
       "id": "storybook_shell_storybooklist",
       "label": "StorybookList()",
@@ -75139,7 +75511,7 @@
       "source_location": "L55"
     },
     {
-      "community": 185,
+      "community": 186,
       "file_type": "code",
       "id": "storybook_shell_storybookpillrow",
       "label": "StorybookPillRow()",
@@ -75148,7 +75520,7 @@
       "source_location": "L88"
     },
     {
-      "community": 185,
+      "community": 186,
       "file_type": "code",
       "id": "storybook_shell_storybooksection",
       "label": "StorybookSection()",
@@ -75157,7 +75529,7 @@
       "source_location": "L34"
     },
     {
-      "community": 185,
+      "community": 186,
       "file_type": "code",
       "id": "storybook_shell_storybookshell",
       "label": "StorybookShell()",
@@ -75166,7 +75538,7 @@
       "source_location": "L13"
     },
     {
-      "community": 186,
+      "community": 187,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_postransaction_ts",
       "label": "posTransaction.ts",
@@ -75175,7 +75547,7 @@
       "source_location": "L1"
     },
     {
-      "community": 186,
+      "community": 187,
       "file_type": "code",
       "id": "postransaction_fetchpostransaction",
       "label": "fetchPosTransaction()",
@@ -75184,7 +75556,7 @@
       "source_location": "L69"
     },
     {
-      "community": 186,
+      "community": 187,
       "file_type": "code",
       "id": "postransaction_getbaseurl",
       "label": "getBaseUrl()",
@@ -75193,7 +75565,7 @@
       "source_location": "L57"
     },
     {
-      "community": 186,
+      "community": 187,
       "file_type": "code",
       "id": "postransaction_getpostransactionbyreceipttoken",
       "label": "getPosTransactionByReceiptToken()",
@@ -75202,7 +75574,7 @@
       "source_location": "L90"
     },
     {
-      "community": 186,
+      "community": 187,
       "file_type": "code",
       "id": "postransaction_postransactionreceipterror",
       "label": "PosTransactionReceiptError",
@@ -75211,7 +75583,7 @@
       "source_location": "L59"
     },
     {
-      "community": 186,
+      "community": 187,
       "file_type": "code",
       "id": "postransaction_postransactionreceipterror_constructor",
       "label": ".constructor()",
@@ -75220,7 +75592,7 @@
       "source_location": "L62"
     },
     {
-      "community": 187,
+      "community": 188,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_promocodes_ts",
       "label": "promoCodes.ts",
@@ -75229,7 +75601,7 @@
       "source_location": "L1"
     },
     {
-      "community": 187,
+      "community": 188,
       "file_type": "code",
       "id": "promocodes_getbaseurl",
       "label": "getBaseUrl()",
@@ -75238,7 +75610,7 @@
       "source_location": "L4"
     },
     {
-      "community": 187,
+      "community": 188,
       "file_type": "code",
       "id": "promocodes_getpromocodeitems",
       "label": "getPromoCodeItems()",
@@ -75247,7 +75619,7 @@
       "source_location": "L49"
     },
     {
-      "community": 187,
+      "community": 188,
       "file_type": "code",
       "id": "promocodes_getpromocodes",
       "label": "getPromoCodes()",
@@ -75256,7 +75628,7 @@
       "source_location": "L34"
     },
     {
-      "community": 187,
+      "community": 188,
       "file_type": "code",
       "id": "promocodes_getredeemedpromocodes",
       "label": "getRedeemedPromoCodes()",
@@ -75265,7 +75637,7 @@
       "source_location": "L74"
     },
     {
-      "community": 187,
+      "community": 188,
       "file_type": "code",
       "id": "promocodes_redeempromocode",
       "label": "redeemPromoCode()",
@@ -75274,7 +75646,7 @@
       "source_location": "L6"
     },
     {
-      "community": 188,
+      "community": 189,
       "file_type": "code",
       "id": "billingdetails_clearform",
       "label": "clearForm()",
@@ -75283,7 +75655,7 @@
       "source_location": "L173"
     },
     {
-      "community": 188,
+      "community": 189,
       "file_type": "code",
       "id": "billingdetails_enteredbillingaddressdetails",
       "label": "EnteredBillingAddressDetails()",
@@ -75292,7 +75664,7 @@
       "source_location": "L102"
     },
     {
-      "community": 188,
+      "community": 189,
       "file_type": "code",
       "id": "billingdetails_handleusebillingaddressonfile",
       "label": "handleUseBillingAddressOnFile()",
@@ -75301,7 +75673,7 @@
       "source_location": "L201"
     },
     {
-      "community": 188,
+      "community": 189,
       "file_type": "code",
       "id": "billingdetails_onsubmit",
       "label": "onSubmit()",
@@ -75310,7 +75682,7 @@
       "source_location": "L150"
     },
     {
-      "community": 188,
+      "community": 189,
       "file_type": "code",
       "id": "billingdetails_togglesameasdelivery",
       "label": "toggleSameAsDelivery()",
@@ -75319,7 +75691,7 @@
       "source_location": "L155"
     },
     {
-      "community": 188,
+      "community": 189,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_billingdetails_tsx",
       "label": "BillingDetails.tsx",
@@ -75328,7 +75700,214 @@
       "source_location": "L1"
     },
     {
-      "community": 189,
+      "community": 19,
+      "file_type": "code",
+      "id": "dailyoperations_attentionseverity",
+      "label": "attentionSeverity()",
+      "norm_label": "attentionseverity()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
+      "source_location": "L287"
+    },
+    {
+      "community": 19,
+      "file_type": "code",
+      "id": "dailyoperations_builddailyoperationssnapshotwithctx",
+      "label": "buildDailyOperationsSnapshotWithCtx()",
+      "norm_label": "builddailyoperationssnapshotwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
+      "source_location": "L683"
+    },
+    {
+      "community": 19,
+      "file_type": "code",
+      "id": "dailyoperations_buildlanes",
+      "label": "buildLanes()",
+      "norm_label": "buildlanes()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
+      "source_location": "L561"
+    },
+    {
+      "community": 19,
+      "file_type": "code",
+      "id": "dailyoperations_buildweekmetricfordate",
+      "label": "buildWeekMetricForDate()",
+      "norm_label": "buildweekmetricfordate()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
+      "source_location": "L187"
+    },
+    {
+      "community": 19,
+      "file_type": "code",
+      "id": "dailyoperations_buildweekmetrics",
+      "label": "buildWeekMetrics()",
+      "norm_label": "buildweekmetrics()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
+      "source_location": "L261"
+    },
+    {
+      "community": 19,
+      "file_type": "code",
+      "id": "dailyoperations_emptyclosesummary",
+      "label": "emptyCloseSummary()",
+      "norm_label": "emptyclosesummary()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
+      "source_location": "L156"
+    },
+    {
+      "community": 19,
+      "file_type": "code",
+      "id": "dailyoperations_getcloseitemcounts",
+      "label": "getCloseItemCounts()",
+      "norm_label": "getcloseitemcounts()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
+      "source_location": "L431"
+    },
+    {
+      "community": 19,
+      "file_type": "code",
+      "id": "dailyoperations_getdailycloserecordfordate",
+      "label": "getDailyCloseRecordForDate()",
+      "norm_label": "getdailycloserecordfordate()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
+      "source_location": "L416"
+    },
+    {
+      "community": 19,
+      "file_type": "code",
+      "id": "dailyoperations_lifecyclecopy",
+      "label": "lifecycleCopy()",
+      "norm_label": "lifecyclecopy()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
+      "source_location": "L479"
+    },
+    {
+      "community": 19,
+      "file_type": "code",
+      "id": "dailyoperations_listopenqueuesnapshot",
+      "label": "listOpenQueueSnapshot()",
+      "norm_label": "listopenqueuesnapshot()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
+      "source_location": "L329"
+    },
+    {
+      "community": 19,
+      "file_type": "code",
+      "id": "dailyoperations_listtimelineevents",
+      "label": "listTimelineEvents()",
+      "norm_label": "listtimelineevents()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
+      "source_location": "L382"
+    },
+    {
+      "community": 19,
+      "file_type": "code",
+      "id": "dailyoperations_openingnotstartedattention",
+      "label": "openingNotStartedAttention()",
+      "norm_label": "openingnotstartedattention()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
+      "source_location": "L310"
+    },
+    {
+      "community": 19,
+      "file_type": "code",
+      "id": "dailyoperations_operatingdaterange",
+      "label": "operatingDateRange()",
+      "norm_label": "operatingdaterange()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
+      "source_location": "L106"
+    },
+    {
+      "community": 19,
+      "file_type": "code",
+      "id": "dailyoperations_pluralize",
+      "label": "pluralize()",
+      "norm_label": "pluralize()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
+      "source_location": "L171"
+    },
+    {
+      "community": 19,
+      "file_type": "code",
+      "id": "dailyoperations_primaryaction",
+      "label": "primaryAction()",
+      "norm_label": "primaryaction()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
+      "source_location": "L523"
+    },
+    {
+      "community": 19,
+      "file_type": "code",
+      "id": "dailyoperations_queueattentionitems",
+      "label": "queueAttentionItems()",
+      "norm_label": "queueattentionitems()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
+      "source_location": "L445"
+    },
+    {
+      "community": 19,
+      "file_type": "code",
+      "id": "dailyoperations_resolverange",
+      "label": "resolveRange()",
+      "norm_label": "resolverange()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
+      "source_location": "L138"
+    },
+    {
+      "community": 19,
+      "file_type": "code",
+      "id": "dailyoperations_saturdayweekendoperatingdate",
+      "label": "saturdayWeekEndOperatingDate()",
+      "norm_label": "saturdayweekendoperatingdate()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
+      "source_location": "L134"
+    },
+    {
+      "community": 19,
+      "file_type": "code",
+      "id": "dailyoperations_shiftoperatingdate",
+      "label": "shiftOperatingDate()",
+      "norm_label": "shiftoperatingdate()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
+      "source_location": "L116"
+    },
+    {
+      "community": 19,
+      "file_type": "code",
+      "id": "dailyoperations_sourceattentionitem",
+      "label": "sourceAttentionItem()",
+      "norm_label": "sourceattentionitem()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
+      "source_location": "L293"
+    },
+    {
+      "community": 19,
+      "file_type": "code",
+      "id": "dailyoperations_sundayweekstartoperatingdate",
+      "label": "sundayWeekStartOperatingDate()",
+      "norm_label": "sundayweekstartoperatingdate()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
+      "source_location": "L124"
+    },
+    {
+      "community": 19,
+      "file_type": "code",
+      "id": "dailyoperations_transactioncashdelta",
+      "label": "transactionCashDelta()",
+      "norm_label": "transactioncashdelta()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
+      "source_location": "L176"
+    },
+    {
+      "community": 19,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_dailyoperations_ts",
+      "label": "dailyOperations.ts",
+      "norm_label": "dailyoperations.ts",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 190,
       "file_type": "code",
       "id": "mobileproductactions_collapseonpageclick",
       "label": "collapseOnPageClick()",
@@ -75337,7 +75916,7 @@
       "source_location": "L76"
     },
     {
-      "community": 189,
+      "community": 190,
       "file_type": "code",
       "id": "mobileproductactions_handleconfirm",
       "label": "handleConfirm()",
@@ -75346,7 +75925,7 @@
       "source_location": "L120"
     },
     {
-      "community": 189,
+      "community": 190,
       "file_type": "code",
       "id": "mobileproductactions_handleprimaryaction",
       "label": "handlePrimaryAction()",
@@ -75355,7 +75934,7 @@
       "source_location": "L129"
     },
     {
-      "community": 189,
+      "community": 190,
       "file_type": "code",
       "id": "mobileproductactions_handlesecondaryaction",
       "label": "handleSecondaryAction()",
@@ -75364,7 +75943,7 @@
       "source_location": "L133"
     },
     {
-      "community": 189,
+      "community": 190,
       "file_type": "code",
       "id": "mobileproductactions_updateposition",
       "label": "updatePosition()",
@@ -75373,7 +75952,7 @@
       "source_location": "L44"
     },
     {
-      "community": 189,
+      "community": 190,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_mobileproductactions_tsx",
       "label": "MobileProductActions.tsx",
@@ -75382,214 +75961,7 @@
       "source_location": "L1"
     },
     {
-      "community": 19,
-      "file_type": "code",
-      "id": "harness_review_buildgitprocessenv",
-      "label": "buildGitProcessEnv()",
-      "norm_label": "buildgitprocessenv()",
-      "source_file": "scripts/harness-review.ts",
-      "source_location": "L469"
-    },
-    {
-      "community": 19,
-      "file_type": "code",
-      "id": "harness_review_collectcommandsforchangedfiles",
-      "label": "collectCommandsForChangedFiles()",
-      "norm_label": "collectcommandsforchangedfiles()",
-      "source_file": "scripts/harness-review.ts",
-      "source_location": "L352"
-    },
-    {
-      "community": 19,
-      "file_type": "code",
-      "id": "harness_review_fileexists",
-      "label": "fileExists()",
-      "norm_label": "fileexists()",
-      "source_file": "scripts/harness-review.ts",
-      "source_location": "L143"
-    },
-    {
-      "community": 19,
-      "file_type": "code",
-      "id": "harness_review_formatmissingpathprefixerror",
-      "label": "formatMissingPathPrefixError()",
-      "norm_label": "formatmissingpathprefixerror()",
-      "source_file": "scripts/harness-review.ts",
-      "source_location": "L133"
-    },
-    {
-      "community": 19,
-      "file_type": "code",
-      "id": "harness_review_getchangedfilesforharnessreview",
-      "label": "getChangedFilesForHarnessReview()",
-      "norm_label": "getchangedfilesforharnessreview()",
-      "source_file": "scripts/harness-review.ts",
-      "source_location": "L475"
-    },
-    {
-      "community": 19,
-      "file_type": "code",
-      "id": "harness_review_hasanyharnessdocs",
-      "label": "hasAnyHarnessDocs()",
-      "norm_label": "hasanyharnessdocs()",
-      "source_file": "scripts/harness-review.ts",
-      "source_location": "L152"
-    },
-    {
-      "community": 19,
-      "file_type": "code",
-      "id": "harness_review_isathenaprtestsprovidedcommand",
-      "label": "isAthenaPrTestsProvidedCommand()",
-      "norm_label": "isathenaprtestsprovidedcommand()",
-      "source_file": "scripts/harness-review.ts",
-      "source_location": "L87"
-    },
-    {
-      "community": 19,
-      "file_type": "code",
-      "id": "harness_review_loadreviewtarget",
-      "label": "loadReviewTarget()",
-      "norm_label": "loadreviewtarget()",
-      "source_file": "scripts/harness-review.ts",
-      "source_location": "L182"
-    },
-    {
-      "community": 19,
-      "file_type": "code",
-      "id": "harness_review_loadreviewtargets",
-      "label": "loadReviewTargets()",
-      "norm_label": "loadreviewtargets()",
-      "source_file": "scripts/harness-review.ts",
-      "source_location": "L319"
-    },
-    {
-      "community": 19,
-      "file_type": "code",
-      "id": "harness_review_matchespathprefix",
-      "label": "matchesPathPrefix()",
-      "norm_label": "matchespathprefix()",
-      "source_file": "scripts/harness-review.ts",
-      "source_location": "L61"
-    },
-    {
-      "community": 19,
-      "file_type": "code",
-      "id": "harness_review_normalizebehaviorscenarioname",
-      "label": "normalizeBehaviorScenarioName()",
-      "norm_label": "normalizebehaviorscenarioname()",
-      "source_file": "scripts/harness-review.ts",
-      "source_location": "L83"
-    },
-    {
-      "community": 19,
-      "file_type": "code",
-      "id": "harness_review_normalizerepopath",
-      "label": "normalizeRepoPath()",
-      "norm_label": "normalizerepopath()",
-      "source_file": "scripts/harness-review.ts",
-      "source_location": "L57"
-    },
-    {
-      "community": 19,
-      "file_type": "code",
-      "id": "harness_review_normalizevalidationcommand",
-      "label": "normalizeValidationCommand()",
-      "norm_label": "normalizevalidationcommand()",
-      "source_file": "scripts/harness-review.ts",
-      "source_location": "L75"
-    },
-    {
-      "community": 19,
-      "file_type": "code",
-      "id": "harness_review_parseharnessreviewargs",
-      "label": "parseHarnessReviewArgs()",
-      "norm_label": "parseharnessreviewargs()",
-      "source_file": "scripts/harness-review.ts",
-      "source_location": "L742"
-    },
-    {
-      "community": 19,
-      "file_type": "code",
-      "id": "harness_review_readjsonfile",
-      "label": "readJsonFile()",
-      "norm_label": "readjsonfile()",
-      "source_file": "scripts/harness-review.ts",
-      "source_location": "L172"
-    },
-    {
-      "community": 19,
-      "file_type": "code",
-      "id": "harness_review_resolveharnessreviewshell",
-      "label": "resolveHarnessReviewShell()",
-      "norm_label": "resolveharnessreviewshell()",
-      "source_file": "scripts/harness-review.ts",
-      "source_location": "L583"
-    },
-    {
-      "community": 19,
-      "file_type": "code",
-      "id": "harness_review_rungitcommand",
-      "label": "runGitCommand()",
-      "norm_label": "rungitcommand()",
-      "source_file": "scripts/harness-review.ts",
-      "source_location": "L448"
-    },
-    {
-      "community": 19,
-      "file_type": "code",
-      "id": "harness_review_runharnessbehaviorscenario",
-      "label": "runHarnessBehaviorScenario()",
-      "norm_label": "runharnessbehaviorscenario()",
-      "source_file": "scripts/harness-review.ts",
-      "source_location": "L618"
-    },
-    {
-      "community": 19,
-      "file_type": "code",
-      "id": "harness_review_runharnessreview",
-      "label": "runHarnessReview()",
-      "norm_label": "runharnessreview()",
-      "source_file": "scripts/harness-review.ts",
-      "source_location": "L632"
-    },
-    {
-      "community": 19,
-      "file_type": "code",
-      "id": "harness_review_runpackagescript",
-      "label": "runPackageScript()",
-      "norm_label": "runpackagescript()",
-      "source_file": "scripts/harness-review.ts",
-      "source_location": "L569"
-    },
-    {
-      "community": 19,
-      "file_type": "code",
-      "id": "harness_review_runrawcommand",
-      "label": "runRawCommand()",
-      "norm_label": "runrawcommand()",
-      "source_file": "scripts/harness-review.ts",
-      "source_location": "L604"
-    },
-    {
-      "community": 19,
-      "file_type": "code",
-      "id": "harness_review_sortuniquepaths",
-      "label": "sortUniquePaths()",
-      "norm_label": "sortuniquepaths()",
-      "source_file": "scripts/harness-review.ts",
-      "source_location": "L176"
-    },
-    {
-      "community": 19,
-      "file_type": "code",
-      "id": "scripts_harness_review_ts",
-      "label": "harness-review.ts",
-      "norm_label": "harness-review.ts",
-      "source_file": "scripts/harness-review.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 190,
+      "community": 191,
       "file_type": "code",
       "id": "checkoutexpired_checkoutexpired",
       "label": "CheckoutExpired()",
@@ -75598,7 +75970,7 @@
       "source_location": "L9"
     },
     {
-      "community": 190,
+      "community": 191,
       "file_type": "code",
       "id": "checkoutexpired_checkoutsessiongeneric",
       "label": "CheckoutSessionGeneric()",
@@ -75607,7 +75979,7 @@
       "source_location": "L73"
     },
     {
-      "community": 190,
+      "community": 191,
       "file_type": "code",
       "id": "checkoutexpired_checkoutsessionnotfound",
       "label": "CheckoutSessionNotFound()",
@@ -75616,7 +75988,7 @@
       "source_location": "L54"
     },
     {
-      "community": 190,
+      "community": 191,
       "file_type": "code",
       "id": "checkoutexpired_handlesendemail",
       "label": "handleSendEmail()",
@@ -75625,7 +75997,7 @@
       "source_location": "L98"
     },
     {
-      "community": 190,
+      "community": 191,
       "file_type": "code",
       "id": "checkoutexpired_nocheckoutsession",
       "label": "NoCheckoutSession()",
@@ -75634,7 +76006,7 @@
       "source_location": "L33"
     },
     {
-      "community": 190,
+      "community": 191,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_checkout_expired_checkoutexpired_tsx",
       "label": "CheckoutExpired.tsx",
@@ -75643,7 +76015,7 @@
       "source_location": "L1"
     },
     {
-      "community": 191,
+      "community": 192,
       "file_type": "code",
       "id": "feeutils_getremainingforfreedelivery",
       "label": "getRemainingForFreeDelivery()",
@@ -75652,7 +76024,7 @@
       "source_location": "L138"
     },
     {
-      "community": 191,
+      "community": 192,
       "file_type": "code",
       "id": "feeutils_haswaiverconfigured",
       "label": "hasWaiverConfigured()",
@@ -75661,7 +76033,7 @@
       "source_location": "L100"
     },
     {
-      "community": 191,
+      "community": 192,
       "file_type": "code",
       "id": "feeutils_isanyfeewaived",
       "label": "isAnyFeeWaived()",
@@ -75670,7 +76042,7 @@
       "source_location": "L74"
     },
     {
-      "community": 191,
+      "community": 192,
       "file_type": "code",
       "id": "feeutils_isfeewaived",
       "label": "isFeeWaived()",
@@ -75679,7 +76051,7 @@
       "source_location": "L34"
     },
     {
-      "community": 191,
+      "community": 192,
       "file_type": "code",
       "id": "feeutils_meetsthreshold",
       "label": "meetsThreshold()",
@@ -75688,7 +76060,7 @@
       "source_location": "L17"
     },
     {
-      "community": 191,
+      "community": 192,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_feeutils_ts",
       "label": "feeUtils.ts",
@@ -75697,7 +76069,7 @@
       "source_location": "L1"
     },
     {
-      "community": 192,
+      "community": 193,
       "file_type": "code",
       "id": "auth_verify_formattime",
       "label": "formatTime()",
@@ -75706,7 +76078,7 @@
       "source_location": "L149"
     },
     {
-      "community": 192,
+      "community": 193,
       "file_type": "code",
       "id": "auth_verify_handlecodechange",
       "label": "handleCodeChange()",
@@ -75715,7 +76087,7 @@
       "source_location": "L156"
     },
     {
-      "community": 192,
+      "community": 193,
       "file_type": "code",
       "id": "auth_verify_onsubmit",
       "label": "onSubmit()",
@@ -75724,7 +76096,7 @@
       "source_location": "L201"
     },
     {
-      "community": 192,
+      "community": 193,
       "file_type": "code",
       "id": "auth_verify_reportauthfailure",
       "label": "reportAuthFailure()",
@@ -75733,7 +76105,7 @@
       "source_location": "L93"
     },
     {
-      "community": 192,
+      "community": 193,
       "file_type": "code",
       "id": "auth_verify_resendverificationcode",
       "label": "resendVerificationCode()",
@@ -75742,7 +76114,7 @@
       "source_location": "L282"
     },
     {
-      "community": 192,
+      "community": 193,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_auth_verify_tsx",
       "label": "auth.verify.tsx",
@@ -75751,7 +76123,7 @@
       "source_location": "L1"
     },
     {
-      "community": 193,
+      "community": 194,
       "file_type": "code",
       "id": "coverage_summary_test_coveragesummary",
       "label": "coverageSummary()",
@@ -75760,7 +76132,7 @@
       "source_location": "L27"
     },
     {
-      "community": 193,
+      "community": 194,
       "file_type": "code",
       "id": "coverage_summary_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -75769,7 +76141,7 @@
       "source_location": "L15"
     },
     {
-      "community": 193,
+      "community": 194,
       "file_type": "code",
       "id": "coverage_summary_test_write",
       "label": "write()",
@@ -75778,7 +76150,7 @@
       "source_location": "L21"
     },
     {
-      "community": 193,
+      "community": 194,
       "file_type": "code",
       "id": "coverage_summary_test_writepackagesummaries",
       "label": "writePackageSummaries()",
@@ -75787,7 +76159,7 @@
       "source_location": "L38"
     },
     {
-      "community": 193,
+      "community": 194,
       "file_type": "code",
       "id": "coverage_summary_test_writerealbaselinesummaries",
       "label": "writeRealBaselineSummaries()",
@@ -75796,7 +76168,7 @@
       "source_location": "L54"
     },
     {
-      "community": 193,
+      "community": 194,
       "file_type": "code",
       "id": "scripts_coverage_summary_test_ts",
       "label": "coverage-summary.test.ts",
@@ -75805,7 +76177,7 @@
       "source_location": "L1"
     },
     {
-      "community": 194,
+      "community": 195,
       "file_type": "code",
       "id": "graphify_check_collectrepocodefiles",
       "label": "collectRepoCodeFiles()",
@@ -75814,7 +76186,7 @@
       "source_location": "L72"
     },
     {
-      "community": 194,
+      "community": 195,
       "file_type": "code",
       "id": "graphify_check_collectstalegraphifyartifacts",
       "label": "collectStaleGraphifyArtifacts()",
@@ -75823,7 +76195,7 @@
       "source_location": "L124"
     },
     {
-      "community": 194,
+      "community": 195,
       "file_type": "code",
       "id": "graphify_check_copygraphifycheckinputs",
       "label": "copyGraphifyCheckInputs()",
@@ -75832,7 +76204,7 @@
       "source_location": "L106"
     },
     {
-      "community": 194,
+      "community": 195,
       "file_type": "code",
       "id": "graphify_check_fileexists",
       "label": "fileExists()",
@@ -75841,7 +76213,7 @@
       "source_location": "L63"
     },
     {
-      "community": 194,
+      "community": 195,
       "file_type": "code",
       "id": "graphify_check_rungraphifycheck",
       "label": "runGraphifyCheck()",
@@ -75850,7 +76222,7 @@
       "source_location": "L151"
     },
     {
-      "community": 194,
+      "community": 195,
       "file_type": "code",
       "id": "scripts_graphify_check_ts",
       "label": "graphify-check.ts",
@@ -75859,7 +76231,7 @@
       "source_location": "L1"
     },
     {
-      "community": 195,
+      "community": 196,
       "file_type": "code",
       "id": "pre_push_validation_proof_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -75868,7 +76240,7 @@
       "source_location": "L19"
     },
     {
-      "community": 195,
+      "community": 196,
       "file_type": "code",
       "id": "pre_push_validation_proof_test_createspawn",
       "label": "createSpawn()",
@@ -75877,7 +76249,7 @@
       "source_location": "L50"
     },
     {
-      "community": 195,
+      "community": 196,
       "file_type": "code",
       "id": "pre_push_validation_proof_test_log",
       "label": "log()",
@@ -75886,7 +76258,7 @@
       "source_location": "L187"
     },
     {
-      "community": 195,
+      "community": 196,
       "file_type": "code",
       "id": "pre_push_validation_proof_test_warn",
       "label": "warn()",
@@ -75895,7 +76267,7 @@
       "source_location": "L187"
     },
     {
-      "community": 195,
+      "community": 196,
       "file_type": "code",
       "id": "pre_push_validation_proof_test_write",
       "label": "write()",
@@ -75904,7 +76276,7 @@
       "source_location": "L13"
     },
     {
-      "community": 195,
+      "community": 196,
       "file_type": "code",
       "id": "scripts_pre_push_validation_proof_test_ts",
       "label": "pre-push-validation-proof.test.ts",
@@ -75913,7 +76285,7 @@
       "source_location": "L1"
     },
     {
-      "community": 196,
+      "community": 197,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cashcontrols_paymentallocationattribution_ts",
       "label": "paymentAllocationAttribution.ts",
@@ -75922,7 +76294,7 @@
       "source_location": "L1"
     },
     {
-      "community": 196,
+      "community": 197,
       "file_type": "code",
       "id": "paymentallocationattribution_buildinstorepaymentallocations",
       "label": "buildInStorePaymentAllocations()",
@@ -75931,7 +76303,7 @@
       "source_location": "L46"
     },
     {
-      "community": 196,
+      "community": 197,
       "file_type": "code",
       "id": "paymentallocationattribution_normalizeinstorepayments",
       "label": "normalizeInStorePayments()",
@@ -75940,7 +76312,7 @@
       "source_location": "L22"
     },
     {
-      "community": 196,
+      "community": 197,
       "file_type": "code",
       "id": "paymentallocationattribution_resolveregistersessionforinstorecollectionwithctx",
       "label": "resolveRegisterSessionForInStoreCollectionWithCtx()",
@@ -75949,7 +76321,7 @@
       "source_location": "L118"
     },
     {
-      "community": 196,
+      "community": 197,
       "file_type": "code",
       "id": "paymentallocationattribution_selectregistersessionforattribution",
       "label": "selectRegisterSessionForAttribution()",
@@ -75958,7 +76330,7 @@
       "source_location": "L81"
     },
     {
-      "community": 197,
+      "community": 198,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cashcontrols_registersessiontracelifecycle_test_ts",
       "label": "registerSessionTraceLifecycle.test.ts",
@@ -75967,7 +76339,7 @@
       "source_location": "L1"
     },
     {
-      "community": 197,
+      "community": 198,
       "file_type": "code",
       "id": "registersessiontracelifecycle_test_buildapprovalproof",
       "label": "buildApprovalProof()",
@@ -75976,7 +76348,7 @@
       "source_location": "L292"
     },
     {
-      "community": 197,
+      "community": 198,
       "file_type": "code",
       "id": "registersessiontracelifecycle_test_buildregistersession",
       "label": "buildRegisterSession()",
@@ -75985,7 +76357,7 @@
       "source_location": "L94"
     },
     {
-      "community": 197,
+      "community": 198,
       "file_type": "code",
       "id": "registersessiontracelifecycle_test_createmutationctx",
       "label": "createMutationCtx()",
@@ -75994,7 +76366,7 @@
       "source_location": "L110"
     },
     {
-      "community": 197,
+      "community": 198,
       "file_type": "code",
       "id": "registersessiontracelifecycle_test_gethandler",
       "label": "getHandler()",
@@ -76003,7 +76375,7 @@
       "source_location": "L311"
     },
     {
-      "community": 198,
+      "community": 199,
       "file_type": "code",
       "id": "expensesessionvalidation_validateexpenseitembelongstosession",
       "label": "validateExpenseItemBelongsToSession()",
@@ -76012,7 +76384,7 @@
       "source_location": "L135"
     },
     {
-      "community": 198,
+      "community": 199,
       "file_type": "code",
       "id": "expensesessionvalidation_validateexpensesessionactive",
       "label": "validateExpenseSessionActive()",
@@ -76021,7 +76393,7 @@
       "source_location": "L39"
     },
     {
-      "community": 198,
+      "community": 199,
       "file_type": "code",
       "id": "expensesessionvalidation_validateexpensesessionexists",
       "label": "validateExpenseSessionExists()",
@@ -76030,7 +76402,7 @@
       "source_location": "L19"
     },
     {
-      "community": 198,
+      "community": 199,
       "file_type": "code",
       "id": "expensesessionvalidation_validateexpensesessionmodifiable",
       "label": "validateExpenseSessionModifiable()",
@@ -76039,57 +76411,12 @@
       "source_location": "L92"
     },
     {
-      "community": 198,
+      "community": 199,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_helpers_expensesessionvalidation_ts",
       "label": "expenseSessionValidation.ts",
       "norm_label": "expensesessionvalidation.ts",
       "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionValidation.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 199,
-      "file_type": "code",
-      "id": "currency_formatstoredamount",
-      "label": "formatStoredAmount()",
-      "norm_label": "formatstoredamount()",
-      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
-      "source_location": "L9"
-    },
-    {
-      "community": 199,
-      "file_type": "code",
-      "id": "currency_todisplayamount",
-      "label": "toDisplayAmount()",
-      "norm_label": "todisplayamount()",
-      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
-      "source_location": "L5"
-    },
-    {
-      "community": 199,
-      "file_type": "code",
-      "id": "currency_topesewas",
-      "label": "toPesewas()",
-      "norm_label": "topesewas()",
-      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 199,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_lib_currency_ts",
-      "label": "currency.ts",
-      "norm_label": "currency.ts",
-      "source_file": "packages/athena-webapp/convex/lib/currency.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 199,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_currency_ts",
-      "label": "currency.ts",
-      "norm_label": "currency.ts",
-      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
       "source_location": "L1"
     },
     {
@@ -76518,203 +76845,257 @@
     {
       "community": 20,
       "file_type": "code",
-      "id": "dailyoperations_attentionseverity",
-      "label": "attentionSeverity()",
-      "norm_label": "attentionseverity()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
-      "source_location": "L286"
+      "id": "harness_review_buildgitprocessenv",
+      "label": "buildGitProcessEnv()",
+      "norm_label": "buildgitprocessenv()",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L469"
     },
     {
       "community": 20,
       "file_type": "code",
-      "id": "dailyoperations_builddailyoperationssnapshotwithctx",
-      "label": "buildDailyOperationsSnapshotWithCtx()",
-      "norm_label": "builddailyoperationssnapshotwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
-      "source_location": "L647"
+      "id": "harness_review_collectcommandsforchangedfiles",
+      "label": "collectCommandsForChangedFiles()",
+      "norm_label": "collectcommandsforchangedfiles()",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L352"
     },
     {
       "community": 20,
       "file_type": "code",
-      "id": "dailyoperations_buildlanes",
-      "label": "buildLanes()",
-      "norm_label": "buildlanes()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
-      "source_location": "L530"
+      "id": "harness_review_fileexists",
+      "label": "fileExists()",
+      "norm_label": "fileexists()",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L143"
     },
     {
       "community": 20,
       "file_type": "code",
-      "id": "dailyoperations_buildweekmetricfordate",
-      "label": "buildWeekMetricForDate()",
-      "norm_label": "buildweekmetricfordate()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
-      "source_location": "L186"
-    },
-    {
-      "community": 20,
-      "file_type": "code",
-      "id": "dailyoperations_buildweekmetrics",
-      "label": "buildWeekMetrics()",
-      "norm_label": "buildweekmetrics()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
-      "source_location": "L260"
-    },
-    {
-      "community": 20,
-      "file_type": "code",
-      "id": "dailyoperations_emptyclosesummary",
-      "label": "emptyCloseSummary()",
-      "norm_label": "emptyclosesummary()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
-      "source_location": "L155"
-    },
-    {
-      "community": 20,
-      "file_type": "code",
-      "id": "dailyoperations_getcloseitemcounts",
-      "label": "getCloseItemCounts()",
-      "norm_label": "getcloseitemcounts()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
-      "source_location": "L415"
-    },
-    {
-      "community": 20,
-      "file_type": "code",
-      "id": "dailyoperations_lifecyclecopy",
-      "label": "lifecycleCopy()",
-      "norm_label": "lifecyclecopy()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
-      "source_location": "L463"
-    },
-    {
-      "community": 20,
-      "file_type": "code",
-      "id": "dailyoperations_listopenqueuesnapshot",
-      "label": "listOpenQueueSnapshot()",
-      "norm_label": "listopenqueuesnapshot()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
-      "source_location": "L328"
-    },
-    {
-      "community": 20,
-      "file_type": "code",
-      "id": "dailyoperations_listtimelineevents",
-      "label": "listTimelineEvents()",
-      "norm_label": "listtimelineevents()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
-      "source_location": "L381"
-    },
-    {
-      "community": 20,
-      "file_type": "code",
-      "id": "dailyoperations_openingnotstartedattention",
-      "label": "openingNotStartedAttention()",
-      "norm_label": "openingnotstartedattention()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
-      "source_location": "L309"
-    },
-    {
-      "community": 20,
-      "file_type": "code",
-      "id": "dailyoperations_operatingdaterange",
-      "label": "operatingDateRange()",
-      "norm_label": "operatingdaterange()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
-      "source_location": "L105"
-    },
-    {
-      "community": 20,
-      "file_type": "code",
-      "id": "dailyoperations_pluralize",
-      "label": "pluralize()",
-      "norm_label": "pluralize()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
-      "source_location": "L170"
-    },
-    {
-      "community": 20,
-      "file_type": "code",
-      "id": "dailyoperations_primaryaction",
-      "label": "primaryAction()",
-      "norm_label": "primaryaction()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
-      "source_location": "L499"
-    },
-    {
-      "community": 20,
-      "file_type": "code",
-      "id": "dailyoperations_queueattentionitems",
-      "label": "queueAttentionItems()",
-      "norm_label": "queueattentionitems()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
-      "source_location": "L429"
-    },
-    {
-      "community": 20,
-      "file_type": "code",
-      "id": "dailyoperations_resolverange",
-      "label": "resolveRange()",
-      "norm_label": "resolverange()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
-      "source_location": "L137"
-    },
-    {
-      "community": 20,
-      "file_type": "code",
-      "id": "dailyoperations_saturdayweekendoperatingdate",
-      "label": "saturdayWeekEndOperatingDate()",
-      "norm_label": "saturdayweekendoperatingdate()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
+      "id": "harness_review_formatmissingpathprefixerror",
+      "label": "formatMissingPathPrefixError()",
+      "norm_label": "formatmissingpathprefixerror()",
+      "source_file": "scripts/harness-review.ts",
       "source_location": "L133"
     },
     {
       "community": 20,
       "file_type": "code",
-      "id": "dailyoperations_shiftoperatingdate",
-      "label": "shiftOperatingDate()",
-      "norm_label": "shiftoperatingdate()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
-      "source_location": "L115"
+      "id": "harness_review_getchangedfilesforharnessreview",
+      "label": "getChangedFilesForHarnessReview()",
+      "norm_label": "getchangedfilesforharnessreview()",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L475"
     },
     {
       "community": 20,
       "file_type": "code",
-      "id": "dailyoperations_sourceattentionitem",
-      "label": "sourceAttentionItem()",
-      "norm_label": "sourceattentionitem()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
-      "source_location": "L292"
+      "id": "harness_review_hasanyharnessdocs",
+      "label": "hasAnyHarnessDocs()",
+      "norm_label": "hasanyharnessdocs()",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L152"
     },
     {
       "community": 20,
       "file_type": "code",
-      "id": "dailyoperations_sundayweekstartoperatingdate",
-      "label": "sundayWeekStartOperatingDate()",
-      "norm_label": "sundayweekstartoperatingdate()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
-      "source_location": "L123"
+      "id": "harness_review_isathenaprtestsprovidedcommand",
+      "label": "isAthenaPrTestsProvidedCommand()",
+      "norm_label": "isathenaprtestsprovidedcommand()",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L87"
     },
     {
       "community": 20,
       "file_type": "code",
-      "id": "dailyoperations_transactioncashdelta",
-      "label": "transactionCashDelta()",
-      "norm_label": "transactioncashdelta()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
-      "source_location": "L175"
+      "id": "harness_review_loadreviewtarget",
+      "label": "loadReviewTarget()",
+      "norm_label": "loadreviewtarget()",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L182"
     },
     {
       "community": 20,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_dailyoperations_ts",
-      "label": "dailyOperations.ts",
-      "norm_label": "dailyoperations.ts",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
+      "id": "harness_review_loadreviewtargets",
+      "label": "loadReviewTargets()",
+      "norm_label": "loadreviewtargets()",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L319"
+    },
+    {
+      "community": 20,
+      "file_type": "code",
+      "id": "harness_review_matchespathprefix",
+      "label": "matchesPathPrefix()",
+      "norm_label": "matchespathprefix()",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L61"
+    },
+    {
+      "community": 20,
+      "file_type": "code",
+      "id": "harness_review_normalizebehaviorscenarioname",
+      "label": "normalizeBehaviorScenarioName()",
+      "norm_label": "normalizebehaviorscenarioname()",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L83"
+    },
+    {
+      "community": 20,
+      "file_type": "code",
+      "id": "harness_review_normalizerepopath",
+      "label": "normalizeRepoPath()",
+      "norm_label": "normalizerepopath()",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L57"
+    },
+    {
+      "community": 20,
+      "file_type": "code",
+      "id": "harness_review_normalizevalidationcommand",
+      "label": "normalizeValidationCommand()",
+      "norm_label": "normalizevalidationcommand()",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L75"
+    },
+    {
+      "community": 20,
+      "file_type": "code",
+      "id": "harness_review_parseharnessreviewargs",
+      "label": "parseHarnessReviewArgs()",
+      "norm_label": "parseharnessreviewargs()",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L742"
+    },
+    {
+      "community": 20,
+      "file_type": "code",
+      "id": "harness_review_readjsonfile",
+      "label": "readJsonFile()",
+      "norm_label": "readjsonfile()",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L172"
+    },
+    {
+      "community": 20,
+      "file_type": "code",
+      "id": "harness_review_resolveharnessreviewshell",
+      "label": "resolveHarnessReviewShell()",
+      "norm_label": "resolveharnessreviewshell()",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L583"
+    },
+    {
+      "community": 20,
+      "file_type": "code",
+      "id": "harness_review_rungitcommand",
+      "label": "runGitCommand()",
+      "norm_label": "rungitcommand()",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L448"
+    },
+    {
+      "community": 20,
+      "file_type": "code",
+      "id": "harness_review_runharnessbehaviorscenario",
+      "label": "runHarnessBehaviorScenario()",
+      "norm_label": "runharnessbehaviorscenario()",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L618"
+    },
+    {
+      "community": 20,
+      "file_type": "code",
+      "id": "harness_review_runharnessreview",
+      "label": "runHarnessReview()",
+      "norm_label": "runharnessreview()",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L632"
+    },
+    {
+      "community": 20,
+      "file_type": "code",
+      "id": "harness_review_runpackagescript",
+      "label": "runPackageScript()",
+      "norm_label": "runpackagescript()",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L569"
+    },
+    {
+      "community": 20,
+      "file_type": "code",
+      "id": "harness_review_runrawcommand",
+      "label": "runRawCommand()",
+      "norm_label": "runrawcommand()",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L604"
+    },
+    {
+      "community": 20,
+      "file_type": "code",
+      "id": "harness_review_sortuniquepaths",
+      "label": "sortUniquePaths()",
+      "norm_label": "sortuniquepaths()",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L176"
+    },
+    {
+      "community": 20,
+      "file_type": "code",
+      "id": "scripts_harness_review_ts",
+      "label": "harness-review.ts",
+      "norm_label": "harness-review.ts",
+      "source_file": "scripts/harness-review.ts",
       "source_location": "L1"
     },
     {
       "community": 200,
+      "file_type": "code",
+      "id": "currency_formatstoredamount",
+      "label": "formatStoredAmount()",
+      "norm_label": "formatstoredamount()",
+      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
+      "source_location": "L9"
+    },
+    {
+      "community": 200,
+      "file_type": "code",
+      "id": "currency_todisplayamount",
+      "label": "toDisplayAmount()",
+      "norm_label": "todisplayamount()",
+      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 200,
+      "file_type": "code",
+      "id": "currency_topesewas",
+      "label": "toPesewas()",
+      "norm_label": "topesewas()",
+      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 200,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_lib_currency_ts",
+      "label": "currency.ts",
+      "norm_label": "currency.ts",
+      "source_file": "packages/athena-webapp/convex/lib/currency.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 200,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_currency_ts",
+      "label": "currency.ts",
+      "norm_label": "currency.ts",
+      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 201,
       "file_type": "code",
       "id": "customerprofiles_compactrecord",
       "label": "compactRecord()",
@@ -76723,7 +77104,7 @@
       "source_location": "L24"
     },
     {
-      "community": 200,
+      "community": 201,
       "file_type": "code",
       "id": "customerprofiles_ensurecustomerprofilefromsourceswithctx",
       "label": "ensureCustomerProfileFromSourcesWithCtx()",
@@ -76732,7 +77113,7 @@
       "source_location": "L207"
     },
     {
-      "community": 200,
+      "community": 201,
       "file_type": "code",
       "id": "customerprofiles_findexistingprofile",
       "label": "findExistingProfile()",
@@ -76741,7 +77122,7 @@
       "source_location": "L45"
     },
     {
-      "community": 200,
+      "community": 201,
       "file_type": "code",
       "id": "customerprofiles_loadcustomersources",
       "label": "loadCustomerSources()",
@@ -76750,7 +77131,7 @@
       "source_location": "L30"
     },
     {
-      "community": 200,
+      "community": 201,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_customerprofiles_ts",
       "label": "customerProfiles.ts",
@@ -76759,7 +77140,7 @@
       "source_location": "L1"
     },
     {
-      "community": 201,
+      "community": 202,
       "file_type": "code",
       "id": "inventorymovements_buildinventorymovement",
       "label": "buildInventoryMovement()",
@@ -76768,7 +77149,7 @@
       "source_location": "L25"
     },
     {
-      "community": 201,
+      "community": 202,
       "file_type": "code",
       "id": "inventorymovements_matchesexistingmovement",
       "label": "matchesExistingMovement()",
@@ -76777,7 +77158,7 @@
       "source_location": "L51"
     },
     {
-      "community": 201,
+      "community": 202,
       "file_type": "code",
       "id": "inventorymovements_recordinventorymovementwithctx",
       "label": "recordInventoryMovementWithCtx()",
@@ -76786,7 +77167,7 @@
       "source_location": "L70"
     },
     {
-      "community": 201,
+      "community": 202,
       "file_type": "code",
       "id": "inventorymovements_summarizeinventorymovements",
       "label": "summarizeInventoryMovements()",
@@ -76795,7 +77176,7 @@
       "source_location": "L36"
     },
     {
-      "community": 201,
+      "community": 202,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_inventorymovements_ts",
       "label": "inventoryMovements.ts",
@@ -76804,7 +77185,7 @@
       "source_location": "L1"
     },
     {
-      "community": 202,
+      "community": 203,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_serviceintake_test_ts",
       "label": "serviceIntake.test.ts",
@@ -76813,7 +77194,7 @@
       "source_location": "L1"
     },
     {
-      "community": 202,
+      "community": 203,
       "file_type": "code",
       "id": "serviceintake_test_buildcreateserviceintakeargs",
       "label": "buildCreateServiceIntakeArgs()",
@@ -76822,7 +77203,7 @@
       "source_location": "L16"
     },
     {
-      "community": 202,
+      "community": 203,
       "file_type": "code",
       "id": "serviceintake_test_createmutationctx",
       "label": "createMutationCtx()",
@@ -76831,7 +77212,7 @@
       "source_location": "L29"
     },
     {
-      "community": 202,
+      "community": 203,
       "file_type": "code",
       "id": "serviceintake_test_gethandler",
       "label": "getHandler()",
@@ -76840,7 +77221,7 @@
       "source_location": "L12"
     },
     {
-      "community": 202,
+      "community": 203,
       "file_type": "code",
       "id": "serviceintake_test_getsource",
       "label": "getSource()",
@@ -76849,7 +77230,7 @@
       "source_location": "L8"
     },
     {
-      "community": 203,
+      "community": 204,
       "file_type": "code",
       "id": "assigncustomer_test_customerprofile",
       "label": "customerProfile()",
@@ -76858,7 +77239,7 @@
       "source_location": "L255"
     },
     {
-      "community": 203,
+      "community": 204,
       "file_type": "code",
       "id": "assigncustomer_test_guest",
       "label": "guest()",
@@ -76867,7 +77248,7 @@
       "source_location": "L282"
     },
     {
-      "community": 203,
+      "community": 204,
       "file_type": "code",
       "id": "assigncustomer_test_poscustomer",
       "label": "posCustomer()",
@@ -76876,7 +77257,7 @@
       "source_location": "L239"
     },
     {
-      "community": 203,
+      "community": 204,
       "file_type": "code",
       "id": "assigncustomer_test_storefrontuser",
       "label": "storeFrontUser()",
@@ -76885,7 +77266,7 @@
       "source_location": "L269"
     },
     {
-      "community": 203,
+      "community": 204,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_commands_assigncustomer_test_ts",
       "label": "assignCustomer.test.ts",
@@ -76894,7 +77275,7 @@
       "source_location": "L1"
     },
     {
-      "community": 204,
+      "community": 205,
       "file_type": "code",
       "id": "correctionpolicy_builddecision",
       "label": "buildDecision()",
@@ -76903,7 +77284,7 @@
       "source_location": "L100"
     },
     {
-      "community": 204,
+      "community": 205,
       "file_type": "code",
       "id": "correctionpolicy_classifycorrectionintent",
       "label": "classifyCorrectionIntent()",
@@ -76912,7 +77293,7 @@
       "source_location": "L110"
     },
     {
-      "community": 204,
+      "community": 205,
       "file_type": "code",
       "id": "correctionpolicy_issupportedcorrectionintent",
       "label": "isSupportedCorrectionIntent()",
@@ -76921,7 +77302,7 @@
       "source_location": "L84"
     },
     {
-      "community": 204,
+      "community": 205,
       "file_type": "code",
       "id": "correctionpolicy_isunsupportedhighriskcorrectionintent",
       "label": "isUnsupportedHighRiskCorrectionIntent()",
@@ -76930,7 +77311,7 @@
       "source_location": "L92"
     },
     {
-      "community": 204,
+      "community": 205,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_corrections_correctionpolicy_ts",
       "label": "correctionPolicy.ts",
@@ -76939,7 +77320,7 @@
       "source_location": "L1"
     },
     {
-      "community": 205,
+      "community": 206,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_services_paystackservice_ts",
       "label": "paystackService.ts",
@@ -76948,7 +77329,7 @@
       "source_location": "L1"
     },
     {
-      "community": 205,
+      "community": 206,
       "file_type": "code",
       "id": "paystackservice_getpaystackheaders",
       "label": "getPaystackHeaders()",
@@ -76957,7 +77338,7 @@
       "source_location": "L11"
     },
     {
-      "community": 205,
+      "community": 206,
       "file_type": "code",
       "id": "paystackservice_initializetransaction",
       "label": "initializeTransaction()",
@@ -76966,7 +77347,7 @@
       "source_location": "L21"
     },
     {
-      "community": 205,
+      "community": 206,
       "file_type": "code",
       "id": "paystackservice_initiaterefund",
       "label": "initiateRefund()",
@@ -76975,7 +77356,7 @@
       "source_location": "L87"
     },
     {
-      "community": 205,
+      "community": 206,
       "file_type": "code",
       "id": "paystackservice_verifytransaction",
       "label": "verifyTransaction()",
@@ -76984,7 +77365,7 @@
       "source_location": "L65"
     },
     {
-      "community": 206,
+      "community": 207,
       "file_type": "code",
       "id": "adjustments_test_createapprovaldecisionmutationctx",
       "label": "createApprovalDecisionMutationCtx()",
@@ -76993,7 +77374,7 @@
       "source_location": "L175"
     },
     {
-      "community": 206,
+      "community": 207,
       "file_type": "code",
       "id": "adjustments_test_createinventorysnapshotqueryctx",
       "label": "createInventorySnapshotQueryCtx()",
@@ -77002,7 +77383,7 @@
       "source_location": "L33"
     },
     {
-      "community": 206,
+      "community": 207,
       "file_type": "code",
       "id": "adjustments_test_createsubmissionmutationctx",
       "label": "createSubmissionMutationCtx()",
@@ -77011,7 +77392,7 @@
       "source_location": "L320"
     },
     {
-      "community": 206,
+      "community": 207,
       "file_type": "code",
       "id": "adjustments_test_getsource",
       "label": "getSource()",
@@ -77020,7 +77401,7 @@
       "source_location": "L29"
     },
     {
-      "community": 206,
+      "community": 207,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_adjustments_test_ts",
       "label": "adjustments.test.ts",
@@ -77029,7 +77410,7 @@
       "source_location": "L1"
     },
     {
-      "community": 207,
+      "community": 208,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_helpers_returnexchangeoperations_ts",
       "label": "returnExchangeOperations.ts",
@@ -77038,7 +77419,7 @@
       "source_location": "L1"
     },
     {
-      "community": 207,
+      "community": 208,
       "file_type": "code",
       "id": "returnexchangeoperations_buildonlineorderreturnexchangeplan",
       "label": "buildOnlineOrderReturnExchangePlan()",
@@ -77047,7 +77428,7 @@
       "source_location": "L116"
     },
     {
-      "community": 207,
+      "community": 208,
       "file_type": "code",
       "id": "returnexchangeoperations_getapprovalreason",
       "label": "getApprovalReason()",
@@ -77056,7 +77437,7 @@
       "source_location": "L91"
     },
     {
-      "community": 207,
+      "community": 208,
       "file_type": "code",
       "id": "returnexchangeoperations_getkind",
       "label": "getKind()",
@@ -77065,7 +77446,7 @@
       "source_location": "L75"
     },
     {
-      "community": 207,
+      "community": 208,
       "file_type": "code",
       "id": "returnexchangeoperations_getlinerefundamount",
       "label": "getLineRefundAmount()",
@@ -77074,7 +77455,7 @@
       "source_location": "L71"
     },
     {
-      "community": 208,
+      "community": 209,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_storefrontobservabilityreport_ts",
       "label": "storefrontObservabilityReport.ts",
@@ -77083,7 +77464,7 @@
       "source_location": "L1"
     },
     {
-      "community": 208,
+      "community": 209,
       "file_type": "code",
       "id": "storefrontobservabilityreport_buildstorefrontobservabilityreport",
       "label": "buildStorefrontObservabilityReport()",
@@ -77092,7 +77473,7 @@
       "source_location": "L124"
     },
     {
-      "community": 208,
+      "community": 209,
       "file_type": "code",
       "id": "storefrontobservabilityreport_getnonemptystring",
       "label": "getNonEmptyString()",
@@ -77101,7 +77482,7 @@
       "source_location": "L67"
     },
     {
-      "community": 208,
+      "community": 209,
       "file_type": "code",
       "id": "storefrontobservabilityreport_gettrafficsource",
       "label": "getTrafficSource()",
@@ -77110,58 +77491,13 @@
       "source_location": "L106"
     },
     {
-      "community": 208,
+      "community": 209,
       "file_type": "code",
       "id": "storefrontobservabilityreport_normalizestorefrontobservabilityevent",
       "label": "normalizeStorefrontObservabilityEvent()",
       "norm_label": "normalizestorefrontobservabilityevent()",
       "source_file": "packages/athena-webapp/convex/storeFront/storefrontObservabilityReport.ts",
       "source_location": "L73"
-    },
-    {
-      "community": 209,
-      "file_type": "code",
-      "id": "navbar_appheader",
-      "label": "AppHeader()",
-      "norm_label": "appheader()",
-      "source_file": "packages/athena-webapp/src/components/Navbar.tsx",
-      "source_location": "L61"
-    },
-    {
-      "community": 209,
-      "file_type": "code",
-      "id": "navbar_header",
-      "label": "Header()",
-      "norm_label": "header()",
-      "source_file": "packages/athena-webapp/src/components/Navbar.tsx",
-      "source_location": "L75"
-    },
-    {
-      "community": 209,
-      "file_type": "code",
-      "id": "navbar_navbar",
-      "label": "Navbar()",
-      "norm_label": "navbar()",
-      "source_file": "packages/athena-webapp/src/components/Navbar.tsx",
-      "source_location": "L116"
-    },
-    {
-      "community": 209,
-      "file_type": "code",
-      "id": "navbar_settingsheader",
-      "label": "SettingsHeader()",
-      "norm_label": "settingsheader()",
-      "source_file": "packages/athena-webapp/src/components/Navbar.tsx",
-      "source_location": "L20"
-    },
-    {
-      "community": 209,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_navbar_tsx",
-      "label": "Navbar.tsx",
-      "norm_label": "navbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/Navbar.tsx",
-      "source_location": "L1"
     },
     {
       "community": 21,
@@ -77364,6 +77700,51 @@
     {
       "community": 210,
       "file_type": "code",
+      "id": "navbar_appheader",
+      "label": "AppHeader()",
+      "norm_label": "appheader()",
+      "source_file": "packages/athena-webapp/src/components/Navbar.tsx",
+      "source_location": "L61"
+    },
+    {
+      "community": 210,
+      "file_type": "code",
+      "id": "navbar_header",
+      "label": "Header()",
+      "norm_label": "header()",
+      "source_file": "packages/athena-webapp/src/components/Navbar.tsx",
+      "source_location": "L75"
+    },
+    {
+      "community": 210,
+      "file_type": "code",
+      "id": "navbar_navbar",
+      "label": "Navbar()",
+      "norm_label": "navbar()",
+      "source_file": "packages/athena-webapp/src/components/Navbar.tsx",
+      "source_location": "L116"
+    },
+    {
+      "community": 210,
+      "file_type": "code",
+      "id": "navbar_settingsheader",
+      "label": "SettingsHeader()",
+      "norm_label": "settingsheader()",
+      "source_file": "packages/athena-webapp/src/components/Navbar.tsx",
+      "source_location": "L20"
+    },
+    {
+      "community": 210,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_navbar_tsx",
+      "label": "Navbar.tsx",
+      "norm_label": "navbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/Navbar.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 211,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productcategorization_tsx",
       "label": "ProductCategorization.tsx",
       "norm_label": "productcategorization.tsx",
@@ -77371,7 +77752,7 @@
       "source_location": "L1"
     },
     {
-      "community": 210,
+      "community": 211,
       "file_type": "code",
       "id": "productcategorization_getproductname",
       "label": "getProductName()",
@@ -77380,7 +77761,7 @@
       "source_location": "L281"
     },
     {
-      "community": 210,
+      "community": 211,
       "file_type": "code",
       "id": "productcategorization_handleproductvisibility",
       "label": "handleProductVisibility()",
@@ -77389,7 +77770,7 @@
       "source_location": "L239"
     },
     {
-      "community": 210,
+      "community": 211,
       "file_type": "code",
       "id": "productcategorization_productcategorization",
       "label": "ProductCategorization()",
@@ -77398,7 +77779,7 @@
       "source_location": "L34"
     },
     {
-      "community": 210,
+      "community": 211,
       "file_type": "code",
       "id": "productcategorization_setinitialselectedoption",
       "label": "setInitialSelectedOption()",
@@ -77407,7 +77788,7 @@
       "source_location": "L226"
     },
     {
-      "community": 211,
+      "community": 212,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_common_pageheader_tsx",
       "label": "PageHeader.tsx",
@@ -77416,7 +77797,7 @@
       "source_location": "L1"
     },
     {
-      "community": 211,
+      "community": 212,
       "file_type": "code",
       "id": "pageheader_navigatebackbutton",
       "label": "NavigateBackButton()",
@@ -77425,7 +77806,7 @@
       "source_location": "L30"
     },
     {
-      "community": 211,
+      "community": 212,
       "file_type": "code",
       "id": "pageheader_pageheader",
       "label": "PageHeader()",
@@ -77434,7 +77815,7 @@
       "source_location": "L8"
     },
     {
-      "community": 211,
+      "community": 212,
       "file_type": "code",
       "id": "pageheader_simplepageheader",
       "label": "SimplePageHeader()",
@@ -77443,7 +77824,7 @@
       "source_location": "L50"
     },
     {
-      "community": 211,
+      "community": 212,
       "file_type": "code",
       "id": "pageheader_viewheader",
       "label": "ViewHeader()",
@@ -77452,7 +77833,7 @@
       "source_location": "L67"
     },
     {
-      "community": 212,
+      "community": 213,
       "file_type": "code",
       "id": "dashboard_getperiodrange",
       "label": "getPeriodRange()",
@@ -77461,7 +77842,7 @@
       "source_location": "L20"
     },
     {
-      "community": 212,
+      "community": 213,
       "file_type": "code",
       "id": "dashboard_loadingsection",
       "label": "LoadingSection()",
@@ -77470,7 +77851,7 @@
       "source_location": "L50"
     },
     {
-      "community": 212,
+      "community": 213,
       "file_type": "code",
       "id": "dashboard_renderproductssection",
       "label": "renderProductsSection()",
@@ -77479,7 +77860,7 @@
       "source_location": "L342"
     },
     {
-      "community": 212,
+      "community": 213,
       "file_type": "code",
       "id": "dashboard_rendersalessection",
       "label": "renderSalesSection()",
@@ -77488,7 +77869,7 @@
       "source_location": "L322"
     },
     {
-      "community": 212,
+      "community": 213,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_dashboard_dashboard_tsx",
       "label": "Dashboard.tsx",
@@ -77497,7 +77878,7 @@
       "source_location": "L1"
     },
     {
-      "community": 213,
+      "community": 214,
       "file_type": "code",
       "id": "herosectiontabs_handledisplaytypechange",
       "label": "handleDisplayTypeChange()",
@@ -77506,7 +77887,7 @@
       "source_location": "L61"
     },
     {
-      "community": 213,
+      "community": 214,
       "file_type": "code",
       "id": "herosectiontabs_handleimageupdate",
       "label": "handleImageUpdate()",
@@ -77515,7 +77896,7 @@
       "source_location": "L57"
     },
     {
-      "community": 213,
+      "community": 214,
       "file_type": "code",
       "id": "herosectiontabs_handleoverlaytoggle",
       "label": "handleOverlayToggle()",
@@ -77524,7 +77905,7 @@
       "source_location": "L98"
     },
     {
-      "community": 213,
+      "community": 214,
       "file_type": "code",
       "id": "herosectiontabs_handletexttoggle",
       "label": "handleTextToggle()",
@@ -77533,7 +77914,7 @@
       "source_location": "L134"
     },
     {
-      "community": 213,
+      "community": 214,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_herosectiontabs_tsx",
       "label": "HeroSectionTabs.tsx",
@@ -77542,7 +77923,7 @@
       "source_location": "L1"
     },
     {
-      "community": 214,
+      "community": 215,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_reeluploader_tsx",
       "label": "ReelUploader.tsx",
@@ -77551,7 +77932,7 @@
       "source_location": "L1"
     },
     {
-      "community": 214,
+      "community": 215,
       "file_type": "code",
       "id": "reeluploader_formatfilesize",
       "label": "formatFileSize()",
@@ -77560,7 +77941,7 @@
       "source_location": "L38"
     },
     {
-      "community": 214,
+      "community": 215,
       "file_type": "code",
       "id": "reeluploader_handlefileselect",
       "label": "handleFileSelect()",
@@ -77569,7 +77950,7 @@
       "source_location": "L64"
     },
     {
-      "community": 214,
+      "community": 215,
       "file_type": "code",
       "id": "reeluploader_handleupload",
       "label": "handleUpload()",
@@ -77578,7 +77959,7 @@
       "source_location": "L135"
     },
     {
-      "community": 214,
+      "community": 215,
       "file_type": "code",
       "id": "reeluploader_validatefile",
       "label": "validateFile()",
@@ -77587,7 +77968,7 @@
       "source_location": "L43"
     },
     {
-      "community": 215,
+      "community": 216,
       "file_type": "code",
       "id": "dailyoperationsview_test_formattestoperatingdate",
       "label": "formatTestOperatingDate()",
@@ -77596,7 +77977,7 @@
       "source_location": "L356"
     },
     {
-      "community": 215,
+      "community": 216,
       "file_type": "code",
       "id": "dailyoperationsview_test_getcurrentlocaloperatingdate",
       "label": "getCurrentLocalOperatingDate()",
@@ -77605,7 +77986,7 @@
       "source_location": "L323"
     },
     {
-      "community": 215,
+      "community": 216,
       "file_type": "code",
       "id": "dailyoperationsview_test_getcurrentsaturdayweekendoperatingdate",
       "label": "getCurrentSaturdayWeekEndOperatingDate()",
@@ -77614,7 +77995,7 @@
       "source_location": "L332"
     },
     {
-      "community": 215,
+      "community": 216,
       "file_type": "code",
       "id": "dailyoperationsview_test_shifttestoperatingdate",
       "label": "shiftTestOperatingDate()",
@@ -77623,7 +78004,7 @@
       "source_location": "L346"
     },
     {
-      "community": 215,
+      "community": 216,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_dailyoperationsview_test_tsx",
       "label": "DailyOperationsView.test.tsx",
@@ -77632,7 +78013,7 @@
       "source_location": "L1"
     },
     {
-      "community": 216,
+      "community": 217,
       "file_type": "code",
       "id": "activityview_iscreatedaction",
       "label": "isCreatedAction()",
@@ -77641,7 +78022,7 @@
       "source_location": "L58"
     },
     {
-      "community": 216,
+      "community": 217,
       "file_type": "code",
       "id": "activityview_isfeedbackrequestaction",
       "label": "isFeedbackRequestAction()",
@@ -77650,7 +78031,7 @@
       "source_location": "L63"
     },
     {
-      "community": 216,
+      "community": 217,
       "file_type": "code",
       "id": "activityview_isrefundaction",
       "label": "isRefundAction()",
@@ -77659,7 +78040,7 @@
       "source_location": "L50"
     },
     {
-      "community": 216,
+      "community": 217,
       "file_type": "code",
       "id": "activityview_istransitionaction",
       "label": "isTransitionAction()",
@@ -77668,7 +78049,7 @@
       "source_location": "L53"
     },
     {
-      "community": 216,
+      "community": 217,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_activityview_tsx",
       "label": "ActivityView.tsx",
@@ -77677,7 +78058,7 @@
       "source_location": "L1"
     },
     {
-      "community": 217,
+      "community": 218,
       "file_type": "code",
       "id": "orderdetailsview_fetchtransactions",
       "label": "fetchTransactions()",
@@ -77686,7 +78067,7 @@
       "source_location": "L140"
     },
     {
-      "community": 217,
+      "community": 218,
       "file_type": "code",
       "id": "orderdetailsview_handlemarkasverified",
       "label": "handleMarkAsVerified()",
@@ -77695,7 +78076,7 @@
       "source_location": "L177"
     },
     {
-      "community": 217,
+      "community": 218,
       "file_type": "code",
       "id": "orderdetailsview_handlemarkpaymentcollected",
       "label": "handleMarkPaymentCollected()",
@@ -77704,7 +78085,7 @@
       "source_location": "L195"
     },
     {
-      "community": 217,
+      "community": 218,
       "file_type": "code",
       "id": "orderdetailsview_verifiedbadge",
       "label": "VerifiedBadge()",
@@ -77713,7 +78094,7 @@
       "source_location": "L45"
     },
     {
-      "community": 217,
+      "community": 218,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orderdetailsview_tsx",
       "label": "OrderDetailsView.tsx",
@@ -77722,7 +78103,7 @@
       "source_location": "L1"
     },
     {
-      "community": 218,
+      "community": 219,
       "file_type": "code",
       "id": "orderitemsview_handlerequestfeedback",
       "label": "handleRequestFeedback()",
@@ -77731,7 +78112,7 @@
       "source_location": "L92"
     },
     {
-      "community": 218,
+      "community": 219,
       "file_type": "code",
       "id": "orderitemsview_handlerestockall",
       "label": "handleRestockAll()",
@@ -77740,7 +78121,7 @@
       "source_location": "L307"
     },
     {
-      "community": 218,
+      "community": 219,
       "file_type": "code",
       "id": "orderitemsview_handlereturnitemtostock",
       "label": "handleReturnItemToStock()",
@@ -77749,7 +78130,7 @@
       "source_location": "L70"
     },
     {
-      "community": 218,
+      "community": 219,
       "file_type": "code",
       "id": "orderitemsview_handleupdateorderitem",
       "label": "handleUpdateOrderItem()",
@@ -77758,57 +78139,12 @@
       "source_location": "L50"
     },
     {
-      "community": 218,
+      "community": 219,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orderitemsview_tsx",
       "label": "OrderItemsView.tsx",
       "norm_label": "orderitemsview.tsx",
       "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 219,
-      "file_type": "code",
-      "id": "ordersummary_test_getbalancedueamount",
-      "label": "getBalanceDueAmount()",
-      "norm_label": "getbalancedueamount()",
-      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.test.tsx",
-      "source_location": "L40"
-    },
-    {
-      "community": 219,
-      "file_type": "code",
-      "id": "ordersummary_test_getbalanceduelabel",
-      "label": "getBalanceDueLabel()",
-      "norm_label": "getbalanceduelabel()",
-      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.test.tsx",
-      "source_location": "L57"
-    },
-    {
-      "community": 219,
-      "file_type": "code",
-      "id": "ordersummary_test_getbalanceduepanel",
-      "label": "getBalanceDuePanel()",
-      "norm_label": "getbalanceduepanel()",
-      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.test.tsx",
-      "source_location": "L66"
-    },
-    {
-      "community": 219,
-      "file_type": "code",
-      "id": "ordersummary_test_stripwhitespace",
-      "label": "stripWhitespace()",
-      "norm_label": "stripwhitespace()",
-      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.test.tsx",
-      "source_location": "L36"
-    },
-    {
-      "community": 219,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_ordersummary_test_tsx",
-      "label": "OrderSummary.test.tsx",
-      "norm_label": "ordersummary.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.test.tsx",
       "source_location": "L1"
     },
     {
@@ -78012,6 +78348,51 @@
     {
       "community": 220,
       "file_type": "code",
+      "id": "ordersummary_test_getbalancedueamount",
+      "label": "getBalanceDueAmount()",
+      "norm_label": "getbalancedueamount()",
+      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.test.tsx",
+      "source_location": "L40"
+    },
+    {
+      "community": 220,
+      "file_type": "code",
+      "id": "ordersummary_test_getbalanceduelabel",
+      "label": "getBalanceDueLabel()",
+      "norm_label": "getbalanceduelabel()",
+      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.test.tsx",
+      "source_location": "L57"
+    },
+    {
+      "community": 220,
+      "file_type": "code",
+      "id": "ordersummary_test_getbalanceduepanel",
+      "label": "getBalanceDuePanel()",
+      "norm_label": "getbalanceduepanel()",
+      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.test.tsx",
+      "source_location": "L66"
+    },
+    {
+      "community": 220,
+      "file_type": "code",
+      "id": "ordersummary_test_stripwhitespace",
+      "label": "stripWhitespace()",
+      "norm_label": "stripwhitespace()",
+      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.test.tsx",
+      "source_location": "L36"
+    },
+    {
+      "community": 220,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_ordersummary_test_tsx",
+      "label": "OrderSummary.test.tsx",
+      "norm_label": "ordersummary.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 221,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_paymentsaddedlist_test_tsx",
       "label": "PaymentsAddedList.test.tsx",
       "norm_label": "paymentsaddedlist.test.tsx",
@@ -78019,7 +78400,7 @@
       "source_location": "L1"
     },
     {
-      "community": 220,
+      "community": 221,
       "file_type": "code",
       "id": "paymentsaddedlist_test_getsummaryamount",
       "label": "getSummaryAmount()",
@@ -78028,7 +78409,7 @@
       "source_location": "L27"
     },
     {
-      "community": 220,
+      "community": 221,
       "file_type": "code",
       "id": "paymentsaddedlist_test_getsummarylabel",
       "label": "getSummaryLabel()",
@@ -78037,7 +78418,7 @@
       "source_location": "L18"
     },
     {
-      "community": 220,
+      "community": 221,
       "file_type": "code",
       "id": "paymentsaddedlist_test_getsummarypanel",
       "label": "getSummaryPanel()",
@@ -78046,7 +78427,7 @@
       "source_location": "L40"
     },
     {
-      "community": 220,
+      "community": 221,
       "file_type": "code",
       "id": "paymentsaddedlist_test_stripwhitespace",
       "label": "stripWhitespace()",
@@ -78055,7 +78436,7 @@
       "source_location": "L14"
     },
     {
-      "community": 221,
+      "community": 222,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_productentry_tsx",
       "label": "ProductEntry.tsx",
@@ -78064,7 +78445,7 @@
       "source_location": "L1"
     },
     {
-      "community": 221,
+      "community": 222,
       "file_type": "code",
       "id": "productentry_handleclearsearch",
       "label": "handleClearSearch()",
@@ -78073,7 +78454,7 @@
       "source_location": "L234"
     },
     {
-      "community": 221,
+      "community": 222,
       "file_type": "code",
       "id": "productentry_handleopenquickadd",
       "label": "handleOpenQuickAdd()",
@@ -78082,7 +78463,7 @@
       "source_location": "L239"
     },
     {
-      "community": 221,
+      "community": 222,
       "file_type": "code",
       "id": "productentry_handlequickaddsubmit",
       "label": "handleQuickAddSubmit()",
@@ -78091,7 +78472,7 @@
       "source_location": "L272"
     },
     {
-      "community": 221,
+      "community": 222,
       "file_type": "code",
       "id": "productentry_resetquickaddform",
       "label": "resetQuickAddForm()",
@@ -78100,7 +78481,7 @@
       "source_location": "L263"
     },
     {
-      "community": 222,
+      "community": 223,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_registerdrawergate_tsx",
       "label": "RegisterDrawerGate.tsx",
@@ -78109,7 +78490,7 @@
       "source_location": "L1"
     },
     {
-      "community": 222,
+      "community": 223,
       "file_type": "code",
       "id": "registerdrawergate_handlecloseoutsubmit",
       "label": "handleCloseoutSubmit()",
@@ -78118,7 +78499,7 @@
       "source_location": "L80"
     },
     {
-      "community": 222,
+      "community": 223,
       "file_type": "code",
       "id": "registerdrawergate_handleopeningfloatcorrectionsubmit",
       "label": "handleOpeningFloatCorrectionSubmit()",
@@ -78127,7 +78508,7 @@
       "source_location": "L84"
     },
     {
-      "community": 222,
+      "community": 223,
       "file_type": "code",
       "id": "registerdrawergate_handlesubmit",
       "label": "handleSubmit()",
@@ -78136,7 +78517,7 @@
       "source_location": "L73"
     },
     {
-      "community": 222,
+      "community": 223,
       "file_type": "code",
       "id": "registerdrawergate_if",
       "label": "if()",
@@ -78145,7 +78526,7 @@
       "source_location": "L61"
     },
     {
-      "community": 223,
+      "community": 224,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodeview_tsx",
       "label": "PromoCodeView.tsx",
@@ -78154,7 +78535,7 @@
       "source_location": "L1"
     },
     {
-      "community": 223,
+      "community": 224,
       "file_type": "code",
       "id": "promocodeview_handleaddpromocode",
       "label": "handleAddPromoCode()",
@@ -78163,7 +78544,7 @@
       "source_location": "L158"
     },
     {
-      "community": 223,
+      "community": 224,
       "file_type": "code",
       "id": "promocodeview_handleupdatepromocode",
       "label": "handleUpdatePromoCode()",
@@ -78172,7 +78553,7 @@
       "source_location": "L231"
     },
     {
-      "community": 223,
+      "community": 224,
       "file_type": "code",
       "id": "promocodeview_updatehomepagediscountcode",
       "label": "updateHomepageDiscountCode()",
@@ -78181,7 +78562,7 @@
       "source_location": "L324"
     },
     {
-      "community": 223,
+      "community": 224,
       "file_type": "code",
       "id": "promocodeview_updateleaveareviewdiscountcode",
       "label": "updateLeaveAReviewDiscountCode()",
@@ -78190,7 +78571,7 @@
       "source_location": "L379"
     },
     {
-      "community": 224,
+      "community": 225,
       "file_type": "code",
       "id": "date_time_picker_handleclear",
       "label": "handleClear()",
@@ -78199,7 +78580,7 @@
       "source_location": "L99"
     },
     {
-      "community": 224,
+      "community": 225,
       "file_type": "code",
       "id": "date_time_picker_handledateselect",
       "label": "handleDateSelect()",
@@ -78208,7 +78589,7 @@
       "source_location": "L53"
     },
     {
-      "community": 224,
+      "community": 225,
       "file_type": "code",
       "id": "date_time_picker_handletimeblur",
       "label": "handleTimeBlur()",
@@ -78217,7 +78598,7 @@
       "source_location": "L75"
     },
     {
-      "community": 224,
+      "community": 225,
       "file_type": "code",
       "id": "date_time_picker_handletimechange",
       "label": "handleTimeChange()",
@@ -78226,7 +78607,7 @@
       "source_location": "L63"
     },
     {
-      "community": 224,
+      "community": 225,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_date_time_picker_tsx",
       "label": "date-time-picker.tsx",
@@ -78235,7 +78616,7 @@
       "source_location": "L1"
     },
     {
-      "community": 225,
+      "community": 226,
       "file_type": "code",
       "id": "custom_modal_example_basicmodalexample",
       "label": "BasicModalExample()",
@@ -78244,7 +78625,7 @@
       "source_location": "L7"
     },
     {
-      "community": 225,
+      "community": 226,
       "file_type": "code",
       "id": "custom_modal_example_customclosebuttonexample",
       "label": "CustomCloseButtonExample()",
@@ -78253,7 +78634,7 @@
       "source_location": "L69"
     },
     {
-      "community": 225,
+      "community": 226,
       "file_type": "code",
       "id": "custom_modal_example_custompositionmodalexample",
       "label": "CustomPositionModalExample()",
@@ -78262,7 +78643,7 @@
       "source_location": "L44"
     },
     {
-      "community": 225,
+      "community": 226,
       "file_type": "code",
       "id": "custom_modal_example_fullscreenmodalexample",
       "label": "FullScreenModalExample()",
@@ -78271,7 +78652,7 @@
       "source_location": "L103"
     },
     {
-      "community": 225,
+      "community": 226,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_custom_modal_example_tsx",
       "label": "custom-modal-example.tsx",
@@ -78280,7 +78661,7 @@
       "source_location": "L1"
     },
     {
-      "community": 226,
+      "community": 227,
       "file_type": "code",
       "id": "config_getruntimeorigin",
       "label": "getRuntimeOrigin()",
@@ -78289,7 +78670,7 @@
       "source_location": "L12"
     },
     {
-      "community": 226,
+      "community": 227,
       "file_type": "code",
       "id": "config_islocalhost",
       "label": "isLocalHost()",
@@ -78298,7 +78679,7 @@
       "source_location": "L20"
     },
     {
-      "community": 226,
+      "community": 227,
       "file_type": "code",
       "id": "config_resolvestorefronturl",
       "label": "resolveStoreFrontUrl()",
@@ -78307,7 +78688,7 @@
       "source_location": "L24"
     },
     {
-      "community": 226,
+      "community": 227,
       "file_type": "code",
       "id": "config_trimtrailingslash",
       "label": "trimTrailingSlash()",
@@ -78316,7 +78697,7 @@
       "source_location": "L8"
     },
     {
-      "community": 226,
+      "community": 227,
       "file_type": "code",
       "id": "packages_athena_webapp_src_config_ts",
       "label": "config.ts",
@@ -78325,7 +78706,7 @@
       "source_location": "L1"
     },
     {
-      "community": 227,
+      "community": 228,
       "file_type": "code",
       "id": "browserfingerprint_buffertohex",
       "label": "bufferToHex()",
@@ -78334,7 +78715,7 @@
       "source_location": "L18"
     },
     {
-      "community": 227,
+      "community": 228,
       "file_type": "code",
       "id": "browserfingerprint_collectbrowserinfo",
       "label": "collectBrowserInfo()",
@@ -78343,7 +78724,7 @@
       "source_location": "L23"
     },
     {
-      "community": 227,
+      "community": 228,
       "file_type": "code",
       "id": "browserfingerprint_generatebrowserfingerprint",
       "label": "generateBrowserFingerprint()",
@@ -78352,7 +78733,7 @@
       "source_location": "L65"
     },
     {
-      "community": 227,
+      "community": 228,
       "file_type": "code",
       "id": "browserfingerprint_hashfingerprintsource",
       "label": "hashFingerprintSource()",
@@ -78361,7 +78742,7 @@
       "source_location": "L45"
     },
     {
-      "community": 227,
+      "community": 228,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_browserfingerprint_ts",
       "label": "browserFingerprint.ts",
@@ -78370,7 +78751,7 @@
       "source_location": "L1"
     },
     {
-      "community": 228,
+      "community": 229,
       "file_type": "code",
       "id": "imageutils_test_arraybuffer",
       "label": "arrayBuffer()",
@@ -78379,7 +78760,7 @@
       "source_location": "L78"
     },
     {
-      "community": 228,
+      "community": 229,
       "file_type": "code",
       "id": "imageutils_test_constructor",
       "label": "constructor()",
@@ -78388,7 +78769,7 @@
       "source_location": "L74"
     },
     {
-      "community": 228,
+      "community": 229,
       "file_type": "code",
       "id": "imageutils_test_mockimage",
       "label": "MockImage",
@@ -78397,7 +78778,7 @@
       "source_location": "L103"
     },
     {
-      "community": 228,
+      "community": 229,
       "file_type": "code",
       "id": "imageutils_test_mockimage_src",
       "label": ".src()",
@@ -78406,57 +78787,12 @@
       "source_location": "L109"
     },
     {
-      "community": 228,
+      "community": 229,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_imageutils_test_ts",
       "label": "imageUtils.test.ts",
       "norm_label": "imageutils.test.ts",
       "source_file": "packages/athena-webapp/src/lib/imageUtils.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 229,
-      "file_type": "code",
-      "id": "imageutils_convertimagestojpg",
-      "label": "convertImagesToJpg()",
-      "norm_label": "convertimagestojpg()",
-      "source_file": "packages/athena-webapp/src/lib/imageUtils.ts",
-      "source_location": "L75"
-    },
-    {
-      "community": 229,
-      "file_type": "code",
-      "id": "imageutils_convertimagestowebp",
-      "label": "convertImagesToWebp()",
-      "norm_label": "convertimagestowebp()",
-      "source_file": "packages/athena-webapp/src/lib/imageUtils.ts",
-      "source_location": "L26"
-    },
-    {
-      "community": 229,
-      "file_type": "code",
-      "id": "imageutils_converttojpg",
-      "label": "convertToJpg()",
-      "norm_label": "converttojpg()",
-      "source_file": "packages/athena-webapp/src/lib/imageUtils.ts",
-      "source_location": "L38"
-    },
-    {
-      "community": 229,
-      "file_type": "code",
-      "id": "imageutils_getuploadimagesdata",
-      "label": "getUploadImagesData()",
-      "norm_label": "getuploadimagesdata()",
-      "source_file": "packages/athena-webapp/src/lib/imageUtils.ts",
-      "source_location": "L4"
-    },
-    {
-      "community": 229,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_imageutils_ts",
-      "label": "imageUtils.ts",
-      "norm_label": "imageutils.ts",
-      "source_file": "packages/athena-webapp/src/lib/imageUtils.ts",
       "source_location": "L1"
     },
     {
@@ -78651,6 +78987,51 @@
     {
       "community": 230,
       "file_type": "code",
+      "id": "imageutils_convertimagestojpg",
+      "label": "convertImagesToJpg()",
+      "norm_label": "convertimagestojpg()",
+      "source_file": "packages/athena-webapp/src/lib/imageUtils.ts",
+      "source_location": "L75"
+    },
+    {
+      "community": 230,
+      "file_type": "code",
+      "id": "imageutils_convertimagestowebp",
+      "label": "convertImagesToWebp()",
+      "norm_label": "convertimagestowebp()",
+      "source_file": "packages/athena-webapp/src/lib/imageUtils.ts",
+      "source_location": "L26"
+    },
+    {
+      "community": 230,
+      "file_type": "code",
+      "id": "imageutils_converttojpg",
+      "label": "convertToJpg()",
+      "norm_label": "converttojpg()",
+      "source_file": "packages/athena-webapp/src/lib/imageUtils.ts",
+      "source_location": "L38"
+    },
+    {
+      "community": 230,
+      "file_type": "code",
+      "id": "imageutils_getuploadimagesdata",
+      "label": "getUploadImagesData()",
+      "norm_label": "getuploadimagesdata()",
+      "source_file": "packages/athena-webapp/src/lib/imageUtils.ts",
+      "source_location": "L4"
+    },
+    {
+      "community": 230,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_imageutils_ts",
+      "label": "imageUtils.ts",
+      "norm_label": "imageutils.ts",
+      "source_file": "packages/athena-webapp/src/lib/imageUtils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 231,
+      "file_type": "code",
       "id": "cart_calculateposcarttotals",
       "label": "calculatePosCartTotals()",
       "norm_label": "calculateposcarttotals()",
@@ -78658,7 +79039,7 @@
       "source_location": "L3"
     },
     {
-      "community": 230,
+      "community": 231,
       "file_type": "code",
       "id": "cart_calculatepositemtotal",
       "label": "calculatePosItemTotal()",
@@ -78667,7 +79048,7 @@
       "source_location": "L29"
     },
     {
-      "community": 230,
+      "community": 231,
       "file_type": "code",
       "id": "cart_getposeffectiveprice",
       "label": "getPosEffectivePrice()",
@@ -78676,7 +79057,7 @@
       "source_location": "L33"
     },
     {
-      "community": 230,
+      "community": 231,
       "file_type": "code",
       "id": "cart_roundposamount",
       "label": "roundPosAmount()",
@@ -78685,7 +79066,7 @@
       "source_location": "L40"
     },
     {
-      "community": 230,
+      "community": 231,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_domain_cart_ts",
       "label": "cart.ts",
@@ -78694,7 +79075,7 @@
       "source_location": "L1"
     },
     {
-      "community": 231,
+      "community": 232,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_registergateway_ts",
       "label": "registerGateway.ts",
@@ -78703,7 +79084,7 @@
       "source_location": "L1"
     },
     {
-      "community": 231,
+      "community": 232,
       "file_type": "code",
       "id": "registergateway_mapregisterstatedto",
       "label": "mapRegisterStateDto()",
@@ -78712,7 +79093,7 @@
       "source_location": "L12"
     },
     {
-      "community": 231,
+      "community": 232,
       "file_type": "code",
       "id": "registergateway_mapterminaldto",
       "label": "mapTerminalDto()",
@@ -78721,7 +79102,7 @@
       "source_location": "L30"
     },
     {
-      "community": 231,
+      "community": 232,
       "file_type": "code",
       "id": "registergateway_useconvexregisterstate",
       "label": "useConvexRegisterState()",
@@ -78730,7 +79111,7 @@
       "source_location": "L36"
     },
     {
-      "community": 231,
+      "community": 232,
       "file_type": "code",
       "id": "registergateway_useconvexterminalbyfingerprint",
       "label": "useConvexTerminalByFingerprint()",
@@ -78739,7 +79120,7 @@
       "source_location": "L58"
     },
     {
-      "community": 232,
+      "community": 233,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_transactionutils_ts",
       "label": "transactionUtils.ts",
@@ -78748,7 +79129,7 @@
       "source_location": "L1"
     },
     {
-      "community": 232,
+      "community": 233,
       "file_type": "code",
       "id": "transactionutils_calculatechange",
       "label": "calculateChange()",
@@ -78757,7 +79138,7 @@
       "source_location": "L42"
     },
     {
-      "community": 232,
+      "community": 233,
       "file_type": "code",
       "id": "transactionutils_formatcurrency",
       "label": "formatCurrency()",
@@ -78766,7 +79147,7 @@
       "source_location": "L29"
     },
     {
-      "community": 232,
+      "community": 233,
       "file_type": "code",
       "id": "transactionutils_formattimestamp",
       "label": "formatTimestamp()",
@@ -78775,7 +79156,7 @@
       "source_location": "L49"
     },
     {
-      "community": 232,
+      "community": 233,
       "file_type": "code",
       "id": "transactionutils_generatetransactionnumber",
       "label": "generateTransactionNumber()",
@@ -78784,7 +79165,7 @@
       "source_location": "L14"
     },
     {
-      "community": 233,
+      "community": 234,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_timelineutils_ts",
       "label": "timelineUtils.ts",
@@ -78793,7 +79174,7 @@
       "source_location": "L1"
     },
     {
-      "community": 233,
+      "community": 234,
       "file_type": "code",
       "id": "timelineutils_enrichtimelineevent",
       "label": "enrichTimelineEvent()",
@@ -78802,7 +79183,7 @@
       "source_location": "L184"
     },
     {
-      "community": 233,
+      "community": 234,
       "file_type": "code",
       "id": "timelineutils_enrichtimelineevents",
       "label": "enrichTimelineEvents()",
@@ -78811,7 +79192,7 @@
       "source_location": "L200"
     },
     {
-      "community": 233,
+      "community": 234,
       "file_type": "code",
       "id": "timelineutils_gettimerangelabel",
       "label": "getTimeRangeLabel()",
@@ -78820,7 +79201,7 @@
       "source_location": "L244"
     },
     {
-      "community": 233,
+      "community": 234,
       "file_type": "code",
       "id": "timelineutils_groupeventsbytimeframe",
       "label": "groupEventsByTimeframe()",
@@ -78829,7 +79210,7 @@
       "source_location": "L206"
     },
     {
-      "community": 234,
+      "community": 235,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_procurement_index_tsx",
       "label": "procurement.index.tsx",
@@ -78838,7 +79219,7 @@
       "source_location": "L1"
     },
     {
-      "community": 234,
+      "community": 235,
       "file_type": "code",
       "id": "procurement_index_getnextprocurementmodesearch",
       "label": "getNextProcurementModeSearch()",
@@ -78847,7 +79228,7 @@
       "source_location": "L16"
     },
     {
-      "community": 234,
+      "community": 235,
       "file_type": "code",
       "id": "procurement_index_getnextprocurementpagesearch",
       "label": "getNextProcurementPageSearch()",
@@ -78856,7 +79237,7 @@
       "source_location": "L34"
     },
     {
-      "community": 234,
+      "community": 235,
       "file_type": "code",
       "id": "procurement_index_getnextprocurementselectedskusearch",
       "label": "getNextProcurementSelectedSkuSearch()",
@@ -78865,7 +79246,7 @@
       "source_location": "L44"
     },
     {
-      "community": 234,
+      "community": 235,
       "file_type": "code",
       "id": "procurement_index_procurementroute",
       "label": "ProcurementRoute()",
@@ -78874,7 +79255,7 @@
       "source_location": "L70"
     },
     {
-      "community": 235,
+      "community": 236,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_traces_traceid_tsx",
       "label": "$traceId.tsx",
@@ -78883,7 +79264,7 @@
       "source_location": "L1"
     },
     {
-      "community": 235,
+      "community": 236,
       "file_type": "code",
       "id": "traceid_hasorgnotfoundpayload",
       "label": "hasOrgNotFoundPayload()",
@@ -78892,7 +79273,7 @@
       "source_location": "L10"
     },
     {
-      "community": 235,
+      "community": 236,
       "file_type": "code",
       "id": "traceid_workflowtraceroute",
       "label": "WorkflowTraceRoute()",
@@ -78901,7 +79282,7 @@
       "source_location": "L85"
     },
     {
-      "community": 235,
+      "community": 236,
       "file_type": "code",
       "id": "traceid_workflowtraceroutecontent",
       "label": "WorkflowTraceRouteContent()",
@@ -78910,7 +79291,7 @@
       "source_location": "L19"
     },
     {
-      "community": 235,
+      "community": 236,
       "file_type": "code",
       "id": "traceid_workflowtracerouteshell",
       "label": "WorkflowTraceRouteShell()",
@@ -78919,7 +79300,7 @@
       "source_location": "L50"
     },
     {
-      "community": 236,
+      "community": 237,
       "file_type": "code",
       "id": "layout_completependingauthsync",
       "label": "completePendingAuthSync()",
@@ -78928,7 +79309,7 @@
       "source_location": "L114"
     },
     {
-      "community": 236,
+      "community": 237,
       "file_type": "code",
       "id": "layout_handlependingauthsync",
       "label": "handlePendingAuthSync()",
@@ -78937,7 +79318,7 @@
       "source_location": "L81"
     },
     {
-      "community": 236,
+      "community": 237,
       "file_type": "code",
       "id": "layout_sleep",
       "label": "sleep()",
@@ -78946,7 +79327,7 @@
       "source_location": "L23"
     },
     {
-      "community": 236,
+      "community": 237,
       "file_type": "code",
       "id": "layout_usedocumentscrolllock",
       "label": "useDocumentScrollLock()",
@@ -78955,7 +79336,7 @@
       "source_location": "L27"
     },
     {
-      "community": 236,
+      "community": 237,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_login_layout_tsx",
       "label": "_layout.tsx",
@@ -78964,7 +79345,7 @@
       "source_location": "L1"
     },
     {
-      "community": 237,
+      "community": 238,
       "file_type": "code",
       "id": "analytics_getproductviewcount",
       "label": "getProductViewCount()",
@@ -78973,7 +79354,7 @@
       "source_location": "L93"
     },
     {
-      "community": 237,
+      "community": 238,
       "file_type": "code",
       "id": "analytics_logout",
       "label": "logout()",
@@ -78982,7 +79363,7 @@
       "source_location": "L75"
     },
     {
-      "community": 237,
+      "community": 238,
       "file_type": "code",
       "id": "analytics_postanalytics",
       "label": "postAnalytics()",
@@ -78991,7 +79372,7 @@
       "source_location": "L4"
     },
     {
-      "community": 237,
+      "community": 238,
       "file_type": "code",
       "id": "analytics_updateanalyticsowner",
       "label": "updateAnalyticsOwner()",
@@ -79000,7 +79381,7 @@
       "source_location": "L47"
     },
     {
-      "community": 237,
+      "community": 238,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_analytics_ts",
       "label": "analytics.ts",
@@ -79009,7 +79390,7 @@
       "source_location": "L1"
     },
     {
-      "community": 238,
+      "community": 239,
       "file_type": "code",
       "id": "category_getallcategories",
       "label": "getAllCategories()",
@@ -79018,7 +79399,7 @@
       "source_location": "L11"
     },
     {
-      "community": 238,
+      "community": 239,
       "file_type": "code",
       "id": "category_getallcategorieswithsubcategories",
       "label": "getAllCategoriesWithSubcategories()",
@@ -79027,7 +79408,7 @@
       "source_location": "L25"
     },
     {
-      "community": 238,
+      "community": 239,
       "file_type": "code",
       "id": "category_getbaseurl",
       "label": "getBaseUrl()",
@@ -79036,7 +79417,7 @@
       "source_location": "L9"
     },
     {
-      "community": 238,
+      "community": 239,
       "file_type": "code",
       "id": "category_getcategory",
       "label": "getCategory()",
@@ -79045,57 +79426,12 @@
       "source_location": "L39"
     },
     {
-      "community": 238,
+      "community": 239,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_category_ts",
       "label": "category.ts",
       "norm_label": "category.ts",
       "source_file": "packages/storefront-webapp/src/api/category.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 239,
-      "file_type": "code",
-      "id": "onlineorder_getbaseurl",
-      "label": "getBaseUrl()",
-      "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/onlineOrder.ts",
-      "source_location": "L4"
-    },
-    {
-      "community": 239,
-      "file_type": "code",
-      "id": "onlineorder_getorder",
-      "label": "getOrder()",
-      "norm_label": "getorder()",
-      "source_file": "packages/storefront-webapp/src/api/onlineOrder.ts",
-      "source_location": "L24"
-    },
-    {
-      "community": 239,
-      "file_type": "code",
-      "id": "onlineorder_getorders",
-      "label": "getOrders()",
-      "norm_label": "getorders()",
-      "source_file": "packages/storefront-webapp/src/api/onlineOrder.ts",
-      "source_location": "L6"
-    },
-    {
-      "community": 239,
-      "file_type": "code",
-      "id": "onlineorder_updateordersowner",
-      "label": "updateOrdersOwner()",
-      "norm_label": "updateordersowner()",
-      "source_file": "packages/storefront-webapp/src/api/onlineOrder.ts",
-      "source_location": "L42"
-    },
-    {
-      "community": 239,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_onlineorder_ts",
-      "label": "onlineOrder.ts",
-      "norm_label": "onlineorder.ts",
-      "source_file": "packages/storefront-webapp/src/api/onlineOrder.ts",
       "source_location": "L1"
     },
     {
@@ -79290,6 +79626,51 @@
     {
       "community": 240,
       "file_type": "code",
+      "id": "onlineorder_getbaseurl",
+      "label": "getBaseUrl()",
+      "norm_label": "getbaseurl()",
+      "source_file": "packages/storefront-webapp/src/api/onlineOrder.ts",
+      "source_location": "L4"
+    },
+    {
+      "community": 240,
+      "file_type": "code",
+      "id": "onlineorder_getorder",
+      "label": "getOrder()",
+      "norm_label": "getorder()",
+      "source_file": "packages/storefront-webapp/src/api/onlineOrder.ts",
+      "source_location": "L24"
+    },
+    {
+      "community": 240,
+      "file_type": "code",
+      "id": "onlineorder_getorders",
+      "label": "getOrders()",
+      "norm_label": "getorders()",
+      "source_file": "packages/storefront-webapp/src/api/onlineOrder.ts",
+      "source_location": "L6"
+    },
+    {
+      "community": 240,
+      "file_type": "code",
+      "id": "onlineorder_updateordersowner",
+      "label": "updateOrdersOwner()",
+      "norm_label": "updateordersowner()",
+      "source_file": "packages/storefront-webapp/src/api/onlineOrder.ts",
+      "source_location": "L42"
+    },
+    {
+      "community": 240,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_api_onlineorder_ts",
+      "label": "onlineOrder.ts",
+      "norm_label": "onlineorder.ts",
+      "source_file": "packages/storefront-webapp/src/api/onlineOrder.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 241,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_api_storefrontuser_ts",
       "label": "storeFrontUser.ts",
       "norm_label": "storefrontuser.ts",
@@ -79297,7 +79678,7 @@
       "source_location": "L1"
     },
     {
-      "community": 240,
+      "community": 241,
       "file_type": "code",
       "id": "storefrontuser_getactiveuser",
       "label": "getActiveUser()",
@@ -79306,7 +79687,7 @@
       "source_location": "L28"
     },
     {
-      "community": 240,
+      "community": 241,
       "file_type": "code",
       "id": "storefrontuser_getbaseurl",
       "label": "getBaseUrl()",
@@ -79315,7 +79696,7 @@
       "source_location": "L5"
     },
     {
-      "community": 240,
+      "community": 241,
       "file_type": "code",
       "id": "storefrontuser_getguest",
       "label": "getGuest()",
@@ -79324,7 +79705,7 @@
       "source_location": "L7"
     },
     {
-      "community": 240,
+      "community": 241,
       "file_type": "code",
       "id": "storefrontuser_updateuser",
       "label": "updateUser()",
@@ -79333,7 +79714,7 @@
       "source_location": "L46"
     },
     {
-      "community": 241,
+      "community": 242,
       "file_type": "code",
       "id": "homepage_enableprompts",
       "label": "enablePrompts()",
@@ -79342,7 +79723,7 @@
       "source_location": "L147"
     },
     {
-      "community": 241,
+      "community": 242,
       "file_type": "code",
       "id": "homepage_handleclickonleavereviewbutton",
       "label": "handleClickOnLeaveReviewButton()",
@@ -79351,7 +79732,7 @@
       "source_location": "L186"
     },
     {
-      "community": 241,
+      "community": 242,
       "file_type": "code",
       "id": "homepage_handlescroll",
       "label": "handleScroll()",
@@ -79360,7 +79741,7 @@
       "source_location": "L115"
     },
     {
-      "community": 241,
+      "community": 242,
       "file_type": "code",
       "id": "homepage_homepagereadyshell",
       "label": "HomePageReadyShell()",
@@ -79369,7 +79750,7 @@
       "source_location": "L31"
     },
     {
-      "community": 241,
+      "community": 242,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_homepage_tsx",
       "label": "HomePage.tsx",
@@ -79378,7 +79759,7 @@
       "source_location": "L1"
     },
     {
-      "community": 242,
+      "community": 243,
       "file_type": "code",
       "id": "inventorylevelbadge_lowstockbadge",
       "label": "LowStockBadge()",
@@ -79387,7 +79768,7 @@
       "source_location": "L14"
     },
     {
-      "community": 242,
+      "community": 243,
       "file_type": "code",
       "id": "inventorylevelbadge_sellingfastbadge",
       "label": "SellingFastBadge()",
@@ -79396,7 +79777,7 @@
       "source_location": "L22"
     },
     {
-      "community": 242,
+      "community": 243,
       "file_type": "code",
       "id": "inventorylevelbadge_sellingfastsignal",
       "label": "SellingFastSignal()",
@@ -79405,7 +79786,7 @@
       "source_location": "L30"
     },
     {
-      "community": 242,
+      "community": 243,
       "file_type": "code",
       "id": "inventorylevelbadge_soldoutbadge",
       "label": "SoldOutBadge()",
@@ -79414,7 +79795,7 @@
       "source_location": "L3"
     },
     {
-      "community": 242,
+      "community": 243,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_inventorylevelbadge_tsx",
       "label": "InventoryLevelBadge.tsx",
@@ -79423,7 +79804,7 @@
       "source_location": "L1"
     },
     {
-      "community": 243,
+      "community": 244,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_storefrontfailureobservability_ts",
       "label": "storefrontFailureObservability.ts",
@@ -79432,7 +79813,7 @@
       "source_location": "L1"
     },
     {
-      "community": 243,
+      "community": 244,
       "file_type": "code",
       "id": "storefrontfailureobservability_createstorefrontfailureevent",
       "label": "createStorefrontFailureEvent()",
@@ -79441,7 +79822,7 @@
       "source_location": "L136"
     },
     {
-      "community": 243,
+      "community": 244,
       "file_type": "code",
       "id": "storefrontfailureobservability_emitstorefrontfailure",
       "label": "emitStorefrontFailure()",
@@ -79450,7 +79831,7 @@
       "source_location": "L154"
     },
     {
-      "community": 243,
+      "community": 244,
       "file_type": "code",
       "id": "storefrontfailureobservability_inferstorefrontjourneyfromroute",
       "label": "inferStorefrontJourneyFromRoute()",
@@ -79459,7 +79840,7 @@
       "source_location": "L25"
     },
     {
-      "community": 243,
+      "community": 244,
       "file_type": "code",
       "id": "storefrontfailureobservability_normalizestorefronterror",
       "label": "normalizeStorefrontError()",
@@ -79468,7 +79849,7 @@
       "source_location": "L47"
     },
     {
-      "community": 244,
+      "community": 245,
       "file_type": "code",
       "id": "convex_node_env_test_resolveesbuildwithenv",
       "label": "resolveEsbuildWithEnv()",
@@ -79477,7 +79858,7 @@
       "source_location": "L48"
     },
     {
-      "community": 244,
+      "community": 245,
       "file_type": "code",
       "id": "convex_node_env_test_resolvewithenv",
       "label": "resolveWithEnv()",
@@ -79486,7 +79867,7 @@
       "source_location": "L26"
     },
     {
-      "community": 244,
+      "community": 245,
       "file_type": "code",
       "id": "convex_node_env_test_withtempdir",
       "label": "withTempDir()",
@@ -79495,7 +79876,7 @@
       "source_location": "L6"
     },
     {
-      "community": 244,
+      "community": 245,
       "file_type": "code",
       "id": "convex_node_env_test_writenodeshim",
       "label": "writeNodeShim()",
@@ -79504,7 +79885,7 @@
       "source_location": "L16"
     },
     {
-      "community": 244,
+      "community": 245,
       "file_type": "code",
       "id": "scripts_convex_node_env_test_ts",
       "label": "convex-node-env.test.ts",
@@ -79513,7 +79894,7 @@
       "source_location": "L1"
     },
     {
-      "community": 245,
+      "community": 246,
       "file_type": "code",
       "id": "harness_behavior_test_createbrowser",
       "label": "createBrowser()",
@@ -79522,7 +79903,7 @@
       "source_location": "L52"
     },
     {
-      "community": 245,
+      "community": 246,
       "file_type": "code",
       "id": "harness_behavior_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -79531,7 +79912,7 @@
       "source_location": "L22"
     },
     {
-      "community": 245,
+      "community": 246,
       "file_type": "code",
       "id": "harness_behavior_test_createplaywrightmodule",
       "label": "createPlaywrightModule()",
@@ -79540,7 +79921,7 @@
       "source_location": "L44"
     },
     {
-      "community": 245,
+      "community": 246,
       "file_type": "code",
       "id": "harness_behavior_test_write",
       "label": "write()",
@@ -79549,7 +79930,7 @@
       "source_location": "L16"
     },
     {
-      "community": 245,
+      "community": 246,
       "file_type": "code",
       "id": "scripts_harness_behavior_test_ts",
       "label": "harness-behavior.test.ts",
@@ -79558,7 +79939,7 @@
       "source_location": "L1"
     },
     {
-      "community": 246,
+      "community": 247,
       "file_type": "code",
       "id": "harness_repo_validation_collectharnessrepovalidationselection",
       "label": "collectHarnessRepoValidationSelection()",
@@ -79567,7 +79948,7 @@
       "source_location": "L48"
     },
     {
-      "community": 246,
+      "community": 247,
       "file_type": "code",
       "id": "harness_repo_validation_matchesharnessrepovalidationpath",
       "label": "matchesHarnessRepoValidationPath()",
@@ -79576,7 +79957,7 @@
       "source_location": "L40"
     },
     {
-      "community": 246,
+      "community": 247,
       "file_type": "code",
       "id": "harness_repo_validation_normalizerepopath",
       "label": "normalizeRepoPath()",
@@ -79585,7 +79966,7 @@
       "source_location": "L30"
     },
     {
-      "community": 246,
+      "community": 247,
       "file_type": "code",
       "id": "harness_repo_validation_sortuniquepaths",
       "label": "sortUniquePaths()",
@@ -79594,7 +79975,7 @@
       "source_location": "L34"
     },
     {
-      "community": 246,
+      "community": 247,
       "file_type": "code",
       "id": "scripts_harness_repo_validation_ts",
       "label": "harness-repo-validation.ts",
@@ -79603,7 +79984,7 @@
       "source_location": "L1"
     },
     {
-      "community": 247,
+      "community": 248,
       "file_type": "code",
       "id": "pre_commit_generated_artifacts_test_log",
       "label": "log()",
@@ -79612,7 +79993,7 @@
       "source_location": "L73"
     },
     {
-      "community": 247,
+      "community": 248,
       "file_type": "code",
       "id": "pre_commit_generated_artifacts_test_spawn",
       "label": "spawn()",
@@ -79621,7 +80002,7 @@
       "source_location": "L65"
     },
     {
-      "community": 247,
+      "community": 248,
       "file_type": "code",
       "id": "pre_commit_generated_artifacts_test_withtemprepo",
       "label": "withTempRepo()",
@@ -79630,7 +80011,7 @@
       "source_location": "L14"
     },
     {
-      "community": 247,
+      "community": 248,
       "file_type": "code",
       "id": "pre_commit_generated_artifacts_test_writeconvexapifixture",
       "label": "writeConvexApiFixture()",
@@ -79639,7 +80020,7 @@
       "source_location": "L24"
     },
     {
-      "community": 247,
+      "community": 248,
       "file_type": "code",
       "id": "scripts_pre_commit_generated_artifacts_test_ts",
       "label": "pre-commit-generated-artifacts.test.ts",
@@ -79648,7 +80029,7 @@
       "source_location": "L1"
     },
     {
-      "community": 248,
+      "community": 249,
       "file_type": "code",
       "id": "scripts_worktree_manager_test_ts",
       "label": "worktree-manager.test.ts",
@@ -79657,7 +80038,7 @@
       "source_location": "L1"
     },
     {
-      "community": 248,
+      "community": 249,
       "file_type": "code",
       "id": "worktree_manager_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -79666,7 +80047,7 @@
       "source_location": "L17"
     },
     {
-      "community": 248,
+      "community": 249,
       "file_type": "code",
       "id": "worktree_manager_test_fixtureenv",
       "label": "fixtureEnv()",
@@ -79675,7 +80056,7 @@
       "source_location": "L72"
     },
     {
-      "community": 248,
+      "community": 249,
       "file_type": "code",
       "id": "worktree_manager_test_rungit",
       "label": "runGit()",
@@ -79684,49 +80065,13 @@
       "source_location": "L45"
     },
     {
-      "community": 248,
+      "community": 249,
       "file_type": "code",
       "id": "worktree_manager_test_runworktreemanager",
       "label": "runWorktreeManager()",
       "norm_label": "runworktreemanager()",
       "source_file": "scripts/worktree-manager.test.ts",
       "source_location": "L59"
-    },
-    {
-      "community": 249,
-      "file_type": "code",
-      "id": "convexpaginationantipatterncheck_test_createtemproot",
-      "label": "createTempRoot()",
-      "norm_label": "createtemproot()",
-      "source_file": "packages/athena-webapp/convex/convexPaginationAntiPatternCheck.test.ts",
-      "source_location": "L12"
-    },
-    {
-      "community": 249,
-      "file_type": "code",
-      "id": "convexpaginationantipatterncheck_test_runpaginationcheck",
-      "label": "runPaginationCheck()",
-      "norm_label": "runpaginationcheck()",
-      "source_file": "packages/athena-webapp/convex/convexPaginationAntiPatternCheck.test.ts",
-      "source_location": "L26"
-    },
-    {
-      "community": 249,
-      "file_type": "code",
-      "id": "convexpaginationantipatterncheck_test_writeconvexfile",
-      "label": "writeConvexFile()",
-      "norm_label": "writeconvexfile()",
-      "source_file": "packages/athena-webapp/convex/convexPaginationAntiPatternCheck.test.ts",
-      "source_location": "L20"
-    },
-    {
-      "community": 249,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_convexpaginationantipatterncheck_test_ts",
-      "label": "convexPaginationAntiPatternCheck.test.ts",
-      "norm_label": "convexpaginationantipatterncheck.test.ts",
-      "source_file": "packages/athena-webapp/convex/convexPaginationAntiPatternCheck.test.ts",
-      "source_location": "L1"
     },
     {
       "community": 25,
@@ -79920,6 +80265,42 @@
     {
       "community": 250,
       "file_type": "code",
+      "id": "convexpaginationantipatterncheck_test_createtemproot",
+      "label": "createTempRoot()",
+      "norm_label": "createtemproot()",
+      "source_file": "packages/athena-webapp/convex/convexPaginationAntiPatternCheck.test.ts",
+      "source_location": "L12"
+    },
+    {
+      "community": 250,
+      "file_type": "code",
+      "id": "convexpaginationantipatterncheck_test_runpaginationcheck",
+      "label": "runPaginationCheck()",
+      "norm_label": "runpaginationcheck()",
+      "source_file": "packages/athena-webapp/convex/convexPaginationAntiPatternCheck.test.ts",
+      "source_location": "L26"
+    },
+    {
+      "community": 250,
+      "file_type": "code",
+      "id": "convexpaginationantipatterncheck_test_writeconvexfile",
+      "label": "writeConvexFile()",
+      "norm_label": "writeconvexfile()",
+      "source_file": "packages/athena-webapp/convex/convexPaginationAntiPatternCheck.test.ts",
+      "source_location": "L20"
+    },
+    {
+      "community": 250,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_convexpaginationantipatterncheck_test_ts",
+      "label": "convexPaginationAntiPatternCheck.test.ts",
+      "norm_label": "convexpaginationantipatterncheck.test.ts",
+      "source_file": "packages/athena-webapp/convex/convexPaginationAntiPatternCheck.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 251,
+      "file_type": "code",
       "id": "domain_maskreceiptphone",
       "label": "maskReceiptPhone()",
       "norm_label": "maskreceiptphone()",
@@ -79927,7 +80308,7 @@
       "source_location": "L67"
     },
     {
-      "community": 250,
+      "community": 251,
       "file_type": "code",
       "id": "domain_normalizereceiptphone",
       "label": "normalizeReceiptPhone()",
@@ -79936,7 +80317,7 @@
       "source_location": "L52"
     },
     {
-      "community": 250,
+      "community": 251,
       "file_type": "code",
       "id": "domain_statusisretryable",
       "label": "statusIsRetryable()",
@@ -79945,7 +80326,7 @@
       "source_location": "L79"
     },
     {
-      "community": 250,
+      "community": 251,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_customermessaging_domain_ts",
       "label": "domain.ts",
@@ -79954,7 +80335,7 @@
       "source_location": "L1"
     },
     {
-      "community": 251,
+      "community": 252,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_customermessaging_token_ts",
       "label": "token.ts",
@@ -79963,7 +80344,7 @@
       "source_location": "L1"
     },
     {
-      "community": 251,
+      "community": 252,
       "file_type": "code",
       "id": "token_createreceiptsharetoken",
       "label": "createReceiptShareToken()",
@@ -79972,7 +80353,7 @@
       "source_location": "L9"
     },
     {
-      "community": 251,
+      "community": 252,
       "file_type": "code",
       "id": "token_hashreceiptsharetoken",
       "label": "hashReceiptShareToken()",
@@ -79981,7 +80362,7 @@
       "source_location": "L15"
     },
     {
-      "community": 251,
+      "community": 252,
       "file_type": "code",
       "id": "token_tohex",
       "label": "toHex()",
@@ -79990,7 +80371,7 @@
       "source_location": "L3"
     },
     {
-      "community": 252,
+      "community": 253,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_customermessaging_webhooksecurity_ts",
       "label": "webhookSecurity.ts",
@@ -79999,7 +80380,7 @@
       "source_location": "L1"
     },
     {
-      "community": 252,
+      "community": 253,
       "file_type": "code",
       "id": "webhooksecurity_timingsafeequal",
       "label": "timingSafeEqual()",
@@ -80008,7 +80389,7 @@
       "source_location": "L9"
     },
     {
-      "community": 252,
+      "community": 253,
       "file_type": "code",
       "id": "webhooksecurity_tohex",
       "label": "toHex()",
@@ -80017,7 +80398,7 @@
       "source_location": "L3"
     },
     {
-      "community": 252,
+      "community": 253,
       "file_type": "code",
       "id": "webhooksecurity_verifymetawebhooksignature",
       "label": "verifyMetaWebhookSignature()",
@@ -80026,7 +80407,7 @@
       "source_location": "L22"
     },
     {
-      "community": 253,
+      "community": 254,
       "file_type": "code",
       "id": "checkout_hasallvisibilesessionitems",
       "label": "hasAllVisibileSessionItems()",
@@ -80035,7 +80416,7 @@
       "source_location": "L109"
     },
     {
-      "community": 253,
+      "community": 254,
       "file_type": "code",
       "id": "checkout_hasvalidcanonicalbagitem",
       "label": "hasValidCanonicalBagItem()",
@@ -80044,7 +80425,7 @@
       "source_location": "L84"
     },
     {
-      "community": 253,
+      "community": 254,
       "file_type": "code",
       "id": "checkout_hasvalidsessionitems",
       "label": "hasValidSessionItems()",
@@ -80053,7 +80434,7 @@
       "source_location": "L95"
     },
     {
-      "community": 253,
+      "community": 254,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_checkout_ts",
       "label": "checkout.ts",
@@ -80062,7 +80443,7 @@
       "source_location": "L1"
     },
     {
-      "community": 254,
+      "community": 255,
       "file_type": "code",
       "id": "expensesessions_test_buildsession",
       "label": "buildSession()",
@@ -80071,7 +80452,7 @@
       "source_location": "L235"
     },
     {
-      "community": 254,
+      "community": 255,
       "file_type": "code",
       "id": "expensesessions_test_createmutationctx",
       "label": "createMutationCtx()",
@@ -80080,7 +80461,7 @@
       "source_location": "L53"
     },
     {
-      "community": 254,
+      "community": 255,
       "file_type": "code",
       "id": "expensesessions_test_gethandler",
       "label": "getHandler()",
@@ -80089,7 +80470,7 @@
       "source_location": "L250"
     },
     {
-      "community": 254,
+      "community": 255,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_expensesessions_test_ts",
       "label": "expenseSessions.test.ts",
@@ -80098,7 +80479,7 @@
       "source_location": "L1"
     },
     {
-      "community": 255,
+      "community": 256,
       "file_type": "code",
       "id": "expensetransactions_createexpensetransactionfromsessionhandler",
       "label": "createExpenseTransactionFromSessionHandler()",
@@ -80107,7 +80488,7 @@
       "source_location": "L50"
     },
     {
-      "community": 255,
+      "community": 256,
       "file_type": "code",
       "id": "expensetransactions_expensetransactionerror",
       "label": "expenseTransactionError()",
@@ -80116,7 +80497,7 @@
       "source_location": "L23"
     },
     {
-      "community": 255,
+      "community": 256,
       "file_type": "code",
       "id": "expensetransactions_formatexpensestaffprofilename",
       "label": "formatExpenseStaffProfileName()",
@@ -80125,7 +80506,7 @@
       "source_location": "L37"
     },
     {
-      "community": 255,
+      "community": 256,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_expensetransactions_ts",
       "label": "expenseTransactions.ts",
@@ -80134,7 +80515,7 @@
       "source_location": "L1"
     },
     {
-      "community": 256,
+      "community": 257,
       "file_type": "code",
       "id": "expensesessionexpiration_calculateexpensesessionexpiration",
       "label": "calculateExpenseSessionExpiration()",
@@ -80143,7 +80524,7 @@
       "source_location": "L21"
     },
     {
-      "community": 256,
+      "community": 257,
       "file_type": "code",
       "id": "expensesessionexpiration_getexpensesessionexpiryduration",
       "label": "getExpenseSessionExpiryDuration()",
@@ -80152,7 +80533,7 @@
       "source_location": "L35"
     },
     {
-      "community": 256,
+      "community": 257,
       "file_type": "code",
       "id": "expensesessionexpiration_getexpensesessionexpirydurationminutes",
       "label": "getExpenseSessionExpiryDurationMinutes()",
@@ -80161,7 +80542,7 @@
       "source_location": "L45"
     },
     {
-      "community": 256,
+      "community": 257,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_helpers_expensesessionexpiration_ts",
       "label": "expenseSessionExpiration.ts",
@@ -80170,7 +80551,7 @@
       "source_location": "L1"
     },
     {
-      "community": 257,
+      "community": 258,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_helpers_sessionexpiration_ts",
       "label": "sessionExpiration.ts",
@@ -80179,7 +80560,7 @@
       "source_location": "L1"
     },
     {
-      "community": 257,
+      "community": 258,
       "file_type": "code",
       "id": "sessionexpiration_calculatesessionexpiration",
       "label": "calculateSessionExpiration()",
@@ -80188,7 +80569,7 @@
       "source_location": "L21"
     },
     {
-      "community": 257,
+      "community": 258,
       "file_type": "code",
       "id": "sessionexpiration_getsessionexpiryduration",
       "label": "getSessionExpiryDuration()",
@@ -80197,7 +80578,7 @@
       "source_location": "L35"
     },
     {
-      "community": 257,
+      "community": 258,
       "file_type": "code",
       "id": "sessionexpiration_getsessionexpirydurationminutes",
       "label": "getSessionExpiryDurationMinutes()",
@@ -80206,7 +80587,7 @@
       "source_location": "L45"
     },
     {
-      "community": 258,
+      "community": 259,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_possessions_trace_test_ts",
       "label": "posSessions.trace.test.ts",
@@ -80215,7 +80596,7 @@
       "source_location": "L1"
     },
     {
-      "community": 258,
+      "community": 259,
       "file_type": "code",
       "id": "possessions_trace_test_buildsession",
       "label": "buildSession()",
@@ -80224,7 +80605,7 @@
       "source_location": "L407"
     },
     {
-      "community": 258,
+      "community": 259,
       "file_type": "code",
       "id": "possessions_trace_test_createmutationctx",
       "label": "createMutationCtx()",
@@ -80233,49 +80614,13 @@
       "source_location": "L161"
     },
     {
-      "community": 258,
+      "community": 259,
       "file_type": "code",
       "id": "possessions_trace_test_gethandler",
       "label": "getHandler()",
       "norm_label": "gethandler()",
       "source_file": "packages/athena-webapp/convex/inventory/posSessions.trace.test.ts",
       "source_location": "L424"
-    },
-    {
-      "community": 259,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_products_sku_test_ts",
-      "label": "products.sku.test.ts",
-      "norm_label": "products.sku.test.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/products.sku.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 259,
-      "file_type": "code",
-      "id": "products_sku_test_createproductsqueryctx",
-      "label": "createProductsQueryCtx()",
-      "norm_label": "createproductsqueryctx()",
-      "source_file": "packages/athena-webapp/convex/inventory/products.sku.test.ts",
-      "source_location": "L146"
-    },
-    {
-      "community": 259,
-      "file_type": "code",
-      "id": "products_sku_test_createskumutationctx",
-      "label": "createSkuMutationCtx()",
-      "norm_label": "createskumutationctx()",
-      "source_file": "packages/athena-webapp/convex/inventory/products.sku.test.ts",
-      "source_location": "L39"
-    },
-    {
-      "community": 259,
-      "file_type": "code",
-      "id": "products_sku_test_gethandler",
-      "label": "getHandler()",
-      "norm_label": "gethandler()",
-      "source_file": "packages/athena-webapp/convex/inventory/products.sku.test.ts",
-      "source_location": "L35"
     },
     {
       "community": 26,
@@ -80469,6 +80814,42 @@
     {
       "community": 260,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_products_sku_test_ts",
+      "label": "products.sku.test.ts",
+      "norm_label": "products.sku.test.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/products.sku.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "products_sku_test_createproductsqueryctx",
+      "label": "createProductsQueryCtx()",
+      "norm_label": "createproductsqueryctx()",
+      "source_file": "packages/athena-webapp/convex/inventory/products.sku.test.ts",
+      "source_location": "L146"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "products_sku_test_createskumutationctx",
+      "label": "createSkuMutationCtx()",
+      "norm_label": "createskumutationctx()",
+      "source_file": "packages/athena-webapp/convex/inventory/products.sku.test.ts",
+      "source_location": "L39"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "products_sku_test_gethandler",
+      "label": "getHandler()",
+      "norm_label": "gethandler()",
+      "source_file": "packages/athena-webapp/convex/inventory/products.sku.test.ts",
+      "source_location": "L35"
+    },
+    {
+      "community": 261,
+      "file_type": "code",
       "id": "collections_getcachedtokenrecord",
       "label": "getCachedTokenRecord()",
       "norm_label": "getcachedtokenrecord()",
@@ -80476,7 +80857,7 @@
       "source_location": "L26"
     },
     {
-      "community": 260,
+      "community": 261,
       "file_type": "code",
       "id": "collections_resolveaccesstokenforstore",
       "label": "resolveAccessTokenForStore()",
@@ -80485,7 +80866,7 @@
       "source_location": "L79"
     },
     {
-      "community": 260,
+      "community": 261,
       "file_type": "code",
       "id": "collections_resolveconfigforstore",
       "label": "resolveConfigForStore()",
@@ -80494,7 +80875,7 @@
       "source_location": "L33"
     },
     {
-      "community": 260,
+      "community": 261,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_collections_ts",
       "label": "collections.ts",
@@ -80503,7 +80884,7 @@
       "source_location": "L1"
     },
     {
-      "community": 261,
+      "community": 262,
       "file_type": "code",
       "id": "normalize_maskmtnpartyid",
       "label": "maskMtnPartyId()",
@@ -80512,7 +80893,7 @@
       "source_location": "L10"
     },
     {
-      "community": 261,
+      "community": 262,
       "file_type": "code",
       "id": "normalize_normalizecollectionstransaction",
       "label": "normalizeCollectionsTransaction()",
@@ -80521,7 +80902,7 @@
       "source_location": "L18"
     },
     {
-      "community": 261,
+      "community": 262,
       "file_type": "code",
       "id": "normalize_parsecollectionsnotificationrequest",
       "label": "parseCollectionsNotificationRequest()",
@@ -80530,7 +80911,7 @@
       "source_location": "L52"
     },
     {
-      "community": 261,
+      "community": 262,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_normalize_ts",
       "label": "normalize.ts",
@@ -80539,7 +80920,7 @@
       "source_location": "L1"
     },
     {
-      "community": 262,
+      "community": 263,
       "file_type": "code",
       "id": "approvalproofs_consumeapprovalproofwithctx",
       "label": "consumeApprovalProofWithCtx()",
@@ -80548,7 +80929,7 @@
       "source_location": "L98"
     },
     {
-      "community": 262,
+      "community": 263,
       "file_type": "code",
       "id": "approvalproofs_createapprovalproofwithctx",
       "label": "createApprovalProofWithCtx()",
@@ -80557,7 +80938,7 @@
       "source_location": "L56"
     },
     {
-      "community": 262,
+      "community": 263,
       "file_type": "code",
       "id": "approvalproofs_invalidapprovalproofresult",
       "label": "invalidApprovalProofResult()",
@@ -80566,48 +80947,12 @@
       "source_location": "L49"
     },
     {
-      "community": 262,
+      "community": 263,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_approvalproofs_ts",
       "label": "approvalProofs.ts",
       "norm_label": "approvalproofs.ts",
       "source_file": "packages/athena-webapp/convex/operations/approvalProofs.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 263,
-      "file_type": "code",
-      "id": "dailyclose_test_createdb",
-      "label": "createDb()",
-      "norm_label": "createdb()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
-      "source_location": "L30"
-    },
-    {
-      "community": 263,
-      "file_type": "code",
-      "id": "dailyclose_test_dailycloseapprovalproof",
-      "label": "dailyCloseApprovalProof()",
-      "norm_label": "dailycloseapprovalproof()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
-      "source_location": "L240"
-    },
-    {
-      "community": 263,
-      "file_type": "code",
-      "id": "dailyclose_test_dailyclosesummary",
-      "label": "dailyCloseSummary()",
-      "norm_label": "dailyclosesummary()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
-      "source_location": "L215"
-    },
-    {
-      "community": 263,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_dailyclose_test_ts",
-      "label": "dailyClose.test.ts",
-      "norm_label": "dailyclose.test.ts",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
       "source_location": "L1"
     },
     {
@@ -87385,7 +87730,7 @@
       "label": "getLocalOperatingDate()",
       "norm_label": "getlocaloperatingdate()",
       "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterOpeningGuard.tsx",
-      "source_location": "L17"
+      "source_location": "L24"
     },
     {
       "community": 393,
@@ -87394,7 +87739,7 @@
       "label": "getLocalOperatingDateRange()",
       "norm_label": "getlocaloperatingdaterange()",
       "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterOpeningGuard.tsx",
-      "source_location": "L25"
+      "source_location": "L32"
     },
     {
       "community": 394,
@@ -87921,154 +88266,154 @@
     {
       "community": 40,
       "file_type": "code",
-      "id": "completetransaction_buildcompletetransactionresult",
-      "label": "buildCompleteTransactionResult()",
-      "norm_label": "buildcompletetransactionresult()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L57"
+      "id": "data_table_view_options_datatableviewoptions",
+      "label": "DataTableViewOptions()",
+      "norm_label": "datatableviewoptions()",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-view-options.tsx",
+      "source_location": "L18"
     },
     {
       "community": 40,
       "file_type": "code",
-      "id": "completetransaction_calculatecanonicaltransactiontotals",
-      "label": "calculateCanonicalTransactionTotals()",
-      "norm_label": "calculatecanonicaltransactiontotals()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L86"
-    },
-    {
-      "community": 40,
-      "file_type": "code",
-      "id": "completetransaction_calculatetotalpaid",
-      "label": "calculateTotalPaid()",
-      "norm_label": "calculatetotalpaid()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L78"
-    },
-    {
-      "community": 40,
-      "file_type": "code",
-      "id": "completetransaction_completetransaction",
-      "label": "completeTransaction()",
-      "norm_label": "completetransaction()",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/useCases/completeTransaction.ts",
-      "source_location": "L5"
-    },
-    {
-      "community": 40,
-      "file_type": "code",
-      "id": "completetransaction_createtransactionfromsessionhandler",
-      "label": "createTransactionFromSessionHandler()",
-      "norm_label": "createtransactionfromsessionhandler()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L564"
-    },
-    {
-      "community": 40,
-      "file_type": "code",
-      "id": "completetransaction_isusableregistersession",
-      "label": "isUsableRegisterSession()",
-      "norm_label": "isusableregistersession()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L137"
-    },
-    {
-      "community": 40,
-      "file_type": "code",
-      "id": "completetransaction_recordregistersessionsale",
-      "label": "recordRegisterSessionSale()",
-      "norm_label": "recordregistersessionsale()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L191"
-    },
-    {
-      "community": 40,
-      "file_type": "code",
-      "id": "completetransaction_recordregistersessionvoid",
-      "label": "recordRegisterSessionVoid()",
-      "norm_label": "recordregistersessionvoid()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L216"
-    },
-    {
-      "community": 40,
-      "file_type": "code",
-      "id": "completetransaction_registersessionmatchesidentity",
-      "label": "registerSessionMatchesIdentity()",
-      "norm_label": "registersessionmatchesidentity()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L122"
-    },
-    {
-      "community": 40,
-      "file_type": "code",
-      "id": "completetransaction_resolvesessionregistersessionid",
-      "label": "resolveSessionRegisterSessionId()",
-      "norm_label": "resolvesessionregistersessionid()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L141"
-    },
-    {
-      "community": 40,
-      "file_type": "code",
-      "id": "completetransaction_roundstoredamount",
-      "label": "roundStoredAmount()",
-      "norm_label": "roundstoredamount()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L82"
-    },
-    {
-      "community": 40,
-      "file_type": "code",
-      "id": "completetransaction_stalesaletotalerror",
-      "label": "staleSaleTotalError()",
-      "norm_label": "stalesaletotalerror()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L115"
-    },
-    {
-      "community": 40,
-      "file_type": "code",
-      "id": "completetransaction_totalsmatch",
-      "label": "totalsMatch()",
-      "norm_label": "totalsmatch()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L104"
-    },
-    {
-      "community": 40,
-      "file_type": "code",
-      "id": "completetransaction_updateinventory",
-      "label": "updateInventory()",
-      "norm_label": "updateinventory()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L241"
-    },
-    {
-      "community": 40,
-      "file_type": "code",
-      "id": "completetransaction_voidtransaction",
-      "label": "voidTransaction()",
-      "norm_label": "voidtransaction()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
-      "source_location": "L488"
-    },
-    {
-      "community": 40,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_commands_completetransaction_ts",
-      "label": "completeTransaction.ts",
-      "norm_label": "completetransaction.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
+      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table-view-options.tsx",
       "source_location": "L1"
     },
     {
       "community": 40,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_application_usecases_completetransaction_ts",
-      "label": "completeTransaction.ts",
-      "norm_label": "completetransaction.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/useCases/completeTransaction.ts",
+      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/data-table-view-options.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 40,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-products-table/data-table-view-options.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 40,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_table_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/table/data-table-view-options.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 40,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/data-table-view-options.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 40,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/assets/assets-table/data-table-view-options.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 40,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/data-table-view-options.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 40,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_base_table_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/base/table/data-table-view-options.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 40,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data-table-view-options.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 40,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table-view-options.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 40,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data-table-view-options.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 40,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/products/products-table/components/data-table-view-options.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 40,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/data-table-view-options.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 40,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/table/data-table-view-options.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 40,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_table_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-view-options.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 40,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-view-options.tsx",
       "source_location": "L1"
     },
     {
@@ -88344,154 +88689,154 @@
     {
       "community": 41,
       "file_type": "code",
-      "id": "data_table_view_options_datatableviewoptions",
-      "label": "DataTableViewOptions()",
-      "norm_label": "datatableviewoptions()",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-view-options.tsx",
-      "source_location": "L18"
+      "id": "completetransaction_buildcompletetransactionresult",
+      "label": "buildCompleteTransactionResult()",
+      "norm_label": "buildcompletetransactionresult()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
+      "source_location": "L57"
     },
     {
       "community": 41,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table-view-options.tsx",
+      "id": "completetransaction_calculatecanonicaltransactiontotals",
+      "label": "calculateCanonicalTransactionTotals()",
+      "norm_label": "calculatecanonicaltransactiontotals()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
+      "source_location": "L86"
+    },
+    {
+      "community": 41,
+      "file_type": "code",
+      "id": "completetransaction_calculatetotalpaid",
+      "label": "calculateTotalPaid()",
+      "norm_label": "calculatetotalpaid()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
+      "source_location": "L78"
+    },
+    {
+      "community": 41,
+      "file_type": "code",
+      "id": "completetransaction_completetransaction",
+      "label": "completeTransaction()",
+      "norm_label": "completetransaction()",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/useCases/completeTransaction.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 41,
+      "file_type": "code",
+      "id": "completetransaction_createtransactionfromsessionhandler",
+      "label": "createTransactionFromSessionHandler()",
+      "norm_label": "createtransactionfromsessionhandler()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
+      "source_location": "L564"
+    },
+    {
+      "community": 41,
+      "file_type": "code",
+      "id": "completetransaction_isusableregistersession",
+      "label": "isUsableRegisterSession()",
+      "norm_label": "isusableregistersession()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
+      "source_location": "L137"
+    },
+    {
+      "community": 41,
+      "file_type": "code",
+      "id": "completetransaction_recordregistersessionsale",
+      "label": "recordRegisterSessionSale()",
+      "norm_label": "recordregistersessionsale()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
+      "source_location": "L191"
+    },
+    {
+      "community": 41,
+      "file_type": "code",
+      "id": "completetransaction_recordregistersessionvoid",
+      "label": "recordRegisterSessionVoid()",
+      "norm_label": "recordregistersessionvoid()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
+      "source_location": "L216"
+    },
+    {
+      "community": 41,
+      "file_type": "code",
+      "id": "completetransaction_registersessionmatchesidentity",
+      "label": "registerSessionMatchesIdentity()",
+      "norm_label": "registersessionmatchesidentity()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
+      "source_location": "L122"
+    },
+    {
+      "community": 41,
+      "file_type": "code",
+      "id": "completetransaction_resolvesessionregistersessionid",
+      "label": "resolveSessionRegisterSessionId()",
+      "norm_label": "resolvesessionregistersessionid()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
+      "source_location": "L141"
+    },
+    {
+      "community": 41,
+      "file_type": "code",
+      "id": "completetransaction_roundstoredamount",
+      "label": "roundStoredAmount()",
+      "norm_label": "roundstoredamount()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
+      "source_location": "L82"
+    },
+    {
+      "community": 41,
+      "file_type": "code",
+      "id": "completetransaction_stalesaletotalerror",
+      "label": "staleSaleTotalError()",
+      "norm_label": "stalesaletotalerror()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
+      "source_location": "L115"
+    },
+    {
+      "community": 41,
+      "file_type": "code",
+      "id": "completetransaction_totalsmatch",
+      "label": "totalsMatch()",
+      "norm_label": "totalsmatch()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
+      "source_location": "L104"
+    },
+    {
+      "community": 41,
+      "file_type": "code",
+      "id": "completetransaction_updateinventory",
+      "label": "updateInventory()",
+      "norm_label": "updateinventory()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
+      "source_location": "L241"
+    },
+    {
+      "community": 41,
+      "file_type": "code",
+      "id": "completetransaction_voidtransaction",
+      "label": "voidTransaction()",
+      "norm_label": "voidtransaction()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
+      "source_location": "L488"
+    },
+    {
+      "community": 41,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_commands_completetransaction_ts",
+      "label": "completeTransaction.ts",
+      "norm_label": "completetransaction.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts",
       "source_location": "L1"
     },
     {
       "community": 41,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/data-table-view-options.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 41,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-products-table/data-table-view-options.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 41,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_table_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/table/data-table-view-options.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 41,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/data-table-view-options.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 41,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/assets/assets-table/data-table-view-options.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 41,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/data-table-view-options.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 41,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_base_table_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/base/table/data-table-view-options.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 41,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data-table-view-options.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 41,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table-view-options.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 41,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data-table-view-options.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 41,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/products/products-table/components/data-table-view-options.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 41,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/data-table-view-options.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 41,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/table/data-table-view-options.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 41,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_table_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-view-options.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 41,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-view-options.tsx",
+      "id": "packages_athena_webapp_src_lib_pos_application_usecases_completetransaction_ts",
+      "label": "completeTransaction.ts",
+      "norm_label": "completetransaction.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/useCases/completeTransaction.ts",
       "source_location": "L1"
     },
     {
@@ -90855,146 +91200,146 @@
     {
       "community": 47,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_transactions_transactionview_tsx",
-      "label": "TransactionView.tsx",
-      "norm_label": "transactionview.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
-      "source_location": "L1"
+      "id": "dailyclosehistoryview_cn",
+      "label": "cn()",
+      "norm_label": "cn()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx",
+      "source_location": "L388"
     },
     {
       "community": 47,
       "file_type": "code",
-      "id": "transactionview_authenticatecorrectionstaff",
-      "label": "authenticateCorrectionStaff()",
-      "norm_label": "authenticatecorrectionstaff()",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
-      "source_location": "L418"
+      "id": "dailyclosehistoryview_dailyclosehistoryapipendingview",
+      "label": "DailyCloseHistoryApiPendingView()",
+      "norm_label": "dailyclosehistoryapipendingview()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx",
+      "source_location": "L223"
     },
     {
       "community": 47,
       "file_type": "code",
-      "id": "transactionview_exitcorrectionworkflow",
-      "label": "exitCorrectionWorkflow()",
-      "norm_label": "exitcorrectionworkflow()",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
-      "source_location": "L442"
+      "id": "dailyclosehistoryview_dailyclosehistoryview",
+      "label": "DailyCloseHistoryView()",
+      "norm_label": "dailyclosehistoryview()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx",
+      "source_location": "L243"
     },
     {
       "community": 47,
       "file_type": "code",
-      "id": "transactionview_formatcorrectioneventtype",
-      "label": "formatCorrectionEventType()",
-      "norm_label": "formatcorrectioneventtype()",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
-      "source_location": "L88"
+      "id": "dailyclosehistoryview_formatcount",
+      "label": "formatCount()",
+      "norm_label": "formatcount()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx",
+      "source_location": "L210"
     },
     {
       "community": 47,
       "file_type": "code",
-      "id": "transactionview_formatcorrectionhistorychange",
-      "label": "formatCorrectionHistoryChange()",
-      "norm_label": "formatcorrectionhistorychange()",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
+      "id": "dailyclosehistoryview_getdailyclosehistoryapi",
+      "label": "getDailyCloseHistoryApi()",
+      "norm_label": "getdailyclosehistoryapi()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx",
+      "source_location": "L99"
+    },
+    {
+      "community": 47,
+      "file_type": "code",
+      "id": "dailyclosehistoryview_gethistorylifecyclelabel",
+      "label": "getHistoryLifecycleLabel()",
+      "norm_label": "gethistorylifecyclelabel()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx",
       "source_location": "L148"
     },
     {
       "community": 47,
       "file_type": "code",
-      "id": "transactionview_formatcorrectionhistorymeta",
-      "label": "formatCorrectionHistoryMeta()",
-      "norm_label": "formatcorrectionhistorymeta()",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
-      "source_location": "L106"
+      "id": "dailyclosehistoryview_gethistoryrecordcompletedat",
+      "label": "getHistoryRecordCompletedAt()",
+      "norm_label": "gethistoryrecordcompletedat()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx",
+      "source_location": "L132"
     },
     {
       "community": 47,
       "file_type": "code",
-      "id": "transactionview_formatcorrectionhistorytitle",
-      "label": "formatCorrectionHistoryTitle()",
-      "norm_label": "formatcorrectionhistorytitle()",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
-      "source_location": "L94"
+      "id": "dailyclosehistoryview_gethistoryrecordcompletedby",
+      "label": "getHistoryRecordCompletedBy()",
+      "norm_label": "gethistoryrecordcompletedby()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx",
+      "source_location": "L136"
     },
     {
       "community": 47,
       "file_type": "code",
-      "id": "transactionview_formatpaymentmethodlabel",
-      "label": "formatPaymentMethodLabel()",
-      "norm_label": "formatpaymentmethodlabel()",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
-      "source_location": "L115"
+      "id": "dailyclosehistoryview_gethistoryrecordid",
+      "label": "getHistoryRecordId()",
+      "norm_label": "gethistoryrecordid()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx",
+      "source_location": "L120"
     },
     {
       "community": 47,
       "file_type": "code",
-      "id": "transactionview_getcorrectionhistorychangeparts",
-      "label": "getCorrectionHistoryChangeParts()",
-      "norm_label": "getcorrectionhistorychangeparts()",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
-      "source_location": "L169"
+      "id": "dailyclosehistoryview_gethistoryrecords",
+      "label": "getHistoryRecords()",
+      "norm_label": "gethistoryrecords()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx",
+      "source_location": "L109"
     },
     {
       "community": 47,
       "file_type": "code",
-      "id": "transactionview_gettransactioncorrectionhistory",
-      "label": "getTransactionCorrectionHistory()",
-      "norm_label": "gettransactioncorrectionhistory()",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
-      "source_location": "L189"
+      "id": "dailyclosehistoryview_gethistoryrecordsnapshot",
+      "label": "getHistoryRecordSnapshot()",
+      "norm_label": "gethistoryrecordsnapshot()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx",
+      "source_location": "L192"
     },
     {
       "community": 47,
       "file_type": "code",
-      "id": "transactionview_gettransactionreceiptdeliveryhistory",
-      "label": "getTransactionReceiptDeliveryHistory()",
-      "norm_label": "gettransactionreceiptdeliveryhistory()",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
-      "source_location": "L142"
+      "id": "dailyclosehistoryview_gethistoryrecordsummary",
+      "label": "getHistoryRecordSummary()",
+      "norm_label": "gethistoryrecordsummary()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx",
+      "source_location": "L144"
     },
     {
       "community": 47,
       "file_type": "code",
-      "id": "transactionview_ismanagerstaff",
-      "label": "isManagerStaff()",
-      "norm_label": "ismanagerstaff()",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
-      "source_location": "L138"
+      "id": "dailyclosehistoryview_iscompletedhistoryrecord",
+      "label": "isCompletedHistoryRecord()",
+      "norm_label": "iscompletedhistoryrecord()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx",
+      "source_location": "L126"
     },
     {
       "community": 47,
       "file_type": "code",
-      "id": "transactionview_requestcorrectionsubmit",
-      "label": "requestCorrectionSubmit()",
-      "norm_label": "requestcorrectionsubmit()",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
-      "source_location": "L578"
+      "id": "dailyclosehistoryview_normalizehistorysnapshot",
+      "label": "normalizeHistorySnapshot()",
+      "norm_label": "normalizehistorysnapshot()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx",
+      "source_location": "L160"
     },
     {
       "community": 47,
       "file_type": "code",
-      "id": "transactionview_requiresinlinemanagerproof",
-      "label": "requiresInlineManagerProof()",
-      "norm_label": "requiresinlinemanagerproof()",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
-      "source_location": "L125"
+      "id": "dailyclosehistoryview_sortnewestfirst",
+      "label": "sortNewestFirst()",
+      "norm_label": "sortnewestfirst()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx",
+      "source_location": "L216"
     },
     {
       "community": 47,
       "file_type": "code",
-      "id": "transactionview_runcustomercorrection",
-      "label": "runCustomerCorrection()",
-      "norm_label": "runcustomercorrection()",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
-      "source_location": "L449"
-    },
-    {
-      "community": 47,
-      "file_type": "code",
-      "id": "transactionview_runpaymentmethodcorrection",
-      "label": "runPaymentMethodCorrection()",
-      "norm_label": "runpaymentmethodcorrection()",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
-      "source_location": "L487"
+      "id": "packages_athena_webapp_src_components_operations_dailyclosehistoryview_tsx",
+      "label": "DailyCloseHistoryView.tsx",
+      "norm_label": "dailyclosehistoryview.tsx",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx",
+      "source_location": "L1"
     },
     {
       "community": 470,
@@ -91269,146 +91614,146 @@
     {
       "community": 48,
       "file_type": "code",
-      "id": "checkoutsession_checkoutsessionerror",
-      "label": "CheckoutSessionError",
-      "norm_label": "checkoutsessionerror",
-      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
-      "source_location": "L64"
+      "id": "packages_athena_webapp_src_components_pos_transactions_transactionview_tsx",
+      "label": "TransactionView.tsx",
+      "norm_label": "transactionview.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
+      "source_location": "L1"
     },
     {
       "community": 48,
       "file_type": "code",
-      "id": "checkoutsession_checkoutsessionerror_constructor",
-      "label": ".constructor()",
-      "norm_label": ".constructor()",
-      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
-      "source_location": "L69"
+      "id": "transactionview_authenticatecorrectionstaff",
+      "label": "authenticateCorrectionStaff()",
+      "norm_label": "authenticatecorrectionstaff()",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
+      "source_location": "L418"
     },
     {
       "community": 48,
       "file_type": "code",
-      "id": "checkoutsession_createcheckoutsession",
-      "label": "createCheckoutSession()",
-      "norm_label": "createcheckoutsession()",
-      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
-      "source_location": "L184"
+      "id": "transactionview_exitcorrectionworkflow",
+      "label": "exitCorrectionWorkflow()",
+      "norm_label": "exitcorrectionworkflow()",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
+      "source_location": "L442"
     },
     {
       "community": 48,
       "file_type": "code",
-      "id": "checkoutsession_defaultcheckoutactionmessage",
-      "label": "defaultCheckoutActionMessage()",
-      "norm_label": "defaultcheckoutactionmessage()",
-      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
-      "source_location": "L135"
+      "id": "transactionview_formatcorrectioneventtype",
+      "label": "formatCorrectionEventType()",
+      "norm_label": "formatcorrectioneventtype()",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
+      "source_location": "L88"
     },
     {
       "community": 48,
       "file_type": "code",
-      "id": "checkoutsession_getactivecheckoutsession",
-      "label": "getActiveCheckoutSession()",
-      "norm_label": "getactivecheckoutsession()",
-      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
-      "source_location": "L204"
+      "id": "transactionview_formatcorrectionhistorychange",
+      "label": "formatCorrectionHistoryChange()",
+      "norm_label": "formatcorrectionhistorychange()",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
+      "source_location": "L148"
     },
     {
       "community": 48,
       "file_type": "code",
-      "id": "checkoutsession_getbaseurl",
-      "label": "getBaseUrl()",
-      "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
-      "source_location": "L5"
+      "id": "transactionview_formatcorrectionhistorymeta",
+      "label": "formatCorrectionHistoryMeta()",
+      "norm_label": "formatcorrectionhistorymeta()",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
+      "source_location": "L106"
     },
     {
       "community": 48,
       "file_type": "code",
-      "id": "checkoutsession_getcheckoutactionerrormessage",
-      "label": "getCheckoutActionErrorMessage()",
-      "norm_label": "getcheckoutactionerrormessage()",
-      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
-      "source_location": "L147"
+      "id": "transactionview_formatcorrectionhistorytitle",
+      "label": "formatCorrectionHistoryTitle()",
+      "norm_label": "formatcorrectionhistorytitle()",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
+      "source_location": "L94"
     },
     {
       "community": 48,
       "file_type": "code",
-      "id": "checkoutsession_getcheckouterrormessagefrompayload",
-      "label": "getCheckoutErrorMessageFromPayload()",
-      "norm_label": "getcheckouterrormessagefrompayload()",
-      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
-      "source_location": "L98"
-    },
-    {
-      "community": 48,
-      "file_type": "code",
-      "id": "checkoutsession_getcheckoutsession",
-      "label": "getCheckoutSession()",
-      "norm_label": "getcheckoutsession()",
-      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
-      "source_location": "L226"
-    },
-    {
-      "community": 48,
-      "file_type": "code",
-      "id": "checkoutsession_getpendingcheckoutsessions",
-      "label": "getPendingCheckoutSessions()",
-      "norm_label": "getpendingcheckoutsessions()",
-      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
-      "source_location": "L215"
-    },
-    {
-      "community": 48,
-      "file_type": "code",
-      "id": "checkoutsession_isrecord",
-      "label": "isRecord()",
-      "norm_label": "isrecord()",
-      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
-      "source_location": "L78"
-    },
-    {
-      "community": 48,
-      "file_type": "code",
-      "id": "checkoutsession_parsecheckoutresponse",
-      "label": "parseCheckoutResponse()",
-      "norm_label": "parsecheckoutresponse()",
-      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
+      "id": "transactionview_formatpaymentmethodlabel",
+      "label": "formatPaymentMethodLabel()",
+      "norm_label": "formatpaymentmethodlabel()",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
       "source_location": "L115"
     },
     {
       "community": 48,
       "file_type": "code",
-      "id": "checkoutsession_parsejson",
-      "label": "parseJson()",
-      "norm_label": "parsejson()",
-      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
-      "source_location": "L81"
+      "id": "transactionview_getcorrectionhistorychangeparts",
+      "label": "getCorrectionHistoryChangeParts()",
+      "norm_label": "getcorrectionhistorychangeparts()",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
+      "source_location": "L169"
     },
     {
       "community": 48,
       "file_type": "code",
-      "id": "checkoutsession_updatecheckoutsession",
-      "label": "updateCheckoutSession()",
-      "norm_label": "updatecheckoutsession()",
-      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
-      "source_location": "L239"
+      "id": "transactionview_gettransactioncorrectionhistory",
+      "label": "getTransactionCorrectionHistory()",
+      "norm_label": "gettransactioncorrectionhistory()",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
+      "source_location": "L189"
     },
     {
       "community": 48,
       "file_type": "code",
-      "id": "checkoutsession_verifycheckoutsessionpayment",
-      "label": "verifyCheckoutSessionPayment()",
-      "norm_label": "verifycheckoutsessionpayment()",
-      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
-      "source_location": "L274"
+      "id": "transactionview_gettransactionreceiptdeliveryhistory",
+      "label": "getTransactionReceiptDeliveryHistory()",
+      "norm_label": "gettransactionreceiptdeliveryhistory()",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
+      "source_location": "L142"
     },
     {
       "community": 48,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_checkoutsession_ts",
-      "label": "checkoutSession.ts",
-      "norm_label": "checkoutsession.ts",
-      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
-      "source_location": "L1"
+      "id": "transactionview_ismanagerstaff",
+      "label": "isManagerStaff()",
+      "norm_label": "ismanagerstaff()",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
+      "source_location": "L138"
+    },
+    {
+      "community": 48,
+      "file_type": "code",
+      "id": "transactionview_requestcorrectionsubmit",
+      "label": "requestCorrectionSubmit()",
+      "norm_label": "requestcorrectionsubmit()",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
+      "source_location": "L578"
+    },
+    {
+      "community": 48,
+      "file_type": "code",
+      "id": "transactionview_requiresinlinemanagerproof",
+      "label": "requiresInlineManagerProof()",
+      "norm_label": "requiresinlinemanagerproof()",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
+      "source_location": "L125"
+    },
+    {
+      "community": 48,
+      "file_type": "code",
+      "id": "transactionview_runcustomercorrection",
+      "label": "runCustomerCorrection()",
+      "norm_label": "runcustomercorrection()",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
+      "source_location": "L449"
+    },
+    {
+      "community": 48,
+      "file_type": "code",
+      "id": "transactionview_runpaymentmethodcorrection",
+      "label": "runPaymentMethodCorrection()",
+      "norm_label": "runpaymentmethodcorrection()",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
+      "source_location": "L487"
     },
     {
       "community": 480,
@@ -91683,145 +92028,145 @@
     {
       "community": 49,
       "file_type": "code",
-      "id": "harness_audit_addgroupederror",
-      "label": "addGroupedError()",
-      "norm_label": "addgroupederror()",
-      "source_file": "scripts/harness-audit.ts",
-      "source_location": "L102"
+      "id": "checkoutsession_checkoutsessionerror",
+      "label": "CheckoutSessionError",
+      "norm_label": "checkoutsessionerror",
+      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
+      "source_location": "L64"
     },
     {
       "community": 49,
       "file_type": "code",
-      "id": "harness_audit_collectlivesurfaceentries",
-      "label": "collectLiveSurfaceEntries()",
-      "norm_label": "collectlivesurfaceentries()",
-      "source_file": "scripts/harness-audit.ts",
-      "source_location": "L145"
+      "id": "checkoutsession_checkoutsessionerror_constructor",
+      "label": ".constructor()",
+      "norm_label": ".constructor()",
+      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
+      "source_location": "L69"
     },
     {
       "community": 49,
       "file_type": "code",
-      "id": "harness_audit_fileexists",
-      "label": "fileExists()",
-      "norm_label": "fileexists()",
-      "source_file": "scripts/harness-audit.ts",
-      "source_location": "L57"
+      "id": "checkoutsession_createcheckoutsession",
+      "label": "createCheckoutSession()",
+      "norm_label": "createcheckoutsession()",
+      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
+      "source_location": "L184"
     },
     {
       "community": 49,
       "file_type": "code",
-      "id": "harness_audit_formatgroupederrors",
-      "label": "formatGroupedErrors()",
-      "norm_label": "formatgroupederrors()",
-      "source_file": "scripts/harness-audit.ts",
-      "source_location": "L351"
+      "id": "checkoutsession_defaultcheckoutactionmessage",
+      "label": "defaultCheckoutActionMessage()",
+      "norm_label": "defaultcheckoutactionmessage()",
+      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
+      "source_location": "L135"
     },
     {
       "community": 49,
       "file_type": "code",
-      "id": "harness_audit_formatmissingvalidationpatherror",
-      "label": "formatMissingValidationPathError()",
-      "norm_label": "formatmissingvalidationpatherror()",
-      "source_file": "scripts/harness-audit.ts",
-      "source_location": "L116"
+      "id": "checkoutsession_getactivecheckoutsession",
+      "label": "getActiveCheckoutSession()",
+      "norm_label": "getactivecheckoutsession()",
+      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
+      "source_location": "L204"
     },
     {
       "community": 49,
       "file_type": "code",
-      "id": "harness_audit_hasanyharnessdocs",
-      "label": "hasAnyHarnessDocs()",
-      "norm_label": "hasanyharnessdocs()",
-      "source_file": "scripts/harness-audit.ts",
-      "source_location": "L66"
+      "id": "checkoutsession_getbaseurl",
+      "label": "getBaseUrl()",
+      "norm_label": "getbaseurl()",
+      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
+      "source_location": "L5"
     },
     {
       "community": 49,
       "file_type": "code",
-      "id": "harness_audit_infergroupfromerror",
-      "label": "inferGroupFromError()",
-      "norm_label": "infergroupfromerror()",
-      "source_file": "scripts/harness-audit.ts",
-      "source_location": "L126"
+      "id": "checkoutsession_getcheckoutactionerrormessage",
+      "label": "getCheckoutActionErrorMessage()",
+      "norm_label": "getcheckoutactionerrormessage()",
+      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
+      "source_location": "L147"
     },
     {
       "community": 49,
       "file_type": "code",
-      "id": "harness_audit_loadaudittarget",
-      "label": "loadAuditTarget()",
-      "norm_label": "loadaudittarget()",
-      "source_file": "scripts/harness-audit.ts",
-      "source_location": "L174"
-    },
-    {
-      "community": 49,
-      "file_type": "code",
-      "id": "harness_audit_matchespathprefix",
-      "label": "matchesPathPrefix()",
-      "norm_label": "matchespathprefix()",
-      "source_file": "scripts/harness-audit.ts",
-      "source_location": "L43"
-    },
-    {
-      "community": 49,
-      "file_type": "code",
-      "id": "harness_audit_normalizebehaviorscenarioname",
-      "label": "normalizeBehaviorScenarioName()",
-      "norm_label": "normalizebehaviorscenarioname()",
-      "source_file": "scripts/harness-audit.ts",
+      "id": "checkoutsession_getcheckouterrormessagefrompayload",
+      "label": "getCheckoutErrorMessageFromPayload()",
+      "norm_label": "getcheckouterrormessagefrompayload()",
+      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L98"
     },
     {
       "community": 49,
       "file_type": "code",
-      "id": "harness_audit_normalizerepopath",
-      "label": "normalizeRepoPath()",
-      "norm_label": "normalizerepopath()",
-      "source_file": "scripts/harness-audit.ts",
-      "source_location": "L39"
+      "id": "checkoutsession_getcheckoutsession",
+      "label": "getCheckoutSession()",
+      "norm_label": "getcheckoutsession()",
+      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
+      "source_location": "L226"
     },
     {
       "community": 49,
       "file_type": "code",
-      "id": "harness_audit_normalizevalidationcommand",
-      "label": "normalizeValidationCommand()",
-      "norm_label": "normalizevalidationcommand()",
-      "source_file": "scripts/harness-audit.ts",
-      "source_location": "L90"
+      "id": "checkoutsession_getpendingcheckoutsessions",
+      "label": "getPendingCheckoutSessions()",
+      "norm_label": "getpendingcheckoutsessions()",
+      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
+      "source_location": "L215"
     },
     {
       "community": 49,
       "file_type": "code",
-      "id": "harness_audit_readjsonfile",
-      "label": "readJsonFile()",
-      "norm_label": "readjsonfile()",
-      "source_file": "scripts/harness-audit.ts",
-      "source_location": "L86"
+      "id": "checkoutsession_isrecord",
+      "label": "isRecord()",
+      "norm_label": "isrecord()",
+      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
+      "source_location": "L78"
     },
     {
       "community": 49,
       "file_type": "code",
-      "id": "harness_audit_runharnessaudit",
-      "label": "runHarnessAudit()",
-      "norm_label": "runharnessaudit()",
-      "source_file": "scripts/harness-audit.ts",
-      "source_location": "L366"
+      "id": "checkoutsession_parsecheckoutresponse",
+      "label": "parseCheckoutResponse()",
+      "norm_label": "parsecheckoutresponse()",
+      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
+      "source_location": "L115"
     },
     {
       "community": 49,
       "file_type": "code",
-      "id": "harness_audit_shouldskipsurfaceentry",
-      "label": "shouldSkipSurfaceEntry()",
-      "norm_label": "shouldskipsurfaceentry()",
-      "source_file": "scripts/harness-audit.ts",
-      "source_location": "L131"
+      "id": "checkoutsession_parsejson",
+      "label": "parseJson()",
+      "norm_label": "parsejson()",
+      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
+      "source_location": "L81"
     },
     {
       "community": 49,
       "file_type": "code",
-      "id": "scripts_harness_audit_ts",
-      "label": "harness-audit.ts",
-      "norm_label": "harness-audit.ts",
-      "source_file": "scripts/harness-audit.ts",
+      "id": "checkoutsession_updatecheckoutsession",
+      "label": "updateCheckoutSession()",
+      "norm_label": "updatecheckoutsession()",
+      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
+      "source_location": "L239"
+    },
+    {
+      "community": 49,
+      "file_type": "code",
+      "id": "checkoutsession_verifycheckoutsessionpayment",
+      "label": "verifyCheckoutSessionPayment()",
+      "norm_label": "verifycheckoutsessionpayment()",
+      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
+      "source_location": "L274"
+    },
+    {
+      "community": 49,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_api_checkoutsession_ts",
+      "label": "checkoutSession.ts",
+      "norm_label": "checkoutsession.ts",
+      "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L1"
     },
     {
@@ -92358,136 +92703,145 @@
     {
       "community": 50,
       "file_type": "code",
-      "id": "correcttransaction_adjustregistersessionexpectedcashforpaymentcorrection",
-      "label": "adjustRegisterSessionExpectedCashForPaymentCorrection()",
-      "norm_label": "adjustregistersessionexpectedcashforpaymentcorrection()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
-      "source_location": "L207"
+      "id": "harness_audit_addgroupederror",
+      "label": "addGroupedError()",
+      "norm_label": "addgroupederror()",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L102"
     },
     {
       "community": 50,
       "file_type": "code",
-      "id": "correcttransaction_applypaymentmethodcorrection",
-      "label": "applyPaymentMethodCorrection()",
-      "norm_label": "applypaymentmethodcorrection()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
-      "source_location": "L284"
+      "id": "harness_audit_collectlivesurfaceentries",
+      "label": "collectLiveSurfaceEntries()",
+      "norm_label": "collectlivesurfaceentries()",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L145"
     },
     {
       "community": 50,
       "file_type": "code",
-      "id": "correcttransaction_buildpaymentmethodcorrectionapprovalrequirement",
-      "label": "buildPaymentMethodCorrectionApprovalRequirement()",
-      "norm_label": "buildpaymentmethodcorrectionapprovalrequirement()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
-      "source_location": "L36"
+      "id": "harness_audit_fileexists",
+      "label": "fileExists()",
+      "norm_label": "fileexists()",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L57"
     },
     {
       "community": 50,
       "file_type": "code",
-      "id": "correcttransaction_consumepaymentmethodcorrectionapprovalproof",
-      "label": "consumePaymentMethodCorrectionApprovalProof()",
-      "norm_label": "consumepaymentmethodcorrectionapprovalproof()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
-      "source_location": "L253"
+      "id": "harness_audit_formatgroupederrors",
+      "label": "formatGroupedErrors()",
+      "norm_label": "formatgroupederrors()",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L351"
     },
     {
       "community": 50,
       "file_type": "code",
-      "id": "correcttransaction_correcttransactioncustomer",
-      "label": "correctTransactionCustomer()",
-      "norm_label": "correcttransactioncustomer()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
-      "source_location": "L376"
+      "id": "harness_audit_formatmissingvalidationpatherror",
+      "label": "formatMissingValidationPathError()",
+      "norm_label": "formatmissingvalidationpatherror()",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L116"
     },
     {
       "community": 50,
       "file_type": "code",
-      "id": "correcttransaction_correcttransactionpaymentmethod",
-      "label": "correctTransactionPaymentMethod()",
-      "norm_label": "correcttransactionpaymentmethod()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
-      "source_location": "L438"
+      "id": "harness_audit_hasanyharnessdocs",
+      "label": "hasAnyHarnessDocs()",
+      "norm_label": "hasanyharnessdocs()",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L66"
     },
     {
       "community": 50,
       "file_type": "code",
-      "id": "correcttransaction_createpaymentmethodcorrectionapprovalrequest",
-      "label": "createPaymentMethodCorrectionApprovalRequest()",
-      "norm_label": "createpaymentmethodcorrectionapprovalrequest()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
-      "source_location": "L85"
+      "id": "harness_audit_infergroupfromerror",
+      "label": "inferGroupFromError()",
+      "norm_label": "infergroupfromerror()",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L126"
     },
     {
       "community": 50,
       "file_type": "code",
-      "id": "correcttransaction_getpaymentmethodcashcontribution",
-      "label": "getPaymentMethodCashContribution()",
-      "norm_label": "getpaymentmethodcashcontribution()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
-      "source_location": "L172"
+      "id": "harness_audit_loadaudittarget",
+      "label": "loadAuditTarget()",
+      "norm_label": "loadaudittarget()",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L174"
     },
     {
       "community": 50,
       "file_type": "code",
-      "id": "correcttransaction_getstringmetadata",
-      "label": "getStringMetadata()",
-      "norm_label": "getstringmetadata()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
-      "source_location": "L565"
+      "id": "harness_audit_matchespathprefix",
+      "label": "matchesPathPrefix()",
+      "norm_label": "matchespathprefix()",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L43"
     },
     {
       "community": 50,
       "file_type": "code",
-      "id": "correcttransaction_requirecompletedtransaction",
-      "label": "requireCompletedTransaction()",
-      "norm_label": "requirecompletedtransaction()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
-      "source_location": "L155"
+      "id": "harness_audit_normalizebehaviorscenarioname",
+      "label": "normalizeBehaviorScenarioName()",
+      "norm_label": "normalizebehaviorscenarioname()",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L98"
     },
     {
       "community": 50,
       "file_type": "code",
-      "id": "correcttransaction_requirematchingpendingpaymentmethodcorrectionapprovalrequest",
-      "label": "requireMatchingPendingPaymentMethodCorrectionApprovalRequest()",
-      "norm_label": "requirematchingpendingpaymentmethodcorrectionapprovalrequest()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
-      "source_location": "L573"
+      "id": "harness_audit_normalizerepopath",
+      "label": "normalizeRepoPath()",
+      "norm_label": "normalizerepopath()",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L39"
     },
     {
       "community": 50,
       "file_type": "code",
-      "id": "correcttransaction_requireregistersessionallowspaymentcorrection",
-      "label": "requireRegisterSessionAllowsPaymentCorrection()",
-      "norm_label": "requireregistersessionallowspaymentcorrection()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
-      "source_location": "L182"
+      "id": "harness_audit_normalizevalidationcommand",
+      "label": "normalizeValidationCommand()",
+      "norm_label": "normalizevalidationcommand()",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L90"
     },
     {
       "community": 50,
       "file_type": "code",
-      "id": "correcttransaction_resolvepaymentmethodcorrectionapprovaldecisionwithctx",
-      "label": "resolvePaymentMethodCorrectionApprovalDecisionWithCtx()",
-      "norm_label": "resolvepaymentmethodcorrectionapprovaldecisionwithctx()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
-      "source_location": "L634"
+      "id": "harness_audit_readjsonfile",
+      "label": "readJsonFile()",
+      "norm_label": "readjsonfile()",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L86"
     },
     {
       "community": 50,
       "file_type": "code",
-      "id": "correcttransaction_transactionlabel",
-      "label": "transactionLabel()",
-      "norm_label": "transactionlabel()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
-      "source_location": "L32"
+      "id": "harness_audit_runharnessaudit",
+      "label": "runHarnessAudit()",
+      "norm_label": "runharnessaudit()",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L366"
     },
     {
       "community": 50,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_commands_correcttransaction_ts",
-      "label": "correctTransaction.ts",
-      "norm_label": "correcttransaction.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
+      "id": "harness_audit_shouldskipsurfaceentry",
+      "label": "shouldSkipSurfaceEntry()",
+      "norm_label": "shouldskipsurfaceentry()",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L131"
+    },
+    {
+      "community": 50,
+      "file_type": "code",
+      "id": "scripts_harness_audit_ts",
+      "label": "harness-audit.ts",
+      "norm_label": "harness-audit.ts",
+      "source_file": "scripts/harness-audit.ts",
       "source_location": "L1"
     },
     {
@@ -92673,137 +93027,137 @@
     {
       "community": 51,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_helpers_paymenthelpers_ts",
-      "label": "paymentHelpers.ts",
-      "norm_label": "paymenthelpers.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 51,
-      "file_type": "code",
-      "id": "paymenthelpers_buildserverpricedcheckoutproducts",
-      "label": "buildServerPricedCheckoutProducts()",
-      "norm_label": "buildserverpricedcheckoutproducts()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
-      "source_location": "L43"
-    },
-    {
-      "community": 51,
-      "file_type": "code",
-      "id": "paymenthelpers_calculateitemssubtotal",
-      "label": "calculateItemsSubtotal()",
-      "norm_label": "calculateitemssubtotal()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
-      "source_location": "L35"
-    },
-    {
-      "community": 51,
-      "file_type": "code",
-      "id": "paymenthelpers_calculateorderamount",
-      "label": "calculateOrderAmount()",
-      "norm_label": "calculateorderamount()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
-      "source_location": "L266"
-    },
-    {
-      "community": 51,
-      "file_type": "code",
-      "id": "paymenthelpers_calculaterewardpoints",
-      "label": "calculateRewardPoints()",
-      "norm_label": "calculaterewardpoints()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
-      "source_location": "L286"
-    },
-    {
-      "community": 51,
-      "file_type": "code",
-      "id": "paymenthelpers_derivedeliveryoptionfromaddress",
-      "label": "deriveDeliveryOptionFromAddress()",
-      "norm_label": "derivedeliveryoptionfromaddress()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
-      "source_location": "L92"
-    },
-    {
-      "community": 51,
-      "file_type": "code",
-      "id": "paymenthelpers_extractorderitems",
-      "label": "extractOrderItems()",
-      "norm_label": "extractorderitems()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
-      "source_location": "L249"
-    },
-    {
-      "community": 51,
-      "file_type": "code",
-      "id": "paymenthelpers_generatepodreference",
-      "label": "generatePODReference()",
-      "norm_label": "generatepodreference()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
-      "source_location": "L240"
-    },
-    {
-      "community": 51,
-      "file_type": "code",
-      "id": "paymenthelpers_getorderdiscountvalue",
-      "label": "getOrderDiscountValue()",
-      "norm_label": "getorderdiscountvalue()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
-      "source_location": "L308"
-    },
-    {
-      "community": 51,
-      "file_type": "code",
-      "id": "paymenthelpers_getremainingrefundablebalance",
-      "label": "getRemainingRefundableBalance()",
-      "norm_label": "getremainingrefundablebalance()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
+      "id": "correcttransaction_adjustregistersessionexpectedcashforpaymentcorrection",
+      "label": "adjustRegisterSessionExpectedCashForPaymentCorrection()",
+      "norm_label": "adjustregistersessionexpectedcashforpaymentcorrection()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
       "source_location": "L207"
     },
     {
       "community": 51,
       "file_type": "code",
-      "id": "paymenthelpers_isdeliveryfeewaived",
-      "label": "isDeliveryFeeWaived()",
-      "norm_label": "isdeliveryfeewaived()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
-      "source_location": "L110"
+      "id": "correcttransaction_applypaymentmethodcorrection",
+      "label": "applyPaymentMethodCorrection()",
+      "norm_label": "applypaymentmethodcorrection()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
+      "source_location": "L284"
     },
     {
       "community": 51,
       "file_type": "code",
-      "id": "paymenthelpers_normalizedeliveryoption",
-      "label": "normalizeDeliveryOption()",
-      "norm_label": "normalizedeliveryoption()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
-      "source_location": "L80"
+      "id": "correcttransaction_buildpaymentmethodcorrectionapprovalrequirement",
+      "label": "buildPaymentMethodCorrectionApprovalRequirement()",
+      "norm_label": "buildpaymentmethodcorrectionapprovalrequirement()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
+      "source_location": "L36"
     },
     {
       "community": 51,
       "file_type": "code",
-      "id": "paymenthelpers_resolverefundamount",
-      "label": "resolveRefundAmount()",
-      "norm_label": "resolverefundamount()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
-      "source_location": "L218"
+      "id": "correcttransaction_consumepaymentmethodcorrectionapprovalproof",
+      "label": "consumePaymentMethodCorrectionApprovalProof()",
+      "norm_label": "consumepaymentmethodcorrectionapprovalproof()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
+      "source_location": "L253"
     },
     {
       "community": 51,
       "file_type": "code",
-      "id": "paymenthelpers_resolveserverdeliveryfee",
-      "label": "resolveServerDeliveryFee()",
-      "norm_label": "resolveserverdeliveryfee()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
-      "source_location": "L151"
+      "id": "correcttransaction_correcttransactioncustomer",
+      "label": "correctTransactionCustomer()",
+      "norm_label": "correcttransactioncustomer()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
+      "source_location": "L376"
     },
     {
       "community": 51,
       "file_type": "code",
-      "id": "paymenthelpers_validatepaymentamount",
-      "label": "validatePaymentAmount()",
-      "norm_label": "validatepaymentamount()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
-      "source_location": "L294"
+      "id": "correcttransaction_correcttransactionpaymentmethod",
+      "label": "correctTransactionPaymentMethod()",
+      "norm_label": "correcttransactionpaymentmethod()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
+      "source_location": "L438"
+    },
+    {
+      "community": 51,
+      "file_type": "code",
+      "id": "correcttransaction_createpaymentmethodcorrectionapprovalrequest",
+      "label": "createPaymentMethodCorrectionApprovalRequest()",
+      "norm_label": "createpaymentmethodcorrectionapprovalrequest()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
+      "source_location": "L85"
+    },
+    {
+      "community": 51,
+      "file_type": "code",
+      "id": "correcttransaction_getpaymentmethodcashcontribution",
+      "label": "getPaymentMethodCashContribution()",
+      "norm_label": "getpaymentmethodcashcontribution()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
+      "source_location": "L172"
+    },
+    {
+      "community": 51,
+      "file_type": "code",
+      "id": "correcttransaction_getstringmetadata",
+      "label": "getStringMetadata()",
+      "norm_label": "getstringmetadata()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
+      "source_location": "L565"
+    },
+    {
+      "community": 51,
+      "file_type": "code",
+      "id": "correcttransaction_requirecompletedtransaction",
+      "label": "requireCompletedTransaction()",
+      "norm_label": "requirecompletedtransaction()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
+      "source_location": "L155"
+    },
+    {
+      "community": 51,
+      "file_type": "code",
+      "id": "correcttransaction_requirematchingpendingpaymentmethodcorrectionapprovalrequest",
+      "label": "requireMatchingPendingPaymentMethodCorrectionApprovalRequest()",
+      "norm_label": "requirematchingpendingpaymentmethodcorrectionapprovalrequest()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
+      "source_location": "L573"
+    },
+    {
+      "community": 51,
+      "file_type": "code",
+      "id": "correcttransaction_requireregistersessionallowspaymentcorrection",
+      "label": "requireRegisterSessionAllowsPaymentCorrection()",
+      "norm_label": "requireregistersessionallowspaymentcorrection()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
+      "source_location": "L182"
+    },
+    {
+      "community": 51,
+      "file_type": "code",
+      "id": "correcttransaction_resolvepaymentmethodcorrectionapprovaldecisionwithctx",
+      "label": "resolvePaymentMethodCorrectionApprovalDecisionWithCtx()",
+      "norm_label": "resolvepaymentmethodcorrectionapprovaldecisionwithctx()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
+      "source_location": "L634"
+    },
+    {
+      "community": 51,
+      "file_type": "code",
+      "id": "correcttransaction_transactionlabel",
+      "label": "transactionLabel()",
+      "norm_label": "transactionlabel()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
+      "source_location": "L32"
+    },
+    {
+      "community": 51,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_commands_correcttransaction_ts",
+      "label": "correctTransaction.ts",
+      "norm_label": "correcttransaction.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
+      "source_location": "L1"
     },
     {
       "community": 510,
@@ -92974,7 +93328,7 @@
       "label": "consumeCommandApprovalProofWithCtx()",
       "norm_label": "consumecommandapprovalproofwithctx()",
       "source_file": "packages/athena-webapp/convex/operations/approvalActions.ts",
-      "source_location": "L46"
+      "source_location": "L50"
     },
     {
       "community": 519,
@@ -92988,137 +93342,137 @@
     {
       "community": 52,
       "file_type": "code",
-      "id": "dailyclosehistoryview_cn",
-      "label": "cn()",
-      "norm_label": "cn()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx",
-      "source_location": "L373"
-    },
-    {
-      "community": 52,
-      "file_type": "code",
-      "id": "dailyclosehistoryview_dailyclosehistoryapipendingview",
-      "label": "DailyCloseHistoryApiPendingView()",
-      "norm_label": "dailyclosehistoryapipendingview()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx",
-      "source_location": "L208"
-    },
-    {
-      "community": 52,
-      "file_type": "code",
-      "id": "dailyclosehistoryview_dailyclosehistoryview",
-      "label": "DailyCloseHistoryView()",
-      "norm_label": "dailyclosehistoryview()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx",
-      "source_location": "L228"
-    },
-    {
-      "community": 52,
-      "file_type": "code",
-      "id": "dailyclosehistoryview_formatcount",
-      "label": "formatCount()",
-      "norm_label": "formatcount()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx",
-      "source_location": "L195"
-    },
-    {
-      "community": 52,
-      "file_type": "code",
-      "id": "dailyclosehistoryview_getdailyclosehistoryapi",
-      "label": "getDailyCloseHistoryApi()",
-      "norm_label": "getdailyclosehistoryapi()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx",
-      "source_location": "L96"
-    },
-    {
-      "community": 52,
-      "file_type": "code",
-      "id": "dailyclosehistoryview_gethistoryrecordcompletedat",
-      "label": "getHistoryRecordCompletedAt()",
-      "norm_label": "gethistoryrecordcompletedat()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx",
-      "source_location": "L129"
-    },
-    {
-      "community": 52,
-      "file_type": "code",
-      "id": "dailyclosehistoryview_gethistoryrecordcompletedby",
-      "label": "getHistoryRecordCompletedBy()",
-      "norm_label": "gethistoryrecordcompletedby()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx",
-      "source_location": "L133"
-    },
-    {
-      "community": 52,
-      "file_type": "code",
-      "id": "dailyclosehistoryview_gethistoryrecordid",
-      "label": "getHistoryRecordId()",
-      "norm_label": "gethistoryrecordid()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx",
-      "source_location": "L117"
-    },
-    {
-      "community": 52,
-      "file_type": "code",
-      "id": "dailyclosehistoryview_gethistoryrecords",
-      "label": "getHistoryRecords()",
-      "norm_label": "gethistoryrecords()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx",
-      "source_location": "L106"
-    },
-    {
-      "community": 52,
-      "file_type": "code",
-      "id": "dailyclosehistoryview_gethistoryrecordsnapshot",
-      "label": "getHistoryRecordSnapshot()",
-      "norm_label": "gethistoryrecordsnapshot()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx",
-      "source_location": "L177"
-    },
-    {
-      "community": 52,
-      "file_type": "code",
-      "id": "dailyclosehistoryview_gethistoryrecordsummary",
-      "label": "getHistoryRecordSummary()",
-      "norm_label": "gethistoryrecordsummary()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx",
-      "source_location": "L141"
-    },
-    {
-      "community": 52,
-      "file_type": "code",
-      "id": "dailyclosehistoryview_iscompletedhistoryrecord",
-      "label": "isCompletedHistoryRecord()",
-      "norm_label": "iscompletedhistoryrecord()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx",
-      "source_location": "L123"
-    },
-    {
-      "community": 52,
-      "file_type": "code",
-      "id": "dailyclosehistoryview_normalizehistorysnapshot",
-      "label": "normalizeHistorySnapshot()",
-      "norm_label": "normalizehistorysnapshot()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx",
-      "source_location": "L145"
-    },
-    {
-      "community": 52,
-      "file_type": "code",
-      "id": "dailyclosehistoryview_sortnewestfirst",
-      "label": "sortNewestFirst()",
-      "norm_label": "sortnewestfirst()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx",
-      "source_location": "L201"
-    },
-    {
-      "community": 52,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_operations_dailyclosehistoryview_tsx",
-      "label": "DailyCloseHistoryView.tsx",
-      "norm_label": "dailyclosehistoryview.tsx",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx",
+      "id": "packages_athena_webapp_convex_storefront_helpers_paymenthelpers_ts",
+      "label": "paymentHelpers.ts",
+      "norm_label": "paymenthelpers.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 52,
+      "file_type": "code",
+      "id": "paymenthelpers_buildserverpricedcheckoutproducts",
+      "label": "buildServerPricedCheckoutProducts()",
+      "norm_label": "buildserverpricedcheckoutproducts()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
+      "source_location": "L43"
+    },
+    {
+      "community": 52,
+      "file_type": "code",
+      "id": "paymenthelpers_calculateitemssubtotal",
+      "label": "calculateItemsSubtotal()",
+      "norm_label": "calculateitemssubtotal()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
+      "source_location": "L35"
+    },
+    {
+      "community": 52,
+      "file_type": "code",
+      "id": "paymenthelpers_calculateorderamount",
+      "label": "calculateOrderAmount()",
+      "norm_label": "calculateorderamount()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
+      "source_location": "L266"
+    },
+    {
+      "community": 52,
+      "file_type": "code",
+      "id": "paymenthelpers_calculaterewardpoints",
+      "label": "calculateRewardPoints()",
+      "norm_label": "calculaterewardpoints()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
+      "source_location": "L286"
+    },
+    {
+      "community": 52,
+      "file_type": "code",
+      "id": "paymenthelpers_derivedeliveryoptionfromaddress",
+      "label": "deriveDeliveryOptionFromAddress()",
+      "norm_label": "derivedeliveryoptionfromaddress()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
+      "source_location": "L92"
+    },
+    {
+      "community": 52,
+      "file_type": "code",
+      "id": "paymenthelpers_extractorderitems",
+      "label": "extractOrderItems()",
+      "norm_label": "extractorderitems()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
+      "source_location": "L249"
+    },
+    {
+      "community": 52,
+      "file_type": "code",
+      "id": "paymenthelpers_generatepodreference",
+      "label": "generatePODReference()",
+      "norm_label": "generatepodreference()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
+      "source_location": "L240"
+    },
+    {
+      "community": 52,
+      "file_type": "code",
+      "id": "paymenthelpers_getorderdiscountvalue",
+      "label": "getOrderDiscountValue()",
+      "norm_label": "getorderdiscountvalue()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
+      "source_location": "L308"
+    },
+    {
+      "community": 52,
+      "file_type": "code",
+      "id": "paymenthelpers_getremainingrefundablebalance",
+      "label": "getRemainingRefundableBalance()",
+      "norm_label": "getremainingrefundablebalance()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
+      "source_location": "L207"
+    },
+    {
+      "community": 52,
+      "file_type": "code",
+      "id": "paymenthelpers_isdeliveryfeewaived",
+      "label": "isDeliveryFeeWaived()",
+      "norm_label": "isdeliveryfeewaived()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
+      "source_location": "L110"
+    },
+    {
+      "community": 52,
+      "file_type": "code",
+      "id": "paymenthelpers_normalizedeliveryoption",
+      "label": "normalizeDeliveryOption()",
+      "norm_label": "normalizedeliveryoption()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
+      "source_location": "L80"
+    },
+    {
+      "community": 52,
+      "file_type": "code",
+      "id": "paymenthelpers_resolverefundamount",
+      "label": "resolveRefundAmount()",
+      "norm_label": "resolverefundamount()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
+      "source_location": "L218"
+    },
+    {
+      "community": 52,
+      "file_type": "code",
+      "id": "paymenthelpers_resolveserverdeliveryfee",
+      "label": "resolveServerDeliveryFee()",
+      "norm_label": "resolveserverdeliveryfee()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
+      "source_location": "L151"
+    },
+    {
+      "community": 52,
+      "file_type": "code",
+      "id": "paymenthelpers_validatepaymentamount",
+      "label": "validatePaymentAmount()",
+      "norm_label": "validatepaymentamount()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
+      "source_location": "L294"
     },
     {
       "community": 520,
@@ -95463,298 +95817,307 @@
     {
       "community": 6,
       "file_type": "code",
-      "id": "harness_check_collectharnessonboardingerrors",
-      "label": "collectHarnessOnboardingErrors()",
-      "norm_label": "collectharnessonboardingerrors()",
-      "source_file": "scripts/harness-check.ts",
-      "source_location": "L402"
+      "id": "dailyopening_approvalmetadataentries",
+      "label": "approvalMetadataEntries()",
+      "norm_label": "approvalmetadataentries()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
+      "source_location": "L303"
     },
     {
       "community": 6,
       "file_type": "code",
-      "id": "harness_check_collectmarkdownlinkerrors",
-      "label": "collectMarkdownLinkErrors()",
-      "norm_label": "collectmarkdownlinkerrors()",
-      "source_file": "scripts/harness-check.ts",
+      "id": "dailyopening_approvalrequesttypelabel",
+      "label": "approvalRequestTypeLabel()",
+      "norm_label": "approvalrequesttypelabel()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
+      "source_location": "L335"
+    },
+    {
+      "community": 6,
+      "file_type": "code",
+      "id": "dailyopening_builddailyopeningsnapshotwithctx",
+      "label": "buildDailyOpeningSnapshotWithCtx()",
+      "norm_label": "builddailyopeningsnapshotwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
+      "source_location": "L669"
+    },
+    {
+      "community": 6,
+      "file_type": "code",
+      "id": "dailyopening_buildreadiness",
+      "label": "buildReadiness()",
+      "norm_label": "buildreadiness()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
+      "source_location": "L566"
+    },
+    {
+      "community": 6,
+      "file_type": "code",
+      "id": "dailyopening_carryforwarditem",
+      "label": "carryForwardItem()",
+      "norm_label": "carryforwarditem()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
+      "source_location": "L539"
+    },
+    {
+      "community": 6,
+      "file_type": "code",
+      "id": "dailyopening_compactmetadataentries",
+      "label": "compactMetadataEntries()",
+      "norm_label": "compactmetadataentries()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
+      "source_location": "L355"
+    },
+    {
+      "community": 6,
+      "file_type": "code",
+      "id": "dailyopening_formatpaymentmethodlabel",
+      "label": "formatPaymentMethodLabel()",
+      "norm_label": "formatpaymentmethodlabel()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
+      "source_location": "L388"
+    },
+    {
+      "community": 6,
+      "file_type": "code",
+      "id": "dailyopening_getdailyopeningfordate",
+      "label": "getDailyOpeningForDate()",
+      "norm_label": "getdailyopeningfordate()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
+      "source_location": "L162"
+    },
+    {
+      "community": 6,
+      "file_type": "code",
+      "id": "dailyopening_getmissingcarryforwarditems",
+      "label": "getMissingCarryForwardItems()",
+      "norm_label": "getmissingcarryforwarditems()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
+      "source_location": "L596"
+    },
+    {
+      "community": 6,
+      "file_type": "code",
+      "id": "dailyopening_getnumbermetadata",
+      "label": "getNumberMetadata()",
+      "norm_label": "getnumbermetadata()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
+      "source_location": "L364"
+    },
+    {
+      "community": 6,
+      "file_type": "code",
+      "id": "dailyopening_getpaymentmethodmetadata",
+      "label": "getPaymentMethodMetadata()",
+      "norm_label": "getpaymentmethodmetadata()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
+      "source_location": "L372"
+    },
+    {
+      "community": 6,
+      "file_type": "code",
+      "id": "dailyopening_getpriordailycloseforopeningreview",
+      "label": "getPriorDailyCloseForOpeningReview()",
+      "norm_label": "getpriordailycloseforopeningreview()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
+      "source_location": "L195"
+    },
+    {
+      "community": 6,
+      "file_type": "code",
+      "id": "dailyopening_getstaffdisplayname",
+      "label": "getStaffDisplayName()",
+      "norm_label": "getstaffdisplayname()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
       "source_location": "L217"
     },
     {
       "community": 6,
       "file_type": "code",
-      "id": "harness_check_collectmissingrequiredlinkerrors",
-      "label": "collectMissingRequiredLinkErrors()",
-      "norm_label": "collectmissingrequiredlinkerrors()",
-      "source_file": "scripts/harness-check.ts",
-      "source_location": "L56"
+      "id": "dailyopening_getstarteddailyopeningfordate",
+      "label": "getStartedDailyOpeningForDate()",
+      "norm_label": "getstarteddailyopeningfordate()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
+      "source_location": "L177"
     },
     {
       "community": 6,
       "file_type": "code",
-      "id": "harness_check_collectpackageguidelinkerrors",
-      "label": "collectPackageGuideLinkErrors()",
-      "norm_label": "collectpackageguidelinkerrors()",
-      "source_file": "scripts/harness-check.ts",
-      "source_location": "L646"
+      "id": "dailyopening_getstore",
+      "label": "getStore()",
+      "norm_label": "getstore()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
+      "source_location": "L155"
     },
     {
       "community": 6,
       "file_type": "code",
-      "id": "harness_check_collectpackagesrouterlinkerrors",
-      "label": "collectPackagesRouterLinkErrors()",
-      "norm_label": "collectpackagesrouterlinkerrors()",
-      "source_file": "scripts/harness-check.ts",
-      "source_location": "L622"
+      "id": "dailyopening_getstringmetadata",
+      "label": "getStringMetadata()",
+      "norm_label": "getstringmetadata()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
+      "source_location": "L380"
     },
     {
       "community": 6,
       "file_type": "code",
-      "id": "harness_check_collectreadmelinkerrors",
-      "label": "collectReadmeLinkErrors()",
-      "norm_label": "collectreadmelinkerrors()",
-      "source_file": "scripts/harness-check.ts",
-      "source_location": "L610"
+      "id": "dailyopening_hydratestartedopening",
+      "label": "hydrateStartedOpening()",
+      "norm_label": "hydratestartedopening()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
+      "source_location": "L227"
     },
     {
       "community": 6,
       "file_type": "code",
-      "id": "harness_check_collectreferencedpatherrors",
-      "label": "collectReferencedPathErrors()",
-      "norm_label": "collectreferencedpatherrors()",
-      "source_file": "scripts/harness-check.ts",
-      "source_location": "L316"
+      "id": "dailyopening_invalidoperatingdateitem",
+      "label": "invalidOperatingDateItem()",
+      "norm_label": "invalidoperatingdateitem()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
+      "source_location": "L423"
     },
     {
       "community": 6,
       "file_type": "code",
-      "id": "harness_check_collectruntimescenariodocsyncerrors",
-      "label": "collectRuntimeScenarioDocSyncErrors()",
-      "norm_label": "collectruntimescenariodocsyncerrors()",
-      "source_file": "scripts/harness-check.ts",
-      "source_location": "L158"
+      "id": "dailyopening_isvalidoperatingdate",
+      "label": "isValidOperatingDate()",
+      "norm_label": "isvalidoperatingdate()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
+      "source_location": "L103"
     },
     {
       "community": 6,
       "file_type": "code",
-      "id": "harness_check_collectservicedocumentedsurfaces",
-      "label": "collectServiceDocumentedSurfaces()",
-      "norm_label": "collectservicedocumentedsurfaces()",
-      "source_file": "scripts/harness-check.ts",
-      "source_location": "L485"
+      "id": "dailyopening_isvalidoperatingdaterange",
+      "label": "isValidOperatingDateRange()",
+      "norm_label": "isvalidoperatingdaterange()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
+      "source_location": "L130"
     },
     {
       "community": 6,
       "file_type": "code",
-      "id": "harness_check_collecttestingdocerrors",
-      "label": "collectTestingDocErrors()",
-      "norm_label": "collecttestingdocerrors()",
-      "source_file": "scripts/harness-check.ts",
-      "source_location": "L557"
+      "id": "dailyopening_listpendingopeningblockerapprovals",
+      "label": "listPendingOpeningBlockerApprovals()",
+      "norm_label": "listpendingopeningblockerapprovals()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
+      "source_location": "L243"
     },
     {
       "community": 6,
       "file_type": "code",
-      "id": "harness_check_collecttestsurfaceroots",
-      "label": "collectTestSurfaceRoots()",
-      "norm_label": "collecttestsurfaceroots()",
-      "source_file": "scripts/harness-check.ts",
-      "source_location": "L510"
+      "id": "dailyopening_missingcarryforwarditem",
+      "label": "missingCarryForwardItem()",
+      "norm_label": "missingcarryforwarditem()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
+      "source_location": "L437"
     },
     {
       "community": 6,
       "file_type": "code",
-      "id": "harness_check_extractinlinecode",
-      "label": "extractInlineCode()",
-      "norm_label": "extractinlinecode()",
-      "source_file": "scripts/harness-check.ts",
-      "source_location": "L246"
+      "id": "dailyopening_missingpriorclosereviewitem",
+      "label": "missingPriorCloseReviewItem()",
+      "norm_label": "missingpriorclosereviewitem()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
+      "source_location": "L394"
     },
     {
       "community": 6,
       "file_type": "code",
-      "id": "harness_check_extractruntimescenariosection",
-      "label": "extractRuntimeScenarioSection()",
-      "norm_label": "extractruntimescenariosection()",
-      "source_file": "scripts/harness-check.ts",
-      "source_location": "L136"
+      "id": "dailyopening_pendingapprovalitem",
+      "label": "pendingApprovalItem()",
+      "norm_label": "pendingapprovalitem()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
+      "source_location": "L262"
     },
     {
       "community": 6,
       "file_type": "code",
-      "id": "harness_check_extracttestscriptfromcommand",
-      "label": "extractTestScriptFromCommand()",
-      "norm_label": "extracttestscriptfromcommand()",
-      "source_file": "scripts/harness-check.ts",
-      "source_location": "L433"
+      "id": "dailyopening_priorclosenotesitem",
+      "label": "priorCloseNotesItem()",
+      "norm_label": "priorclosenotesitem()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
+      "source_location": "L514"
     },
     {
       "community": 6,
       "file_type": "code",
-      "id": "harness_check_fileexists",
-      "label": "fileExists()",
-      "norm_label": "fileexists()",
-      "source_file": "scripts/harness-check.ts",
-      "source_location": "L81"
+      "id": "dailyopening_priorclosereadyitem",
+      "label": "priorCloseReadyItem()",
+      "norm_label": "priorclosereadyitem()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
+      "source_location": "L460"
     },
     {
       "community": 6,
       "file_type": "code",
-      "id": "harness_check_formatscenariolist",
-      "label": "formatScenarioList()",
-      "norm_label": "formatscenariolist()",
-      "source_file": "scripts/harness-check.ts",
-      "source_location": "L123"
+      "id": "dailyopening_priorclosereopeneditem",
+      "label": "priorCloseReopenedItem()",
+      "norm_label": "priorclosereopeneditem()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
+      "source_location": "L486"
     },
     {
       "community": 6,
       "file_type": "code",
-      "id": "harness_check_hasanyharnessdocs",
-      "label": "hasAnyHarnessDocs()",
-      "norm_label": "hasanyharnessdocs()",
-      "source_file": "scripts/harness-check.ts",
-      "source_location": "L90"
+      "id": "dailyopening_resolveopeningactor",
+      "label": "resolveOpeningActor()",
+      "norm_label": "resolveopeningactor()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
+      "source_location": "L612"
     },
     {
       "community": 6,
       "file_type": "code",
-      "id": "harness_check_isenforcedharnessapp",
-      "label": "isEnforcedHarnessApp()",
-      "norm_label": "isenforcedharnessapp()",
-      "source_file": "scripts/harness-check.ts",
-      "source_location": "L106"
+      "id": "dailyopening_resolveoperatingdaterange",
+      "label": "resolveOperatingDateRange()",
+      "norm_label": "resolveoperatingdaterange()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
+      "source_location": "L141"
     },
     {
       "community": 6,
       "file_type": "code",
-      "id": "harness_check_islikelypathreference",
-      "label": "isLikelyPathReference()",
-      "norm_label": "islikelypathreference()",
-      "source_file": "scripts/harness-check.ts",
-      "source_location": "L265"
-    },
-    {
-      "community": 6,
-      "file_type": "code",
-      "id": "harness_check_isrelativelink",
-      "label": "isRelativeLink()",
-      "norm_label": "isrelativelink()",
-      "source_file": "scripts/harness-check.ts",
-      "source_location": "L73"
-    },
-    {
-      "community": 6,
-      "file_type": "code",
-      "id": "harness_check_isruntimescenarioname",
-      "label": "isRuntimeScenarioName()",
-      "norm_label": "isruntimescenarioname()",
-      "source_file": "scripts/harness-check.ts",
-      "source_location": "L127"
-    },
-    {
-      "community": 6,
-      "file_type": "code",
-      "id": "harness_check_listworkspacepackagedirs",
-      "label": "listWorkspacePackageDirs()",
-      "norm_label": "listworkspacepackagedirs()",
-      "source_file": "scripts/harness-check.ts",
-      "source_location": "L379"
-    },
-    {
-      "community": 6,
-      "file_type": "code",
-      "id": "harness_check_normalizepathreference",
-      "label": "normalizePathReference()",
-      "norm_label": "normalizepathreference()",
-      "source_file": "scripts/harness-check.ts",
-      "source_location": "L252"
-    },
-    {
-      "community": 6,
-      "file_type": "code",
-      "id": "harness_check_normalizerepopath",
-      "label": "normalizeRepoPath()",
-      "norm_label": "normalizerepopath()",
-      "source_file": "scripts/harness-check.ts",
-      "source_location": "L40"
-    },
-    {
-      "community": 6,
-      "file_type": "code",
-      "id": "harness_check_readpackageconfig",
-      "label": "readPackageConfig()",
-      "norm_label": "readpackageconfig()",
-      "source_file": "scripts/harness-check.ts",
-      "source_location": "L351"
-    },
-    {
-      "community": 6,
-      "file_type": "code",
-      "id": "harness_check_resolvepathreference",
-      "label": "resolvePathReference()",
-      "norm_label": "resolvepathreference()",
-      "source_file": "scripts/harness-check.ts",
-      "source_location": "L290"
-    },
-    {
-      "community": 6,
-      "file_type": "code",
-      "id": "harness_check_runharnesscheck",
-      "label": "runHarnessCheck()",
-      "norm_label": "runharnesscheck()",
-      "source_file": "scripts/harness-check.ts",
-      "source_location": "L827"
-    },
-    {
-      "community": 6,
-      "file_type": "code",
-      "id": "harness_check_sortuniqueentries",
-      "label": "sortUniqueEntries()",
-      "norm_label": "sortuniqueentries()",
-      "source_file": "scripts/harness-check.ts",
+      "id": "dailyopening_safeoperatingdaterange",
+      "label": "safeOperatingDateRange()",
+      "norm_label": "safeoperatingdaterange()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
       "source_location": "L117"
     },
     {
       "community": 6,
       "file_type": "code",
-      "id": "harness_check_striplinkdecorations",
-      "label": "stripLinkDecorations()",
-      "norm_label": "striplinkdecorations()",
-      "source_file": "scripts/harness-check.ts",
-      "source_location": "L44"
+      "id": "dailyopening_startstoredaywithctx",
+      "label": "startStoreDayWithCtx()",
+      "norm_label": "startstoredaywithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
+      "source_location": "L790"
     },
     {
       "community": 6,
       "file_type": "code",
-      "id": "harness_check_torelativelinktarget",
-      "label": "toRelativeLinkTarget()",
-      "norm_label": "torelativelinktarget()",
-      "source_file": "scripts/harness-check.ts",
-      "source_location": "L48"
+      "id": "dailyopening_trimoptional",
+      "label": "trimOptional()",
+      "norm_label": "trimoptional()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
+      "source_location": "L98"
     },
     {
       "community": 6,
       "file_type": "code",
-      "id": "harness_check_validateharnessdocs",
-      "label": "validateHarnessDocs()",
-      "norm_label": "validateharnessdocs()",
-      "source_file": "scripts/harness-check.ts",
-      "source_location": "L668"
+      "id": "dailyopening_uniquesourcesubjects",
+      "label": "uniqueSourceSubjects()",
+      "norm_label": "uniquesourcesubjects()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
+      "source_location": "L586"
     },
     {
       "community": 6,
       "file_type": "code",
-      "id": "harness_check_walkfiles",
-      "label": "walkFiles()",
-      "norm_label": "walkfiles()",
-      "source_file": "scripts/harness-check.ts",
-      "source_location": "L465"
-    },
-    {
-      "community": 6,
-      "file_type": "code",
-      "id": "scripts_harness_check_ts",
-      "label": "harness-check.ts",
-      "norm_label": "harness-check.ts",
-      "source_file": "scripts/harness-check.ts",
+      "id": "packages_athena_webapp_convex_operations_dailyopening_ts",
+      "label": "dailyOpening.ts",
+      "norm_label": "dailyopening.ts",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
       "source_location": "L1"
     },
     {
@@ -98730,289 +99093,298 @@
     {
       "community": 7,
       "file_type": "code",
-      "id": "dailyopening_approvalmetadataentries",
-      "label": "approvalMetadataEntries()",
-      "norm_label": "approvalmetadataentries()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L281"
+      "id": "harness_check_collectharnessonboardingerrors",
+      "label": "collectHarnessOnboardingErrors()",
+      "norm_label": "collectharnessonboardingerrors()",
+      "source_file": "scripts/harness-check.ts",
+      "source_location": "L402"
     },
     {
       "community": 7,
       "file_type": "code",
-      "id": "dailyopening_approvalrequesttypelabel",
-      "label": "approvalRequestTypeLabel()",
-      "norm_label": "approvalrequesttypelabel()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L313"
+      "id": "harness_check_collectmarkdownlinkerrors",
+      "label": "collectMarkdownLinkErrors()",
+      "norm_label": "collectmarkdownlinkerrors()",
+      "source_file": "scripts/harness-check.ts",
+      "source_location": "L217"
     },
     {
       "community": 7,
       "file_type": "code",
-      "id": "dailyopening_builddailyopeningsnapshotwithctx",
-      "label": "buildDailyOpeningSnapshotWithCtx()",
-      "norm_label": "builddailyopeningsnapshotwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L619"
+      "id": "harness_check_collectmissingrequiredlinkerrors",
+      "label": "collectMissingRequiredLinkErrors()",
+      "norm_label": "collectmissingrequiredlinkerrors()",
+      "source_file": "scripts/harness-check.ts",
+      "source_location": "L56"
     },
     {
       "community": 7,
       "file_type": "code",
-      "id": "dailyopening_buildreadiness",
-      "label": "buildReadiness()",
-      "norm_label": "buildreadiness()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L516"
+      "id": "harness_check_collectpackageguidelinkerrors",
+      "label": "collectPackageGuideLinkErrors()",
+      "norm_label": "collectpackageguidelinkerrors()",
+      "source_file": "scripts/harness-check.ts",
+      "source_location": "L646"
     },
     {
       "community": 7,
       "file_type": "code",
-      "id": "dailyopening_carryforwarditem",
-      "label": "carryForwardItem()",
-      "norm_label": "carryforwarditem()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L489"
+      "id": "harness_check_collectpackagesrouterlinkerrors",
+      "label": "collectPackagesRouterLinkErrors()",
+      "norm_label": "collectpackagesrouterlinkerrors()",
+      "source_file": "scripts/harness-check.ts",
+      "source_location": "L622"
     },
     {
       "community": 7,
       "file_type": "code",
-      "id": "dailyopening_compactmetadataentries",
-      "label": "compactMetadataEntries()",
-      "norm_label": "compactmetadataentries()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L333"
+      "id": "harness_check_collectreadmelinkerrors",
+      "label": "collectReadmeLinkErrors()",
+      "norm_label": "collectreadmelinkerrors()",
+      "source_file": "scripts/harness-check.ts",
+      "source_location": "L610"
     },
     {
       "community": 7,
       "file_type": "code",
-      "id": "dailyopening_formatpaymentmethodlabel",
-      "label": "formatPaymentMethodLabel()",
-      "norm_label": "formatpaymentmethodlabel()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L366"
+      "id": "harness_check_collectreferencedpatherrors",
+      "label": "collectReferencedPathErrors()",
+      "norm_label": "collectreferencedpatherrors()",
+      "source_file": "scripts/harness-check.ts",
+      "source_location": "L316"
     },
     {
       "community": 7,
       "file_type": "code",
-      "id": "dailyopening_getdailyopeningfordate",
-      "label": "getDailyOpeningForDate()",
-      "norm_label": "getdailyopeningfordate()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L162"
+      "id": "harness_check_collectruntimescenariodocsyncerrors",
+      "label": "collectRuntimeScenarioDocSyncErrors()",
+      "norm_label": "collectruntimescenariodocsyncerrors()",
+      "source_file": "scripts/harness-check.ts",
+      "source_location": "L158"
     },
     {
       "community": 7,
       "file_type": "code",
-      "id": "dailyopening_getmissingcarryforwarditems",
-      "label": "getMissingCarryForwardItems()",
-      "norm_label": "getmissingcarryforwarditems()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L546"
+      "id": "harness_check_collectservicedocumentedsurfaces",
+      "label": "collectServiceDocumentedSurfaces()",
+      "norm_label": "collectservicedocumentedsurfaces()",
+      "source_file": "scripts/harness-check.ts",
+      "source_location": "L485"
     },
     {
       "community": 7,
       "file_type": "code",
-      "id": "dailyopening_getnumbermetadata",
-      "label": "getNumberMetadata()",
-      "norm_label": "getnumbermetadata()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L342"
+      "id": "harness_check_collecttestingdocerrors",
+      "label": "collectTestingDocErrors()",
+      "norm_label": "collecttestingdocerrors()",
+      "source_file": "scripts/harness-check.ts",
+      "source_location": "L557"
     },
     {
       "community": 7,
       "file_type": "code",
-      "id": "dailyopening_getpaymentmethodmetadata",
-      "label": "getPaymentMethodMetadata()",
-      "norm_label": "getpaymentmethodmetadata()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L350"
+      "id": "harness_check_collecttestsurfaceroots",
+      "label": "collectTestSurfaceRoots()",
+      "norm_label": "collecttestsurfaceroots()",
+      "source_file": "scripts/harness-check.ts",
+      "source_location": "L510"
     },
     {
       "community": 7,
       "file_type": "code",
-      "id": "dailyopening_getstaffdisplayname",
-      "label": "getStaffDisplayName()",
-      "norm_label": "getstaffdisplayname()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L195"
+      "id": "harness_check_extractinlinecode",
+      "label": "extractInlineCode()",
+      "norm_label": "extractinlinecode()",
+      "source_file": "scripts/harness-check.ts",
+      "source_location": "L246"
     },
     {
       "community": 7,
       "file_type": "code",
-      "id": "dailyopening_getstarteddailyopeningfordate",
-      "label": "getStartedDailyOpeningForDate()",
-      "norm_label": "getstarteddailyopeningfordate()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L177"
+      "id": "harness_check_extractruntimescenariosection",
+      "label": "extractRuntimeScenarioSection()",
+      "norm_label": "extractruntimescenariosection()",
+      "source_file": "scripts/harness-check.ts",
+      "source_location": "L136"
     },
     {
       "community": 7,
       "file_type": "code",
-      "id": "dailyopening_getstore",
-      "label": "getStore()",
-      "norm_label": "getstore()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L155"
+      "id": "harness_check_extracttestscriptfromcommand",
+      "label": "extractTestScriptFromCommand()",
+      "norm_label": "extracttestscriptfromcommand()",
+      "source_file": "scripts/harness-check.ts",
+      "source_location": "L433"
     },
     {
       "community": 7,
       "file_type": "code",
-      "id": "dailyopening_getstringmetadata",
-      "label": "getStringMetadata()",
-      "norm_label": "getstringmetadata()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L358"
+      "id": "harness_check_fileexists",
+      "label": "fileExists()",
+      "norm_label": "fileexists()",
+      "source_file": "scripts/harness-check.ts",
+      "source_location": "L81"
     },
     {
       "community": 7,
       "file_type": "code",
-      "id": "dailyopening_hydratestartedopening",
-      "label": "hydrateStartedOpening()",
-      "norm_label": "hydratestartedopening()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L205"
+      "id": "harness_check_formatscenariolist",
+      "label": "formatScenarioList()",
+      "norm_label": "formatscenariolist()",
+      "source_file": "scripts/harness-check.ts",
+      "source_location": "L123"
     },
     {
       "community": 7,
       "file_type": "code",
-      "id": "dailyopening_invalidoperatingdateitem",
-      "label": "invalidOperatingDateItem()",
-      "norm_label": "invalidoperatingdateitem()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L401"
+      "id": "harness_check_hasanyharnessdocs",
+      "label": "hasAnyHarnessDocs()",
+      "norm_label": "hasanyharnessdocs()",
+      "source_file": "scripts/harness-check.ts",
+      "source_location": "L90"
     },
     {
       "community": 7,
       "file_type": "code",
-      "id": "dailyopening_isvalidoperatingdate",
-      "label": "isValidOperatingDate()",
-      "norm_label": "isvalidoperatingdate()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L103"
+      "id": "harness_check_isenforcedharnessapp",
+      "label": "isEnforcedHarnessApp()",
+      "norm_label": "isenforcedharnessapp()",
+      "source_file": "scripts/harness-check.ts",
+      "source_location": "L106"
     },
     {
       "community": 7,
       "file_type": "code",
-      "id": "dailyopening_isvalidoperatingdaterange",
-      "label": "isValidOperatingDateRange()",
-      "norm_label": "isvalidoperatingdaterange()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L130"
+      "id": "harness_check_islikelypathreference",
+      "label": "isLikelyPathReference()",
+      "norm_label": "islikelypathreference()",
+      "source_file": "scripts/harness-check.ts",
+      "source_location": "L265"
     },
     {
       "community": 7,
       "file_type": "code",
-      "id": "dailyopening_listpendingopeningblockerapprovals",
-      "label": "listPendingOpeningBlockerApprovals()",
-      "norm_label": "listpendingopeningblockerapprovals()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L221"
+      "id": "harness_check_isrelativelink",
+      "label": "isRelativeLink()",
+      "norm_label": "isrelativelink()",
+      "source_file": "scripts/harness-check.ts",
+      "source_location": "L73"
     },
     {
       "community": 7,
       "file_type": "code",
-      "id": "dailyopening_missingcarryforwarditem",
-      "label": "missingCarryForwardItem()",
-      "norm_label": "missingcarryforwarditem()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L415"
+      "id": "harness_check_isruntimescenarioname",
+      "label": "isRuntimeScenarioName()",
+      "norm_label": "isruntimescenarioname()",
+      "source_file": "scripts/harness-check.ts",
+      "source_location": "L127"
     },
     {
       "community": 7,
       "file_type": "code",
-      "id": "dailyopening_missingpriorclosereviewitem",
-      "label": "missingPriorCloseReviewItem()",
-      "norm_label": "missingpriorclosereviewitem()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L372"
+      "id": "harness_check_listworkspacepackagedirs",
+      "label": "listWorkspacePackageDirs()",
+      "norm_label": "listworkspacepackagedirs()",
+      "source_file": "scripts/harness-check.ts",
+      "source_location": "L379"
     },
     {
       "community": 7,
       "file_type": "code",
-      "id": "dailyopening_pendingapprovalitem",
-      "label": "pendingApprovalItem()",
-      "norm_label": "pendingapprovalitem()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L240"
+      "id": "harness_check_normalizepathreference",
+      "label": "normalizePathReference()",
+      "norm_label": "normalizepathreference()",
+      "source_file": "scripts/harness-check.ts",
+      "source_location": "L252"
     },
     {
       "community": 7,
       "file_type": "code",
-      "id": "dailyopening_priorclosenotesitem",
-      "label": "priorCloseNotesItem()",
-      "norm_label": "priorclosenotesitem()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L464"
+      "id": "harness_check_normalizerepopath",
+      "label": "normalizeRepoPath()",
+      "norm_label": "normalizerepopath()",
+      "source_file": "scripts/harness-check.ts",
+      "source_location": "L40"
     },
     {
       "community": 7,
       "file_type": "code",
-      "id": "dailyopening_priorclosereadyitem",
-      "label": "priorCloseReadyItem()",
-      "norm_label": "priorclosereadyitem()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L438"
+      "id": "harness_check_readpackageconfig",
+      "label": "readPackageConfig()",
+      "norm_label": "readpackageconfig()",
+      "source_file": "scripts/harness-check.ts",
+      "source_location": "L351"
     },
     {
       "community": 7,
       "file_type": "code",
-      "id": "dailyopening_resolveopeningactor",
-      "label": "resolveOpeningActor()",
-      "norm_label": "resolveopeningactor()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L562"
+      "id": "harness_check_resolvepathreference",
+      "label": "resolvePathReference()",
+      "norm_label": "resolvepathreference()",
+      "source_file": "scripts/harness-check.ts",
+      "source_location": "L290"
     },
     {
       "community": 7,
       "file_type": "code",
-      "id": "dailyopening_resolveoperatingdaterange",
-      "label": "resolveOperatingDateRange()",
-      "norm_label": "resolveoperatingdaterange()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L141"
+      "id": "harness_check_runharnesscheck",
+      "label": "runHarnessCheck()",
+      "norm_label": "runharnesscheck()",
+      "source_file": "scripts/harness-check.ts",
+      "source_location": "L827"
     },
     {
       "community": 7,
       "file_type": "code",
-      "id": "dailyopening_safeoperatingdaterange",
-      "label": "safeOperatingDateRange()",
-      "norm_label": "safeoperatingdaterange()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
+      "id": "harness_check_sortuniqueentries",
+      "label": "sortUniqueEntries()",
+      "norm_label": "sortuniqueentries()",
+      "source_file": "scripts/harness-check.ts",
       "source_location": "L117"
     },
     {
       "community": 7,
       "file_type": "code",
-      "id": "dailyopening_startstoredaywithctx",
-      "label": "startStoreDayWithCtx()",
-      "norm_label": "startstoredaywithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L733"
+      "id": "harness_check_striplinkdecorations",
+      "label": "stripLinkDecorations()",
+      "norm_label": "striplinkdecorations()",
+      "source_file": "scripts/harness-check.ts",
+      "source_location": "L44"
     },
     {
       "community": 7,
       "file_type": "code",
-      "id": "dailyopening_trimoptional",
-      "label": "trimOptional()",
-      "norm_label": "trimoptional()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L98"
+      "id": "harness_check_torelativelinktarget",
+      "label": "toRelativeLinkTarget()",
+      "norm_label": "torelativelinktarget()",
+      "source_file": "scripts/harness-check.ts",
+      "source_location": "L48"
     },
     {
       "community": 7,
       "file_type": "code",
-      "id": "dailyopening_uniquesourcesubjects",
-      "label": "uniqueSourceSubjects()",
-      "norm_label": "uniquesourcesubjects()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
-      "source_location": "L536"
+      "id": "harness_check_validateharnessdocs",
+      "label": "validateHarnessDocs()",
+      "norm_label": "validateharnessdocs()",
+      "source_file": "scripts/harness-check.ts",
+      "source_location": "L668"
     },
     {
       "community": 7,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_dailyopening_ts",
-      "label": "dailyOpening.ts",
-      "norm_label": "dailyopening.ts",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOpening.ts",
+      "id": "harness_check_walkfiles",
+      "label": "walkFiles()",
+      "norm_label": "walkfiles()",
+      "source_file": "scripts/harness-check.ts",
+      "source_location": "L465"
+    },
+    {
+      "community": 7,
+      "file_type": "code",
+      "id": "scripts_harness_check_ts",
+      "label": "harness-check.ts",
+      "norm_label": "harness-check.ts",
+      "source_file": "scripts/harness-check.ts",
       "source_location": "L1"
     },
     {
@@ -99306,101 +99678,101 @@
     {
       "community": 71,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_utils_ts",
-      "label": "utils.ts",
-      "norm_label": "utils.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/utils.ts",
+      "id": "data_table_toolbar_provider_orderstabletoolbarprovider",
+      "label": "OrdersTableToolbarProvider()",
+      "norm_label": "orderstabletoolbarprovider()",
+      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar-provider.tsx",
+      "source_location": "L16"
+    },
+    {
+      "community": 71,
+      "file_type": "code",
+      "id": "data_table_toolbar_provider_useorderstabletoolbar",
+      "label": "useOrdersTableToolbar()",
+      "norm_label": "useorderstabletoolbar()",
+      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar-provider.tsx",
+      "source_location": "L46"
+    },
+    {
+      "community": 71,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table-toolbar-provider.tsx",
       "source_location": "L1"
     },
     {
       "community": 71,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_utils_ts",
-      "label": "utils.ts",
-      "norm_label": "utils.ts",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "id": "packages_athena_webapp_src_components_analytics_table_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/table/data-table-toolbar-provider.tsx",
       "source_location": "L1"
     },
     {
       "community": 71,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_utils_ts",
-      "label": "utils.ts",
-      "norm_label": "utils.ts",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/assets/assets-table/data-table-toolbar-provider.tsx",
       "source_location": "L1"
     },
     {
       "community": 71,
       "file_type": "code",
-      "id": "utils_formatdeliveryaddress",
-      "label": "formatDeliveryAddress()",
-      "norm_label": "formatdeliveryaddress()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L74"
-    },
-    {
-      "community": 71,
-      "file_type": "code",
-      "id": "utils_getamountpaidfororder",
-      "label": "getAmountPaidForOrder()",
-      "norm_label": "getamountpaidfororder()",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
-      "source_location": "L128"
-    },
-    {
-      "community": 71,
-      "file_type": "code",
-      "id": "utils_getdiscountvalue",
-      "label": "getDiscountValue()",
-      "norm_label": "getdiscountvalue()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L17"
-    },
-    {
-      "community": 71,
-      "file_type": "code",
-      "id": "utils_getorderamount",
-      "label": "getOrderAmount()",
-      "norm_label": "getorderamount()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L51"
-    },
-    {
-      "community": 71,
-      "file_type": "code",
-      "id": "utils_getorderstate",
-      "label": "getOrderState()",
-      "norm_label": "getorderstate()",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "id": "packages_athena_webapp_src_components_base_table_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/base/table/data-table-toolbar-provider.tsx",
       "source_location": "L1"
     },
     {
       "community": 71,
       "file_type": "code",
-      "id": "utils_getpickupactionstate",
-      "label": "getPickupActionState()",
-      "norm_label": "getpickupactionstate()",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
-      "source_location": "L61"
+      "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data-table-toolbar-provider.tsx",
+      "source_location": "L1"
     },
     {
       "community": 71,
       "file_type": "code",
-      "id": "utils_getpotentialpoints",
-      "label": "getPotentialPoints()",
-      "norm_label": "getpotentialpoints()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L107"
+      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table-toolbar-provider.tsx",
+      "source_location": "L1"
     },
     {
       "community": 71,
       "file_type": "code",
-      "id": "utils_getproductdiscountvalue",
-      "label": "getProductDiscountValue()",
-      "norm_label": "getproductdiscountvalue()",
-      "source_file": "packages/athena-webapp/convex/inventory/utils.ts",
-      "source_location": "L75"
+      "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data-table-toolbar-provider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 71,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/table/data-table-toolbar-provider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 71,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_table_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar-provider.tsx",
+      "source_location": "L1"
     },
     {
       "community": 710,
@@ -99585,101 +99957,101 @@
     {
       "community": 72,
       "file_type": "code",
-      "id": "data_table_toolbar_provider_orderstabletoolbarprovider",
-      "label": "OrdersTableToolbarProvider()",
-      "norm_label": "orderstabletoolbarprovider()",
-      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar-provider.tsx",
-      "source_location": "L16"
-    },
-    {
-      "community": 72,
-      "file_type": "code",
-      "id": "data_table_toolbar_provider_useorderstabletoolbar",
-      "label": "useOrdersTableToolbar()",
-      "norm_label": "useorderstabletoolbar()",
-      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar-provider.tsx",
-      "source_location": "L46"
-    },
-    {
-      "community": 72,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table-toolbar-provider.tsx",
+      "id": "packages_athena_webapp_src_components_pos_register_registercustomerattribution_tsx",
+      "label": "RegisterCustomerAttribution.tsx",
+      "norm_label": "registercustomerattribution.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
       "source_location": "L1"
     },
     {
       "community": 72,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_table_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/table/data-table-toolbar-provider.tsx",
-      "source_location": "L1"
+      "id": "registercustomerattribution_buildcustomercreateinput",
+      "label": "buildCustomerCreateInput()",
+      "norm_label": "buildcustomercreateinput()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
+      "source_location": "L48"
     },
     {
       "community": 72,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/assets/assets-table/data-table-toolbar-provider.tsx",
-      "source_location": "L1"
+      "id": "registercustomerattribution_cancelpendingadd",
+      "label": "cancelPendingAdd()",
+      "norm_label": "cancelpendingadd()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
+      "source_location": "L122"
     },
     {
       "community": 72,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_base_table_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/base/table/data-table-toolbar-provider.tsx",
-      "source_location": "L1"
+      "id": "registercustomerattribution_cn",
+      "label": "cn()",
+      "norm_label": "cn()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
+      "source_location": "L363"
     },
     {
       "community": 72,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data-table-toolbar-provider.tsx",
-      "source_location": "L1"
+      "id": "registercustomerattribution_commitcustomer",
+      "label": "commitCustomer()",
+      "norm_label": "commitcustomer()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
+      "source_location": "L127"
     },
     {
       "community": 72,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table-toolbar-provider.tsx",
-      "source_location": "L1"
+      "id": "registercustomerattribution_getsecondaryidentifier",
+      "label": "getSecondaryIdentifier()",
+      "norm_label": "getsecondaryidentifier()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
+      "source_location": "L75"
     },
     {
       "community": 72,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data-table-toolbar-provider.tsx",
-      "source_location": "L1"
+      "id": "registercustomerattribution_handleaddfromsearch",
+      "label": "handleAddFromSearch()",
+      "norm_label": "handleaddfromsearch()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
+      "source_location": "L156"
     },
     {
       "community": 72,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/table/data-table-toolbar-provider.tsx",
-      "source_location": "L1"
+      "id": "registercustomerattribution_handleclearcustomer",
+      "label": "handleClearCustomer()",
+      "norm_label": "handleclearcustomer()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
+      "source_location": "L144"
     },
     {
       "community": 72,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_table_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar-provider.tsx",
-      "source_location": "L1"
+      "id": "registercustomerattribution_handleselectcustomer",
+      "label": "handleSelectCustomer()",
+      "norm_label": "handleselectcustomer()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
+      "source_location": "L132"
+    },
+    {
+      "community": 72,
+      "file_type": "code",
+      "id": "registercustomerattribution_tocustomerinfo",
+      "label": "toCustomerInfo()",
+      "norm_label": "tocustomerinfo()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
+      "source_location": "L79"
+    },
+    {
+      "community": 72,
+      "file_type": "code",
+      "id": "registercustomerattribution_trimcustomerinfo",
+      "label": "trimCustomerInfo()",
+      "norm_label": "trimcustomerinfo()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
+      "source_location": "L39"
     },
     {
       "community": 720,
@@ -99864,101 +100236,101 @@
     {
       "community": 73,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_register_registercustomerattribution_tsx",
-      "label": "RegisterCustomerAttribution.tsx",
-      "norm_label": "registercustomerattribution.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
+      "id": "packages_athena_webapp_src_components_services_servicecatalogview_tsx",
+      "label": "ServiceCatalogView.tsx",
+      "norm_label": "servicecatalogview.tsx",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
       "source_location": "L1"
     },
     {
       "community": 73,
       "file_type": "code",
-      "id": "registercustomerattribution_buildcustomercreateinput",
-      "label": "buildCustomerCreateInput()",
-      "norm_label": "buildcustomercreateinput()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
-      "source_location": "L48"
-    },
-    {
-      "community": 73,
-      "file_type": "code",
-      "id": "registercustomerattribution_cancelpendingadd",
-      "label": "cancelPendingAdd()",
-      "norm_label": "cancelpendingadd()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
-      "source_location": "L122"
-    },
-    {
-      "community": 73,
-      "file_type": "code",
-      "id": "registercustomerattribution_cn",
+      "id": "servicecatalogview_cn",
       "label": "cn()",
       "norm_label": "cn()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
-      "source_location": "L363"
+      "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
+      "source_location": "L620"
     },
     {
       "community": 73,
       "file_type": "code",
-      "id": "registercustomerattribution_commitcustomer",
-      "label": "commitCustomer()",
-      "norm_label": "commitcustomer()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
-      "source_location": "L127"
+      "id": "servicecatalogview_formatservicecatalogname",
+      "label": "formatServiceCatalogName()",
+      "norm_label": "formatservicecatalogname()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
+      "source_location": "L104"
     },
     {
       "community": 73,
       "file_type": "code",
-      "id": "registercustomerattribution_getsecondaryidentifier",
-      "label": "getSecondaryIdentifier()",
-      "norm_label": "getsecondaryidentifier()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
-      "source_location": "L75"
+      "id": "servicecatalogview_handlechange",
+      "label": "handleChange()",
+      "norm_label": "handlechange()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
+      "source_location": "L289"
     },
     {
       "community": 73,
       "file_type": "code",
-      "id": "registercustomerattribution_handleaddfromsearch",
-      "label": "handleAddFromSearch()",
-      "norm_label": "handleaddfromsearch()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
-      "source_location": "L156"
+      "id": "servicecatalogview_handleedit",
+      "label": "handleEdit()",
+      "norm_label": "handleedit()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
+      "source_location": "L302"
     },
     {
       "community": 73,
       "file_type": "code",
-      "id": "registercustomerattribution_handleclearcustomer",
-      "label": "handleClearCustomer()",
-      "norm_label": "handleclearcustomer()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
-      "source_location": "L144"
+      "id": "servicecatalogview_handlereset",
+      "label": "handleReset()",
+      "norm_label": "handlereset()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
+      "source_location": "L308"
     },
     {
       "community": 73,
       "file_type": "code",
-      "id": "registercustomerattribution_handleselectcustomer",
-      "label": "handleSelectCustomer()",
-      "norm_label": "handleselectcustomer()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
-      "source_location": "L132"
+      "id": "servicecatalogview_handlesubmit",
+      "label": "handleSubmit()",
+      "norm_label": "handlesubmit()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
+      "source_location": "L314"
     },
     {
       "community": 73,
       "file_type": "code",
-      "id": "registercustomerattribution_tocustomerinfo",
-      "label": "toCustomerInfo()",
-      "norm_label": "tocustomerinfo()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
-      "source_location": "L79"
+      "id": "servicecatalogview_itemtoformstate",
+      "label": "itemToFormState()",
+      "norm_label": "itemtoformstate()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
+      "source_location": "L178"
     },
     {
       "community": 73,
       "file_type": "code",
-      "id": "registercustomerattribution_trimcustomerinfo",
-      "label": "trimCustomerInfo()",
-      "norm_label": "trimcustomerinfo()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
-      "source_location": "L39"
+      "id": "servicecatalogview_parseservicecatalogform",
+      "label": "parseServiceCatalogForm()",
+      "norm_label": "parseservicecatalogform()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
+      "source_location": "L200"
+    },
+    {
+      "community": 73,
+      "file_type": "code",
+      "id": "servicecatalogview_validateservicecatalogform",
+      "label": "validateServiceCatalogForm()",
+      "norm_label": "validateservicecatalogform()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
+      "source_location": "L126"
+    },
+    {
+      "community": 73,
+      "file_type": "code",
+      "id": "servicecatalogview_withsavestate",
+      "label": "withSaveState()",
+      "norm_label": "withsavestate()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
+      "source_location": "L716"
     },
     {
       "community": 730,
@@ -100143,101 +100515,101 @@
     {
       "community": 74,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_services_servicecatalogview_tsx",
-      "label": "ServiceCatalogView.tsx",
-      "norm_label": "servicecatalogview.tsx",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
+      "id": "backend_test_completesession",
+      "label": "completeSession()",
+      "norm_label": "completesession()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L629"
+    },
+    {
+      "community": 74,
+      "file_type": "code",
+      "id": "backend_test_createtransaction",
+      "label": "createTransaction()",
+      "norm_label": "createtransaction()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L391"
+    },
+    {
+      "community": 74,
+      "file_type": "code",
+      "id": "backend_test_createtransactionitems",
+      "label": "createTransactionItems()",
+      "norm_label": "createtransactionitems()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L467"
+    },
+    {
+      "community": 74,
+      "file_type": "code",
+      "id": "backend_test_generatetransactionnumber",
+      "label": "generateTransactionNumber()",
+      "norm_label": "generatetransactionnumber()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L374"
+    },
+    {
+      "community": 74,
+      "file_type": "code",
+      "id": "backend_test_handledatabaseerror",
+      "label": "handleDatabaseError()",
+      "norm_label": "handledatabaseerror()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L671"
+    },
+    {
+      "community": 74,
+      "file_type": "code",
+      "id": "backend_test_rollbackinventory",
+      "label": "rollbackInventory()",
+      "norm_label": "rollbackinventory()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L692"
+    },
+    {
+      "community": 74,
+      "file_type": "code",
+      "id": "backend_test_updateinventory",
+      "label": "updateInventory()",
+      "norm_label": "updateinventory()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L422"
+    },
+    {
+      "community": 74,
+      "file_type": "code",
+      "id": "backend_test_validateinventory",
+      "label": "validateInventory()",
+      "norm_label": "validateinventory()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L58"
+    },
+    {
+      "community": 74,
+      "file_type": "code",
+      "id": "backend_test_validatesession",
+      "label": "validateSession()",
+      "norm_label": "validatesession()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L553"
+    },
+    {
+      "community": 74,
+      "file_type": "code",
+      "id": "backend_test_validatesessioninventory",
+      "label": "validateSessionInventory()",
+      "norm_label": "validatesessioninventory()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L593"
+    },
+    {
+      "community": 74,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_tests_pos_backend_test_ts",
+      "label": "backend.test.ts",
+      "norm_label": "backend.test.ts",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 74,
-      "file_type": "code",
-      "id": "servicecatalogview_cn",
-      "label": "cn()",
-      "norm_label": "cn()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
-      "source_location": "L620"
-    },
-    {
-      "community": 74,
-      "file_type": "code",
-      "id": "servicecatalogview_formatservicecatalogname",
-      "label": "formatServiceCatalogName()",
-      "norm_label": "formatservicecatalogname()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
-      "source_location": "L104"
-    },
-    {
-      "community": 74,
-      "file_type": "code",
-      "id": "servicecatalogview_handlechange",
-      "label": "handleChange()",
-      "norm_label": "handlechange()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
-      "source_location": "L289"
-    },
-    {
-      "community": 74,
-      "file_type": "code",
-      "id": "servicecatalogview_handleedit",
-      "label": "handleEdit()",
-      "norm_label": "handleedit()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
-      "source_location": "L302"
-    },
-    {
-      "community": 74,
-      "file_type": "code",
-      "id": "servicecatalogview_handlereset",
-      "label": "handleReset()",
-      "norm_label": "handlereset()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
-      "source_location": "L308"
-    },
-    {
-      "community": 74,
-      "file_type": "code",
-      "id": "servicecatalogview_handlesubmit",
-      "label": "handleSubmit()",
-      "norm_label": "handlesubmit()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
-      "source_location": "L314"
-    },
-    {
-      "community": 74,
-      "file_type": "code",
-      "id": "servicecatalogview_itemtoformstate",
-      "label": "itemToFormState()",
-      "norm_label": "itemtoformstate()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
-      "source_location": "L178"
-    },
-    {
-      "community": 74,
-      "file_type": "code",
-      "id": "servicecatalogview_parseservicecatalogform",
-      "label": "parseServiceCatalogForm()",
-      "norm_label": "parseservicecatalogform()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
-      "source_location": "L200"
-    },
-    {
-      "community": 74,
-      "file_type": "code",
-      "id": "servicecatalogview_validateservicecatalogform",
-      "label": "validateServiceCatalogForm()",
-      "norm_label": "validateservicecatalogform()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
-      "source_location": "L126"
-    },
-    {
-      "community": 74,
-      "file_type": "code",
-      "id": "servicecatalogview_withsavestate",
-      "label": "withSaveState()",
-      "norm_label": "withsavestate()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.tsx",
-      "source_location": "L716"
     },
     {
       "community": 740,
@@ -100422,101 +100794,101 @@
     {
       "community": 75,
       "file_type": "code",
-      "id": "backend_test_completesession",
-      "label": "completeSession()",
-      "norm_label": "completesession()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L629"
-    },
-    {
-      "community": 75,
-      "file_type": "code",
-      "id": "backend_test_createtransaction",
-      "label": "createTransaction()",
-      "norm_label": "createtransaction()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L391"
-    },
-    {
-      "community": 75,
-      "file_type": "code",
-      "id": "backend_test_createtransactionitems",
-      "label": "createTransactionItems()",
-      "norm_label": "createtransactionitems()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L467"
-    },
-    {
-      "community": 75,
-      "file_type": "code",
-      "id": "backend_test_generatetransactionnumber",
-      "label": "generateTransactionNumber()",
-      "norm_label": "generatetransactionnumber()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L374"
-    },
-    {
-      "community": 75,
-      "file_type": "code",
-      "id": "backend_test_handledatabaseerror",
-      "label": "handleDatabaseError()",
-      "norm_label": "handledatabaseerror()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L671"
-    },
-    {
-      "community": 75,
-      "file_type": "code",
-      "id": "backend_test_rollbackinventory",
-      "label": "rollbackInventory()",
-      "norm_label": "rollbackinventory()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L692"
-    },
-    {
-      "community": 75,
-      "file_type": "code",
-      "id": "backend_test_updateinventory",
-      "label": "updateInventory()",
-      "norm_label": "updateinventory()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L422"
-    },
-    {
-      "community": 75,
-      "file_type": "code",
-      "id": "backend_test_validateinventory",
-      "label": "validateInventory()",
-      "norm_label": "validateinventory()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L58"
-    },
-    {
-      "community": 75,
-      "file_type": "code",
-      "id": "backend_test_validatesession",
-      "label": "validateSession()",
-      "norm_label": "validatesession()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L553"
-    },
-    {
-      "community": 75,
-      "file_type": "code",
-      "id": "backend_test_validatesessioninventory",
-      "label": "validateSessionInventory()",
-      "norm_label": "validatesessioninventory()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L593"
-    },
-    {
-      "community": 75,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_tests_pos_backend_test_ts",
-      "label": "backend.test.ts",
-      "norm_label": "backend.test.ts",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "id": "packages_athena_webapp_convex_inventory_utils_ts",
+      "label": "utils.ts",
+      "norm_label": "utils.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/utils.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 75,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_utils_ts",
+      "label": "utils.ts",
+      "norm_label": "utils.ts",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 75,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_utils_ts",
+      "label": "utils.ts",
+      "norm_label": "utils.ts",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 75,
+      "file_type": "code",
+      "id": "utils_formatdeliveryaddress",
+      "label": "formatDeliveryAddress()",
+      "norm_label": "formatdeliveryaddress()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L74"
+    },
+    {
+      "community": 75,
+      "file_type": "code",
+      "id": "utils_getamountpaidfororder",
+      "label": "getAmountPaidForOrder()",
+      "norm_label": "getamountpaidfororder()",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "source_location": "L128"
+    },
+    {
+      "community": 75,
+      "file_type": "code",
+      "id": "utils_getdiscountvalue",
+      "label": "getDiscountValue()",
+      "norm_label": "getdiscountvalue()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L17"
+    },
+    {
+      "community": 75,
+      "file_type": "code",
+      "id": "utils_getorderamount",
+      "label": "getOrderAmount()",
+      "norm_label": "getorderamount()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L51"
+    },
+    {
+      "community": 75,
+      "file_type": "code",
+      "id": "utils_getorderstate",
+      "label": "getOrderState()",
+      "norm_label": "getorderstate()",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 75,
+      "file_type": "code",
+      "id": "utils_getpickupactionstate",
+      "label": "getPickupActionState()",
+      "norm_label": "getpickupactionstate()",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "source_location": "L61"
+    },
+    {
+      "community": 75,
+      "file_type": "code",
+      "id": "utils_getpotentialpoints",
+      "label": "getPotentialPoints()",
+      "norm_label": "getpotentialpoints()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L107"
+    },
+    {
+      "community": 75,
+      "file_type": "code",
+      "id": "utils_getproductdiscountvalue",
+      "label": "getProductDiscountValue()",
+      "norm_label": "getproductdiscountvalue()",
+      "source_file": "packages/athena-webapp/convex/inventory/utils.ts",
+      "source_location": "L75"
     },
     {
       "community": 750,

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,19 +8,19 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 1681
-- Graph nodes: 5072
-- Graph edges: 5082
+- Graph nodes: 5084
+- Graph edges: 5104
 - Communities: 1610
 
 ## Graph Hotspots
-- `DailyCloseView.tsx` (74 edges, Community 0) - [`packages/athena-webapp/src/components/operations/DailyCloseView.tsx`](../../packages/athena-webapp/src/components/operations/DailyCloseView.tsx)
-- `dailyClose.ts` (55 edges, Community 1) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../packages/athena-webapp/convex/operations/dailyClose.ts)
+- `DailyCloseView.tsx` (76 edges, Community 0) - [`packages/athena-webapp/src/components/operations/DailyCloseView.tsx`](../../packages/athena-webapp/src/components/operations/DailyCloseView.tsx)
+- `dailyClose.ts` (57 edges, Community 1) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../packages/athena-webapp/convex/operations/dailyClose.ts)
 - `harness-inferential-review.ts` (46 edges, Community 2) - [`scripts/harness-inferential-review.ts`](../../scripts/harness-inferential-review.ts)
 - `storefrontJourneyEvents.ts` (45 edges, Community 3) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
 - `createJourneyEvent()` (40 edges, Community 3) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
 - `ProcurementView.tsx` (39 edges, Community 4) - [`packages/athena-webapp/src/components/procurement/ProcurementView.tsx`](../../packages/athena-webapp/src/components/procurement/ProcurementView.tsx)
 - `DailyOpeningView.tsx` (35 edges, Community 5) - [`packages/athena-webapp/src/components/operations/DailyOpeningView.tsx`](../../packages/athena-webapp/src/components/operations/DailyOpeningView.tsx)
-- `harness-check.ts` (32 edges, Community 6) - [`scripts/harness-check.ts`](../../scripts/harness-check.ts)
+- `dailyOpening.ts` (33 edges, Community 6) - [`packages/athena-webapp/convex/operations/dailyOpening.ts`](../../packages/athena-webapp/convex/operations/dailyOpening.ts)
 
 ## Registered Packages
 - [Athena Webapp](packages/athena-webapp.md)

--- a/graphify-out/wiki/packages/athena-webapp.md
+++ b/graphify-out/wiki/packages/athena-webapp.md
@@ -17,11 +17,11 @@ Landing page for packages/athena-webapp. Use this page to orient around graph ho
 - [validation-map.json](../../../packages/athena-webapp/docs/agent/validation-map.json)
 
 ## Graph Hotspots
-- `DailyCloseView.tsx` (74 edges, Community 0) - [`packages/athena-webapp/src/components/operations/DailyCloseView.tsx`](../../../packages/athena-webapp/src/components/operations/DailyCloseView.tsx)
-- `dailyClose.ts` (55 edges, Community 1) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../../packages/athena-webapp/convex/operations/dailyClose.ts)
+- `DailyCloseView.tsx` (76 edges, Community 0) - [`packages/athena-webapp/src/components/operations/DailyCloseView.tsx`](../../../packages/athena-webapp/src/components/operations/DailyCloseView.tsx)
+- `dailyClose.ts` (57 edges, Community 1) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../../packages/athena-webapp/convex/operations/dailyClose.ts)
 - `ProcurementView.tsx` (39 edges, Community 4) - [`packages/athena-webapp/src/components/procurement/ProcurementView.tsx`](../../../packages/athena-webapp/src/components/procurement/ProcurementView.tsx)
 - `DailyOpeningView.tsx` (35 edges, Community 5) - [`packages/athena-webapp/src/components/operations/DailyOpeningView.tsx`](../../../packages/athena-webapp/src/components/operations/DailyOpeningView.tsx)
-- `dailyOpening.ts` (31 edges, Community 7) - [`packages/athena-webapp/convex/operations/dailyOpening.ts`](../../../packages/athena-webapp/convex/operations/dailyOpening.ts)
+- `dailyOpening.ts` (33 edges, Community 6) - [`packages/athena-webapp/convex/operations/dailyOpening.ts`](../../../packages/athena-webapp/convex/operations/dailyOpening.ts)
 
 ## Navigation
 - [wiki index](../index.md) - back to the wiki index

--- a/graphify-out/wiki/packages/storefront-webapp.md
+++ b/graphify-out/wiki/packages/storefront-webapp.md
@@ -20,7 +20,7 @@ Landing page for packages/storefront-webapp. Use this page to orient around grap
 - `storefrontJourneyEvents.ts` (45 edges, Community 3) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
 - `createJourneyEvent()` (40 edges, Community 3) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
 - `getStoreConfigV2()` (17 edges, Community 22) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)
-- `checkoutSession.ts` (14 edges, Community 48) - [`packages/storefront-webapp/src/api/checkoutSession.ts`](../../../packages/storefront-webapp/src/api/checkoutSession.ts)
+- `checkoutSession.ts` (14 edges, Community 49) - [`packages/storefront-webapp/src/api/checkoutSession.ts`](../../../packages/storefront-webapp/src/api/checkoutSession.ts)
 - `storeConfig.ts` (14 edges, Community 22) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)
 
 ## Navigation

--- a/packages/athena-webapp/convex/operations/approvalActions.ts
+++ b/packages/athena-webapp/convex/operations/approvalActions.ts
@@ -28,6 +28,10 @@ export const APPROVAL_ACTIONS = {
     key: "operations.daily_close.complete",
     label: "Complete End-of-Day Review",
   },
+  dailyCloseReopen: {
+    key: "operations.daily_close.reopen",
+    label: "Reopen End-of-Day Review",
+  },
   transactionPaymentMethodCorrection: {
     key: "pos.transaction.correct_payment_method",
     label: "Correct payment method",

--- a/packages/athena-webapp/convex/operations/dailyClose.test.ts
+++ b/packages/athena-webapp/convex/operations/dailyClose.test.ts
@@ -7,6 +7,7 @@ import {
   getCompletedDailyCloseHistoryDetailWithCtx,
   getDailyCloseOpeningContextWithCtx,
   listCompletedDailyCloseHistoryWithCtx,
+  reopenDailyCloseWithCtx,
 } from "./dailyClose";
 
 type TableName =
@@ -251,6 +252,103 @@ function dailyCloseApprovalProof(overrides: Partial<Row> = {}): Row {
     subjectId: "store-1:2026-05-07",
     subjectLabel: "End-of-Day Review 2026-05-07",
     subjectType: "daily_close",
+    ...overrides,
+  };
+}
+
+function dailyCloseReopenApprovalProof(overrides: Partial<Row> = {}): Row {
+  return {
+    _id: "approval-proof-reopen-1",
+    actionKey: "operations.daily_close.reopen",
+    approvedByCredentialId: "credential-manager-1",
+    approvedByStaffProfileId: "staff-manager-1",
+    createdAt: Date.UTC(2026, 4, 8, 10),
+    expiresAt: Date.UTC(2026, 4, 8, 12),
+    requiredRole: "manager",
+    requestedByStaffProfileId: "staff-1",
+    storeId: "store-1",
+    subjectId: "daily-close-1",
+    subjectLabel: "End-of-Day Review 2026-05-07",
+    subjectType: "daily_close",
+    ...overrides,
+  };
+}
+
+function completedDailyCloseSnapshot(overrides: Record<string, unknown> = {}) {
+  return {
+    closeMetadata: {
+      completedAt: Date.UTC(2026, 4, 7, 22),
+      completedByStaffProfileId: "staff-manager-1",
+      completedByUserId: "user-1",
+      operatingDate: "2026-05-07",
+      organizationId: "org-1",
+      startAt: Date.UTC(2026, 4, 7),
+      endAt: Date.UTC(2026, 4, 8),
+      storeId: "store-1",
+    },
+    readiness: {
+      blockerCount: 0,
+      carryForwardCount: 0,
+      readyCount: 1,
+      reviewCount: 0,
+      status: "ready",
+    },
+    summary: {
+      salesTotal: 12000,
+      transactionCount: 1,
+    },
+    reviewedItems: [],
+    carryForwardItems: [],
+    readyItems: [
+      {
+        key: "pos_transaction:txn-1:completed",
+        severity: "ready",
+        category: "sale",
+        title: "Completed sale",
+        message: "Completed sale is included in End-of-Day Review.",
+        subject: {
+          id: "txn-1",
+          label: "TXN-1",
+          type: "pos_transaction",
+        },
+        metadata: {
+          total: 12000,
+          transaction: "TXN-1",
+        },
+      },
+    ],
+    sourceSubjects: [
+      {
+        id: "txn-1",
+        label: "TXN-1",
+        type: "pos_transaction",
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function completedDailyCloseRow(overrides: Partial<Row> = {}): Row {
+  const reportSnapshot = completedDailyCloseSnapshot();
+
+  return {
+    _id: "daily-close-1",
+    carryForwardWorkItemIds: [],
+    completedAt: Date.UTC(2026, 4, 7, 22),
+    completedByStaffProfileId: "staff-manager-1",
+    completedByUserId: "user-1",
+    createdAt: Date.UTC(2026, 4, 7, 22),
+    isCurrent: true,
+    lifecycleStatus: "active",
+    operatingDate: "2026-05-07",
+    organizationId: "org-1",
+    readiness: reportSnapshot.readiness,
+    reportSnapshot,
+    sourceSubjects: reportSnapshot.sourceSubjects,
+    status: "completed",
+    storeId: "store-1",
+    summary: reportSnapshot.summary,
+    updatedAt: Date.UTC(2026, 4, 7, 22),
     ...overrides,
   };
 }
@@ -1037,9 +1135,9 @@ describe("end-of-day review backend foundation", () => {
     expect(originalDaySnapshot.readyItems.map((item) => item.key)).toContain(
       "register_session:register-reopened:closed",
     );
-    expect(reopenedDaySnapshot.readyItems.map((item) => item.key)).not.toContain(
-      "register_session:register-reopened:closed",
-    );
+    expect(
+      reopenedDaySnapshot.readyItems.map((item) => item.key),
+    ).not.toContain("register_session:register-reopened:closed");
     expect(reopenedDaySnapshot.summary.closedRegisterSessionCount).toBe(0);
   });
 
@@ -1332,7 +1430,8 @@ describe("end-of-day review backend foundation", () => {
       kind: "user_error",
       error: {
         code: "precondition_failed",
-        message: "End-of-Day Review cannot be completed while blocker items remain.",
+        message:
+          "End-of-Day Review cannot be completed while blocker items remain.",
         metadata: { blockerCount: 1 },
       },
     });
@@ -1602,6 +1701,328 @@ describe("end-of-day review backend foundation", () => {
     });
   });
 
+  it("requires manager approval and a reason before reopening a completed daily close", async () => {
+    const { db, inserts } = createDb({
+      dailyClose: [completedDailyCloseRow()],
+    });
+
+    await expect(
+      reopenDailyCloseWithCtx({ db } as unknown as MutationCtx, {
+        actorStaffProfileId: "staff-1" as Id<"staffProfile">,
+        dailyCloseId: "daily-close-1" as Id<"dailyClose">,
+        reason: "  ",
+        storeId: "store-1" as Id<"store">,
+      }),
+    ).resolves.toEqual({
+      kind: "user_error",
+      error: {
+        code: "validation_failed",
+        message: "A reopen reason is required.",
+      },
+    });
+
+    const result = await reopenDailyCloseWithCtx(
+      { db } as unknown as MutationCtx,
+      {
+        actorStaffProfileId: "staff-1" as Id<"staffProfile">,
+        dailyCloseId: "daily-close-1" as Id<"dailyClose">,
+        reason: "Late cash sale was missed.",
+        storeId: "store-1" as Id<"store">,
+      },
+    );
+
+    expect(result).toEqual({
+      kind: "approval_required",
+      approval: {
+        action: {
+          key: "operations.daily_close.reopen",
+          label: "Reopen End-of-Day Review",
+        },
+        copy: {
+          message:
+            "A manager needs to approve reopening this End-of-Day Review before the operating day can be revised.",
+          primaryActionLabel: "Approve and reopen",
+          secondaryActionLabel: "Cancel",
+          title: "Manager approval required",
+        },
+        metadata: {
+          dailyCloseId: "daily-close-1",
+          operatingDate: "2026-05-07",
+        },
+        reason: "Manager approval is required to reopen End-of-Day Review.",
+        requiredRole: "manager",
+        resolutionModes: [{ kind: "inline_manager_proof" }],
+        selfApproval: "allowed",
+        subject: {
+          id: "daily-close-1",
+          label: "End-of-Day Review 2026-05-07",
+          type: "daily_close",
+        },
+      },
+    });
+    expect(inserts).toEqual([]);
+  });
+
+  it("reopens a completed close without mutating its report snapshot and makes live readiness active", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(Date.UTC(2026, 4, 8, 10));
+    const originalSnapshot = completedDailyCloseSnapshot();
+    const { db, inserts, tables } = createDb({
+      approvalProof: [dailyCloseReopenApprovalProof()],
+      dailyClose: [
+        completedDailyCloseRow({ reportSnapshot: originalSnapshot }),
+      ],
+      posTransaction: [
+        {
+          _id: "txn-1",
+          completedAt: Date.UTC(2026, 4, 7, 14),
+          payments: [{ amount: 12000, method: "cash", timestamp: 1 }],
+          status: "completed",
+          storeId: "store-1",
+          subtotal: 12000,
+          tax: 0,
+          total: 12000,
+          totalPaid: 12000,
+          transactionNumber: "TXN-1",
+        },
+        {
+          _id: "txn-late",
+          completedAt: Date.UTC(2026, 4, 7, 19),
+          payments: [{ amount: 5000, method: "cash", timestamp: 1 }],
+          status: "completed",
+          storeId: "store-1",
+          subtotal: 5000,
+          tax: 0,
+          total: 5000,
+          totalPaid: 5000,
+          transactionNumber: "TXN-LATE",
+        },
+      ],
+      store: [store],
+    });
+
+    const result = await reopenDailyCloseWithCtx(
+      { db } as unknown as MutationCtx,
+      {
+        actorStaffProfileId: "staff-1" as Id<"staffProfile">,
+        actorUserId: "user-1" as Id<"athenaUser">,
+        approvalProofId: "approval-proof-reopen-1" as Id<"approvalProof">,
+        dailyCloseId: "daily-close-1" as Id<"dailyClose">,
+        reason: "Late cash sale was missed.",
+        storeId: "store-1" as Id<"store">,
+      },
+    );
+
+    expect(result).toMatchObject({
+      kind: "ok",
+      data: {
+        action: "reopened",
+        originalDailyClose: {
+          _id: "daily-close-1",
+          isCurrent: false,
+          lifecycleStatus: "reopened",
+          reportSnapshot: originalSnapshot,
+          reopenReason: "Late cash sale was missed.",
+          status: "completed",
+        },
+        reopenedDailyClose: {
+          isCurrent: true,
+          lifecycleStatus: "active",
+          reopenedFromDailyCloseId: "daily-close-1",
+          status: "open",
+          supersedesDailyCloseId: "daily-close-1",
+        },
+      },
+    });
+    expect(
+      tables.get("dailyClose")?.get("daily-close-1")?.reportSnapshot,
+    ).toEqual(originalSnapshot);
+
+    await db.patch("posTransaction", "txn-1", {
+      total: 99000,
+      transactionNumber: "MUTATED",
+    });
+    const snapshot = await buildDailyCloseSnapshotWithCtx(
+      { db } as unknown as QueryCtx,
+      {
+        operatingDate: "2026-05-07",
+        storeId: "store-1" as Id<"store">,
+      },
+    );
+    expect(snapshot.status).toBe("ready");
+    expect(snapshot.existingClose?.status).toBe("open");
+    expect(snapshot.completedClose).toBeNull();
+    expect(snapshot.readyItems.map((item) => item.key)).toEqual(
+      expect.arrayContaining([
+        "pos_transaction:txn-1:completed",
+        "pos_transaction:txn-late:completed",
+      ]),
+    );
+
+    const detail = await getCompletedDailyCloseHistoryDetailWithCtx(
+      { db } as unknown as QueryCtx,
+      {
+        dailyCloseId: "daily-close-1" as Id<"dailyClose">,
+        storeId: "store-1" as Id<"store">,
+      },
+    );
+    expect(detail?.reportSnapshot).toEqual(originalSnapshot);
+    expect(inserts.map((insert) => insert.table)).toEqual([
+      "operationalEvent",
+      "dailyClose",
+      "operationalEvent",
+    ]);
+    expect(
+      inserts.find(
+        (insert) =>
+          insert.table === "operationalEvent" &&
+          insert.value.eventType === "daily_close_reopened",
+      )?.value,
+    ).toMatchObject({
+      actorStaffProfileId: "staff-manager-1",
+      metadata: {
+        approvalProofId: "approval-proof-reopen-1",
+        reason: "Late cash sale was missed.",
+        reopenedDailyCloseId: "dailyClose-2",
+      },
+    });
+  });
+
+  it("returns the existing reopened close when reopen is retried", async () => {
+    const { db, inserts } = createDb({
+      dailyClose: [
+        completedDailyCloseRow({
+          isCurrent: false,
+          lifecycleStatus: "reopened",
+          reopenedAt: Date.UTC(2026, 4, 8, 10),
+          supersededByDailyCloseId: "daily-close-reopened",
+        }),
+        {
+          ...completedDailyCloseRow({
+            _id: "daily-close-reopened",
+            completedAt: undefined,
+            completedByStaffProfileId: undefined,
+            completedByUserId: undefined,
+            isCurrent: true,
+            lifecycleStatus: "active",
+            reopenedFromDailyCloseId: "daily-close-1",
+            reportSnapshot: undefined,
+            status: "open",
+            supersedesDailyCloseId: "daily-close-1",
+          }),
+        },
+      ],
+    });
+
+    const result = await reopenDailyCloseWithCtx(
+      { db } as unknown as MutationCtx,
+      {
+        actorStaffProfileId: "staff-1" as Id<"staffProfile">,
+        approvalProofId: "approval-proof-reopen-1" as Id<"approvalProof">,
+        dailyCloseId: "daily-close-1" as Id<"dailyClose">,
+        reason: "Late cash sale was missed.",
+        storeId: "store-1" as Id<"store">,
+      },
+    );
+
+    expect(result).toMatchObject({
+      kind: "ok",
+      data: {
+        action: "already_reopened",
+        originalDailyClose: {
+          _id: "daily-close-1",
+          lifecycleStatus: "reopened",
+          status: "completed",
+        },
+        reopenedDailyClose: {
+          _id: "daily-close-reopened",
+          lifecycleStatus: "active",
+          reopenedFromDailyCloseId: "daily-close-1",
+          status: "open",
+        },
+      },
+    });
+    expect(inserts).toEqual([]);
+  });
+
+  it("supersedes the original completed close when a reopened close is completed", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(Date.UTC(2026, 4, 8, 11));
+    const { db, tables } = createDb({
+      approvalProof: [
+        dailyCloseApprovalProof({
+          _id: "approval-proof-complete-reopened",
+          expiresAt: Date.UTC(2026, 4, 8, 12),
+        }),
+      ],
+      dailyClose: [
+        completedDailyCloseRow({
+          isCurrent: false,
+          lifecycleStatus: "reopened",
+          supersededByDailyCloseId: "daily-close-reopened",
+        }),
+        {
+          ...completedDailyCloseRow({
+            _id: "daily-close-reopened",
+            completedAt: undefined,
+            completedByStaffProfileId: undefined,
+            completedByUserId: undefined,
+            isCurrent: true,
+            lifecycleStatus: "active",
+            reopenedFromDailyCloseId: "daily-close-1",
+            reportSnapshot: undefined,
+            status: "open",
+            supersedesDailyCloseId: "daily-close-1",
+          }),
+        },
+      ],
+      posTransaction: [
+        {
+          _id: "txn-1",
+          completedAt: Date.UTC(2026, 4, 7, 14),
+          payments: [{ amount: 12000, method: "cash", timestamp: 1 }],
+          status: "completed",
+          storeId: "store-1",
+          subtotal: 12000,
+          tax: 0,
+          total: 12000,
+          totalPaid: 12000,
+          transactionNumber: "TXN-1",
+        },
+      ],
+      store: [store],
+    });
+
+    const result = await completeDailyCloseWithCtx(
+      { db } as unknown as MutationCtx,
+      {
+        actorStaffProfileId: "staff-1" as Id<"staffProfile">,
+        approvalProofId:
+          "approval-proof-complete-reopened" as Id<"approvalProof">,
+        operatingDate: "2026-05-07",
+        storeId: "store-1" as Id<"store">,
+      },
+    );
+
+    expect(result).toMatchObject({
+      kind: "ok",
+      data: {
+        action: "completed",
+        dailyClose: {
+          _id: "daily-close-reopened",
+          lifecycleStatus: "active",
+          status: "completed",
+          supersedesDailyCloseId: "daily-close-1",
+        },
+      },
+    });
+    expect(tables.get("dailyClose")?.get("daily-close-1")).toMatchObject({
+      lifecycleStatus: "superseded",
+      isCurrent: false,
+      supersededByDailyCloseId: "daily-close-reopened",
+      reportSnapshot: completedDailyCloseSnapshot(),
+      status: "completed",
+    });
+  });
+
   it("lists completed daily close history for a store newest first and returns snapshot-backed detail", async () => {
     const completedSnapshot = {
       closeMetadata: {
@@ -1633,7 +2054,8 @@ describe("end-of-day review backend foundation", () => {
           severity: "carry_forward",
           category: "open_work",
           title: "Carry forward",
-          message: "Open operational work will carry forward after End-of-Day Review.",
+          message:
+            "Open operational work will carry forward after End-of-Day Review.",
           subject: {
             id: "work-1",
             label: "Carry forward",

--- a/packages/athena-webapp/convex/operations/dailyClose.ts
+++ b/packages/athena-webapp/convex/operations/dailyClose.ts
@@ -30,6 +30,7 @@ const TERMINAL_WORK_ITEM_STATUSES = new Set(["completed", "cancelled"]);
 const ACTIVE_REGISTER_STATUSES = ["open", "active", "closing"] as const;
 const OPEN_POS_SESSION_STATUSES = ["active", "held"] as const;
 const DAILY_CLOSE_COMPLETION_ACTION = APPROVAL_ACTIONS.dailyCloseCompletion;
+const DAILY_CLOSE_REOPEN_ACTION = APPROVAL_ACTIONS.dailyCloseReopen;
 const DAILY_CLOSE_BLOCKER_CATEGORY_PRECEDENCE: Record<string, number> = {
   approval: 0,
   register_session: 10,
@@ -242,6 +243,22 @@ type CompleteDailyCloseResult = ApprovalCommandResult<{
   carryForwardWorkItems: Array<Doc<"operationalWorkItem">>;
 }>;
 
+type ReopenDailyCloseArgs = {
+  actorUserId?: Id<"athenaUser">;
+  actorStaffProfileId?: Id<"staffProfile">;
+  approvalProofId?: Id<"approvalProof">;
+  dailyCloseId: Id<"dailyClose">;
+  organizationId?: Id<"organization">;
+  reason: string;
+  storeId: Id<"store">;
+};
+
+type ReopenDailyCloseResult = ApprovalCommandResult<{
+  action: "reopened" | "already_reopened";
+  originalDailyClose: Doc<"dailyClose">;
+  reopenedDailyClose: Doc<"dailyClose">;
+}>;
+
 function buildDailyCloseApprovalSubject(args: {
   operatingDate: string;
   storeId: Id<"store">;
@@ -276,6 +293,40 @@ function buildDailyCloseCompletionApprovalRequirement(args: {
       },
     ],
     metadata: {
+      operatingDate: args.operatingDate,
+    },
+  };
+}
+
+function buildDailyCloseReopenApprovalRequirement(args: {
+  dailyCloseId: Id<"dailyClose">;
+  operatingDate: string;
+  storeId: Id<"store">;
+}): ApprovalRequirement {
+  return {
+    action: DAILY_CLOSE_REOPEN_ACTION,
+    reason: "Manager approval is required to reopen End-of-Day Review.",
+    requiredRole: "manager",
+    selfApproval: "allowed",
+    subject: {
+      id: args.dailyCloseId,
+      label: `End-of-Day Review ${args.operatingDate}`,
+      type: DAILY_CLOSE_SUBJECT_TYPE,
+    },
+    copy: {
+      title: "Manager approval required",
+      message:
+        "A manager needs to approve reopening this End-of-Day Review before the operating day can be revised.",
+      primaryActionLabel: "Approve and reopen",
+      secondaryActionLabel: "Cancel",
+    },
+    resolutionModes: [
+      {
+        kind: "inline_manager_proof",
+      },
+    ],
+    metadata: {
+      dailyCloseId: args.dailyCloseId,
       operatingDate: args.operatingDate,
     },
   };
@@ -503,7 +554,8 @@ function asCarryForwardItem(
     severity: "carry_forward",
     category: "open_work",
     title: workItem.title,
-    message: "Open operational work will carry forward after End-of-Day Review.",
+    message:
+      "Open operational work will carry forward after End-of-Day Review.",
     subject: {
       type: "operational_work_item",
       id: workItem._id,
@@ -531,12 +583,36 @@ async function getDailyCloseForDate(
     storeId: Id<"store">;
   },
 ) {
-  return ctx.db
+  const activeClose = await ctx.db
+    .query("dailyClose")
+    .withIndex("by_storeId_operatingDate_lifecycleStatus", (q) =>
+      q
+        .eq("storeId", args.storeId)
+        .eq("operatingDate", args.operatingDate)
+        .eq("lifecycleStatus", "active"),
+    )
+    .first();
+
+  if (activeClose) {
+    return activeClose;
+  }
+
+  const legacyClose = await ctx.db
     .query("dailyClose")
     .withIndex("by_storeId_operatingDate", (q) =>
       q.eq("storeId", args.storeId).eq("operatingDate", args.operatingDate),
     )
     .first();
+
+  if (
+    legacyClose &&
+    (legacyClose.lifecycleStatus === undefined ||
+      legacyClose.lifecycleStatus === "active")
+  ) {
+    return legacyClose;
+  }
+
+  return null;
 }
 
 async function getPriorCompletedDailyClose(
@@ -556,7 +632,10 @@ async function getPriorCompletedDailyClose(
 
   return (
     completedCloses.find(
-      (dailyClose) => dailyClose.operatingDate < args.operatingDate,
+      (dailyClose) =>
+        dailyClose.operatingDate < args.operatingDate &&
+        (dailyClose.lifecycleStatus === undefined ||
+          dailyClose.lifecycleStatus === "active"),
     ) ?? null
   );
 }
@@ -956,7 +1035,9 @@ function snapshotReviewedItems(
   }
 
   const reviewedItemKeySet = new Set(reviewedItemKeys);
-  return snapshot.reviewItems.filter((item) => reviewedItemKeySet.has(item.key));
+  return snapshot.reviewItems.filter((item) =>
+    reviewedItemKeySet.has(item.key),
+  );
 }
 
 function toDailyCloseHistoryListItem(
@@ -1049,7 +1130,8 @@ export async function buildDailyCloseSnapshotWithCtx(
       severity: "blocker",
       category: "operating_date",
       title: "Invalid operating date",
-      message: "End-of-Day Review requires an operating date in YYYY-MM-DD format.",
+      message:
+        "End-of-Day Review requires an operating date in YYYY-MM-DD format.",
       subject: {
         type: DAILY_CLOSE_SUBJECT_TYPE,
         id: args.operatingDate,
@@ -1098,7 +1180,7 @@ export async function buildDailyCloseSnapshotWithCtx(
       dailyClose: existingClose,
       completedByStaffProfileId,
       completedByStaffName: completedByStaffProfileId
-        ? staffNamesById.get(completedByStaffProfileId) ?? null
+        ? (staffNamesById.get(completedByStaffProfileId) ?? null)
         : null,
     });
 
@@ -1168,11 +1250,11 @@ export async function buildDailyCloseSnapshotWithCtx(
   );
   const completedByStaffProfileId =
     existingClose?.status === "completed"
-      ? existingClose.completedByStaffProfileId ??
+      ? (existingClose.completedByStaffProfileId ??
         (await getDailyCloseCompletionEventStaffProfileId(ctx, {
           dailyCloseId: existingClose._id,
           storeId: args.storeId,
-        }))
+        })))
       : undefined;
   const terminalLabelsById = await buildTerminalLabelsById(ctx, [
     ...activeRegisterSessions.map((session) => session.terminalId),
@@ -1188,8 +1270,12 @@ export async function buildDailyCloseSnapshotWithCtx(
     ...activeRegisterSessions.map((session) => session.closedByStaffProfileId),
     ...closedRegisterSessions.map((session) => session.openedByStaffProfileId),
     ...closedRegisterSessions.map((session) => session.closedByStaffProfileId),
-    ...approvalRegisterSessions.map((session) => session.openedByStaffProfileId),
-    ...approvalRegisterSessions.map((session) => session.closedByStaffProfileId),
+    ...approvalRegisterSessions.map(
+      (session) => session.openedByStaffProfileId,
+    ),
+    ...approvalRegisterSessions.map(
+      (session) => session.closedByStaffProfileId,
+    ),
     ...openPosSessions.map((session) => session.staffProfileId),
     ...completedTransactions.map((transaction) => transaction.staffProfileId),
     ...voidedTransactions.map((transaction) => transaction.staffProfileId),
@@ -1450,7 +1536,8 @@ export async function buildDailyCloseSnapshotWithCtx(
         severity: "review",
         category: "cash_variance",
         title: "Closed register has a cash variance",
-        message: "Review the cash variance before completing End-of-Day Review.",
+        message:
+          "Review the cash variance before completing End-of-Day Review.",
         subject: {
           type: "register_session",
           id: session._id,
@@ -1547,7 +1634,7 @@ export async function buildDailyCloseSnapshotWithCtx(
       ? `Register ${transaction.registerNumber}`
       : expenseSessionRegisterNumber
         ? `Register ${expenseSessionRegisterNumber}`
-      : undefined;
+        : undefined;
 
     readyItems.push({
       key: `expense_transaction:${transaction._id}:completed`,
@@ -1680,8 +1767,8 @@ export async function buildDailyCloseSnapshotWithCtx(
     openWorkItemCount: openWorkItems.length,
     pendingApprovalCount: pendingApprovals.length,
     registerCount: relevantRegisterSessions.length,
-    registerVarianceCount: relevantRegisterSessions.filter(
-      (session) => Boolean(session.variance),
+    registerVarianceCount: relevantRegisterSessions.filter((session) =>
+      Boolean(session.variance),
     ).length,
     salesTotal: completedTransactions.reduce(
       (sum, transaction) => sum + transaction.total,
@@ -1710,7 +1797,7 @@ export async function buildDailyCloseSnapshotWithCtx(
           completedAt: existingClose.completedAt,
           completedByStaffProfileId,
           completedByStaffName: completedByStaffProfileId
-            ? staffNamesById.get(completedByStaffProfileId) ?? null
+            ? (staffNamesById.get(completedByStaffProfileId) ?? null)
             : null,
           completedByUserId: existingClose.completedByUserId,
           notes: existingClose.notes,
@@ -2002,6 +2089,7 @@ export async function completeDailyCloseWithCtx(
     organizationId: store.organizationId,
     operatingDate: args.operatingDate,
     status: "completed" as const,
+    lifecycleStatus: "active" as const,
     isCurrent: true,
     readiness,
     summary,
@@ -2053,6 +2141,15 @@ export async function completeDailyCloseWithCtx(
     });
   }
 
+  if (dailyClose.supersedesDailyCloseId) {
+    await ctx.db.patch("dailyClose", dailyClose.supersedesDailyCloseId, {
+      lifecycleStatus: "superseded",
+      isCurrent: false,
+      supersededByDailyCloseId: dailyClose._id,
+      updatedAt: now,
+    });
+  }
+
   await recordOperationalEventWithCtx(ctx, {
     storeId: args.storeId,
     organizationId: store.organizationId,
@@ -2095,6 +2192,200 @@ export async function completeDailyCloseWithCtx(
     action: "completed",
     dailyClose,
     carryForwardWorkItems,
+  });
+}
+
+export async function reopenDailyCloseWithCtx(
+  ctx: MutationCtx,
+  args: ReopenDailyCloseArgs,
+): Promise<ReopenDailyCloseResult> {
+  const reason = trimOptional(args.reason);
+
+  if (!reason) {
+    return userError({
+      code: "validation_failed",
+      message: "A reopen reason is required.",
+    });
+  }
+
+  const originalDailyClose = await ctx.db.get("dailyClose", args.dailyCloseId);
+
+  if (!originalDailyClose || originalDailyClose.storeId !== args.storeId) {
+    return userError({
+      code: "not_found",
+      message: "End-of-Day Review was not found for this store.",
+    });
+  }
+
+  if (
+    args.organizationId &&
+    args.organizationId !== originalDailyClose.organizationId
+  ) {
+    return userError({
+      code: "authorization_failed",
+      message: "End-of-Day Review store does not belong to this organization.",
+    });
+  }
+
+  if (
+    originalDailyClose.status !== "completed" ||
+    !originalDailyClose.reportSnapshot
+  ) {
+    return userError({
+      code: "precondition_failed",
+      message: "Only a completed End-of-Day Review can be reopened.",
+    });
+  }
+
+  if (originalDailyClose.lifecycleStatus === "superseded") {
+    return userError({
+      code: "precondition_failed",
+      message: "This End-of-Day Review has already been superseded.",
+    });
+  }
+
+  const existingReopenedClose = await ctx.db
+    .query("dailyClose")
+    .withIndex("by_storeId_operatingDate_lifecycleStatus", (q) =>
+      q
+        .eq("storeId", args.storeId)
+        .eq("operatingDate", originalDailyClose.operatingDate)
+        .eq("lifecycleStatus", "active"),
+    )
+    .first();
+  const activeReopenedClose =
+    existingReopenedClose?._id === originalDailyClose._id
+      ? null
+      : existingReopenedClose;
+
+  if (
+    activeReopenedClose?.status === "open" &&
+    activeReopenedClose.reopenedFromDailyCloseId === originalDailyClose._id
+  ) {
+    return ok({
+      action: "already_reopened",
+      originalDailyClose,
+      reopenedDailyClose: activeReopenedClose,
+    });
+  }
+
+  if (
+    originalDailyClose.lifecycleStatus === "reopened" ||
+    activeReopenedClose
+  ) {
+    return userError({
+      code: "precondition_failed",
+      message: "This End-of-Day Review is already reopened.",
+    });
+  }
+
+  if (!args.approvalProofId) {
+    return approvalRequired(
+      buildDailyCloseReopenApprovalRequirement({
+        dailyCloseId: originalDailyClose._id,
+        operatingDate: originalDailyClose.operatingDate,
+        storeId: args.storeId,
+      }),
+    );
+  }
+
+  const approvalProof = await consumeCommandApprovalProofWithCtx(ctx, {
+    action: DAILY_CLOSE_REOPEN_ACTION,
+    approvalProofId: args.approvalProofId,
+    requiredRole: "manager",
+    requestedByStaffProfileId: args.actorStaffProfileId,
+    storeId: args.storeId,
+    subject: {
+      id: originalDailyClose._id,
+      label: `End-of-Day Review ${originalDailyClose.operatingDate}`,
+      type: DAILY_CLOSE_SUBJECT_TYPE,
+    },
+  });
+
+  if (approvalProof.kind !== "ok") {
+    return approvalProof;
+  }
+
+  const now = Date.now();
+  const reopenedDailyCloseId = await ctx.db.insert("dailyClose", {
+    storeId: originalDailyClose.storeId,
+    organizationId: originalDailyClose.organizationId,
+    operatingDate: originalDailyClose.operatingDate,
+    status: "open",
+    lifecycleStatus: "active",
+    isCurrent: true,
+    readiness: originalDailyClose.readiness,
+    summary: originalDailyClose.summary,
+    sourceSubjects: originalDailyClose.sourceSubjects,
+    carryForwardWorkItemIds: originalDailyClose.carryForwardWorkItemIds,
+    reviewedItemKeys: originalDailyClose.reviewedItemKeys,
+    notes: originalDailyClose.notes,
+    createdAt: now,
+    updatedAt: now,
+    reopenedAt: now,
+    reopenedByUserId: args.actorUserId,
+    reopenedByStaffProfileId: approvalProof.data.approvedByStaffProfileId,
+    reopenReason: reason,
+    reopenedFromDailyCloseId: originalDailyClose._id,
+    supersedesDailyCloseId: originalDailyClose._id,
+  });
+
+  await ctx.db.patch("dailyClose", originalDailyClose._id, {
+    lifecycleStatus: "reopened",
+    isCurrent: false,
+    reopenedAt: now,
+    reopenedByUserId: args.actorUserId,
+    reopenedByStaffProfileId: approvalProof.data.approvedByStaffProfileId,
+    reopenReason: reason,
+    supersededByDailyCloseId: reopenedDailyCloseId,
+    updatedAt: now,
+  });
+
+  await markOtherDailyClosesNotCurrent(ctx, {
+    currentCloseId: reopenedDailyCloseId,
+    storeId: args.storeId,
+  });
+
+  const reopenedDailyClose = await ctx.db.get(
+    "dailyClose",
+    reopenedDailyCloseId,
+  );
+  const updatedOriginalDailyClose = await ctx.db.get(
+    "dailyClose",
+    originalDailyClose._id,
+  );
+
+  if (!reopenedDailyClose || !updatedOriginalDailyClose) {
+    return userError({
+      code: "unavailable",
+      message: "Reopened End-of-Day Review could not be loaded.",
+      retryable: true,
+    });
+  }
+
+  await recordOperationalEventWithCtx(ctx, {
+    storeId: args.storeId,
+    organizationId: originalDailyClose.organizationId,
+    eventType: "daily_close_reopened",
+    subjectType: DAILY_CLOSE_SUBJECT_TYPE,
+    subjectId: originalDailyClose._id,
+    subjectLabel: `End-of-Day Review ${originalDailyClose.operatingDate}`,
+    message: `End-of-Day Review reopened for ${originalDailyClose.operatingDate}.`,
+    actorUserId: args.actorUserId,
+    actorStaffProfileId: approvalProof.data.approvedByStaffProfileId,
+    metadata: {
+      approvalProofId: approvalProof.data.approvalProofId,
+      approvedByStaffProfileId: approvalProof.data.approvedByStaffProfileId,
+      operatingDate: originalDailyClose.operatingDate,
+      reason,
+      reopenedDailyCloseId,
+    },
+  });
+
+  return ok({
+    action: "reopened",
+    originalDailyClose: updatedOriginalDailyClose,
+    reopenedDailyClose,
   });
 }
 
@@ -2176,7 +2467,7 @@ export async function listCompletedDailyCloseHistoryWithCtx(
     return toDailyCloseHistoryListItem(
       dailyClose,
       completedByStaffProfileId
-        ? staffNamesById.get(completedByStaffProfileId) ?? null
+        ? (staffNamesById.get(completedByStaffProfileId) ?? null)
         : null,
       completedByStaffProfileId,
     );
@@ -2218,7 +2509,7 @@ export async function getCompletedDailyCloseHistoryDetailWithCtx(
     completedByUserId: dailyClose.completedByUserId,
     completedByStaffProfileId,
     completedByStaffName: completedByStaffProfileId
-      ? staffNamesById.get(completedByStaffProfileId) ?? null
+      ? (staffNamesById.get(completedByStaffProfileId) ?? null)
       : null,
     reportSnapshot: dailyClose.reportSnapshot,
   };
@@ -2264,6 +2555,20 @@ export const completeDailyClose = mutation({
   handler: (ctx, args) => completeDailyCloseWithCtx(ctx, args),
 });
 
+export const reopenDailyClose = mutation({
+  args: {
+    actorUserId: v.optional(v.id("athenaUser")),
+    actorStaffProfileId: v.optional(v.id("staffProfile")),
+    approvalProofId: v.optional(v.id("approvalProof")),
+    dailyCloseId: v.id("dailyClose"),
+    organizationId: v.optional(v.id("organization")),
+    reason: v.string(),
+    storeId: v.id("store"),
+  },
+  returns: commandResultValidator(v.any()),
+  handler: (ctx, args) => reopenDailyCloseWithCtx(ctx, args),
+});
+
 export const getDailyCloseOpeningContext = query({
   args: {
     operatingDate: v.string(),
@@ -2285,6 +2590,5 @@ export const getCompletedDailyCloseHistoryDetail = query({
     dailyCloseId: v.id("dailyClose"),
     storeId: v.id("store"),
   },
-  handler: (ctx, args) =>
-    getCompletedDailyCloseHistoryDetailWithCtx(ctx, args),
+  handler: (ctx, args) => getCompletedDailyCloseHistoryDetailWithCtx(ctx, args),
 });

--- a/packages/athena-webapp/convex/operations/dailyOpening.test.ts
+++ b/packages/athena-webapp/convex/operations/dailyOpening.test.ts
@@ -239,6 +239,35 @@ describe("daily opening backend foundation", () => {
     ]);
   });
 
+  it("does not treat a reopened prior close as clean", async () => {
+    const { db } = createDb({
+      dailyClose: [
+        completedDailyClose({
+          lifecycleStatus: "reopened",
+          reopenedAt: Date.UTC(2026, 4, 8, 7),
+          reopenReason: "Cash deposit was corrected.",
+        }),
+      ],
+      store: [store],
+    });
+
+    const snapshot = await buildDailyOpeningSnapshotWithCtx(
+      { db } as unknown as QueryCtx,
+      { operatingDate: "2026-05-08", storeId: "store-1" as Id<"store"> },
+    );
+
+    expect(snapshot.status).toBe("needs_attention");
+    expect(snapshot.readyItems).toEqual([]);
+    expect(snapshot.reviewItems).toContainEqual(
+      expect.objectContaining({
+        key: "daily_close:daily-close-1:reopened",
+        title: "Prior End-of-Day Review reopened",
+        message:
+          "The prior store day was reopened. Complete the revised End-of-Day Review before treating the prior close as clean.",
+      }),
+    );
+  });
+
   it("summarizes pending approval blockers with operator-facing metadata", async () => {
     const { db } = createDb({
       approvalRequest: [

--- a/packages/athena-webapp/convex/operations/dailyOpening.ts
+++ b/packages/athena-webapp/convex/operations/dailyOpening.ts
@@ -192,6 +192,28 @@ async function getStartedDailyOpeningForDate(
     .first();
 }
 
+async function getPriorDailyCloseForOpeningReview(
+  ctx: Pick<QueryCtx, "db">,
+  args: {
+    operatingDate: string;
+    storeId: Id<"store">;
+  },
+) {
+  const completedCloses = await ctx.db
+    .query("dailyClose")
+    .withIndex("by_storeId_status_operatingDate", (q) =>
+      q.eq("storeId", args.storeId).eq("status", "completed"),
+    )
+    .order("desc")
+    .take(DAILY_OPENING_QUERY_LIMIT);
+
+  return (
+    completedCloses.find(
+      (dailyClose) => dailyClose.operatingDate < args.operatingDate,
+    ) ?? null
+  );
+}
+
 function getStaffDisplayName(staffProfile: Doc<"staffProfile"> | null) {
   if (!staffProfile) return null;
 
@@ -461,6 +483,34 @@ function priorCloseReadyItem(priorClose: Doc<"dailyClose">): DailyOpeningItem {
   };
 }
 
+function priorCloseReopenedItem(priorClose: Doc<"dailyClose">): DailyOpeningItem {
+  return {
+    key: `daily_close:${priorClose._id}:reopened`,
+    severity: "review",
+    category: "prior_close",
+    title: "Prior End-of-Day Review reopened",
+    message:
+      "The prior store day was reopened. Complete the revised End-of-Day Review before treating the prior close as clean.",
+    subject: {
+      type: DAILY_CLOSE_SUBJECT_TYPE,
+      id: priorClose._id,
+      label: `End-of-Day Review ${priorClose.operatingDate}`,
+    },
+    link: {
+      label: "Review End-of-Day Review",
+      search: {
+        operatingDate: priorClose.operatingDate,
+      },
+      to: "/$orgUrlSlug/store/$storeUrlSlug/operations/daily-close",
+    },
+    metadata: {
+      operatingDate: priorClose.operatingDate,
+      reopenedAt: priorClose.reopenedAt,
+      reopenReason: priorClose.reopenReason,
+    },
+  };
+}
+
 function priorCloseNotesItem(priorClose: Doc<"dailyClose">): DailyOpeningItem | null {
   const notes = trimOptional(priorClose.notes);
 
@@ -668,6 +718,9 @@ export async function buildDailyOpeningSnapshotWithCtx(
     getDailyCloseOpeningContextWithCtx(ctx, args),
     listPendingOpeningBlockerApprovals(ctx, args.storeId),
   ]);
+  const priorClose =
+    openingContext.priorClose ??
+    (await getPriorDailyCloseForOpeningReview(ctx, args));
 
   const blockers: DailyOpeningItem[] = openingContext.priorClose
     ? await getMissingCarryForwardItems(ctx, openingContext.priorClose)
@@ -678,10 +731,14 @@ export async function buildDailyOpeningSnapshotWithCtx(
     .map(carryForwardItem);
   const readyItems: DailyOpeningItem[] = [];
 
-  if (openingContext.priorClose) {
-    readyItems.push(priorCloseReadyItem(openingContext.priorClose));
+  if (priorClose) {
+    if (priorClose.lifecycleStatus === "reopened") {
+      reviewItems.push(priorCloseReopenedItem(priorClose));
+    } else {
+      readyItems.push(priorCloseReadyItem(priorClose));
+    }
 
-    const notesItem = priorCloseNotesItem(openingContext.priorClose);
+    const notesItem = priorCloseNotesItem(priorClose);
 
     if (notesItem) {
       reviewItems.push(notesItem);
@@ -711,7 +768,7 @@ export async function buildDailyOpeningSnapshotWithCtx(
     storeId: args.storeId,
     organizationId: store?.organizationId ?? null,
     existingOpening,
-    priorClose: openingContext.priorClose,
+    priorClose,
     status: existingOpening ? "started" : readiness.status,
     blockers,
     reviewItems,

--- a/packages/athena-webapp/convex/operations/dailyOperations.test.ts
+++ b/packages/athena-webapp/convex/operations/dailyOperations.test.ts
@@ -272,6 +272,46 @@ describe("daily operations overview read model", () => {
     });
   });
 
+  it("shows a reopened active close as needing revised End-of-Day Review", async () => {
+    const snapshot = await buildDailyOperationsSnapshotWithCtx(
+      buildCtx({
+        dailyClose: [
+          priorClose,
+          {
+            ...priorClose,
+            _id: "close-reopened",
+            completedAt: Date.UTC(2026, 4, 8, 22),
+            isCurrent: true,
+            lifecycleStatus: "reopened",
+            operatingDate: "2026-05-08",
+            reopenedAt: Date.UTC(2026, 4, 9, 8),
+            reopenReason: "Cash count corrected after close.",
+          },
+        ],
+        dailyOpening: [startedOpening],
+        store: [store],
+      }),
+      { operatingDate: "2026-05-08", storeId: "store-1" as Id<"store"> },
+    );
+
+    expect(snapshot.lifecycle.status).toBe("reopened");
+    expect(snapshot.primaryAction).toMatchObject({
+      label: "Revise End-of-Day Review",
+    });
+    expect(snapshot.lanes.find((lane) => lane.key === "close")).toMatchObject({
+      status: "needs_attention",
+      description:
+        "End-of-Day Review was reopened and needs a revised close.",
+    });
+    expect(snapshot.attentionItems).toContainEqual(
+      expect.objectContaining({
+        owner: "daily_close",
+        label: "End-of-Day Review reopened",
+        severity: "warning",
+      }),
+    );
+  });
+
   it("keeps the week summary anchored separately from the selected operating date", async () => {
     const snapshot = await buildDailyOperationsSnapshotWithCtx(
       buildCtx({

--- a/packages/athena-webapp/convex/operations/dailyOperations.ts
+++ b/packages/athena-webapp/convex/operations/dailyOperations.ts
@@ -44,6 +44,7 @@ type LifecycleStatus =
   | "operating"
   | "close_blocked"
   | "ready_to_close"
+  | "reopened"
   | "closed";
 
 type DailyOperationsAttentionItem = {
@@ -412,6 +413,21 @@ async function listTimelineEvents(
   }));
 }
 
+async function getDailyCloseRecordForDate(
+  ctx: Pick<QueryCtx, "db">,
+  args: {
+    operatingDate: string;
+    storeId: Id<"store">;
+  },
+) {
+  return ctx.db
+    .query("dailyClose")
+    .withIndex("by_storeId_operatingDate", (q) =>
+      q.eq("storeId", args.storeId).eq("operatingDate", args.operatingDate),
+    )
+    .first();
+}
+
 function getCloseItemCounts(items: SourceItem[]) {
   return {
     approvalCount: items.filter((item) => item.category === "approval").length,
@@ -489,6 +505,14 @@ function lifecycleCopy(status: LifecycleStatus) {
     };
   }
 
+  if (status === "reopened") {
+    return {
+      description:
+        "End-of-Day Review was reopened. Complete the revised review before treating the store day as closed.",
+      label: "Reopened",
+    };
+  }
+
   return {
     description:
       "Opening Handoff is complete. Keep open work visible through End-of-Day Review.",
@@ -521,6 +545,13 @@ function primaryAction(status: LifecycleStatus): {
     };
   }
 
+  if (status === "reopened") {
+    return {
+      label: "Revise End-of-Day Review",
+      to: "/$orgUrlSlug/store/$storeUrlSlug/operations/daily-close",
+    };
+  }
+
   return {
     label: "Start End-of-Day Review",
     to: "/$orgUrlSlug/store/$storeUrlSlug/operations/daily-close",
@@ -530,6 +561,7 @@ function primaryAction(status: LifecycleStatus): {
 function buildLanes(args: {
   closeBlockerCounts: ReturnType<typeof getCloseItemCounts>;
   closeStatus: string;
+  isCloseReopened: boolean;
   isOpeningStarted: boolean;
   openingAttentionCount: number;
   queueCounts: {
@@ -543,7 +575,9 @@ function buildLanes(args: {
     ? "ready"
     : "needs_attention";
   const closeStatus: LaneStatus =
-    args.closeStatus === "completed"
+    args.isCloseReopened
+      ? "needs_attention"
+      : args.closeStatus === "completed"
       ? "closed"
       : args.closeStatus === "blocked"
         ? "blocked"
@@ -564,13 +598,15 @@ function buildLanes(args: {
     },
     {
       count:
-        args.closeStatus === "completed"
+        args.closeStatus === "completed" && !args.isCloseReopened
           ? 0
           : args.closeBlockerCounts.registerCount +
             args.closeBlockerCounts.posSessionCount +
             args.closeBlockerCounts.approvalCount,
       description:
-        args.closeStatus === "completed"
+        args.isCloseReopened
+          ? "End-of-Day Review was reopened and needs a revised close."
+          : args.closeStatus === "completed"
           ? "End-of-Day Review is saved for this store day."
           : args.closeStatus === "blocked"
             ? "End-of-Day Review has blockers to resolve."
@@ -655,10 +691,19 @@ export async function buildDailyOperationsSnapshotWithCtx(
   },
 ) {
   const range = resolveRange(args);
-  const [openingSnapshot, closeSnapshot, queueCounts, timeline, store, weekMetrics] =
+  const [
+    openingSnapshot,
+    closeSnapshot,
+    dailyCloseRecord,
+    queueCounts,
+    timeline,
+    store,
+    weekMetrics,
+  ] =
     await Promise.all([
       buildDailyOpeningSnapshotWithCtx(ctx, args),
       buildDailyCloseSnapshotWithCtx(ctx, args),
+      getDailyCloseRecordForDate(ctx, args),
       listOpenQueueSnapshot(ctx, args.storeId),
       listTimelineEvents(ctx, { ...range, storeId: args.storeId }),
       ctx.db.get("store", args.storeId),
@@ -666,6 +711,9 @@ export async function buildDailyOperationsSnapshotWithCtx(
     ]);
 
   const isOpeningStarted = openingSnapshot.status === "started";
+  const isCloseReopened =
+    closeSnapshot.existingClose?.lifecycleStatus === "reopened" ||
+    dailyCloseRecord?.lifecycleStatus === "reopened";
   const closeBlockers = closeSnapshot.blockers as SourceItem[];
   const closeReviews = closeSnapshot.reviewItems as SourceItem[];
   const openingAttention = [
@@ -683,6 +731,25 @@ export async function buildDailyOperationsSnapshotWithCtx(
       ),
     );
   } else {
+    if (isCloseReopened) {
+      attentionItems.push({
+        id: `daily_close:${args.storeId}:${args.operatingDate}:reopened`,
+        label: "End-of-Day Review reopened",
+        message:
+          "Complete the revised End-of-Day Review before treating the store day as closed.",
+        owner: "daily_close",
+        severity: "warning",
+        source: {
+          id:
+            closeSnapshot.existingClose?._id ??
+            dailyCloseRecord?._id ??
+            `${args.storeId}:${args.operatingDate}`,
+          label: `End-of-Day Review ${args.operatingDate}`,
+          type: "daily_close",
+        },
+        to: "/$orgUrlSlug/store/$storeUrlSlug/operations/daily-close",
+      });
+    }
     attentionItems.push(
       ...closeBlockers.map((item) => sourceAttentionItem("daily_close", item)),
       ...closeReviews.map((item) => sourceAttentionItem("daily_close", item)),
@@ -697,7 +764,9 @@ export async function buildDailyOperationsSnapshotWithCtx(
 
   const lifecycleStatus: LifecycleStatus = !isOpeningStarted
     ? "not_opened"
-    : closeSnapshot.status === "completed"
+    : isCloseReopened
+      ? "reopened"
+      : closeSnapshot.status === "completed"
       ? "closed"
       : closeSnapshot.blockers.length > 0
         ? "close_blocked"
@@ -731,6 +800,7 @@ export async function buildDailyOperationsSnapshotWithCtx(
     lanes: buildLanes({
       closeBlockerCounts,
       closeStatus: closeSnapshot.status,
+      isCloseReopened,
       isOpeningStarted,
       openingAttentionCount: openingAttention.length,
       queueCounts: {

--- a/packages/athena-webapp/convex/operations/operationsQueryIndexes.test.ts
+++ b/packages/athena-webapp/convex/operations/operationsQueryIndexes.test.ts
@@ -156,6 +156,11 @@ describe("operations query indexing", () => {
       },
       {
         table: "dailyClose",
+        descriptor: "by_storeId_operatingDate_lifecycleStatus",
+        fields: ["storeId", "operatingDate", "lifecycleStatus"],
+      },
+      {
+        table: "dailyClose",
         descriptor: "by_storeId_status",
         fields: ["storeId", "status"],
       },
@@ -224,6 +229,9 @@ describe("operations query indexing", () => {
       '.withIndex("by_storeId_createdAt"',
     );
     expect(dailyCloseSource).toContain('.withIndex("by_storeId_operatingDate"');
+    expect(dailyCloseSource).toContain(
+      '.withIndex("by_storeId_operatingDate_lifecycleStatus"',
+    );
     expect(dailyCloseSource).toContain(
       '.withIndex("by_storeId_status_operatingDate"',
     );

--- a/packages/athena-webapp/convex/pos/application/queries/listRegisterCatalog.test.ts
+++ b/packages/athena-webapp/convex/pos/application/queries/listRegisterCatalog.test.ts
@@ -171,6 +171,13 @@ describe("listRegisterCatalog", () => {
           name: "Archived Wig",
           availability: "archived",
         },
+        {
+          _id: "product-zero-price",
+          storeId: "store-a",
+          categoryId: "category-store-a",
+          description: "Unpriced SKU",
+          name: "Bottle Water",
+        },
       ],
       productSku: [
         {
@@ -214,6 +221,17 @@ describe("listRegisterCatalog", () => {
           images: [],
           price: 1000,
           quantityAvailable: 9,
+        },
+        {
+          _id: "sku-zero-price",
+          storeId: "store-a",
+          productId: "product-zero-price",
+          sku: "BOTTLE-WATER-ZERO",
+          barcode: "777",
+          images: [],
+          netPrice: 0,
+          price: 0,
+          quantityAvailable: 200,
         },
       ],
     });

--- a/packages/athena-webapp/convex/pos/application/queries/listRegisterCatalog.ts
+++ b/packages/athena-webapp/convex/pos/application/queries/listRegisterCatalog.ts
@@ -81,7 +81,7 @@ function mapSkuToRegisterCatalogRow(args: {
     name: args.product.name,
     sku: args.sku.sku ?? "",
     barcode: args.sku.barcode ?? "",
-    price: args.sku.netPrice ?? args.sku.price,
+    price: getRegisterCatalogPrice(args.sku),
     category: args.category,
     description: args.product.description ?? "",
     image: args.sku.images[0] ?? null,
@@ -90,6 +90,10 @@ function mapSkuToRegisterCatalogRow(args: {
     color: args.color,
     areProcessingFeesAbsorbed: args.product.areProcessingFeesAbsorbed ?? false,
   };
+}
+
+function getRegisterCatalogPrice(sku: Doc<"productSku">) {
+  return sku.netPrice ?? sku.price;
 }
 
 export async function listRegisterCatalog(
@@ -118,6 +122,10 @@ export async function listRegisterCatalog(
       product.storeId !== args.storeId ||
       product.availability === "archived"
     ) {
+      continue;
+    }
+
+    if (getRegisterCatalogPrice(sku) <= 0) {
       continue;
     }
 

--- a/packages/athena-webapp/convex/schema.ts
+++ b/packages/athena-webapp/convex/schema.ts
@@ -192,6 +192,11 @@ const schema = defineSchema({
     .index("by_posCustomerId", ["posCustomerId"]),
   dailyClose: defineTable(dailyCloseSchema)
     .index("by_storeId_operatingDate", ["storeId", "operatingDate"])
+    .index("by_storeId_operatingDate_lifecycleStatus", [
+      "storeId",
+      "operatingDate",
+      "lifecycleStatus",
+    ])
     .index("by_storeId_status", ["storeId", "status"])
     .index("by_storeId_isCurrent", ["storeId", "isCurrent"])
     .index("by_storeId_status_operatingDate", [

--- a/packages/athena-webapp/convex/schemas/operations/dailyClose.ts
+++ b/packages/athena-webapp/convex/schemas/operations/dailyClose.ts
@@ -69,6 +69,13 @@ export const dailyCloseSchema = v.object({
   organizationId: v.id("organization"),
   operatingDate: v.string(),
   status: v.union(v.literal("open"), v.literal("completed")),
+  lifecycleStatus: v.optional(
+    v.union(
+      v.literal("active"),
+      v.literal("reopened"),
+      v.literal("superseded"),
+    ),
+  ),
   isCurrent: v.boolean(),
   readiness: v.object({
     status: dailyCloseReadinessStatusValidator,
@@ -88,4 +95,11 @@ export const dailyCloseSchema = v.object({
   completedAt: v.optional(v.number()),
   completedByUserId: v.optional(v.id("athenaUser")),
   completedByStaffProfileId: v.optional(v.id("staffProfile")),
+  reopenedAt: v.optional(v.number()),
+  reopenedByUserId: v.optional(v.id("athenaUser")),
+  reopenedByStaffProfileId: v.optional(v.id("staffProfile")),
+  reopenReason: v.optional(v.string()),
+  reopenedFromDailyCloseId: v.optional(v.id("dailyClose")),
+  supersededByDailyCloseId: v.optional(v.id("dailyClose")),
+  supersedesDailyCloseId: v.optional(v.id("dailyClose")),
 });

--- a/packages/athena-webapp/src/components/operations/DailyCloseHistoryView.test.tsx
+++ b/packages/athena-webapp/src/components/operations/DailyCloseHistoryView.test.tsx
@@ -363,6 +363,25 @@ describe("DailyCloseHistoryView", () => {
     expect(screen.queryByText(/manager approval/i)).not.toBeInTheDocument();
   });
 
+  it("shows reopened metadata without exposing a reopen action", () => {
+    mockQueries([
+      historyRecord({
+        _id: "daily-close-reopened",
+        reopenedAt: Date.UTC(2026, 4, 9, 8),
+        reopenReason: "Cash deposit corrected.",
+      }),
+    ]);
+
+    render(<DailyCloseHistoryView />);
+
+    expect(screen.getByText("Reopened")).toBeInTheDocument();
+    expect(screen.getByText("Reopened after completion")).toBeInTheDocument();
+    expect(screen.getByText(/Cash deposit corrected/i)).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Reopen End-of-Day Review" }),
+    ).not.toBeInTheDocument();
+  });
+
   it("keeps source links as navigation with origin context", () => {
     render(<DailyCloseHistoryView />);
 

--- a/packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx
+++ b/packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx
@@ -54,7 +54,10 @@ export type DailyCloseHistoryRecord = {
   readinessStatus?: DailyCloseSnapshot["readiness"] extends { status: infer Status }
     ? Status
     : string;
+  reopenedAt?: number | null;
+  reopenReason?: string | null;
   reportSnapshot?: DailyCloseStoredSnapshot | DailyCloseSnapshot | null;
+  supersededByDailyCloseId?: Id<"dailyClose"> | string | null;
   reviewCount?: number;
   status?: string;
   summary?: DailyCloseSnapshot["summary"];
@@ -140,6 +143,18 @@ function getHistoryRecordCompletedBy(record: DailyCloseHistoryRecord) {
 
 function getHistoryRecordSummary(record: DailyCloseHistoryRecord) {
   return record.summary ?? record.reportSnapshot?.summary;
+}
+
+function getHistoryLifecycleLabel(record: DailyCloseHistoryRecord) {
+  if (record.status === "superseded" || record.supersededByDailyCloseId) {
+    return "Superseded";
+  }
+
+  if (record.reopenedAt || record.reopenReason) {
+    return "Reopened";
+  }
+
+  return "Completed";
 }
 
 function normalizeHistorySnapshot(
@@ -390,7 +405,7 @@ function DailyCloseHistoryConnectedView({
                               </p>
                             </div>
                             <Badge className="border-border bg-transparent text-muted-foreground">
-                              Completed
+                              {getHistoryLifecycleLabel(record)}
                             </Badge>
                           </div>
 
@@ -489,6 +504,23 @@ function DailyCloseHistoryConnectedView({
                         <p className="mt-layout-md rounded-md border border-border bg-surface p-layout-sm text-sm leading-6 text-foreground">
                           {selectedSnapshot.completedClose.notes}
                         </p>
+                      ) : null}
+                      {selectedRecord.reopenedAt || selectedRecord.reopenReason ? (
+                        <div className="mt-layout-md rounded-md border border-warning/30 bg-warning/10 p-layout-sm text-sm leading-6">
+                          <p className="font-medium text-warning-foreground">
+                            Reopened after completion
+                          </p>
+                          <p className="mt-1 text-muted-foreground">
+                            {selectedRecord.reopenedAt
+                              ? formatDailyCloseCompletedAt(
+                                  selectedRecord.reopenedAt,
+                                )
+                              : "Reopen time unavailable"}
+                            {selectedRecord.reopenReason
+                              ? `. ${selectedRecord.reopenReason}`
+                              : "."}
+                          </p>
+                        </div>
                       ) : null}
                     </div>
 

--- a/packages/athena-webapp/src/components/operations/DailyCloseView.test.tsx
+++ b/packages/athena-webapp/src/components/operations/DailyCloseView.test.tsx
@@ -1170,6 +1170,104 @@ describe("DailyCloseViewContent", () => {
     expect(screen.getByText("Enter manager credentials")).toBeInTheDocument();
   });
 
+  it("shows manager-approved reopen only for current completed close and requires a reason", async () => {
+    const user = userEvent.setup();
+    const onReopen = vi.fn(async () => ok({ action: "reopened" }));
+
+    renderContent(
+      {
+        ...readySnapshot,
+        completedClose: {
+          completedAt: Date.UTC(2026, 4, 7, 23, 15),
+          completedByStaffName: "Ama Mensah",
+        },
+        existingClose: {
+          _id: "daily-close-1",
+          isCurrent: true,
+          lifecycleStatus: "active",
+        },
+        status: "completed",
+      },
+      { onReopen },
+    );
+
+    const reopenButton = screen.getByRole("button", {
+      name: "Reopen End-of-Day Review",
+    });
+
+    expect(reopenButton).toBeDisabled();
+
+    await user.type(
+      screen.getByLabelText("Reopen reason"),
+      "Cash deposit corrected.",
+    );
+    await user.click(reopenButton);
+
+    expect(onReopen).toHaveBeenCalledWith({
+      endAt: readySnapshot.endAt,
+      operatingDate: readySnapshot.operatingDate,
+      reason: "Cash deposit corrected.",
+      startAt: readySnapshot.startAt,
+    });
+  });
+
+  it("does not show reopen for superseded or already reopened close records", () => {
+    const { rerender } = renderContent(
+      {
+        ...readySnapshot,
+        completedClose: {
+          completedAt: Date.UTC(2026, 4, 7, 23, 15),
+          completedByStaffName: "Ama Mensah",
+        },
+        existingClose: {
+          _id: "daily-close-1",
+          isCurrent: true,
+          lifecycleStatus: "superseded",
+        },
+        status: "completed",
+      },
+      { onReopen: vi.fn(async () => ok({ action: "reopened" })) },
+    );
+
+    expect(
+      screen.queryByRole("button", { name: "Reopen End-of-Day Review" }),
+    ).not.toBeInTheDocument();
+
+    rerender(
+      <DailyCloseViewContent
+        currency="GHS"
+        hasFullAdminAccess
+        isAuthenticated
+        isCompleting={false}
+        isLoadingAccess={false}
+        isLoadingSnapshot={false}
+        onComplete={vi.fn(async () => ok({ closeId: "close-1" }))}
+        onReopen={vi.fn(async () => ok({ action: "reopened" }))}
+        orgUrlSlug="wigclub"
+        snapshot={{
+          ...readySnapshot,
+          completedClose: {
+            completedAt: Date.UTC(2026, 4, 7, 23, 15),
+            completedByStaffName: "Ama Mensah",
+          },
+          existingClose: {
+            _id: "daily-close-1",
+            isCurrent: true,
+            lifecycleStatus: "reopened",
+          },
+          status: "completed",
+        }}
+        storeId={"store-1" as Id<"store">}
+        storeUrlSlug="osu"
+      />,
+    );
+
+    expect(screen.getByText("Review required")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Reopen End-of-Day Review" }),
+    ).not.toBeInTheDocument();
+  });
+
   it("renders command-result user errors inline with operator-safe copy", async () => {
     const user = userEvent.setup();
 

--- a/packages/athena-webapp/src/components/operations/DailyCloseView.tsx
+++ b/packages/athena-webapp/src/components/operations/DailyCloseView.tsx
@@ -76,6 +76,7 @@ import { OperationsSummaryMetric } from "./OperationsSummaryMetric";
 type DailyCloseApi = {
   completeDailyClose?: unknown;
   getDailyCloseSnapshot?: unknown;
+  reopenDailyClose?: unknown;
 };
 
 const useExpectedDailyCloseQuery = useQuery as unknown as (
@@ -131,6 +132,15 @@ export type DailyCloseSnapshot = {
     completedAt?: number | null;
     completedByStaffName?: string | null;
     notes?: string | null;
+  } | null;
+  existingClose?: {
+    _id?: Id<"dailyClose"> | string;
+    isCurrent?: boolean;
+    lifecycleStatus?: "active" | "reopened" | "superseded";
+    reopenedAt?: number | null;
+    reopenedByStaffProfileId?: Id<"staffProfile"> | null;
+    reopenReason?: string | null;
+    supersededByDailyCloseId?: Id<"dailyClose"> | string | null;
   } | null;
   operatingDate: string;
   readyItems: DailyCloseItem[];
@@ -206,6 +216,14 @@ type CompletionArgs = {
   startAt: number;
 };
 
+type ReopenArgs = {
+  approvalProofId?: Id<"approvalProof">;
+  endAt: number;
+  operatingDate: string;
+  reason: string;
+  startAt: number;
+};
+
 export type BucketStatus = "blocked" | "carry-forward" | "ready" | "review";
 
 const bucketTabValues: BucketStatus[] = [
@@ -236,6 +254,9 @@ type DailyCloseViewContentProps = {
   latestSelectableOperatingDate?: Date;
   onComplete: (
     args: CompletionArgs,
+  ) => Promise<NormalizedApprovalCommandResult<unknown>>;
+  onReopen?: (
+    args: ReopenArgs,
   ) => Promise<NormalizedApprovalCommandResult<unknown>>;
   onOperatingDateChange?: (date: Date) => void;
   onAuthenticateForApproval?: (args: {
@@ -585,6 +606,13 @@ function normalizeCommandMessage(
 }
 
 function getDailyCloseStatus(snapshot: DailyCloseSnapshot): DailyCloseStatus {
+  if (
+    snapshot.existingClose?.lifecycleStatus === "reopened" ||
+    snapshot.existingClose?.lifecycleStatus === "superseded"
+  ) {
+    return snapshot.readiness?.status === "blocked" ? "blocked" : "needs_review";
+  }
+
   if (snapshot.status) return snapshot.status;
 
   if (snapshot.completedClose) return "completed";
@@ -596,6 +624,15 @@ function getDailyCloseStatus(snapshot: DailyCloseSnapshot): DailyCloseStatus {
   if (snapshot.carryForwardItems.length > 0) return "carry_forward";
 
   return "ready";
+}
+
+function canReopenDailyClose(snapshot: DailyCloseSnapshot) {
+  return (
+    getDailyCloseStatus(snapshot) === "completed" &&
+    snapshot.existingClose?.isCurrent !== false &&
+    snapshot.existingClose?.lifecycleStatus !== "reopened" &&
+    snapshot.existingClose?.lifecycleStatus !== "superseded"
+  );
 }
 
 function getItemId(item: DailyCloseItem) {
@@ -1371,7 +1408,12 @@ function getStatusDisplayCopy(
 function normalizeCompletedReportSnapshot(
   snapshot: DailyCloseSnapshot,
 ): DailyCloseSnapshot {
-  if (snapshot.status !== "completed" || !snapshot.reportSnapshot) {
+  if (
+    snapshot.status !== "completed" ||
+    snapshot.existingClose?.lifecycleStatus === "reopened" ||
+    snapshot.existingClose?.lifecycleStatus === "superseded" ||
+    !snapshot.reportSnapshot
+  ) {
     return snapshot;
   }
 
@@ -2365,12 +2407,16 @@ function OperatingDatePicker({
 
 function CompletionRail({
   commandMessage,
+  canReopen,
   isBlocked,
   isCompleted,
   isCompleting,
   notes,
   onComplete,
   onNotesChange,
+  onReopen,
+  onReopenReasonChange,
+  reopenReason,
   snapshot,
   status,
 }: {
@@ -2378,12 +2424,16 @@ function CompletionRail({
     kind: "error" | "success";
     message: string;
   } | null;
+  canReopen: boolean;
   isBlocked: boolean;
   isCompleted: boolean;
   isCompleting: boolean;
   notes: string;
   onComplete: () => void;
   onNotesChange: (notes: string) => void;
+  onReopen?: () => void;
+  onReopenReasonChange: (reason: string) => void;
+  reopenReason: string;
   snapshot: DailyCloseSnapshot;
   status: DailyCloseStatus;
 }) {
@@ -2521,6 +2571,35 @@ function CompletionRail({
                 {snapshot.completedClose.notes}
               </p>
             ) : null}
+            {canReopen ? (
+              <div className="mt-layout-md space-y-layout-sm border-t border-success/30 pt-layout-md">
+                <label
+                  className="text-sm font-medium text-foreground"
+                  htmlFor="daily-close-reopen-reason"
+                >
+                  Reopen reason
+                </label>
+                <textarea
+                  className="min-h-20 w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                  id="daily-close-reopen-reason"
+                  onChange={(event) =>
+                    onReopenReasonChange(event.target.value)
+                  }
+                  placeholder="Enter why this close needs revision."
+                  value={reopenReason}
+                />
+                <LoadingButton
+                  className="w-full"
+                  disabled={!reopenReason.trim()}
+                  isLoading={isCompleting}
+                  onClick={onReopen}
+                  type="button"
+                  variant="outline"
+                >
+                  Reopen End-of-Day Review
+                </LoadingButton>
+              </div>
+            ) : null}
           </div>
         ) : (
           <div className="mt-layout-md space-y-layout-sm">
@@ -2578,6 +2657,7 @@ export function DailyCloseViewContent({
   latestSelectableOperatingDate,
   onComplete,
   onOperatingDateChange,
+  onReopen,
   onAuthenticateForApproval,
   orgUrlSlug,
   snapshot,
@@ -2585,6 +2665,7 @@ export function DailyCloseViewContent({
   storeUrlSlug,
 }: DailyCloseViewContentProps) {
   const [notes, setNotes] = useState("");
+  const [reopenReason, setReopenReason] = useState("");
   const [commandMessage, setCommandMessage] = useState<{
     kind: "error" | "success";
     message: string;
@@ -2622,6 +2703,7 @@ export function DailyCloseViewContent({
 
   useEffect(() => {
     setCommandMessage(null);
+    setReopenReason("");
   }, [snapshot?.operatingDate]);
 
   if (isLoadingAccess) {
@@ -2657,6 +2739,9 @@ export function DailyCloseViewContent({
     : "ready";
   const isBlocked = status === "blocked";
   const isCompleted = status === "completed";
+  const canReopen = displaySnapshot
+    ? canReopenDailyClose(displaySnapshot) && Boolean(onReopen)
+    : false;
   const displayCopy = displaySnapshot
     ? getStatusDisplayCopy(displaySnapshot, status)
     : statusCopy[status];
@@ -2703,6 +2788,60 @@ export function DailyCloseViewContent({
             kind: "success",
             message: "End-of-day review completed.",
           });
+          return;
+        }
+
+        setCommandMessage({
+          kind: "error",
+          message: normalizeCommandMessage(commandResult),
+        });
+      },
+    });
+
+    if (result.kind === "approval_required") return;
+  };
+
+  const handleReopen = async () => {
+    if (!snapshot || !onReopen || !canReopen) return;
+
+    const reason = reopenReason.trim();
+
+    if (!reason) {
+      setCommandMessage({
+        kind: "error",
+        message: "Reopen reason required. Enter a reason before reopening.",
+      });
+      return;
+    }
+
+    setCommandMessage(null);
+
+    const reopenArgs = {
+      endAt: snapshot.endAt,
+      operatingDate: snapshot.operatingDate,
+      reason,
+      startAt: snapshot.startAt,
+    };
+
+    const result = await completionApprovalRunner.run({
+      execute: (approvalArgs: ApprovalRetryArgs) =>
+        onReopen({
+          ...reopenArgs,
+          ...(approvalArgs.approvalProofId
+            ? { approvalProofId: approvalArgs.approvalProofId }
+            : {}),
+        }),
+      onResult: (commandResult) => {
+        if (commandResult.kind === "approval_required") {
+          return;
+        }
+
+        if (commandResult.kind === "ok") {
+          setCommandMessage({
+            kind: "success",
+            message: "End-of-Day Review reopened.",
+          });
+          setReopenReason("");
           return;
         }
 
@@ -2881,6 +3020,7 @@ export function DailyCloseViewContent({
       rail={
         displaySnapshot ? (
           <CompletionRail
+            canReopen={canReopen}
             commandMessage={commandMessage}
             isBlocked={isBlocked}
             isCompleted={isCompleted}
@@ -2888,6 +3028,9 @@ export function DailyCloseViewContent({
             notes={notes}
             onComplete={() => void handleComplete()}
             onNotesChange={setNotes}
+            onReopen={() => void handleReopen()}
+            onReopenReasonChange={setReopenReason}
+            reopenReason={reopenReason}
             snapshot={displaySnapshot}
             status={status}
           />
@@ -2926,11 +3069,13 @@ function DailyCloseApiPendingView() {
 type DailyCloseConnectedViewProps = {
   completeDailyClose: unknown;
   getDailyCloseSnapshot: unknown;
+  reopenDailyClose?: unknown;
 };
 
 function DailyCloseConnectedView({
   completeDailyClose,
   getDailyCloseSnapshot,
+  reopenDailyClose,
 }: DailyCloseConnectedViewProps) {
   const {
     activeStore,
@@ -2964,6 +3109,9 @@ function DailyCloseConnectedView({
   ) as DailyCloseSnapshot | undefined;
   const completeDailyCloseMutation =
     useExpectedDailyCloseMutation(completeDailyClose);
+  const reopenDailyCloseMutation = useExpectedDailyCloseMutation(
+    reopenDailyClose ?? completeDailyClose,
+  );
   const authenticateForApproval = useMutation(
     api.operations.staffCredentials.authenticateStaffCredentialForApproval,
   );
@@ -3000,6 +3148,36 @@ function DailyCloseConnectedView({
     }
   };
 
+  const handleReopen = async (args: ReopenArgs) => {
+    if (!activeStore?._id || !reopenDailyClose) {
+      return {
+        kind: "user_error",
+        error: {
+          code: "validation_failed",
+          message: "Reopen action is not available yet.",
+        },
+      } as NormalizedCommandResult<unknown>;
+    }
+
+    setIsCompleting(true);
+
+    try {
+      return await runCommand(
+        () =>
+          reopenDailyCloseMutation({
+            approvalProofId: args.approvalProofId,
+            endAt: args.endAt,
+            operatingDate: args.operatingDate,
+            reason: args.reason,
+            startAt: args.startAt,
+            storeId: activeStore._id,
+          }) as Promise<ApprovalCommandResult<unknown>>,
+      );
+    } finally {
+      setIsCompleting(false);
+    }
+  };
+
   const handleOperatingDateChange = (date: Date) => {
     const nextRange = getLocalOperatingDateRange(date);
 
@@ -3022,6 +3200,7 @@ function DailyCloseConnectedView({
       isLoadingSnapshot={snapshot === undefined}
       onComplete={handleComplete}
       onOperatingDateChange={handleOperatingDateChange}
+      onReopen={reopenDailyClose ? handleReopen : undefined}
       onAuthenticateForApproval={(args) =>
         runCommand(
           () =>
@@ -3066,6 +3245,7 @@ export function DailyCloseView() {
     <DailyCloseConnectedView
       completeDailyClose={dailyCloseApi.completeDailyClose}
       getDailyCloseSnapshot={dailyCloseApi.getDailyCloseSnapshot}
+      reopenDailyClose={dailyCloseApi.reopenDailyClose}
     />
   );
 }

--- a/packages/athena-webapp/src/components/pos/register/POSRegisterOpeningGuard.test.tsx
+++ b/packages/athena-webapp/src/components/pos/register/POSRegisterOpeningGuard.test.tsx
@@ -72,6 +72,9 @@ vi.mock("@/hooks/useGetActiveStore", () => ({
 vi.mock("~/convex/_generated/api", () => ({
   api: {
     operations: {
+      dailyClose: {
+        getDailyCloseSnapshot: "getDailyCloseSnapshot",
+      },
       dailyOpening: {
         getDailyOpeningSnapshot: "getDailyOpeningSnapshot",
       },
@@ -90,6 +93,17 @@ describe("POSRegisterOpeningGuard", () => {
       },
       isLoadingStores: false,
     });
+    useQueryMock.mockImplementation((queryName: string) => {
+      if (queryName === "getDailyOpeningSnapshot") {
+        return { status: "started" };
+      }
+
+      if (queryName === "getDailyCloseSnapshot") {
+        return { status: "ready" };
+      }
+
+      return undefined;
+    });
   });
 
   afterEach(() => {
@@ -97,10 +111,6 @@ describe("POSRegisterOpeningGuard", () => {
   });
 
   it("renders the register when the store day has started", () => {
-    useQueryMock.mockReturnValue({
-      status: "started",
-    });
-
     render(
       <POSRegisterOpeningGuard>
         <div>Register workspace</div>
@@ -115,11 +125,26 @@ describe("POSRegisterOpeningGuard", () => {
         storeId: "store-1",
       }),
     );
+    expect(useQueryMock).toHaveBeenCalledWith(
+      "getDailyCloseSnapshot",
+      expect.objectContaining({
+        operatingDate: "2026-05-09",
+        storeId: "store-1",
+      }),
+    );
   });
 
   it("shows a blocked state when the store day has not started", () => {
-    useQueryMock.mockReturnValue({
-      status: "ready",
+    useQueryMock.mockImplementation((queryName: string) => {
+      if (queryName === "getDailyOpeningSnapshot") {
+        return { status: "ready" };
+      }
+
+      if (queryName === "getDailyCloseSnapshot") {
+        return { status: "ready" };
+      }
+
+      return undefined;
     });
 
     render(
@@ -143,8 +168,93 @@ describe("POSRegisterOpeningGuard", () => {
     );
   });
 
+  it("directs the operator to End-of-Day Review when the store day is closed", () => {
+    useQueryMock.mockImplementation((queryName: string) => {
+      if (queryName === "getDailyOpeningSnapshot") {
+        return { status: "started" };
+      }
+
+      if (queryName === "getDailyCloseSnapshot") {
+        return { status: "completed" };
+      }
+
+      return undefined;
+    });
+
+    render(
+      <POSRegisterOpeningGuard>
+        <div>Register workspace</div>
+      </POSRegisterOpeningGuard>,
+    );
+
+    expect(screen.queryByText("Register workspace")).not.toBeInTheDocument();
+    expect(screen.getByText("Store day closed")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "End-of-Day Review has already closed this operating day. Reopen the day from End-of-Day Review before entering POS.",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /End-of-Day Review/i }),
+    ).toHaveAttribute(
+      "href",
+      "/wigclub/store/wigclub/operations/daily-close",
+    );
+  });
+
+  it("allows POS when the active close was reopened and Opening Handoff is started", () => {
+    useQueryMock.mockImplementation((queryName: string) => {
+      if (queryName === "getDailyOpeningSnapshot") {
+        return { status: "started" };
+      }
+
+      if (queryName === "getDailyCloseSnapshot") {
+        return {
+          existingClose: { lifecycleStatus: "reopened" },
+          status: "completed",
+        };
+      }
+
+      return undefined;
+    });
+
+    render(
+      <POSRegisterOpeningGuard>
+        <div>Register workspace</div>
+      </POSRegisterOpeningGuard>,
+    );
+
+    expect(screen.getByText("Register workspace")).toBeInTheDocument();
+    expect(screen.queryByText("Store day closed")).not.toBeInTheDocument();
+  });
+
+
   it("waits for the opening snapshot before rendering or redirecting", () => {
-    useQueryMock.mockReturnValue(undefined);
+    useQueryMock.mockImplementation((queryName: string) => {
+      if (queryName === "getDailyCloseSnapshot") {
+        return { status: "ready" };
+      }
+
+      return undefined;
+    });
+
+    render(
+      <POSRegisterOpeningGuard>
+        <div>Register workspace</div>
+      </POSRegisterOpeningGuard>,
+    );
+
+    expect(screen.queryByText("Register workspace")).not.toBeInTheDocument();
+  });
+
+  it("waits for the close snapshot before rendering or redirecting", () => {
+    useQueryMock.mockImplementation((queryName: string) => {
+      if (queryName === "getDailyOpeningSnapshot") {
+        return { status: "started" };
+      }
+
+      return undefined;
+    });
 
     render(
       <POSRegisterOpeningGuard>

--- a/packages/athena-webapp/src/components/pos/register/POSRegisterOpeningGuard.tsx
+++ b/packages/athena-webapp/src/components/pos/register/POSRegisterOpeningGuard.tsx
@@ -14,6 +14,13 @@ type DailyOpeningSnapshot = {
   status?: "blocked" | "needs_attention" | "ready" | "started";
 };
 
+type DailyCloseSnapshot = {
+  existingClose?: {
+    lifecycleStatus?: "active" | "reopened" | "superseded";
+  } | null;
+  status?: "blocked" | "needs_review" | "carry_forward" | "ready" | "completed";
+};
+
 function getLocalOperatingDate(date = new Date()) {
   const localDate = new Date(
     date.getTime() - date.getTimezoneOffset() * 60_000,
@@ -57,13 +64,34 @@ export function POSRegisterOpeningGuard({
         }
       : "skip",
   ) as DailyOpeningSnapshot | undefined;
+  const dailyCloseSnapshot = useQuery(
+    api.operations.dailyClose.getDailyCloseSnapshot,
+    activeStore?._id
+      ? {
+          ...operatingDateRange,
+          storeId: activeStore._id,
+        }
+      : "skip",
+  ) as DailyCloseSnapshot | undefined;
 
-  if (isLoadingStores || !activeStore?._id || snapshot === undefined) {
+  if (
+    isLoadingStores ||
+    !activeStore?._id ||
+    snapshot === undefined ||
+    dailyCloseSnapshot === undefined
+  ) {
     return null;
   }
 
   if (snapshot.status !== "started") {
     return <StoreDayNotStartedState />;
+  }
+
+  if (
+    dailyCloseSnapshot.status === "completed" &&
+    dailyCloseSnapshot.existingClose?.lifecycleStatus !== "reopened"
+  ) {
+    return <StoreDayClosedState />;
   }
 
   return <>{children}</>;
@@ -125,6 +153,72 @@ function StoreDayNotStartedState() {
                 to="/$orgUrlSlug/store/$storeUrlSlug/operations/opening"
               >
                 Opening Handoff
+                <ArrowUpRight className="h-4 w-4" />
+              </Link>
+            </Button>
+          ) : null}
+        </div>
+      </FadeIn>
+    </View>
+  );
+}
+
+function StoreDayClosedState() {
+  const params = useParams({ strict: false }) as
+    | {
+        orgUrlSlug?: string;
+        storeUrlSlug?: string;
+      }
+    | undefined;
+  const canLinkToDailyClose = Boolean(params?.orgUrlSlug && params.storeUrlSlug);
+
+  return (
+    <View
+      fullHeight
+      width="full"
+      contentClassName="flex h-full max-h-full flex-col overflow-hidden rounded-2xl border border-border/80 bg-white"
+      headerClassName="shrink-0"
+      mainClassName="min-h-0 flex-1"
+      header={
+        <ComposedPageHeader
+          width="full"
+          className="h-auto flex-wrap gap-x-4 gap-y-3 py-4"
+          leadingContent={
+            <div className="flex min-w-0 flex-1 items-center gap-3">
+              <div className="w-2 h-2 bg-background rounded-full" />
+              <p className="text-lg font-semibold text-gray-900">POS</p>
+            </div>
+          }
+        />
+      }
+    >
+      <FadeIn className="flex h-full min-h-0 items-center justify-center p-6">
+        <div className="flex w-full max-w-2xl flex-col items-center rounded-lg border border-border bg-surface px-12 py-16 text-center shadow-sm">
+          <div className="mb-6 flex h-[4.5rem] w-[4.5rem] items-center justify-center rounded-full bg-warning/10 text-warning">
+            <Store className="h-7 w-7" />
+          </div>
+          <h2 className="text-xl font-medium text-foreground/80">
+            Store day closed
+          </h2>
+          <p className="mt-3 max-w-lg text-base leading-7 text-muted-foreground">
+            End-of-Day Review has already closed this operating day. Reopen the
+            day from End-of-Day Review before entering POS.
+          </p>
+          {canLinkToDailyClose ? (
+            <Button
+              asChild
+              className="mt-8 bg-background/80 text-muted-foreground hover:text-foreground"
+              size="lg"
+              variant="outline"
+            >
+              <Link
+                params={{
+                  orgUrlSlug: params!.orgUrlSlug!,
+                  storeUrlSlug: params!.storeUrlSlug!,
+                }}
+                to="/$orgUrlSlug/store/$storeUrlSlug/operations/daily-close"
+              >
+                End-of-Day Review
                 <ArrowUpRight className="h-4 w-4" />
               </Link>
             </Button>


### PR DESCRIPTION
## Summary
- add immutable Daily Close lifecycle states for active, reopened, and superseded closes
- add the manager-approved Daily Close reopen command and revised close completion behavior
- update Daily Operations, Opening Handoff, POS entry gating, End-of-Day Review, and history views for reopened closes
- include local dirty POS catalog and POS opening-guard changes, plus refreshed plan, solution docs, and graph artifacts

## Linear
- V26-544: https://linear.app/v26-labs/issue/V26-544/model-immutable-daily-close-reopen-lifecycle
- V26-545: https://linear.app/v26-labs/issue/V26-545/add-manager-approved-end-of-day-review-reopen-command
- V26-546: https://linear.app/v26-labs/issue/V26-546/update-store-day-read-models-and-pos-gate-for-reopened-closes
- V26-547: https://linear.app/v26-labs/issue/V26-547/add-end-of-day-review-reopen-ui-through-manager-approval-dialog
- V26-548: https://linear.app/v26-labs/issue/V26-548/refresh-daily-close-reopen-lifecycle-docs-and-graph-artifacts

## Validation
- bun run pr:athena
- bun run --filter '@athena/webapp' test -- convex/operations/dailyClose.test.ts convex/operations/approvalRequests.test.ts convex/operations/operationsQueryIndexes.test.ts convex/operations/dailyOperations.test.ts convex/operations/dailyOpening.test.ts src/components/pos/register/POSRegisterOpeningGuard.test.tsx src/components/operations/DailyCloseHistoryView.test.tsx src/components/operations/DailyCloseView.test.tsx
- bun run --filter '@athena/webapp' test -- src/components/ui/calendar.test.tsx src/components/operations/DailyCloseView.test.tsx src/components/services/ServiceAppointmentsView.test.tsx
- bunx tsc --noEmit -p packages/athena-webapp/tsconfig.json
- bun run --filter '@athena/webapp' audit:convex
- git diff --check
