### PR TITLE
Refine daily operations lifecycle state

### DIFF
--- a/docs/solutions/logic-errors/athena-daily-operations-state-and-eod-review-2026-05-11.md
+++ b/docs/solutions/logic-errors/athena-daily-operations-state-and-eod-review-2026-05-11.md
@@ -1,0 +1,97 @@
+---
+title: Daily Operations State Must Come From Store-Day Snapshots
+date: 2026-05-11
+category: logic-errors
+module: athena-webapp
+problem_type: logic_error
+component: frontend
+symptoms:
+  - "Daily Operations could report future-day sales when local operating dates were derived from UTC ranges."
+  - "Reopened or completed EOD Review records could show the wrong status because UI state was inferred from route context or stale close records."
+  - "Stored historical item copy could leak older End-of-Day Review phrasing after the UI moved to EOD Review titles and end of day review body copy."
+root_cause: logic_error
+resolution_type: code_fix
+severity: medium
+tags:
+  - daily-operations
+  - eod-review
+  - operating-date
+  - store-day
+  - snapshot-state
+---
+
+# Daily Operations State Must Come From Store-Day Snapshots
+
+## Problem
+
+The Daily Operations surface sits above several workflows: opening handoff,
+EOD Review, open work, approvals, registers, POS sessions, expenses, and weekly
+operating metrics. Small UI inferences can drift quickly when they are based on
+route origin, UTC date ranges, or stale record labels instead of the store-day
+snapshot.
+
+This showed up while refining the May 10 and May 11 store-day flow. Reopening a
+closed EOD Review needed to use the current daily close record, state badges
+needed to reflect reopened/blocked/ready cases, and week metrics needed to
+bucket sales by the store's operating date rather than by a future UTC date.
+
+## Symptoms
+
+- Reopening a closed day errored when `dailyCloseId` was missing from the
+  mutation arguments.
+- A reopened EOD Review could display as needs review even when the snapshot was
+  blocked or ready to close.
+- The week strip could show sales on a future operating date because the bucket
+  boundary did not include the store's operating timezone offset.
+- EOD Review copy was mixed between title copy (`EOD Review`) and body copy
+  (`end of day review`), especially in stored historical item messages.
+- Reopen controls briefly depended on the `o=` route origin, which hid a domain
+  action for the wrong reason.
+
+## Solution
+
+Keep Daily Operations and EOD Review UI state tied to the snapshot fields that
+represent store-day truth:
+
+- Reopen actions pass the current `dailyCloseId` and are shown only when the
+  snapshot status is completed, the close is current, and the close lifecycle is
+  neither reopened nor superseded.
+- Daily close lookups prefer the current close record before falling back to
+  older records, so reopened/superseded records do not masquerade as the active
+  close.
+- Week metrics accept the operating timezone offset and bucket transaction
+  totals into the local operating date.
+- Status cards and icons render from lane/status values, not from incidental
+  label text.
+- Historical stored item copy is normalized at render time so old
+  `End-of-Day Review` messages do not leak into the current copy system.
+
+The important boundary is that route origin can help navigation, but it should
+not decide whether an EOD Review can be reopened. The snapshot already carries
+the authoritative lifecycle/currentness information; use that.
+
+## Why This Works
+
+Daily Operations is an aggregate read model. The UI should present the current
+store-day state, not reconstruct it from whichever workflow linked into the
+page. Keeping status, reopenability, and metrics tied to snapshot fields makes
+the behavior stable across direct navigation, opening handoff links, daily close
+links, and historical week navigation.
+
+The same rule applies to copy. Titles and navigation can use `EOD Review`, while
+sentences in item messages can use `end of day review`; render-time
+normalization protects older stored snapshots without rewriting historical data.
+
+## Prevention
+
+- When adding Daily Operations UI state, first look for an existing field on the
+  Daily Operations, Daily Opening, or Daily Close snapshot. Add one to the
+  backend read model if the UI needs a new domain decision.
+- Do not use `o=` or any route-origin parameter to decide domain permissions,
+  lifecycle state, or reopenability. Route origin is navigation context only.
+- For operating-day metrics, pass the store-day timezone/offset through the
+  backend boundary and test with current, historical, and future local dates.
+- Keep EOD Review copy split by context: title/navigation/button text uses
+  `EOD Review`; body sentences use `end of day review`.
+- Add tests for both active snapshots and persisted historical report snapshots
+  whenever changing EOD Review display logic.

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 5085 nodes · 5107 edges · 1610 communities detected
+- 5091 nodes · 5114 edges · 1610 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -1649,7 +1649,7 @@
 
 ### Community 0 - "Community 0"
 Cohesion: 0.04
-Nodes (48): buildDailyCloseTransactionSearch(), canReopenDailyClose(), cn(), formatCarriedOverRegisterCount(), formatDailyCloseMoney(), formatExpenseTransactionCount(), formatMetadataDisplayValue(), formatMetadataValue() (+40 more)
+Nodes (50): buildDailyCloseTransactionSearch(), canReopenDailyClose(), cn(), formatDailyCloseMoney(), formatMetadataDisplayValue(), formatMetadataValue(), formatTimestampMetadata(), getBucketConfigs() (+42 more)
 
 ### Community 1 - "Community 1"
 Cohesion: 0.07
@@ -2240,16 +2240,16 @@ Cohesion: 0.29
 Nodes (0):
 
 ### Community 148 - "Community 148"
+Cohesion: 0.33
+Nodes (2): getProductName(), sortProduct()
+
+### Community 149 - "Community 149"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 149 - "Community 149"
+### Community 150 - "Community 150"
 Cohesion: 0.52
 Nodes (6): addItemToSavedBag(), getActiveSavedBag(), getBaseUrl(), removeItemFromSavedBag(), updateSavedBagItem(), updateSavedBagOwner()
-
-### Community 150 - "Community 150"
-Cohesion: 0.33
-Nodes (2): getProductName(), sortProduct()
 
 ### Community 151 - "Community 151"
 Cohesion: 0.43

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -5615,7 +5615,7 @@
       "relation": "calls",
       "source": "dailyoperations_buildlanes",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
-      "source_location": "L844",
+      "source_location": "L851",
       "target": "dailyoperations_builddailyoperationssnapshotwithctx",
       "weight": 1
     },
@@ -5627,7 +5627,7 @@
       "relation": "calls",
       "source": "dailyoperations_buildweekmetrics",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
-      "source_location": "L750",
+      "source_location": "L755",
       "target": "dailyoperations_builddailyoperationssnapshotwithctx",
       "weight": 1
     },
@@ -5639,7 +5639,7 @@
       "relation": "calls",
       "source": "dailyoperations_getcloseitemcounts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
-      "source_location": "L825",
+      "source_location": "L832",
       "target": "dailyoperations_builddailyoperationssnapshotwithctx",
       "weight": 1
     },
@@ -5651,7 +5651,7 @@
       "relation": "calls",
       "source": "dailyoperations_getdailycloserecordfordate",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
-      "source_location": "L746",
+      "source_location": "L751",
       "target": "dailyoperations_builddailyoperationssnapshotwithctx",
       "weight": 1
     },
@@ -5663,7 +5663,7 @@
       "relation": "calls",
       "source": "dailyoperations_lifecyclecopy",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
-      "source_location": "L823",
+      "source_location": "L830",
       "target": "dailyoperations_builddailyoperationssnapshotwithctx",
       "weight": 1
     },
@@ -5675,7 +5675,7 @@
       "relation": "calls",
       "source": "dailyoperations_listopenqueuesnapshot",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
-      "source_location": "L747",
+      "source_location": "L752",
       "target": "dailyoperations_builddailyoperationssnapshotwithctx",
       "weight": 1
     },
@@ -5687,7 +5687,7 @@
       "relation": "calls",
       "source": "dailyoperations_listtimelineevents",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
-      "source_location": "L748",
+      "source_location": "L753",
       "target": "dailyoperations_builddailyoperationssnapshotwithctx",
       "weight": 1
     },
@@ -5699,7 +5699,7 @@
       "relation": "calls",
       "source": "dailyoperations_openingnotstartedattention",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
-      "source_location": "L767",
+      "source_location": "L773",
       "target": "dailyoperations_builddailyoperationssnapshotwithctx",
       "weight": 1
     },
@@ -5711,7 +5711,7 @@
       "relation": "calls",
       "source": "dailyoperations_primaryaction",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
-      "source_location": "L859",
+      "source_location": "L867",
       "target": "dailyoperations_builddailyoperationssnapshotwithctx",
       "weight": 1
     },
@@ -5723,7 +5723,7 @@
       "relation": "calls",
       "source": "dailyoperations_queueattentionitems",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
-      "source_location": "L803",
+      "source_location": "L810",
       "target": "dailyoperations_builddailyoperationssnapshotwithctx",
       "weight": 1
     },
@@ -5735,7 +5735,7 @@
       "relation": "calls",
       "source": "dailyoperations_resolverange",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
-      "source_location": "L733",
+      "source_location": "L738",
       "target": "dailyoperations_builddailyoperationssnapshotwithctx",
       "weight": 1
     },
@@ -5747,7 +5747,7 @@
       "relation": "calls",
       "source": "dailyoperations_pluralize",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
-      "source_location": "L633",
+      "source_location": "L638",
       "target": "dailyoperations_buildlanes",
       "weight": 1
     },
@@ -17447,7 +17447,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyoperations_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
-      "source_location": "L722",
+      "source_location": "L727",
       "target": "dailyoperations_builddailyoperationssnapshotwithctx",
       "weight": 1
     },
@@ -74995,7 +74995,7 @@
       "label": "buildDailyOperationsSnapshotWithCtx()",
       "norm_label": "builddailyoperationssnapshotwithctx()",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperations.ts",
-      "source_location": "L722"
+      "source_location": "L727"
     },
     {
       "community": 18,

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -3695,7 +3695,7 @@
       "relation": "calls",
       "source": "dailyclose_isinrange",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L743",
+      "source_location": "L744",
       "target": "dailyclose_approvalbelongstorange",
       "weight": 1
     },
@@ -3707,7 +3707,7 @@
       "relation": "calls",
       "source": "dailyclose_registersessionbelongstorange",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L760",
+      "source_location": "L761",
       "target": "dailyclose_approvalbelongstorange",
       "weight": 1
     },
@@ -3719,7 +3719,7 @@
       "relation": "calls",
       "source": "dailyclose_formatpaymentmethodlabel",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L466",
+      "source_location": "L467",
       "target": "dailyclose_approvalrequesttypelabel",
       "weight": 1
     },
@@ -3731,7 +3731,7 @@
       "relation": "calls",
       "source": "dailyclose_builddailycloseapprovalsubject",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L282",
+      "source_location": "L283",
       "target": "dailyclose_builddailyclosecompletionapprovalrequirement",
       "weight": 1
     },
@@ -3743,7 +3743,7 @@
       "relation": "calls",
       "source": "dailyclose_builddailyclosereportsnapshot",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1019",
+      "source_location": "L1031",
       "target": "dailyclose_snapshotrevieweditems",
       "weight": 1
     },
@@ -3755,7 +3755,7 @@
       "relation": "calls",
       "source": "dailyclose_uniquedailycloseitems",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1020",
+      "source_location": "L1032",
       "target": "dailyclose_builddailyclosereportsnapshot",
       "weight": 1
     },
@@ -3767,7 +3767,7 @@
       "relation": "calls",
       "source": "dailyclose_buildexpensesessionsbyid",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1244",
+      "source_location": "L1256",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -3779,7 +3779,7 @@
       "relation": "calls",
       "source": "dailyclose_buildpaymenttotals",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1779",
+      "source_location": "L1791",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -3791,7 +3791,7 @@
       "relation": "calls",
       "source": "dailyclose_buildreadiness",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1782",
+      "source_location": "L1794",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -3803,7 +3803,7 @@
       "relation": "calls",
       "source": "dailyclose_buildregistersessionsbyid",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1237",
+      "source_location": "L1249",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -3815,7 +3815,7 @@
       "relation": "calls",
       "source": "dailyclose_buildstaffnamesbyid",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1176",
+      "source_location": "L1188",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -3827,7 +3827,7 @@
       "relation": "calls",
       "source": "dailyclose_buildterminallabelsbyid",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1259",
+      "source_location": "L1271",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -3839,7 +3839,7 @@
       "relation": "calls",
       "source": "dailyclose_cashdeltasbyregistersessionid",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1234",
+      "source_location": "L1246",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -3851,7 +3851,7 @@
       "relation": "calls",
       "source": "dailyclose_emptysummary",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1162",
+      "source_location": "L1174",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -3863,7 +3863,7 @@
       "relation": "calls",
       "source": "dailyclose_getdailyclosecompletioneventstaffprofileid",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1172",
+      "source_location": "L1184",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -3875,7 +3875,7 @@
       "relation": "calls",
       "source": "dailyclose_getdailyclosefordate",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1167",
+      "source_location": "L1179",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -3887,7 +3887,7 @@
       "relation": "calls",
       "source": "dailyclose_getpriorcompleteddailyclose",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1221",
+      "source_location": "L1233",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -3899,7 +3899,7 @@
       "relation": "calls",
       "source": "dailyclose_getstore",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1125",
+      "source_location": "L1137",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -3911,7 +3911,7 @@
       "relation": "calls",
       "source": "dailyclose_listactiveregistersessions",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1204",
+      "source_location": "L1216",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -3923,7 +3923,7 @@
       "relation": "calls",
       "source": "dailyclose_listclosedregistersessionsforday",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1205",
+      "source_location": "L1217",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -3935,7 +3935,7 @@
       "relation": "calls",
       "source": "dailyclose_listdepositsforday",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1220",
+      "source_location": "L1232",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -3947,7 +3947,7 @@
       "relation": "calls",
       "source": "dailyclose_listexpensesforday",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1219",
+      "source_location": "L1231",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -3959,7 +3959,7 @@
       "relation": "calls",
       "source": "dailyclose_listopenoperationalworkitems",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1208",
+      "source_location": "L1220",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -3971,7 +3971,7 @@
       "relation": "calls",
       "source": "dailyclose_listopenpossessions",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1207",
+      "source_location": "L1219",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -3983,7 +3983,7 @@
       "relation": "calls",
       "source": "dailyclose_listpendingcloseoutapprovals",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1206",
+      "source_location": "L1218",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -3995,7 +3995,7 @@
       "relation": "calls",
       "source": "dailyclose_listtransactionsforday",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1209",
+      "source_location": "L1221",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -4007,7 +4007,7 @@
       "relation": "calls",
       "source": "dailyclose_normalizecompleteddailyclosesnapshot",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1179",
+      "source_location": "L1191",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -4019,7 +4019,7 @@
       "relation": "calls",
       "source": "dailyclose_resolveoperatingdaterange",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1124",
+      "source_location": "L1136",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -4031,7 +4031,7 @@
       "relation": "calls",
       "source": "dailyclose_sortdailycloseblockers",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1781",
+      "source_location": "L1793",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -4043,7 +4043,7 @@
       "relation": "calls",
       "source": "dailyclose_uniquesourcesubjects",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1828",
+      "source_location": "L1840",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -4055,7 +4055,7 @@
       "relation": "calls",
       "source": "dailyclose_builddailycloseapprovalsubject",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2043",
+      "source_location": "L2055",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -4067,7 +4067,7 @@
       "relation": "calls",
       "source": "dailyclose_builddailyclosecompletionapprovalrequirement",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2030",
+      "source_location": "L2042",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -4079,7 +4079,7 @@
       "relation": "calls",
       "source": "dailyclose_builddailyclosereportsnapshot",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2097",
+      "source_location": "L2109",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -4091,7 +4091,7 @@
       "relation": "calls",
       "source": "dailyclose_builddailyclosesnapshotwithctx",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1965",
+      "source_location": "L1977",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -4103,7 +4103,7 @@
       "relation": "calls",
       "source": "dailyclose_createcarryforwardworkitems",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2053",
+      "source_location": "L2065",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -4115,7 +4115,7 @@
       "relation": "calls",
       "source": "dailyclose_getstore",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1940",
+      "source_location": "L1952",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -4127,7 +4127,7 @@
       "relation": "calls",
       "source": "dailyclose_markotherdailyclosesnotcurrent",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2129",
+      "source_location": "L2141",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -4139,7 +4139,7 @@
       "relation": "calls",
       "source": "dailyclose_resolveoperatingdaterange",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1956",
+      "source_location": "L1968",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -4151,7 +4151,7 @@
       "relation": "calls",
       "source": "dailyclose_trimoptional",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2078",
+      "source_location": "L2090",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -4163,7 +4163,7 @@
       "relation": "calls",
       "source": "dailyclose_validatecarryforwardworkitemids",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2016",
+      "source_location": "L2028",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -4175,7 +4175,7 @@
       "relation": "calls",
       "source": "dailyclose_trimoptional",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1874",
+      "source_location": "L1886",
       "target": "dailyclose_createcarryforwardworkitems",
       "weight": 1
     },
@@ -4187,7 +4187,7 @@
       "relation": "calls",
       "source": "dailyclose_buildstaffnamesbyid",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2501",
+      "source_location": "L2513",
       "target": "dailyclose_getcompleteddailyclosehistorydetailwithctx",
       "weight": 1
     },
@@ -4199,7 +4199,7 @@
       "relation": "calls",
       "source": "dailyclose_getdailyclosecompletioneventstaffprofileid",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2497",
+      "source_location": "L2509",
       "target": "dailyclose_getcompleteddailyclosehistorydetailwithctx",
       "weight": 1
     },
@@ -4211,7 +4211,7 @@
       "relation": "calls",
       "source": "dailyclose_getpriorcompleteddailyclose",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2399",
+      "source_location": "L2411",
       "target": "dailyclose_getdailycloseopeningcontextwithctx",
       "weight": 1
     },
@@ -4223,7 +4223,7 @@
       "relation": "calls",
       "source": "dailyclose_buildstaffnamesbyid",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2459",
+      "source_location": "L2471",
       "target": "dailyclose_listcompleteddailyclosehistorywithctx",
       "weight": 1
     },
@@ -4235,7 +4235,7 @@
       "relation": "calls",
       "source": "dailyclose_isinrange",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L705",
+      "source_location": "L706",
       "target": "dailyclose_registersessionbelongstorange",
       "weight": 1
     },
@@ -4247,7 +4247,7 @@
       "relation": "calls",
       "source": "dailyclose_registersessioncloseoutoperatingat",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L702",
+      "source_location": "L703",
       "target": "dailyclose_registersessionbelongstorange",
       "weight": 1
     },
@@ -4259,7 +4259,7 @@
       "relation": "calls",
       "source": "dailyclose_registersessionintersectsrange",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L708",
+      "source_location": "L709",
       "target": "dailyclose_registersessionbelongstorange",
       "weight": 1
     },
@@ -4271,7 +4271,7 @@
       "relation": "calls",
       "source": "dailyclose_builddailyclosereopenapprovalrequirement",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2284",
+      "source_location": "L2296",
       "target": "dailyclose_reopendailyclosewithctx",
       "weight": 1
     },
@@ -4283,7 +4283,7 @@
       "relation": "calls",
       "source": "dailyclose_markotherdailyclosesnotcurrent",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2344",
+      "source_location": "L2356",
       "target": "dailyclose_reopendailyclosewithctx",
       "weight": 1
     },
@@ -4295,7 +4295,7 @@
       "relation": "calls",
       "source": "dailyclose_trimoptional",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2202",
+      "source_location": "L2214",
       "target": "dailyclose_reopendailyclosewithctx",
       "weight": 1
     },
@@ -4307,7 +4307,7 @@
       "relation": "calls",
       "source": "dailyclose_isvalidoperatingdaterange",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L379",
+      "source_location": "L380",
       "target": "dailyclose_resolveoperatingdaterange",
       "weight": 1
     },
@@ -4319,7 +4319,7 @@
       "relation": "calls",
       "source": "dailyclose_safeoperatingdaterange",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L373",
+      "source_location": "L374",
       "target": "dailyclose_resolveoperatingdaterange",
       "weight": 1
     },
@@ -4343,7 +4343,7 @@
       "relation": "calls",
       "source": "dailyclose_formatpaymentmethodlabel",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L445",
+      "source_location": "L446",
       "target": "dailyclose_transactionpaymentsummary",
       "weight": 1
     },
@@ -4403,7 +4403,7 @@
       "relation": "calls",
       "source": "dailycloseview_getlocaloperatingdate",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L548",
+      "source_location": "L590",
       "target": "dailycloseview_builddailyclosetransactionsearch",
       "weight": 1
     },
@@ -4415,32 +4415,8 @@
       "relation": "calls",
       "source": "dailycloseview_getdailyclosestatus",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L629",
+      "source_location": "L671",
       "target": "dailycloseview_canreopendailyclose",
-      "weight": 1
-    },
-    {
-      "_src": "dailycloseview_formatdailyclosemoney",
-      "_tgt": "dailycloseview_formatcarriedoverregistercount",
-      "confidence": "EXTRACTED",
-      "confidence_score": 1,
-      "relation": "calls",
-      "source": "dailycloseview_formatcarriedoverregistercount",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L2983",
-      "target": "dailycloseview_formatdailyclosemoney",
-      "weight": 1
-    },
-    {
-      "_src": "dailycloseview_formatdailyclosemoney",
-      "_tgt": "dailycloseview_getsummarycount",
-      "confidence": "EXTRACTED",
-      "confidence_score": 1,
-      "relation": "calls",
-      "source": "dailycloseview_formatdailyclosemoney",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L2984",
-      "target": "dailycloseview_getsummarycount",
       "weight": 1
     },
     {
@@ -4451,7 +4427,7 @@
       "relation": "calls",
       "source": "dailycloseview_formatmetadatavalue",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L996",
+      "source_location": "L1044",
       "target": "dailycloseview_formatmetadatadisplayvalue",
       "weight": 1
     },
@@ -4463,7 +4439,7 @@
       "relation": "calls",
       "source": "dailycloseview_getmetadatastringvalue",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L998",
+      "source_location": "L1046",
       "target": "dailycloseview_formatmetadatadisplayvalue",
       "weight": 1
     },
@@ -4475,7 +4451,7 @@
       "relation": "calls",
       "source": "dailycloseview_getnumericmetadatavalue",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1047",
+      "source_location": "L1095",
       "target": "dailycloseview_formatmetadatadisplayvalue",
       "weight": 1
     },
@@ -4487,7 +4463,7 @@
       "relation": "calls",
       "source": "dailycloseview_getvariancetone",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1052",
+      "source_location": "L1100",
       "target": "dailycloseview_formatmetadatadisplayvalue",
       "weight": 1
     },
@@ -4499,7 +4475,7 @@
       "relation": "calls",
       "source": "dailycloseview_normalizemetadatalabel",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1006",
+      "source_location": "L1054",
       "target": "dailycloseview_formatmetadatadisplayvalue",
       "weight": 1
     },
@@ -4511,7 +4487,7 @@
       "relation": "calls",
       "source": "dailycloseview_formatdailyclosemoney",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L940",
+      "source_location": "L988",
       "target": "dailycloseview_formatmetadatavalue",
       "weight": 1
     },
@@ -4523,7 +4499,7 @@
       "relation": "calls",
       "source": "dailycloseview_formattimestampmetadata",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L936",
+      "source_location": "L984",
       "target": "dailycloseview_formatmetadatavalue",
       "weight": 1
     },
@@ -4535,7 +4511,7 @@
       "relation": "calls",
       "source": "dailycloseview_humanizemetadatalabel",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L968",
+      "source_location": "L1016",
       "target": "dailycloseview_formatmetadatavalue",
       "weight": 1
     },
@@ -4547,7 +4523,7 @@
       "relation": "calls",
       "source": "dailycloseview_ismoneymetadatalabel",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L939",
+      "source_location": "L987",
       "target": "dailycloseview_formatmetadatavalue",
       "weight": 1
     },
@@ -4559,7 +4535,7 @@
       "relation": "calls",
       "source": "dailycloseview_istimestampmetadatalabel",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L935",
+      "source_location": "L983",
       "target": "dailycloseview_formatmetadatavalue",
       "weight": 1
     },
@@ -4571,7 +4547,7 @@
       "relation": "calls",
       "source": "dailycloseview_normalizemetadatalabel",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L928",
+      "source_location": "L976",
       "target": "dailycloseview_formatmetadatavalue",
       "weight": 1
     },
@@ -4583,7 +4559,7 @@
       "relation": "calls",
       "source": "dailycloseview_iszeroactivitydailyclose",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1473",
+      "source_location": "L1521",
       "target": "dailycloseview_getbucketconfigs",
       "weight": 1
     },
@@ -4595,7 +4571,7 @@
       "relation": "calls",
       "source": "dailycloseview_getbucketcountclassname",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L441",
+      "source_location": "L483",
       "target": "dailycloseview_cn",
       "weight": 1
     },
@@ -4607,7 +4583,7 @@
       "relation": "calls",
       "source": "dailycloseview_getitemid",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L651",
+      "source_location": "L693",
       "target": "dailycloseview_getcarryforwardworkitemid",
       "weight": 1
     },
@@ -4619,7 +4595,7 @@
       "relation": "calls",
       "source": "dailycloseview_getlocaloperatingdate",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L554",
+      "source_location": "L596",
       "target": "dailycloseview_getdailyclosesalesmetriclabels",
       "weight": 1
     },
@@ -4631,7 +4607,7 @@
       "relation": "calls",
       "source": "dailycloseview_humanizemetadatalabel",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L893",
+      "source_location": "L941",
       "target": "dailycloseview_getdisplaymetadatalabel",
       "weight": 1
     },
@@ -4643,7 +4619,7 @@
       "relation": "calls",
       "source": "dailycloseview_normalizemetadatalabel",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L881",
+      "source_location": "L929",
       "target": "dailycloseview_getdisplaymetadatalabel",
       "weight": 1
     },
@@ -4655,8 +4631,20 @@
       "relation": "calls",
       "source": "dailycloseview_getitemcontextlabel",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L670",
+      "source_location": "L718",
       "target": "dailycloseview_humanizemetadatalabel",
+      "weight": 1
+    },
+    {
+      "_src": "dailycloseview_getitemdescription",
+      "_tgt": "dailycloseview_normalizedailycloseitemcopy",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "dailycloseview_getitemdescription",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
+      "source_location": "L701",
+      "target": "dailycloseview_normalizedailycloseitemcopy",
       "weight": 1
     },
     {
@@ -4667,7 +4655,7 @@
       "relation": "calls",
       "source": "dailycloseview_getlocaloperatingdate",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L575",
+      "source_location": "L617",
       "target": "dailycloseview_getlocaloperatingdaterange",
       "weight": 1
     },
@@ -4679,7 +4667,7 @@
       "relation": "calls",
       "source": "dailycloseview_getlocaldatefromoperatingdate",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L583",
+      "source_location": "L625",
       "target": "dailycloseview_getlocaloperatingdaterangefromsearch",
       "weight": 1
     },
@@ -4691,7 +4679,7 @@
       "relation": "calls",
       "source": "dailycloseview_getlocaloperatingdaterange",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L586",
+      "source_location": "L628",
       "target": "dailycloseview_getlocaloperatingdaterangefromsearch",
       "weight": 1
     },
@@ -4703,7 +4691,7 @@
       "relation": "calls",
       "source": "dailycloseview_normalizemetadatalabel",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1071",
+      "source_location": "L1119",
       "target": "dailycloseview_getmetadataentries",
       "weight": 1
     },
@@ -4715,7 +4703,7 @@
       "relation": "calls",
       "source": "dailycloseview_getmetadatavalue",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1545",
+      "source_location": "L1593",
       "target": "dailycloseview_getmetadatastringornumber",
       "weight": 1
     },
@@ -4727,7 +4715,7 @@
       "relation": "calls",
       "source": "dailycloseview_normalizemetadatalabel",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L918",
+      "source_location": "L966",
       "target": "dailycloseview_getmetadatavalue",
       "weight": 1
     },
@@ -4739,7 +4727,7 @@
       "relation": "calls",
       "source": "dailycloseview_iszeroactivitydailyclose",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1394",
+      "source_location": "L1442",
       "target": "dailycloseview_getstatusdisplaycopy",
       "weight": 1
     },
@@ -4751,7 +4739,7 @@
       "relation": "calls",
       "source": "dailycloseview_getstatuslabelclassname",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L370",
+      "source_location": "L412",
       "target": "dailycloseview_cn",
       "weight": 1
     },
@@ -4763,7 +4751,7 @@
       "relation": "calls",
       "source": "dailycloseview_getstatusrailbadgeclassname",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L432",
+      "source_location": "L474",
       "target": "dailycloseview_cn",
       "weight": 1
     },
@@ -4775,32 +4763,8 @@
       "relation": "calls",
       "source": "dailycloseview_getstatusrailiconclassname",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L382",
+      "source_location": "L424",
       "target": "dailycloseview_cn",
-      "weight": 1
-    },
-    {
-      "_src": "dailycloseview_getsummaryamount",
-      "_tgt": "dailycloseview_formatexpensetransactioncount",
-      "confidence": "EXTRACTED",
-      "confidence_score": 1,
-      "relation": "calls",
-      "source": "dailycloseview_formatexpensetransactioncount",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L3001",
-      "target": "dailycloseview_getsummaryamount",
-      "weight": 1
-    },
-    {
-      "_src": "dailycloseview_getsummaryamount",
-      "_tgt": "dailycloseview_getexpensetransactioncount",
-      "confidence": "EXTRACTED",
-      "confidence_score": 1,
-      "relation": "calls",
-      "source": "dailycloseview_getsummaryamount",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L3002",
-      "target": "dailycloseview_getexpensetransactioncount",
       "weight": 1
     },
     {
@@ -4811,7 +4775,7 @@
       "relation": "calls",
       "source": "dailycloseview_getsummaryamount",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1317",
+      "source_location": "L1365",
       "target": "dailycloseview_getsummaryregistervariancecount",
       "weight": 1
     },
@@ -4823,7 +4787,7 @@
       "relation": "calls",
       "source": "dailycloseview_formatdailyclosemoney",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1564",
+      "source_location": "L1612",
       "target": "dailycloseview_gettransactionreportamount",
       "weight": 1
     },
@@ -4835,7 +4799,7 @@
       "relation": "calls",
       "source": "dailycloseview_getmetadatastringornumber",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1561",
+      "source_location": "L1609",
       "target": "dailycloseview_gettransactionreportamount",
       "weight": 1
     },
@@ -4847,7 +4811,7 @@
       "relation": "calls",
       "source": "dailycloseview_getnumericmetadatavalue",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1560",
+      "source_location": "L1608",
       "target": "dailycloseview_gettransactionreportamount",
       "weight": 1
     },
@@ -4859,7 +4823,7 @@
       "relation": "calls",
       "source": "dailycloseview_getmetadatastringornumber",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1551",
+      "source_location": "L1599",
       "target": "dailycloseview_gettransactionreportidentifier",
       "weight": 1
     },
@@ -4871,7 +4835,7 @@
       "relation": "calls",
       "source": "dailycloseview_getmetadatastringornumber",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1573",
+      "source_location": "L1621",
       "target": "dailycloseview_gettransactionreportpayment",
       "weight": 1
     },
@@ -4883,7 +4847,7 @@
       "relation": "calls",
       "source": "dailycloseview_getmetadatastringornumber",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1568",
+      "source_location": "L1616",
       "target": "dailycloseview_gettransactionreportstaff",
       "weight": 1
     },
@@ -4895,7 +4859,7 @@
       "relation": "calls",
       "source": "dailycloseview_formattimestampmetadata",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1626",
+      "source_location": "L1674",
       "target": "dailycloseview_gettransactionreporttime",
       "weight": 1
     },
@@ -4907,7 +4871,7 @@
       "relation": "calls",
       "source": "dailycloseview_getmetadatastringornumber",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1622",
+      "source_location": "L1670",
       "target": "dailycloseview_gettransactionreporttime",
       "weight": 1
     },
@@ -4919,7 +4883,7 @@
       "relation": "calls",
       "source": "dailycloseview_getnumericmetadatavalue",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1621",
+      "source_location": "L1669",
       "target": "dailycloseview_gettransactionreporttime",
       "weight": 1
     },
@@ -4931,7 +4895,7 @@
       "relation": "calls",
       "source": "dailycloseview_normalizemetadatalabel",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L827",
+      "source_location": "L875",
       "target": "dailycloseview_ismoneymetadatalabel",
       "weight": 1
     },
@@ -4943,7 +4907,7 @@
       "relation": "calls",
       "source": "dailycloseview_normalizemetadatalabel",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L831",
+      "source_location": "L879",
       "target": "dailycloseview_istimestampmetadatalabel",
       "weight": 1
     },
@@ -4955,7 +4919,7 @@
       "relation": "calls",
       "source": "dailycloseview_getmetadatastringvalue",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L911",
+      "source_location": "L959",
       "target": "dailycloseview_isvarianceapprovalitem",
       "weight": 1
     },
@@ -4967,7 +4931,7 @@
       "relation": "calls",
       "source": "dailycloseview_normalizemetadatalabel",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L907",
+      "source_location": "L955",
       "target": "dailycloseview_isvarianceapprovalitem",
       "weight": 1
     },
@@ -4979,7 +4943,7 @@
       "relation": "calls",
       "source": "dailycloseview_getexpensestaffcount",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1372",
+      "source_location": "L1420",
       "target": "dailycloseview_iszeroactivitydailyclose",
       "weight": 1
     },
@@ -4991,7 +4955,7 @@
       "relation": "calls",
       "source": "dailycloseview_getsummaryamount",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1374",
+      "source_location": "L1422",
       "target": "dailycloseview_iszeroactivitydailyclose",
       "weight": 1
     },
@@ -5003,7 +4967,7 @@
       "relation": "calls",
       "source": "dailycloseview_getsummarycount",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1357",
+      "source_location": "L1405",
       "target": "dailycloseview_iszeroactivitydailyclose",
       "weight": 1
     },
@@ -5015,8 +4979,32 @@
       "relation": "calls",
       "source": "dailycloseview_getsummaryregistervariancecount",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1373",
+      "source_location": "L1421",
       "target": "dailycloseview_iszeroactivitydailyclose",
+      "weight": 1
+    },
+    {
+      "_src": "dailycloseview_shouldshowexpensemetric",
+      "_tgt": "dailycloseview_getexpensetransactioncount",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "dailycloseview_shouldshowexpensemetric",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
+      "source_location": "L384",
+      "target": "dailycloseview_getexpensetransactioncount",
+      "weight": 1
+    },
+    {
+      "_src": "dailycloseview_shouldshowexpensemetric",
+      "_tgt": "dailycloseview_getsummaryamount",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "dailycloseview_shouldshowexpensemetric",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
+      "source_location": "L379",
+      "target": "dailycloseview_getsummaryamount",
       "weight": 1
     },
     {
@@ -5027,7 +5015,7 @@
       "relation": "calls",
       "source": "dailycloseview_getnumericmetadatavalue",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L863",
+      "source_location": "L911",
       "target": "dailycloseview_shouldshowmetadataentry",
       "weight": 1
     },
@@ -5039,8 +5027,32 @@
       "relation": "calls",
       "source": "dailycloseview_normalizemetadatalabel",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L856",
+      "source_location": "L904",
       "target": "dailycloseview_shouldshowmetadataentry",
+      "weight": 1
+    },
+    {
+      "_src": "dailycloseview_shouldshowvariancemetric",
+      "_tgt": "dailycloseview_getsummaryamount",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "dailycloseview_shouldshowvariancemetric",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
+      "source_location": "L389",
+      "target": "dailycloseview_getsummaryamount",
+      "weight": 1
+    },
+    {
+      "_src": "dailycloseview_shouldshowvariancemetric",
+      "_tgt": "dailycloseview_getsummaryregistervariancecount",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "dailycloseview_shouldshowvariancemetric",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
+      "source_location": "L394",
+      "target": "dailycloseview_getsummaryregistervariancecount",
       "weight": 1
     },
     {
@@ -5891,7 +5903,7 @@
       "relation": "calls",
       "source": "dailyoperationsview_getlocaloperatingdate",
       "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L298",
+      "source_location": "L300",
       "target": "dailyoperationsview_builddailyclosesearch",
       "weight": 1
     },
@@ -5903,7 +5915,7 @@
       "relation": "calls",
       "source": "dailyoperationsview_getlocaloperatingdate",
       "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L309",
+      "source_location": "L311",
       "target": "dailyoperationsview_builddailyoperationssearch",
       "weight": 1
     },
@@ -5915,7 +5927,7 @@
       "relation": "calls",
       "source": "dailyoperationsview_getlocaloperatingdate",
       "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L329",
+      "source_location": "L331",
       "target": "dailyoperationsview_buildoperationstransactionsearch",
       "weight": 1
     },
@@ -5927,7 +5939,7 @@
       "relation": "calls",
       "source": "dailyoperationsview_getlocaldatefromoperatingdate",
       "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L408",
+      "source_location": "L410",
       "target": "dailyoperationsview_formatweekdaydate",
       "weight": 1
     },
@@ -5939,7 +5951,7 @@
       "relation": "calls",
       "source": "dailyoperationsview_getlocaldatefromoperatingdate",
       "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L400",
+      "source_location": "L402",
       "target": "dailyoperationsview_formatweekdaylabel",
       "weight": 1
     },
@@ -5951,7 +5963,7 @@
       "relation": "calls",
       "source": "dailyoperationsview_getlocaloperatingdate",
       "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L335",
+      "source_location": "L337",
       "target": "dailyoperationsview_getdailyoperationsmetriclabels",
       "weight": 1
     },
@@ -6059,7 +6071,7 @@
       "relation": "calls",
       "source": "dailyoperationsview_getlocaldatefromoperatingdate",
       "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L350",
+      "source_location": "L352",
       "target": "dailyoperationsview_getweekendoperatingdatefromsearch",
       "weight": 1
     },
@@ -6071,7 +6083,7 @@
       "relation": "calls",
       "source": "dailyoperationsview_getlocaloperatingdate",
       "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L355",
+      "source_location": "L357",
       "target": "dailyoperationsview_getweekendoperatingdatefromsearch",
       "weight": 1
     },
@@ -6083,7 +6095,7 @@
       "relation": "calls",
       "source": "dailyoperationsview_getsaturdayweekendoperatingdate",
       "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L352",
+      "source_location": "L354",
       "target": "dailyoperationsview_getweekendoperatingdatefromsearch",
       "weight": 1
     },
@@ -6095,7 +6107,7 @@
       "relation": "calls",
       "source": "dailyoperationsview_builddailyclosesearch",
       "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L366",
+      "source_location": "L368",
       "target": "dailyoperationsview_getworkflowsearch",
       "weight": 1
     },
@@ -6107,7 +6119,7 @@
       "relation": "calls",
       "source": "dailyoperationsview_getlocaloperatingdaterange",
       "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L1207",
+      "source_location": "L1209",
       "target": "dailyoperationsview_handleoperatingdatechange",
       "weight": 1
     },
@@ -6119,7 +6131,7 @@
       "relation": "calls",
       "source": "dailyoperationsview_getsaturdayweekendoperatingdate",
       "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L1208",
+      "source_location": "L1210",
       "target": "dailyoperationsview_handleoperatingdatechange",
       "weight": 1
     },
@@ -6131,7 +6143,7 @@
       "relation": "calls",
       "source": "dailyoperationsview_getlocaloperatingdate",
       "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L344",
+      "source_location": "L346",
       "target": "dailyoperationsview_ishistoricaloperatingdate",
       "weight": 1
     },
@@ -6167,7 +6179,7 @@
       "relation": "calls",
       "source": "dailyoperationsview_ishistoricaloperatingdate",
       "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L359",
+      "source_location": "L361",
       "target": "dailyoperationsview_shouldshowprimaryaction",
       "weight": 1
     },
@@ -16307,7 +16319,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L727",
+      "source_location": "L728",
       "target": "dailyclose_approvalbelongstorange",
       "weight": 1
     },
@@ -16319,7 +16331,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L453",
+      "source_location": "L454",
       "target": "dailyclose_approvalrequesttypelabel",
       "weight": 1
     },
@@ -16331,7 +16343,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L549",
+      "source_location": "L550",
       "target": "dailyclose_ascarryforwarditem",
       "weight": 1
     },
@@ -16343,7 +16355,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L262",
+      "source_location": "L263",
       "target": "dailyclose_builddailycloseapprovalsubject",
       "weight": 1
     },
@@ -16355,7 +16367,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L273",
+      "source_location": "L274",
       "target": "dailyclose_builddailyclosecompletionapprovalrequirement",
       "weight": 1
     },
@@ -16367,7 +16379,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L301",
+      "source_location": "L302",
       "target": "dailyclose_builddailyclosereopenapprovalrequirement",
       "weight": 1
     },
@@ -16379,7 +16391,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L991",
+      "source_location": "L1003",
       "target": "dailyclose_builddailyclosereportsnapshot",
       "weight": 1
     },
@@ -16391,7 +16403,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1115",
+      "source_location": "L1127",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -16403,7 +16415,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L529",
+      "source_location": "L530",
       "target": "dailyclose_buildexpensesessionsbyid",
       "weight": 1
     },
@@ -16415,7 +16427,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L906",
+      "source_location": "L907",
       "target": "dailyclose_buildpaymenttotals",
       "weight": 1
     },
@@ -16427,7 +16439,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L953",
+      "source_location": "L965",
       "target": "dailyclose_buildreadiness",
       "weight": 1
     },
@@ -16439,7 +16451,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L509",
+      "source_location": "L510",
       "target": "dailyclose_buildregistersessionsbyid",
       "weight": 1
     },
@@ -16451,7 +16463,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L489",
+      "source_location": "L490",
       "target": "dailyclose_buildstaffnamesbyid",
       "weight": 1
     },
@@ -16463,7 +16475,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L469",
+      "source_location": "L470",
       "target": "dailyclose_buildterminallabelsbyid",
       "weight": 1
     },
@@ -16475,7 +16487,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L935",
+      "source_location": "L947",
       "target": "dailyclose_cashdeltasbyregistersessionid",
       "weight": 1
     },
@@ -16487,7 +16499,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1936",
+      "source_location": "L1948",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -16499,7 +16511,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1860",
+      "source_location": "L1872",
       "target": "dailyclose_createcarryforwardworkitems",
       "weight": 1
     },
@@ -16511,7 +16523,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1091",
+      "source_location": "L1103",
       "target": "dailyclose_emptysummary",
       "weight": 1
     },
@@ -16523,7 +16535,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L425",
+      "source_location": "L426",
       "target": "dailyclose_formatpaymentmethodlabel",
       "weight": 1
     },
@@ -16535,7 +16547,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2477",
+      "source_location": "L2489",
       "target": "dailyclose_getcompleteddailyclosehistorydetailwithctx",
       "weight": 1
     },
@@ -16547,7 +16559,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1064",
+      "source_location": "L1076",
       "target": "dailyclose_getdailyclosecompletioneventstaffprofileid",
       "weight": 1
     },
@@ -16559,7 +16571,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L579",
+      "source_location": "L580",
       "target": "dailyclose_getdailyclosefordate",
       "weight": 1
     },
@@ -16571,7 +16583,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2392",
+      "source_location": "L2404",
       "target": "dailyclose_getdailycloseopeningcontextwithctx",
       "weight": 1
     },
@@ -16583,7 +16595,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L618",
+      "source_location": "L619",
       "target": "dailyclose_getpriorcompleteddailyclose",
       "weight": 1
     },
@@ -16595,7 +16607,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L572",
+      "source_location": "L573",
       "target": "dailyclose_getstore",
       "weight": 1
     },
@@ -16607,7 +16619,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L389",
+      "source_location": "L390",
       "target": "dailyclose_isinrange",
       "weight": 1
     },
@@ -16619,7 +16631,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L357",
+      "source_location": "L358",
       "target": "dailyclose_isvalidoperatingdaterange",
       "weight": 1
     },
@@ -16631,7 +16643,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L643",
+      "source_location": "L644",
       "target": "dailyclose_listactiveregistersessions",
       "weight": 1
     },
@@ -16643,7 +16655,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L661",
+      "source_location": "L662",
       "target": "dailyclose_listclosedregistersessionsforday",
       "weight": 1
     },
@@ -16655,7 +16667,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2428",
+      "source_location": "L2440",
       "target": "dailyclose_listcompleteddailyclosehistorywithctx",
       "weight": 1
     },
@@ -16667,7 +16679,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L884",
+      "source_location": "L885",
       "target": "dailyclose_listdepositsforday",
       "weight": 1
     },
@@ -16679,7 +16691,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L864",
+      "source_location": "L865",
       "target": "dailyclose_listexpensesforday",
       "weight": 1
     },
@@ -16691,7 +16703,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L829",
+      "source_location": "L830",
       "target": "dailyclose_listopenoperationalworkitems",
       "weight": 1
     },
@@ -16703,7 +16715,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L801",
+      "source_location": "L802",
       "target": "dailyclose_listopenpossessions",
       "weight": 1
     },
@@ -16715,7 +16727,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L767",
+      "source_location": "L768",
       "target": "dailyclose_listpendingcloseoutapprovals",
       "weight": 1
     },
@@ -16727,7 +16739,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L843",
+      "source_location": "L844",
       "target": "dailyclose_listtransactionsforday",
       "weight": 1
     },
@@ -16739,7 +16751,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1913",
+      "source_location": "L1925",
       "target": "dailyclose_markotherdailyclosesnotcurrent",
       "weight": 1
     },
@@ -16751,7 +16763,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L449",
+      "source_location": "L450",
       "target": "dailyclose_nonzerovariancemetadata",
       "weight": 1
     },
@@ -16763,7 +16775,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L164",
+      "source_location": "L165",
       "target": "dailyclose_normalizecompleteddailyclosesnapshot",
       "weight": 1
     },
@@ -16775,7 +16787,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L711",
+      "source_location": "L712",
       "target": "dailyclose_possessionintersectsrange",
       "weight": 1
     },
@@ -16787,7 +16799,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L412",
+      "source_location": "L413",
       "target": "dailyclose_registermetadatalabel",
       "weight": 1
     },
@@ -16799,7 +16811,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L695",
+      "source_location": "L696",
       "target": "dailyclose_registersessionbelongstorange",
       "weight": 1
     },
@@ -16811,7 +16823,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L393",
+      "source_location": "L394",
       "target": "dailyclose_registersessioncloseoutoperatingat",
       "weight": 1
     },
@@ -16823,7 +16835,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L685",
+      "source_location": "L686",
       "target": "dailyclose_registersessionintersectsrange",
       "weight": 1
     },
@@ -16835,7 +16847,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L404",
+      "source_location": "L405",
       "target": "dailyclose_registersessionlabel",
       "weight": 1
     },
@@ -16847,7 +16859,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2198",
+      "source_location": "L2210",
       "target": "dailyclose_reopendailyclosewithctx",
       "weight": 1
     },
@@ -16859,7 +16871,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L368",
+      "source_location": "L369",
       "target": "dailyclose_resolveoperatingdaterange",
       "weight": 1
     },
@@ -16871,7 +16883,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L340",
+      "source_location": "L341",
       "target": "dailyclose_safeoperatingdaterange",
       "weight": 1
     },
@@ -16883,7 +16895,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1029",
+      "source_location": "L1041",
       "target": "dailyclose_snapshotrevieweditems",
       "weight": 1
     },
@@ -16895,7 +16907,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L127",
+      "source_location": "L128",
       "target": "dailyclose_sortdailycloseblockers",
       "weight": 1
     },
@@ -16907,7 +16919,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1043",
+      "source_location": "L1055",
       "target": "dailyclose_todailyclosehistorylistitem",
       "weight": 1
     },
@@ -16919,7 +16931,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L924",
+      "source_location": "L936",
       "target": "dailyclose_transactioncashdelta",
       "weight": 1
     },
@@ -16931,7 +16943,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L431",
+      "source_location": "L432",
       "target": "dailyclose_transactionpaymentsummary",
       "weight": 1
     },
@@ -16943,7 +16955,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L335",
+      "source_location": "L336",
       "target": "dailyclose_trimoptional",
       "weight": 1
     },
@@ -16955,7 +16967,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L983",
+      "source_location": "L995",
       "target": "dailyclose_uniquedailycloseitems",
       "weight": 1
     },
@@ -16967,7 +16979,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L973",
+      "source_location": "L985",
       "target": "dailyclose_uniquesourcesubjects",
       "weight": 1
     },
@@ -16979,7 +16991,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1832",
+      "source_location": "L1844",
       "target": "dailyclose_validatecarryforwardworkitemids",
       "weight": 1
     },
@@ -29195,7 +29207,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_test_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.test.tsx",
-      "source_location": "L313",
+      "source_location": "L318",
       "target": "dailycloseview_test_disconnect",
       "weight": 1
     },
@@ -29207,7 +29219,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_test_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.test.tsx",
-      "source_location": "L314",
+      "source_location": "L319",
       "target": "dailycloseview_test_observe",
       "weight": 1
     },
@@ -29219,7 +29231,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_test_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.test.tsx",
-      "source_location": "L315",
+      "source_location": "L320",
       "target": "dailycloseview_test_unobserve",
       "weight": 1
     },
@@ -29231,7 +29243,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L539",
+      "source_location": "L581",
       "target": "dailycloseview_builddailyclosetransactionsearch",
       "weight": 1
     },
@@ -29243,7 +29255,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L627",
+      "source_location": "L669",
       "target": "dailycloseview_canreopendailyclose",
       "weight": 1
     },
@@ -29255,7 +29267,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L2523",
+      "source_location": "L2594",
       "target": "dailycloseview_cn",
       "weight": 1
     },
@@ -29267,7 +29279,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L392",
+      "source_location": "L434",
       "target": "dailycloseview_dailyclosestatustitle",
       "weight": 1
     },
@@ -29279,7 +29291,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L357",
+      "source_location": "L399",
       "target": "dailycloseview_formatcarriedoverregistercount",
       "weight": 1
     },
@@ -29291,7 +29303,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L340",
+      "source_location": "L341",
       "target": "dailycloseview_formatchecklistcount",
       "weight": 1
     },
@@ -29303,7 +29315,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L519",
+      "source_location": "L561",
       "target": "dailycloseview_formatdailyclosecompletedat",
       "weight": 1
     },
@@ -29315,7 +29327,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L2973",
+      "source_location": "L516",
       "target": "dailycloseview_formatdailyclosemoney",
       "weight": 1
     },
@@ -29327,7 +29339,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L485",
+      "source_location": "L527",
       "target": "dailycloseview_formatdailycloseoperatingdate",
       "weight": 1
     },
@@ -29339,7 +29351,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L330",
+      "source_location": "L331",
       "target": "dailycloseview_formatentitycount",
       "weight": 1
     },
@@ -29351,7 +29363,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L452",
+      "source_location": "L494",
       "target": "dailycloseview_formatexpensetransactioncount",
       "weight": 1
     },
@@ -29363,7 +29375,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L981",
+      "source_location": "L1029",
       "target": "dailycloseview_formatmetadatadisplayvalue",
       "weight": 1
     },
@@ -29375,8 +29387,32 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L925",
+      "source_location": "L973",
       "target": "dailycloseview_formatmetadatavalue",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
+      "_tgt": "dailycloseview_formatpaymentcount",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
+      "source_location": "L358",
+      "target": "dailycloseview_formatpaymentcount",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
+      "_tgt": "dailycloseview_formatpaymentmethodlabel",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
+      "source_location": "L366",
+      "target": "dailycloseview_formatpaymentmethodlabel",
       "weight": 1
     },
     {
@@ -29387,7 +29423,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L458",
+      "source_location": "L500",
       "target": "dailycloseview_formatpossalecount",
       "weight": 1
     },
@@ -29399,7 +29435,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L363",
+      "source_location": "L405",
       "target": "dailycloseview_formatregistervariancecount",
       "weight": 1
     },
@@ -29411,7 +29447,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L870",
+      "source_location": "L918",
       "target": "dailycloseview_formattimestampmetadata",
       "weight": 1
     },
@@ -29423,7 +29459,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L351",
+      "source_location": "L352",
       "target": "dailycloseview_formattodaycashtransactioncount",
       "weight": 1
     },
@@ -29435,7 +29471,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L464",
+      "source_location": "L506",
       "target": "dailycloseview_formatvoidedsalecount",
       "weight": 1
     },
@@ -29447,7 +29483,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1472",
+      "source_location": "L1520",
       "target": "dailycloseview_getbucketconfigs",
       "weight": 1
     },
@@ -29459,7 +29495,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L440",
+      "source_location": "L482",
       "target": "dailycloseview_getbucketcountclassname",
       "weight": 1
     },
@@ -29471,7 +29507,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L648",
+      "source_location": "L690",
       "target": "dailycloseview_getcarryforwardworkitemid",
       "weight": 1
     },
@@ -29483,7 +29519,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L654",
+      "source_location": "L696",
       "target": "dailycloseview_getcarryforwardworkitemids",
       "weight": 1
     },
@@ -29495,7 +29531,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1256",
+      "source_location": "L1304",
       "target": "dailycloseview_getcollapsedmetadataentries",
       "weight": 1
     },
@@ -29507,7 +29543,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L320",
+      "source_location": "L321",
       "target": "dailycloseview_getdailycloseapi",
       "weight": 1
     },
@@ -29519,7 +29555,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L553",
+      "source_location": "L595",
       "target": "dailycloseview_getdailyclosesalesmetriclabels",
       "weight": 1
     },
@@ -29531,7 +29567,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L606",
+      "source_location": "L648",
       "target": "dailycloseview_getdailyclosestatus",
       "weight": 1
     },
@@ -29543,7 +29579,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1449",
+      "source_location": "L1497",
       "target": "dailycloseview_getdefaultbucketvalue",
       "weight": 1
     },
@@ -29555,7 +29591,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L880",
+      "source_location": "L928",
       "target": "dailycloseview_getdisplaymetadatalabel",
       "weight": 1
     },
@@ -29567,7 +29603,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1325",
+      "source_location": "L1373",
       "target": "dailycloseview_getexpensestaffcount",
       "weight": 1
     },
@@ -29579,7 +29615,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1337",
+      "source_location": "L1385",
       "target": "dailycloseview_getexpensetransactioncount",
       "weight": 1
     },
@@ -29591,7 +29627,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L668",
+      "source_location": "L716",
       "target": "dailycloseview_getitemcontextlabel",
       "weight": 1
     },
@@ -29603,7 +29639,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L658",
+      "source_location": "L700",
       "target": "dailycloseview_getitemdescription",
       "weight": 1
     },
@@ -29615,7 +29651,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L636",
+      "source_location": "L678",
       "target": "dailycloseview_getitemid",
       "weight": 1
     },
@@ -29627,7 +29663,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L500",
+      "source_location": "L542",
       "target": "dailycloseview_getlocaldatefromoperatingdate",
       "weight": 1
     },
@@ -29639,7 +29675,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L531",
+      "source_location": "L573",
       "target": "dailycloseview_getlocaloperatingdate",
       "weight": 1
     },
@@ -29651,7 +29687,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L562",
+      "source_location": "L604",
       "target": "dailycloseview_getlocaloperatingdaterange",
       "weight": 1
     },
@@ -29663,7 +29699,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L581",
+      "source_location": "L623",
       "target": "dailycloseview_getlocaloperatingdaterangefromsearch",
       "weight": 1
     },
@@ -29675,7 +29711,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1063",
+      "source_location": "L1111",
       "target": "dailycloseview_getmetadataentries",
       "weight": 1
     },
@@ -29687,7 +29723,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1539",
+      "source_location": "L1587",
       "target": "dailycloseview_getmetadatastringornumber",
       "weight": 1
     },
@@ -29699,7 +29735,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L896",
+      "source_location": "L944",
       "target": "dailycloseview_getmetadatastringvalue",
       "weight": 1
     },
@@ -29711,7 +29747,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L917",
+      "source_location": "L965",
       "target": "dailycloseview_getmetadatavalue",
       "weight": 1
     },
@@ -29723,8 +29759,20 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L842",
+      "source_location": "L890",
       "target": "dailycloseview_getnumericmetadatavalue",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
+      "_tgt": "dailycloseview_getotherpaymenttotals",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
+      "source_location": "L372",
+      "target": "dailycloseview_getotherpaymenttotals",
       "weight": 1
     },
     {
@@ -29735,7 +29783,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L644",
+      "source_location": "L686",
       "target": "dailycloseview_getrevieweditemkeys",
       "weight": 1
     },
@@ -29747,7 +29795,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1390",
+      "source_location": "L1438",
       "target": "dailycloseview_getstatusdisplaycopy",
       "weight": 1
     },
@@ -29759,7 +29807,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L369",
+      "source_location": "L411",
       "target": "dailycloseview_getstatuslabelclassname",
       "weight": 1
     },
@@ -29771,7 +29819,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L431",
+      "source_location": "L473",
       "target": "dailycloseview_getstatusrailbadgeclassname",
       "weight": 1
     },
@@ -29783,7 +29831,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L381",
+      "source_location": "L423",
       "target": "dailycloseview_getstatusrailiconclassname",
       "weight": 1
     },
@@ -29795,7 +29843,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L2993",
+      "source_location": "L1328",
       "target": "dailycloseview_getsummaryamount",
       "weight": 1
     },
@@ -29807,7 +29855,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1295",
+      "source_location": "L1343",
       "target": "dailycloseview_getsummarycount",
       "weight": 1
     },
@@ -29819,7 +29867,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1310",
+      "source_location": "L1358",
       "target": "dailycloseview_getsummaryregistervariancecount",
       "weight": 1
     },
@@ -29831,7 +29879,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1559",
+      "source_location": "L1607",
       "target": "dailycloseview_gettransactionreportamount",
       "weight": 1
     },
@@ -29843,7 +29891,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1549",
+      "source_location": "L1597",
       "target": "dailycloseview_gettransactionreportidentifier",
       "weight": 1
     },
@@ -29855,7 +29903,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1520",
+      "source_location": "L1568",
       "target": "dailycloseview_gettransactionreportitems",
       "weight": 1
     },
@@ -29867,7 +29915,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1629",
+      "source_location": "L1677",
       "target": "dailycloseview_gettransactionreportlink",
       "weight": 1
     },
@@ -29879,7 +29927,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1572",
+      "source_location": "L1620",
       "target": "dailycloseview_gettransactionreportpayment",
       "weight": 1
     },
@@ -29891,7 +29939,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1567",
+      "source_location": "L1615",
       "target": "dailycloseview_gettransactionreportstaff",
       "weight": 1
     },
@@ -29903,7 +29951,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1620",
+      "source_location": "L1668",
       "target": "dailycloseview_gettransactionreporttime",
       "weight": 1
     },
@@ -29915,7 +29963,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L834",
+      "source_location": "L882",
       "target": "dailycloseview_getvariancetone",
       "weight": 1
     },
@@ -29927,7 +29975,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1870",
+      "source_location": "L1918",
       "target": "dailycloseview_handlepagechange",
       "weight": 1
     },
@@ -29939,7 +29987,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L676",
+      "source_location": "L724",
       "target": "dailycloseview_humanizemetadatalabel",
       "weight": 1
     },
@@ -29951,7 +29999,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L3159",
+      "source_location": "L3255",
       "target": "dailycloseview_if",
       "weight": 1
     },
@@ -29963,7 +30011,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L826",
+      "source_location": "L874",
       "target": "dailycloseview_ismoneymetadatalabel",
       "weight": 1
     },
@@ -29975,7 +30023,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L830",
+      "source_location": "L878",
       "target": "dailycloseview_istimestampmetadatalabel",
       "weight": 1
     },
@@ -29987,7 +30035,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L906",
+      "source_location": "L954",
       "target": "dailycloseview_isvarianceapprovalitem",
       "weight": 1
     },
@@ -29999,7 +30047,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1351",
+      "source_location": "L1399",
       "target": "dailycloseview_iszeroactivitydailyclose",
       "weight": 1
     },
@@ -30011,7 +30059,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1459",
+      "source_location": "L1507",
       "target": "dailycloseview_normalizebuckettab",
       "weight": 1
     },
@@ -30023,7 +30071,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L593",
+      "source_location": "L635",
       "target": "dailycloseview_normalizecommandmessage",
       "weight": 1
     },
@@ -30035,8 +30083,20 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1406",
+      "source_location": "L1454",
       "target": "dailycloseview_normalizecompletedreportsnapshot",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
+      "_tgt": "dailycloseview_normalizedailycloseitemcopy",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
+      "source_location": "L704",
+      "target": "dailycloseview_normalizedailycloseitemcopy",
       "weight": 1
     },
     {
@@ -30047,7 +30107,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L822",
+      "source_location": "L870",
       "target": "dailycloseview_normalizemetadatalabel",
       "weight": 1
     },
@@ -30059,7 +30119,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1466",
+      "source_location": "L1514",
       "target": "dailycloseview_normalizepage",
       "weight": 1
     },
@@ -30071,7 +30131,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1585",
+      "source_location": "L1633",
       "target": "dailycloseview_normalizetransactionreportpaymentmethod",
       "weight": 1
     },
@@ -30083,7 +30143,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L470",
+      "source_location": "L512",
       "target": "dailycloseview_sentencefragment",
       "weight": 1
     },
@@ -30095,8 +30155,20 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L662",
+      "source_location": "L708",
       "target": "dailycloseview_shouldshowcollapseddescription",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
+      "_tgt": "dailycloseview_shouldshowexpensemetric",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
+      "source_location": "L378",
+      "target": "dailycloseview_shouldshowexpensemetric",
       "weight": 1
     },
     {
@@ -30107,8 +30179,20 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L855",
+      "source_location": "L903",
       "target": "dailycloseview_shouldshowmetadataentry",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
+      "_tgt": "dailycloseview_shouldshowvariancemetric",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
+      "source_location": "L388",
+      "target": "dailycloseview_shouldshowvariancemetric",
       "weight": 1
     },
     {
@@ -30119,7 +30203,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L409",
+      "source_location": "L451",
       "target": "dailycloseview_successcheckicon",
       "weight": 1
     },
@@ -30131,7 +30215,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailycloseview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1592",
+      "source_location": "L1640",
       "target": "dailycloseview_transactionreportpaymenticon",
       "weight": 1
     },
@@ -30671,7 +30755,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailyoperationsview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L296",
+      "source_location": "L298",
       "target": "dailyoperationsview_builddailyclosesearch",
       "weight": 1
     },
@@ -30683,7 +30767,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailyoperationsview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L302",
+      "source_location": "L304",
       "target": "dailyoperationsview_builddailyoperationssearch",
       "weight": 1
     },
@@ -30695,7 +30779,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailyoperationsview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L320",
+      "source_location": "L322",
       "target": "dailyoperationsview_buildoperationstransactionsearch",
       "weight": 1
     },
@@ -30707,7 +30791,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailyoperationsview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L431",
+      "source_location": "L433",
       "target": "dailyoperationsview_formatcarriedoverregistercount",
       "weight": 1
     },
@@ -30719,7 +30803,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailyoperationsview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L415",
+      "source_location": "L417",
       "target": "dailyoperationsview_formatentitycount",
       "weight": 1
     },
@@ -30731,7 +30815,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailyoperationsview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L373",
+      "source_location": "L375",
       "target": "dailyoperationsview_formateventtime",
       "weight": 1
     },
@@ -30743,7 +30827,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailyoperationsview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L443",
+      "source_location": "L445",
       "target": "dailyoperationsview_formatmoney",
       "weight": 1
     },
@@ -30755,7 +30839,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailyoperationsview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L263",
+      "source_location": "L265",
       "target": "dailyoperationsview_formatoperatingdate",
       "weight": 1
     },
@@ -30767,7 +30851,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailyoperationsview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L279",
+      "source_location": "L281",
       "target": "dailyoperationsview_formatoperatingdatewithweekday",
       "weight": 1
     },
@@ -30779,7 +30863,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailyoperationsview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L437",
+      "source_location": "L439",
       "target": "dailyoperationsview_formatregistervariancecount",
       "weight": 1
     },
@@ -30791,7 +30875,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailyoperationsview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L380",
+      "source_location": "L382",
       "target": "dailyoperationsview_formattimelinemessage",
       "weight": 1
     },
@@ -30803,7 +30887,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailyoperationsview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L425",
+      "source_location": "L427",
       "target": "dailyoperationsview_formattodaycashtransactioncount",
       "weight": 1
     },
@@ -30815,7 +30899,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailyoperationsview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L407",
+      "source_location": "L409",
       "target": "dailyoperationsview_formatweekdaydate",
       "weight": 1
     },
@@ -30827,7 +30911,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailyoperationsview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L399",
+      "source_location": "L401",
       "target": "dailyoperationsview_formatweekdaylabel",
       "weight": 1
     },
@@ -30851,7 +30935,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailyoperationsview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L334",
+      "source_location": "L336",
       "target": "dailyoperationsview_getdailyoperationsmetriclabels",
       "weight": 1
     },
@@ -30947,7 +31031,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailyoperationsview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L347",
+      "source_location": "L349",
       "target": "dailyoperationsview_getweekendoperatingdatefromsearch",
       "weight": 1
     },
@@ -30959,7 +31043,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailyoperationsview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L942",
+      "source_location": "L944",
       "target": "dailyoperationsview_getworkflowsearch",
       "weight": 1
     },
@@ -30971,7 +31055,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailyoperationsview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L1206",
+      "source_location": "L1208",
       "target": "dailyoperationsview_handleoperatingdatechange",
       "weight": 1
     },
@@ -30983,7 +31067,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailyoperationsview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L343",
+      "source_location": "L345",
       "target": "dailyoperationsview_ishistoricaloperatingdate",
       "weight": 1
     },
@@ -31007,7 +31091,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailyoperationsview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L358",
+      "source_location": "L360",
       "target": "dailyoperationsview_shouldshowprimaryaction",
       "weight": 1
     },
@@ -31019,7 +31103,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailyoperationsview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L447",
+      "source_location": "L449",
       "target": "dailyoperationsview_statusclassname",
       "weight": 1
     },
@@ -61297,7 +61381,7 @@
       "label": "buildDailyCloseTransactionSearch()",
       "norm_label": "builddailyclosetransactionsearch()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L539"
+      "source_location": "L581"
     },
     {
       "community": 0,
@@ -61306,7 +61390,7 @@
       "label": "canReopenDailyClose()",
       "norm_label": "canreopendailyclose()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L627"
+      "source_location": "L669"
     },
     {
       "community": 0,
@@ -61315,7 +61399,7 @@
       "label": "cn()",
       "norm_label": "cn()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1992"
+      "source_location": "L2040"
     },
     {
       "community": 0,
@@ -61324,7 +61408,7 @@
       "label": "DailyCloseStatusTitle()",
       "norm_label": "dailyclosestatustitle()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L392"
+      "source_location": "L434"
     },
     {
       "community": 0,
@@ -61333,7 +61417,7 @@
       "label": "formatCarriedOverRegisterCount()",
       "norm_label": "formatcarriedoverregistercount()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L357"
+      "source_location": "L399"
     },
     {
       "community": 0,
@@ -61342,7 +61426,7 @@
       "label": "formatChecklistCount()",
       "norm_label": "formatchecklistcount()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L340"
+      "source_location": "L341"
     },
     {
       "community": 0,
@@ -61351,7 +61435,7 @@
       "label": "formatDailyCloseCompletedAt()",
       "norm_label": "formatdailyclosecompletedat()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L519"
+      "source_location": "L561"
     },
     {
       "community": 0,
@@ -61360,7 +61444,7 @@
       "label": "formatDailyCloseMoney()",
       "norm_label": "formatdailyclosemoney()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L474"
+      "source_location": "L516"
     },
     {
       "community": 0,
@@ -61369,7 +61453,7 @@
       "label": "formatDailyCloseOperatingDate()",
       "norm_label": "formatdailycloseoperatingdate()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L485"
+      "source_location": "L527"
     },
     {
       "community": 0,
@@ -61378,7 +61462,7 @@
       "label": "formatEntityCount()",
       "norm_label": "formatentitycount()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L330"
+      "source_location": "L331"
     },
     {
       "community": 0,
@@ -61387,7 +61471,7 @@
       "label": "formatExpenseTransactionCount()",
       "norm_label": "formatexpensetransactioncount()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L452"
+      "source_location": "L494"
     },
     {
       "community": 0,
@@ -61396,7 +61480,7 @@
       "label": "formatMetadataDisplayValue()",
       "norm_label": "formatmetadatadisplayvalue()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L981"
+      "source_location": "L1029"
     },
     {
       "community": 0,
@@ -61405,7 +61489,25 @@
       "label": "formatMetadataValue()",
       "norm_label": "formatmetadatavalue()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L925"
+      "source_location": "L973"
+    },
+    {
+      "community": 0,
+      "file_type": "code",
+      "id": "dailycloseview_formatpaymentcount",
+      "label": "formatPaymentCount()",
+      "norm_label": "formatpaymentcount()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
+      "source_location": "L358"
+    },
+    {
+      "community": 0,
+      "file_type": "code",
+      "id": "dailycloseview_formatpaymentmethodlabel",
+      "label": "formatPaymentMethodLabel()",
+      "norm_label": "formatpaymentmethodlabel()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
+      "source_location": "L366"
     },
     {
       "community": 0,
@@ -61414,7 +61516,7 @@
       "label": "formatPosSaleCount()",
       "norm_label": "formatpossalecount()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L458"
+      "source_location": "L500"
     },
     {
       "community": 0,
@@ -61423,7 +61525,7 @@
       "label": "formatRegisterVarianceCount()",
       "norm_label": "formatregistervariancecount()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L363"
+      "source_location": "L405"
     },
     {
       "community": 0,
@@ -61432,7 +61534,7 @@
       "label": "formatTimestampMetadata()",
       "norm_label": "formattimestampmetadata()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L870"
+      "source_location": "L918"
     },
     {
       "community": 0,
@@ -61441,7 +61543,7 @@
       "label": "formatTodayCashTransactionCount()",
       "norm_label": "formattodaycashtransactioncount()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L351"
+      "source_location": "L352"
     },
     {
       "community": 0,
@@ -61450,7 +61552,7 @@
       "label": "formatVoidedSaleCount()",
       "norm_label": "formatvoidedsalecount()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L464"
+      "source_location": "L506"
     },
     {
       "community": 0,
@@ -61459,7 +61561,7 @@
       "label": "getBucketConfigs()",
       "norm_label": "getbucketconfigs()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1472"
+      "source_location": "L1520"
     },
     {
       "community": 0,
@@ -61468,7 +61570,7 @@
       "label": "getBucketCountClassName()",
       "norm_label": "getbucketcountclassname()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L440"
+      "source_location": "L482"
     },
     {
       "community": 0,
@@ -61477,7 +61579,7 @@
       "label": "getCarryForwardWorkItemId()",
       "norm_label": "getcarryforwardworkitemid()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L648"
+      "source_location": "L690"
     },
     {
       "community": 0,
@@ -61486,7 +61588,7 @@
       "label": "getCarryForwardWorkItemIds()",
       "norm_label": "getcarryforwardworkitemids()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L654"
+      "source_location": "L696"
     },
     {
       "community": 0,
@@ -61495,7 +61597,7 @@
       "label": "getCollapsedMetadataEntries()",
       "norm_label": "getcollapsedmetadataentries()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1256"
+      "source_location": "L1304"
     },
     {
       "community": 0,
@@ -61504,7 +61606,7 @@
       "label": "getDailyCloseApi()",
       "norm_label": "getdailycloseapi()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L320"
+      "source_location": "L321"
     },
     {
       "community": 0,
@@ -61513,7 +61615,7 @@
       "label": "getDailyCloseSalesMetricLabels()",
       "norm_label": "getdailyclosesalesmetriclabels()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L553"
+      "source_location": "L595"
     },
     {
       "community": 0,
@@ -61522,7 +61624,7 @@
       "label": "getDailyCloseStatus()",
       "norm_label": "getdailyclosestatus()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L606"
+      "source_location": "L648"
     },
     {
       "community": 0,
@@ -61531,7 +61633,7 @@
       "label": "getDefaultBucketValue()",
       "norm_label": "getdefaultbucketvalue()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1449"
+      "source_location": "L1497"
     },
     {
       "community": 0,
@@ -61540,7 +61642,7 @@
       "label": "getDisplayMetadataLabel()",
       "norm_label": "getdisplaymetadatalabel()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L880"
+      "source_location": "L928"
     },
     {
       "community": 0,
@@ -61549,7 +61651,7 @@
       "label": "getExpenseStaffCount()",
       "norm_label": "getexpensestaffcount()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1325"
+      "source_location": "L1373"
     },
     {
       "community": 0,
@@ -61558,7 +61660,7 @@
       "label": "getExpenseTransactionCount()",
       "norm_label": "getexpensetransactioncount()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1337"
+      "source_location": "L1385"
     },
     {
       "community": 0,
@@ -61567,7 +61669,7 @@
       "label": "getItemContextLabel()",
       "norm_label": "getitemcontextlabel()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L668"
+      "source_location": "L716"
     },
     {
       "community": 0,
@@ -61576,7 +61678,7 @@
       "label": "getItemDescription()",
       "norm_label": "getitemdescription()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L658"
+      "source_location": "L700"
     },
     {
       "community": 0,
@@ -61585,7 +61687,7 @@
       "label": "getItemId()",
       "norm_label": "getitemid()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L636"
+      "source_location": "L678"
     },
     {
       "community": 0,
@@ -61594,7 +61696,7 @@
       "label": "getLocalDateFromOperatingDate()",
       "norm_label": "getlocaldatefromoperatingdate()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L500"
+      "source_location": "L542"
     },
     {
       "community": 0,
@@ -61603,7 +61705,7 @@
       "label": "getLocalOperatingDate()",
       "norm_label": "getlocaloperatingdate()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L531"
+      "source_location": "L573"
     },
     {
       "community": 0,
@@ -61612,7 +61714,7 @@
       "label": "getLocalOperatingDateRange()",
       "norm_label": "getlocaloperatingdaterange()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L562"
+      "source_location": "L604"
     },
     {
       "community": 0,
@@ -61621,7 +61723,7 @@
       "label": "getLocalOperatingDateRangeFromSearch()",
       "norm_label": "getlocaloperatingdaterangefromsearch()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L581"
+      "source_location": "L623"
     },
     {
       "community": 0,
@@ -61630,7 +61732,7 @@
       "label": "getMetadataEntries()",
       "norm_label": "getmetadataentries()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1063"
+      "source_location": "L1111"
     },
     {
       "community": 0,
@@ -61639,7 +61741,7 @@
       "label": "getMetadataStringOrNumber()",
       "norm_label": "getmetadatastringornumber()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1539"
+      "source_location": "L1587"
     },
     {
       "community": 0,
@@ -61648,7 +61750,7 @@
       "label": "getMetadataStringValue()",
       "norm_label": "getmetadatastringvalue()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L896"
+      "source_location": "L944"
     },
     {
       "community": 0,
@@ -61657,7 +61759,7 @@
       "label": "getMetadataValue()",
       "norm_label": "getmetadatavalue()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L917"
+      "source_location": "L965"
     },
     {
       "community": 0,
@@ -61666,7 +61768,16 @@
       "label": "getNumericMetadataValue()",
       "norm_label": "getnumericmetadatavalue()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L842"
+      "source_location": "L890"
+    },
+    {
+      "community": 0,
+      "file_type": "code",
+      "id": "dailycloseview_getotherpaymenttotals",
+      "label": "getOtherPaymentTotals()",
+      "norm_label": "getotherpaymenttotals()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
+      "source_location": "L372"
     },
     {
       "community": 0,
@@ -61675,7 +61786,7 @@
       "label": "getReviewedItemKeys()",
       "norm_label": "getrevieweditemkeys()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L644"
+      "source_location": "L686"
     },
     {
       "community": 0,
@@ -61684,7 +61795,7 @@
       "label": "getStatusDisplayCopy()",
       "norm_label": "getstatusdisplaycopy()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1390"
+      "source_location": "L1438"
     },
     {
       "community": 0,
@@ -61693,7 +61804,7 @@
       "label": "getStatusLabelClassName()",
       "norm_label": "getstatuslabelclassname()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L369"
+      "source_location": "L411"
     },
     {
       "community": 0,
@@ -61702,7 +61813,7 @@
       "label": "getStatusRailBadgeClassName()",
       "norm_label": "getstatusrailbadgeclassname()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L431"
+      "source_location": "L473"
     },
     {
       "community": 0,
@@ -61711,7 +61822,7 @@
       "label": "getStatusRailIconClassName()",
       "norm_label": "getstatusrailiconclassname()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L381"
+      "source_location": "L423"
     },
     {
       "community": 0,
@@ -61720,7 +61831,7 @@
       "label": "getSummaryAmount()",
       "norm_label": "getsummaryamount()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1280"
+      "source_location": "L1328"
     },
     {
       "community": 0,
@@ -61729,7 +61840,7 @@
       "label": "getSummaryCount()",
       "norm_label": "getsummarycount()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1295"
+      "source_location": "L1343"
     },
     {
       "community": 0,
@@ -61738,7 +61849,7 @@
       "label": "getSummaryRegisterVarianceCount()",
       "norm_label": "getsummaryregistervariancecount()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1310"
+      "source_location": "L1358"
     },
     {
       "community": 0,
@@ -61747,7 +61858,7 @@
       "label": "getTransactionReportAmount()",
       "norm_label": "gettransactionreportamount()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1559"
+      "source_location": "L1607"
     },
     {
       "community": 0,
@@ -61756,7 +61867,7 @@
       "label": "getTransactionReportIdentifier()",
       "norm_label": "gettransactionreportidentifier()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1549"
+      "source_location": "L1597"
     },
     {
       "community": 0,
@@ -61765,7 +61876,7 @@
       "label": "getTransactionReportItems()",
       "norm_label": "gettransactionreportitems()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1520"
+      "source_location": "L1568"
     },
     {
       "community": 0,
@@ -61774,7 +61885,7 @@
       "label": "getTransactionReportLink()",
       "norm_label": "gettransactionreportlink()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1629"
+      "source_location": "L1677"
     },
     {
       "community": 0,
@@ -61783,7 +61894,7 @@
       "label": "getTransactionReportPayment()",
       "norm_label": "gettransactionreportpayment()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1572"
+      "source_location": "L1620"
     },
     {
       "community": 0,
@@ -61792,7 +61903,7 @@
       "label": "getTransactionReportStaff()",
       "norm_label": "gettransactionreportstaff()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1567"
+      "source_location": "L1615"
     },
     {
       "community": 0,
@@ -61801,7 +61912,7 @@
       "label": "getTransactionReportTime()",
       "norm_label": "gettransactionreporttime()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1620"
+      "source_location": "L1668"
     },
     {
       "community": 0,
@@ -61810,7 +61921,7 @@
       "label": "getVarianceTone()",
       "norm_label": "getvariancetone()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L834"
+      "source_location": "L882"
     },
     {
       "community": 0,
@@ -61819,7 +61930,7 @@
       "label": "handlePageChange()",
       "norm_label": "handlepagechange()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1870"
+      "source_location": "L1918"
     },
     {
       "community": 0,
@@ -61828,7 +61939,7 @@
       "label": "humanizeMetadataLabel()",
       "norm_label": "humanizemetadatalabel()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L676"
+      "source_location": "L724"
     },
     {
       "community": 0,
@@ -61837,7 +61948,7 @@
       "label": "if()",
       "norm_label": "if()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L3159"
+      "source_location": "L3255"
     },
     {
       "community": 0,
@@ -61846,7 +61957,7 @@
       "label": "isMoneyMetadataLabel()",
       "norm_label": "ismoneymetadatalabel()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L826"
+      "source_location": "L874"
     },
     {
       "community": 0,
@@ -61855,7 +61966,7 @@
       "label": "isTimestampMetadataLabel()",
       "norm_label": "istimestampmetadatalabel()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L830"
+      "source_location": "L878"
     },
     {
       "community": 0,
@@ -61864,7 +61975,7 @@
       "label": "isVarianceApprovalItem()",
       "norm_label": "isvarianceapprovalitem()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L906"
+      "source_location": "L954"
     },
     {
       "community": 0,
@@ -61873,7 +61984,7 @@
       "label": "isZeroActivityDailyClose()",
       "norm_label": "iszeroactivitydailyclose()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1351"
+      "source_location": "L1399"
     },
     {
       "community": 0,
@@ -61882,7 +61993,7 @@
       "label": "normalizeBucketTab()",
       "norm_label": "normalizebuckettab()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1459"
+      "source_location": "L1507"
     },
     {
       "community": 0,
@@ -61891,7 +62002,7 @@
       "label": "normalizeCommandMessage()",
       "norm_label": "normalizecommandmessage()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L593"
+      "source_location": "L635"
     },
     {
       "community": 0,
@@ -61900,7 +62011,16 @@
       "label": "normalizeCompletedReportSnapshot()",
       "norm_label": "normalizecompletedreportsnapshot()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1406"
+      "source_location": "L1454"
+    },
+    {
+      "community": 0,
+      "file_type": "code",
+      "id": "dailycloseview_normalizedailycloseitemcopy",
+      "label": "normalizeDailyCloseItemCopy()",
+      "norm_label": "normalizedailycloseitemcopy()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
+      "source_location": "L704"
     },
     {
       "community": 0,
@@ -61909,7 +62029,7 @@
       "label": "normalizeMetadataLabel()",
       "norm_label": "normalizemetadatalabel()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L822"
+      "source_location": "L870"
     },
     {
       "community": 0,
@@ -61918,7 +62038,7 @@
       "label": "normalizePage()",
       "norm_label": "normalizepage()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1466"
+      "source_location": "L1514"
     },
     {
       "community": 0,
@@ -61927,7 +62047,7 @@
       "label": "normalizeTransactionReportPaymentMethod()",
       "norm_label": "normalizetransactionreportpaymentmethod()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1585"
+      "source_location": "L1633"
     },
     {
       "community": 0,
@@ -61936,7 +62056,7 @@
       "label": "sentenceFragment()",
       "norm_label": "sentencefragment()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L470"
+      "source_location": "L512"
     },
     {
       "community": 0,
@@ -61945,7 +62065,16 @@
       "label": "shouldShowCollapsedDescription()",
       "norm_label": "shouldshowcollapseddescription()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L662"
+      "source_location": "L708"
+    },
+    {
+      "community": 0,
+      "file_type": "code",
+      "id": "dailycloseview_shouldshowexpensemetric",
+      "label": "shouldShowExpenseMetric()",
+      "norm_label": "shouldshowexpensemetric()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
+      "source_location": "L378"
     },
     {
       "community": 0,
@@ -61954,7 +62083,16 @@
       "label": "shouldShowMetadataEntry()",
       "norm_label": "shouldshowmetadataentry()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L855"
+      "source_location": "L903"
+    },
+    {
+      "community": 0,
+      "file_type": "code",
+      "id": "dailycloseview_shouldshowvariancemetric",
+      "label": "shouldShowVarianceMetric()",
+      "norm_label": "shouldshowvariancemetric()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
+      "source_location": "L388"
     },
     {
       "community": 0,
@@ -61963,7 +62101,7 @@
       "label": "SuccessCheckIcon()",
       "norm_label": "successcheckicon()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L409"
+      "source_location": "L451"
     },
     {
       "community": 0,
@@ -61972,7 +62110,7 @@
       "label": "TransactionReportPaymentIcon()",
       "norm_label": "transactionreportpaymenticon()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.tsx",
-      "source_location": "L1592"
+      "source_location": "L1640"
     },
     {
       "community": 0,
@@ -61990,7 +62128,7 @@
       "label": "approvalBelongsToRange()",
       "norm_label": "approvalbelongstorange()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L727"
+      "source_location": "L728"
     },
     {
       "community": 1,
@@ -61999,7 +62137,7 @@
       "label": "approvalRequestTypeLabel()",
       "norm_label": "approvalrequesttypelabel()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L453"
+      "source_location": "L454"
     },
     {
       "community": 1,
@@ -62008,7 +62146,7 @@
       "label": "asCarryForwardItem()",
       "norm_label": "ascarryforwarditem()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L549"
+      "source_location": "L550"
     },
     {
       "community": 1,
@@ -62017,7 +62155,7 @@
       "label": "buildDailyCloseApprovalSubject()",
       "norm_label": "builddailycloseapprovalsubject()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L262"
+      "source_location": "L263"
     },
     {
       "community": 1,
@@ -62026,7 +62164,7 @@
       "label": "buildDailyCloseCompletionApprovalRequirement()",
       "norm_label": "builddailyclosecompletionapprovalrequirement()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L273"
+      "source_location": "L274"
     },
     {
       "community": 1,
@@ -62035,7 +62173,7 @@
       "label": "buildDailyCloseReopenApprovalRequirement()",
       "norm_label": "builddailyclosereopenapprovalrequirement()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L301"
+      "source_location": "L302"
     },
     {
       "community": 1,
@@ -62044,7 +62182,7 @@
       "label": "buildDailyCloseReportSnapshot()",
       "norm_label": "builddailyclosereportsnapshot()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L991"
+      "source_location": "L1003"
     },
     {
       "community": 1,
@@ -62053,7 +62191,7 @@
       "label": "buildDailyCloseSnapshotWithCtx()",
       "norm_label": "builddailyclosesnapshotwithctx()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1115"
+      "source_location": "L1127"
     },
     {
       "community": 1,
@@ -62062,7 +62200,7 @@
       "label": "buildExpenseSessionsById()",
       "norm_label": "buildexpensesessionsbyid()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L529"
+      "source_location": "L530"
     },
     {
       "community": 1,
@@ -62071,7 +62209,7 @@
       "label": "buildPaymentTotals()",
       "norm_label": "buildpaymenttotals()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L906"
+      "source_location": "L907"
     },
     {
       "community": 1,
@@ -62080,7 +62218,7 @@
       "label": "buildReadiness()",
       "norm_label": "buildreadiness()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L953"
+      "source_location": "L965"
     },
     {
       "community": 1,
@@ -62089,7 +62227,7 @@
       "label": "buildRegisterSessionsById()",
       "norm_label": "buildregistersessionsbyid()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L509"
+      "source_location": "L510"
     },
     {
       "community": 1,
@@ -62098,7 +62236,7 @@
       "label": "buildStaffNamesById()",
       "norm_label": "buildstaffnamesbyid()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L489"
+      "source_location": "L490"
     },
     {
       "community": 1,
@@ -62107,7 +62245,7 @@
       "label": "buildTerminalLabelsById()",
       "norm_label": "buildterminallabelsbyid()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L469"
+      "source_location": "L470"
     },
     {
       "community": 1,
@@ -62116,7 +62254,7 @@
       "label": "cashDeltasByRegisterSessionId()",
       "norm_label": "cashdeltasbyregistersessionid()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L935"
+      "source_location": "L947"
     },
     {
       "community": 1,
@@ -62125,7 +62263,7 @@
       "label": "completeDailyCloseWithCtx()",
       "norm_label": "completedailyclosewithctx()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1936"
+      "source_location": "L1948"
     },
     {
       "community": 1,
@@ -62134,7 +62272,7 @@
       "label": "createCarryForwardWorkItems()",
       "norm_label": "createcarryforwardworkitems()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1860"
+      "source_location": "L1872"
     },
     {
       "community": 1,
@@ -62143,7 +62281,7 @@
       "label": "emptySummary()",
       "norm_label": "emptysummary()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1091"
+      "source_location": "L1103"
     },
     {
       "community": 1,
@@ -62152,7 +62290,7 @@
       "label": "formatPaymentMethodLabel()",
       "norm_label": "formatpaymentmethodlabel()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L425"
+      "source_location": "L426"
     },
     {
       "community": 1,
@@ -62161,7 +62299,7 @@
       "label": "getCompletedDailyCloseHistoryDetailWithCtx()",
       "norm_label": "getcompleteddailyclosehistorydetailwithctx()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2477"
+      "source_location": "L2489"
     },
     {
       "community": 1,
@@ -62170,7 +62308,7 @@
       "label": "getDailyCloseCompletionEventStaffProfileId()",
       "norm_label": "getdailyclosecompletioneventstaffprofileid()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1064"
+      "source_location": "L1076"
     },
     {
       "community": 1,
@@ -62179,7 +62317,7 @@
       "label": "getDailyCloseForDate()",
       "norm_label": "getdailyclosefordate()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L579"
+      "source_location": "L580"
     },
     {
       "community": 1,
@@ -62188,7 +62326,7 @@
       "label": "getDailyCloseOpeningContextWithCtx()",
       "norm_label": "getdailycloseopeningcontextwithctx()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2392"
+      "source_location": "L2404"
     },
     {
       "community": 1,
@@ -62197,7 +62335,7 @@
       "label": "getPriorCompletedDailyClose()",
       "norm_label": "getpriorcompleteddailyclose()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L618"
+      "source_location": "L619"
     },
     {
       "community": 1,
@@ -62206,7 +62344,7 @@
       "label": "getStore()",
       "norm_label": "getstore()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L572"
+      "source_location": "L573"
     },
     {
       "community": 1,
@@ -62215,7 +62353,7 @@
       "label": "isInRange()",
       "norm_label": "isinrange()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L389"
+      "source_location": "L390"
     },
     {
       "community": 1,
@@ -62224,7 +62362,7 @@
       "label": "isValidOperatingDateRange()",
       "norm_label": "isvalidoperatingdaterange()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L357"
+      "source_location": "L358"
     },
     {
       "community": 1,
@@ -62233,7 +62371,7 @@
       "label": "listActiveRegisterSessions()",
       "norm_label": "listactiveregistersessions()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L643"
+      "source_location": "L644"
     },
     {
       "community": 1,
@@ -62242,7 +62380,7 @@
       "label": "listClosedRegisterSessionsForDay()",
       "norm_label": "listclosedregistersessionsforday()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L661"
+      "source_location": "L662"
     },
     {
       "community": 1,
@@ -62251,7 +62389,7 @@
       "label": "listCompletedDailyCloseHistoryWithCtx()",
       "norm_label": "listcompleteddailyclosehistorywithctx()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2428"
+      "source_location": "L2440"
     },
     {
       "community": 1,
@@ -62260,7 +62398,7 @@
       "label": "listDepositsForDay()",
       "norm_label": "listdepositsforday()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L884"
+      "source_location": "L885"
     },
     {
       "community": 1,
@@ -62269,7 +62407,7 @@
       "label": "listExpensesForDay()",
       "norm_label": "listexpensesforday()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L864"
+      "source_location": "L865"
     },
     {
       "community": 1,
@@ -62278,7 +62416,7 @@
       "label": "listOpenOperationalWorkItems()",
       "norm_label": "listopenoperationalworkitems()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L829"
+      "source_location": "L830"
     },
     {
       "community": 1,
@@ -62287,7 +62425,7 @@
       "label": "listOpenPosSessions()",
       "norm_label": "listopenpossessions()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L801"
+      "source_location": "L802"
     },
     {
       "community": 1,
@@ -62296,7 +62434,7 @@
       "label": "listPendingCloseoutApprovals()",
       "norm_label": "listpendingcloseoutapprovals()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L767"
+      "source_location": "L768"
     },
     {
       "community": 1,
@@ -62305,7 +62443,7 @@
       "label": "listTransactionsForDay()",
       "norm_label": "listtransactionsforday()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L843"
+      "source_location": "L844"
     },
     {
       "community": 1,
@@ -62314,7 +62452,7 @@
       "label": "markOtherDailyClosesNotCurrent()",
       "norm_label": "markotherdailyclosesnotcurrent()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1913"
+      "source_location": "L1925"
     },
     {
       "community": 1,
@@ -62323,7 +62461,7 @@
       "label": "nonZeroVarianceMetadata()",
       "norm_label": "nonzerovariancemetadata()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L449"
+      "source_location": "L450"
     },
     {
       "community": 1,
@@ -62332,7 +62470,7 @@
       "label": "normalizeCompletedDailyCloseSnapshot()",
       "norm_label": "normalizecompleteddailyclosesnapshot()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L164"
+      "source_location": "L165"
     },
     {
       "community": 1,
@@ -62341,7 +62479,7 @@
       "label": "posSessionIntersectsRange()",
       "norm_label": "possessionintersectsrange()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L711"
+      "source_location": "L712"
     },
     {
       "community": 1,
@@ -62350,7 +62488,7 @@
       "label": "registerMetadataLabel()",
       "norm_label": "registermetadatalabel()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L412"
+      "source_location": "L413"
     },
     {
       "community": 1,
@@ -62359,7 +62497,7 @@
       "label": "registerSessionBelongsToRange()",
       "norm_label": "registersessionbelongstorange()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L695"
+      "source_location": "L696"
     },
     {
       "community": 1,
@@ -62368,7 +62506,7 @@
       "label": "registerSessionCloseoutOperatingAt()",
       "norm_label": "registersessioncloseoutoperatingat()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L393"
+      "source_location": "L394"
     },
     {
       "community": 1,
@@ -62377,7 +62515,7 @@
       "label": "registerSessionIntersectsRange()",
       "norm_label": "registersessionintersectsrange()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L685"
+      "source_location": "L686"
     },
     {
       "community": 1,
@@ -62386,7 +62524,7 @@
       "label": "registerSessionLabel()",
       "norm_label": "registersessionlabel()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L404"
+      "source_location": "L405"
     },
     {
       "community": 1,
@@ -62395,7 +62533,7 @@
       "label": "reopenDailyCloseWithCtx()",
       "norm_label": "reopendailyclosewithctx()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2198"
+      "source_location": "L2210"
     },
     {
       "community": 1,
@@ -62404,7 +62542,7 @@
       "label": "resolveOperatingDateRange()",
       "norm_label": "resolveoperatingdaterange()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L368"
+      "source_location": "L369"
     },
     {
       "community": 1,
@@ -62413,7 +62551,7 @@
       "label": "safeOperatingDateRange()",
       "norm_label": "safeoperatingdaterange()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L340"
+      "source_location": "L341"
     },
     {
       "community": 1,
@@ -62422,7 +62560,7 @@
       "label": "snapshotReviewedItems()",
       "norm_label": "snapshotrevieweditems()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1029"
+      "source_location": "L1041"
     },
     {
       "community": 1,
@@ -62431,7 +62569,7 @@
       "label": "sortDailyCloseBlockers()",
       "norm_label": "sortdailycloseblockers()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L127"
+      "source_location": "L128"
     },
     {
       "community": 1,
@@ -62440,7 +62578,7 @@
       "label": "toDailyCloseHistoryListItem()",
       "norm_label": "todailyclosehistorylistitem()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1043"
+      "source_location": "L1055"
     },
     {
       "community": 1,
@@ -62449,7 +62587,7 @@
       "label": "transactionCashDelta()",
       "norm_label": "transactioncashdelta()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L924"
+      "source_location": "L936"
     },
     {
       "community": 1,
@@ -62458,7 +62596,7 @@
       "label": "transactionPaymentSummary()",
       "norm_label": "transactionpaymentsummary()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L431"
+      "source_location": "L432"
     },
     {
       "community": 1,
@@ -62467,7 +62605,7 @@
       "label": "trimOptional()",
       "norm_label": "trimoptional()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L335"
+      "source_location": "L336"
     },
     {
       "community": 1,
@@ -62476,7 +62614,7 @@
       "label": "uniqueDailyCloseItems()",
       "norm_label": "uniquedailycloseitems()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L983"
+      "source_location": "L995"
     },
     {
       "community": 1,
@@ -62485,7 +62623,7 @@
       "label": "uniqueSourceSubjects()",
       "norm_label": "uniquesourcesubjects()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L973"
+      "source_location": "L985"
     },
     {
       "community": 1,
@@ -62494,7 +62632,7 @@
       "label": "validateCarryForwardWorkItemIds()",
       "norm_label": "validatecarryforwardworkitemids()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1832"
+      "source_location": "L1844"
     },
     {
       "community": 1,
@@ -62512,7 +62650,7 @@
       "label": "buildDailyCloseSearch()",
       "norm_label": "builddailyclosesearch()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L296"
+      "source_location": "L298"
     },
     {
       "community": 10,
@@ -62521,7 +62659,7 @@
       "label": "buildDailyOperationsSearch()",
       "norm_label": "builddailyoperationssearch()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L302"
+      "source_location": "L304"
     },
     {
       "community": 10,
@@ -62530,7 +62668,7 @@
       "label": "buildOperationsTransactionSearch()",
       "norm_label": "buildoperationstransactionsearch()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L320"
+      "source_location": "L322"
     },
     {
       "community": 10,
@@ -62539,7 +62677,7 @@
       "label": "formatCarriedOverRegisterCount()",
       "norm_label": "formatcarriedoverregistercount()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L431"
+      "source_location": "L433"
     },
     {
       "community": 10,
@@ -62548,7 +62686,7 @@
       "label": "formatEntityCount()",
       "norm_label": "formatentitycount()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L415"
+      "source_location": "L417"
     },
     {
       "community": 10,
@@ -62557,7 +62695,7 @@
       "label": "formatEventTime()",
       "norm_label": "formateventtime()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L373"
+      "source_location": "L375"
     },
     {
       "community": 10,
@@ -62566,7 +62704,7 @@
       "label": "formatMoney()",
       "norm_label": "formatmoney()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L443"
+      "source_location": "L445"
     },
     {
       "community": 10,
@@ -62575,7 +62713,7 @@
       "label": "formatOperatingDate()",
       "norm_label": "formatoperatingdate()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L263"
+      "source_location": "L265"
     },
     {
       "community": 10,
@@ -62584,7 +62722,7 @@
       "label": "formatOperatingDateWithWeekday()",
       "norm_label": "formatoperatingdatewithweekday()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L279"
+      "source_location": "L281"
     },
     {
       "community": 10,
@@ -62593,7 +62731,7 @@
       "label": "formatRegisterVarianceCount()",
       "norm_label": "formatregistervariancecount()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L437"
+      "source_location": "L439"
     },
     {
       "community": 10,
@@ -62602,7 +62740,7 @@
       "label": "formatTimelineMessage()",
       "norm_label": "formattimelinemessage()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L380"
+      "source_location": "L382"
     },
     {
       "community": 10,
@@ -62611,7 +62749,7 @@
       "label": "formatTodayCashTransactionCount()",
       "norm_label": "formattodaycashtransactioncount()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L425"
+      "source_location": "L427"
     },
     {
       "community": 10,
@@ -62620,7 +62758,7 @@
       "label": "formatWeekdayDate()",
       "norm_label": "formatweekdaydate()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L407"
+      "source_location": "L409"
     },
     {
       "community": 10,
@@ -62629,7 +62767,7 @@
       "label": "formatWeekdayLabel()",
       "norm_label": "formatweekdaylabel()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L399"
+      "source_location": "L401"
     },
     {
       "community": 10,
@@ -62647,7 +62785,7 @@
       "label": "getDailyOperationsMetricLabels()",
       "norm_label": "getdailyoperationsmetriclabels()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L334"
+      "source_location": "L336"
     },
     {
       "community": 10,
@@ -62719,7 +62857,7 @@
       "label": "getWeekEndOperatingDateFromSearch()",
       "norm_label": "getweekendoperatingdatefromsearch()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L347"
+      "source_location": "L349"
     },
     {
       "community": 10,
@@ -62728,7 +62866,7 @@
       "label": "getWorkflowSearch()",
       "norm_label": "getworkflowsearch()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L362"
+      "source_location": "L364"
     },
     {
       "community": 10,
@@ -62737,7 +62875,7 @@
       "label": "handleOperatingDateChange()",
       "norm_label": "handleoperatingdatechange()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L1206"
+      "source_location": "L1208"
     },
     {
       "community": 10,
@@ -62746,7 +62884,7 @@
       "label": "isHistoricalOperatingDate()",
       "norm_label": "ishistoricaloperatingdate()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L343"
+      "source_location": "L345"
     },
     {
       "community": 10,
@@ -62764,7 +62902,7 @@
       "label": "shouldShowPrimaryAction()",
       "norm_label": "shouldshowprimaryaction()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L358"
+      "source_location": "L360"
     },
     {
       "community": 10,
@@ -62773,7 +62911,7 @@
       "label": "statusClassName()",
       "norm_label": "statusclassname()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L447"
+      "source_location": "L449"
     },
     {
       "community": 10,
@@ -71355,65 +71493,65 @@
     {
       "community": 148,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_templates_reference_fixtures_tsx",
-      "label": "reference-fixtures.tsx",
-      "norm_label": "reference-fixtures.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "id": "packages_athena_webapp_src_lib_productutils_ts",
+      "label": "productUtils.ts",
+      "norm_label": "productutils.ts",
+      "source_file": "packages/athena-webapp/src/lib/productUtils.ts",
       "source_location": "L1"
     },
     {
       "community": 148,
       "file_type": "code",
-      "id": "reference_fixtures_compacttable",
-      "label": "CompactTable()",
-      "norm_label": "compacttable()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L263"
+      "id": "packages_storefront_webapp_src_lib_productutils_ts",
+      "label": "productUtils.ts",
+      "norm_label": "productutils.ts",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L1"
     },
     {
       "community": 148,
       "file_type": "code",
-      "id": "reference_fixtures_framecard",
-      "label": "FrameCard()",
-      "norm_label": "framecard()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L163"
+      "id": "productutils_getproductname",
+      "label": "getProductName()",
+      "norm_label": "getproductname()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L18"
     },
     {
       "community": 148,
       "file_type": "code",
-      "id": "reference_fixtures_lanecard",
-      "label": "LaneCard()",
-      "norm_label": "lanecard()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L213"
+      "id": "productutils_haslowstock",
+      "label": "hasLowStock()",
+      "norm_label": "haslowstock()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L52"
     },
     {
       "community": 148,
       "file_type": "code",
-      "id": "reference_fixtures_metrictile",
-      "label": "MetricTile()",
-      "norm_label": "metrictile()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L194"
+      "id": "productutils_issoldout",
+      "label": "isSoldOut()",
+      "norm_label": "issoldout()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L45"
     },
     {
       "community": 148,
       "file_type": "code",
-      "id": "reference_fixtures_minitrendchart",
-      "label": "MiniTrendChart()",
-      "norm_label": "minitrendchart()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L240"
+      "id": "productutils_sortproduct",
+      "label": "sortProduct()",
+      "norm_label": "sortproduct()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L66"
     },
     {
       "community": 148,
       "file_type": "code",
-      "id": "reference_fixtures_referencepageshell",
-      "label": "ReferencePageShell()",
-      "norm_label": "referencepageshell()",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
-      "source_location": "L145"
+      "id": "productutils_sortskusbylength",
+      "label": "sortSkusByLength()",
+      "norm_label": "sortskusbylength()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L62"
     },
     {
       "community": 1480,
@@ -71508,65 +71646,65 @@
     {
       "community": 149,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_savedbag_ts",
-      "label": "savedBag.ts",
-      "norm_label": "savedbag.ts",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "id": "packages_athena_webapp_src_stories_templates_reference_fixtures_tsx",
+      "label": "reference-fixtures.tsx",
+      "norm_label": "reference-fixtures.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
       "source_location": "L1"
     },
     {
       "community": 149,
       "file_type": "code",
-      "id": "savedbag_additemtosavedbag",
-      "label": "addItemToSavedBag()",
-      "norm_label": "additemtosavedbag()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L25"
+      "id": "reference_fixtures_compacttable",
+      "label": "CompactTable()",
+      "norm_label": "compacttable()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L263"
     },
     {
       "community": 149,
       "file_type": "code",
-      "id": "savedbag_getactivesavedbag",
-      "label": "getActiveSavedBag()",
-      "norm_label": "getactivesavedbag()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L10"
+      "id": "reference_fixtures_framecard",
+      "label": "FrameCard()",
+      "norm_label": "framecard()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L163"
     },
     {
       "community": 149,
       "file_type": "code",
-      "id": "savedbag_getbaseurl",
-      "label": "getBaseUrl()",
-      "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L8"
+      "id": "reference_fixtures_lanecard",
+      "label": "LaneCard()",
+      "norm_label": "lanecard()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L213"
     },
     {
       "community": 149,
       "file_type": "code",
-      "id": "savedbag_removeitemfromsavedbag",
-      "label": "removeItemFromSavedBag()",
-      "norm_label": "removeitemfromsavedbag()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L91"
+      "id": "reference_fixtures_metrictile",
+      "label": "MetricTile()",
+      "norm_label": "metrictile()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L194"
     },
     {
       "community": 149,
       "file_type": "code",
-      "id": "savedbag_updatesavedbagitem",
-      "label": "updateSavedBagItem()",
-      "norm_label": "updatesavedbagitem()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L61"
+      "id": "reference_fixtures_minitrendchart",
+      "label": "MiniTrendChart()",
+      "norm_label": "minitrendchart()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L240"
     },
     {
       "community": 149,
       "file_type": "code",
-      "id": "savedbag_updatesavedbagowner",
-      "label": "updateSavedBagOwner()",
-      "norm_label": "updatesavedbagowner()",
-      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
-      "source_location": "L109"
+      "id": "reference_fixtures_referencepageshell",
+      "label": "ReferencePageShell()",
+      "norm_label": "referencepageshell()",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.tsx",
+      "source_location": "L145"
     },
     {
       "community": 1490,
@@ -71886,65 +72024,65 @@
     {
       "community": 150,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_productutils_ts",
-      "label": "productUtils.ts",
-      "norm_label": "productutils.ts",
-      "source_file": "packages/athena-webapp/src/lib/productUtils.ts",
+      "id": "packages_storefront_webapp_src_api_savedbag_ts",
+      "label": "savedBag.ts",
+      "norm_label": "savedbag.ts",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
       "source_location": "L1"
     },
     {
       "community": 150,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_productutils_ts",
-      "label": "productUtils.ts",
-      "norm_label": "productutils.ts",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L1"
+      "id": "savedbag_additemtosavedbag",
+      "label": "addItemToSavedBag()",
+      "norm_label": "additemtosavedbag()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L25"
     },
     {
       "community": 150,
       "file_type": "code",
-      "id": "productutils_getproductname",
-      "label": "getProductName()",
-      "norm_label": "getproductname()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L18"
+      "id": "savedbag_getactivesavedbag",
+      "label": "getActiveSavedBag()",
+      "norm_label": "getactivesavedbag()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L10"
     },
     {
       "community": 150,
       "file_type": "code",
-      "id": "productutils_haslowstock",
-      "label": "hasLowStock()",
-      "norm_label": "haslowstock()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L52"
+      "id": "savedbag_getbaseurl",
+      "label": "getBaseUrl()",
+      "norm_label": "getbaseurl()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L8"
     },
     {
       "community": 150,
       "file_type": "code",
-      "id": "productutils_issoldout",
-      "label": "isSoldOut()",
-      "norm_label": "issoldout()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L45"
+      "id": "savedbag_removeitemfromsavedbag",
+      "label": "removeItemFromSavedBag()",
+      "norm_label": "removeitemfromsavedbag()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L91"
     },
     {
       "community": 150,
       "file_type": "code",
-      "id": "productutils_sortproduct",
-      "label": "sortProduct()",
-      "norm_label": "sortproduct()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L66"
+      "id": "savedbag_updatesavedbagitem",
+      "label": "updateSavedBagItem()",
+      "norm_label": "updatesavedbagitem()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L61"
     },
     {
       "community": 150,
       "file_type": "code",
-      "id": "productutils_sortskusbylength",
-      "label": "sortSkusByLength()",
-      "norm_label": "sortskusbylength()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L62"
+      "id": "savedbag_updatesavedbagowner",
+      "label": "updateSavedBagOwner()",
+      "norm_label": "updatesavedbagowner()",
+      "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
+      "source_location": "L109"
     },
     {
       "community": 1500,
@@ -82267,7 +82405,7 @@
       "label": "disconnect()",
       "norm_label": "disconnect()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.test.tsx",
-      "source_location": "L313"
+      "source_location": "L318"
     },
     {
       "community": 289,
@@ -82276,7 +82414,7 @@
       "label": "observe()",
       "norm_label": "observe()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.test.tsx",
-      "source_location": "L314"
+      "source_location": "L319"
     },
     {
       "community": 289,
@@ -82285,7 +82423,7 @@
       "label": "unobserve()",
       "norm_label": "unobserve()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyCloseView.test.tsx",
-      "source_location": "L315"
+      "source_location": "L320"
     },
     {
       "community": 289,

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,12 +8,12 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 1681
-- Graph nodes: 5085
-- Graph edges: 5107
+- Graph nodes: 5091
+- Graph edges: 5114
 - Communities: 1610
 
 ## Graph Hotspots
-- `DailyCloseView.tsx` (76 edges, Community 0) - [`packages/athena-webapp/src/components/operations/DailyCloseView.tsx`](../../packages/athena-webapp/src/components/operations/DailyCloseView.tsx)
+- `DailyCloseView.tsx` (82 edges, Community 0) - [`packages/athena-webapp/src/components/operations/DailyCloseView.tsx`](../../packages/athena-webapp/src/components/operations/DailyCloseView.tsx)
 - `dailyClose.ts` (57 edges, Community 1) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../packages/athena-webapp/convex/operations/dailyClose.ts)
 - `harness-inferential-review.ts` (46 edges, Community 2) - [`scripts/harness-inferential-review.ts`](../../scripts/harness-inferential-review.ts)
 - `storefrontJourneyEvents.ts` (45 edges, Community 3) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)

--- a/graphify-out/wiki/packages/athena-webapp.md
+++ b/graphify-out/wiki/packages/athena-webapp.md
@@ -17,7 +17,7 @@ Landing page for packages/athena-webapp. Use this page to orient around graph ho
 - [validation-map.json](../../../packages/athena-webapp/docs/agent/validation-map.json)
 
 ## Graph Hotspots
-- `DailyCloseView.tsx` (76 edges, Community 0) - [`packages/athena-webapp/src/components/operations/DailyCloseView.tsx`](../../../packages/athena-webapp/src/components/operations/DailyCloseView.tsx)
+- `DailyCloseView.tsx` (82 edges, Community 0) - [`packages/athena-webapp/src/components/operations/DailyCloseView.tsx`](../../../packages/athena-webapp/src/components/operations/DailyCloseView.tsx)
 - `dailyClose.ts` (57 edges, Community 1) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../../packages/athena-webapp/convex/operations/dailyClose.ts)
 - `ProcurementView.tsx` (39 edges, Community 4) - [`packages/athena-webapp/src/components/procurement/ProcurementView.tsx`](../../../packages/athena-webapp/src/components/procurement/ProcurementView.tsx)
 - `DailyOpeningView.tsx` (35 edges, Community 5) - [`packages/athena-webapp/src/components/operations/DailyOpeningView.tsx`](../../../packages/athena-webapp/src/components/operations/DailyOpeningView.tsx)

--- a/packages/athena-webapp/convex/operations/approvalActions.ts
+++ b/packages/athena-webapp/convex/operations/approvalActions.ts
@@ -26,11 +26,11 @@ export const APPROVAL_ACTIONS = {
   },
   dailyCloseCompletion: {
     key: "operations.daily_close.complete",
-    label: "Complete End-of-Day Review",
+    label: "Complete EOD Review",
   },
   dailyCloseReopen: {
     key: "operations.daily_close.reopen",
-    label: "Reopen End-of-Day Review",
+    label: "Reopen EOD Review",
   },
   transactionPaymentMethodCorrection: {
     key: "pos.transaction.correct_payment_method",

--- a/packages/athena-webapp/convex/operations/dailyClose.test.ts
+++ b/packages/athena-webapp/convex/operations/dailyClose.test.ts
@@ -250,7 +250,7 @@ function dailyCloseApprovalProof(overrides: Partial<Row> = {}): Row {
     requestedByStaffProfileId: "staff-1",
     storeId: "store-1",
     subjectId: "store-1:2026-05-07",
-    subjectLabel: "End-of-Day Review 2026-05-07",
+    subjectLabel: "EOD Review 2026-05-07",
     subjectType: "daily_close",
     ...overrides,
   };
@@ -268,7 +268,7 @@ function dailyCloseReopenApprovalProof(overrides: Partial<Row> = {}): Row {
     requestedByStaffProfileId: "staff-1",
     storeId: "store-1",
     subjectId: "daily-close-1",
-    subjectLabel: "End-of-Day Review 2026-05-07",
+    subjectLabel: "EOD Review 2026-05-07",
     subjectType: "daily_close",
     ...overrides,
   };
@@ -305,7 +305,7 @@ function completedDailyCloseSnapshot(overrides: Record<string, unknown> = {}) {
         severity: "ready",
         category: "sale",
         title: "Completed sale",
-        message: "Completed sale is included in End-of-Day Review.",
+        message: "Completed sale is included in the end of day review.",
         subject: {
           id: "txn-1",
           label: "TXN-1",
@@ -840,6 +840,18 @@ describe("end-of-day review backend foundation", () => {
       netCashVariance: -2500,
       openWorkItemCount: 1,
       pendingApprovalCount: 1,
+      paymentTotals: expect.arrayContaining([
+        {
+          amount: 10000,
+          method: "cash",
+          transactionCount: 1,
+        },
+        {
+          amount: 2500,
+          method: "mobile_money",
+          transactionCount: 1,
+        },
+      ]),
       registerCount: 3,
       registerVarianceCount: 2,
       salesTotal: 12000,
@@ -863,7 +875,7 @@ describe("end-of-day review backend foundation", () => {
     );
   });
 
-  it("serves the persisted report snapshot for completed End-of-Day Reviews", async () => {
+  it("serves the persisted report snapshot for completed EOD Reviews", async () => {
     vi.spyOn(Date, "now").mockReturnValue(Date.UTC(2026, 4, 9, 12));
 
     const { db } = createDb({
@@ -921,7 +933,7 @@ describe("end-of-day review backend foundation", () => {
               {
                 category: "sale",
                 key: "pos_transaction:txn-closed-day:completed",
-                message: "Completed sale is included in End-of-Day Review.",
+                message: "Completed sale is included in the end of day review.",
                 severity: "ready",
                 subject: {
                   id: "txn-closed-day",
@@ -1227,14 +1239,14 @@ describe("end-of-day review backend foundation", () => {
           _id: "event-1",
           createdAt: Date.UTC(2026, 4, 9, 1, 8),
           eventType: "daily_close_completed",
-          message: "End-of-Day Review completed for 2026-05-08.",
+          message: "EOD Review completed for 2026-05-08.",
           metadata: {
             approvedByStaffProfileId: "staff-manager-1",
           },
           organizationId: "org-1",
           storeId: "store-1",
           subjectId: "daily-close-1",
-          subjectLabel: "End-of-Day Review 2026-05-08",
+          subjectLabel: "EOD Review 2026-05-08",
           subjectType: "daily_close",
         },
       ],
@@ -1431,7 +1443,7 @@ describe("end-of-day review backend foundation", () => {
       error: {
         code: "precondition_failed",
         message:
-          "End-of-Day Review cannot be completed while blocker items remain.",
+          "EOD Review cannot be completed while blocker items remain.",
         metadata: { blockerCount: 1 },
       },
     });
@@ -1511,11 +1523,11 @@ describe("end-of-day review backend foundation", () => {
       approval: {
         action: {
           key: "operations.daily_close.complete",
-          label: "Complete End-of-Day Review",
+          label: "Complete EOD Review",
         },
         copy: {
           message:
-            "A manager needs to approve this End-of-Day Review before the operating day is saved.",
+            "A manager needs to approve this end of day review before the operating day is saved.",
           primaryActionLabel: "Approve and complete",
           secondaryActionLabel: "Cancel",
           title: "Manager approval required",
@@ -1523,13 +1535,13 @@ describe("end-of-day review backend foundation", () => {
         metadata: {
           operatingDate: "2026-05-07",
         },
-        reason: "Manager approval is required to complete End-of-Day Review.",
+        reason: "Manager approval is required to complete EOD Review.",
         requiredRole: "manager",
         resolutionModes: [{ kind: "inline_manager_proof" }],
         selfApproval: "allowed",
         subject: {
           id: "store-1:2026-05-07",
-          label: "End-of-Day Review 2026-05-07",
+          label: "EOD Review 2026-05-07",
           type: "daily_close",
         },
       },
@@ -1736,11 +1748,11 @@ describe("end-of-day review backend foundation", () => {
       approval: {
         action: {
           key: "operations.daily_close.reopen",
-          label: "Reopen End-of-Day Review",
+          label: "Reopen EOD Review",
         },
         copy: {
           message:
-            "A manager needs to approve reopening this End-of-Day Review before the operating day can be revised.",
+            "A manager needs to approve reopening this EOD Review before the operating day can be revised.",
           primaryActionLabel: "Approve and reopen",
           secondaryActionLabel: "Cancel",
           title: "Manager approval required",
@@ -1749,13 +1761,13 @@ describe("end-of-day review backend foundation", () => {
           dailyCloseId: "daily-close-1",
           operatingDate: "2026-05-07",
         },
-        reason: "Manager approval is required to reopen End-of-Day Review.",
+        reason: "Manager approval is required to reopen EOD Review.",
         requiredRole: "manager",
         resolutionModes: [{ kind: "inline_manager_proof" }],
         selfApproval: "allowed",
         subject: {
           id: "daily-close-1",
-          label: "End-of-Day Review 2026-05-07",
+          label: "EOD Review 2026-05-07",
           type: "daily_close",
         },
       },
@@ -2055,7 +2067,7 @@ describe("end-of-day review backend foundation", () => {
           category: "open_work",
           title: "Carry forward",
           message:
-            "Open operational work will carry forward after End-of-Day Review.",
+            "Open operational work will carry forward after the end of day review.",
           subject: {
             id: "work-1",
             label: "Carry forward",
@@ -2069,7 +2081,7 @@ describe("end-of-day review backend foundation", () => {
           severity: "ready",
           category: "sales",
           title: "Completed transaction",
-          message: "Transaction included in End-of-Day Review.",
+          message: "Transaction included in the end of day review.",
           subject: {
             id: "txn-2",
             label: "TXN-2",
@@ -2188,14 +2200,14 @@ describe("end-of-day review backend foundation", () => {
           _id: "event-old-complete",
           createdAt: Date.UTC(2026, 4, 7, 22),
           eventType: "daily_close_completed",
-          message: "End-of-Day Review completed for 2026-05-07.",
+          message: "EOD Review completed for 2026-05-07.",
           metadata: {
             approvedByStaffProfileId: "staff-manager-1",
           },
           organizationId: "org-1",
           storeId: "store-1",
           subjectId: "daily-close-old",
-          subjectLabel: "End-of-Day Review 2026-05-07",
+          subjectLabel: "EOD Review 2026-05-07",
           subjectType: "daily_close",
         },
       ],

--- a/packages/athena-webapp/convex/operations/dailyClose.ts
+++ b/packages/athena-webapp/convex/operations/dailyClose.ts
@@ -92,6 +92,7 @@ type DailyCloseSummary = {
   paymentTotals: Array<{
     method: string;
     amount: number;
+    transactionCount: number;
   }>;
 };
 
@@ -265,7 +266,7 @@ function buildDailyCloseApprovalSubject(args: {
 }) {
   return {
     id: `${args.storeId}:${args.operatingDate}`,
-    label: `End-of-Day Review ${args.operatingDate}`,
+    label: `EOD Review ${args.operatingDate}`,
     type: DAILY_CLOSE_SUBJECT_TYPE,
   };
 }
@@ -276,14 +277,14 @@ function buildDailyCloseCompletionApprovalRequirement(args: {
 }): ApprovalRequirement {
   return {
     action: DAILY_CLOSE_COMPLETION_ACTION,
-    reason: "Manager approval is required to complete End-of-Day Review.",
+    reason: "Manager approval is required to complete EOD Review.",
     requiredRole: "manager",
     selfApproval: "allowed",
     subject: buildDailyCloseApprovalSubject(args),
     copy: {
       title: "Manager approval required",
       message:
-        "A manager needs to approve this End-of-Day Review before the operating day is saved.",
+        "A manager needs to approve this end of day review before the operating day is saved.",
       primaryActionLabel: "Approve and complete",
       secondaryActionLabel: "Cancel",
     },
@@ -305,18 +306,18 @@ function buildDailyCloseReopenApprovalRequirement(args: {
 }): ApprovalRequirement {
   return {
     action: DAILY_CLOSE_REOPEN_ACTION,
-    reason: "Manager approval is required to reopen End-of-Day Review.",
+    reason: "Manager approval is required to reopen EOD Review.",
     requiredRole: "manager",
     selfApproval: "allowed",
     subject: {
       id: args.dailyCloseId,
-      label: `End-of-Day Review ${args.operatingDate}`,
+      label: `EOD Review ${args.operatingDate}`,
       type: DAILY_CLOSE_SUBJECT_TYPE,
     },
     copy: {
       title: "Manager approval required",
       message:
-        "A manager needs to approve reopening this End-of-Day Review before the operating day can be revised.",
+        "A manager needs to approve reopening this EOD Review before the operating day can be revised.",
       primaryActionLabel: "Approve and reopen",
       secondaryActionLabel: "Cancel",
     },
@@ -555,7 +556,7 @@ function asCarryForwardItem(
     category: "open_work",
     title: workItem.title,
     message:
-      "Open operational work will carry forward after End-of-Day Review.",
+      "Open operational work will carry forward after the end of day review.",
     subject: {
       type: "operational_work_item",
       id: workItem._id,
@@ -904,20 +905,31 @@ async function listDepositsForDay(
 }
 
 function buildPaymentTotals(transactions: Array<Doc<"posTransaction">>) {
-  const paymentTotals = new Map<string, number>();
+  const paymentTotals = new Map<
+    string,
+    {
+      amount: number;
+      transactionCount: number;
+    }
+  >();
 
   transactions.forEach((transaction) => {
     transaction.payments.forEach((payment) => {
-      paymentTotals.set(
-        payment.method,
-        (paymentTotals.get(payment.method) ?? 0) + payment.amount,
-      );
+      const existing = paymentTotals.get(payment.method) ?? {
+        amount: 0,
+        transactionCount: 0,
+      };
+
+      paymentTotals.set(payment.method, {
+        amount: existing.amount + payment.amount,
+        transactionCount: existing.transactionCount + 1,
+      });
     });
   });
 
-  return Array.from(paymentTotals.entries()).map(([method, amount]) => ({
+  return Array.from(paymentTotals.entries()).map(([method, total]) => ({
     method,
-    amount,
+    ...total,
   }));
 }
 
@@ -1131,7 +1143,7 @@ export async function buildDailyCloseSnapshotWithCtx(
       category: "operating_date",
       title: "Invalid operating date",
       message:
-        "End-of-Day Review requires an operating date in YYYY-MM-DD format.",
+        "EOD Review requires an operating date in YYYY-MM-DD format.",
       subject: {
         type: DAILY_CLOSE_SUBJECT_TYPE,
         id: args.operatingDate,
@@ -1318,10 +1330,10 @@ export async function buildDailyCloseSnapshotWithCtx(
           : "Register session is still open",
       message:
         session.status === "closing"
-          ? "Finish the register closeout before completing End-of-Day Review."
+          ? "Finish the register closeout before completing the end of day review."
           : isCarriedOver
-            ? "Close the register session carried over from a prior operating day before completing End-of-Day Review."
-            : "Close the register session before completing End-of-Day Review.",
+            ? "Close the register session carried over from a prior operating day before completing the end of day review."
+            : "Close the register session before completing the end of day review.",
       subject: {
         type: "register_session",
         id: session._id,
@@ -1395,7 +1407,7 @@ export async function buildDailyCloseSnapshotWithCtx(
       category: "approval",
       title: `${approvalRequestTypeLabel(approval.requestType)} pending`,
       message:
-        "Resolve pending closeout approval before completing End-of-Day Review.",
+        "Resolve pending closeout approval before completing the end of day review.",
       subject: {
         type: "approval_request",
         id: approval._id,
@@ -1448,7 +1460,7 @@ export async function buildDailyCloseSnapshotWithCtx(
       category: "pos_session",
       title: "POS session is still unresolved",
       message:
-        "Complete, void, or release held POS sessions before End-of-Day Review.",
+        "Complete, void, or release held POS sessions before the end of day review.",
       subject: {
         type: "pos_session",
         id: session._id,
@@ -1498,7 +1510,7 @@ export async function buildDailyCloseSnapshotWithCtx(
       severity: "ready",
       category: "register_session",
       title: "Register session closed",
-      message: "Closed register session is included in End-of-Day Review.",
+      message: "Closed register session is included in the end of day review.",
       subject: {
         type: "register_session",
         id: session._id,
@@ -1537,7 +1549,7 @@ export async function buildDailyCloseSnapshotWithCtx(
         category: "cash_variance",
         title: "Closed register has a cash variance",
         message:
-          "Review the cash variance before completing End-of-Day Review.",
+          "Review the cash variance before completing the end of day review.",
         subject: {
           type: "register_session",
           id: session._id,
@@ -1588,7 +1600,7 @@ export async function buildDailyCloseSnapshotWithCtx(
       severity: "ready",
       category: "sale",
       title: "Completed sale",
-      message: "Completed sale is included in End-of-Day Review.",
+      message: "Completed sale is included in the end of day review.",
       subject: {
         type: "pos_transaction",
         id: transaction._id,
@@ -1641,7 +1653,7 @@ export async function buildDailyCloseSnapshotWithCtx(
       severity: "ready",
       category: "expense",
       title: "Completed expense",
-      message: "Completed expense is included in End-of-Day Review.",
+      message: "Completed expense is included in the end of day review.",
       subject: {
         type: "expense_transaction",
         id: transaction._id,
@@ -1691,7 +1703,7 @@ export async function buildDailyCloseSnapshotWithCtx(
       severity: "review",
       category: "voided_sale",
       title: "Voided sale needs review",
-      message: "Review voided sales before completing End-of-Day Review.",
+      message: "Review voided sales before completing the end of day review.",
       subject: {
         type: "pos_transaction",
         id: transaction._id,
@@ -1949,7 +1961,7 @@ export async function completeDailyCloseWithCtx(
   if (args.organizationId && args.organizationId !== store.organizationId) {
     return userError({
       code: "authorization_failed",
-      message: "End-of-Day Review store does not belong to this organization.",
+      message: "EOD Review store does not belong to this organization.",
     });
   }
 
@@ -1989,7 +2001,7 @@ export async function completeDailyCloseWithCtx(
     return userError({
       code: "precondition_failed",
       message:
-        "End-of-Day Review cannot be completed while blocker items remain.",
+        "EOD Review cannot be completed while blocker items remain.",
       metadata: {
         blockerCount: snapshot.blockers.length,
       },
@@ -2005,7 +2017,7 @@ export async function completeDailyCloseWithCtx(
     return userError({
       code: "precondition_failed",
       message:
-        "End-of-Day Review items must be acknowledged before completion.",
+        "EOD Review items must be acknowledged before completion.",
       metadata: {
         reviewItemCount: snapshot.reviewItems.length,
         unreviewedItemKeys,
@@ -2136,7 +2148,7 @@ export async function completeDailyCloseWithCtx(
   if (!dailyClose) {
     return userError({
       code: "unavailable",
-      message: "End-of-Day Review could not be loaded after completion.",
+      message: "EOD Review could not be loaded after completion.",
       retryable: true,
     });
   }
@@ -2156,8 +2168,8 @@ export async function completeDailyCloseWithCtx(
     eventType: "daily_close_completed",
     subjectType: DAILY_CLOSE_SUBJECT_TYPE,
     subjectId: dailyClose._id,
-    subjectLabel: `End-of-Day Review ${args.operatingDate}`,
-    message: `End-of-Day Review completed for ${args.operatingDate}.`,
+    subjectLabel: `EOD Review ${args.operatingDate}`,
+    message: `EOD Review completed for ${args.operatingDate}.`,
     actorUserId: args.actorUserId,
     actorStaffProfileId: completedByStaffProfileId,
     metadata: {
@@ -2176,8 +2188,8 @@ export async function completeDailyCloseWithCtx(
       eventType: "daily_close_carry_forward_created",
       subjectType: DAILY_CLOSE_SUBJECT_TYPE,
       subjectId: dailyClose._id,
-      subjectLabel: `End-of-Day Review ${args.operatingDate}`,
-      message: "End-of-Day Review created a carry-forward work item.",
+      subjectLabel: `EOD Review ${args.operatingDate}`,
+      message: "EOD Review created a carry-forward work item.",
       actorUserId: args.actorUserId,
       actorStaffProfileId: args.actorStaffProfileId,
       workItemId: workItem._id,
@@ -2213,7 +2225,7 @@ export async function reopenDailyCloseWithCtx(
   if (!originalDailyClose || originalDailyClose.storeId !== args.storeId) {
     return userError({
       code: "not_found",
-      message: "End-of-Day Review was not found for this store.",
+      message: "EOD Review was not found for this store.",
     });
   }
 
@@ -2223,7 +2235,7 @@ export async function reopenDailyCloseWithCtx(
   ) {
     return userError({
       code: "authorization_failed",
-      message: "End-of-Day Review store does not belong to this organization.",
+      message: "EOD Review store does not belong to this organization.",
     });
   }
 
@@ -2233,14 +2245,14 @@ export async function reopenDailyCloseWithCtx(
   ) {
     return userError({
       code: "precondition_failed",
-      message: "Only a completed End-of-Day Review can be reopened.",
+      message: "Only a completed EOD Review can be reopened.",
     });
   }
 
   if (originalDailyClose.lifecycleStatus === "superseded") {
     return userError({
       code: "precondition_failed",
-      message: "This End-of-Day Review has already been superseded.",
+      message: "This EOD Review has already been superseded.",
     });
   }
 
@@ -2275,7 +2287,7 @@ export async function reopenDailyCloseWithCtx(
   ) {
     return userError({
       code: "precondition_failed",
-      message: "This End-of-Day Review is already reopened.",
+      message: "This EOD Review is already reopened.",
     });
   }
 
@@ -2297,7 +2309,7 @@ export async function reopenDailyCloseWithCtx(
     storeId: args.storeId,
     subject: {
       id: originalDailyClose._id,
-      label: `End-of-Day Review ${originalDailyClose.operatingDate}`,
+      label: `EOD Review ${originalDailyClose.operatingDate}`,
       type: DAILY_CLOSE_SUBJECT_TYPE,
     },
   });
@@ -2358,7 +2370,7 @@ export async function reopenDailyCloseWithCtx(
   if (!reopenedDailyClose || !updatedOriginalDailyClose) {
     return userError({
       code: "unavailable",
-      message: "Reopened End-of-Day Review could not be loaded.",
+      message: "Reopened EOD Review could not be loaded.",
       retryable: true,
     });
   }
@@ -2369,8 +2381,8 @@ export async function reopenDailyCloseWithCtx(
     eventType: "daily_close_reopened",
     subjectType: DAILY_CLOSE_SUBJECT_TYPE,
     subjectId: originalDailyClose._id,
-    subjectLabel: `End-of-Day Review ${originalDailyClose.operatingDate}`,
-    message: `End-of-Day Review reopened for ${originalDailyClose.operatingDate}.`,
+    subjectLabel: `EOD Review ${originalDailyClose.operatingDate}`,
+    message: `EOD Review reopened for ${originalDailyClose.operatingDate}.`,
     actorUserId: args.actorUserId,
     actorStaffProfileId: approvalProof.data.approvedByStaffProfileId,
     metadata: {

--- a/packages/athena-webapp/convex/operations/dailyOpening.test.ts
+++ b/packages/athena-webapp/convex/operations/dailyOpening.test.ts
@@ -199,7 +199,7 @@ describe("daily opening backend foundation", () => {
     vi.restoreAllMocks();
   });
 
-  it("returns a ready snapshot when the prior End-of-Day Review completed cleanly", async () => {
+  it("returns a ready snapshot when the prior EOD Review completed cleanly", async () => {
     const { db } = createDb({
       dailyClose: [completedDailyClose()],
       store: [store],
@@ -233,7 +233,7 @@ describe("daily opening backend foundation", () => {
     expect(snapshot.sourceSubjects).toEqual([
       {
         id: "daily-close-1",
-        label: "End-of-Day Review 2026-05-07",
+        label: "EOD Review 2026-05-07",
         type: "daily_close",
       },
     ]);
@@ -261,9 +261,9 @@ describe("daily opening backend foundation", () => {
     expect(snapshot.reviewItems).toContainEqual(
       expect.objectContaining({
         key: "daily_close:daily-close-1:reopened",
-        title: "Prior End-of-Day Review reopened",
+        title: "Prior EOD Review reopened",
         message:
-          "The prior store day was reopened. Complete the revised End-of-Day Review before treating the prior close as clean.",
+          "The prior store day was reopened. Complete the revised end of day review before treating the prior close as clean.",
       }),
     );
   });
@@ -581,7 +581,7 @@ describe("daily opening backend foundation", () => {
     expect(inserts).toEqual([]);
   });
 
-  it("requires acknowledgement when there is no prior completed End-of-Day Review", async () => {
+  it("requires acknowledgement when there is no prior completed EOD Review", async () => {
     vi.spyOn(Date, "now").mockReturnValue(Date.UTC(2026, 4, 8, 8));
 
     const { db, inserts } = createDb({

--- a/packages/athena-webapp/convex/operations/dailyOpening.ts
+++ b/packages/athena-webapp/convex/operations/dailyOpening.ts
@@ -399,16 +399,16 @@ function missingPriorCloseReviewItem(args: {
     key: "daily_close:prior:missing",
     severity: "review",
     category: "prior_close",
-    title: "Prior End-of-Day Review not found",
+    title: "Prior EOD Review not found",
     message:
-      "No completed End-of-Day Review was found for the prior store day. Acknowledge this before starting the store day.",
+      "No completed end of day review was found for the prior store day. Acknowledge this before starting the store day.",
     subject: {
       type: DAILY_CLOSE_SUBJECT_TYPE,
       id: `${args.storeId}:${args.operatingDate}:prior`,
-      label: "Prior End-of-Day Review",
+      label: "Prior EOD Review",
     },
     link: {
-      label: "Review End-of-Day Review",
+      label: "Review EOD Review",
       search: {
         operatingDate: args.operatingDate,
       },
@@ -444,7 +444,7 @@ function missingCarryForwardItem(args: {
     category: "carry_forward",
     title: "Carry-forward work is missing",
     message:
-      "A carry-forward item referenced by the prior End-of-Day Review could not be loaded. Resolve the missing handoff before Opening Handoff can be acknowledged.",
+      "A carry-forward item referenced by the prior end of day review could not be loaded. Resolve the missing handoff before Opening Handoff can be acknowledged.",
     subject: {
       type: "operational_work_item",
       id: args.workItemId,
@@ -462,15 +462,15 @@ function priorCloseReadyItem(priorClose: Doc<"dailyClose">): DailyOpeningItem {
     key: `daily_close:${priorClose._id}:completed`,
     severity: "ready",
     category: "prior_close",
-    title: "Prior End-of-Day Review completed",
-    message: "The prior store day has a completed End-of-Day Review.",
+    title: "Prior EOD Review completed",
+    message: "The prior store day has a completed end of day review.",
     subject: {
       type: DAILY_CLOSE_SUBJECT_TYPE,
       id: priorClose._id,
-      label: `End-of-Day Review ${priorClose.operatingDate}`,
+      label: `EOD Review ${priorClose.operatingDate}`,
     },
     link: {
-      label: "View End-of-Day Review",
+      label: "View EOD Review",
       search: {
         operatingDate: priorClose.operatingDate,
       },
@@ -488,16 +488,16 @@ function priorCloseReopenedItem(priorClose: Doc<"dailyClose">): DailyOpeningItem
     key: `daily_close:${priorClose._id}:reopened`,
     severity: "review",
     category: "prior_close",
-    title: "Prior End-of-Day Review reopened",
+    title: "Prior EOD Review reopened",
     message:
-      "The prior store day was reopened. Complete the revised End-of-Day Review before treating the prior close as clean.",
+      "The prior store day was reopened. Complete the revised end of day review before treating the prior close as clean.",
     subject: {
       type: DAILY_CLOSE_SUBJECT_TYPE,
       id: priorClose._id,
-      label: `End-of-Day Review ${priorClose.operatingDate}`,
+      label: `EOD Review ${priorClose.operatingDate}`,
     },
     link: {
-      label: "Review End-of-Day Review",
+      label: "Review EOD Review",
       search: {
         operatingDate: priorClose.operatingDate,
       },
@@ -522,12 +522,12 @@ function priorCloseNotesItem(priorClose: Doc<"dailyClose">): DailyOpeningItem | 
     key: `daily_close:${priorClose._id}:notes`,
     severity: "review",
     category: "prior_close",
-    title: "Prior End-of-Day Review notes",
-    message: "Review the prior End-of-Day Review notes before acknowledging Opening Handoff.",
+    title: "Prior EOD Review notes",
+    message: "Review the prior end of day review notes before acknowledging Opening Handoff.",
     subject: {
       type: DAILY_CLOSE_SUBJECT_TYPE,
       id: priorClose._id,
-      label: `End-of-Day Review ${priorClose.operatingDate}`,
+      label: `EOD Review ${priorClose.operatingDate}`,
     },
     metadata: {
       notes,

--- a/packages/athena-webapp/convex/operations/dailyOperations.test.ts
+++ b/packages/athena-webapp/convex/operations/dailyOperations.test.ts
@@ -241,7 +241,7 @@ describe("daily operations overview read model", () => {
     );
   });
 
-  it("keeps Opening Handoff in review when prior End-of-Day Review is missing", async () => {
+  it("keeps Opening Handoff in review when prior EOD Review is missing", async () => {
     const snapshot = await buildDailyOperationsSnapshotWithCtx(
       buildCtx({
         store: [store],
@@ -262,7 +262,7 @@ describe("daily operations overview read model", () => {
     );
     expect(snapshot.attentionItems).toContainEqual(
       expect.objectContaining({
-        label: "Prior End-of-Day Review not found",
+        label: "Prior EOD Review not found",
         owner: "daily_opening",
         severity: "warning",
       }),
@@ -281,7 +281,7 @@ describe("daily operations overview read model", () => {
 
     expect(snapshot.lifecycle.status).toBe("ready_to_close");
     expect(snapshot.primaryAction).toMatchObject({
-      label: "Start End-of-Day Review",
+      label: "Start EOD Review",
       to: "/$orgUrlSlug/store/$storeUrlSlug/operations/daily-close",
     });
     expect(snapshot.lanes.find((lane) => lane.key === "close")).toMatchObject({
@@ -322,17 +322,17 @@ describe("daily operations overview read model", () => {
 
     expect(snapshot.lifecycle.status).toBe("ready_to_close");
     expect(snapshot.primaryAction).toMatchObject({
-      label: "Start End-of-Day Review",
+      label: "Start EOD Review",
     });
     expect(snapshot.lanes.find((lane) => lane.key === "close")).toMatchObject({
-      description: "End-of-Day Review is available for review.",
+      description: "The end of day review is available for review.",
       status: "ready",
     });
     expect(
       snapshot.attentionItems.some(
         (item) =>
           item.owner === "daily_close" &&
-          item.label === "End-of-Day Review reopened",
+          item.label === "EOD Review reopened",
       ),
     ).toBe(false);
   });
@@ -376,13 +376,13 @@ describe("daily operations overview read model", () => {
     expect(snapshot.lanes.find((lane) => lane.key === "close")).toMatchObject({
       count: 1,
       description:
-        "1 close blocker must be resolved after reopening End-of-Day Review.",
+        "1 close blocker must be resolved after reopening the end of day review.",
       status: "blocked",
     });
     expect(snapshot.attentionItems).toContainEqual(
       expect.objectContaining({
         owner: "daily_close",
-        label: "End-of-Day Review reopened",
+        label: "EOD Review reopened",
         severity: "warning",
       }),
     );
@@ -750,7 +750,7 @@ describe("daily operations overview read model", () => {
             _id: "event-2",
             createdAt: Date.UTC(2026, 4, 8, 22),
             eventType: "daily_close.completed",
-            message: "End-of-Day Review completed.",
+            message: "EOD Review completed.",
             storeId: "store-1",
             subjectId: "close-current",
             subjectType: "daily_close",
@@ -772,7 +772,7 @@ describe("daily operations overview read model", () => {
 
     expect(snapshot.lifecycle.status).toBe("closed");
     expect(snapshot.primaryAction).toMatchObject({
-      label: "Review End-of-Day Review",
+      label: "Review EOD Review",
       to: "/$orgUrlSlug/store/$storeUrlSlug/operations/daily-close",
     });
     expect(snapshot.timeline.map((event) => event.id)).toEqual([

--- a/packages/athena-webapp/convex/operations/dailyOperations.test.ts
+++ b/packages/athena-webapp/convex/operations/dailyOperations.test.ts
@@ -218,7 +218,7 @@ describe("daily operations overview read model", () => {
     vi.restoreAllMocks();
   });
 
-  it("treats a store day with no opening as not opened and points to Opening Handoff", async () => {
+  it("treats a store day with no opening as ready to start when opening has no review work", async () => {
     const snapshot = await buildDailyOperationsSnapshotWithCtx(
       buildCtx({
         dailyClose: [priorClose],
@@ -232,14 +232,40 @@ describe("daily operations overview read model", () => {
       label: "Start Opening Handoff",
       to: "/$orgUrlSlug/store/$storeUrlSlug/operations/opening",
     });
-    expect(snapshot.attentionItems[0]).toMatchObject({
-      owner: "daily_opening",
-      severity: "warning",
+    expect(snapshot.attentionItems).toHaveLength(0);
+    expect(snapshot.lanes.find((lane) => lane.key === "opening")).toMatchObject(
+      {
+        description: "Opening Handoff is ready to start.",
+        status: "ready",
+      },
+    );
+  });
+
+  it("keeps Opening Handoff in review when prior End-of-Day Review is missing", async () => {
+    const snapshot = await buildDailyOperationsSnapshotWithCtx(
+      buildCtx({
+        store: [store],
+      }),
+      { operatingDate: "2026-05-08", storeId: "store-1" as Id<"store"> },
+    );
+
+    expect(snapshot.lifecycle.status).toBe("not_opened");
+    expect(snapshot.primaryAction).toMatchObject({
+      label: "Start Opening Handoff",
+      to: "/$orgUrlSlug/store/$storeUrlSlug/operations/opening",
     });
     expect(snapshot.lanes.find((lane) => lane.key === "opening")).toMatchObject(
       {
+        description: "1 opening item will be reviewed when Opening Handoff starts.",
         status: "needs_attention",
       },
+    );
+    expect(snapshot.attentionItems).toContainEqual(
+      expect.objectContaining({
+        label: "Prior End-of-Day Review not found",
+        owner: "daily_opening",
+        severity: "warning",
+      }),
     );
   });
 

--- a/packages/athena-webapp/convex/operations/dailyOperations.ts
+++ b/packages/athena-webapp/convex/operations/dailyOperations.ts
@@ -530,7 +530,7 @@ function lifecycleCopy(status: LifecycleStatus) {
 
   if (status === "ready_to_close") {
     return {
-      description: "Opening Handoff is complete and End-of-Day Review has no blockers.",
+      description: "Opening Handoff is complete and the end of day review has no blockers.",
       label: "Ready to close",
     };
   }
@@ -545,14 +545,14 @@ function lifecycleCopy(status: LifecycleStatus) {
   if (status === "reopened") {
     return {
       description:
-        "End-of-Day Review was reopened. Complete the revised review before treating the store day as closed.",
+        "The end of day review was reopened. Complete the revised review before treating the store day as closed.",
       label: "Reopened",
     };
   }
 
   return {
     description:
-      "Opening Handoff is complete. Keep open work visible through End-of-Day Review.",
+      "Opening Handoff is complete. Keep open work visible through end of day review.",
     label: "Operating",
   };
 }
@@ -577,20 +577,20 @@ function primaryAction(status: LifecycleStatus): {
 
   if (status === "closed") {
     return {
-      label: "Review End-of-Day Review",
+      label: "Review EOD Review",
       to: "/$orgUrlSlug/store/$storeUrlSlug/operations/daily-close",
     };
   }
 
   if (status === "reopened") {
     return {
-      label: "Revise End-of-Day Review",
+      label: "Revise EOD Review",
       to: "/$orgUrlSlug/store/$storeUrlSlug/operations/daily-close",
     };
   }
 
   return {
-    label: "Start End-of-Day Review",
+    label: "Start EOD Review",
     to: "/$orgUrlSlug/store/$storeUrlSlug/operations/daily-close",
   };
 }
@@ -649,14 +649,14 @@ function buildLanes(args: {
           : closeBlockerCount,
       description:
         args.closeStatus === "blocked" && args.isCloseReopened
-          ? `${pluralize(closeBlockerCount, "close blocker")} must be resolved after reopening End-of-Day Review.`
+          ? `${pluralize(closeBlockerCount, "close blocker")} must be resolved after reopening the end of day review.`
           : args.closeStatus === "completed"
-            ? "End-of-Day Review is saved for this store day."
+            ? "The end of day review is saved for this store day."
             : args.closeStatus === "blocked"
               ? `${pluralize(closeBlockerCount, "close blocker")} must be resolved before close.`
-              : "End-of-Day Review is available for review.",
+              : "The end of day review is available for review.",
       key: "close",
-      label: "End-of-Day Review",
+      label: "EOD Review",
       status: closeStatus,
       to: "/$orgUrlSlug/store/$storeUrlSlug/operations/daily-close",
     },
@@ -785,9 +785,9 @@ export async function buildDailyOperationsSnapshotWithCtx(
     ) {
       attentionItems.push({
         id: `daily_close:${args.storeId}:${args.operatingDate}:reopened`,
-        label: "End-of-Day Review reopened",
+        label: "EOD Review reopened",
         message:
-          "Complete the revised End-of-Day Review before treating the store day as closed.",
+          "Complete the revised end of day review before treating the store day as closed.",
         owner: "daily_close",
         severity: "warning",
         source: {
@@ -795,7 +795,7 @@ export async function buildDailyOperationsSnapshotWithCtx(
             closeSnapshot.existingClose?._id ??
             dailyCloseRecord?._id ??
             `${args.storeId}:${args.operatingDate}`,
-          label: `End-of-Day Review ${args.operatingDate}`,
+          label: `EOD Review ${args.operatingDate}`,
           type: "daily_close",
         },
         to: "/$orgUrlSlug/store/$storeUrlSlug/operations/daily-close",

--- a/packages/athena-webapp/convex/operations/dailyOperations.ts
+++ b/packages/athena-webapp/convex/operations/dailyOperations.ts
@@ -601,6 +601,7 @@ function buildLanes(args: {
   isCloseReopened: boolean;
   isOpeningStarted: boolean;
   openingAttentionCount: number;
+  openingStatus: string;
   queueCounts: {
     approvalCount: number;
     approvalCountLabel: string;
@@ -610,7 +611,11 @@ function buildLanes(args: {
 }): DailyOperationsLane[] {
   const openingStatus: LaneStatus = args.isOpeningStarted
     ? "ready"
-    : "needs_attention";
+    : args.openingStatus === "blocked"
+      ? "blocked"
+      : args.openingStatus === "needs_attention"
+        ? "needs_attention"
+        : "ready";
   const closeStatus: LaneStatus =
     args.closeStatus === "blocked"
       ? "blocked"
@@ -630,8 +635,8 @@ function buildLanes(args: {
       description: args.isOpeningStarted
         ? "Opening Handoff is complete."
         : args.openingAttentionCount > 0
-          ? `${pluralize(args.openingAttentionCount, "opening item")} still needs operator acknowledgement.`
-          : "Opening Handoff still needs operator acknowledgement.",
+          ? `${pluralize(args.openingAttentionCount, "opening item")} will be reviewed when Opening Handoff starts.`
+          : "Opening Handoff is ready to start.",
       key: "opening",
       label: "Opening Handoff",
       status: openingStatus,
@@ -764,7 +769,9 @@ export async function buildDailyOperationsSnapshotWithCtx(
   const attentionItems: DailyOperationsAttentionItem[] = [];
 
   if (!isOpeningStarted) {
-    attentionItems.push(openingNotStartedAttention(args));
+    if (openingSnapshot.status !== "ready") {
+      attentionItems.push(openingNotStartedAttention(args));
+    }
     attentionItems.push(
       ...openingAttention.map((item) =>
         sourceAttentionItem("daily_opening", item),
@@ -847,6 +854,7 @@ export async function buildDailyOperationsSnapshotWithCtx(
       isCloseReopened,
       isOpeningStarted,
       openingAttentionCount: openingAttention.length,
+      openingStatus: openingSnapshot.status,
       queueCounts: {
         approvalCount: queueCounts.approvalRequests.length,
         approvalCountLabel: queueCounts.approvalRequestsCountLabel,

--- a/packages/athena-webapp/src/components/app-sidebar.tsx
+++ b/packages/athena-webapp/src/components/app-sidebar.tsx
@@ -228,72 +228,7 @@ export function AppSidebar() {
                       </Link>
                     </SidebarMenuButton>
                   </SidebarMenuSubItem>
-                </SidebarMenuSub>
 
-                <SidebarMenuSub>
-                  <SidebarMenuSubItem>
-                    <SidebarMenuButton
-                      disabled={!canAccessStoreDaySurfaces()}
-                      asChild
-                    >
-                      <Link
-                        to="/$orgUrlSlug/store/$storeUrlSlug/operations/open-work"
-                        params={(p) => ({
-                          ...p,
-                          orgUrlSlug: activeOrganization?.slug,
-                          storeUrlSlug: activeStore?.slug,
-                        })}
-                        className="flex items-center"
-                      >
-                        <p className="font-medium">Open work</p>
-                      </Link>
-                    </SidebarMenuButton>
-                  </SidebarMenuSubItem>
-                </SidebarMenuSub>
-
-                <SidebarMenuSub>
-                  <SidebarMenuSubItem>
-                    <SidebarMenuButton
-                      disabled={!canAccessStoreDaySurfaces()}
-                      asChild
-                    >
-                      <Link
-                        to="/$orgUrlSlug/store/$storeUrlSlug/operations/approvals"
-                        params={(p) => ({
-                          ...p,
-                          orgUrlSlug: activeOrganization?.slug,
-                          storeUrlSlug: activeStore?.slug,
-                        })}
-                        className="flex items-center"
-                      >
-                        <p className="font-medium">Approvals</p>
-                      </Link>
-                    </SidebarMenuButton>
-                  </SidebarMenuSubItem>
-                </SidebarMenuSub>
-
-                <SidebarMenuSub>
-                  <SidebarMenuSubItem>
-                    <SidebarMenuButton
-                      disabled={!canAccessStoreDaySurfaces()}
-                      asChild
-                    >
-                      <Link
-                        to="/$orgUrlSlug/store/$storeUrlSlug/operations/stock-adjustments"
-                        params={(p) => ({
-                          ...p,
-                          orgUrlSlug: activeOrganization?.slug,
-                          storeUrlSlug: activeStore?.slug,
-                        })}
-                        className="flex items-center"
-                      >
-                        <p className="font-medium">Stock adjustments</p>
-                      </Link>
-                    </SidebarMenuButton>
-                  </SidebarMenuSubItem>
-                </SidebarMenuSub>
-
-                <SidebarMenuSub>
                   <SidebarMenuSubItem>
                     <SidebarMenuButton
                       disabled={!canAccessStoreDaySurfaces()}
@@ -312,9 +247,7 @@ export function AppSidebar() {
                       </Link>
                     </SidebarMenuButton>
                   </SidebarMenuSubItem>
-                </SidebarMenuSub>
 
-                <SidebarMenuSub>
                   <SidebarMenuSubItem>
                     <SidebarMenuButton
                       disabled={!canAccessStoreDaySurfaces()}
@@ -329,7 +262,64 @@ export function AppSidebar() {
                         })}
                         className="flex items-center"
                       >
-                        <p className="font-medium">End-of-Day Review</p>
+                        <p className="font-medium">EOD Review</p>
+                      </Link>
+                    </SidebarMenuButton>
+                  </SidebarMenuSubItem>
+
+                  <SidebarMenuSubItem>
+                    <SidebarMenuButton
+                      disabled={!canAccessStoreDaySurfaces()}
+                      asChild
+                    >
+                      <Link
+                        to="/$orgUrlSlug/store/$storeUrlSlug/operations/open-work"
+                        params={(p) => ({
+                          ...p,
+                          orgUrlSlug: activeOrganization?.slug,
+                          storeUrlSlug: activeStore?.slug,
+                        })}
+                        className="flex items-center"
+                      >
+                        <p className="font-medium">Open work</p>
+                      </Link>
+                    </SidebarMenuButton>
+                  </SidebarMenuSubItem>
+
+                  <SidebarMenuSubItem>
+                    <SidebarMenuButton
+                      disabled={!canAccessStoreDaySurfaces()}
+                      asChild
+                    >
+                      <Link
+                        to="/$orgUrlSlug/store/$storeUrlSlug/operations/approvals"
+                        params={(p) => ({
+                          ...p,
+                          orgUrlSlug: activeOrganization?.slug,
+                          storeUrlSlug: activeStore?.slug,
+                        })}
+                        className="flex items-center"
+                      >
+                        <p className="font-medium">Approvals</p>
+                      </Link>
+                    </SidebarMenuButton>
+                  </SidebarMenuSubItem>
+
+                  <SidebarMenuSubItem>
+                    <SidebarMenuButton
+                      disabled={!canAccessStoreDaySurfaces()}
+                      asChild
+                    >
+                      <Link
+                        to="/$orgUrlSlug/store/$storeUrlSlug/operations/stock-adjustments"
+                        params={(p) => ({
+                          ...p,
+                          orgUrlSlug: activeOrganization?.slug,
+                          storeUrlSlug: activeStore?.slug,
+                        })}
+                        className="flex items-center"
+                      >
+                        <p className="font-medium">Stock adjustments</p>
                       </Link>
                     </SidebarMenuButton>
                   </SidebarMenuSubItem>

--- a/packages/athena-webapp/src/components/operations/DailyCloseHistoryView.test.tsx
+++ b/packages/athena-webapp/src/components/operations/DailyCloseHistoryView.test.tsx
@@ -119,7 +119,7 @@ function snapshot(
     readyItems: [
       {
         category: "sale",
-        description: "Completed sale is included in End-of-Day Review.",
+        description: "Completed sale is included in the end of day review.",
         id: "sale-1",
         link: {
           label: "Open transaction",
@@ -356,7 +356,7 @@ describe("DailyCloseHistoryView", () => {
     render(<DailyCloseHistoryView />);
 
     expect(
-      screen.queryByRole("button", { name: "Complete End-of-Day Review" }),
+      screen.queryByRole("button", { name: "Complete EOD Review" }),
     ).not.toBeInTheDocument();
     expect(screen.queryByRole("checkbox")).not.toBeInTheDocument();
     expect(screen.queryByLabelText("Close notes")).not.toBeInTheDocument();
@@ -378,7 +378,7 @@ describe("DailyCloseHistoryView", () => {
     expect(screen.getByText("Reopened after completion")).toBeInTheDocument();
     expect(screen.getByText(/Cash deposit corrected/i)).toBeInTheDocument();
     expect(
-      screen.queryByRole("button", { name: "Reopen End-of-Day Review" }),
+      screen.queryByRole("button", { name: "Reopen EOD Review" }),
     ).not.toBeInTheDocument();
   });
 

--- a/packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx
+++ b/packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx
@@ -345,12 +345,12 @@ function DailyCloseHistoryConnectedView({
           <PageLevelHeader
             eyebrow="Store Ops"
             title="Daily Close History"
-            description="Review completed End-of-Day Reviews as read-only store-day records."
+            description="Review completed EOD Reviews as read-only store-day records."
           />
 
           {completedRecords.length === 0 ? (
             <EmptyState
-              description="Completed End-of-Day Reviews will appear here after store days are closed."
+              description="Completed EOD Reviews will appear here after store days are closed."
               title="No completed Daily Close records"
             />
           ) : (
@@ -467,7 +467,7 @@ function DailyCloseHistoryConnectedView({
                     to="/$orgUrlSlug/store/$storeUrlSlug/operations/daily-close"
                   >
                     <ArrowUpRight aria-hidden="true" />
-                    Current End-of-Day Review
+                    Current EOD Review
                   </Link>
                 </Button>
               </PageWorkspaceRail>

--- a/packages/athena-webapp/src/components/operations/DailyCloseView.test.tsx
+++ b/packages/athena-webapp/src/components/operations/DailyCloseView.test.tsx
@@ -102,6 +102,11 @@ const baseSummary = {
   currentDayCashTotal: 45000,
   expenseTransactionCount: 1,
   expenseTotal: 12500,
+  paymentTotals: [
+    { amount: 45000, method: "cash", transactionCount: 2 },
+    { amount: 710, method: "card", transactionCount: 1 },
+    { amount: 2500, method: "mobile_money", transactionCount: 1 },
+  ],
   registerCount: 2,
   registerVarianceCount: 0,
   staffCount: 3,
@@ -142,7 +147,7 @@ const readySnapshot: DailyCloseSnapshot = {
     },
     {
       category: "sale",
-      description: "Completed sale is included in End-of-Day Review.",
+      description: "Completed sale is included in the end of day review.",
       id: "ready-2",
       metadata: {
         completedAt: Date.UTC(2026, 4, 7, 14),
@@ -162,7 +167,7 @@ const readySnapshot: DailyCloseSnapshot = {
     },
     {
       category: "expense",
-      description: "Completed expense is included in End-of-Day Review.",
+      description: "Completed expense is included in the end of day review.",
       id: "ready-3",
       link: {
         label: "View expense",
@@ -204,7 +209,7 @@ const blockedSnapshot: DailyCloseSnapshot = {
     {
       category: "register_session",
       description:
-        "Close the register session before completing End-of-Day Review.",
+        "Close the register session before completing the end of day review.",
       id: "blocker-1",
       link: {
         label: "View session",
@@ -230,7 +235,7 @@ const blockedSnapshot: DailyCloseSnapshot = {
     {
       category: "approval",
       description:
-        "Resolve pending closeout approval before completing End-of-Day Review.",
+        "Resolve pending closeout approval before completing the end of day review.",
       id: "approval-1",
       link: {
         label: "View approvals",
@@ -261,7 +266,7 @@ const blockedSnapshot: DailyCloseSnapshot = {
     {
       category: "pos_session",
       description:
-        "Complete, void, or release held POS sessions before End-of-Day Review.",
+        "Complete, void, or release held POS sessions before the end of day review.",
       id: "blocker-2",
       metadata: {
         customer: "Ama Mensah",
@@ -322,9 +327,9 @@ describe("DailyCloseViewContent", () => {
   it("renders the workspace frame while loading", () => {
     renderContent(undefined);
 
-    expect(screen.getByText("End-of-Day Review")).toBeInTheDocument();
+    expect(screen.getByText("EOD Review")).toBeInTheDocument();
     expect(
-      screen.queryByLabelText("Loading end-of-day review workspace"),
+      screen.queryByLabelText("Loading EOD Review workspace"),
     ).not.toBeInTheDocument();
   });
 
@@ -414,7 +419,7 @@ describe("DailyCloseViewContent", () => {
     expect(
       within(approvalItem as HTMLElement).queryByText("Opened At"),
     ).not.toBeInTheDocument();
-    expect(screen.getByText("Mobile Money")).toBeInTheDocument();
+    expect(screen.getAllByText("Mobile Money").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Cash").length).toBeGreaterThan(0);
     expect(
       screen.getByText("POS session is still unresolved"),
@@ -427,7 +432,7 @@ describe("DailyCloseViewContent", () => {
     expect(screen.getByText("Held")).toBeInTheDocument();
     expect(screen.getByText("Expired At")).toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: /complete end-of-day review/i }),
+      screen.getByRole("button", { name: /complete EOD review/i }),
     ).toBeDisabled();
   });
 
@@ -472,10 +477,12 @@ describe("DailyCloseViewContent", () => {
     expect(screen.getByText("Ready to close")).toBeInTheDocument();
     expect(screen.getByText("14 transactions")).toBeInTheDocument();
     expect(screen.getByText("2 cash transactions")).toBeInTheDocument();
+    expect(screen.getByText("Mobile Money")).toBeInTheDocument();
+    expect(screen.getByText("Card")).toBeInTheDocument();
+    expect(screen.getAllByText("1 payment")).toHaveLength(2);
     expect(
       screen.getByText("No registers from prior days"),
     ).toBeInTheDocument();
-    expect(screen.getByText("No register variances")).toBeInTheDocument();
     expect(screen.getByText("Register closeouts complete")).toBeInTheDocument();
     const closedRegisterItem = screen
       .getByText("Register closeouts complete")
@@ -591,7 +598,7 @@ describe("DailyCloseViewContent", () => {
       "/wigclub/store/osu/pos/expense-reports/expense-1?o=%252F",
     );
     expect(
-      screen.getByRole("button", { name: /complete end-of-day review/i }),
+      screen.getByRole("button", { name: /complete EOD review/i }),
     ).toBeEnabled();
     const checklist = screen.getByText("Close checklist").closest("div");
     expect(checklist).not.toBeNull();
@@ -610,6 +617,82 @@ describe("DailyCloseViewContent", () => {
     ).toBeInTheDocument();
     expect(within(checklist as HTMLElement).queryByText("Clear")).toBeNull();
     expect(within(checklist as HTMLElement).queryByText("None")).toBeNull();
+  });
+
+  it("does not claim zero payments for historical payment totals without counts", () => {
+    renderContent({
+      ...readySnapshot,
+      summary: {
+        ...baseSummary,
+        paymentTotals: [{ amount: 710, method: "card" }],
+      },
+    });
+
+    expect(screen.getByText("Card")).toBeInTheDocument();
+    expect(screen.getByText("Payment total")).toBeInTheDocument();
+    expect(screen.queryByText("No payments")).not.toBeInTheDocument();
+  });
+
+  it("hides zero-value expense and variance summary cards when net sales are positive", () => {
+    renderContent({
+      ...readySnapshot,
+      summary: {
+        ...baseSummary,
+        expenseTotal: 0,
+        expenseTransactionCount: 0,
+        registerVarianceCount: 0,
+        varianceTotal: 0,
+      },
+    });
+
+    expect(screen.queryByText("Expenses")).not.toBeInTheDocument();
+    expect(screen.queryByText("Variance")).not.toBeInTheDocument();
+    expect(screen.queryByText("No expense transactions")).not.toBeInTheDocument();
+    expect(screen.queryByText("No register variances")).not.toBeInTheDocument();
+  });
+
+  it("normalizes legacy end of day review item copy", async () => {
+    const user = userEvent.setup();
+
+    renderContent({
+      ...readySnapshot,
+      readyItems: [
+        {
+          ...readySnapshot.readyItems[0],
+          description:
+            "Closed register session is included in End-of-Day Review.",
+        },
+      ],
+    });
+
+    expect(screen.queryByText(/End-of-Day Review/)).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /show details/i }));
+
+    expect(
+      screen.getByText(
+        "Closed register session is included in end of day review.",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("keeps zero-value expense and variance summary cards when net sales are zero", () => {
+    renderContent({
+      ...readySnapshot,
+      summary: {
+        ...baseSummary,
+        expenseTotal: 0,
+        expenseTransactionCount: 0,
+        registerVarianceCount: 0,
+        totalSales: 0,
+        varianceTotal: 0,
+      },
+    });
+
+    expect(screen.getByText("Expenses")).toBeInTheDocument();
+    expect(screen.getByText("Variance")).toBeInTheDocument();
+    expect(screen.getByText("No expense transactions")).toBeInTheDocument();
+    expect(screen.getByText("No register variances")).toBeInTheDocument();
   });
 
   it("paginates daily close item cards at five items per page", async () => {
@@ -816,7 +899,7 @@ describe("DailyCloseViewContent", () => {
 
     expect(
       within(report).getByText(
-        "14 POS sales, 1 expense transaction, no voided sales available from the End-of-Day Review workspace.",
+        "14 POS sales, 1 expense transaction, no voided sales available from the end of day review workspace.",
       ),
     ).toBeInTheDocument();
     expect(within(report).getByText("Item")).toBeInTheDocument();
@@ -867,7 +950,7 @@ describe("DailyCloseViewContent", () => {
 
     expect(
       await screen.findByText(
-        "no POS sales, no expense transactions, no voided sales available from the End-of-Day Review workspace.",
+        "no POS sales, no expense transactions, no voided sales available from the end of day review workspace.",
       ),
     ).toBeInTheDocument();
   });
@@ -906,7 +989,7 @@ describe("DailyCloseViewContent", () => {
       screen.getByText("No activity was recorded for this operating day."),
     ).toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: /complete end-of-day review/i }),
+      screen.getByRole("button", { name: /complete EOD review/i }),
     ).toBeEnabled();
   });
 
@@ -954,6 +1037,8 @@ describe("DailyCloseViewContent", () => {
     expect(screen.getByText("1 transaction")).toBeInTheDocument();
     expect(screen.getByText("No cash transactions")).toBeInTheDocument();
     expect(screen.getByText("1 register from a prior day")).toBeInTheDocument();
+    expect(screen.getByText("Expenses")).toBeInTheDocument();
+    expect(screen.getByText("Variance")).toBeInTheDocument();
     expect(screen.getByText("1 register variance")).toBeInTheDocument();
     expect(screen.getByText("1 expense transaction")).toBeInTheDocument();
   });
@@ -982,6 +1067,12 @@ describe("DailyCloseViewContent", () => {
     ).toHaveAttribute(
       "href",
       "/wigclub/store/osu/pos/transactions?o=%252Fwigclub%252Fstore%252Fosu%252Foperations%252Fdaily-close&operatingDate=2026-05-07&paymentMethod=cash",
+    );
+    expect(
+      screen.getByRole("link", { name: "Open Card transactions" }),
+    ).toHaveAttribute(
+      "href",
+      "/wigclub/store/osu/pos/transactions?o=%252Fwigclub%252Fstore%252Fosu%252Foperations%252Fdaily-close&operatingDate=2026-05-07&paymentMethod=card",
     );
   });
 
@@ -1026,6 +1117,7 @@ describe("DailyCloseViewContent", () => {
         expenseTotal: 0,
         pendingApprovalCount: 1,
         staffCount: undefined,
+        totalSales: 0,
       },
     });
 
@@ -1113,7 +1205,7 @@ describe("DailyCloseViewContent", () => {
     renderContent(snapshot, { onComplete });
 
     await user.click(
-      screen.getByRole("button", { name: /complete end-of-day review/i }),
+      screen.getByRole("button", { name: /complete EOD review/i }),
     );
 
     await waitFor(() => {
@@ -1137,22 +1229,22 @@ describe("DailyCloseViewContent", () => {
         approval: {
           action: {
             key: "operations.daily_close.complete",
-            label: "Complete End-of-Day Review",
+            label: "Complete EOD Review",
           },
           copy: {
             message:
-              "A manager needs to approve this End-of-Day Review before the operating day is saved.",
+              "A manager needs to approve this end of day review before the operating day is saved.",
             primaryActionLabel: "Approve and complete",
             secondaryActionLabel: "Cancel",
             title: "Manager approval required",
           },
-          reason: "Manager approval is required to complete End-of-Day Review.",
+          reason: "Manager approval is required to complete EOD Review.",
           requiredRole: "manager" as const,
           resolutionModes: [{ kind: "inline_manager_proof" as const }],
           selfApproval: "allowed" as const,
           subject: {
             id: "store-1:2026-05-07",
-            label: "End-of-Day Review 2026-05-07",
+            label: "EOD Review 2026-05-07",
             type: "daily_close",
           },
         },
@@ -1160,7 +1252,7 @@ describe("DailyCloseViewContent", () => {
     });
 
     await user.click(
-      screen.getByRole("button", { name: /complete end-of-day review/i }),
+      screen.getByRole("button", { name: /complete EOD review/i }),
     );
 
     expect(
@@ -1193,7 +1285,7 @@ describe("DailyCloseViewContent", () => {
     );
 
     const reopenButton = screen.getByRole("button", {
-      name: "Reopen End-of-Day Review",
+      name: "Reopen EOD Review",
     });
 
     expect(reopenButton).toBeDisabled();
@@ -1229,7 +1321,7 @@ describe("DailyCloseViewContent", () => {
     );
 
     expect(
-      screen.queryByRole("button", { name: "Reopen End-of-Day Review" }),
+      screen.queryByRole("button", { name: "Reopen EOD Review" }),
     ).not.toBeInTheDocument();
 
     rerender(
@@ -1263,7 +1355,7 @@ describe("DailyCloseViewContent", () => {
 
     expect(screen.getByText("Review required")).toBeInTheDocument();
     expect(
-      screen.queryByRole("button", { name: "Reopen End-of-Day Review" }),
+      screen.queryByRole("button", { name: "Reopen EOD Review" }),
     ).not.toBeInTheDocument();
   });
 
@@ -1280,7 +1372,7 @@ describe("DailyCloseViewContent", () => {
     });
 
     await user.click(
-      screen.getByRole("button", { name: /complete end-of-day review/i }),
+      screen.getByRole("button", { name: /complete EOD review/i }),
     );
 
     expect(
@@ -1295,14 +1387,14 @@ describe("DailyCloseViewContent", () => {
     const renderResult = renderContent(readySnapshot);
 
     await user.click(
-      screen.getByRole("button", { name: /complete end-of-day review/i }),
+      screen.getByRole("button", { name: /complete EOD review/i }),
     );
 
     expect(
       await screen.findByRole("status", {
         name: "",
       }),
-    ).toHaveTextContent("End-of-day review completed.");
+    ).toHaveTextContent("EOD Review completed.");
 
     renderResult.rerender(
       <DailyCloseViewContent
@@ -1327,12 +1419,12 @@ describe("DailyCloseViewContent", () => {
 
     await waitFor(() => {
       expect(
-        screen.queryByText("End-of-day review completed."),
+        screen.queryByText("EOD Review completed."),
       ).not.toBeInTheDocument();
     });
   });
 
-  it("renders completed End-of-Day Review summary after reload", () => {
+  it("renders completed EOD Review summary after reload", () => {
     renderContent({
       ...readySnapshot,
       blockers: blockedSnapshot.blockers,
@@ -1354,7 +1446,7 @@ describe("DailyCloseViewContent", () => {
         readyItems: [
           {
             category: "sale",
-            description: "Completed sale is included in End-of-Day Review.",
+            description: "Completed sale is included in the end of day review.",
             id: "persisted-sale",
             metadata: {
               completedAt: Date.UTC(2026, 4, 7, 14),
@@ -1386,7 +1478,7 @@ describe("DailyCloseViewContent", () => {
       status: "completed",
     });
 
-    expect(screen.getByText("End-of-day review completed")).toBeInTheDocument();
+    expect(screen.getByText("EOD Review completed")).toBeInTheDocument();
     expect(screen.getByText(/Ama Mensah/)).toBeInTheDocument();
     expect(screen.getByText("Clean close.")).toBeInTheDocument();
     expect(
@@ -1421,7 +1513,7 @@ describe("DailyCloseView", () => {
     mockedHooks.useMutation.mockReturnValue(vi.fn(async () => ok({})));
   });
 
-  it("queries End-of-Day Review with the active store and route params", () => {
+  it("queries EOD Review with the active store and route params", () => {
     render(<DailyCloseView />);
 
     expect(mockedHooks.useQuery).toHaveBeenCalledWith(
@@ -1433,10 +1525,10 @@ describe("DailyCloseView", () => {
         storeId: "store-1",
       },
     );
-    expect(screen.getByText("End-of-Day Review")).toBeInTheDocument();
+    expect(screen.getByText("EOD Review")).toBeInTheDocument();
   });
 
-  it("queries End-of-Day Review for the operating date in route search", () => {
+  it("queries EOD Review for the operating date in route search", () => {
     mockedRouter.search = { operatingDate: "2026-05-08" };
 
     render(<DailyCloseView />);
@@ -1482,7 +1574,7 @@ describe("DailyCloseView", () => {
       "Cash deposit corrected.",
     );
     await user.click(
-      screen.getByRole("button", { name: "Reopen End-of-Day Review" }),
+      screen.getByRole("button", { name: "Reopen EOD Review" }),
     );
 
     expect(reopenMutation).toHaveBeenCalledWith({

--- a/packages/athena-webapp/src/components/operations/DailyCloseView.tsx
+++ b/packages/athena-webapp/src/components/operations/DailyCloseView.tsx
@@ -175,6 +175,7 @@ export type DailyCloseSnapshot = {
     paymentTotals?: Array<{
       amount: number;
       method: string;
+      transactionCount?: number | null;
     }>;
     pendingApprovalCount?: number | null;
     registerCount?: number | null;
@@ -303,7 +304,7 @@ const statusCopy: Record<
   completed: {
     badge: "Completed",
     description: "The operating day has a saved close summary.",
-    title: "End-of-day review completed",
+    title: "EOD Review completed",
   },
   needs_review: {
     badge: "Needs review",
@@ -352,6 +353,47 @@ function formatTodayCashTransactionCount(value: number) {
   if (value === 0) return "No cash transactions";
   if (value === 1) return "1 cash transaction";
   return `${value} cash transactions`;
+}
+
+function formatPaymentCount(value?: number | null) {
+  if (value === undefined || value === null) return "Payment total";
+
+  if (value === 0) return "No payments";
+  if (value === 1) return "1 payment";
+  return `${value} payments`;
+}
+
+function formatPaymentMethodLabel(method: string) {
+  return method
+    .replace(/[_-]+/g, " ")
+    .replace(/\b\w/g, (character) => character.toUpperCase());
+}
+
+function getOtherPaymentTotals(summary: DailyCloseSnapshot["summary"]) {
+  return (summary.paymentTotals ?? [])
+    .filter((paymentTotal) => paymentTotal.method.toLowerCase() !== "cash")
+    .sort((left, right) => right.amount - left.amount);
+}
+
+function shouldShowExpenseMetric(summary: DailyCloseSnapshot["summary"]) {
+  if ((getSummaryAmount(summary, "totalSales", "salesTotal") ?? 0) <= 0) {
+    return true;
+  }
+
+  return (
+    getExpenseTransactionCount(summary) > 0 || (summary.expenseTotal ?? 0) !== 0
+  );
+}
+
+function shouldShowVarianceMetric(summary: DailyCloseSnapshot["summary"]) {
+  if ((getSummaryAmount(summary, "totalSales", "salesTotal") ?? 0) <= 0) {
+    return true;
+  }
+
+  return (
+    getSummaryRegisterVarianceCount(summary) > 0 ||
+    getSummaryAmount(summary, "varianceTotal", "netCashVariance") !== 0
+  );
 }
 
 function formatCarriedOverRegisterCount(value: number) {
@@ -656,13 +698,19 @@ function getCarryForwardWorkItemIds(items: DailyCloseItem[]) {
 }
 
 function getItemDescription(item: DailyCloseItem) {
-  return item.description ?? item.message;
+  return normalizeDailyCloseItemCopy(item.description ?? item.message);
+}
+
+function normalizeDailyCloseItemCopy(value?: string | null) {
+  return value?.replace(/\bEnd-of-Day Review\b/g, "end of day review");
 }
 
 function shouldShowCollapsedDescription(description?: string | null) {
   if (!description) return false;
 
-  return !/included in End-of-Day Review\.?$/i.test(description.trim());
+  return !/included in (?:the )?end[- ]of[- ]day review\.?$/i.test(
+    description.trim(),
+  );
 }
 
 function getItemContextLabel(item: DailyCloseItem) {
@@ -2073,7 +2121,7 @@ function TransactionReportAction({
           <SheetHeader className="border-b border-border px-layout-xl py-layout-lg">
             <SheetTitle>POS and expense transactions</SheetTitle>
             <SheetDescription>
-              {reportSummary} available from the End-of-Day Review workspace.
+              {reportSummary} available from the end of day review workspace.
             </SheetDescription>
           </SheetHeader>
 
@@ -2160,6 +2208,7 @@ export function DailyCloseReadOnlyReport({
   const salesMetricLabels = getDailyCloseSalesMetricLabels(
     displaySnapshot.operatingDate,
   );
+  const otherPaymentTotals = getOtherPaymentTotals(displaySnapshot.summary);
 
   return (
     <PageWorkspace>
@@ -2244,6 +2293,24 @@ export function DailyCloseReadOnlyReport({
               ),
             )}
           />
+          {otherPaymentTotals.map((paymentTotal) => (
+            <OperationsSummaryMetric
+              helper={formatPaymentCount(paymentTotal.transactionCount)}
+              key={paymentTotal.method}
+              label={formatPaymentMethodLabel(paymentTotal.method)}
+              link={{
+                ariaLabel: `Open ${formatPaymentMethodLabel(paymentTotal.method)} transactions`,
+                orgUrlSlug,
+                search: buildDailyCloseTransactionSearch({
+                  operatingDate: displaySnapshot.operatingDate,
+                  paymentMethod: paymentTotal.method,
+                }),
+                storeUrlSlug,
+                to: "/$orgUrlSlug/store/$storeUrlSlug/pos/transactions",
+              }}
+              value={formatDailyCloseMoney(currency, paymentTotal.amount)}
+            />
+          ))}
           <OperationsSummaryMetric
             helper={formatCarriedOverRegisterCount(
               getSummaryCount(
@@ -2262,30 +2329,34 @@ export function DailyCloseReadOnlyReport({
               ),
             )}
           />
-          <OperationsSummaryMetric
-            helper={formatExpenseTransactionCount(
-              getExpenseTransactionCount(displaySnapshot.summary),
-            )}
-            label="Expenses"
-            value={formatDailyCloseMoney(
-              currency,
-              displaySnapshot.summary.expenseTotal,
-            )}
-          />
-          <OperationsSummaryMetric
-            helper={formatRegisterVarianceCount(
-              getSummaryRegisterVarianceCount(displaySnapshot.summary),
-            )}
-            label="Variance"
-            value={formatDailyCloseMoney(
-              currency,
-              getSummaryAmount(
-                displaySnapshot.summary,
-                "varianceTotal",
-                "netCashVariance",
-              ),
-            )}
-          />
+          {shouldShowExpenseMetric(displaySnapshot.summary) ? (
+            <OperationsSummaryMetric
+              helper={formatExpenseTransactionCount(
+                getExpenseTransactionCount(displaySnapshot.summary),
+              )}
+              label="Expenses"
+              value={formatDailyCloseMoney(
+                currency,
+                displaySnapshot.summary.expenseTotal,
+              )}
+            />
+          ) : null}
+          {shouldShowVarianceMetric(displaySnapshot.summary) ? (
+            <OperationsSummaryMetric
+              helper={formatRegisterVarianceCount(
+                getSummaryRegisterVarianceCount(displaySnapshot.summary),
+              )}
+              label="Variance"
+              value={formatDailyCloseMoney(
+                currency,
+                getSummaryAmount(
+                  displaySnapshot.summary,
+                  "varianceTotal",
+                  "netCashVariance",
+                ),
+              )}
+            />
+          ) : null}
         </div>
       </section>
 
@@ -2594,7 +2665,7 @@ function CompletionRail({
                   type="button"
                   variant="outline"
                 >
-                  Reopen End-of-Day Review
+                  Reopen EOD Review
                 </LoadingButton>
               </div>
             ) : null}
@@ -2622,7 +2693,7 @@ function CompletionRail({
               type="button"
               variant="workflow"
             >
-              Complete End-of-Day Review
+              Complete EOD Review
             </LoadingButton>
           </div>
         )}
@@ -2710,7 +2781,7 @@ export function DailyCloseViewContent({
 
   if (!isAuthenticated) {
     return (
-      <ProtectedAdminSignInView description="Your Athena session needs to reconnect before End-of-Day Review can load protected operating-day data" />
+      <ProtectedAdminSignInView description="Your Athena session needs to reconnect before the end of day review can load protected operating-day data" />
     );
   }
 
@@ -2722,7 +2793,7 @@ export function DailyCloseViewContent({
     return (
       <div className="container mx-auto py-8">
         <EmptyState
-          description="Select a store before opening End-of-Day Review."
+          description="Select a store before opening the end of day review."
           title="No active store"
         />
       </div>
@@ -2746,6 +2817,9 @@ export function DailyCloseViewContent({
   const salesMetricLabels = displaySnapshot
     ? getDailyCloseSalesMetricLabels(displaySnapshot.operatingDate)
     : null;
+  const otherPaymentTotals = displaySnapshot
+    ? getOtherPaymentTotals(displaySnapshot.summary)
+    : [];
   const buckets = displaySnapshot ? getBucketConfigs(displaySnapshot) : [];
   const defaultBucketValue = displaySnapshot
     ? getDefaultBucketValue(displaySnapshot, status)
@@ -2784,7 +2858,7 @@ export function DailyCloseViewContent({
         if (commandResult.kind === "ok") {
           setCommandMessage({
             kind: "success",
-            message: "End-of-day review completed.",
+            message: "EOD Review completed.",
           });
           return;
         }
@@ -2820,7 +2894,7 @@ export function DailyCloseViewContent({
       setCommandMessage({
         kind: "error",
         message:
-          "End-of-Day Review record unavailable. Refresh before reopening.",
+          "end of day review record unavailable. Refresh before reopening.",
       });
       return;
     }
@@ -2846,7 +2920,7 @@ export function DailyCloseViewContent({
         if (commandResult.kind === "ok") {
           setCommandMessage({
             kind: "success",
-            message: "End-of-Day Review reopened.",
+            message: "EOD Review reopened.",
           });
           setReopenReason("");
           return;
@@ -2979,6 +3053,24 @@ export function DailyCloseViewContent({
                 ),
               )}
             />
+            {otherPaymentTotals.map((paymentTotal) => (
+              <OperationsSummaryMetric
+                helper={formatPaymentCount(paymentTotal.transactionCount)}
+                key={paymentTotal.method}
+                label={formatPaymentMethodLabel(paymentTotal.method)}
+                link={{
+                  ariaLabel: `Open ${formatPaymentMethodLabel(paymentTotal.method)} transactions`,
+                  orgUrlSlug,
+                  search: buildDailyCloseTransactionSearch({
+                    operatingDate: displaySnapshot.operatingDate,
+                    paymentMethod: paymentTotal.method,
+                  }),
+                  storeUrlSlug,
+                  to: "/$orgUrlSlug/store/$storeUrlSlug/pos/transactions",
+                }}
+                value={formatDailyCloseMoney(currency, paymentTotal.amount)}
+              />
+            ))}
             <OperationsSummaryMetric
               helper={formatCarriedOverRegisterCount(
                 getSummaryCount(
@@ -2997,30 +3089,34 @@ export function DailyCloseViewContent({
                 ),
               )}
             />
-            <OperationsSummaryMetric
-              helper={formatExpenseTransactionCount(
-                getExpenseTransactionCount(displaySnapshot.summary),
-              )}
-              label="Expenses"
-              value={formatDailyCloseMoney(
-                currency,
-                displaySnapshot.summary.expenseTotal,
-              )}
-            />
-            <OperationsSummaryMetric
-              helper={formatRegisterVarianceCount(
-                getSummaryRegisterVarianceCount(displaySnapshot.summary),
-              )}
-              label="Variance"
-              value={formatDailyCloseMoney(
-                currency,
-                getSummaryAmount(
-                  displaySnapshot.summary,
-                  "varianceTotal",
-                  "netCashVariance",
-                ),
-              )}
-            />
+            {shouldShowExpenseMetric(displaySnapshot.summary) ? (
+              <OperationsSummaryMetric
+                helper={formatExpenseTransactionCount(
+                  getExpenseTransactionCount(displaySnapshot.summary),
+                )}
+                label="Expenses"
+                value={formatDailyCloseMoney(
+                  currency,
+                  displaySnapshot.summary.expenseTotal,
+                )}
+              />
+            ) : null}
+            {shouldShowVarianceMetric(displaySnapshot.summary) ? (
+              <OperationsSummaryMetric
+                helper={formatRegisterVarianceCount(
+                  getSummaryRegisterVarianceCount(displaySnapshot.summary),
+                )}
+                label="Variance"
+                value={formatDailyCloseMoney(
+                  currency,
+                  getSummaryAmount(
+                    displaySnapshot.summary,
+                    "varianceTotal",
+                    "netCashVariance",
+                  ),
+                )}
+              />
+            ) : null}
           </>
         ) : null
       }
@@ -3048,7 +3144,7 @@ export function DailyCloseViewContent({
       statusTitle={
         <DailyCloseStatusTitle status={status} title={displayCopy.title} />
       }
-      title="End-of-Day Review"
+      title="EOD Review"
     />
   );
 }
@@ -3060,12 +3156,12 @@ function DailyCloseApiPendingView() {
         <PageWorkspace>
           <PageLevelHeader
             eyebrow="Store Ops"
-            title="End-of-Day Review"
-            description="End-of-Day Review is waiting for the server close snapshot and completion command."
+            title="EOD Review"
+            description="The end of day review workspace is waiting for the server close snapshot and completion command."
           />
           <EmptyState
             description="The frontend is wired to api.operations.dailyClose.getDailyCloseSnapshot and completeDailyClose."
-            title="End-of-Day Review server API pending"
+            title="EOD Review server API pending"
           />
         </PageWorkspace>
       </FadeIn>
@@ -3129,7 +3225,7 @@ function DailyCloseConnectedView({
         kind: "user_error",
         error: {
           code: "validation_failed",
-          message: "Select a store before completing End-of-Day Review.",
+          message: "Select a store before completing the end of day review.",
         },
       } as NormalizedCommandResult<unknown>;
     }

--- a/packages/athena-webapp/src/components/operations/DailyOpeningView.test.tsx
+++ b/packages/athena-webapp/src/components/operations/DailyOpeningView.test.tsx
@@ -170,10 +170,10 @@ const readySnapshot: DailyOpeningSnapshot = {
   },
   readyItems: [
     {
-      description: "End-of-Day Review for 7 May is complete.",
+      description: "end of day review for 7 May is complete.",
       id: "ready-1",
       link: {
-        label: "View End-of-Day Review",
+        label: "View EOD Review",
         search: {
           operatingDate: "2026-05-07",
         },
@@ -332,7 +332,7 @@ describe("DailyOpeningViewContent", () => {
     expect(screen.getByText("No carry-forward items")).toBeInTheDocument();
     expect(screen.queryByText(/opening float/i)).not.toBeInTheDocument();
     expect(
-      screen.getByRole("link", { name: /view end-of-day review/i }),
+      screen.getByRole("link", { name: /view EOD review/i }),
     ).toHaveAttribute(
       "href",
       "/wigclub/store/osu/operations/daily-close?o=%252F&operatingDate=2026-05-07",
@@ -474,7 +474,7 @@ describe("DailyOpeningViewContent", () => {
     );
   });
 
-  it("explains the store day when prior End-of-Day Review is missing", () => {
+  it("explains the store day when prior EOD Review is missing", () => {
     renderContent({
       ...readySnapshot,
       blockers: [],
@@ -489,7 +489,7 @@ describe("DailyOpeningViewContent", () => {
             operatingDate: "2026-05-08",
           },
           statusLabel: "Needs review",
-          title: "Prior End-of-Day Review not found",
+          title: "Prior EOD Review not found",
         },
       ],
       status: "needs_attention",

--- a/packages/athena-webapp/src/components/operations/DailyOperationsView.test.tsx
+++ b/packages/athena-webapp/src/components/operations/DailyOperationsView.test.tsx
@@ -180,7 +180,7 @@ const operatingSnapshot: DailyOperationsSnapshot = {
       count: 0,
       description: "No close blockers are active.",
       key: "close",
-      label: "End-of-Day Review",
+      label: "EOD Review",
       status: "ready",
       to: "/$orgUrlSlug/store/$storeUrlSlug/operations/daily-close",
     },
@@ -195,13 +195,13 @@ const operatingSnapshot: DailyOperationsSnapshot = {
   ],
   lifecycle: {
     description:
-      "Opening Handoff is complete and End-of-Day Review has no blockers.",
+      "Opening Handoff is complete and the end of day review has no blockers.",
     label: "Ready to close",
     status: "ready_to_close",
   },
   operatingDate: "2026-05-08",
   primaryAction: {
-    label: "Start End-of-Day Review",
+    label: "Start EOD Review",
     to: "/$orgUrlSlug/store/$storeUrlSlug/operations/daily-close",
   },
   storeId: "store-1" as Id<"store">,
@@ -215,7 +215,7 @@ const blockedSnapshot: DailyOperationsSnapshot = {
     {
       id: "register_session:register-1:open",
       label: "Register session is still open",
-      message: "Close the register session before completing End-of-Day Review.",
+      message: "Close the register session before completing the end of day review.",
       owner: "daily_close",
       severity: "critical",
       source: {
@@ -268,7 +268,7 @@ const closedSnapshot: DailyOperationsSnapshot = {
     lane.key === "close"
       ? {
           ...lane,
-          description: "End-of-Day Review is saved for this store day.",
+          description: "The end of day review is saved for this store day.",
           status: "closed",
         }
       : lane,
@@ -279,14 +279,14 @@ const closedSnapshot: DailyOperationsSnapshot = {
     status: "closed",
   },
   primaryAction: {
-    label: "Review End-of-Day Review",
+    label: "Review EOD Review",
     to: "/$orgUrlSlug/store/$storeUrlSlug/operations/daily-close",
   },
   timeline: [
     {
       createdAt: Date.UTC(2026, 4, 8, 22),
       id: "event-close",
-      message: "End-of-Day Review completed.",
+      message: "EOD Review completed.",
       subject: {
         id: "close-1",
         type: "daily_close",
@@ -469,7 +469,7 @@ describe("DailyOperationsViewContent", () => {
       }),
     ).toBeDisabled();
     expect(
-      screen.queryByRole("link", { name: "Start End-of-Day Review" }),
+      screen.queryByRole("link", { name: "Start EOD Review" }),
     ).not.toBeInTheDocument();
     expect(
       screen.getByRole("heading", { name: "Historical store-day view" }),
@@ -491,7 +491,7 @@ describe("DailyOperationsViewContent", () => {
       screen.queryByRole("link", { name: "Open Opening" }),
     ).not.toBeInTheDocument();
     expect(
-      screen.queryByRole("link", { name: "Open End-of-Day Review" }),
+      screen.queryByRole("link", { name: "Open EOD Review" }),
     ).not.toBeInTheDocument();
     expect(
       screen.queryByRole("link", { name: "Open Open work" }),
@@ -519,7 +519,7 @@ describe("DailyOperationsViewContent", () => {
       "/wigclub/store/osu/pos/transactions?o=%252Fwigclub%252Fstore%252Fosu%252Foperations&paymentMethod=cash",
     );
     expect(
-      screen.getByRole("link", { name: "Start End-of-Day Review" }),
+      screen.getByRole("link", { name: "Start EOD Review" }),
     ).toHaveAttribute(
       "href",
       "/wigclub/store/osu/operations/daily-close?o=%252Fwigclub%252Fstore%252Fosu%252Foperations",
@@ -527,7 +527,7 @@ describe("DailyOperationsViewContent", () => {
     expect(screen.queryByText("Current day only")).not.toBeInTheDocument();
     expect(screen.getByLabelText("Opening ready")).toBeInTheDocument();
     expect(
-      screen.getByLabelText("End-of-Day Review ready"),
+      screen.getByLabelText("EOD Review ready"),
     ).toBeInTheDocument();
     expect(screen.getByLabelText("Open work ready")).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Open Opening" })).toHaveAttribute(
@@ -535,7 +535,7 @@ describe("DailyOperationsViewContent", () => {
       "/wigclub/store/osu/operations/opening?o=%252Fwigclub%252Fstore%252Fosu%252Foperations",
     );
     expect(
-      screen.getByRole("link", { name: "Open End-of-Day Review" }),
+      screen.getByRole("link", { name: "Open EOD Review" }),
     ).toHaveAttribute(
       "href",
       "/wigclub/store/osu/operations/daily-close?o=%252Fwigclub%252Fstore%252Fosu%252Foperations",
@@ -588,7 +588,7 @@ describe("DailyOperationsViewContent", () => {
         },
         {
           ...operatingSnapshot.lanes[1],
-          description: "End-of-Day Review was reopened and needs a revised close.",
+          description: "EOD Review was reopened and needs a revised close.",
           status: "needs_attention",
         },
         {
@@ -605,7 +605,7 @@ describe("DailyOperationsViewContent", () => {
 
     expect(screen.getByLabelText("Opening ready")).toBeInTheDocument();
     expect(
-      screen.getByLabelText("End-of-Day Review needs attention"),
+      screen.getByLabelText("EOD Review needs attention"),
     ).toBeInTheDocument();
     expect(screen.getByLabelText("Registers blocked")).toBeInTheDocument();
     expect(screen.queryByText("Needs attention")).not.toBeInTheDocument();
@@ -734,7 +734,7 @@ describe("DailyOperationsViewContent", () => {
     expect(screen.queryByText("Register session is still open")).not.toBeInTheDocument();
   });
 
-  it("keeps historical End-of-Day Review links on the selected operating date", () => {
+  it("keeps historical EOD Review links on the selected operating date", () => {
     renderContent(closedSnapshot);
 
     expect(
@@ -742,7 +742,7 @@ describe("DailyOperationsViewContent", () => {
     ).toBeInTheDocument();
     expect(
       screen.queryByText(
-        "This operating date is closed. The saved End-of-Day Review is available for this store-day record.",
+        "This operating date is closed. The saved The end of day review is available for this store-day record.",
       ),
     ).not.toBeInTheDocument();
     expect(
@@ -751,18 +751,18 @@ describe("DailyOperationsViewContent", () => {
       ),
     ).not.toBeInTheDocument();
     expect(
-      screen.getByRole("link", { name: "Review End-of-Day Review" }),
+      screen.getByRole("link", { name: "Review EOD Review" }),
     ).toHaveAttribute(
       "href",
       "/wigclub/store/osu/operations/daily-close?o=%252Fwigclub%252Fstore%252Fosu%252Foperations&operatingDate=2026-05-08",
     );
     expect(screen.queryByText("Workflow status")).not.toBeInTheDocument();
     expect(
-      screen.queryByRole("link", { name: "Open End-of-Day Review" }),
+      screen.queryByRole("link", { name: "Open EOD Review" }),
     ).not.toBeInTheDocument();
     expect(
       screen.queryByRole("button", {
-        name: "Open End-of-Day Review unavailable for May 8, 2026",
+        name: "Open EOD Review unavailable for May 8, 2026",
       }),
     ).not.toBeInTheDocument();
   });
@@ -771,14 +771,14 @@ describe("DailyOperationsViewContent", () => {
     renderContent(closedSnapshot);
 
     expect(
-      screen.getByRole("link", { name: "Review End-of-Day Review" }),
+      screen.getByRole("link", { name: "Review EOD Review" }),
     ).toBeInTheDocument();
-    expect(screen.getByText("End-of-Day Review completed.")).toBeInTheDocument();
+    expect(screen.getByText("EOD Review completed.")).toBeInTheDocument();
     expect(
       screen.getByText("Store day acknowledged for May 8, 2026."),
     ).toBeInTheDocument();
     expect(screen.queryByText("2026-05-08")).not.toBeInTheDocument();
-    expect(screen.queryByText("Complete End-of-Day Review")).not.toBeInTheDocument();
+    expect(screen.queryByText("Complete EOD Review")).not.toBeInTheDocument();
   });
 
   it("previews the five most recent timeline events and opens the full list in a sheet", () => {

--- a/packages/athena-webapp/src/components/operations/DailyOperationsView.tsx
+++ b/packages/athena-webapp/src/components/operations/DailyOperationsView.tsx
@@ -257,7 +257,9 @@ function getLocalOperatingDateRangeFromSearch(operatingDate?: unknown) {
 function getOperatingTimezoneOffsetMinutes(operatingDate: string) {
   const localDate = getLocalDateFromOperatingDate(operatingDate);
 
-  return localDate ? localDate.getTimezoneOffset() : new Date().getTimezoneOffset();
+  return localDate
+    ? localDate.getTimezoneOffset()
+    : new Date().getTimezoneOffset();
 }
 
 function formatOperatingDate(operatingDate?: string | null) {
@@ -608,7 +610,7 @@ function HistoricalWorkflowPanel({
               }
               to="/$orgUrlSlug/store/$storeUrlSlug/operations/daily-close"
             >
-              Review End-of-Day Review
+              Review EOD Review
               <ArrowUpRight aria-hidden="true" className="h-4 w-4" />
             </Link>
           </Button>

--- a/packages/athena-webapp/src/components/pos/register/POSRegisterOpeningGuard.test.tsx
+++ b/packages/athena-webapp/src/components/pos/register/POSRegisterOpeningGuard.test.tsx
@@ -168,7 +168,7 @@ describe("POSRegisterOpeningGuard", () => {
     );
   });
 
-  it("directs the operator to End-of-Day Review when the store day is closed", () => {
+  it("directs the operator to EOD Review when the store day is closed", () => {
     useQueryMock.mockImplementation((queryName: string) => {
       if (queryName === "getDailyOpeningSnapshot") {
         return { status: "started" };
@@ -191,11 +191,11 @@ describe("POSRegisterOpeningGuard", () => {
     expect(screen.getByText("Store day closed")).toBeInTheDocument();
     expect(
       screen.getByText(
-        "End-of-Day Review has already closed this operating day. Reopen the day from End-of-Day Review before entering POS.",
+        "The end of day review has already closed this operating day. Reopen the day from the end of day review before entering POS.",
       ),
     ).toBeInTheDocument();
     expect(
-      screen.getByRole("link", { name: /End-of-Day Review/i }),
+      screen.getByRole("link", { name: /EOD Review/i }),
     ).toHaveAttribute(
       "href",
       "/wigclub/store/wigclub/operations/daily-close",

--- a/packages/athena-webapp/src/components/pos/register/POSRegisterOpeningGuard.tsx
+++ b/packages/athena-webapp/src/components/pos/register/POSRegisterOpeningGuard.tsx
@@ -201,8 +201,8 @@ function StoreDayClosedState() {
             Store day closed
           </h2>
           <p className="mt-3 max-w-lg text-base leading-7 text-muted-foreground">
-            End-of-Day Review has already closed this operating day. Reopen the
-            day from End-of-Day Review before entering POS.
+            The end of day review has already closed this operating day. Reopen the
+            day from the end of day review before entering POS.
           </p>
           {canLinkToDailyClose ? (
             <Button
@@ -218,7 +218,7 @@ function StoreDayClosedState() {
                 }}
                 to="/$orgUrlSlug/store/$storeUrlSlug/operations/daily-close"
               >
-                End-of-Day Review
+                EOD Review
                 <ArrowUpRight className="h-4 w-4" />
               </Link>
             </Button>


### PR DESCRIPTION
## Summary
- Fix daily close reopen argument and lifecycle/current-close handling.
- Align Daily Operations and EOD Review state, icons, counts, payment splits, copy, and sidebar ordering.
- Bucket operating-day metrics by local store-day boundaries and document the snapshot-state pattern.

## Validation
- bun run pr:athena
- pre-push reused current pr:athena proof for tree 2353599e11483d446d7892ca75f6187bd6a50038
