### PR TITLE
refine SKU activity inspector layout

### DIFF
--- a/packages/athena-webapp/src/components/app-sidebar.tsx
+++ b/packages/athena-webapp/src/components/app-sidebar.tsx
@@ -19,7 +19,6 @@ import {
   CogIcon,
   Image,
   PanelTop,
-  PackageSearch,
   RotateCcw,
   ScanBarcode,
   ShoppingBag,
@@ -179,7 +178,10 @@ export function AppSidebar() {
               </SidebarMenuItem>
 
               <SidebarMenuItem>
-                <SidebarMenuButton disabled={!canAccessStoreDaySurfaces()} asChild>
+                <SidebarMenuButton
+                  disabled={!canAccessStoreDaySurfaces()}
+                  asChild
+                >
                   <Link
                     to="/$orgUrlSlug/store/$storeUrlSlug/cash-controls"
                     params={(p) => ({
@@ -339,7 +341,6 @@ export function AppSidebar() {
                         })}
                         className="flex items-center gap-2"
                       >
-                        <PackageSearch className="h-3.5 w-3.5" />
                         <p className="font-medium">SKU activity</p>
                       </Link>
                     </SidebarMenuButton>

--- a/packages/athena-webapp/src/components/operations/SkuActivityTimeline.test.tsx
+++ b/packages/athena-webapp/src/components/operations/SkuActivityTimeline.test.tsx
@@ -114,8 +114,8 @@ describe("SkuActivityTimeline", () => {
       },
     });
 
-    expect(screen.getByText("Kinky closure wig")).toBeInTheDocument();
-    expect(screen.getByText("KK38-X3C-MQE")).toBeInTheDocument();
+    expect(screen.getByText("Kinky Closure Wig")).toBeInTheDocument();
+    expect(screen.queryByText("KK38-X3C-MQE")).not.toBeInTheDocument();
     expect(screen.getByText("On hand")).toBeInTheDocument();
     expect(screen.getAllByText("6").length).toBeGreaterThanOrEqual(2);
     expect(screen.getByText("No SKU activity recorded.")).toBeInTheDocument();

--- a/packages/athena-webapp/src/components/operations/SkuActivityTimeline.tsx
+++ b/packages/athena-webapp/src/components/operations/SkuActivityTimeline.tsx
@@ -320,23 +320,15 @@ export function SkuActivityTimeline({
   return (
     <section className="space-y-layout-lg rounded-lg border border-border bg-surface-raised px-layout-md py-layout-md shadow-surface">
       <div className="flex flex-col gap-layout-sm border-b border-border pb-layout-md">
-        <div className="flex flex-wrap items-start justify-between gap-layout-sm">
+        <div className="flex flex-wrap items-end gap-layout-xs">
           <div className="min-w-0">
             <p className="text-[11px] font-medium uppercase tracking-[0.18em] text-muted-foreground">
               SKU activity
             </p>
             <h2 className="mt-1 line-clamp-2 text-base font-medium text-foreground">
-              {viewModel.sku.displayName}
+              {capitalizeWords(viewModel.sku.displayName)}
             </h2>
           </div>
-          {viewModel.sku.sku ? (
-            <Badge
-              className="rounded-md border-border bg-background font-mono text-[11px] text-foreground"
-              variant="outline"
-            >
-              {viewModel.sku.sku}
-            </Badge>
-          ) : null}
         </div>
         {viewModel.sku.barcode ? (
           <p className="text-xs text-muted-foreground">

--- a/packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/sku-activity.tsx
+++ b/packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/sku-activity.tsx
@@ -8,7 +8,11 @@ import { useAuth } from "@/hooks/useAuth";
 import { useProtectedAdminPageState } from "@/hooks/useProtectedAdminPageState";
 import { api } from "~/convex/_generated/api";
 import type { Id } from "~/convex/_generated/dataModel";
-import { PageLevelHeader, PageWorkspace } from "~/src/components/common/PageLevelHeader";
+import { FadeIn } from "~/src/components/common/FadeIn";
+import {
+  PageLevelHeader,
+  PageWorkspace,
+} from "~/src/components/common/PageLevelHeader";
 import { SkuActivityTimeline } from "~/src/components/operations/SkuActivityTimeline";
 import {
   buildSkuActivityTimelineViewModel,
@@ -80,38 +84,44 @@ function SkuActivityRouteContent({
   }
 
   return (
-    <View>
-      <PageWorkspace>
-        <PageLevelHeader
-          eyebrow="Operations"
-          title="SKU activity"
-          description="Inspect current stock, active reservations, and source-linked activity for a SKU."
-        />
+    <View hideBorder hideHeaderBottomBorder scrollMode="page">
+      <FadeIn className="container mx-auto py-layout-xl">
+        <PageWorkspace>
+          <PageLevelHeader
+            eyebrow="Store Ops"
+            title="SKU activity"
+            description="Inspect current stock, active reservations, and source-linked activity for a SKU."
+          />
 
-        <form
-          className="flex flex-col gap-layout-sm rounded-lg border border-border bg-surface-raised px-layout-md py-layout-md shadow-surface md:flex-row md:items-end"
-          onSubmit={handleSubmit}
-        >
-          <div className="min-w-0 flex-1 space-y-layout-xs">
-            <Label htmlFor="sku-activity-search">SKU</Label>
-            <Input
-              id="sku-activity-search"
-              onChange={(event) => setSkuInput(event.target.value)}
-              placeholder="Enter SKU"
-              value={skuInput}
-            />
-          </div>
-          <Button className="gap-layout-xs md:w-auto" type="submit">
-            <Search className="h-4 w-4" />
-            Inspect
-          </Button>
-        </form>
+          <form
+            className="flex w-full flex-col gap-layout-sm md:w-fit md:flex-row md:items-end"
+            onSubmit={handleSubmit}
+          >
+            <div className="min-w-0 space-y-layout-xs md:w-56 md:flex-none">
+              <Label htmlFor="sku-activity-search">SKU</Label>
+              <Input
+                id="sku-activity-search"
+                onChange={(event) => setSkuInput(event.target.value)}
+                placeholder="Enter SKU"
+                value={skuInput}
+              />
+            </div>
+            <Button
+              className="gap-layout-xs md:w-auto"
+              type="submit"
+              variant="workflow"
+            >
+              <Search className="h-4 w-4" />
+              Inspect
+            </Button>
+          </form>
 
-        <SkuActivityTimeline
-          isLoading={hasSelection && skuActivity === undefined}
-          viewModel={viewModel}
-        />
-      </PageWorkspace>
+          <SkuActivityTimeline
+            isLoading={hasSelection && skuActivity === undefined}
+            viewModel={viewModel}
+          />
+        </PageWorkspace>
+      </FadeIn>
     </View>
   );
 }
@@ -198,15 +208,17 @@ function SkuActivityRoute() {
 
 function SkuActivityRouteErrorView() {
   return (
-    <View>
-      <PageWorkspace>
-        <PageLevelHeader
-          eyebrow="Operations"
-          title="SKU activity"
-          description="Inspect current stock, active reservations, and source-linked activity for a SKU."
-        />
-        <SkuActivityTimeline error={true} viewModel={null} />
-      </PageWorkspace>
+    <View hideBorder hideHeaderBottomBorder scrollMode="page">
+      <FadeIn className="container mx-auto py-layout-xl">
+        <PageWorkspace>
+          <PageLevelHeader
+            eyebrow="Store Ops"
+            title="SKU activity"
+            description="Inspect current stock, active reservations, and source-linked activity for a SKU."
+          />
+          <SkuActivityTimeline error={true} viewModel={null} />
+        </PageWorkspace>
+      </FadeIn>
     </View>
   );
 }


### PR DESCRIPTION
## Summary

Refines the SKU activity inspector so it uses the app's standard operations layout, keeps the SKU lookup compact, and removes duplicated SKU chrome from the activity header. The Inspect action now uses the workflow button tone, and the sidebar import cleanup keeps changed-file frontend lint green.

## Validation

- `bun run --filter '@athena/webapp' lint:frontend:changed`
- `bun run test -- SkuActivityTimeline.test.tsx skuActivityTimelineAdapter.test.ts sku-activity.test.tsx convex/operations/skuActivity.test.ts`
- `bun run pr:athena`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)