### PR TITLE
Implement POS local staff authority

### DIFF
--- a/docs/plans/2026-05-14-003-feat-pos-local-staff-authority-plan.html
+++ b/docs/plans/2026-05-14-003-feat-pos-local-staff-authority-plan.html
@@ -1,0 +1,354 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>feat: Add POS local staff authority</title>
+  <style type="text/css">
+    :root {
+      color-scheme: light;
+      --bg: #f7f7f5;
+      --paper: #ffffff;
+      --ink: #18181b;
+      --muted: #666b76;
+      --line: #d9ddd7;
+      --soft: #eef4f1;
+      --accent: #0f766e;
+      --warn: #9a3412;
+      --danger: #991b1b;
+      --code: #f4f4f0;
+    }
+    body {
+      margin: 0;
+      background: var(--bg);
+      color: var(--ink);
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      line-height: 1.55;
+    }
+    .page {
+      max-width: 1120px;
+      margin: 0 auto;
+      padding: 40px 22px 56px;
+    }
+    .hero {
+      background: var(--paper);
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      padding: 28px;
+    }
+    .eyebrow {
+      color: var(--accent);
+      font-size: 13px;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: .04em;
+    }
+    h1 {
+      margin: 8px 0 10px;
+      font-size: 34px;
+      line-height: 1.15;
+      letter-spacing: 0;
+    }
+    h2 {
+      margin: 34px 0 12px;
+      font-size: 22px;
+      letter-spacing: 0;
+    }
+    h3 {
+      margin: 20px 0 8px;
+      font-size: 16px;
+      letter-spacing: 0;
+    }
+    p {
+      margin: 0 0 12px;
+    }
+    a {
+      color: var(--accent);
+      text-decoration: none;
+    }
+    a:hover {
+      text-decoration: underline;
+    }
+    .meta {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      margin-top: 16px;
+    }
+    .pill {
+      border: 1px solid var(--line);
+      border-radius: 999px;
+      padding: 5px 10px;
+      color: var(--muted);
+      background: #fbfbf9;
+      font-size: 13px;
+    }
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap: 14px;
+      margin-top: 18px;
+    }
+    .card {
+      background: var(--paper);
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      padding: 18px;
+    }
+    .card strong {
+      display: block;
+      margin-bottom: 6px;
+    }
+    .toc {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 10px;
+      margin: 18px 0 4px;
+    }
+    .toc a {
+      border: 1px solid var(--line);
+      border-radius: 6px;
+      padding: 8px 10px;
+      background: var(--paper);
+      color: var(--ink);
+      font-size: 14px;
+    }
+    ul {
+      margin: 8px 0 0 20px;
+      padding: 0;
+    }
+    li {
+      margin: 6px 0;
+    }
+    code {
+      background: var(--code);
+      border-radius: 4px;
+      padding: 1px 4px;
+      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      font-size: .92em;
+    }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      background: var(--paper);
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      overflow: hidden;
+    }
+    th, td {
+      border-bottom: 1px solid var(--line);
+      padding: 10px 12px;
+      text-align: left;
+      vertical-align: top;
+    }
+    th {
+      background: var(--soft);
+      font-size: 13px;
+      text-transform: uppercase;
+      color: var(--muted);
+      letter-spacing: .04em;
+    }
+    tr:last-child td {
+      border-bottom: 0;
+    }
+    .flow {
+      background: var(--paper);
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      padding: 18px;
+      overflow-x: auto;
+    }
+    .flow ol {
+      margin: 0 0 0 22px;
+      padding: 0;
+    }
+    .unit {
+      border-left: 4px solid var(--accent);
+      background: var(--paper);
+      border-radius: 8px;
+      padding: 16px 18px;
+      margin: 12px 0;
+      border-top: 1px solid var(--line);
+      border-right: 1px solid var(--line);
+      border-bottom: 1px solid var(--line);
+    }
+    .callout {
+      background: #fff7ed;
+      border: 1px solid #fed7aa;
+      color: var(--warn);
+      border-radius: 8px;
+      padding: 14px 16px;
+      margin: 14px 0;
+    }
+    .danger {
+      background: #fef2f2;
+      border-color: #fecaca;
+      color: var(--danger);
+    }
+    @media (max-width: 820px) {
+      .grid {
+        grid-template-columns: 1fr;
+      }
+      h1 {
+        font-size: 28px;
+      }
+      .hero {
+        padding: 22px;
+      }
+    }
+  </style>
+</head>
+<body>
+  <div class="page">
+    <div class="hero">
+      <div class="eyebrow">Implementation Plan</div>
+      <h1>feat: Add POS local staff authority</h1>
+      <p>Add a POS-only local staff authority layer so registered staff can sign into an already-provisioned terminal without a live Convex connection.</p>
+      <div class="meta">
+        <span class="pill">Date: 2026-05-14</span>
+        <span class="pill">Type: feat</span>
+        <span class="pill">Status: active</span>
+        <span class="pill">Canonical markdown: <a href="2026-05-14-003-feat-pos-local-staff-authority-plan.md">plan.md</a></span>
+      </div>
+    </div>
+
+    <div class="toc">
+      <a href="#problem">Problem</a>
+      <a href="#requirements">Requirements</a>
+      <a href="#decisions">Decisions</a>
+      <a href="#flow">Design Flow</a>
+      <a href="#units">Units</a>
+      <a href="#risks">Risks</a>
+      <a href="#verification">Verification</a>
+    </div>
+
+    <div id="problem">
+      <h2>Problem Frame</h2>
+      <p>POS can now render from local readiness work, but cashier authentication still depends on the live Convex terminal staff-auth mutation. A provisioned terminal needs enough scoped local authority to verify registered staff while offline, without turning browser storage into a global login bypass.</p>
+      <div class="callout">
+        This plan separates local login authority from <code>posLocalStaffProof</code>. The proof remains sync/event evidence; local sign-in needs verifier material proving the entered PIN matches a registered staff credential.
+      </div>
+    </div>
+
+    <div id="requirements">
+      <h2>Requirements Digest</h2>
+      <div class="grid">
+        <div class="card">
+          <strong>Offline staff sign-in</strong>
+          <p>Registered active POS staff can sign into a provisioned terminal without a live connection when local authority is fresh and scoped.</p>
+        </div>
+        <div class="card">
+          <strong>Scoped verifier material</strong>
+          <p>Local records include store, terminal, staff, credential, role, version, expiry, and slow verifier metadata. They never include plaintext PINs.</p>
+        </div>
+        <div class="card">
+          <strong>Server reconciliation</strong>
+          <p>Sync validates authority drift and preserves completed local register work while creating review items when permissions changed.</p>
+        </div>
+      </div>
+    </div>
+
+    <div id="decisions">
+      <h2>Key Decisions</h2>
+      <ul>
+        <li>Use a dedicated POS local staff authority store/module instead of trusting <code>posLocalStaffProof</code> as login proof.</li>
+        <li>Use slow salted local verifier metadata for offline PIN checks; keep the current online hash path as compatibility unless migrated deliberately.</li>
+        <li>Refresh local authority after successful online staff auth and terminal authority refresh.</li>
+        <li>Keep local cashier auth separate from manager elevation and command approval proofs.</li>
+        <li>Fail closed when authority is missing, expired, unsupported, or scoped to another terminal/store.</li>
+      </ul>
+    </div>
+
+    <div id="flow">
+      <h2>Design Flow</h2>
+      <div class="flow">
+        <ol>
+          <li>Manager assigns staff credentials online in Athena.</li>
+          <li>Provisioned POS terminal refreshes staff authority for its store and terminal.</li>
+          <li>Client writes scoped verifier records to IndexedDB.</li>
+          <li>Cashier signs in offline with username and PIN.</li>
+          <li>POS verifies against local authority and signs cashier into the local register.</li>
+          <li>Local POS events carry staff context.</li>
+          <li>Sync later validates staff/role/credential state and records permission conflicts when needed.</li>
+        </ol>
+      </div>
+    </div>
+
+    <div id="units">
+      <h2>Implementation Units</h2>
+      <div class="unit">
+        <h3>U1. Model local staff authority in the POS local store</h3>
+        <p>Add durable IndexedDB storage for staff authority records keyed by store, terminal, and normalized username.</p>
+        <p><strong>Primary files:</strong> <code>posLocalStore.ts</code>, <code>localStaffAuthority.ts</code>, and tests.</p>
+      </div>
+      <div class="unit">
+        <h3>U2. Introduce a slow local PIN verifier</h3>
+        <p>Create Web Crypto-compatible verifier generation and matching with per-record salt and explicit algorithm metadata.</p>
+      </div>
+      <div class="unit">
+        <h3>U3. Export online staff authority snapshots from Convex</h3>
+        <p>Project active POS-authorized staff authority from Convex, filtered by terminal/store scope and credential status.</p>
+      </div>
+      <div class="unit">
+        <h3>U4. Refresh terminal-local staff authority in the client</h3>
+        <p>Persist refreshed local authority after online staff authentication and terminal provisioning/readiness refresh.</p>
+      </div>
+      <div class="unit">
+        <h3>U5. Authenticate cashier sign-in from local authority while offline</h3>
+        <p>Replace the offline fail-fast guard with local verification when authority exists, while keeping fail-closed states explicit.</p>
+      </div>
+      <div class="unit">
+        <h3>U6. Revalidate local staff authority during sync projection</h3>
+        <p>Extend sync evidence and projection tests so permission drift creates reconciliation records without deleting local sales.</p>
+      </div>
+      <div class="unit">
+        <h3>U7. Expose operator-safe readiness and diagnostics</h3>
+        <p>Show useful authority readiness states without leaking verifier, token, PIN hash, or raw credential material.</p>
+      </div>
+    </div>
+
+    <div id="risks">
+      <h2>Risk Summary</h2>
+      <table summary="Key implementation risks and mitigations for POS local staff authority">
+        <thead>
+          <tr>
+            <th>Risk</th>
+            <th>Mitigation</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>IndexedDB snapshot is copied and attacked offline.</td>
+            <td>Store only scoped, expiring, salted slow verifiers; never raw PINs or global credentials.</td>
+          </tr>
+          <tr>
+            <td>Staff is revoked while the terminal is offline.</td>
+            <td>Expire local authority and create permission-drift reconciliation during sync.</td>
+          </tr>
+          <tr>
+            <td>Cashier auth is mistaken for manager approval.</td>
+            <td>Keep command approval proof minting and consumption server-bound and action-scoped.</td>
+          </tr>
+          <tr>
+            <td>Verifier work factor hurts low-end terminal responsiveness.</td>
+            <td>Choose concrete parameters during implementation with Web Crypto and focused performance-sensitive tests.</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <div id="verification">
+      <h2>Verification Strategy</h2>
+      <ul>
+        <li>React tests prove offline cashier sign-in succeeds from local authority and never calls Convex.</li>
+        <li>Local store tests prove authority refresh, expiry, scoping, and no raw PIN persistence.</li>
+        <li>Convex tests prove server authority snapshot filtering and permission-drift sync behavior.</li>
+        <li>Register view-model tests prove local staff identity reaches local POS events after offline sign-in.</li>
+      </ul>
+      <div class="callout danger">
+        Command approval and manager elevation remain unchanged authority boundaries. Local cashier auth must not satisfy protected command approvals.
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/docs/plans/2026-05-14-003-feat-pos-local-staff-authority-plan.md
+++ b/docs/plans/2026-05-14-003-feat-pos-local-staff-authority-plan.md
@@ -1,0 +1,530 @@
+---
+title: "feat: Add POS local staff authority"
+type: feat
+status: active
+date: 2026-05-14
+origin: docs/brainstorms/2026-05-13-pos-local-first-register-requirements.md
+deepened: 2026-05-14
+---
+
+# feat: Add POS local staff authority
+
+## Summary
+
+Add a POS-only local staff authority layer so registered staff can sign into an already-provisioned terminal without a live Convex connection. Online staff registration and terminal sync will produce terminal-scoped verifier material in IndexedDB; offline cashier sign-in will verify username and PIN locally, then sync will later validate permission drift without deleting completed local register work.
+
+---
+
+## Problem Frame
+
+POS now has local boot/readiness work, but staff authentication still depends on `api.operations.staffCredentials.authenticateStaffCredentialForTerminal`. When the browser has no connection, the register can render but a valid staff PIN cannot be verified, leaving POS short of the origin requirement that a provisioned terminal can authenticate staff locally (see origin: `docs/brainstorms/2026-05-13-pos-local-first-register-requirements.md`).
+
+---
+
+## Requirements
+
+- R1. A provisioned POS terminal must be able to authenticate registered, active POS staff locally while offline.
+- R2. Local staff authentication must be scoped to the terminal, store, organization, credential, staff profile, active POS roles, credential version, and expiry known at the last successful online authority sync.
+- R3. Local staff authentication must not store plaintext PINs, reusable server credentials, or unscoped bearer tokens as login proof.
+- R4. Staff credential assignment/reset must create distributable offline verifier metadata because Convex cannot derive a slow verifier later from the existing stored `pinHash`.
+- R5. Successful online staff authentication and terminal authority refresh must write or replace the local authority snapshot needed for later offline sign-in.
+- R6. Expired, missing, revoked, suspended, inactive, store-mismatched, terminal-mismatched, and role-mismatched local authority states must fail closed with operator-safe copy.
+- R7. Offline cashier sign-in must establish POS operator identity and roles for local register events without granting global Athena access, manager elevation, or command approval proof.
+- R8. Sync projection must revalidate local staff authority and route permission drift to reconciliation without silently rewriting already-recorded local register history.
+- R9. The implementation must remain POS-only and must not expand offline authentication to non-POS workspaces.
+
+**Origin actors:** A1 Cashier, A2 Store manager, A3 Athena POS terminal, A4 Athena cloud
+**Origin flows:** F1 Provision a POS terminal for offline use, F2 Operate the register while offline, F5 Sync and reconcile local POS history
+**Origin acceptance examples:** AE1, AE2, AE3, AE7
+
+---
+
+## Scope Boundaries
+
+- Offline first-time staff creation, credential assignment, and PIN reset remain out of scope. Those operations require online Athena staff management.
+- Non-POS offline login for analytics, procurement, staff management, admin, or cash-control review remains out of scope.
+- Local cashier sign-in is not manager elevation and is not command approval. Protected commands must continue to enforce their own proof or policy boundary.
+- Offline local authority is not permanent trust. It is a bounded cache that expires and is revalidated during sync.
+- Payment-provider-specific offline authorization remains out of scope; this plan only establishes staff identity/role authority for POS register operation.
+- Full PWA/service-worker shell hardening remains out of scope except where tests need to prove the existing POS page can consume local authority after reload.
+
+### Deferred to Follow-Up Work
+
+- A richer manager reconciliation workbench for permission-drift conflicts beyond the existing local sync conflict surface.
+- Hardware-backed keychain/TPM storage if Athena later needs stronger protection than browser IndexedDB can provide.
+- Offline command approval proofs for manager-only actions. This plan preserves the current command-boundary approval model and does not make local cashier auth a proof.
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `packages/athena-webapp/src/components/pos/CashierAuthDialog.tsx` is the cashier sign-in entry point and currently calls the Convex terminal authentication mutation.
+- `packages/athena-webapp/src/components/staff-auth/StaffAuthenticationDialog.tsx` owns username/PIN collection, hashing, loading state, and toast presentation.
+- `packages/athena-webapp/convex/operations/staffCredentials.ts` authenticates credentials by store username, PIN hash, staff status, active roles, terminal status, and active-session constraints, then mints `posLocalStaffProof`.
+- `packages/athena-webapp/convex/schemas/operations/staffCredential.ts`, `staffProfile.ts`, and `staffRoleAssignment.ts` are the source-of-truth staff authority records that local snapshots must derive from.
+- `packages/athena-webapp/convex/schemas/pos/posLocalStaffProof.ts` stores server-side sync proof state. It is event authority, not sufficient as local login proof.
+- `packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.ts` is the existing IndexedDB-backed POS local store for terminal seed, events, mappings, and readiness-style local records.
+- `packages/athena-webapp/convex/pos/application/sync/staffProof.ts` and `projectLocalEvents.ts` already validate production local staff proofs during sync projection.
+- `packages/athena-webapp/src/lib/security/pinHash.ts` uses deterministic SHA-256 with a fixed salt. That may remain for current online compatibility but should not become the long-term offline verifier format.
+
+### Institutional Learnings
+
+- `docs/solutions/architecture/athena-pos-local-first-sync-2026-05-13.md` says POS local-first should use a durable local event log, strict ordering, idempotent projection, and reconciliation rather than mutation replay.
+- `docs/solutions/logic-errors/athena-terminal-manager-elevation-command-boundary-2026-05-10.md` says terminal manager elevation is surface access, not command approval, and must not blur command-proof boundaries.
+- `docs/solutions/logic-errors/athena-command-approval-policy-boundary-2026-05-01.md` says protected actions must enforce approval at the command boundary, not by trusting browser-supplied staff state.
+- `docs/product-copy-tone.md` requires restrained, operational copy and normalized backend wording before errors reach the operator.
+
+### External References
+
+- OWASP Password Storage Cheat Sheet recommends modern password hashing with salts and work factors, and explicitly discourages fast hashes for password storage.
+- NIST SP 800-63B treats PINs as memorized secrets and recommends salted, suitable password hashing schemes for verifier storage.
+
+---
+
+## Key Technical Decisions
+
+- Separate local login authority from `posLocalStaffProof`: `posLocalStaffProof` remains a scoped event/sync proof. Local sign-in needs verifier material that can answer whether the entered username and PIN match an active registered staff credential.
+- Store only scoped verifier material: the local snapshot stores username, staff identity, roles, store/terminal scope, expiry, credential version, and a slow salted verifier, never plaintext PINs.
+- Prefer a new local authority module over embedding IndexedDB reads inside `CashierAuthDialog`: auth-sensitive matching, expiry, role filtering, and diagnostics belong in a testable local infrastructure module.
+- Refresh local authority online at two points: after successful terminal staff authentication and during terminal authority sync/provisioning refresh. This supports both first-time staff setup and later credential/role changes.
+- Fail closed offline when authority is stale: expired or missing local authority prompts reconnect instead of falling back to Convex or trusting previous UI state.
+- Keep local cashier auth POS-scoped: it sets the current POS staff profile/roles for local register events, but it does not authenticate the Athena account globally and does not satisfy manager approval proofs.
+- Reconcile permission drift server-side: sync accepts the existence of locally completed customer interactions but records a permission conflict when cloud staff state says the local action should no longer have been authorized.
+
+---
+
+## Open Questions
+
+### Resolved During Planning
+
+- Should `posLocalStaffProof` be reused as login proof? No. It is a bearer token suitable for event/sync validation, not proof that the current person knows a PIN.
+- Should local staff auth apply outside POS? No. The origin scope is POS-only offline operation.
+- Should local cashier auth satisfy command approval? No. Command approval remains action-bound and server-validated.
+- Should the offline verifier use the current fast SHA-256 `pinHash` directly? No for the long-term local verifier. A slow salted verifier is required for the new local authority cache.
+
+### Deferred to Implementation
+
+- Exact verifier algorithm parameters: choose concrete Web Crypto-compatible PBKDF2 parameters during implementation, balancing low-end POS device performance with offline attack resistance.
+- Exact local authority TTL: derive from operational expectations and existing `POS_LOCAL_STAFF_PROOF_TTL_MS`, then encode explicitly in tests.
+- Whether to add a Convex staff-authority query or include local authority in the existing terminal/provisioning response: decide while integrating with current terminal provisioning and staff-management mutation surfaces.
+- Final shape of permission-drift conflict payloads: align with the existing `posLocalSyncConflict` schema and projection code during implementation.
+
+---
+
+## Output Structure
+
+    packages/athena-webapp/src/lib/pos/infrastructure/local/
+      localStaffAuthority.ts
+      localStaffAuthority.test.ts
+      posLocalStore.ts
+      posLocalStore.test.ts
+
+The new file names are a planning target. The implementer may split small shared crypto helpers if tests show that doing so keeps the boundary clearer.
+
+---
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+```mermaid
+sequenceDiagram
+    participant Manager as Online staff setup
+    participant Cloud as Convex staff authority
+    participant POS as Provisioned terminal
+    participant Store as POS IndexedDB
+    participant Cashier
+    participant Sync as Local event sync
+
+    Manager->>Cloud: Assign username, PIN, roles
+    POS->>Cloud: Online terminal authority refresh
+    Cloud-->>POS: Scoped staff authority snapshot
+    POS->>Store: Store verifier, scope, roles, expiry
+    Cashier->>POS: Enter username and PIN offline
+    POS->>Store: Verify local authority
+    Store-->>POS: Staff profile, roles, verifier result
+    POS-->>Cashier: Sign into local register
+    POS->>Store: Append local POS events with staff context
+    Sync->>Cloud: Upload local events when online
+    Cloud-->>Sync: Accepted mappings or permission conflict
+```
+
+```mermaid
+flowchart TD
+    A["Cashier enters username/PIN"] --> B{"Browser online?"}
+    B -->|Yes| C["Run Convex terminal staff auth"]
+    C --> D["Write refreshed local authority"]
+    D --> E["Sign into POS register"]
+    B -->|No| F["Read local staff authority"]
+    F --> G{"Authority valid, scoped, unexpired?"}
+    G -->|No| H["Fail closed: reconnect to refresh staff sign-in"]
+    G -->|Yes| I["Verify PIN using slow local verifier"]
+    I --> J{"Verifier matches?"}
+    J -->|No| K["Safe invalid credentials message"]
+    J -->|Yes| E
+```
+
+---
+
+## Implementation Units
+
+- U1. **Model local staff authority in the POS local store**
+
+**Goal:** Add durable IndexedDB storage for terminal-scoped staff authority records without mixing them into the POS event ledger.
+
+**Requirements:** R1, R2, R3, R4, R5, R6, R9
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.ts`
+- Modify: `packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.test.ts`
+- Create: `packages/athena-webapp/src/lib/pos/infrastructure/local/localStaffAuthority.ts`
+- Create: `packages/athena-webapp/src/lib/pos/infrastructure/local/localStaffAuthority.test.ts`
+
+**Approach:**
+- Add a new local object store or equivalent store abstraction for POS staff authority records keyed by store, terminal, and normalized username.
+- Store staff profile identity, display name, credential identity, credential version/update timestamp, active role list, verifier metadata, issued time, expiry, and status.
+- Keep authority records separate from local event records so pruning/refreshing authority cannot mutate already-recorded POS history.
+- Provide local helpers for write, bulk replace for a terminal, read-by-username, prune expired records, and validate scope.
+
+**Execution note:** Implement test-first because this is auth-sensitive persistence.
+
+**Patterns to follow:**
+- `packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.ts`
+- `packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.test.ts`
+
+**Test scenarios:**
+- Happy path: writing authority records for two staff members on the same terminal can read each by normalized username.
+- Happy path: replacing a terminal authority snapshot removes staff records no longer present in the refreshed snapshot while preserving unrelated terminal/store records.
+- Edge case: a record scoped to another store or terminal is not returned for the current POS terminal.
+- Edge case: expired records are pruned and no longer authenticate.
+- Error path: unsupported local store schema version returns an explicit local-store failure rather than throwing into the UI.
+- Integration: authority writes do not modify existing local POS events, mappings, readiness, or terminal seed records.
+
+**Verification:**
+- The local store can persist, refresh, scope-check, and expire staff authority records without affecting the event ledger.
+
+---
+
+- U2. **Introduce a slow local PIN verifier**
+
+**Goal:** Create verifier generation and verification utilities suitable for local offline staff sign-in, without relying on plaintext PINs or the current fast SHA-256 online compatibility hash as the local cache format.
+
+**Requirements:** R1, R2, R3, R4, R6
+
+**Dependencies:** U1
+
+**Files:**
+- Modify: `packages/athena-webapp/src/lib/pos/infrastructure/local/localStaffAuthority.ts`
+- Modify: `packages/athena-webapp/src/lib/pos/infrastructure/local/localStaffAuthority.test.ts`
+- Modify if needed: `packages/athena-webapp/src/lib/security/pinHash.ts`
+- Test if modified: `packages/athena-webapp/src/lib/security/pinHash.test.ts`
+
+**Approach:**
+- Add Web Crypto-compatible verifier generation for local authority records using a per-record random salt, explicit algorithm name, iteration/work factor metadata, and encoded verifier hash.
+- Keep the current `hashPin` behavior available for existing online mutation compatibility unless the implementation deliberately migrates both online and local paths together.
+- Verify entered PINs by recomputing the local verifier and comparing against the stored value.
+- Return structured outcomes for match, mismatch, unsupported algorithm, expired authority, and invalid scope.
+
+**Execution note:** Treat verifier comparison and failure classification as security-sensitive; tests should assert that no raw PIN is persisted.
+
+**Patterns to follow:**
+- `packages/athena-webapp/src/lib/security/pinHash.ts`
+- `packages/athena-webapp/convex/pos/application/sync/staffProof.ts`
+
+**Test scenarios:**
+- Happy path: a verifier generated from a PIN validates the same PIN and rejects a different PIN.
+- Happy path: generated records use unique salts for the same PIN.
+- Edge case: unsupported verifier algorithm returns a reconnect/refresh-required result.
+- Edge case: malformed verifier metadata fails closed without attempting online fallback while offline.
+- Error path: unavailable `crypto.subtle` returns a safe local-auth-unavailable result.
+- Security assertion: serialized local authority contains no plaintext PIN and no current online `pinHash` field unless implementation explicitly documents a migration bridge.
+
+**Verification:**
+- Local verifier utilities can authenticate entered PINs offline while preserving a clear migration boundary from existing online PIN hashing.
+
+---
+
+- U3. **Export online staff authority snapshots from Convex**
+
+**Goal:** Make Convex produce scoped local authority records when staff credentials are assigned, refreshed, or authenticated from a provisioned terminal.
+
+**Requirements:** R1, R2, R3, R4, R5, R6, R8
+
+**Dependencies:** U1, U2
+
+**Files:**
+- Modify: `packages/athena-webapp/convex/operations/staffCredentials.ts`
+- Modify: `packages/athena-webapp/convex/operations/staffCredentials.test.ts`
+- Modify: `packages/athena-webapp/convex/schemas/operations/staffCredential.ts`
+- Modify: `packages/athena-webapp/src/components/staff/StaffManagement.tsx`
+- Modify: `packages/athena-webapp/src/components/staff/StaffManagement.test.tsx`
+- Modify if needed: `packages/athena-webapp/convex/operations/staffProfiles.ts`
+- Modify if needed: `packages/athena-webapp/convex/operations/staffProfiles.test.ts`
+- Modify if needed: `packages/athena-webapp/convex/pos/public/terminals.ts`
+- Test if modified: `packages/athena-webapp/convex/pos/public/terminals.test.ts`
+
+**Approach:**
+- Add a server-owned projection that returns only POS-authorized, active staff authority for a terminal's store.
+- Include credential status, staff profile status, active roles, display name, credential id/version, issued/expiry metadata, and verifier material suitable for local storage.
+- Extend credential assignment/reset so the client can generate and submit offline verifier metadata at the same time it submits the online-compatible PIN hash.
+- Treat legacy active credentials without offline verifier metadata as online-only until the staff member's PIN is reset or the staff member successfully authenticates online on the terminal and refreshes their own local authority.
+- Exclude suspended/revoked credentials, inactive staff profiles, credentials without PINs, and staff with no POS cashier/manager authority.
+- Reuse existing staff-role derivation and terminal ownership checks rather than creating a parallel authorization rule.
+- Ensure successful `authenticateStaffCredentialForTerminal` can return or trigger a refreshed local authority record for the authenticated staff member.
+
+**Execution note:** Start with Convex tests that characterize current staff credential status and role filtering before adding the local authority projection.
+
+**Patterns to follow:**
+- `packages/athena-webapp/convex/operations/staffCredentials.ts`
+- `packages/athena-webapp/convex/operations/staffProfiles.ts`
+- `packages/athena-webapp/convex/operations/staffRoles.ts`
+
+**Test scenarios:**
+- Happy path: an active cashier credential for the terminal's store appears in the authority snapshot with cashier role and verifier metadata.
+- Happy path: creating or resetting a staff PIN stores offline verifier metadata alongside the existing credential record.
+- Happy path: an active manager credential appears with manager role and can later support manager-scoped POS checks.
+- Edge case: pending, suspended, revoked, or no-PIN credentials are omitted.
+- Edge case: active legacy credential without offline verifier metadata is omitted from bulk terminal authority refresh and marked refresh-required.
+- Edge case: inactive staff profiles and staff from another store are omitted.
+- Edge case: terminal from another store cannot request this store's authority snapshot.
+- Error path: duplicate active credentials for one username remain a server error and are not serialized locally.
+- Integration: online terminal staff authentication returns enough data for the client to refresh that staff member's local authority.
+
+**Verification:**
+- Convex exposes only scoped, active, POS-authorized staff authority needed by a provisioned terminal.
+
+---
+
+- U4. **Refresh terminal-local staff authority in the client**
+
+**Goal:** Write local staff authority records to IndexedDB after successful online authentication and during terminal readiness/provisioning refresh.
+
+**Requirements:** R1, R2, R5, R6, R9
+
+**Dependencies:** U1, U2, U3
+
+**Files:**
+- Modify: `packages/athena-webapp/src/components/pos/CashierAuthDialog.tsx`
+- Modify: `packages/athena-webapp/src/components/pos/CashierAuthDialog.test.tsx`
+- Modify if needed: `packages/athena-webapp/src/lib/pos/application/registerAndProvisionPosTerminal.ts`
+- Modify if needed: `packages/athena-webapp/src/components/pos/settings/POSSettingsView.tsx`
+- Test if modified: `packages/athena-webapp/src/components/pos/settings/POSSettingsView.test.tsx`
+- Modify if needed: `packages/athena-webapp/src/lib/pos/infrastructure/local/localPosEntryContext.ts`
+- Test if modified: `packages/athena-webapp/src/lib/pos/infrastructure/local/localPosEntryContext.test.ts`
+
+**Approach:**
+- On successful online cashier authentication, persist refreshed local authority for that staff member and terminal before treating the local cache as ready for later offline use.
+- During terminal provisioning or readiness refresh, replace the terminal staff authority snapshot from the server-provided list.
+- When online cashier authentication has the raw entered PIN available but server-side verifier metadata is absent for that credential, generate a terminal-local authority record for the authenticated staff member and mark bulk offline authority incomplete until the credential is reset or upgraded.
+- Surface local authority refresh failures as diagnostics/debug state without blocking a currently successful online authentication unless the write failure means offline readiness cannot be claimed.
+- Keep debug output focused on readiness states such as `authority: ready | missing | expired | refresh_failed`, not raw verifier data.
+
+**Patterns to follow:**
+- `packages/athena-webapp/src/components/pos/CashierAuthDialog.tsx`
+- `packages/athena-webapp/src/lib/pos/infrastructure/local/localPosEntryContext.ts`
+- `packages/athena-webapp/src/components/pos/settings/POSSettingsView.tsx`
+
+**Test scenarios:**
+- Happy path: successful online cashier auth writes a local authority record for the authenticated staff member.
+- Happy path: terminal provisioning refresh replaces local staff authority for the terminal.
+- Edge case: authority refresh for one terminal does not overwrite records for another terminal.
+- Error path: IndexedDB write failure logs/surfaces offline-readiness failure without leaking verifier data.
+- Error path: successful online auth still signs in the cashier even if optional authority cache refresh fails, but POS does not report offline staff readiness.
+- Integration: after refresh and simulated reload, local store contains the authority needed for offline sign-in.
+
+**Verification:**
+- A terminal that has been online can persist the exact staff authority needed for later offline POS authentication.
+
+---
+
+- U5. **Authenticate cashier sign-in from local authority while offline**
+
+**Goal:** Update the POS cashier sign-in flow so offline browsers verify staff credentials locally instead of waiting on Convex or only failing fast.
+
+**Requirements:** R1, R2, R3, R6, R7, R9
+
+**Dependencies:** U1, U2, U4
+
+**Files:**
+- Modify: `packages/athena-webapp/src/components/pos/CashierAuthDialog.tsx`
+- Modify: `packages/athena-webapp/src/components/pos/CashierAuthDialog.test.tsx`
+- Modify: `packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts`
+- Modify: `packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts`
+- Modify if needed: `packages/athena-webapp/src/lib/pos/presentation/register/registerUiState.ts`
+
+**Approach:**
+- Branch cashier authentication by capability, not optimism: online path uses Convex and refreshes authority; offline path uses local authority only when terminal seed, store scope, terminal scope, unexpired authority, and verifier support are present.
+- Return the same `StaffAuthenticationResult` shape expected by the register view model, with local-source metadata where useful for sync/debug.
+- Use local active roles to set cashier/manager POS capabilities, while leaving manager elevation and command approval untouched.
+- Replace the current offline fail-fast guard with local verification. Keep fail-fast behavior only for missing/expired/unsupported authority states.
+
+**Execution note:** Add regression coverage for the current spinner/offline fail-fast behavior before changing it to successful local verification.
+
+**Patterns to follow:**
+- `packages/athena-webapp/src/components/staff-auth/StaffAuthenticationDialog.tsx`
+- `packages/athena-webapp/src/components/pos/CashierAuthDialog.test.tsx`
+- `packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts`
+
+**Test scenarios:**
+- Covers AE1. Happy path: with `navigator.onLine === false` and valid local authority, entering username and PIN signs the cashier into POS without calling Convex.
+- Happy path: local manager authority signs in with manager role for POS register capabilities.
+- Edge case: missing local authority prompts reconnect/refresh copy and clears the PIN.
+- Edge case: expired local authority prompts reconnect/refresh copy and clears the PIN.
+- Edge case: wrong PIN produces the normalized invalid-credentials copy and does not call Convex.
+- Edge case: local authority for another terminal or store is rejected.
+- Error path: unsupported verifier metadata returns a reconnect/refresh-required result.
+- Integration: after local offline sign-in, adding a cart item appends a local event with the staffProfileId and local staff authority context expected by sync.
+
+**Verification:**
+- Offline cashier sign-in succeeds only with valid scoped local authority and never waits on a live Convex mutation.
+
+---
+
+- U6. **Revalidate local staff authority during sync projection**
+
+**Goal:** Ensure cloud sync validates locally authenticated staff events against current or historically acceptable staff authority and records permission drift as reconciliation work.
+
+**Requirements:** R2, R6, R7, R8
+
+**Dependencies:** U3, U5
+
+**Files:**
+- Modify: `packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.ts`
+- Modify: `packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts`
+- Modify: `packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.test.ts`
+- Modify: `packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.test.ts`
+- Modify if needed: `packages/athena-webapp/convex/pos/infrastructure/repositories/localSyncRepository.ts`
+
+**Approach:**
+- Extend the sync payload or existing staff-proof evidence so Convex can tell whether an event came from locally verified staff authority and which credential/version/authority expiry was used.
+- Validate event staffProfileId, storeId, terminalId, credential status, staff status, and required role against server state.
+- Preserve completed local events but create a permission-drift conflict when the cloud rejects the authority context.
+- Keep projection idempotent so retrying the same permission-drift event does not duplicate conflicts or side effects.
+
+**Execution note:** Use integration-style Convex tests because this unit crosses client evidence, sync ingestion, projection, conflicts, and existing POS records.
+
+**Patterns to follow:**
+- `packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.test.ts`
+- `packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.test.ts`
+- `packages/athena-webapp/convex/pos/application/sync/staffProof.ts`
+
+**Test scenarios:**
+- Covers AE7. Happy path: a locally authenticated cashier sale syncs once and projects with staff attribution.
+- Happy path: retrying the same accepted local staff event is idempotent.
+- Edge case: staff was revoked after offline sale; sync preserves the sale and creates one permission conflict.
+- Edge case: cashier role was removed before sync; manager reconciliation is created without deleting local receipt/transaction context.
+- Error path: event missing required staff authority evidence becomes needs-review rather than projecting as trusted staff action.
+- Integration: permission conflict appears in the existing local sync conflict/query surface consumed by POS sync status.
+
+**Verification:**
+- Cloud projection can distinguish valid local staff authority from permission drift and preserves local register history either way.
+
+---
+
+- U7. **Expose operator-safe readiness and diagnostics**
+
+**Goal:** Make local staff authority state visible enough for operators and developers to understand why offline sign-in is available or blocked, without leaking credential material.
+
+**Requirements:** R6, R7, R9
+
+**Dependencies:** U4, U5, U6
+
+**Files:**
+- Modify: `packages/athena-webapp/src/lib/pos/presentation/register/registerUiState.ts`
+- Modify: `packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts`
+- Modify: `packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts`
+- Modify: `packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx`
+- Modify: `packages/athena-webapp/src/components/pos/register/POSRegisterView.test.tsx`
+- Modify if needed: `docs/product-copy-tone.md`
+
+**Approach:**
+- Add POS-local debug/readiness state for staff authority: ready, missing, expired, refresh failed, unsupported verifier, scope mismatch.
+- Show operator copy only when action is blocked. Keep debug details in the existing local debug strip or development diagnostics, not as noisy primary UI.
+- Normalize backend/local authority failure messages through existing operator-message patterns.
+- Ensure no verifier, token, PIN hash, salt, or raw credential identifier is rendered in UI or logs beyond safe ids already used for diagnostics.
+
+**Patterns to follow:**
+- `packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx`
+- `packages/athena-webapp/src/lib/errors/operatorMessages.ts`
+- `docs/product-copy-tone.md`
+
+**Test scenarios:**
+- Happy path: local staff authority ready state is reflected in view-model debug output while the cashier auth dialog is open.
+- Edge case: expired authority renders reconnect/refresh copy rather than raw expiry or backend terms.
+- Edge case: missing authority does not render as generic app failure; it tells the operator local sign-in needs refresh.
+- Error path: refresh failure logs safe context and does not include verifier fields.
+- Integration: permission-drift conflict from sync changes sync status to needs-review without signing the cashier out mid-sale.
+
+**Verification:**
+- Operators receive clear sign-in readiness feedback and developers get enough safe diagnostics to debug local authority issues.
+
+---
+
+## System-Wide Impact
+
+- **Interaction graph:** Staff management and terminal provisioning feed local staff authority; cashier auth consumes it; register view-model uses resulting staff identity; local command gateway records staff context; sync projection revalidates authority.
+- **Error propagation:** Local authority failures should return normalized command-style user errors so `StaffAuthenticationDialog` can clear PIN/loading state and show safe copy.
+- **State lifecycle risks:** Authority refresh must not mutate local event history, and authority expiry must not invalidate already-recorded local events. Sync handles drift after the fact.
+- **API surface parity:** Online cashier auth, terminal provisioning/refresh, local auth, and sync payloads need matching authority fields and version semantics.
+- **Integration coverage:** Unit tests alone are not enough. Convex sync tests must prove permission drift handling, and React tests must prove offline sign-in does not call Convex or hang.
+- **Unchanged invariants:** POS remains the only offline-first workspace. Command approval proofs remain server-minted, action-bound, and one-use. Manager elevation remains separate from cashier sign-in.
+
+---
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| IndexedDB compromise exposes offline verifier material. | Store only scoped, expiring, salted slow verifiers; no raw PINs, no global account tokens, no unscoped authority. |
+| Staff credential revocation happens while the terminal is offline. | Fail expired authority locally and create permission-drift reconciliation during sync for actions recorded before refresh. |
+| Local cashier auth is mistaken for manager approval. | Preserve command-bound approval proofs and test that local cashier/manager roles do not satisfy approval proof consumption. |
+| Low-end terminals struggle with verifier work factor. | Choose Web Crypto parameters during implementation and test enough performance envelope to avoid blocking POS entry. |
+| Online and local PIN verifier formats drift. | Keep current online compatibility path explicit and isolate the local verifier in `localStaffAuthority.ts` with migration metadata. |
+| Authority refresh becomes too broad and includes non-POS staff. | Server projection filters to active POS-authorized roles and terminal store scope. |
+
+---
+
+## Documentation / Operational Notes
+
+- Update POS terminal provisioning/readiness documentation to explain that offline staff sign-in requires a recent authority sync.
+- Add a durable `docs/solutions/` note after implementation describing the distinction between local login authority, `posLocalStaffProof`, manager elevation, and command approval proofs.
+- Add validation-map coverage for new local authority modules and sync permission-drift tests if the repo validation map requires explicit entries.
+- Existing debug copy added during offline POS investigation should be revisited so staff authority readiness appears as a clear POS-local diagnostic.
+
+---
+
+## Alternative Approaches Considered
+
+- Reuse `posLocalStaffProof` for offline login: rejected because it is a bearer token and does not prove the current person knows the assigned PIN.
+- Store the existing `pinHash` locally as the verifier: rejected as the long-term design because it is a fast deterministic hash with fixed salt and is weak if local storage is copied.
+- Always require reconnect for staff sign-in: rejected because it fails the origin requirement for locally authenticated POS operation after provisioning.
+- Make local manager sign-in satisfy command approvals: rejected because it violates the command-boundary approval model and would widen the blast radius of local browser authority.
+
+---
+
+## Success Metrics
+
+- A provisioned terminal with a fresh staff authority snapshot can reload offline and sign in a cashier without calling Convex.
+- Invalid PIN, missing authority, expired authority, and scope mismatch all fail quickly with safe operator copy and no spinner hang.
+- Local POS events created after offline staff sign-in include enough staff context for sync projection and reconciliation.
+- Sync preserves completed local register history while surfacing permission drift as manager-review work.
+
+---
+
+## Sources & References
+
+- **Origin document:** [docs/brainstorms/2026-05-13-pos-local-first-register-requirements.md](../brainstorms/2026-05-13-pos-local-first-register-requirements.md)
+- Related plan: [docs/plans/2026-05-14-001-feat-pos-always-local-first-flow-plan.md](2026-05-14-001-feat-pos-always-local-first-flow-plan.md)
+- Related plan: [docs/plans/2026-05-14-002-feat-pos-offline-entry-readiness-plan.md](2026-05-14-002-feat-pos-offline-entry-readiness-plan.md)
+- Related solution: [docs/solutions/architecture/athena-pos-local-first-sync-2026-05-13.md](../solutions/architecture/athena-pos-local-first-sync-2026-05-13.md)
+- Related solution: [docs/solutions/logic-errors/athena-terminal-manager-elevation-command-boundary-2026-05-10.md](../solutions/logic-errors/athena-terminal-manager-elevation-command-boundary-2026-05-10.md)
+- Related solution: [docs/solutions/logic-errors/athena-command-approval-policy-boundary-2026-05-01.md](../solutions/logic-errors/athena-command-approval-policy-boundary-2026-05-01.md)
+- Related code: `packages/athena-webapp/src/components/pos/CashierAuthDialog.tsx`
+- Related code: `packages/athena-webapp/convex/operations/staffCredentials.ts`
+- Related code: `packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.ts`
+- External reference: [OWASP Password Storage Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html)
+- External reference: [NIST SP 800-63B](https://pages.nist.gov/800-63-4/sp800-63b.html)

--- a/docs/solutions/architecture/athena-pos-local-staff-authority-2026-05-14.md
+++ b/docs/solutions/architecture/athena-pos-local-staff-authority-2026-05-14.md
@@ -1,0 +1,89 @@
+---
+title: Athena POS Local Staff Authority Uses Terminal-Scoped Verifiers
+date: 2026-05-14
+category: architecture
+module: athena-webapp
+problem_type: offline_pos_staff_authority
+component: pos
+symptoms:
+  - "Offline POS sign-in can block the register even when the terminal is otherwise ready"
+  - "Staff PIN hashes are tempting to reuse as offline credentials"
+  - "Local sync proofs can outlive a staff credential reset without explicit drift evidence"
+root_cause: offline_staff_authority_was_not_a_first_class_terminal_snapshot
+resolution_type: authority_snapshot_and_versioned_proof
+severity: high
+tags:
+  - pos
+  - staff
+  - local-first
+  - offline
+  - security
+---
+
+# Athena POS Local Staff Authority Uses Terminal-Scoped Verifiers
+
+## Problem
+
+The POS register can be local-first for sale commands while still depending on
+Convex for cashier sign-in. That leaves a freshly provisioned terminal unable to
+operate offline unless a cashier was already authenticated, and it creates
+pressure to reuse the online `pinHash` as the local credential.
+
+That is the wrong boundary. The online PIN hash is compatibility data for server
+authentication. Offline login needs a terminal-scoped authority snapshot with a
+local verifier that can be checked without exposing broader staff credential
+state.
+
+## Solution
+
+When a staff PIN is created or reset, Athena stores versioned
+`PBKDF2-SHA256` verifier metadata alongside the server credential. A registered
+terminal can refresh its local staff authority snapshot while online. The
+snapshot is scoped to the store and terminal, contains only active cashier or
+manager credentials with local verifiers, and is stored in the POS IndexedDB
+local store.
+
+Offline cashier sign-in reads that local snapshot by normalized username,
+rejects expired or revoked records, verifies the raw PIN against the local
+verifier, unwraps that staff member's previously issued local sync proof, and
+returns the matching staff profile plus the unwrapped proof. Missing, malformed,
+or still-locked authority fails closed with operator-facing copy instead of
+falling back to server auth.
+
+## Proof Boundary
+
+The local staff authority verifier proves a human can sign in to the terminal
+while offline. The `posLocalStaffProof` token proves that local events emitted by
+that staff member may be accepted by the server during sync. They are related,
+but they are not interchangeable.
+
+The authority snapshot must not store plaintext proof tokens for the roster.
+Proof tokens are issued by the server after online staff authentication and
+stored locally only as PIN-wrapped ciphertext for that specific staff member.
+Offline sign-in therefore needs both the verifier check and the same PIN-derived
+unwrap step before any sync bearer token can be used.
+
+Server sync checks the proof token, terminal scope, store scope, expiry, staff
+credential, staff profile state, role eligibility, and credential version. A PIN
+reset increments the local verifier version, and older local proofs stop
+validating once that credential version drifts.
+
+Manager elevation and command approval proofs remain separate server-side
+approval boundaries. Local cashier authority should not be treated as approval
+for manager-only commands.
+
+## Prevention
+
+- Do not use online `pinHash` as an offline verifier.
+- Do not persist plaintext `posLocalStaffProof` tokens in local staff authority.
+- Keep local staff authority snapshots scoped to store and terminal ids.
+- Include credential-version evidence in local sync proofs.
+- Refresh local staff authority after online cashier authentication and during
+  terminal-ready POS startup paths.
+- Surface local staff authority readiness in POS diagnostics so offline gaps are
+  visible before they block checkout.
+
+## Related
+
+- [Athena POS Local-First Sync Uses Event Logs](./athena-pos-local-first-sync-2026-05-13.md)
+- [Athena POS Register Commands Are Always Local First](./athena-pos-always-local-first-register-2026-05-14.md)

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,11 +1,11 @@
 # Graph Report - .
 
 ## Corpus Check
-- 1734 files · ~0 words
+- 1736 files · ~0 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 5428 nodes · 5624 edges · 1663 communities detected
+- 5457 nodes · 5676 edges · 1665 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -1673,6 +1673,8 @@
 - [[_COMMUNITY_Community 1660|Community 1660]]
 - [[_COMMUNITY_Community 1661|Community 1661]]
 - [[_COMMUNITY_Community 1662|Community 1662]]
+- [[_COMMUNITY_Community 1663|Community 1663]]
+- [[_COMMUNITY_Community 1664|Community 1664]]
 
 ## God Nodes (most connected - your core abstractions)
 1. `createJourneyEvent()` - 40 edges
@@ -1741,16 +1743,16 @@ Cohesion: 0.15
 Nodes (31): collectHarnessOnboardingErrors(), collectMarkdownLinkErrors(), collectMissingRequiredLinkErrors(), collectPackageGuideLinkErrors(), collectPackagesRouterLinkErrors(), collectReadmeLinkErrors(), collectReferencedPathErrors(), collectRuntimeScenarioDocSyncErrors() (+23 more)
 
 ### Community 10 - "Community 10"
-Cohesion: 0.12
-Nodes (28): asRegExp(), collectLatencyDiagnostics(), collectRuntimeSignalDiagnostics(), collectRuntimeSignalMatches(), consumeLines(), escapeRegExp(), formatAssertionDiagnostics(), formatError() (+20 more)
+Cohesion: 0.09
+Nodes (15): asCloudOperableSession(), buildCompletedSalePayload(), cartItemsFromLocalRegisterModel(), completedCustomerInfo(), createPaymentId(), getCloseoutCloudRegisterSessionId(), hasCustomerDetails(), isCloudOperableSession() (+7 more)
 
 ### Community 11 - "Community 11"
 Cohesion: 0.12
-Nodes (19): buildDailyCloseSearch(), buildDailyOperationsSearch(), buildOperationsTransactionSearch(), formatWeekdayDate(), formatWeekdayLabel(), getDailyOperationsMetricLabels(), getLocalDateFromOperatingDate(), getLocalOperatingDate() (+11 more)
+Nodes (28): asRegExp(), collectLatencyDiagnostics(), collectRuntimeSignalDiagnostics(), collectRuntimeSignalMatches(), consumeLines(), escapeRegExp(), formatAssertionDiagnostics(), formatError() (+20 more)
 
 ### Community 12 - "Community 12"
-Cohesion: 0.09
-Nodes (15): asCloudOperableSession(), buildCompletedSalePayload(), cartItemsFromLocalRegisterModel(), completedCustomerInfo(), createPaymentId(), getCloseoutCloudRegisterSessionId(), hasCustomerDetails(), isCloudOperableSession() (+7 more)
+Cohesion: 0.12
+Nodes (19): buildDailyCloseSearch(), buildDailyOperationsSearch(), buildOperationsTransactionSearch(), formatWeekdayDate(), formatWeekdayLabel(), getDailyOperationsMetricLabels(), getLocalDateFromOperatingDate(), getLocalOperatingDate() (+11 more)
 
 ### Community 13 - "Community 13"
 Cohesion: 0.15
@@ -1793,72 +1795,72 @@ Cohesion: 0.15
 Nodes (19): acquireExpenseQuantityPatchHold(), adjustExpenseQuantityPatchHold(), createDefaultExpenseSessionCommandService(), createExpenseInventoryHoldGateway(), createExpenseSessionCommandService(), failure(), isActiveRegisterSession(), isSessionExpired() (+11 more)
 
 ### Community 23 - "Community 23"
+Cohesion: 0.19
+Nodes (21): assertStaffProfileReadyForCredential(), authenticateStaffCredentialForApprovalWithCtx(), authenticateStaffCredentialForTerminalWithCtx(), authenticateStaffCredentialWithCtx(), createStaffCredentialWithCtx(), getActiveRolesForStaffProfile(), getCredentialById(), getCredentialByUsername() (+13 more)
+
+### Community 24 - "Community 24"
 Cohesion: 0.24
 Nodes (22): asRecord(), createMappingIndex(), errorFor(), errorMessage(), getCompletedSale(), getExpectedCashDelta(), getOrCreateSale(), getPhase() (+14 more)
 
-### Community 24 - "Community 24"
+### Community 25 - "Community 25"
 Cohesion: 0.15
 Nodes (16): buildGitProcessEnv(), collectCommandsForChangedFiles(), fileExists(), formatMissingPathPrefixError(), getChangedFilesForHarnessReview(), hasAnyHarnessDocs(), loadReviewTarget(), loadReviewTargets() (+8 more)
 
-### Community 25 - "Community 25"
+### Community 26 - "Community 26"
 Cohesion: 0.25
 Nodes (21): buildActiveCycleCountDraftsSubmissionKey(), buildCycleCountDraftSubmissionKey(), createCycleCountDraftWithCtx(), discardCycleCountDraftCommandWithCtx(), ensureCycleCountDraftCommandWithCtx(), ensureCycleCountDraftWithCtx(), findOpenCycleCountDraftWithCtx(), getActiveCycleCountDraftSummaryWithCtx() (+13 more)
 
-### Community 26 - "Community 26"
+### Community 27 - "Community 27"
 Cohesion: 0.27
 Nodes (20): asBoolean(), asMtnMomoSetupStatus(), asNumber(), asOptionalArray(), asRecord(), asString(), cleanUndefined(), firstDefined() (+12 more)
 
-### Community 27 - "Community 27"
+### Community 28 - "Community 28"
 Cohesion: 0.22
 Nodes (18): acquireInventoryHold(), acquireInventoryHoldsBatch(), adjustInventoryHold(), buildSkuActivityIdempotencyKey(), consumeInventoryHoldsForSession(), getActiveHoldForSessionSku(), listActiveSessionHolds(), markHoldExpired() (+10 more)
 
-### Community 28 - "Community 28"
+### Community 29 - "Community 29"
 Cohesion: 0.17
 Nodes (17): assertRegisterSessionIdentity(), assertRegisterSessionMatchesTransaction(), assertValidRegisterSessionTransition(), buildClosedRegisterSessionPatch(), buildRegisterSession(), buildRegisterSessionCloseoutPatch(), buildRegisterSessionDepositPatch(), buildRegisterSessionOpeningFloatCorrectionPatch() (+9 more)
 
-### Community 29 - "Community 29"
+### Community 30 - "Community 30"
 Cohesion: 0.18
 Nodes (19): assertIdempotentReplayMatches(), assertProductSkuBelongsToStore(), assertSkuActivityArgs(), buildActiveReservationEntries(), buildAvailabilityWarnings(), buildSkuActivityEvent(), buildTimeline(), getImpactQuantities() (+11 more)
 
-### Community 30 - "Community 30"
+### Community 31 - "Community 31"
 Cohesion: 0.18
 Nodes (16): createDefaultSessionCommandService(), createPosSessionCommandService(), failure(), isActiveRegisterSession(), isSessionExpired(), registerSessionMatchesIdentity(), resolveRegisterSessionBinding(), runBindSessionToRegisterSessionCommand() (+8 more)
 
-### Community 31 - "Community 31"
+### Community 32 - "Community 32"
 Cohesion: 0.1
 Nodes (4): handleChange(), isSkuReserved(), parseVariantInputValue(), shouldDisable()
 
-### Community 32 - "Community 32"
+### Community 33 - "Community 33"
 Cohesion: 0.13
 Nodes (11): CashPositionSummary(), cn(), formatCashExposureSupporting(), formatCurrency(), formatStaffByline(), formatTimestamp(), getSessionActionLabel(), getSessionOpenedLine() (+3 more)
 
-### Community 33 - "Community 33"
+### Community 34 - "Community 34"
 Cohesion: 0.12
 Nodes (7): buildMissingDraftResult(), getApprovalRequestCopy(), handleDecideApprovalRequest(), handleDiscardCycleCountDraft(), handleRefreshCycleCountDraftLineBaseline(), handleSaveCycleCountDraftLine(), handleSubmitCycleCountDraft()
 
-### Community 34 - "Community 34"
+### Community 35 - "Community 35"
 Cohesion: 0.11
 Nodes (2): buildCashControlsDashboardSnapshot(), sumDepositsBySession()
 
-### Community 35 - "Community 35"
+### Community 36 - "Community 36"
 Cohesion: 0.15
 Nodes (11): checkIfItemsHaveChanged(), createOnlineOrder(), createPatchObject(), findBestValuePromoCode(), handleExistingSession(), handleOrderCreation(), handlePlaceOrder(), listSessionItems() (+3 more)
 
-### Community 36 - "Community 36"
+### Community 37 - "Community 37"
 Cohesion: 0.13
 Nodes (8): formatInventoryNumber(), formatReservationSourceSummary(), getInventoryItemDisplayName(), getReservationLabels(), getSkuDetailEntries(), handleDraftChange(), rowMatchesStockAdjustmentSearch(), setDraftValue()
 
-### Community 37 - "Community 37"
+### Community 38 - "Community 38"
 Cohesion: 0.15
 Nodes (10): capitalizeFirstLetter(), capitalizeWords(), cn(), currencyFormatter(), formatDate(), getErrorForField(), getProductName(), getRelativeTime() (+2 more)
 
-### Community 38 - "Community 38"
+### Community 39 - "Community 39"
 Cohesion: 0.21
 Nodes (16): commandForPort(), defaultCommand(), isProcessAlive(), isReachable(), listPreviews(), optionsFromEnv(), pruneState(), readState() (+8 more)
-
-### Community 39 - "Community 39"
-Cohesion: 0.24
-Nodes (17): assertStaffProfileReadyForCredential(), authenticateStaffCredentialForApprovalWithCtx(), authenticateStaffCredentialForTerminalWithCtx(), authenticateStaffCredentialWithCtx(), createStaffCredentialWithCtx(), getActiveRolesForStaffProfile(), getCredentialById(), getCredentialByUsername() (+9 more)
 
 ### Community 40 - "Community 40"
 Cohesion: 0.12
@@ -1885,232 +1887,232 @@ Cohesion: 0.11
 Nodes (0):
 
 ### Community 46 - "Community 46"
+Cohesion: 0.14
+Nodes (7): createEmptyMemoryStore(), createMemoryPosLocalStorageAdapter(), normalizeStaffAuthorityRecord(), normalizeUsername(), PosLocalStoreSchemaError, preserveWrappedStaffProof(), staffAuthorityKey()
+
+### Community 47 - "Community 47"
 Cohesion: 0.22
 Nodes (16): buildDegreeIndex(), buildHotspotLines(), buildPackagePage(), buildRootIndexPage(), collectRepoCodeFiles(), compareHotspots(), countCommunities(), fileExists() (+8 more)
 
-### Community 47 - "Community 47"
+### Community 48 - "Community 48"
 Cohesion: 0.12
 Nodes (1): DataTableViewOptions()
 
-### Community 48 - "Community 48"
+### Community 49 - "Community 49"
 Cohesion: 0.3
 Nodes (16): asRecord(), buildPosLocalSyncUploadEvents(), customerInfoFromPayload(), getCompletedSaleItems(), getSyncableUploadSequence(), hasLaterCompletedSale(), isPendingSyncUploadEvent(), isSkippedSaleClearEvent() (+8 more)
 
-### Community 49 - "Community 49"
+### Community 50 - "Community 50"
+Cohesion: 0.15
+Nodes (8): collectAcceptedEventIdsWithLocalPrecursors(), collectReviewLocalEventIds(), collectRuntimeRelevantEvents(), collectSyncedLocalEventIds(), derivePosLocalRuntimeSyncStatus(), hasPendingLocalCloseout(), toLocalCloudMappingEntity(), writeReturnedLocalCloudMappings()
+
+### Community 51 - "Community 51"
 Cohesion: 0.19
 Nodes (13): compareSnapshots(), fileExists(), formatArtifactList(), formatDetailLines(), formatError(), formatHarnessJanitorReport(), readUtf8OrNull(), runCheckStep() (+5 more)
 
-### Community 50 - "Community 50"
+### Community 52 - "Community 52"
 Cohesion: 0.21
 Nodes (14): buildNumericTrendStats(), buildRegressionWarnings(), buildRuntimeTrendOutput(), buildScenarioTrend(), collectHarnessRuntimeTrends(), formatMs(), formatPercent(), parseHarnessBehaviorReportLines() (+6 more)
 
-### Community 51 - "Community 51"
+### Community 53 - "Community 53"
 Cohesion: 0.15
 Nodes (4): asBoolean(), asNumber(), asRecord(), getCashControlsConfig()
 
-### Community 52 - "Community 52"
+### Community 54 - "Community 54"
 Cohesion: 0.27
 Nodes (15): assertValidOnlineOrderStatusTransition(), getOnlineOrderPaymentAmount(), getOnlineOrderPaymentMethodLabel(), getOnlineOrderStatusEventType(), getStoreOrganizationId(), isPaymentOnDeliveryOrder(), recordOnlineOrderCreatedEvent(), recordOnlineOrderFulfillmentMovement() (+7 more)
 
-### Community 53 - "Community 53"
+### Community 55 - "Community 55"
 Cohesion: 0.14
 Nodes (4): DailyCloseHistoryView(), getDailyCloseHistoryApi(), getHistoryRecordSnapshot(), normalizeHistorySnapshot()
 
-### Community 54 - "Community 54"
+### Community 56 - "Community 56"
 Cohesion: 0.17
 Nodes (9): exitCorrectionWorkflow(), formatCorrectionEventType(), formatCorrectionHistoryChange(), formatCorrectionHistoryTitle(), formatPaymentMethodLabel(), getCorrectionHistoryChangeParts(), isManagerStaff(), runCustomerCorrection() (+1 more)
 
-### Community 55 - "Community 55"
-Cohesion: 0.17
-Nodes (8): collectAcceptedEventIdsWithLocalPrecursors(), collectReviewLocalEventIds(), collectRuntimeRelevantEvents(), collectSyncedLocalEventIds(), derivePosLocalRuntimeSyncStatus(), hasPendingLocalCloseout(), toLocalCloudMappingEntity(), writeReturnedLocalCloudMappings()
-
-### Community 56 - "Community 56"
+### Community 57 - "Community 57"
 Cohesion: 0.21
 Nodes (14): CheckoutSessionError, createCheckoutSession(), defaultCheckoutActionMessage(), getActiveCheckoutSession(), getBaseUrl(), getCheckoutActionErrorMessage(), getCheckoutErrorMessageFromPayload(), getCheckoutSession() (+6 more)
 
-### Community 57 - "Community 57"
+### Community 58 - "Community 58"
 Cohesion: 0.26
 Nodes (13): addGroupedError(), collectLiveSurfaceEntries(), fileExists(), formatGroupedErrors(), formatMissingValidationPathError(), hasAnyHarnessDocs(), inferGroupFromError(), loadAuditTarget() (+5 more)
 
-### Community 58 - "Community 58"
+### Community 59 - "Community 59"
 Cohesion: 0.33
 Nodes (14): adjustRegisterSessionExpectedCashForPaymentCorrection(), applyPaymentMethodCorrection(), buildPaymentMethodCorrectionApprovalRequirement(), consumePaymentMethodCorrectionApprovalProof(), correctTransactionCustomer(), correctTransactionPaymentMethod(), createPaymentMethodCorrectionApprovalRequest(), getPaymentMethodCashContribution() (+6 more)
 
-### Community 59 - "Community 59"
+### Community 60 - "Community 60"
 Cohesion: 0.17
 Nodes (6): buildServerPricedCheckoutProducts(), calculateItemsSubtotal(), deriveDeliveryOptionFromAddress(), isDeliveryFeeWaived(), normalizeDeliveryOption(), resolveServerDeliveryFee()
 
-### Community 60 - "Community 60"
+### Community 61 - "Community 61"
 Cohesion: 0.24
 Nodes (9): clearPaymentEditing(), handleCancelEdit(), handleClearPayments(), handleRemovePayment(), handleSaveEdit(), handleStartEdit(), resetPaymentCollectionControls(), setPaymentEditing() (+1 more)
 
-### Community 61 - "Community 61"
+### Community 62 - "Community 62"
 Cohesion: 0.22
 Nodes (10): createApp(), createHandlers(), createRedisClient(), createRedisCluster(), deleteKeysIndividually(), invalidateAcrossCluster(), invalidateAcrossClusterWithPipeline(), scanNodeForPattern() (+2 more)
 
-### Community 62 - "Community 62"
+### Community 63 - "Community 63"
 Cohesion: 0.35
 Nodes (12): assertRoleConfiguration(), buildRoleAssignmentDrafts(), buildStaffFullName(), buildStaffProfileResult(), createStaffProfileWithCtx(), ensureLinkedUserAvailable(), getStaffProfileByIdWithCtx(), normalizeOptionalString() (+4 more)
 
-### Community 63 - "Community 63"
+### Community 64 - "Community 64"
 Cohesion: 0.31
 Nodes (13): advancePurchaseOrderToOrderedCommandWithCtx(), advancePurchaseOrderToOrderedWithCtx(), assertValidPurchaseOrderStatusTransition(), buildPurchaseOrderNumber(), calculatePurchaseOrderTotals(), createPurchaseOrderCommandWithCtx(), createPurchaseOrderWithCtx(), getOperationalWorkItemStatus() (+5 more)
 
-### Community 64 - "Community 64"
+### Community 65 - "Community 65"
 Cohesion: 0.15
 Nodes (2): formatTimelineRange(), formatTimelineTime()
 
-### Community 65 - "Community 65"
+### Community 66 - "Community 66"
 Cohesion: 0.18
 Nodes (5): handleSave(), hasReceivingAccountDetails(), normalizePrimaryAccounts(), toPatchReceivingAccounts(), trimToUndefined()
 
-### Community 66 - "Community 66"
+### Community 67 - "Community 67"
 Cohesion: 0.18
 Nodes (5): isOverpayPaymentMethod(), isValidEmail(), isValidPhone(), validateCustomer(), validatePaymentAmount()
 
-### Community 67 - "Community 67"
+### Community 68 - "Community 68"
 Cohesion: 0.26
 Nodes (12): deleteHeadBranch(), enablePullRequestAutoMerge(), encodeGitRefPath(), ghJson(), HelpRequested, mergePullRequest(), parseArgs(), parseMergeMethod() (+4 more)
 
-### Community 68 - "Community 68"
+### Community 69 - "Community 69"
 Cohesion: 0.26
 Nodes (10): createCustomer(), fullNameFromParts(), guestResult(), linkToGuest(), linkToStoreFrontUser(), posCustomerResult(), resolveGuestMatch(), resolvePosCustomerSelection() (+2 more)
 
-### Community 69 - "Community 69"
+### Community 70 - "Community 70"
 Cohesion: 0.21
 Nodes (6): buildServiceCase(), createServiceCaseWithCtx(), deriveServiceCasePaymentStatus(), listServiceCaseAllocationsWithCtx(), listServiceCaseLineItemsWithCtx(), syncServiceCaseFinancialsWithCtx()
 
-### Community 70 - "Community 70"
+### Community 71 - "Community 71"
 Cohesion: 0.29
 Nodes (12): assertDistinctReceivingLineItems(), assertReceivablePurchaseOrderStatus(), assertReceivingLineQuantities(), buildReceivingBatchSourceId(), calculatePurchaseOrderReceivingStatus(), calculateReceivingBatchTotals(), listPurchaseOrderLineItems(), mapReceivePurchaseOrderBatchError() (+4 more)
 
-### Community 71 - "Community 71"
+### Community 72 - "Community 72"
 Cohesion: 0.17
 Nodes (2): formatRegisterLabel(), getRegisterLabel()
 
-### Community 72 - "Community 72"
-Cohesion: 0.17
-Nodes (3): createEmptyMemoryStore(), createMemoryPosLocalStorageAdapter(), PosLocalStoreSchemaError
-
 ### Community 73 - "Community 73"
+Cohesion: 0.38
+Nodes (12): base64ToBytes(), bytesToBase64(), createLocalPinVerifier(), cryptoRefDecrypt(), derivePinHash(), deriveWrappingKey(), getCrypto(), isLocalPinVerifierMetadata() (+4 more)
+
+### Community 74 - "Community 74"
 Cohesion: 0.29
 Nodes (12): createReview(), deleteReview(), getBaseUrl(), getReviewByOrderItem(), getReviewsByProductId(), getReviewsByProductSkuId(), getUserReviews(), getUserReviewsForProduct() (+4 more)
 
-### Community 74 - "Community 74"
+### Community 75 - "Community 75"
 Cohesion: 0.28
 Nodes (11): buildCoverageReport(), checkSourceThresholds(), emptySummary(), formatMetric(), parseLcovSummary(), percentage(), pickMetric(), printCoverageReport() (+3 more)
 
-### Community 75 - "Community 75"
+### Community 76 - "Community 76"
 Cohesion: 0.26
 Nodes (11): collectConvexSourceModules(), collectConvexSourceModulesFromDir(), readCommandStdout(), readGeneratedConvexApiModules(), refreshAthenaConvexGeneratedApi(), resolveSupportedConvexNodeBin(), runPreCommitGeneratedArtifacts(), stageTrackedGeneratedArtifacts() (+3 more)
 
-### Community 76 - "Community 76"
+### Community 77 - "Community 77"
 Cohesion: 0.31
 Nodes (12): collectFilesUnder(), collectProofSnapshot(), collectValidationFingerprintPaths(), evaluatePrePushValidationProof(), hashValidationWiring(), normalizeRepoPath(), readPrAthenaScript(), recordPrePushValidationProof() (+4 more)
 
-### Community 77 - "Community 77"
+### Community 78 - "Community 78"
 Cohesion: 0.23
 Nodes (5): getTransactionById(), listStaffNames(), loadCorrectionEvents(), loadCustomerProfile(), summarizeCashierName()
 
-### Community 78 - "Community 78"
+### Community 79 - "Community 79"
 Cohesion: 0.18
 Nodes (2): formatBlockerList(), runPrePushReview()
 
-### Community 79 - "Community 79"
+### Community 80 - "Community 80"
 Cohesion: 0.29
 Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
 
-### Community 80 - "Community 80"
+### Community 81 - "Community 81"
 Cohesion: 0.33
 Nodes (2): OrdersTableToolbarProvider(), useOrdersTableToolbar()
 
-### Community 81 - "Community 81"
+### Community 82 - "Community 82"
 Cohesion: 0.24
 Nodes (5): formatBackendLabel(), formatInventoryNumber(), formatQuantity(), getActivityTitle(), pluralize()
 
-### Community 82 - "Community 82"
+### Community 83 - "Community 83"
 Cohesion: 0.31
 Nodes (7): buildCustomerCreateInput(), cancelPendingAdd(), commitCustomer(), handleAddFromSearch(), handleClearCustomer(), handleSelectCustomer(), toCustomerInfo()
 
-### Community 83 - "Community 83"
+### Community 84 - "Community 84"
 Cohesion: 0.25
 Nodes (6): handleEdit(), handleReset(), handleSubmit(), itemToFormState(), parseServiceCatalogForm(), validateServiceCatalogForm()
-
-### Community 84 - "Community 84"
-Cohesion: 0.18
-Nodes (0):
 
 ### Community 85 - "Community 85"
 Cohesion: 0.18
 Nodes (0):
 
 ### Community 86 - "Community 86"
+Cohesion: 0.18
+Nodes (0):
+
+### Community 87 - "Community 87"
 Cohesion: 0.2
 Nodes (2): diagnoseAthenaQaLiveSmoke(), stripUrlQuery()
 
-### Community 87 - "Community 87"
+### Community 88 - "Community 88"
 Cohesion: 0.31
 Nodes (6): expenseItemSuccess(), expenseSessionSuccess(), itemSuccess(), operationSuccess(), sessionSuccess(), success()
 
-### Community 88 - "Community 88"
+### Community 89 - "Community 89"
 Cohesion: 0.22
 Nodes (2): isValidEmail(), validateCustomerInfo()
 
-### Community 89 - "Community 89"
+### Community 90 - "Community 90"
 Cohesion: 0.22
 Nodes (2): listProductSkusByProductId(), readAllQueryResults()
 
-### Community 90 - "Community 90"
+### Community 91 - "Community 91"
 Cohesion: 0.22
 Nodes (2): getTerminalByFingerprint(), mapTerminalRecord()
 
-### Community 91 - "Community 91"
+### Community 92 - "Community 92"
 Cohesion: 0.31
 Nodes (7): buildVariantSkuMoneyPayload(), createVariantSku(), modifyProduct(), onSubmit(), parseVariantDisplayMoney(), saveProduct(), updateVariantSku()
 
-### Community 92 - "Community 92"
+### Community 93 - "Community 93"
 Cohesion: 0.29
 Nodes (6): handleFileSelect(), handleRevert(), handleUpload(), resetEditState(), uploadImage(), validateFile()
 
-### Community 93 - "Community 93"
-Cohesion: 0.22
-Nodes (2): buildUsername(), normalizeNameSegment()
-
 ### Community 94 - "Community 94"
-Cohesion: 0.27
-Nodes (5): blocked(), evaluateLocalPosReadiness(), localReadinessMatchesInput(), localReadinessRecordFromSnapshots(), refreshLocalPosReadinessFromSnapshots()
-
-### Community 95 - "Community 95"
 Cohesion: 0.2
 Nodes (0):
 
+### Community 95 - "Community 95"
+Cohesion: 0.27
+Nodes (5): blocked(), evaluateLocalPosReadiness(), localReadinessMatchesInput(), localReadinessRecordFromSnapshots(), refreshLocalPosReadinessFromSnapshots()
+
 ### Community 96 - "Community 96"
+Cohesion: 0.2
+Nodes (0):
+
+### Community 97 - "Community 97"
 Cohesion: 0.38
 Nodes (9): awardPointsForGuestOrders(), awardPointsForPastOrder(), getBaseUrl(), getEligiblePastOrders(), getOrderRewardPoints(), getPointHistory(), getRewardTiers(), getUserPoints() (+1 more)
 
-### Community 97 - "Community 97"
+### Community 98 - "Community 98"
 Cohesion: 0.4
 Nodes (8): fileExists(), isJsonObject(), normalizeGraphJsonArtifact(), normalizeGraphJsonContents(), resolveGraphifyPython(), runGraphifyRebuild(), sortJsonArray(), sortJsonValue()
 
-### Community 98 - "Community 98"
+### Community 99 - "Community 99"
 Cohesion: 0.42
 Nodes (7): buildTraceEvent(), buildTraceRecord(), displayTraceAmount(), recordRegisterSessionTraceBestEffort(), resolveOccurredAt(), resolveStoreCurrency(), safeTraceWrite()
 
-### Community 99 - "Community 99"
+### Community 100 - "Community 100"
 Cohesion: 0.28
 Nodes (4): buildCtx(), buildManagerProof(), buildRegisterOpenedEvent(), createFakeConvexCtx()
 
-### Community 100 - "Community 100"
+### Community 101 - "Community 101"
 Cohesion: 0.5
 Nodes (7): getNonEmptyString(), getOperationalEventJourney(), getOperationalEventStatus(), getOperationalEventStep(), isFailureStatus(), isOperationalEventDoc(), normalizeEvent()
 
-### Community 101 - "Community 101"
+### Community 102 - "Community 102"
 Cohesion: 0.39
 Nodes (7): calculateRefundAmount(), getAmountRefunded(), getAvailableItems(), getItemsToRefund(), getNetAmount(), shouldShowReturnToStock(), validateRefund()
-
-### Community 102 - "Community 102"
-Cohesion: 0.22
-Nodes (0):
 
 ### Community 103 - "Community 103"
 Cohesion: 0.39
@@ -2213,244 +2215,244 @@ Cohesion: 0.25
 Nodes (0):
 
 ### Community 128 - "Community 128"
+Cohesion: 0.29
+Nodes (2): buildUsername(), normalizeNameSegment()
+
+### Community 129 - "Community 129"
 Cohesion: 0.39
 Nodes (4): isMoneyOperation(), parseOperationValue(), useBulkOperations(), validateOperationValue()
 
-### Community 129 - "Community 129"
+### Community 130 - "Community 130"
 Cohesion: 0.29
 Nodes (2): mapProductByIdResult(), useConvexProductIdLookup()
 
-### Community 130 - "Community 130"
+### Community 131 - "Community 131"
 Cohesion: 0.25
 Nodes (0):
 
-### Community 131 - "Community 131"
+### Community 132 - "Community 132"
+Cohesion: 0.25
+Nodes (0):
+
+### Community 133 - "Community 133"
 Cohesion: 0.46
 Nodes (7): addItemToBag(), clearBag(), getActiveBag(), getBaseUrl(), removeItemFromBag(), updateBagItem(), updateBagOwner()
 
-### Community 132 - "Community 132"
+### Community 134 - "Community 134"
 Cohesion: 0.43
 Nodes (6): buildQueryString(), getAllProducts(), getBaseUrl(), getBestSellers(), getFeatured(), getProduct()
 
-### Community 133 - "Community 133"
+### Community 135 - "Community 135"
 Cohesion: 0.25
 Nodes (0):
 
-### Community 134 - "Community 134"
+### Community 136 - "Community 136"
 Cohesion: 0.43
 Nodes (7): createStorefrontObservabilityContext(), createStorefrontObservabilityPayload(), getOrCreateStorefrontObservabilitySessionId(), isBrowserAutomationContext(), isSyntheticMonitorOrigin(), resolveStorefrontAnalyticsOrigin(), trackStorefrontEvent()
 
-### Community 135 - "Community 135"
+### Community 137 - "Community 137"
 Cohesion: 0.39
 Nodes (5): createPackage(), installFixtureToolchain(), linkWorkspacePackage(), writeFixtureManifests(), writeJson()
 
-### Community 136 - "Community 136"
+### Community 138 - "Community 138"
 Cohesion: 0.52
 Nodes (5): getWhatsAppReceiptConfig(), getWhatsAppWebhookAppSecret(), getWhatsAppWebhookVerifyToken(), optionalEnv(), requiredEnv()
 
-### Community 137 - "Community 137"
+### Community 139 - "Community 139"
 Cohesion: 0.33
 Nodes (2): expenseSessionError(), mapExpenseSessionValidationError()
 
-### Community 138 - "Community 138"
+### Community 140 - "Community 140"
 Cohesion: 0.57
 Nodes (6): buildHeaders(), createCollectionsAccessToken(), encodeBasicAuth(), getRequestToPayStatus(), requestToPay(), toError()
 
-### Community 139 - "Community 139"
+### Community 141 - "Community 141"
 Cohesion: 0.33
 Nodes (2): completedDailyCloseRow(), completedDailyCloseSnapshot()
 
-### Community 140 - "Community 140"
+### Community 142 - "Community 142"
 Cohesion: 0.52
 Nodes (6): buildCustomerProfileDraft(), buildFullName(), findMatchingCustomerProfile(), normalizeLookupValue(), normalizePhoneNumber(), splitFullName()
 
-### Community 141 - "Community 141"
+### Community 143 - "Community 143"
 Cohesion: 0.48
 Nodes (5): buildExpenseSessionTraceEvent(), buildExpenseSessionTraceRecord(), buildTraceSummary(), recordExpenseSessionTraceBestEffort(), safeTraceWrite()
 
-### Community 142 - "Community 142"
+### Community 144 - "Community 144"
 Cohesion: 0.43
 Nodes (4): assertRegisterNumberIsAvailable(), mapRegisterTerminalError(), normalizeRegisterNumber(), registerTerminal()
 
-### Community 143 - "Community 143"
+### Community 145 - "Community 145"
 Cohesion: 0.52
 Nodes (5): getRegisterCatalogPrice(), listRegisterCatalog(), mapSkuToRegisterCatalogRow(), readCategoryName(), readColorName()
-
-### Community 144 - "Community 144"
-Cohesion: 0.29
-Nodes (0):
-
-### Community 145 - "Community 145"
-Cohesion: 0.48
-Nodes (5): getActiveSessionForRegisterState(), listHeldSessionsForRegisterState(), querySessionsByStatus(), selectRegisterStateLookupStrategy(), summarizeRegisterStateSessions()
 
 ### Community 146 - "Community 146"
 Cohesion: 0.29
 Nodes (0):
 
 ### Community 147 - "Community 147"
-Cohesion: 0.33
-Nodes (2): getCustomerOperationalTimelineEvents(), resolveCustomerProfileIdForTimeline()
+Cohesion: 0.48
+Nodes (5): getActiveSessionForRegisterState(), listHeldSessionsForRegisterState(), querySessionsByStatus(), selectRegisterStateLookupStrategy(), summarizeRegisterStateSessions()
 
 ### Community 148 - "Community 148"
-Cohesion: 0.38
-Nodes (3): clearBagItems(), createOrderFromCheckoutSession(), generateOrderNumber()
-
-### Community 149 - "Community 149"
-Cohesion: 0.57
-Nodes (5): getDeliveryAddress(), getLocationDetails(), getPickupLocation(), handleOrderStatusUpdate(), processOrderUpdateEmail()
-
-### Community 150 - "Community 150"
-Cohesion: 0.33
-Nodes (2): appendTransition(), applyOnlineOrderUpdate()
-
-### Community 151 - "Community 151"
-Cohesion: 0.38
-Nodes (3): createWorkflowTraceWithCtx(), getWorkflowTraceByIdWithCtx(), getWorkflowTraceByLookupWithCtx()
-
-### Community 152 - "Community 152"
-Cohesion: 0.38
-Nodes (4): calculateCycleCountQuantityDelta(), hasHighStockAdjustmentVariance(), requiresStockAdjustmentApproval(), resolveStockAdjustmentQuantityDelta()
-
-### Community 153 - "Community 153"
-Cohesion: 0.33
-Nodes (2): handleKeypadPress(), setAmountFromTouch()
-
-### Community 154 - "Community 154"
-Cohesion: 0.48
-Nodes (4): applyCommandResult(), async(), handleSubmit(), parseDateTimeLocal()
-
-### Community 155 - "Community 155"
-Cohesion: 0.38
-Nodes (3): formatDeposit(), formatMoney(), summarizeService()
-
-### Community 156 - "Community 156"
-Cohesion: 0.52
-Nodes (6): deriveRegisterPhase(), hasActiveRegisterSession(), hasResumableRegisterSession(), isRegisterReadyToStart(), requiresCashier(), requiresTerminal()
-
-### Community 157 - "Community 157"
-Cohesion: 0.33
-Nodes (2): selectNextOrderedBatch(), selectOrderedBatches()
-
-### Community 158 - "Community 158"
 Cohesion: 0.29
 Nodes (0):
 
+### Community 149 - "Community 149"
+Cohesion: 0.33
+Nodes (2): getCustomerOperationalTimelineEvents(), resolveCustomerProfileIdForTimeline()
+
+### Community 150 - "Community 150"
+Cohesion: 0.38
+Nodes (3): clearBagItems(), createOrderFromCheckoutSession(), generateOrderNumber()
+
+### Community 151 - "Community 151"
+Cohesion: 0.57
+Nodes (5): getDeliveryAddress(), getLocationDetails(), getPickupLocation(), handleOrderStatusUpdate(), processOrderUpdateEmail()
+
+### Community 152 - "Community 152"
+Cohesion: 0.33
+Nodes (2): appendTransition(), applyOnlineOrderUpdate()
+
+### Community 153 - "Community 153"
+Cohesion: 0.38
+Nodes (3): createWorkflowTraceWithCtx(), getWorkflowTraceByIdWithCtx(), getWorkflowTraceByLookupWithCtx()
+
+### Community 154 - "Community 154"
+Cohesion: 0.38
+Nodes (4): calculateCycleCountQuantityDelta(), hasHighStockAdjustmentVariance(), requiresStockAdjustmentApproval(), resolveStockAdjustmentQuantityDelta()
+
+### Community 155 - "Community 155"
+Cohesion: 0.33
+Nodes (2): handleKeypadPress(), setAmountFromTouch()
+
+### Community 156 - "Community 156"
+Cohesion: 0.48
+Nodes (4): applyCommandResult(), async(), handleSubmit(), parseDateTimeLocal()
+
+### Community 157 - "Community 157"
+Cohesion: 0.38
+Nodes (3): formatDeposit(), formatMoney(), summarizeService()
+
+### Community 158 - "Community 158"
+Cohesion: 0.52
+Nodes (6): deriveRegisterPhase(), hasActiveRegisterSession(), hasResumableRegisterSession(), isRegisterReadyToStart(), requiresCashier(), requiresTerminal()
+
 ### Community 159 - "Community 159"
 Cohesion: 0.33
-Nodes (2): getProductName(), sortProduct()
+Nodes (2): selectNextOrderedBatch(), selectOrderedBatches()
 
 ### Community 160 - "Community 160"
 Cohesion: 0.29
 Nodes (0):
 
 ### Community 161 - "Community 161"
-Cohesion: 0.52
-Nodes (6): addItemToSavedBag(), getActiveSavedBag(), getBaseUrl(), removeItemFromSavedBag(), updateSavedBagItem(), updateSavedBagOwner()
+Cohesion: 0.33
+Nodes (2): getProductName(), sortProduct()
 
 ### Community 162 - "Community 162"
-Cohesion: 0.43
-Nodes (4): createFixtureRepo(), gitEnv(), runGit(), write()
+Cohesion: 0.29
+Nodes (0):
 
 ### Community 163 - "Community 163"
 Cohesion: 0.52
-Nodes (5): emitSignal(), handleCheckoutSessionFetch(), handleCheckoutSessionUpdate(), jsonResponse(), withCorsHeaders()
+Nodes (6): addItemToSavedBag(), getActiveSavedBag(), getBaseUrl(), removeItemFromSavedBag(), updateSavedBagItem(), updateSavedBagOwner()
 
 ### Community 164 - "Community 164"
-Cohesion: 0.33
-Nodes (2): overwriteFreshGraphifyArtifacts(), write()
+Cohesion: 0.43
+Nodes (4): createFixtureRepo(), gitEnv(), runGit(), write()
 
 ### Community 165 - "Community 165"
-Cohesion: 0.38
-Nodes (4): createFixtureRepo(), initializeGitHistory(), runGit(), write()
+Cohesion: 0.52
+Nodes (5): emitSignal(), handleCheckoutSessionFetch(), handleCheckoutSessionUpdate(), jsonResponse(), withCorsHeaders()
 
 ### Community 166 - "Community 166"
 Cohesion: 0.33
-Nodes (1): ValkeyClient
+Nodes (2): overwriteFreshGraphifyArtifacts(), write()
 
 ### Community 167 - "Community 167"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.38
+Nodes (4): createFixtureRepo(), initializeGitHistory(), runGit(), write()
 
 ### Community 168 - "Community 168"
 Cohesion: 0.33
-Nodes (0):
+Nodes (1): ValkeyClient
 
 ### Community 169 - "Community 169"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 170 - "Community 170"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 171 - "Community 171"
 Cohesion: 0.73
 Nodes (5): buildOrderStatusMessage(), buildPickupDetails(), sendPaymentVerificationEmails(), sendPODOrderEmails(), shouldSendToAdmins()
 
-### Community 170 - "Community 170"
+### Community 172 - "Community 172"
 Cohesion: 0.6
 Nodes (5): createVendorCommandWithCtx(), createVendorWithCtx(), mapCreateVendorError(), normalizeVendorLookupKey(), trimOptional()
 
-### Community 171 - "Community 171"
+### Community 173 - "Community 173"
 Cohesion: 0.6
 Nodes (5): find_block_end(), list_convex_files(), main(), scan_file(), strip_code()
 
-### Community 172 - "Community 172"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 173 - "Community 173"
-Cohesion: 0.53
-Nodes (4): includesRegisterSessionStatus(), isCashControlVisibleRegisterSessionStatus(), isPosUsableRegisterSessionStatus(), isRegisterSessionConflictBlockingStatus()
-
 ### Community 174 - "Community 174"
 Cohesion: 0.33
-Nodes (1): DataTableToolbar()
+Nodes (0):
 
 ### Community 175 - "Community 175"
 Cohesion: 0.53
-Nodes (2): SelectedProductsProvider(), useSelectedProducts()
+Nodes (4): includesRegisterSessionStatus(), isCashControlVisibleRegisterSessionStatus(), isPosUsableRegisterSessionStatus(), isRegisterSessionConflictBlockingStatus()
 
 ### Community 176 - "Community 176"
-Cohesion: 0.4
-Nodes (2): handlePinChange(), normalizeOtpCode()
+Cohesion: 0.33
+Nodes (1): DataTableToolbar()
 
 ### Community 177 - "Community 177"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.53
+Nodes (2): SelectedProductsProvider(), useSelectedProducts()
 
 ### Community 178 - "Community 178"
-Cohesion: 0.47
-Nodes (3): historyRecord(), snapshot(), storedReportSnapshot()
+Cohesion: 0.4
+Nodes (2): handlePinChange(), normalizeOtpCode()
 
 ### Community 179 - "Community 179"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 180 - "Community 180"
+Cohesion: 0.47
+Nodes (3): historyRecord(), snapshot(), storedReportSnapshot()
+
+### Community 181 - "Community 181"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 182 - "Community 182"
 Cohesion: 0.4
 Nodes (2): buildApprovalRetryArgs(), getAsyncApprovalRequestId()
 
-### Community 181 - "Community 181"
+### Community 183 - "Community 183"
 Cohesion: 0.47
 Nodes (3): getSummaryAmount(), getSummaryLabel(), getSummaryPanel()
-
-### Community 182 - "Community 182"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 183 - "Community 183"
-Cohesion: 0.33
-Nodes (0):
 
 ### Community 184 - "Community 184"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 185 - "Community 185"
-Cohesion: 0.53
-Nodes (3): handleUpdateFees(), parseDeliveryFeeInputs(), parseOptionalDeliveryFeeInput()
-
-### Community 186 - "Community 186"
-Cohesion: 0.47
-Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
-
-### Community 187 - "Community 187"
 Cohesion: 0.33
 Nodes (0):
+
+### Community 186 - "Community 186"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 187 - "Community 187"
+Cohesion: 0.53
+Nodes (3): handleUpdateFees(), parseDeliveryFeeInputs(), parseOptionalDeliveryFeeInput()
 
 ### Community 188 - "Community 188"
 Cohesion: 0.33
@@ -2473,12 +2475,12 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 193 - "Community 193"
-Cohesion: 0.53
-Nodes (4): calculatePosChange(), calculatePosRemainingDue(), calculatePosTotalPaid(), roundPosAmount()
-
-### Community 194 - "Community 194"
 Cohesion: 0.33
 Nodes (0):
+
+### Community 194 - "Community 194"
+Cohesion: 0.53
+Nodes (4): calculatePosChange(), calculatePosRemainingDue(), calculatePosTotalPaid(), roundPosAmount()
 
 ### Community 195 - "Community 195"
 Cohesion: 0.33
@@ -2521,80 +2523,80 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 205 - "Community 205"
+Cohesion: 0.47
+Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
+
+### Community 206 - "Community 206"
 Cohesion: 0.53
 Nodes (5): getRemainingForFreeDelivery(), hasWaiverConfigured(), isAnyFeeWaived(), isFeeWaived(), meetsThreshold()
 
-### Community 206 - "Community 206"
+### Community 207 - "Community 207"
 Cohesion: 0.47
 Nodes (3): onSubmit(), reportAuthFailure(), resendVerificationCode()
 
-### Community 207 - "Community 207"
+### Community 208 - "Community 208"
 Cohesion: 0.53
 Nodes (4): coverageSummary(), write(), writePackageSummaries(), writeRealBaselineSummaries()
 
-### Community 208 - "Community 208"
+### Community 209 - "Community 209"
 Cohesion: 0.67
 Nodes (5): collectRepoCodeFiles(), collectStaleGraphifyArtifacts(), copyGraphifyCheckInputs(), fileExists(), runGraphifyCheck()
 
-### Community 209 - "Community 209"
+### Community 210 - "Community 210"
 Cohesion: 0.4
 Nodes (2): createFixtureRoot(), write()
 
-### Community 210 - "Community 210"
+### Community 211 - "Community 211"
 Cohesion: 0.5
 Nodes (2): createAuthorizedRegisterDepositCtx(), createQueryCtx()
 
-### Community 211 - "Community 211"
+### Community 212 - "Community 212"
 Cohesion: 0.6
 Nodes (4): buildInStorePaymentAllocations(), normalizeInStorePayments(), resolveRegisterSessionForInStoreCollectionWithCtx(), selectRegisterSessionForAttribution()
-
-### Community 212 - "Community 212"
-Cohesion: 0.4
-Nodes (0):
 
 ### Community 213 - "Community 213"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 214 - "Community 214"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 215 - "Community 215"
+Cohesion: 0.6
+Nodes (3): formatStoredAmount(), toDisplayAmount(), toPesewas()
+
+### Community 216 - "Community 216"
 Cohesion: 0.7
 Nodes (4): compactRecord(), ensureCustomerProfileFromSourcesWithCtx(), findExistingProfile(), loadCustomerSources()
 
-### Community 215 - "Community 215"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 216 - "Community 216"
-Cohesion: 0.4
-Nodes (0):
-
 ### Community 217 - "Community 217"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 218 - "Community 218"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 219 - "Community 219"
 Cohesion: 0.7
 Nodes (4): buildDecision(), classifyCorrectionIntent(), isSupportedCorrectionIntent(), isUnsupportedHighRiskCorrectionIntent()
 
-### Community 218 - "Community 218"
+### Community 220 - "Community 220"
 Cohesion: 0.7
 Nodes (4): getPaystackHeaders(), initializeTransaction(), initiateRefund(), verifyTransaction()
 
-### Community 219 - "Community 219"
+### Community 221 - "Community 221"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 220 - "Community 220"
+### Community 222 - "Community 222"
 Cohesion: 0.6
 Nodes (3): buildOnlineOrderReturnExchangePlan(), getApprovalReason(), getKind()
 
-### Community 221 - "Community 221"
+### Community 223 - "Community 223"
 Cohesion: 0.5
 Nodes (2): getNonEmptyString(), normalizeStorefrontObservabilityEvent()
-
-### Community 222 - "Community 222"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 223 - "Community 223"
-Cohesion: 0.4
-Nodes (0):
 
 ### Community 224 - "Community 224"
 Cohesion: 0.4
@@ -2609,16 +2611,16 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 227 - "Community 227"
-Cohesion: 0.5
-Nodes (2): handleFileSelect(), validateFile()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 228 - "Community 228"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 229 - "Community 229"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.5
+Nodes (2): handleFileSelect(), validateFile()
 
 ### Community 230 - "Community 230"
 Cohesion: 0.4
@@ -2629,20 +2631,20 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 232 - "Community 232"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 233 - "Community 233"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 234 - "Community 234"
 Cohesion: 0.5
 Nodes (2): getBalanceDueLabel(), getBalanceDuePanel()
 
-### Community 233 - "Community 233"
+### Community 235 - "Community 235"
 Cohesion: 0.6
 Nodes (3): handleClearSearch(), handleQuickAddSubmit(), resetQuickAddForm()
-
-### Community 234 - "Community 234"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 235 - "Community 235"
-Cohesion: 0.4
-Nodes (0):
 
 ### Community 236 - "Community 236"
 Cohesion: 0.4
@@ -2653,36 +2655,36 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 238 - "Community 238"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 239 - "Community 239"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 240 - "Community 240"
 Cohesion: 0.7
 Nodes (4): getRuntimeOrigin(), isLocalHost(), resolveStoreFrontUrl(), trimTrailingSlash()
 
-### Community 239 - "Community 239"
+### Community 241 - "Community 241"
 Cohesion: 0.7
 Nodes (4): bufferToHex(), collectBrowserInfo(), generateBrowserFingerprint(), hashFingerprintSource()
 
-### Community 240 - "Community 240"
+### Community 242 - "Community 242"
 Cohesion: 0.4
 Nodes (1): MockImage
 
-### Community 241 - "Community 241"
+### Community 243 - "Community 243"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 242 - "Community 242"
+### Community 244 - "Community 244"
 Cohesion: 0.6
 Nodes (3): calculatePosCartTotals(), calculatePosItemTotal(), roundPosAmount()
 
-### Community 243 - "Community 243"
+### Community 245 - "Community 245"
 Cohesion: 0.6
 Nodes (4): mapRegisterStateDto(), mapTerminalDto(), useConvexRegisterState(), useConvexTerminalByFingerprint()
-
-### Community 244 - "Community 244"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 245 - "Community 245"
-Cohesion: 0.4
-Nodes (0):
 
 ### Community 246 - "Community 246"
 Cohesion: 0.4
@@ -2701,92 +2703,92 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 250 - "Community 250"
-Cohesion: 0.5
-Nodes (2): completePendingAuthSync(), sleep()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 251 - "Community 251"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 252 - "Community 252"
-Cohesion: 0.7
-Nodes (4): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory()
+Cohesion: 0.5
+Nodes (2): completePendingAuthSync(), sleep()
 
 ### Community 253 - "Community 253"
-Cohesion: 0.7
-Nodes (4): getBaseUrl(), getOrder(), getOrders(), updateOrdersOwner()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 254 - "Community 254"
 Cohesion: 0.7
-Nodes (4): getActiveUser(), getBaseUrl(), getGuest(), updateUser()
+Nodes (4): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory()
 
 ### Community 255 - "Community 255"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.7
+Nodes (4): getBaseUrl(), getOrder(), getOrders(), updateOrdersOwner()
 
 ### Community 256 - "Community 256"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.7
+Nodes (4): getActiveUser(), getBaseUrl(), getGuest(), updateUser()
 
 ### Community 257 - "Community 257"
-Cohesion: 0.6
-Nodes (3): formatStoredAmount(), toDisplayAmount(), toPesewas()
-
-### Community 258 - "Community 258"
-Cohesion: 0.7
-Nodes (4): createStorefrontFailureEvent(), emitStorefrontFailure(), inferStorefrontJourneyFromRoute(), normalizeStorefrontError()
-
-### Community 259 - "Community 259"
 Cohesion: 0.4
 Nodes (0):
+
+### Community 258 - "Community 258"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 259 - "Community 259"
+Cohesion: 0.7
+Nodes (4): createStorefrontFailureEvent(), emitStorefrontFailure(), inferStorefrontJourneyFromRoute(), normalizeStorefrontError()
 
 ### Community 260 - "Community 260"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 261 - "Community 261"
-Cohesion: 0.6
-Nodes (4): collectHarnessRepoValidationSelection(), matchesHarnessRepoValidationPath(), normalizeRepoPath(), sortUniquePaths()
-
-### Community 262 - "Community 262"
 Cohesion: 0.4
 Nodes (0):
 
+### Community 262 - "Community 262"
+Cohesion: 0.6
+Nodes (4): collectHarnessRepoValidationSelection(), matchesHarnessRepoValidationPath(), normalizeRepoPath(), sortUniquePaths()
+
 ### Community 263 - "Community 263"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 264 - "Community 264"
 Cohesion: 0.7
 Nodes (4): createFixtureRepo(), fixtureEnv(), runGit(), runWorktreeManager()
 
-### Community 264 - "Community 264"
+### Community 265 - "Community 265"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 265 - "Community 265"
+### Community 266 - "Community 266"
 Cohesion: 0.67
 Nodes (2): maskReceiptPhone(), normalizeReceiptPhone()
 
-### Community 266 - "Community 266"
+### Community 267 - "Community 267"
 Cohesion: 0.83
 Nodes (3): createReceiptShareToken(), hashReceiptShareToken(), toHex()
 
-### Community 267 - "Community 267"
+### Community 268 - "Community 268"
 Cohesion: 0.83
 Nodes (3): timingSafeEqual(), toHex(), verifyMetaWebhookSignature()
-
-### Community 268 - "Community 268"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 269 - "Community 269"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 270 - "Community 270"
-Cohesion: 0.67
-Nodes (2): createExpenseTransactionFromSessionHandler(), expenseTransactionError()
-
-### Community 271 - "Community 271"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 271 - "Community 271"
+Cohesion: 0.67
+Nodes (2): createExpenseTransactionFromSessionHandler(), expenseTransactionError()
 
 ### Community 272 - "Community 272"
 Cohesion: 0.5
@@ -2797,72 +2799,72 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 274 - "Community 274"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 275 - "Community 275"
 Cohesion: 0.67
 Nodes (2): createProductsQueryCtx(), createSkuMutationCtx()
 
-### Community 275 - "Community 275"
+### Community 276 - "Community 276"
 Cohesion: 0.83
 Nodes (3): getCachedTokenRecord(), resolveAccessTokenForStore(), resolveConfigForStore()
 
-### Community 276 - "Community 276"
+### Community 277 - "Community 277"
 Cohesion: 0.67
 Nodes (2): maskMtnPartyId(), normalizeCollectionsTransaction()
 
-### Community 277 - "Community 277"
+### Community 278 - "Community 278"
 Cohesion: 0.67
 Nodes (2): consumeApprovalProofWithCtx(), invalidApprovalProofResult()
 
-### Community 278 - "Community 278"
+### Community 279 - "Community 279"
 Cohesion: 0.67
 Nodes (2): buildOperationalEvent(), recordOperationalEventWithCtx()
 
-### Community 279 - "Community 279"
+### Community 280 - "Community 280"
 Cohesion: 0.67
 Nodes (2): buildOperationalWorkItem(), createOperationalWorkItemWithCtx()
 
-### Community 280 - "Community 280"
+### Community 281 - "Community 281"
 Cohesion: 0.67
 Nodes (2): expectIndex(), getTableIndexes()
-
-### Community 281 - "Community 281"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 282 - "Community 282"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 283 - "Community 283"
-Cohesion: 0.83
-Nodes (3): resolveServiceIntakeCustomerProfile(), splitFullName(), trimOptional()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 284 - "Community 284"
 Cohesion: 0.83
-Nodes (3): mapOpenDrawerUserError(), normalizeRegisterNumber(), openDrawer()
+Nodes (3): resolveServiceIntakeCustomerProfile(), splitFullName(), trimOptional()
 
 ### Community 285 - "Community 285"
 Cohesion: 0.83
-Nodes (3): createDbGetMock(), createDbMock(), createDbQueryMock()
+Nodes (3): mapOpenDrawerUserError(), normalizeRegisterNumber(), openDrawer()
 
 ### Community 286 - "Community 286"
 Cohesion: 0.83
-Nodes (3): buildRegisterState(), getActiveSessionConflictForRegisterState(), getRegisterState()
+Nodes (3): createDbGetMock(), createDbMock(), createDbQueryMock()
 
 ### Community 287 - "Community 287"
+Cohesion: 0.83
+Nodes (3): buildRegisterState(), getActiveSessionConflictForRegisterState(), getRegisterState()
+
+### Community 288 - "Community 288"
 Cohesion: 0.67
 Nodes (2): lookupByBarcode(), mapSkuToCatalogResult()
 
-### Community 288 - "Community 288"
+### Community 289 - "Community 289"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 289 - "Community 289"
-Cohesion: 0.83
-Nodes (3): createPosLocalStaffProofToken(), hashPosLocalStaffProofToken(), toHex()
 
 ### Community 290 - "Community 290"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): createPosLocalStaffProofToken(), hashPosLocalStaffProofToken(), toHex()
 
 ### Community 291 - "Community 291"
 Cohesion: 0.5
@@ -2877,24 +2879,24 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 294 - "Community 294"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 295 - "Community 295"
 Cohesion: 0.67
 Nodes (2): expectIndex(), getTableIndexes()
 
-### Community 295 - "Community 295"
+### Community 296 - "Community 296"
 Cohesion: 0.83
 Nodes (3): findExistingCustomerProfileId(), getStoreOrganizationId(), recordStoreFrontCustomerMilestone()
 
-### Community 296 - "Community 296"
+### Community 297 - "Community 297"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 297 - "Community 297"
-Cohesion: 0.83
-Nodes (3): formatStaffDisplayName(), formatStaffDisplayNameOrFallback(), normalizeNamePart()
 
 ### Community 298 - "Community 298"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): formatStaffDisplayName(), formatStaffDisplayNameOrFallback(), normalizeNamePart()
 
 ### Community 299 - "Community 299"
 Cohesion: 0.5
@@ -2909,12 +2911,12 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 302 - "Community 302"
-Cohesion: 0.67
-Nodes (2): countGroupedAnalytics(), groupAnalytics()
-
-### Community 303 - "Community 303"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 303 - "Community 303"
+Cohesion: 0.67
+Nodes (2): countGroupedAnalytics(), groupAnalytics()
 
 ### Community 304 - "Community 304"
 Cohesion: 0.5
@@ -2937,24 +2939,24 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 309 - "Community 309"
-Cohesion: 0.67
-Nodes (2): handleSubmit(), resetReplacementFields()
-
-### Community 310 - "Community 310"
 Cohesion: 0.5
 Nodes (0):
 
+### Community 310 - "Community 310"
+Cohesion: 0.67
+Nodes (2): handleSubmit(), resetReplacementFields()
+
 ### Community 311 - "Community 311"
 Cohesion: 0.67
-Nodes (2): getLocalOperatingDate(), getLocalOperatingDateRange()
+Nodes (2): CashierAuthDialog(), getStaffDisplayName()
 
 ### Community 312 - "Community 312"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 313 - "Community 313"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): getLocalOperatingDate(), getLocalOperatingDateRange()
 
 ### Community 314 - "Community 314"
 Cohesion: 0.5
@@ -2969,20 +2971,20 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 317 - "Community 317"
-Cohesion: 0.67
-Nodes (2): applyCommandResult(), handleCreateCase()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 318 - "Community 318"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 319 - "Community 319"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): applyCommandResult(), handleCreateCase()
 
 ### Community 320 - "Community 320"
-Cohesion: 0.67
-Nodes (2): getRiskStyles(), RiskIndicators()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 321 - "Community 321"
 Cohesion: 0.5
@@ -2990,19 +2992,19 @@ Nodes (0):
 
 ### Community 322 - "Community 322"
 Cohesion: 0.67
-Nodes (2): useGetArchivedProducts(), useGetProducts()
+Nodes (2): getRiskStyles(), RiskIndicators()
 
 ### Community 323 - "Community 323"
-Cohesion: 1.0
-Nodes (3): canAccessFullAdminSurface(), canAccessStoreDaySurface(), getSurfaceAccess()
-
-### Community 324 - "Community 324"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 325 - "Community 325"
+### Community 324 - "Community 324"
 Cohesion: 0.67
-Nodes (2): extractTraceId(), runCommand()
+Nodes (2): useGetArchivedProducts(), useGetProducts()
+
+### Community 325 - "Community 325"
+Cohesion: 1.0
+Nodes (3): canAccessFullAdminSurface(), canAccessStoreDaySurface(), getSurfaceAccess()
 
 ### Community 326 - "Community 326"
 Cohesion: 0.5
@@ -3010,7 +3012,7 @@ Nodes (0):
 
 ### Community 327 - "Community 327"
 Cohesion: 0.67
-Nodes (2): formatStoredAmount(), formatStoredCurrencyAmount()
+Nodes (2): extractTraceId(), runCommand()
 
 ### Community 328 - "Community 328"
 Cohesion: 0.5
@@ -3018,59 +3020,59 @@ Nodes (0):
 
 ### Community 329 - "Community 329"
 Cohesion: 0.67
-Nodes (2): mapActiveSessionDto(), normalizeCartItems()
+Nodes (2): formatStoredAmount(), formatStoredCurrencyAmount()
 
 ### Community 330 - "Community 330"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 331 - "Community 331"
+Cohesion: 0.67
+Nodes (2): mapActiveSessionDto(), normalizeCartItems()
+
+### Community 332 - "Community 332"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 332 - "Community 332"
+### Community 333 - "Community 333"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 334 - "Community 334"
 Cohesion: 0.67
 Nodes (2): isSeedReadLoading(), resolveLocalPosEntryContext()
 
-### Community 333 - "Community 333"
+### Community 335 - "Community 335"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 336 - "Community 336"
 Cohesion: 0.83
 Nodes (3): derivePosLocalSyncStatus(), getContiguousSyncedSequence(), getSyncState()
 
-### Community 334 - "Community 334"
+### Community 337 - "Community 337"
 Cohesion: 0.83
 Nodes (3): isBrowserFingerprintResult(), readStoredTerminalFingerprint(), readStoredTerminalFingerprintHash()
 
-### Community 335 - "Community 335"
+### Community 338 - "Community 338"
 Cohesion: 0.67
 Nodes (2): getCashierDisplayName(), useExpenseRegisterViewModel()
 
-### Community 336 - "Community 336"
+### Community 339 - "Community 339"
 Cohesion: 0.67
 Nodes (2): buildPosSyncStatusPresentation(), normalizeStatus()
 
-### Community 337 - "Community 337"
+### Community 340 - "Community 340"
 Cohesion: 0.83
 Nodes (3): getBaseUrl(), getUserRedeemedOffers(), submitOffer()
 
-### Community 338 - "Community 338"
+### Community 341 - "Community 341"
 Cohesion: 0.83
 Nodes (3): getAllStores(), getBaseUrl(), getStore()
 
-### Community 339 - "Community 339"
+### Community 342 - "Community 342"
 Cohesion: 0.83
 Nodes (3): getAllSubcategories(), getBaseUrl(), getSubategory()
-
-### Community 340 - "Community 340"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 341 - "Community 341"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 342 - "Community 342"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 343 - "Community 343"
 Cohesion: 0.5
@@ -3093,68 +3095,68 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 348 - "Community 348"
-Cohesion: 0.67
-Nodes (2): useOptionalStoreContext(), useStoreContext()
-
-### Community 349 - "Community 349"
-Cohesion: 0.67
-Nodes (2): clearFilters(), onMobileFiltersCloseClick()
-
-### Community 350 - "Community 350"
-Cohesion: 0.83
-Nodes (3): cancelOrder(), getErrorMessage(), placeOrder()
-
-### Community 351 - "Community 351"
 Cohesion: 0.5
 Nodes (0):
 
+### Community 349 - "Community 349"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 350 - "Community 350"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 351 - "Community 351"
+Cohesion: 0.67
+Nodes (2): useOptionalStoreContext(), useStoreContext()
+
 ### Community 352 - "Community 352"
-Cohesion: 0.83
-Nodes (3): bootstrapCheckout(), createBootstrapToken(), createMarker()
+Cohesion: 0.67
+Nodes (2): clearFilters(), onMobileFiltersCloseClick()
 
 ### Community 353 - "Community 353"
 Cohesion: 0.83
-Nodes (3): createFixtureRoot(), write(), writeGraphifyWikiArtifacts()
+Nodes (3): cancelOrder(), getErrorMessage(), placeOrder()
 
 ### Community 354 - "Community 354"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 355 - "Community 355"
-Cohesion: 0.67
-Nodes (2): buildHarnessDocPaths(), buildHarnessDocPathsForArchetype()
+Cohesion: 0.83
+Nodes (3): bootstrapCheckout(), createBootstrapToken(), createMarker()
 
 ### Community 356 - "Community 356"
-Cohesion: 0.67
-Nodes (2): shutdown(), stopValkeyRuntimeServer()
+Cohesion: 0.83
+Nodes (3): createFixtureRoot(), write(), writeGraphifyWikiArtifacts()
 
 ### Community 357 - "Community 357"
-Cohesion: 0.83
-Nodes (3): createFixtureRepo(), createInferentialArtifact(), write()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 358 - "Community 358"
 Cohesion: 0.67
-Nodes (2): collectHarnessTestTargets(), runHarnessTest()
+Nodes (2): buildHarnessDocPaths(), buildHarnessDocPathsForArchetype()
 
 ### Community 359 - "Community 359"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): shutdown(), stopValkeyRuntimeServer()
 
 ### Community 360 - "Community 360"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): createFixtureRepo(), createInferentialArtifact(), write()
 
 ### Community 361 - "Community 361"
 Cohesion: 0.67
-Nodes (0):
+Nodes (2): collectHarnessTestTargets(), runHarnessTest()
 
 ### Community 362 - "Community 362"
-Cohesion: 0.67
+Cohesion: 0.5
 Nodes (0):
 
 ### Community 363 - "Community 363"
-Cohesion: 1.0
-Nodes (2): providerErrorCategory(), sendWhatsAppReceiptTemplate()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 364 - "Community 364"
 Cohesion: 0.67
@@ -3165,8 +3167,8 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 366 - "Community 366"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): providerErrorCategory(), sendWhatsAppReceiptTemplate()
 
 ### Community 367 - "Community 367"
 Cohesion: 0.67
@@ -3189,8 +3191,8 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 372 - "Community 372"
-Cohesion: 1.0
-Nodes (2): buildCtx(), createDb()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 373 - "Community 373"
 Cohesion: 0.67
@@ -3201,8 +3203,8 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 375 - "Community 375"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): buildCtx(), createDb()
 
 ### Community 376 - "Community 376"
 Cohesion: 0.67
@@ -3217,32 +3219,32 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 379 - "Community 379"
-Cohesion: 1.0
-Nodes (2): hashPosTerminalSyncSecret(), toHex()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 380 - "Community 380"
 Cohesion: 0.67
-Nodes (1): PosServerError
+Nodes (0):
 
 ### Community 381 - "Community 381"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 382 - "Community 382"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): hashPosTerminalSyncSecret(), toHex()
 
 ### Community 383 - "Community 383"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): PosServerError
 
 ### Community 384 - "Community 384"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 385 - "Community 385"
-Cohesion: 1.0
-Nodes (2): getActiveRegisterSessionForRegisterState(), mapRegisterSessionToCashDrawerSummary()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 386 - "Community 386"
 Cohesion: 0.67
@@ -3253,80 +3255,80 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 388 - "Community 388"
+Cohesion: 1.0
+Nodes (2): getActiveRegisterSessionForRegisterState(), mapRegisterSessionToCashDrawerSummary()
+
+### Community 389 - "Community 389"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 389 - "Community 389"
-Cohesion: 1.0
-Nodes (2): buildServiceCatalogItem(), normalizeServiceCatalogNameKey()
-
 ### Community 390 - "Community 390"
-Cohesion: 1.0
-Nodes (2): expectIndex(), getTableIndexes()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 391 - "Community 391"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 392 - "Community 392"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): buildServiceCatalogItem(), normalizeServiceCatalogNameKey()
 
 ### Community 393 - "Community 393"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): expectIndex(), getTableIndexes()
 
 ### Community 394 - "Community 394"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 395 - "Community 395"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 396 - "Community 396"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 397 - "Community 397"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 398 - "Community 398"
 Cohesion: 1.0
 Nodes (2): listBagItems(), loadBagWithItems()
 
-### Community 396 - "Community 396"
+### Community 399 - "Community 399"
 Cohesion: 1.0
 Nodes (2): buildRegisterSessionTraceSeed(), formatRegisterSessionLabel()
 
-### Community 397 - "Community 397"
+### Community 400 - "Community 400"
 Cohesion: 1.0
 Nodes (2): getWorkflowTraceViewByIdWithCtx(), getWorkflowTraceViewByLookupWithCtx()
 
-### Community 398 - "Community 398"
-Cohesion: 0.67
-Nodes (0):
-
-### Community 399 - "Community 399"
-Cohesion: 0.67
-Nodes (0):
-
-### Community 400 - "Community 400"
-Cohesion: 1.0
-Nodes (2): createWorkflowTraceId(), normalizeWorkflowTraceLookupValue()
-
 ### Community 401 - "Community 401"
 Cohesion: 0.67
-Nodes (1): View()
+Nodes (0):
 
 ### Community 402 - "Community 402"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 403 - "Community 403"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): createWorkflowTraceId(), normalizeWorkflowTraceLookupValue()
 
 ### Community 404 - "Community 404"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): View()
 
 ### Community 405 - "Community 405"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 406 - "Community 406"
-Cohesion: 1.0
-Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 407 - "Community 407"
 Cohesion: 0.67
@@ -3337,12 +3339,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 409 - "Community 409"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
 
 ### Community 410 - "Community 410"
 Cohesion: 0.67
-Nodes (1): FadeIn()
+Nodes (0):
 
 ### Community 411 - "Community 411"
 Cohesion: 0.67
@@ -3354,11 +3356,11 @@ Nodes (0):
 
 ### Community 413 - "Community 413"
 Cohesion: 0.67
-Nodes (1): VideoPlayer()
+Nodes (1): FadeIn()
 
 ### Community 414 - "Community 414"
-Cohesion: 1.0
-Nodes (2): handleRefundOrder(), toast()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 415 - "Community 415"
 Cohesion: 0.67
@@ -3366,11 +3368,11 @@ Nodes (0):
 
 ### Community 416 - "Community 416"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): VideoPlayer()
 
 ### Community 417 - "Community 417"
 Cohesion: 1.0
-Nodes (2): CashierAuthDialog(), getStaffDisplayName()
+Nodes (2): handleRefundOrder(), toast()
 
 ### Community 418 - "Community 418"
 Cohesion: 0.67
@@ -3426,83 +3428,83 @@ Nodes (0):
 
 ### Community 431 - "Community 431"
 Cohesion: 0.67
-Nodes (1): SingleLineError()
+Nodes (0):
 
 ### Community 432 - "Community 432"
 Cohesion: 0.67
-Nodes (1): ErrorPage()
+Nodes (0):
 
 ### Community 433 - "Community 433"
 Cohesion: 0.67
-Nodes (1): AppSkeleton()
+Nodes (1): SingleLineError()
 
 ### Community 434 - "Community 434"
 Cohesion: 0.67
-Nodes (1): DashboardSkeleton()
+Nodes (1): ErrorPage()
 
 ### Community 435 - "Community 435"
 Cohesion: 0.67
-Nodes (1): TableSkeleton()
+Nodes (1): AppSkeleton()
 
 ### Community 436 - "Community 436"
 Cohesion: 0.67
-Nodes (1): TransactionsSkeleton()
+Nodes (1): DashboardSkeleton()
 
 ### Community 437 - "Community 437"
 Cohesion: 0.67
-Nodes (1): NotFound()
+Nodes (1): TableSkeleton()
 
 ### Community 438 - "Community 438"
-Cohesion: 1.0
-Nodes (2): getWorkflowTraceRouteTarget(), WorkflowTraceRouteLink()
+Cohesion: 0.67
+Nodes (1): TransactionsSkeleton()
 
 ### Community 439 - "Community 439"
 Cohesion: 0.67
-Nodes (1): AppContextMenu()
+Nodes (1): NotFound()
 
 ### Community 440 - "Community 440"
-Cohesion: 0.67
-Nodes (1): Badge()
+Cohesion: 1.0
+Nodes (2): getWorkflowTraceRouteTarget(), WorkflowTraceRouteLink()
 
 ### Community 441 - "Community 441"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): AppContextMenu()
 
 ### Community 442 - "Community 442"
 Cohesion: 0.67
-Nodes (1): LoadingButton()
+Nodes (1): Badge()
 
 ### Community 443 - "Community 443"
 Cohesion: 0.67
-Nodes (1): onChange()
+Nodes (0):
 
 ### Community 444 - "Community 444"
 Cohesion: 0.67
-Nodes (1): AlertModal()
+Nodes (1): LoadingButton()
 
 ### Community 445 - "Community 445"
 Cohesion: 0.67
-Nodes (1): OverlayModal()
+Nodes (1): onChange()
 
 ### Community 446 - "Community 446"
 Cohesion: 0.67
-Nodes (1): Skeleton()
+Nodes (1): AlertModal()
 
 ### Community 447 - "Community 447"
 Cohesion: 0.67
-Nodes (1): Toaster()
+Nodes (1): OverlayModal()
 
 ### Community 448 - "Community 448"
 Cohesion: 0.67
-Nodes (1): Spinner()
+Nodes (1): Skeleton()
 
 ### Community 449 - "Community 449"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): Toaster()
 
 ### Community 450 - "Community 450"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): Spinner()
 
 ### Community 451 - "Community 451"
 Cohesion: 0.67
@@ -3530,7 +3532,7 @@ Nodes (0):
 
 ### Community 457 - "Community 457"
 Cohesion: 0.67
-Nodes (1): useAuth()
+Nodes (0):
 
 ### Community 458 - "Community 458"
 Cohesion: 0.67
@@ -3538,27 +3540,27 @@ Nodes (0):
 
 ### Community 459 - "Community 459"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): useAuth()
 
 ### Community 460 - "Community 460"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 461 - "Community 461"
-Cohesion: 1.0
-Nodes (2): getApprovalGuidance(), presentCommandToast()
-
-### Community 462 - "Community 462"
-Cohesion: 0.67
-Nodes (1): isInMaintenanceMode()
-
-### Community 463 - "Community 463"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 464 - "Community 464"
+### Community 462 - "Community 462"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 463 - "Community 463"
 Cohesion: 1.0
-Nodes (2): createTerminalSyncSecretToken(), registerAndProvisionPosTerminal()
+Nodes (2): getApprovalGuidance(), presentCommandToast()
+
+### Community 464 - "Community 464"
+Cohesion: 0.67
+Nodes (1): isInMaintenanceMode()
 
 ### Community 465 - "Community 465"
 Cohesion: 0.67
@@ -3566,15 +3568,15 @@ Nodes (0):
 
 ### Community 466 - "Community 466"
 Cohesion: 1.0
-Nodes (2): readProjectedLocalRegisterModel(), readScopedPosLocalEvents()
+Nodes (2): createTerminalSyncSecretToken(), registerAndProvisionPosTerminal()
 
 ### Community 467 - "Community 467"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 468 - "Community 468"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): readProjectedLocalRegisterModel(), readScopedPosLocalEvents()
 
 ### Community 469 - "Community 469"
 Cohesion: 0.67
@@ -3590,67 +3592,67 @@ Nodes (0):
 
 ### Community 472 - "Community 472"
 Cohesion: 0.67
-Nodes (1): App()
+Nodes (0):
 
 ### Community 473 - "Community 473"
-Cohesion: 1.0
-Nodes (2): collectSourceFiles(), findIllegalConvexImports()
+Cohesion: 0.67
+Nodes (1): App()
 
 ### Community 474 - "Community 474"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): collectSourceFiles(), findIllegalConvexImports()
 
 ### Community 475 - "Community 475"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 476 - "Community 476"
-Cohesion: 1.0
-Nodes (2): getAthenaDesignTokenStyle(), withAthenaTheme()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 477 - "Community 477"
 Cohesion: 1.0
-Nodes (2): mockGetSku(), validateInventoryForTransaction()
+Nodes (2): getAthenaDesignTokenStyle(), withAthenaTheme()
 
 ### Community 478 - "Community 478"
-Cohesion: 0.67
-Nodes (1): hashPassword()
+Cohesion: 1.0
+Nodes (2): mockGetSku(), validateInventoryForTransaction()
 
 ### Community 479 - "Community 479"
 Cohesion: 0.67
-Nodes (1): createVersionChecker()
+Nodes (1): hashPassword()
 
 ### Community 480 - "Community 480"
 Cohesion: 0.67
-Nodes (1): manualChunks()
+Nodes (1): createVersionChecker()
 
 ### Community 481 - "Community 481"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): manualChunks()
 
 ### Community 482 - "Community 482"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 483 - "Community 483"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 484 - "Community 484"
 Cohesion: 1.0
 Nodes (2): getAllColors(), getBaseUrl()
 
-### Community 484 - "Community 484"
+### Community 485 - "Community 485"
 Cohesion: 0.67
 Nodes (0):
-
-### Community 485 - "Community 485"
-Cohesion: 1.0
-Nodes (2): getBaseUrl(), getLastViewedProduct()
 
 ### Community 486 - "Community 486"
 Cohesion: 1.0
-Nodes (2): getBaseUrl(), getUserOffersEligibility()
+Nodes (2): getBaseUrl(), getLastViewedProduct()
 
 ### Community 487 - "Community 487"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getBaseUrl(), getUserOffersEligibility()
 
 ### Community 488 - "Community 488"
 Cohesion: 0.67
@@ -3665,12 +3667,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 491 - "Community 491"
-Cohesion: 1.0
-Nodes (2): handleKeyDown(), handleRedeemPromoCode()
-
-### Community 492 - "Community 492"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 492 - "Community 492"
+Cohesion: 1.0
+Nodes (2): handleKeyDown(), handleRedeemPromoCode()
 
 ### Community 493 - "Community 493"
 Cohesion: 0.67
@@ -3681,12 +3683,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 495 - "Community 495"
-Cohesion: 1.0
-Nodes (2): getPromoAlertCopy(), PromoAlert()
-
-### Community 496 - "Community 496"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 496 - "Community 496"
+Cohesion: 1.0
+Nodes (2): getPromoAlertCopy(), PromoAlert()
 
 ### Community 497 - "Community 497"
 Cohesion: 0.67
@@ -3753,16 +3755,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 513 - "Community 513"
-Cohesion: 1.0
-Nodes (2): collectWorkflowFiles(), runWorkflowCheck()
-
-### Community 514 - "Community 514"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 515 - "Community 515"
+### Community 514 - "Community 514"
 Cohesion: 1.0
-Nodes (2): createFixtureRepo(), write()
+Nodes (2): collectWorkflowFiles(), runWorkflowCheck()
+
+### Community 515 - "Community 515"
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 516 - "Community 516"
 Cohesion: 1.0
@@ -3781,20 +3783,20 @@ Cohesion: 1.0
 Nodes (2): createFixtureRepo(), write()
 
 ### Community 520 - "Community 520"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): createFixtureRepo(), write()
 
 ### Community 521 - "Community 521"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 522 - "Community 522"
-Cohesion: 1.0
-Nodes (2): collectRootScriptTestFiles(), runRootScriptsCoverage()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 523 - "Community 523"
 Cohesion: 1.0
-Nodes (0):
+Nodes (2): collectRootScriptTestFiles(), runRootScriptsCoverage()
 
 ### Community 524 - "Community 524"
 Cohesion: 1.0
@@ -8352,2288 +8354,2298 @@ Nodes (0):
 Cohesion: 1.0
 Nodes (0):
 
+### Community 1663 - "Community 1663"
+Cohesion: 1.0
+Nodes (0):
+
+### Community 1664 - "Community 1664"
+Cohesion: 1.0
+Nodes (0):
+
 ## Knowledge Gaps
 - **1 isolated node(s):** `HelpRequested`
   These have ≤1 connection - possible missing edges or undocumented components.
-- **Thin community `Community 523`** (2 nodes): `paymentAllocationAttribution.test.ts`, `readProjectFile()`
+- **Thin community `Community 524`** (2 nodes): `paymentAllocationAttribution.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 524`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
+- **Thin community `Community 525`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 525`** (2 nodes): `createCommandShimBin()`, `convexAuditScript.test.ts`
+- **Thin community `Community 526`** (2 nodes): `createCommandShimBin()`, `convexAuditScript.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 526`** (2 nodes): `policy.ts`, `assertSupportedCustomerMessagePolicy()`
+- **Thin community `Community 527`** (2 nodes): `policy.ts`, `assertSupportedCustomerMessagePolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 527`** (2 nodes): `repository.test.ts`, `queryResult()`
+- **Thin community `Community 528`** (2 nodes): `repository.test.ts`, `queryResult()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 528`** (2 nodes): `webhookSecurity.test.ts`, `sign()`
+- **Thin community `Community 529`** (2 nodes): `webhookSecurity.test.ts`, `sign()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 529`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
+- **Thin community `Community 530`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 530`** (2 nodes): `subcategories.ts`, `removeStorefrontHiddenSubcategoryList()`
+- **Thin community `Community 531`** (2 nodes): `subcategories.ts`, `removeStorefrontHiddenSubcategoryList()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 531`** (2 nodes): `storefrontCors.test.ts`, `readRouteFile()`
+- **Thin community `Community 532`** (2 nodes): `storefrontCors.test.ts`, `readRouteFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 532`** (2 nodes): `whatsapp.ts`, `mapWebhookStatus()`
+- **Thin community `Community 533`** (2 nodes): `whatsapp.ts`, `mapWebhookStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 533`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
+- **Thin community `Community 534`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 534`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
+- **Thin community `Community 535`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 535`** (2 nodes): `mapAthenaAuthSyncError()`, `auth.ts`
+- **Thin community `Community 536`** (2 nodes): `mapAthenaAuthSyncError()`, `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 536`** (2 nodes): `getHandler()`, `bestSeller.test.ts`
+- **Thin community `Community 537`** (2 nodes): `getHandler()`, `bestSeller.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 537`** (2 nodes): `userErrorFromExpenseItemCommandFailure()`, `expenseSessionItems.ts`
+- **Thin community `Community 538`** (2 nodes): `userErrorFromExpenseItemCommandFailure()`, `expenseSessionItems.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 538`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
+- **Thin community `Community 539`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 539`** (2 nodes): `posSessionItems.ts`, `userErrorFromSessionItemFailure()`
+- **Thin community `Community 540`** (2 nodes): `posSessionItems.ts`, `userErrorFromSessionItemFailure()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 540`** (2 nodes): `productUtil.ts`, `buildAllProductsCacheKey()`
+- **Thin community `Community 541`** (2 nodes): `productUtil.ts`, `buildAllProductsCacheKey()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 541`** (2 nodes): `promoCode.ts`, `calculateSelectedProductPromoDiscount()`
+- **Thin community `Community 542`** (2 nodes): `promoCode.ts`, `calculateSelectedProductPromoDiscount()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 542`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
+- **Thin community `Community 543`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 543`** (2 nodes): `commandResultValidator()`, `commandResultValidators.ts`
+- **Thin community `Community 544`** (2 nodes): `commandResultValidator()`, `commandResultValidators.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 544`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
+- **Thin community `Community 545`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 545`** (2 nodes): `callAnthropic()`, `anthropic.ts`
+- **Thin community `Community 546`** (2 nodes): `callAnthropic()`, `anthropic.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 546`** (2 nodes): `callOpenAi()`, `openai.ts`
+- **Thin community `Community 547`** (2 nodes): `callOpenAi()`, `openai.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 547`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
+- **Thin community `Community 548`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 548`** (2 nodes): `consumeCommandApprovalProofWithCtx()`, `approvalActions.ts`
+- **Thin community `Community 549`** (2 nodes): `consumeCommandApprovalProofWithCtx()`, `approvalActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 549`** (2 nodes): `createOperationalEventCtx()`, `approvalAuditEvents.test.ts`
+- **Thin community `Community 550`** (2 nodes): `createOperationalEventCtx()`, `approvalAuditEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 550`** (2 nodes): `createApprovalProofMutationCtx()`, `approvalProofs.test.ts`
+- **Thin community `Community 551`** (2 nodes): `createApprovalProofMutationCtx()`, `approvalProofs.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 551`** (2 nodes): `buildApprovalRequest()`, `approvalRequestHelpers.ts`
+- **Thin community `Community 552`** (2 nodes): `buildApprovalRequest()`, `approvalRequestHelpers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 552`** (2 nodes): `createApprovalRequestMutationCtx()`, `approvalRequests.test.ts`
+- **Thin community `Community 553`** (2 nodes): `createApprovalRequestMutationCtx()`, `approvalRequests.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 553`** (2 nodes): `buildOperationalEventMessage()`, `eventBuilders.ts`
+- **Thin community `Community 554`** (2 nodes): `buildOperationalEventMessage()`, `eventBuilders.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 554`** (2 nodes): `createInventoryMovementCtx()`, `inventoryMovements.test.ts`
+- **Thin community `Community 555`** (2 nodes): `createInventoryMovementCtx()`, `inventoryMovements.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 555`** (2 nodes): `skuActivity.test.ts`, `createIndexedDb()`
+- **Thin community `Community 556`** (2 nodes): `skuActivity.test.ts`, `createIndexedDb()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 556`** (2 nodes): `formatValidTime()`, `EmailOTP.ts`
+- **Thin community `Community 557`** (2 nodes): `formatValidTime()`, `EmailOTP.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 557`** (2 nodes): `quickAddCatalogItem.test.ts`, `createQuickAddCtx()`
+- **Thin community `Community 558`** (2 nodes): `quickAddCatalogItem.test.ts`, `createQuickAddCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 558`** (2 nodes): `expectNoCompletionSideEffects()`, `completeTransaction.test.ts`
+- **Thin community `Community 559`** (2 nodes): `expectNoCompletionSideEffects()`, `completeTransaction.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 559`** (2 nodes): `createMutationCtx()`, `correctTransactionPaymentMethod.test.ts`
+- **Thin community `Community 560`** (2 nodes): `createMutationCtx()`, `correctTransactionPaymentMethod.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 560`** (2 nodes): `buildCorrectionOperationalEvent()`, `correctionEvents.ts`
+- **Thin community `Community 561`** (2 nodes): `buildCorrectionOperationalEvent()`, `correctionEvents.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 561`** (2 nodes): `mockCorrectionHistoryDb()`, `getTransactions.test.ts`
+- **Thin community `Community 562`** (2 nodes): `mockCorrectionHistoryDb()`, `getTransactions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 562`** (2 nodes): `createRegisterCatalogCtx()`, `listRegisterCatalog.test.ts`
+- **Thin community `Community 563`** (2 nodes): `createRegisterCatalogCtx()`, `listRegisterCatalog.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 563`** (2 nodes): `getCashierForRegisterState()`, `cashierRepository.ts`
+- **Thin community `Community 564`** (2 nodes): `getCashierForRegisterState()`, `cashierRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 564`** (2 nodes): `createExpenseSessionCommandRepository()`, `expenseSessionCommandRepository.ts`
+- **Thin community `Community 565`** (2 nodes): `createExpenseSessionCommandRepository()`, `expenseSessionCommandRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 565`** (2 nodes): `createConvexLocalSyncRepository()`, `localSyncRepository.ts`
+- **Thin community `Community 566`** (2 nodes): `createConvexLocalSyncRepository()`, `localSyncRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 566`** (2 nodes): `sessionCommandRepository.test.ts`, `readProjectFile()`
+- **Thin community `Community 567`** (2 nodes): `sessionCommandRepository.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 567`** (2 nodes): `sessionRepository.test.ts`, `buildSession()`
+- **Thin community `Community 568`** (2 nodes): `sessionRepository.test.ts`, `buildSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 568`** (2 nodes): `transactions.ts`, `mapCorrectionError()`
+- **Thin community `Community 569`** (2 nodes): `transactions.ts`, `mapCorrectionError()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 569`** (2 nodes): `getSource()`, `moduleWiring.test.ts`
+- **Thin community `Community 570`** (2 nodes): `getSource()`, `moduleWiring.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 570`** (2 nodes): `createStockOpsAccessQueryCtx()`, `access.test.ts`
+- **Thin community `Community 571`** (2 nodes): `createStockOpsAccessQueryCtx()`, `access.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 571`** (2 nodes): `requireStoreFullAdminAccess()`, `access.ts`
+- **Thin community `Community 572`** (2 nodes): `requireStoreFullAdminAccess()`, `access.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 572`** (2 nodes): `createCycleCountDraftCtx()`, `cycleCountDrafts.test.ts`
+- **Thin community `Community 573`** (2 nodes): `createCycleCountDraftCtx()`, `cycleCountDrafts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 573`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
+- **Thin community `Community 574`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 574`** (2 nodes): `createReservationActivityCtx()`, `checkoutSession.test.ts`
+- **Thin community `Community 575`** (2 nodes): `createReservationActivityCtx()`, `checkoutSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 575`** (2 nodes): `createQueryCtx()`, `customerBehaviorTimeline.test.ts`
+- **Thin community `Community 576`** (2 nodes): `createQueryCtx()`, `customerBehaviorTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 576`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
+- **Thin community `Community 577`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 577`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
+- **Thin community `Community 578`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 578`** (2 nodes): `createMutationCtx()`, `customerEngagementEvents.test.ts`
+- **Thin community `Community 579`** (2 nodes): `createMutationCtx()`, `customerEngagementEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 579`** (2 nodes): `getSource()`, `onlineOrder.test.ts`
+- **Thin community `Community 580`** (2 nodes): `getSource()`, `onlineOrder.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 580`** (2 nodes): `updateOnlineOrderItem()`, `onlineOrderItem.ts`
+- **Thin community `Community 581`** (2 nodes): `updateOnlineOrderItem()`, `onlineOrderItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 581`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
+- **Thin community `Community 582`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 582`** (2 nodes): `rewards.ts`, `formatPointsLabel()`
+- **Thin community `Community 583`** (2 nodes): `rewards.ts`, `formatPointsLabel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 583`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
+- **Thin community `Community 584`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 584`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
+- **Thin community `Community 585`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 585`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
+- **Thin community `Community 586`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 586`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
+- **Thin community `Community 587`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 587`** (2 nodes): `user.ts`, `getStoreFrontActorById()`
+- **Thin community `Community 588`** (2 nodes): `user.ts`, `getStoreFrontActorById()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 588`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
+- **Thin community `Community 589`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 589`** (2 nodes): `buildExpenseSessionTraceSeed()`, `expenseSession.ts`
+- **Thin community `Community 590`** (2 nodes): `buildExpenseSessionTraceSeed()`, `expenseSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 590`** (2 nodes): `posSession.ts`, `buildPosSessionTraceSeed()`
+- **Thin community `Community 591`** (2 nodes): `posSession.ts`, `buildPosSessionTraceSeed()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 591`** (2 nodes): `presentation.ts`, `buildWorkflowTraceViewModel()`
+- **Thin community `Community 592`** (2 nodes): `presentation.ts`, `buildWorkflowTraceViewModel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 592`** (2 nodes): `schemaIndexes.test.ts`, `getTableIndexes()`
+- **Thin community `Community 593`** (2 nodes): `schemaIndexes.test.ts`, `getTableIndexes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 593`** (2 nodes): `serviceIntake.ts`, `validateServiceIntakeInput()`
+- **Thin community `Community 594`** (2 nodes): `serviceIntake.ts`, `validateServiceIntakeInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 594`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
+- **Thin community `Community 595`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 595`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
+- **Thin community `Community 596`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 596`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
+- **Thin community `Community 597`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 597`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
+- **Thin community `Community 598`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 598`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
+- **Thin community `Community 599`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 599`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
+- **Thin community `Community 600`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 600`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
+- **Thin community `Community 601`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 601`** (2 nodes): `StoreView.tsx`, `Navigation()`
+- **Thin community `Community 602`** (2 nodes): `StoreView.tsx`, `Navigation()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 602`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
+- **Thin community `Community 603`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 603`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
+- **Thin community `Community 604`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 604`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
+- **Thin community `Community 605`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 605`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
+- **Thin community `Community 606`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 606`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
+- **Thin community `Community 607`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 607`** (2 nodes): `ProductImages.tsx`, `Header()`
+- **Thin community `Community 608`** (2 nodes): `ProductImages.tsx`, `Header()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 608`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
+- **Thin community `Community 609`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 609`** (2 nodes): `setIsUpdatingSku()`, `CopyImagesView.tsx`
+- **Thin community `Community 610`** (2 nodes): `setIsUpdatingSku()`, `CopyImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 610`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
+- **Thin community `Community 611`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 611`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
+- **Thin community `Community 612`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 612`** (2 nodes): `AnalyticsCombinedUsers()`, `AnalyticsCombinedUsers.tsx`
+- **Thin community `Community 613`** (2 nodes): `AnalyticsCombinedUsers()`, `AnalyticsCombinedUsers.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 613`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
+- **Thin community `Community 614`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 614`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
+- **Thin community `Community 615`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 615`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
+- **Thin community `Community 616`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 616`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
+- **Thin community `Community 617`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 617`** (2 nodes): `StoreInsights.tsx`, `getTrendIcon()`
+- **Thin community `Community 618`** (2 nodes): `StoreInsights.tsx`, `getTrendIcon()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 618`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
+- **Thin community `Community 619`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 619`** (2 nodes): `readSource()`, `analyticsWorkspaceEfficiency.test.ts`
+- **Thin community `Community 620`** (2 nodes): `readSource()`, `analyticsWorkspaceEfficiency.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 620`** (2 nodes): `LogItems()`, `LogItems.tsx`
+- **Thin community `Community 621`** (2 nodes): `LogItems()`, `LogItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 621`** (2 nodes): `Header()`, `LogView.tsx`
+- **Thin community `Community 622`** (2 nodes): `Header()`, `LogView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 622`** (2 nodes): `Navigation()`, `LogsView.tsx`
+- **Thin community `Community 623`** (2 nodes): `Navigation()`, `LogsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 623`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
+- **Thin community `Community 624`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 624`** (2 nodes): `Passthrough()`, `app-sidebar.test.tsx`
+- **Thin community `Community 625`** (2 nodes): `Passthrough()`, `app-sidebar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 625`** (2 nodes): `SidebarMenuCollapsible()`, `app-sidebar.tsx`
+- **Thin community `Community 626`** (2 nodes): `SidebarMenuCollapsible()`, `app-sidebar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 626`** (2 nodes): `Auth()`, `Auth.tsx`
+- **Thin community `Community 627`** (2 nodes): `Auth()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 627`** (2 nodes): `resolveSignIn()`, `InputOTP.test.tsx`
+- **Thin community `Community 628`** (2 nodes): `resolveSignIn()`, `InputOTP.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 628`** (2 nodes): `Login()`, `index.tsx`
+- **Thin community `Community 629`** (2 nodes): `Login()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 629`** (2 nodes): `DataTableColumnHeader()`, `data-table-column-header.tsx`
+- **Thin community `Community 630`** (2 nodes): `DataTableColumnHeader()`, `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 630`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
+- **Thin community `Community 631`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 631`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
+- **Thin community `Community 632`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 632`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
+- **Thin community `Community 633`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 633`** (2 nodes): `formatReviewReason()`, `formatReviewReason.ts`
+- **Thin community `Community 634`** (2 nodes): `formatReviewReason()`, `formatReviewReason.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 634`** (2 nodes): `registerSessionColumns.tsx`, `RegisterSessionLink()`
+- **Thin community `Community 635`** (2 nodes): `registerSessionColumns.tsx`, `RegisterSessionLink()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 635`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
+- **Thin community `Community 636`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 636`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
+- **Thin community `Community 637`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 637`** (2 nodes): `ExpenseCompletion()`, `ExpenseCompletion.tsx`
+- **Thin community `Community 638`** (2 nodes): `ExpenseCompletion()`, `ExpenseCompletion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 638`** (2 nodes): `ExpenseView()`, `ExpenseView.tsx`
+- **Thin community `Community 639`** (2 nodes): `ExpenseView()`, `ExpenseView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 639`** (2 nodes): `handleAddBestSeller()`, `BestSellersDialog.tsx`
+- **Thin community `Community 640`** (2 nodes): `handleAddBestSeller()`, `BestSellersDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 640`** (2 nodes): `handleAddFeaturedItem()`, `FeaturedSectionDialog.tsx`
+- **Thin community `Community 641`** (2 nodes): `handleAddFeaturedItem()`, `FeaturedSectionDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 641`** (2 nodes): `Navigation()`, `Home.tsx`
+- **Thin community `Community 642`** (2 nodes): `Navigation()`, `Home.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 642`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
+- **Thin community `Community 643`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 643`** (2 nodes): `ShopLookDialog.tsx`, `handleAddFeaturedItem()`
+- **Thin community `Community 644`** (2 nodes): `ShopLookDialog.tsx`, `handleAddFeaturedItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 644`** (2 nodes): `ShopLookImageUploader.tsx`, `ShopLookImageUploader()`
+- **Thin community `Community 645`** (2 nodes): `ShopLookImageUploader.tsx`, `ShopLookImageUploader()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 645`** (2 nodes): `JoinTeam()`, `index.tsx`
+- **Thin community `Community 646`** (2 nodes): `JoinTeam()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 646`** (2 nodes): `Reveal()`, `AthenaLandingPage.tsx`
+- **Thin community `Community 647`** (2 nodes): `Reveal()`, `AthenaLandingPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 647`** (2 nodes): `cn()`, `OperationReviewItemCard.tsx`
+- **Thin community `Community 648`** (2 nodes): `cn()`, `OperationReviewItemCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 648`** (2 nodes): `buildParams()`, `OperationsSummaryMetric.tsx`
+- **Thin community `Community 649`** (2 nodes): `buildParams()`, `OperationsSummaryMetric.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 649`** (2 nodes): `StockAdjustmentWorkspace.test.tsx`, `renderStockAdjustmentWorkspace()`
+- **Thin community `Community 650`** (2 nodes): `StockAdjustmentWorkspace.test.tsx`, `renderStockAdjustmentWorkspace()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 650`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
+- **Thin community `Community 651`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 651`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
+- **Thin community `Community 652`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 652`** (2 nodes): `OrderMetricsPanel()`, `OrderMetricsPanel.tsx`
+- **Thin community `Community 653`** (2 nodes): `OrderMetricsPanel()`, `OrderMetricsPanel.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 653`** (2 nodes): `getTimeFilter()`, `OrdersView.tsx`
+- **Thin community `Community 654`** (2 nodes): `getTimeFilter()`, `OrdersView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 654`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
+- **Thin community `Community 655`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 655`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
+- **Thin community `Community 656`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 656`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
+- **Thin community `Community 657`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 657`** (2 nodes): `if()`, `orderColumns.tsx`
+- **Thin community `Community 658`** (2 nodes): `if()`, `orderColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 658`** (2 nodes): `OrganizationSwitcher()`, `organization-switcher.tsx`
+- **Thin community `Community 659`** (2 nodes): `OrganizationSwitcher()`, `organization-switcher.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 659`** (2 nodes): `cn()`, `CartItems.tsx`
+- **Thin community `Community 660`** (2 nodes): `cn()`, `CartItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 660`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
+- **Thin community `Community 661`** (2 nodes): `buildLocalAuthorityRecord()`, `CashierAuthDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 661`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
+- **Thin community `Community 662`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 662`** (2 nodes): `PinInput.tsx`, `PinInput()`
+- **Thin community `Community 663`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 663`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
+- **Thin community `Community 664`** (2 nodes): `PinInput.tsx`, `PinInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 664`** (2 nodes): `ProductCard.tsx`, `ProductCard()`
+- **Thin community `Community 665`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 665`** (2 nodes): `SearchResultsSection.test.tsx`, `buildProduct()`
+- **Thin community `Community 666`** (2 nodes): `ProductCard.tsx`, `ProductCard()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 666`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
+- **Thin community `Community 667`** (2 nodes): `SearchResultsSection.test.tsx`, `buildProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 667`** (2 nodes): `isToday()`, `ExpenseReportsView.tsx`
+- **Thin community `Community 668`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 668`** (2 nodes): `toExpenseReportRows()`, `expenseReportRows.ts`
+- **Thin community `Community 669`** (2 nodes): `isToday()`, `ExpenseReportsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 669`** (2 nodes): `ExpenseCompletionPanel()`, `ExpenseCompletionPanel.tsx`
+- **Thin community `Community 670`** (2 nodes): `toExpenseReportRows()`, `expenseReportRows.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 670`** (2 nodes): `RegisterCustomerAttribution.test.tsx`, `makeCustomer()`
+- **Thin community `Community 671`** (2 nodes): `ExpenseCompletionPanel()`, `ExpenseCompletionPanel.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 671`** (2 nodes): `RegisterCustomerPanel.tsx`, `RegisterCustomerPanel()`
+- **Thin community `Community 672`** (2 nodes): `RegisterCustomerAttribution.test.tsx`, `makeCustomer()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 672`** (2 nodes): `RegisterDrawerGate.test.tsx`, `renderGate()`
+- **Thin community `Community 673`** (2 nodes): `RegisterCustomerPanel.tsx`, `RegisterCustomerPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 673`** (2 nodes): `RegisterSessionPanel.tsx`, `RegisterSessionPanel()`
+- **Thin community `Community 674`** (2 nodes): `RegisterDrawerGate.test.tsx`, `renderGate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 674`** (2 nodes): `transactionColumns.test.tsx`, `renderTransactionCell()`
+- **Thin community `Community 675`** (2 nodes): `RegisterSessionPanel.tsx`, `RegisterSessionPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 675`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
+- **Thin community `Community 676`** (2 nodes): `transactionColumns.test.tsx`, `renderTransactionCell()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 676`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
+- **Thin community `Community 677`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 677`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
+- **Thin community `Community 678`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 678`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
+- **Thin community `Community 679`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 679`** (2 nodes): `ProductStatus.tsx`, `ProductStatus()`
+- **Thin community `Community 680`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 680`** (2 nodes): `SKUSelector.tsx`, `SKUSelector()`
+- **Thin community `Community 681`** (2 nodes): `ProductStatus.tsx`, `ProductStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 681`** (2 nodes): `product-actions.tsx`, `useArchiveProduct()`
+- **Thin community `Community 682`** (2 nodes): `SKUSelector.tsx`, `SKUSelector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 682`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
+- **Thin community `Community 683`** (2 nodes): `product-actions.tsx`, `useArchiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 683`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
+- **Thin community `Community 684`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 684`** (2 nodes): `Products.tsx`, `Products()`
+- **Thin community `Community 685`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 685`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
+- **Thin community `Community 686`** (2 nodes): `Products.tsx`, `Products()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 686`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
+- **Thin community `Community 687`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 687`** (2 nodes): `PromoCodePreview.tsx`, `Discount()`
+- **Thin community `Community 688`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 688`** (2 nodes): `PromoCodesView.test.tsx`, `readSource()`
+- **Thin community `Community 689`** (2 nodes): `PromoCodePreview.tsx`, `Discount()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 689`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
+- **Thin community `Community 690`** (2 nodes): `PromoCodesView.test.tsx`, `readSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 690`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
+- **Thin community `Community 691`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 691`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
+- **Thin community `Community 692`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 692`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
+- **Thin community `Community 693`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 693`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
+- **Thin community `Community 694`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 694`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
+- **Thin community `Community 695`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 695`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
+- **Thin community `Community 696`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 696`** (2 nodes): `ServiceCasesView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 697`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 697`** (2 nodes): `ServiceCatalogView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 698`** (2 nodes): `ServiceCasesView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 698`** (2 nodes): `ServiceIntakeForm.tsx`, `ServiceIntakeForm()`
+- **Thin community `Community 699`** (2 nodes): `ServiceCatalogView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 699`** (2 nodes): `ServiceIntakeView.auth.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 700`** (2 nodes): `ServiceIntakeForm.tsx`, `ServiceIntakeForm()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 700`** (2 nodes): `ServiceIntakeView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 701`** (2 nodes): `ServiceIntakeView.auth.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 701`** (2 nodes): `StaffAuthenticationDialog.tsx`, `handleKeyDown()`
+- **Thin community `Community 702`** (2 nodes): `ServiceIntakeView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 702`** (2 nodes): `onClick()`, `empty-state.tsx`
+- **Thin community `Community 703`** (2 nodes): `StaffAuthenticationDialog.tsx`, `handleKeyDown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 703`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
+- **Thin community `Community 704`** (2 nodes): `onClick()`, `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 704`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
+- **Thin community `Community 705`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 705`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
+- **Thin community `Community 706`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 706`** (2 nodes): `ProtectedAdminSignInView.tsx`, `ProtectedAdminSignInView()`
+- **Thin community `Community 707`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 707`** (2 nodes): `ContactView()`, `ContactView.tsx`
+- **Thin community `Community 708`** (2 nodes): `ProtectedAdminSignInView.tsx`, `ProtectedAdminSignInView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 708`** (2 nodes): `Header()`, `Header.tsx`
+- **Thin community `Community 709`** (2 nodes): `ContactView()`, `ContactView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 709`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
+- **Thin community `Community 710`** (2 nodes): `Header()`, `Header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 710`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
+- **Thin community `Community 711`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 711`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
+- **Thin community `Community 712`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 712`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
+- **Thin community `Community 713`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 713`** (2 nodes): `useChart()`, `chart.tsx`
+- **Thin community `Community 714`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 714`** (2 nodes): `handleCopy()`, `copy-button.tsx`
+- **Thin community `Community 715`** (2 nodes): `useChart()`, `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 715`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
+- **Thin community `Community 716`** (2 nodes): `handleCopy()`, `copy-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 716`** (2 nodes): `Label()`, `label.tsx`
+- **Thin community `Community 717`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 717`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
+- **Thin community `Community 718`** (2 nodes): `Label()`, `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 718`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
+- **Thin community `Community 719`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 719`** (2 nodes): `store-modal.tsx`, `onSubmit()`
+- **Thin community `Community 720`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 720`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
+- **Thin community `Community 721`** (2 nodes): `store-modal.tsx`, `onSubmit()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 721`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
+- **Thin community `Community 722`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 722`** (2 nodes): `select-native.tsx`, `cn()`
+- **Thin community `Community 723`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 723`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
+- **Thin community `Community 724`** (2 nodes): `select-native.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 724`** (2 nodes): `webp-image.tsx`, `WebpImage()`
+- **Thin community `Community 725`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 725`** (2 nodes): `BagItems()`, `BagItems.tsx`
+- **Thin community `Community 726`** (2 nodes): `webp-image.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 726`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
+- **Thin community `Community 727`** (2 nodes): `BagItems()`, `BagItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 727`** (2 nodes): `Bags()`, `Bags.tsx`
+- **Thin community `Community 728`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 728`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
+- **Thin community `Community 729`** (2 nodes): `Bags()`, `Bags.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 729`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
+- **Thin community `Community 730`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 730`** (2 nodes): `UserBag.tsx`, `UserBag()`
+- **Thin community `Community 731`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 731`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
+- **Thin community `Community 732`** (2 nodes): `UserBag.tsx`, `UserBag()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 732`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
+- **Thin community `Community 733`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 733`** (2 nodes): `UserView.tsx`, `UserActions()`
+- **Thin community `Community 734`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 734`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
+- **Thin community `Community 735`** (2 nodes): `UserView.tsx`, `UserActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 735`** (2 nodes): `UserBehaviorInsights.tsx`, `UserBehaviorInsights()`
+- **Thin community `Community 736`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 736`** (2 nodes): `wrapper()`, `ManagerElevationContext.test.tsx`
+- **Thin community `Community 737`** (2 nodes): `UserBehaviorInsights.tsx`, `UserBehaviorInsights()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 737`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
+- **Thin community `Community 738`** (2 nodes): `wrapper()`, `ManagerElevationContext.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 738`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
+- **Thin community `Community 739`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 739`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
+- **Thin community `Community 740`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 740`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
+- **Thin community `Community 741`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 741`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
+- **Thin community `Community 742`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 742`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
+- **Thin community `Community 743`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 743`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
+- **Thin community `Community 744`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 744`** (2 nodes): `useConvexAuthIdentity.ts`, `useConvexAuthIdentity()`
+- **Thin community `Community 745`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 745`** (2 nodes): `useCopyText.ts`, `useCopyText()`
+- **Thin community `Community 746`** (2 nodes): `useConvexAuthIdentity.ts`, `useConvexAuthIdentity()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 746`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
+- **Thin community `Community 747`** (2 nodes): `useCopyText.ts`, `useCopyText()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 747`** (2 nodes): `useDebounce.ts`, `useDebounce()`
+- **Thin community `Community 748`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 748`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
+- **Thin community `Community 749`** (2 nodes): `useDebounce.ts`, `useDebounce()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 749`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
+- **Thin community `Community 750`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 750`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
+- **Thin community `Community 751`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 751`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
+- **Thin community `Community 752`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 752`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
+- **Thin community `Community 753`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 753`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
+- **Thin community `Community 754`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 754`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
+- **Thin community `Community 755`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 755`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
+- **Thin community `Community 756`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 756`** (2 nodes): `usePermissions.ts`, `usePermissions()`
+- **Thin community `Community 757`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 757`** (2 nodes): `usePrint.ts`, `usePrint()`
+- **Thin community `Community 758`** (2 nodes): `usePermissions.ts`, `usePermissions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 758`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
+- **Thin community `Community 759`** (2 nodes): `usePrint.ts`, `usePrint()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 759`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
+- **Thin community `Community 760`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 760`** (2 nodes): `useProtectedAdminPageState.ts`, `useProtectedAdminPageState()`
+- **Thin community `Community 761`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 761`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
+- **Thin community `Community 762`** (2 nodes): `useProtectedAdminPageState.ts`, `useProtectedAdminPageState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 762`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
+- **Thin community `Community 763`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 763`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
+- **Thin community `Community 764`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 764`** (2 nodes): `toOperatorMessage()`, `operatorMessages.ts`
+- **Thin community `Community 765`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 765`** (2 nodes): `presentUnexpectedErrorToast.ts`, `presentUnexpectedErrorToast()`
+- **Thin community `Community 766`** (2 nodes): `toOperatorMessage()`, `operatorMessages.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 766`** (2 nodes): `getOrigin()`, `navigationUtils.ts`
+- **Thin community `Community 767`** (2 nodes): `presentUnexpectedErrorToast.ts`, `presentUnexpectedErrorToast()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 767`** (2 nodes): `addItem()`, `addItem.ts`
+- **Thin community `Community 768`** (2 nodes): `getOrigin()`, `navigationUtils.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 768`** (2 nodes): `bootstrapRegister()`, `bootstrapRegister.ts`
+- **Thin community `Community 769`** (2 nodes): `addItem()`, `addItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 769`** (2 nodes): `holdSession()`, `holdSession.ts`
+- **Thin community `Community 770`** (2 nodes): `bootstrapRegister()`, `bootstrapRegister.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 770`** (2 nodes): `openDrawer()`, `openDrawer.ts`
+- **Thin community `Community 771`** (2 nodes): `holdSession()`, `holdSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 771`** (2 nodes): `startSession.ts`, `startSession()`
+- **Thin community `Community 772`** (2 nodes): `openDrawer()`, `openDrawer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 772`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
+- **Thin community `Community 773`** (2 nodes): `startSession.ts`, `startSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 773`** (2 nodes): `syncContract.test.ts`, `buildLocalEvent()`
+- **Thin community `Community 774`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 774`** (2 nodes): `syncScheduler.test.ts`, `baseEvent()`
+- **Thin community `Community 775`** (2 nodes): `syncContract.test.ts`, `buildLocalEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 775`** (2 nodes): `syncStatus.test.ts`, `event()`
+- **Thin community `Community 776`** (2 nodes): `syncScheduler.test.ts`, `baseEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 776`** (2 nodes): `useRegisterCatalogIndex.ts`, `useRegisterCatalogIndex()`
+- **Thin community `Community 777`** (2 nodes): `syncStatus.test.ts`, `event()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 777`** (2 nodes): `pinHash.ts`, `hashPin()`
+- **Thin community `Community 778`** (2 nodes): `useRegisterCatalogIndex.ts`, `useRegisterCatalogIndex()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 778`** (2 nodes): `hasOrgNotFoundPayload()`, `index.tsx`
+- **Thin community `Community 779`** (2 nodes): `pinHash.ts`, `hashPin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 779`** (2 nodes): `$sessionId.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 780`** (2 nodes): `hasOrgNotFoundPayload()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 780`** (2 nodes): `registers.index.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 781`** (2 nodes): `$sessionId.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 781`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
+- **Thin community `Community 782`** (2 nodes): `registers.index.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 782`** (2 nodes): `ApprovalsRoute()`, `approvals.tsx`
+- **Thin community `Community 783`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 783`** (2 nodes): `DailyCloseHistoryRoute()`, `daily-close-history.tsx`
+- **Thin community `Community 784`** (2 nodes): `ApprovalsRoute()`, `approvals.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 784`** (2 nodes): `DailyCloseRoute()`, `daily-close.tsx`
+- **Thin community `Community 785`** (2 nodes): `DailyCloseHistoryRoute()`, `daily-close-history.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 785`** (2 nodes): `OpenWorkRoute()`, `open-work.tsx`
+- **Thin community `Community 786`** (2 nodes): `DailyCloseRoute()`, `daily-close.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 786`** (2 nodes): `DailyOpeningRoute()`, `opening.tsx`
+- **Thin community `Community 787`** (2 nodes): `OpenWorkRoute()`, `open-work.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 787`** (2 nodes): `stock-adjustments.tsx`, `StockAdjustmentsRoute()`
+- **Thin community `Community 788`** (2 nodes): `DailyOpeningRoute()`, `opening.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 788`** (2 nodes): `ExpenseRouteComponent()`, `expense.index.tsx`
+- **Thin community `Community 789`** (2 nodes): `stock-adjustments.tsx`, `StockAdjustmentsRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 789`** (2 nodes): `published.index.tsx`, `RouteComponent()`
+- **Thin community `Community 790`** (2 nodes): `ExpenseRouteComponent()`, `expense.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 790`** (2 nodes): `Index()`, `index.tsx`
+- **Thin community `Community 791`** (2 nodes): `published.index.tsx`, `RouteComponent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 791`** (2 nodes): `AthenaLoginReadyView()`, `_layout.index.tsx`
+- **Thin community `Community 792`** (2 nodes): `Index()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 792`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
+- **Thin community `Community 793`** (2 nodes): `AthenaLoginReadyView()`, `_layout.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 793`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 794`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 794`** (2 nodes): `view-patterns.tsx`, `cn()`
+- **Thin community `Community 795`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 795`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
+- **Thin community `Community 796`** (2 nodes): `view-patterns.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 796`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
+- **Thin community `Community 797`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 797`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
+- **Thin community `Community 798`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 798`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 799`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 799`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
+- **Thin community `Community 800`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 800`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
+- **Thin community `Community 801`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 801`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
+- **Thin community `Community 802`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 802`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 803`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 803`** (2 nodes): `usePrint.test.ts`, `setWindowOpenMock()`
+- **Thin community `Community 804`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 804`** (2 nodes): `formatNumber()`, `formatNumber.ts`
+- **Thin community `Community 805`** (2 nodes): `usePrint.test.ts`, `setWindowOpenMock()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 805`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
+- **Thin community `Community 806`** (2 nodes): `formatNumber()`, `formatNumber.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 806`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
+- **Thin community `Community 807`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 807`** (2 nodes): `updateGuest()`, `guest.ts`
+- **Thin community `Community 808`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 808`** (2 nodes): `posTransaction.test.ts`, `jsonResponse()`
+- **Thin community `Community 809`** (2 nodes): `updateGuest()`, `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 809`** (2 nodes): `storefront.ts`, `getStore()`
+- **Thin community `Community 810`** (2 nodes): `posTransaction.test.ts`, `jsonResponse()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 810`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
+- **Thin community `Community 811`** (2 nodes): `storefront.ts`, `getStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 811`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
+- **Thin community `Community 812`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 812`** (2 nodes): `AuthComponent()`, `Auth.tsx`
+- **Thin community `Community 813`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 813`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
+- **Thin community `Community 814`** (2 nodes): `AuthComponent()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 814`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
+- **Thin community `Community 815`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 815`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
+- **Thin community `Community 816`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 816`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
+- **Thin community `Community 817`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 817`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
+- **Thin community `Community 818`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 818`** (2 nodes): `PickupDetails()`, `index.tsx`
+- **Thin community `Community 819`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 819`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
+- **Thin community `Community 820`** (2 nodes): `PickupDetails()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 820`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
+- **Thin community `Community 821`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 821`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
+- **Thin community `Community 822`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 822`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
+- **Thin community `Community 823`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 823`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
+- **Thin community `Community 824`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 824`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
+- **Thin community `Community 825`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 825`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
+- **Thin community `Community 826`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 826`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
+- **Thin community `Community 827`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 827`** (2 nodes): `useCountdown()`, `hooks.ts`
+- **Thin community `Community 828`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 828`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
+- **Thin community `Community 829`** (2 nodes): `useCountdown()`, `hooks.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 829`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
+- **Thin community `Community 830`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 830`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
+- **Thin community `Community 831`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 831`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
+- **Thin community `Community 832`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 832`** (2 nodes): `resolveHomepageContent()`, `homePageContent.ts`
+- **Thin community `Community 833`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 833`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
+- **Thin community `Community 834`** (2 nodes): `resolveHomepageContent()`, `homePageContent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 834`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
+- **Thin community `Community 835`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 835`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
+- **Thin community `Community 836`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 836`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
+- **Thin community `Community 837`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 837`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
+- **Thin community `Community 838`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 838`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
+- **Thin community `Community 839`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 839`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
+- **Thin community `Community 840`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 840`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
+- **Thin community `Community 841`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 841`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
+- **Thin community `Community 842`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 842`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
+- **Thin community `Community 843`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 843`** (2 nodes): `ProductPage.test.tsx`, `makePageState()`
+- **Thin community `Community 844`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 844`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
+- **Thin community `Community 845`** (2 nodes): `ProductPage.test.tsx`, `makePageState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 845`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
+- **Thin community `Community 846`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 846`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
+- **Thin community `Community 847`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 847`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
+- **Thin community `Community 848`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 848`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
+- **Thin community `Community 849`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 849`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
+- **Thin community `Community 850`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 850`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
+- **Thin community `Community 851`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 851`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
+- **Thin community `Community 852`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 852`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
+- **Thin community `Community 853`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 853`** (2 nodes): `BagItem()`, `BagItem.tsx`
+- **Thin community `Community 854`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 854`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
+- **Thin community `Community 855`** (2 nodes): `BagItem()`, `BagItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 855`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
+- **Thin community `Community 856`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 856`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
+- **Thin community `Community 857`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 857`** (2 nodes): `CountrySelect()`, `country-select.tsx`
+- **Thin community `Community 858`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 858`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
+- **Thin community `Community 859`** (2 nodes): `CountrySelect()`, `country-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 859`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
+- **Thin community `Community 860`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 860`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
+- **Thin community `Community 861`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 861`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
+- **Thin community `Community 862`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 862`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
+- **Thin community `Community 863`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 863`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
+- **Thin community `Community 864`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 864`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
+- **Thin community `Community 865`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 865`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
+- **Thin community `Community 866`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 866`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
+- **Thin community `Community 867`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 867`** (2 nodes): `useCheckout.ts`, `useCheckout()`
+- **Thin community `Community 868`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 868`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
+- **Thin community `Community 869`** (2 nodes): `useCheckout.ts`, `useCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 869`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
+- **Thin community `Community 870`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 870`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
+- **Thin community `Community 871`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 871`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
+- **Thin community `Community 872`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 872`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
+- **Thin community `Community 873`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 873`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
+- **Thin community `Community 874`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 874`** (2 nodes): `useGetStore.ts`, `useGetStore()`
+- **Thin community `Community 875`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 875`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
+- **Thin community `Community 876`** (2 nodes): `useGetStore.ts`, `useGetStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 876`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
+- **Thin community `Community 877`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 877`** (2 nodes): `useLogout.ts`, `useLogout()`
+- **Thin community `Community 878`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 878`** (2 nodes): `useModalState.tsx`, `useModalState()`
+- **Thin community `Community 879`** (2 nodes): `useLogout.ts`, `useLogout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 879`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
+- **Thin community `Community 880`** (2 nodes): `useModalState.tsx`, `useModalState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 880`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
+- **Thin community `Community 881`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 881`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
+- **Thin community `Community 882`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 882`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
+- **Thin community `Community 883`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 883`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
+- **Thin community `Community 884`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 884`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
+- **Thin community `Community 885`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 885`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
+- **Thin community `Community 886`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 886`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
+- **Thin community `Community 887`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 887`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
+- **Thin community `Community 888`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 888`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
+- **Thin community `Community 889`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 889`** (2 nodes): `useBagQueries()`, `bag.ts`
+- **Thin community `Community 890`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 890`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
+- **Thin community `Community 891`** (2 nodes): `useBagQueries()`, `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 891`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
+- **Thin community `Community 892`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 892`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
+- **Thin community `Community 893`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 893`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
+- **Thin community `Community 894`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 894`** (2 nodes): `posTransaction.ts`, `usePosTransactionQueries()`
+- **Thin community `Community 895`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 895`** (2 nodes): `product.ts`, `useProductQueries()`
+- **Thin community `Community 896`** (2 nodes): `posTransaction.ts`, `usePosTransactionQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 896`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
+- **Thin community `Community 897`** (2 nodes): `product.ts`, `useProductQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 897`** (2 nodes): `reviews.ts`, `useReviewQueries()`
+- **Thin community `Community 898`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 898`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
+- **Thin community `Community 899`** (2 nodes): `reviews.ts`, `useReviewQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 899`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
+- **Thin community `Community 900`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 900`** (2 nodes): `user.ts`, `useUserQueries()`
+- **Thin community `Community 901`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 901`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
+- **Thin community `Community 902`** (2 nodes): `user.ts`, `useUserQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 902`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
+- **Thin community `Community 903`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 903`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
+- **Thin community `Community 904`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 904`** (2 nodes): `validateEmail()`, `email.ts`
+- **Thin community `Community 905`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 905`** (2 nodes): `router.tsx`, `createRouter()`
+- **Thin community `Community 906`** (2 nodes): `validateEmail()`, `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 906`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
+- **Thin community `Community 907`** (2 nodes): `router.tsx`, `createRouter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 907`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
+- **Thin community `Community 908`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 908`** (2 nodes): `ContactUs()`, `contact-us.tsx`
+- **Thin community `Community 909`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 909`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
+- **Thin community `Community 910`** (2 nodes): `ContactUs()`, `contact-us.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 910`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
+- **Thin community `Community 911`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 911`** (2 nodes): `tos.index.tsx`, `TosSection()`
+- **Thin community `Community 912`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 912`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
+- **Thin community `Community 913`** (2 nodes): `tos.index.tsx`, `TosSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 913`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
+- **Thin community `Community 914`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 914`** (2 nodes): `HomeRoute()`, `index.tsx`
+- **Thin community `Community 915`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 915`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
+- **Thin community `Community 916`** (2 nodes): `HomeRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 916`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
+- **Thin community `Community 917`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 917`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
+- **Thin community `Community 918`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 918`** (2 nodes): `ReceiptShareRoute()`, `index.tsx`
+- **Thin community `Community 919`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 919`** (2 nodes): `test-connection.js`, `main()`
+- **Thin community `Community 920`** (2 nodes): `ReceiptShareRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 920`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
+- **Thin community `Community 921`** (2 nodes): `test-connection.js`, `main()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 921`** (2 nodes): `run()`, `architecture-boundary-check.ts`
+- **Thin community `Community 922`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 922`** (2 nodes): `readRepoFile()`, `deploy-qa-vps.test.ts`
+- **Thin community `Community 923`** (2 nodes): `run()`, `architecture-boundary-check.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 923`** (2 nodes): `runCommand()`, `github-pr-merge.test.ts`
+- **Thin community `Community 924`** (2 nodes): `readRepoFile()`, `deploy-qa-vps.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 924`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
+- **Thin community `Community 925`** (2 nodes): `runCommand()`, `github-pr-merge.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 925`** (2 nodes): `shutdown()`, `sample-app.ts`
+- **Thin community `Community 926`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 926`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
+- **Thin community `Community 927`** (2 nodes): `shutdown()`, `sample-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 927`** (1 nodes): `api.d.ts`
+- **Thin community `Community 928`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 928`** (1 nodes): `api.js`
+- **Thin community `Community 929`** (1 nodes): `api.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 929`** (1 nodes): `dataModel.d.ts`
+- **Thin community `Community 930`** (1 nodes): `api.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 930`** (1 nodes): `server.d.ts`
+- **Thin community `Community 931`** (1 nodes): `dataModel.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 931`** (1 nodes): `server.js`
+- **Thin community `Community 932`** (1 nodes): `server.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 932`** (1 nodes): `app.ts`
+- **Thin community `Community 933`** (1 nodes): `server.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 933`** (1 nodes): `auth.config.js`
+- **Thin community `Community 934`** (1 nodes): `app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 934`** (1 nodes): `auth.ts`
+- **Thin community `Community 935`** (1 nodes): `auth.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 935`** (1 nodes): `registerSessions.test.ts`
+- **Thin community `Community 936`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 936`** (1 nodes): `r2.test.ts`
+- **Thin community `Community 937`** (1 nodes): `registerSessions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 937`** (1 nodes): `countries.ts`
+- **Thin community `Community 938`** (1 nodes): `r2.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 938`** (1 nodes): `email.ts`
+- **Thin community `Community 939`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 939`** (1 nodes): `ghana.ts`
+- **Thin community `Community 940`** (1 nodes): `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 940`** (1 nodes): `payment.ts`
+- **Thin community `Community 941`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 941`** (1 nodes): `crons.ts`
+- **Thin community `Community 942`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 942`** (1 nodes): `domain.test.ts`
+- **Thin community `Community 943`** (1 nodes): `crons.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 943`** (1 nodes): `internal.ts`
+- **Thin community `Community 944`** (1 nodes): `domain.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 944`** (1 nodes): `public.test.ts`
+- **Thin community `Community 945`** (1 nodes): `internal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 945`** (1 nodes): `token.test.ts`
+- **Thin community `Community 946`** (1 nodes): `public.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 946`** (1 nodes): `whatsappClient.test.ts`
+- **Thin community `Community 947`** (1 nodes): `token.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 947`** (1 nodes): `whatsappConfig.test.ts`
+- **Thin community `Community 948`** (1 nodes): `whatsappClient.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 948`** (1 nodes): `devPatchBadTransaction.ts`
+- **Thin community `Community 949`** (1 nodes): `whatsappConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 949`** (1 nodes): `FeedbackRequest.tsx`
+- **Thin community `Community 950`** (1 nodes): `devPatchBadTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 950`** (1 nodes): `NewOrderAdmin.tsx`
+- **Thin community `Community 951`** (1 nodes): `FeedbackRequest.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 951`** (1 nodes): `OrderEmail.tsx`
+- **Thin community `Community 952`** (1 nodes): `NewOrderAdmin.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 952`** (1 nodes): `PosReceiptEmail.tsx`
+- **Thin community `Community 953`** (1 nodes): `OrderEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 953`** (1 nodes): `env.ts`
+- **Thin community `Community 954`** (1 nodes): `PosReceiptEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 954`** (1 nodes): `analytics.ts`
+- **Thin community `Community 955`** (1 nodes): `env.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 955`** (1 nodes): `auth.ts`
+- **Thin community `Community 956`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 956`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 957`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 957`** (1 nodes): `colors.ts`
+- **Thin community `Community 958`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 958`** (1 nodes): `index.ts`
+- **Thin community `Community 959`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 959`** (1 nodes): `organizations.ts`
+- **Thin community `Community 960`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 960`** (1 nodes): `products.ts`
+- **Thin community `Community 961`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 961`** (1 nodes): `storefrontHidden.test.ts`
+- **Thin community `Community 962`** (1 nodes): `products.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 962`** (1 nodes): `stores.ts`
+- **Thin community `Community 963`** (1 nodes): `storefrontHidden.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 963`** (1 nodes): `bag.ts`
+- **Thin community `Community 964`** (1 nodes): `stores.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 964`** (1 nodes): `guest.ts`
+- **Thin community `Community 965`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 965`** (1 nodes): `index.ts`
+- **Thin community `Community 966`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 966`** (1 nodes): `me.ts`
+- **Thin community `Community 967`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 967`** (1 nodes): `offers.ts`
+- **Thin community `Community 968`** (1 nodes): `me.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 968`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 969`** (1 nodes): `offers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 969`** (1 nodes): `paystack.ts`
+- **Thin community `Community 970`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 970`** (1 nodes): `posTransaction.ts`
+- **Thin community `Community 971`** (1 nodes): `paystack.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 971`** (1 nodes): `reviews.ts`
+- **Thin community `Community 972`** (1 nodes): `posTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 972`** (1 nodes): `rewards.ts`
+- **Thin community `Community 973`** (1 nodes): `reviews.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 973`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 974`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 974`** (1 nodes): `security.test.ts`
+- **Thin community `Community 975`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 975`** (1 nodes): `storefront.ts`
+- **Thin community `Community 976`** (1 nodes): `security.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 976`** (1 nodes): `upsells.ts`
+- **Thin community `Community 977`** (1 nodes): `storefront.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 977`** (1 nodes): `user.ts`
+- **Thin community `Community 978`** (1 nodes): `upsells.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 978`** (1 nodes): `userOffers.ts`
+- **Thin community `Community 979`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 979`** (1 nodes): `index.ts`
+- **Thin community `Community 980`** (1 nodes): `userOffers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 980`** (1 nodes): `health.test.ts`
+- **Thin community `Community 981`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 981`** (1 nodes): `http.ts`
+- **Thin community `Community 982`** (1 nodes): `health.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 982`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 983`** (1 nodes): `http.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 983`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 984`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 984`** (1 nodes): `bestSeller.ts`
+- **Thin community `Community 985`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 985`** (1 nodes): `categories.ts`
+- **Thin community `Community 986`** (1 nodes): `bestSeller.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 986`** (1 nodes): `colors.ts`
+- **Thin community `Community 987`** (1 nodes): `categories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 987`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 988`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 988`** (1 nodes): `expenseTransactions.test.ts`
+- **Thin community `Community 989`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 989`** (1 nodes): `featuredItem.ts`
+- **Thin community `Community 990`** (1 nodes): `expenseTransactions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 990`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 991`** (1 nodes): `featuredItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 991`** (1 nodes): `organizationMembers.ts`
+- **Thin community `Community 992`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 992`** (1 nodes): `organizations.ts`
+- **Thin community `Community 993`** (1 nodes): `organizationMembers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 993`** (1 nodes): `pos.ts`
+- **Thin community `Community 994`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 994`** (1 nodes): `posCustomers.ts`
+- **Thin community `Community 995`** (1 nodes): `pos.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 995`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 996`** (1 nodes): `posCustomers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 996`** (1 nodes): `productSku.ts`
+- **Thin community `Community 997`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 997`** (1 nodes): `productUtil.test.ts`
+- **Thin community `Community 998`** (1 nodes): `productSku.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 998`** (1 nodes): `promoCode.test.ts`
+- **Thin community `Community 999`** (1 nodes): `productUtil.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 999`** (1 nodes): `stockValidation.ts`
+- **Thin community `Community 1000`** (1 nodes): `promoCode.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1000`** (1 nodes): `storeConfigV2.test.ts`
+- **Thin community `Community 1001`** (1 nodes): `stockValidation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1001`** (1 nodes): `subcategories.ts`
+- **Thin community `Community 1002`** (1 nodes): `storeConfigV2.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1002`** (1 nodes): `commandResultValidators.test.ts`
+- **Thin community `Community 1003`** (1 nodes): `subcategories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1003`** (1 nodes): `currency.test.ts`
+- **Thin community `Community 1004`** (1 nodes): `commandResultValidators.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1004`** (1 nodes): `storeInsights.ts`
+- **Thin community `Community 1005`** (1 nodes): `currency.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1005`** (1 nodes): `userInsights.ts`
+- **Thin community `Community 1006`** (1 nodes): `storeInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1006`** (1 nodes): `migrateAmountsToPesewas.ts`
+- **Thin community `Community 1007`** (1 nodes): `userInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1007`** (1 nodes): `client.test.ts`
+- **Thin community `Community 1008`** (1 nodes): `migrateAmountsToPesewas.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1008`** (1 nodes): `config.test.ts`
+- **Thin community `Community 1009`** (1 nodes): `client.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1009`** (1 nodes): `normalize.test.ts`
+- **Thin community `Community 1010`** (1 nodes): `config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1010`** (1 nodes): `types.ts`
+- **Thin community `Community 1011`** (1 nodes): `normalize.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1011`** (1 nodes): `customerProfiles.test.ts`
+- **Thin community `Community 1012`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1012`** (1 nodes): `paymentAllocations.test.ts`
+- **Thin community `Community 1013`** (1 nodes): `customerProfiles.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1013`** (1 nodes): `EmailOTP.test.ts`
+- **Thin community `Community 1014`** (1 nodes): `paymentAllocations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1014`** (1 nodes): `correctTransactionCustomer.test.ts`
+- **Thin community `Community 1015`** (1 nodes): `EmailOTP.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1015`** (1 nodes): `correctionEvents.test.ts`
+- **Thin community `Community 1016`** (1 nodes): `correctTransactionCustomer.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1016`** (1 nodes): `correctionPolicy.test.ts`
+- **Thin community `Community 1017`** (1 nodes): `correctionEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1017`** (1 nodes): `dto.ts`
+- **Thin community `Community 1018`** (1 nodes): `correctionPolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1018`** (1 nodes): `getRegisterState.test.ts`
+- **Thin community `Community 1019`** (1 nodes): `dto.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1019`** (1 nodes): `posSessionTracing.test.ts`
+- **Thin community `Community 1020`** (1 nodes): `getRegisterState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1020`** (1 nodes): `types.ts`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1021`** (1 nodes): `terminals.test.ts`
+- **Thin community `Community 1021`** (1 nodes): `posSessionTracing.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1022`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1023`** (1 nodes): `registerSessionRepository.test.ts`
+- **Thin community `Community 1023`** (1 nodes): `terminals.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1024`** (1 nodes): `catalog.ts`
+- **Thin community `Community 1024`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1025`** (1 nodes): `customers.ts`
+- **Thin community `Community 1025`** (1 nodes): `registerSessionRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1026`** (1 nodes): `register.ts`
+- **Thin community `Community 1026`** (1 nodes): `catalog.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1027`** (1 nodes): `sync.ts`
+- **Thin community `Community 1027`** (1 nodes): `customers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1028`** (1 nodes): `schema.ts`
+- **Thin community `Community 1028`** (1 nodes): `register.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1029`** (1 nodes): `customerMessageDelivery.ts`
+- **Thin community `Community 1029`** (1 nodes): `sync.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1030`** (1 nodes): `index.ts`
+- **Thin community `Community 1030`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1031`** (1 nodes): `receiptShareToken.ts`
+- **Thin community `Community 1031`** (1 nodes): `customerMessageDelivery.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1032`** (1 nodes): `appVerificationCode.ts`
+- **Thin community `Community 1032`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1033`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 1033`** (1 nodes): `receiptShareToken.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1034`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 1034`** (1 nodes): `appVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1035`** (1 nodes): `bestSeller.ts`
+- **Thin community `Community 1035`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1036`** (1 nodes): `category.ts`
+- **Thin community `Community 1036`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1037`** (1 nodes): `color.ts`
+- **Thin community `Community 1037`** (1 nodes): `bestSeller.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1038`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 1038`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1039`** (1 nodes): `featuredItem.ts`
+- **Thin community `Community 1039`** (1 nodes): `color.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1040`** (1 nodes): `index.ts`
+- **Thin community `Community 1040`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1041`** (1 nodes): `inventoryHold.ts`
+- **Thin community `Community 1041`** (1 nodes): `featuredItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1042`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 1042`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1043`** (1 nodes): `organization.ts`
+- **Thin community `Community 1043`** (1 nodes): `inventoryHold.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1044`** (1 nodes): `organizationMember.ts`
+- **Thin community `Community 1044`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1045`** (1 nodes): `product.ts`
+- **Thin community `Community 1045`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1046`** (1 nodes): `promoCode.ts`
+- **Thin community `Community 1046`** (1 nodes): `organizationMember.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1047`** (1 nodes): `redeemedPromoCode.ts`
+- **Thin community `Community 1047`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1048`** (1 nodes): `store.ts`
+- **Thin community `Community 1048`** (1 nodes): `promoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1049`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1049`** (1 nodes): `redeemedPromoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1050`** (1 nodes): `index.ts`
+- **Thin community `Community 1050`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1051`** (1 nodes): `workflowTrace.ts`
+- **Thin community `Community 1051`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1052`** (1 nodes): `workflowTraceEvent.ts`
+- **Thin community `Community 1052`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1053`** (1 nodes): `workflowTraceLookup.ts`
+- **Thin community `Community 1053`** (1 nodes): `workflowTrace.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1054`** (1 nodes): `approvalRequest.ts`
+- **Thin community `Community 1054`** (1 nodes): `workflowTraceEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1055`** (1 nodes): `customerProfile.ts`
+- **Thin community `Community 1055`** (1 nodes): `workflowTraceLookup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1056`** (1 nodes): `dailyClose.ts`
+- **Thin community `Community 1056`** (1 nodes): `approvalRequest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1057`** (1 nodes): `dailyOpening.ts`
+- **Thin community `Community 1057`** (1 nodes): `customerProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1058`** (1 nodes): `index.ts`
+- **Thin community `Community 1058`** (1 nodes): `dailyClose.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1059`** (1 nodes): `inventoryMovement.ts`
+- **Thin community `Community 1059`** (1 nodes): `dailyOpening.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1060`** (1 nodes): `managerElevation.ts`
+- **Thin community `Community 1060`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1061`** (1 nodes): `operationalEvent.ts`
+- **Thin community `Community 1061`** (1 nodes): `inventoryMovement.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1062`** (1 nodes): `operationalWorkItem.ts`
+- **Thin community `Community 1062`** (1 nodes): `managerElevation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1063`** (1 nodes): `paymentAllocation.ts`
+- **Thin community `Community 1063`** (1 nodes): `operationalEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1064`** (1 nodes): `registerSession.ts`
+- **Thin community `Community 1064`** (1 nodes): `operationalWorkItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1065`** (1 nodes): `skuActivityEvent.ts`
+- **Thin community `Community 1065`** (1 nodes): `paymentAllocation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1066`** (1 nodes): `staffCredential.ts`
+- **Thin community `Community 1066`** (1 nodes): `registerSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1067`** (1 nodes): `staffProfile.ts`
+- **Thin community `Community 1067`** (1 nodes): `skuActivityEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1068`** (1 nodes): `staffRoleAssignment.ts`
+- **Thin community `Community 1068`** (1 nodes): `staffCredential.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1069`** (1 nodes): `mtnCollections.ts`
+- **Thin community `Community 1069`** (1 nodes): `staffProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1070`** (1 nodes): `customer.ts`
+- **Thin community `Community 1070`** (1 nodes): `staffRoleAssignment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1071`** (1 nodes): `expenseSession.ts`
+- **Thin community `Community 1071`** (1 nodes): `mtnCollections.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1072`** (1 nodes): `expenseSessionItem.ts`
+- **Thin community `Community 1072`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1073`** (1 nodes): `expenseTransaction.ts`
+- **Thin community `Community 1073`** (1 nodes): `expenseSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1074`** (1 nodes): `expenseTransactionItem.ts`
+- **Thin community `Community 1074`** (1 nodes): `expenseSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1075`** (1 nodes): `index.ts`
+- **Thin community `Community 1075`** (1 nodes): `expenseTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1076`** (1 nodes): `posLocalStaffProof.ts`
+- **Thin community `Community 1076`** (1 nodes): `expenseTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1077`** (1 nodes): `posLocalSyncConflict.ts`
+- **Thin community `Community 1077`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1078`** (1 nodes): `posLocalSyncCursor.ts`
+- **Thin community `Community 1078`** (1 nodes): `posLocalStaffProof.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1079`** (1 nodes): `posLocalSyncEvent.ts`
+- **Thin community `Community 1079`** (1 nodes): `posLocalSyncConflict.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1080`** (1 nodes): `posLocalSyncMapping.ts`
+- **Thin community `Community 1080`** (1 nodes): `posLocalSyncCursor.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1081`** (1 nodes): `posSession.ts`
+- **Thin community `Community 1081`** (1 nodes): `posLocalSyncEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1082`** (1 nodes): `posSessionItem.ts`
+- **Thin community `Community 1082`** (1 nodes): `posLocalSyncMapping.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1083`** (1 nodes): `posTerminal.test.ts`
+- **Thin community `Community 1083`** (1 nodes): `posSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1084`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 1084`** (1 nodes): `posSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1085`** (1 nodes): `posTransaction.ts`
+- **Thin community `Community 1085`** (1 nodes): `posTerminal.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1086`** (1 nodes): `posTransactionItem.ts`
+- **Thin community `Community 1086`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1087`** (1 nodes): `index.ts`
+- **Thin community `Community 1087`** (1 nodes): `posTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1088`** (1 nodes): `serviceAppointment.ts`
+- **Thin community `Community 1088`** (1 nodes): `posTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1089`** (1 nodes): `serviceCase.ts`
+- **Thin community `Community 1089`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1090`** (1 nodes): `serviceCaseLineItem.ts`
+- **Thin community `Community 1090`** (1 nodes): `serviceAppointment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1091`** (1 nodes): `serviceCatalog.ts`
+- **Thin community `Community 1091`** (1 nodes): `serviceCase.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1092`** (1 nodes): `serviceInventoryUsage.ts`
+- **Thin community `Community 1092`** (1 nodes): `serviceCaseLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1093`** (1 nodes): `cycleCountDraft.ts`
+- **Thin community `Community 1093`** (1 nodes): `serviceCatalog.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1094`** (1 nodes): `index.ts`
+- **Thin community `Community 1094`** (1 nodes): `serviceInventoryUsage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1095`** (1 nodes): `purchaseOrder.ts`
+- **Thin community `Community 1095`** (1 nodes): `cycleCountDraft.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1096`** (1 nodes): `purchaseOrderLineItem.ts`
+- **Thin community `Community 1096`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1097`** (1 nodes): `receivingBatch.ts`
+- **Thin community `Community 1097`** (1 nodes): `purchaseOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1098`** (1 nodes): `stockAdjustmentBatch.ts`
+- **Thin community `Community 1098`** (1 nodes): `purchaseOrderLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1099`** (1 nodes): `vendor.ts`
+- **Thin community `Community 1099`** (1 nodes): `receivingBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1100`** (1 nodes): `analytics.ts`
+- **Thin community `Community 1100`** (1 nodes): `stockAdjustmentBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1101`** (1 nodes): `bag.ts`
+- **Thin community `Community 1101`** (1 nodes): `vendor.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1102`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1102`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1103`** (1 nodes): `checkoutSession.ts`
+- **Thin community `Community 1103`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1104`** (1 nodes): `checkoutSessionItem.ts`
+- **Thin community `Community 1104`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1105`** (1 nodes): `guest.ts`
+- **Thin community `Community 1105`** (1 nodes): `checkoutSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1106`** (1 nodes): `index.ts`
+- **Thin community `Community 1106`** (1 nodes): `checkoutSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1107`** (1 nodes): `offer.ts`
+- **Thin community `Community 1107`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1108`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 1108`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1109`** (1 nodes): `onlineOrderItem.ts`
+- **Thin community `Community 1109`** (1 nodes): `offer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1110`** (1 nodes): `review.ts`
+- **Thin community `Community 1110`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1111`** (1 nodes): `rewards.ts`
+- **Thin community `Community 1111`** (1 nodes): `onlineOrderItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1112`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 1112`** (1 nodes): `review.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1113`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 1113`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1114`** (1 nodes): `storeFrontSession.ts`
+- **Thin community `Community 1114`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1115`** (1 nodes): `storeFrontUser.ts`
+- **Thin community `Community 1115`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1116`** (1 nodes): `storeFrontVerificationCode.ts`
+- **Thin community `Community 1116`** (1 nodes): `storeFrontSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1117`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 1117`** (1 nodes): `storeFrontUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1118`** (1 nodes): `catalogAppointments.test.ts`
+- **Thin community `Community 1118`** (1 nodes): `storeFrontVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1119`** (1 nodes): `bag.ts`
+- **Thin community `Community 1119`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1120`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1120`** (1 nodes): `catalogAppointments.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1121`** (1 nodes): `customer.ts`
+- **Thin community `Community 1121`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1122`** (1 nodes): `guest.ts`
+- **Thin community `Community 1122`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1123`** (1 nodes): `offers.test.ts`
+- **Thin community `Community 1123`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1124`** (1 nodes): `onlineOrderUtilFns.ts`
+- **Thin community `Community 1124`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1125`** (1 nodes): `orderOperations.test.ts`
+- **Thin community `Community 1125`** (1 nodes): `offers.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1126`** (1 nodes): `payment.test.ts`
+- **Thin community `Community 1126`** (1 nodes): `onlineOrderUtilFns.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1127`** (1 nodes): `payment.ts`
+- **Thin community `Community 1127`** (1 nodes): `orderOperations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1128`** (1 nodes): `paystackActions.ts`
+- **Thin community `Community 1128`** (1 nodes): `payment.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1129`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 1129`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1130`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 1130`** (1 nodes): `paystackActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1131`** (1 nodes): `users.ts`
+- **Thin community `Community 1131`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1132`** (1 nodes): `payment.ts`
+- **Thin community `Community 1132`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1133`** (1 nodes): `posSession.test.ts`
+- **Thin community `Community 1133`** (1 nodes): `users.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1134`** (1 nodes): `registerSession.test.ts`
+- **Thin community `Community 1134`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1135`** (1 nodes): `presentation.test.ts`
+- **Thin community `Community 1135`** (1 nodes): `posSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1136`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 1136`** (1 nodes): `registerSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1137`** (1 nodes): `index.ts`
+- **Thin community `Community 1137`** (1 nodes): `presentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1138`** (1 nodes): `postcss.config.js`
+- **Thin community `Community 1138`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1139`** (1 nodes): `approvalPolicy.ts`
+- **Thin community `Community 1139`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1140`** (1 nodes): `auth.ts`
+- **Thin community `Community 1140`** (1 nodes): `postcss.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1141`** (1 nodes): `commandResult.test.ts`
+- **Thin community `Community 1141`** (1 nodes): `approvalPolicy.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1142`** (1 nodes): `currencyFormatter.test.ts`
+- **Thin community `Community 1142`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1143`** (1 nodes): `posLocalSyncContract.ts`
+- **Thin community `Community 1143`** (1 nodes): `commandResult.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1144`** (1 nodes): `registerSessionStatus.test.ts`
+- **Thin community `Community 1144`** (1 nodes): `currencyFormatter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1145`** (1 nodes): `staffDisplayName.test.ts`
+- **Thin community `Community 1145`** (1 nodes): `posLocalSyncContract.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1146`** (1 nodes): `GenericComboBox.tsx`
+- **Thin community `Community 1146`** (1 nodes): `registerSessionStatus.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1147`** (1 nodes): `StoreAccordion.tsx`
+- **Thin community `Community 1147`** (1 nodes): `staffDisplayName.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1148`** (1 nodes): `StoresAccordion.tsx`
+- **Thin community `Community 1148`** (1 nodes): `GenericComboBox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1149`** (1 nodes): `ThemeToggle.tsx`
+- **Thin community `Community 1149`** (1 nodes): `StoreAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1150`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
+- **Thin community `Community 1150`** (1 nodes): `StoresAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1151`** (1 nodes): `ProductAttributes.tsx`
+- **Thin community `Community 1151`** (1 nodes): `ThemeToggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1152`** (1 nodes): `ProductAttributesView.tsx`
+- **Thin community `Community 1152`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1153`** (1 nodes): `ProductStock.test.ts`
+- **Thin community `Community 1153`** (1 nodes): `ProductAttributes.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1154`** (1 nodes): `ProductView.test.tsx`
+- **Thin community `Community 1154`** (1 nodes): `ProductAttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1155`** (1 nodes): `constants.ts`
+- **Thin community `Community 1155`** (1 nodes): `ProductStock.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1156`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1156`** (1 nodes): `ProductView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1157`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1157`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1158`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1158`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1159`** (1 nodes): `types.ts`
+- **Thin community `Community 1159`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1160`** (1 nodes): `ConversionFunnelChart.tsx`
+- **Thin community `Community 1160`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1161`** (1 nodes): `RevenueChart.tsx`
+- **Thin community `Community 1161`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1162`** (1 nodes): `analytics-columns.tsx`
+- **Thin community `Community 1162`** (1 nodes): `ConversionFunnelChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1163`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1163`** (1 nodes): `RevenueChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1164`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1164`** (1 nodes): `analytics-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1165`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1165`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1166`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1166`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1167`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1167`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1168`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1168`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1169`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1169`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1170`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1170`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1171`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1171`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1172`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1172`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1173`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1173`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1174`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1174`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1175`** (1 nodes): `chart.tsx`
+- **Thin community `Community 1175`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1176`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1176`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1177`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1177`** (1 nodes): `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1178`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1178`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1179`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1179`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1180`** (1 nodes): `constants.ts`
+- **Thin community `Community 1180`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1181`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1181`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1182`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1182`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1183`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1183`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1184`** (1 nodes): `data.ts`
+- **Thin community `Community 1184`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1185`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1185`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1186`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1186`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1187`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1187`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1188`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1188`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1189`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1189`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1190`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1190`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1191`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1191`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1192`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1192`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1193`** (1 nodes): `assetsColumns.tsx`
+- **Thin community `Community 1193`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1194`** (1 nodes): `constants.ts`
+- **Thin community `Community 1194`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1195`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1195`** (1 nodes): `assetsColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1196`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1196`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1197`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1197`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1198`** (1 nodes): `data.ts`
+- **Thin community `Community 1198`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1199`** (1 nodes): `DefaultCatchBoundary.test.tsx`
+- **Thin community `Community 1199`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1200`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 1200`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1201`** (1 nodes): `LoginForm.test.tsx`
+- **Thin community `Community 1201`** (1 nodes): `DefaultCatchBoundary.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1202`** (1 nodes): `LoginForm.tsx`
+- **Thin community `Community 1202`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1203`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1203`** (1 nodes): `LoginForm.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1204`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1204`** (1 nodes): `LoginForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1205`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1205`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1206`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1206`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1207`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1207`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1208`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1208`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1209`** (1 nodes): `constants.ts`
+- **Thin community `Community 1209`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1210`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1210`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1211`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1211`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1212`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1212`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1213`** (1 nodes): `BulkOperationsPage.tsx`
+- **Thin community `Community 1213`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1214`** (1 nodes): `CashControlsDashboard.auth.test.tsx`
+- **Thin community `Community 1214`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1215`** (1 nodes): `CashControlsDashboard.test.tsx`
+- **Thin community `Community 1215`** (1 nodes): `BulkOperationsPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1216`** (1 nodes): `CashControlsWorkspaceHeader.tsx`
+- **Thin community `Community 1216`** (1 nodes): `CashControlsDashboard.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1217`** (1 nodes): `RegisterSessionView.auth.test.tsx`
+- **Thin community `Community 1217`** (1 nodes): `CashControlsDashboard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1218`** (1 nodes): `RegisterSessionView.test.tsx`
+- **Thin community `Community 1218`** (1 nodes): `CashControlsWorkspaceHeader.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1219`** (1 nodes): `RegisterSessionsView.test.tsx`
+- **Thin community `Community 1219`** (1 nodes): `RegisterSessionView.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1220`** (1 nodes): `formatReviewReason.test.ts`
+- **Thin community `Community 1220`** (1 nodes): `RegisterSessionView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1221`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1221`** (1 nodes): `RegisterSessionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1222`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1222`** (1 nodes): `formatReviewReason.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1223`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1223`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1224`** (1 nodes): `ListPagination.tsx`
+- **Thin community `Community 1224`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1225`** (1 nodes): `PageLevelHeader.test.tsx`
+- **Thin community `Community 1225`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1226`** (1 nodes): `PageLevelHeader.tsx`
+- **Thin community `Community 1226`** (1 nodes): `ListPagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1227`** (1 nodes): `MetricCard.tsx`
+- **Thin community `Community 1227`** (1 nodes): `PageLevelHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1228`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 1228`** (1 nodes): `PageLevelHeader.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1229`** (1 nodes): `CommandApprovalDialog.test.tsx`
+- **Thin community `Community 1229`** (1 nodes): `MetricCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1230`** (1 nodes): `OperationReviewWorkspace.tsx`
+- **Thin community `Community 1230`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1231`** (1 nodes): `OperationsQueueView.auth.test.tsx`
+- **Thin community `Community 1231`** (1 nodes): `CommandApprovalDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1232`** (1 nodes): `SkuActivityTimeline.test.tsx`
+- **Thin community `Community 1232`** (1 nodes): `OperationReviewWorkspace.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1233`** (1 nodes): `skuActivityTimelineAdapter.test.ts`
+- **Thin community `Community 1233`** (1 nodes): `OperationsQueueView.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1234`** (1 nodes): `useApprovedCommand.test.tsx`
+- **Thin community `Community 1234`** (1 nodes): `SkuActivityTimeline.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1235`** (1 nodes): `OrderStatus.test.tsx`
+- **Thin community `Community 1235`** (1 nodes): `skuActivityTimelineAdapter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1236`** (1 nodes): `OrderStatus.tsx`
+- **Thin community `Community 1236`** (1 nodes): `useApprovedCommand.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1237`** (1 nodes): `OrderSummary.tsx`
+- **Thin community `Community 1237`** (1 nodes): `OrderStatus.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1238`** (1 nodes): `Orders.tsx`
+- **Thin community `Community 1238`** (1 nodes): `OrderStatus.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1239`** (1 nodes): `RefundsView.test.tsx`
+- **Thin community `Community 1239`** (1 nodes): `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1240`** (1 nodes): `ReturnExchangeView.test.tsx`
+- **Thin community `Community 1240`** (1 nodes): `Orders.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1241`** (1 nodes): `constants.ts`
+- **Thin community `Community 1241`** (1 nodes): `RefundsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1242`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1242`** (1 nodes): `ReturnExchangeView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1243`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1243`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1244`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1244`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1245`** (1 nodes): `data.ts`
+- **Thin community `Community 1245`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1246`** (1 nodes): `refundUtils.test.ts`
+- **Thin community `Community 1246`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1247`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1247`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1248`** (1 nodes): `constants.ts`
+- **Thin community `Community 1248`** (1 nodes): `refundUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1249`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1249`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1250`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1250`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1251`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1251`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1252`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1252`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1253`** (1 nodes): `data.ts`
+- **Thin community `Community 1253`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1254`** (1 nodes): `inviteColumns.tsx`
+- **Thin community `Community 1254`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1255`** (1 nodes): `constants.ts`
+- **Thin community `Community 1255`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1256`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1256`** (1 nodes): `inviteColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1257`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1257`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1258`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1258`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1259`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1259`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1260`** (1 nodes): `data.ts`
+- **Thin community `Community 1260`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1261`** (1 nodes): `membersColumns.tsx`
+- **Thin community `Community 1261`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1262`** (1 nodes): `organization-switcher.test.tsx`
+- **Thin community `Community 1262`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1263`** (1 nodes): `CashierAuthDialog.test.tsx`
+- **Thin community `Community 1263`** (1 nodes): `membersColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1264`** (1 nodes): `CashierView.tsx`
+- **Thin community `Community 1264`** (1 nodes): `organization-switcher.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1265`** (1 nodes): `POSRegisterView.tsx`
+- **Thin community `Community 1265`** (1 nodes): `CashierView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1266`** (1 nodes): `PaymentView.test.tsx`
+- **Thin community `Community 1266`** (1 nodes): `POSRegisterView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1267`** (1 nodes): `PointOfSaleView.test.tsx`
+- **Thin community `Community 1267`** (1 nodes): `PaymentView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1268`** (1 nodes): `PointOfSaleView.tsx`
+- **Thin community `Community 1268`** (1 nodes): `PointOfSaleView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1269`** (1 nodes): `ProductLookup.tsx`
+- **Thin community `Community 1269`** (1 nodes): `PointOfSaleView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1270`** (1 nodes): `RegisterActions.tsx`
+- **Thin community `Community 1270`** (1 nodes): `ProductLookup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1271`** (1 nodes): `SessionManager.test.tsx`
+- **Thin community `Community 1271`** (1 nodes): `RegisterActions.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1272`** (1 nodes): `SessionManager.tsx`
+- **Thin community `Community 1272`** (1 nodes): `SessionManager.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1273`** (1 nodes): `TotalsDisplay.test.tsx`
+- **Thin community `Community 1273`** (1 nodes): `SessionManager.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1274`** (1 nodes): `TotalsDisplay.tsx`
+- **Thin community `Community 1274`** (1 nodes): `TotalsDisplay.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1275`** (1 nodes): `ExpenseReportView.tsx`
+- **Thin community `Community 1275`** (1 nodes): `TotalsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1276`** (1 nodes): `ExpenseReportsView.test.ts`
+- **Thin community `Community 1276`** (1 nodes): `ExpenseReportView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1277`** (1 nodes): `ExpenseReportsView.test.tsx`
+- **Thin community `Community 1277`** (1 nodes): `ExpenseReportsView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1278`** (1 nodes): `expenseReportColumns.tsx`
+- **Thin community `Community 1278`** (1 nodes): `ExpenseReportsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1279`** (1 nodes): `PosReceiptShareControl.test.tsx`
+- **Thin community `Community 1279`** (1 nodes): `expenseReportColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1280`** (1 nodes): `POSRegisterOpeningGuard.test.tsx`
+- **Thin community `Community 1280`** (1 nodes): `PosReceiptShareControl.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1281`** (1 nodes): `POSRegisterView.test.tsx`
+- **Thin community `Community 1281`** (1 nodes): `POSRegisterOpeningGuard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1282`** (1 nodes): `RegisterActionBar.test.tsx`
+- **Thin community `Community 1282`** (1 nodes): `POSRegisterView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1283`** (1 nodes): `RegisterActionBar.tsx`
+- **Thin community `Community 1283`** (1 nodes): `RegisterActionBar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1284`** (1 nodes): `RegisterCheckoutPanel.tsx`
+- **Thin community `Community 1284`** (1 nodes): `RegisterActionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1285`** (1 nodes): `HeldSessionsList.test.tsx`
+- **Thin community `Community 1285`** (1 nodes): `RegisterCheckoutPanel.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1286`** (1 nodes): `POSSessionsView.test.tsx`
+- **Thin community `Community 1286`** (1 nodes): `HeldSessionsList.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1287`** (1 nodes): `posSessionColumns.tsx`
+- **Thin community `Community 1287`** (1 nodes): `POSSessionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1288`** (1 nodes): `POSSettingsView.test.tsx`
+- **Thin community `Community 1288`** (1 nodes): `posSessionColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1289`** (1 nodes): `TransactionsView.test.tsx`
+- **Thin community `Community 1289`** (1 nodes): `POSSettingsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1290`** (1 nodes): `types.ts`
+- **Thin community `Community 1290`** (1 nodes): `TransactionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1291`** (1 nodes): `ReceivingView.test.tsx`
+- **Thin community `Community 1291`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1292`** (1 nodes): `AnalyticsInsights.tsx`
+- **Thin community `Community 1292`** (1 nodes): `ReceivingView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1293`** (1 nodes): `AttributesView.tsx`
+- **Thin community `Community 1293`** (1 nodes): `AnalyticsInsights.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1294`** (1 nodes): `DetailsView.tsx`
+- **Thin community `Community 1294`** (1 nodes): `AttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1295`** (1 nodes): `ProductDetailView.tsx`
+- **Thin community `Community 1295`** (1 nodes): `DetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1296`** (1 nodes): `ArchivedProducts.tsx`
+- **Thin community `Community 1296`** (1 nodes): `ProductDetailView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1297`** (1 nodes): `CategoryListView.tsx`
+- **Thin community `Community 1297`** (1 nodes): `ArchivedProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1298`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
+- **Thin community `Community 1298`** (1 nodes): `CategoryListView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1299`** (1 nodes): `Products.tsx`
+- **Thin community `Community 1299`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1300`** (1 nodes): `StoreProducts.tsx`
+- **Thin community `Community 1300`** (1 nodes): `Products.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1301`** (1 nodes): `UnresolvedProducts.tsx`
+- **Thin community `Community 1301`** (1 nodes): `StoreProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1302`** (1 nodes): `ComplimentaryProducts.tsx`
+- **Thin community `Community 1302`** (1 nodes): `UnresolvedProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1303`** (1 nodes): `complimentaryProductsColumn.tsx`
+- **Thin community `Community 1303`** (1 nodes): `ComplimentaryProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1304`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1304`** (1 nodes): `complimentaryProductsColumn.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1305`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1305`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1306`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1306`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1307`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1307`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1308`** (1 nodes): `data.ts`
+- **Thin community `Community 1308`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1309`** (1 nodes): `productColumns.tsx`
+- **Thin community `Community 1309`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1310`** (1 nodes): `PromoCodeHeader.test.tsx`
+- **Thin community `Community 1310`** (1 nodes): `productColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1311`** (1 nodes): `PromoCodes.tsx`
+- **Thin community `Community 1311`** (1 nodes): `PromoCodeHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1312`** (1 nodes): `PromoCodeAnalytics.tsx`
+- **Thin community `Community 1312`** (1 nodes): `PromoCodes.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1313`** (1 nodes): `captured-emails-columns.tsx`
+- **Thin community `Community 1313`** (1 nodes): `PromoCodeAnalytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1314`** (1 nodes): `promoCodeMoney.test.ts`
+- **Thin community `Community 1314`** (1 nodes): `captured-emails-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1315`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1315`** (1 nodes): `promoCodeMoney.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1316`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1316`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1317`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1317`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1318`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1318`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1319`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1319`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1320`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1320`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1321`** (1 nodes): `constants.ts`
+- **Thin community `Community 1321`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1322`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1322`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1323`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1323`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1324`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1324`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1325`** (1 nodes): `data.ts`
+- **Thin community `Community 1325`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1326`** (1 nodes): `types.ts`
+- **Thin community `Community 1326`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1327`** (1 nodes): `welcome-offer-card.tsx`
+- **Thin community `Community 1327`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1328`** (1 nodes): `RatingStars.tsx`
+- **Thin community `Community 1328`** (1 nodes): `welcome-offer-card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1329`** (1 nodes): `ReviewCard.tsx`
+- **Thin community `Community 1329`** (1 nodes): `RatingStars.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1330`** (1 nodes): `ReviewMetadata.tsx`
+- **Thin community `Community 1330`** (1 nodes): `ReviewCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1331`** (1 nodes): `ServicesWorkspaceView.test.tsx`
+- **Thin community `Community 1331`** (1 nodes): `ReviewMetadata.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1332`** (1 nodes): `index.tsx`
+- **Thin community `Community 1332`** (1 nodes): `ServicesWorkspaceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1333`** (1 nodes): `StaffAuthenticationDialog.test.tsx`
+- **Thin community `Community 1333`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1334`** (1 nodes): `FeesView.test.ts`
+- **Thin community `Community 1334`** (1 nodes): `StaffAuthenticationDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1335`** (1 nodes): `FulfillmentView.test.tsx`
+- **Thin community `Community 1335`** (1 nodes): `FeesView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1336`** (1 nodes): `MaintenanceView.test.tsx`
+- **Thin community `Community 1336`** (1 nodes): `FulfillmentView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1337`** (1 nodes): `MtnMomoView.test.tsx`
+- **Thin community `Community 1337`** (1 nodes): `MaintenanceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1338`** (1 nodes): `useStoreConfigUpdate.test.tsx`
+- **Thin community `Community 1338`** (1 nodes): `MtnMomoView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1339`** (1 nodes): `index.tsx`
+- **Thin community `Community 1339`** (1 nodes): `useStoreConfigUpdate.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1340`** (1 nodes): `WorkflowTraceView.test.tsx`
+- **Thin community `Community 1340`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1341`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 1341`** (1 nodes): `WorkflowTraceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1342`** (1 nodes): `button.test.tsx`
+- **Thin community `Community 1342`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1343`** (1 nodes): `button.tsx`
+- **Thin community `Community 1343`** (1 nodes): `button.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1344`** (1 nodes): `calendar.test.tsx`
+- **Thin community `Community 1344`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1345`** (1 nodes): `card.tsx`
+- **Thin community `Community 1345`** (1 nodes): `calendar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1346`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 1346`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1347`** (1 nodes): `collapsible.tsx`
+- **Thin community `Community 1347`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1348`** (1 nodes): `command.tsx`
+- **Thin community `Community 1348`** (1 nodes): `collapsible.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1349`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 1349`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1350`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 1350`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1351`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 1351`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1352`** (1 nodes): `form.tsx`
+- **Thin community `Community 1352`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1353`** (1 nodes): `icons.tsx`
+- **Thin community `Community 1353`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1354`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 1354`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1355`** (1 nodes): `input.tsx`
+- **Thin community `Community 1355`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1356`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 1356`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1357`** (1 nodes): `panel-header.tsx`
+- **Thin community `Community 1357`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1358`** (1 nodes): `popover.tsx`
+- **Thin community `Community 1358`** (1 nodes): `panel-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1359`** (1 nodes): `primitives.test.tsx`
+- **Thin community `Community 1359`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1360`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 1360`** (1 nodes): `primitives.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1361`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 1361`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1362`** (1 nodes): `select.tsx`
+- **Thin community `Community 1362`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1363`** (1 nodes): `separator.tsx`
+- **Thin community `Community 1363`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1364`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 1364`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1365`** (1 nodes): `switch.tsx`
+- **Thin community `Community 1365`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1366`** (1 nodes): `table.tsx`
+- **Thin community `Community 1366`** (1 nodes): `switch.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1367`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 1367`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1368`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 1368`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1369`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 1369`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1370`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 1370`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1371`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 1371`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1372`** (1 nodes): `upload-button.tsx`
+- **Thin community `Community 1372`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1373`** (1 nodes): `BagView.tsx`
+- **Thin community `Community 1373`** (1 nodes): `upload-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1374`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1374`** (1 nodes): `BagView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1375`** (1 nodes): `constants.ts`
+- **Thin community `Community 1375`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1376`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1376`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1377`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1377`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1378`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1378`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1379`** (1 nodes): `data.ts`
+- **Thin community `Community 1379`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1380`** (1 nodes): `bag-columns.tsx`
+- **Thin community `Community 1380`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1381`** (1 nodes): `bags-table.tsx`
+- **Thin community `Community 1381`** (1 nodes): `bag-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1382`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1382`** (1 nodes): `bags-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1383`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1383`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1384`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1384`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1385`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1385`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1386`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1386`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1387`** (1 nodes): `LinkedAccounts.tsx`
+- **Thin community `Community 1387`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1388`** (1 nodes): `TimelineEventCard.test.tsx`
+- **Thin community `Community 1388`** (1 nodes): `LinkedAccounts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1389`** (1 nodes): `UserCheckoutSession.tsx`
+- **Thin community `Community 1389`** (1 nodes): `TimelineEventCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1390`** (1 nodes): `UserInsightsSection.tsx`
+- **Thin community `Community 1390`** (1 nodes): `UserCheckoutSession.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1391`** (1 nodes): `index.ts`
+- **Thin community `Community 1391`** (1 nodes): `UserInsightsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1392`** (1 nodes): `config.test.ts`
+- **Thin community `Community 1392`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1393`** (1 nodes): `ThemeContext.tsx`
+- **Thin community `Community 1393`** (1 nodes): `config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1394`** (1 nodes): `design-system-build-config.test.ts`
+- **Thin community `Community 1394`** (1 nodes): `ThemeContext.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1395`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 1395`** (1 nodes): `design-system-build-config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1396`** (1 nodes): `useAuth.test.tsx`
+- **Thin community `Community 1396`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1397`** (1 nodes): `useExpenseSessions.test.ts`
+- **Thin community `Community 1397`** (1 nodes): `useAuth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1398`** (1 nodes): `useGetTerminal.test.ts`
+- **Thin community `Community 1398`** (1 nodes): `useExpenseSessions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1399`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 1399`** (1 nodes): `useGetTerminal.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1400`** (1 nodes): `useProtectedAdminPageState.test.tsx`
+- **Thin community `Community 1400`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1401`** (1 nodes): `capabilities.test.ts`
+- **Thin community `Community 1401`** (1 nodes): `useProtectedAdminPageState.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1402`** (1 nodes): `aws.ts`
+- **Thin community `Community 1402`** (1 nodes): `capabilities.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1403`** (1 nodes): `constants.ts`
+- **Thin community `Community 1403`** (1 nodes): `aws.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1404`** (1 nodes): `countries.ts`
+- **Thin community `Community 1404`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1405`** (1 nodes): `operatorMessages.test.ts`
+- **Thin community `Community 1405`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1406`** (1 nodes): `presentCommandToast.test.ts`
+- **Thin community `Community 1406`** (1 nodes): `operatorMessages.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1407`** (1 nodes): `presentUnexpectedErrorToast.test.ts`
+- **Thin community `Community 1407`** (1 nodes): `presentCommandToast.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1408`** (1 nodes): `runCommand.test.ts`
+- **Thin community `Community 1408`** (1 nodes): `presentUnexpectedErrorToast.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1409`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1409`** (1 nodes): `runCommand.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1410`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 1410`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1411`** (1 nodes): `dto.ts`
+- **Thin community `Community 1411`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1412`** (1 nodes): `ports.ts`
+- **Thin community `Community 1412`** (1 nodes): `dto.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1413`** (1 nodes): `constants.ts`
+- **Thin community `Community 1413`** (1 nodes): `ports.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1414`** (1 nodes): `displayAmounts.test.ts`
+- **Thin community `Community 1414`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1415`** (1 nodes): `cart.test.ts`
+- **Thin community `Community 1415`** (1 nodes): `displayAmounts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1416`** (1 nodes): `index.ts`
+- **Thin community `Community 1416`** (1 nodes): `cart.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1417`** (1 nodes): `session.test.ts`
+- **Thin community `Community 1417`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1418`** (1 nodes): `types.ts`
+- **Thin community `Community 1418`** (1 nodes): `session.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1419`** (1 nodes): `registerGateway.test.ts`
+- **Thin community `Community 1419`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1420`** (1 nodes): `sessionGateway.test.ts`
+- **Thin community `Community 1420`** (1 nodes): `registerGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1421`** (1 nodes): `localCommandGateway.test.ts`
+- **Thin community `Community 1421`** (1 nodes): `sessionGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1422`** (1 nodes): `localPosEntryContext.test.ts`
+- **Thin community `Community 1422`** (1 nodes): `localCommandGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1423`** (1 nodes): `localPosReadiness.test.ts`
+- **Thin community `Community 1423`** (1 nodes): `localPosEntryContext.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1424`** (1 nodes): `loggerGateway.ts`
+- **Thin community `Community 1424`** (1 nodes): `localPosReadiness.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1425`** (1 nodes): `catalogSearch.test.ts`
+- **Thin community `Community 1425`** (1 nodes): `loggerGateway.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1426`** (1 nodes): `registerUiState.ts`
+- **Thin community `Community 1426`** (1 nodes): `catalogSearch.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1427`** (1 nodes): `syncStatusPresentation.test.ts`
+- **Thin community `Community 1427`** (1 nodes): `registerUiState.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1428`** (1 nodes): `productUtils.test.ts`
+- **Thin community `Community 1428`** (1 nodes): `syncStatusPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1429`** (1 nodes): `category.ts`
+- **Thin community `Community 1429`** (1 nodes): `productUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1430`** (1 nodes): `product.ts`
+- **Thin community `Community 1430`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1431`** (1 nodes): `store.ts`
+- **Thin community `Community 1431`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1432`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1432`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1433`** (1 nodes): `user.ts`
+- **Thin community `Community 1433`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1434`** (1 nodes): `storeConfig.test.ts`
+- **Thin community `Community 1434`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1435`** (1 nodes): `createWorkflowTraceId.test.ts`
+- **Thin community `Community 1435`** (1 nodes): `localPinVerifier.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1436`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1436`** (1 nodes): `storeConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1437`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 1437`** (1 nodes): `createWorkflowTraceId.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1438`** (1 nodes): `__root.tsx`
+- **Thin community `Community 1438`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1439`** (1 nodes): `index.tsx`
+- **Thin community `Community 1439`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1440`** (1 nodes): `index.tsx`
+- **Thin community `Community 1440`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1441`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1442`** (1 nodes): `$storeUrlSlug.tsx`
+- **Thin community `Community 1442`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1443`** (1 nodes): `analytics.tsx`
+- **Thin community `Community 1443`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1444`** (1 nodes): `assets.index.tsx`
+- **Thin community `Community 1444`** (1 nodes): `$storeUrlSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1445`** (1 nodes): `bags.$bagId.tsx`
+- **Thin community `Community 1445`** (1 nodes): `analytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1446`** (1 nodes): `bags.index.tsx`
+- **Thin community `Community 1446`** (1 nodes): `assets.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1447`** (1 nodes): `index.tsx`
+- **Thin community `Community 1447`** (1 nodes): `bags.$bagId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1448`** (1 nodes): `checkout-sessions.index.tsx`
+- **Thin community `Community 1448`** (1 nodes): `bags.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1449`** (1 nodes): `configuration.index.tsx`
+- **Thin community `Community 1449`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1450`** (1 nodes): `dashboard.index.tsx`
+- **Thin community `Community 1450`** (1 nodes): `checkout-sessions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1451`** (1 nodes): `home.tsx`
+- **Thin community `Community 1451`** (1 nodes): `configuration.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1452`** (1 nodes): `logs.$logId.tsx`
+- **Thin community `Community 1452`** (1 nodes): `dashboard.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1453`** (1 nodes): `logs.index.tsx`
+- **Thin community `Community 1453`** (1 nodes): `home.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1454`** (1 nodes): `members.index.tsx`
+- **Thin community `Community 1454`** (1 nodes): `logs.$logId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1455`** (1 nodes): `index.tsx`
+- **Thin community `Community 1455`** (1 nodes): `logs.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1456`** (1 nodes): `sku-activity.test.tsx`
+- **Thin community `Community 1456`** (1 nodes): `members.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1457`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1458`** (1 nodes): `all.index.tsx`
+- **Thin community `Community 1458`** (1 nodes): `sku-activity.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1459`** (1 nodes): `cancelled.index.tsx`
+- **Thin community `Community 1459`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1460`** (1 nodes): `completed.index.tsx`
+- **Thin community `Community 1460`** (1 nodes): `all.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1461`** (1 nodes): `index.tsx`
+- **Thin community `Community 1461`** (1 nodes): `cancelled.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1462`** (1 nodes): `open.index.tsx`
+- **Thin community `Community 1462`** (1 nodes): `completed.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1463`** (1 nodes): `out-for-delivery.index.tsx`
+- **Thin community `Community 1463`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1464`** (1 nodes): `ready.index.tsx`
+- **Thin community `Community 1464`** (1 nodes): `open.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1465`** (1 nodes): `refunded.index.tsx`
+- **Thin community `Community 1465`** (1 nodes): `out-for-delivery.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1466`** (1 nodes): `$reportId.tsx`
+- **Thin community `Community 1466`** (1 nodes): `ready.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1467`** (1 nodes): `expense-reports.index.tsx`
+- **Thin community `Community 1467`** (1 nodes): `refunded.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1468`** (1 nodes): `index.tsx`
+- **Thin community `Community 1468`** (1 nodes): `$reportId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1469`** (1 nodes): `register.index.tsx`
+- **Thin community `Community 1469`** (1 nodes): `expense-reports.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1470`** (1 nodes): `sessions.index.tsx`
+- **Thin community `Community 1470`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1471`** (1 nodes): `settings.index.tsx`
+- **Thin community `Community 1471`** (1 nodes): `register.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1472`** (1 nodes): `$transactionId.tsx`
+- **Thin community `Community 1472`** (1 nodes): `sessions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1473`** (1 nodes): `transactions.index.tsx`
+- **Thin community `Community 1473`** (1 nodes): `settings.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1474`** (1 nodes): `procurement.index.test.ts`
+- **Thin community `Community 1474`** (1 nodes): `$transactionId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1475`** (1 nodes): `edit.tsx`
+- **Thin community `Community 1475`** (1 nodes): `transactions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1476`** (1 nodes): `index.tsx`
+- **Thin community `Community 1476`** (1 nodes): `procurement.index.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1477`** (1 nodes): `archived.tsx`
+- **Thin community `Community 1477`** (1 nodes): `edit.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1478`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1479`** (1 nodes): `new.tsx`
+- **Thin community `Community 1479`** (1 nodes): `archived.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1480`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1481`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1482`** (1 nodes): `unresolved.tsx`
+- **Thin community `Community 1482`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1483`** (1 nodes): `$promoCodeSlug.tsx`
+- **Thin community `Community 1483`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1484`** (1 nodes): `index.tsx`
+- **Thin community `Community 1484`** (1 nodes): `unresolved.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1485`** (1 nodes): `new.tsx`
+- **Thin community `Community 1485`** (1 nodes): `$promoCodeSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1486`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1487`** (1 nodes): `new.index.tsx`
+- **Thin community `Community 1487`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1488`** (1 nodes): `active-cases.index.tsx`
+- **Thin community `Community 1488`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1489`** (1 nodes): `appointments.index.tsx`
+- **Thin community `Community 1489`** (1 nodes): `new.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1490`** (1 nodes): `catalog-management.index.tsx`
+- **Thin community `Community 1490`** (1 nodes): `active-cases.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1491`** (1 nodes): `index.tsx`
+- **Thin community `Community 1491`** (1 nodes): `appointments.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1492`** (1 nodes): `intake.index.tsx`
+- **Thin community `Community 1492`** (1 nodes): `catalog-management.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1493`** (1 nodes): `$traceId.test.tsx`
+- **Thin community `Community 1493`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1494`** (1 nodes): `users.$userId.tsx`
+- **Thin community `Community 1494`** (1 nodes): `intake.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1495`** (1 nodes): `index.tsx`
+- **Thin community `Community 1495`** (1 nodes): `$traceId.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1496`** (1 nodes): `_authed.test.tsx`
+- **Thin community `Community 1496`** (1 nodes): `users.$userId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1497`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 1497`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1498`** (1 nodes): `join-team.index.tsx`
+- **Thin community `Community 1498`** (1 nodes): `_authed.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1499`** (1 nodes): `landing.tsx`
+- **Thin community `Community 1499`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1500`** (1 nodes): `_layout.index.test.tsx`
+- **Thin community `Community 1500`** (1 nodes): `join-team.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1501`** (1 nodes): `_layout.test.tsx`
+- **Thin community `Community 1501`** (1 nodes): `landing.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1502`** (1 nodes): `StoresSettingsAccordion.tsx`
+- **Thin community `Community 1502`** (1 nodes): `_layout.index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1503`** (1 nodes): `expenseStore.ts`
+- **Thin community `Community 1503`** (1 nodes): `_layout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1504`** (1 nodes): `Overview.stories.tsx`
+- **Thin community `Community 1504`** (1 nodes): `StoresSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1505`** (1 nodes): `foundations-content.test.tsx`
+- **Thin community `Community 1505`** (1 nodes): `expenseStore.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1506`** (1 nodes): `Introduction.stories.tsx`
+- **Thin community `Community 1506`** (1 nodes): `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1507`** (1 nodes): `introduction-content.test.tsx`
+- **Thin community `Community 1507`** (1 nodes): `foundations-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1508`** (1 nodes): `introduction-content.tsx`
+- **Thin community `Community 1508`** (1 nodes): `Introduction.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1509`** (1 nodes): `AdminShell.stories.tsx`
+- **Thin community `Community 1509`** (1 nodes): `introduction-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1510`** (1 nodes): `View.stories.tsx`
+- **Thin community `Community 1510`** (1 nodes): `introduction-content.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1511`** (1 nodes): `admin-shell-patterns.test.tsx`
+- **Thin community `Community 1511`** (1 nodes): `AdminShell.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1512`** (1 nodes): `view-patterns.test.tsx`
+- **Thin community `Community 1512`** (1 nodes): `View.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1513`** (1 nodes): `Surfaces.stories.tsx`
+- **Thin community `Community 1513`** (1 nodes): `admin-shell-patterns.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1514`** (1 nodes): `DashboardWorkspace.stories.tsx`
+- **Thin community `Community 1514`** (1 nodes): `view-patterns.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1515`** (1 nodes): `DataWorkspace.stories.tsx`
+- **Thin community `Community 1515`** (1 nodes): `Surfaces.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1516`** (1 nodes): `SettingsWorkspace.stories.tsx`
+- **Thin community `Community 1516`** (1 nodes): `DashboardWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1517`** (1 nodes): `reference-fixtures.test.tsx`
+- **Thin community `Community 1517`** (1 nodes): `DataWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1518`** (1 nodes): `storybook-config.test.ts`
+- **Thin community `Community 1518`** (1 nodes): `SettingsWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1519`** (1 nodes): `storybook-theme-decorator.test.ts`
+- **Thin community `Community 1519`** (1 nodes): `reference-fixtures.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1520`** (1 nodes): `setup.ts`
+- **Thin community `Community 1520`** (1 nodes): `storybook-config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1521`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 1521`** (1 nodes): `storybook-theme-decorator.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1522`** (1 nodes): `types.ts`
+- **Thin community `Community 1522`** (1 nodes): `setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1523`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 1523`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1524`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 1524`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1525`** (1 nodes): `global.d.ts`
+- **Thin community `Community 1525`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1526`** (1 nodes): `playwright.config.ts`
+- **Thin community `Community 1526`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1527`** (1 nodes): `analytics.test.ts`
+- **Thin community `Community 1527`** (1 nodes): `global.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1528`** (1 nodes): `types.ts`
+- **Thin community `Community 1528`** (1 nodes): `playwright.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1529`** (1 nodes): `HeartIconFilled.tsx`
+- **Thin community `Community 1529`** (1 nodes): `analytics.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1530`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 1530`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1531`** (1 nodes): `HomePage.test.tsx`
+- **Thin community `Community 1531`** (1 nodes): `HeartIconFilled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1532`** (1 nodes): `ProductCard.test.tsx`
+- **Thin community `Community 1532`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1533`** (1 nodes): `ProductCard.tsx`
+- **Thin community `Community 1533`** (1 nodes): `HomePage.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1534`** (1 nodes): `Upsell.tsx`
+- **Thin community `Community 1534`** (1 nodes): `ProductCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1535`** (1 nodes): `Checkout.test.tsx`
+- **Thin community `Community 1535`** (1 nodes): `ProductCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1536`** (1 nodes): `Checkout.tsx`
+- **Thin community `Community 1536`** (1 nodes): `Upsell.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1537`** (1 nodes): `CustomerInfoSection.tsx`
+- **Thin community `Community 1537`** (1 nodes): `Checkout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1538`** (1 nodes): `schema.ts`
+- **Thin community `Community 1538`** (1 nodes): `Checkout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1539`** (1 nodes): `DeliveryDetailsSection.tsx`
+- **Thin community `Community 1539`** (1 nodes): `CustomerInfoSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1540`** (1 nodes): `checkoutStorage.test.ts`
+- **Thin community `Community 1540`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1541`** (1 nodes): `deliveryFees.test.ts`
+- **Thin community `Community 1541`** (1 nodes): `DeliveryDetailsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1542`** (1 nodes): `deriveCheckoutState.test.ts`
+- **Thin community `Community 1542`** (1 nodes): `checkoutStorage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1543`** (1 nodes): `billingDetailsSchema.ts`
+- **Thin community `Community 1543`** (1 nodes): `deliveryFees.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1544`** (1 nodes): `checkoutFormSchema.ts`
+- **Thin community `Community 1544`** (1 nodes): `deriveCheckoutState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1545`** (1 nodes): `customerDetailsSchema.ts`
+- **Thin community `Community 1545`** (1 nodes): `billingDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1546`** (1 nodes): `deliveryDetailsSchema.ts`
+- **Thin community `Community 1546`** (1 nodes): `checkoutFormSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1547`** (1 nodes): `webOrderSchema.ts`
+- **Thin community `Community 1547`** (1 nodes): `customerDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1548`** (1 nodes): `types.ts`
+- **Thin community `Community 1548`** (1 nodes): `deliveryDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1549`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1549`** (1 nodes): `webOrderSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1550`** (1 nodes): `ProductFilterBar.tsx`
+- **Thin community `Community 1550`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1551`** (1 nodes): `BestSellersSection.test.tsx`
+- **Thin community `Community 1551`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1552`** (1 nodes): `HomeHero.tsx`
+- **Thin community `Community 1552`** (1 nodes): `ProductFilterBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1553`** (1 nodes): `HomeHeroSection.tsx`
+- **Thin community `Community 1553`** (1 nodes): `BestSellersSection.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1554`** (1 nodes): `homePageContent.test.ts`
+- **Thin community `Community 1554`** (1 nodes): `HomeHero.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1555`** (1 nodes): `MobileMenu.tsx`
+- **Thin community `Community 1555`** (1 nodes): `HomeHeroSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1556`** (1 nodes): `constants.ts`
+- **Thin community `Community 1556`** (1 nodes): `homePageContent.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1557`** (1 nodes): `navBarConstants.ts`
+- **Thin community `Community 1557`** (1 nodes): `MobileMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1558`** (1 nodes): `About.tsx`
+- **Thin community `Community 1558`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1559`** (1 nodes): `AboutProduct.tsx`
+- **Thin community `Community 1559`** (1 nodes): `navBarConstants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1560`** (1 nodes): `ProductActions.test.tsx`
+- **Thin community `Community 1560`** (1 nodes): `About.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1561`** (1 nodes): `ProductInfo.tsx`
+- **Thin community `Community 1561`** (1 nodes): `AboutProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1562`** (1 nodes): `ProductReviews.tsx`
+- **Thin community `Community 1562`** (1 nodes): `ProductActions.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1563`** (1 nodes): `ProductsNavigationBar.tsx`
+- **Thin community `Community 1563`** (1 nodes): `ProductInfo.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1564`** (1 nodes): `ErrorMessage.tsx`
+- **Thin community `Community 1564`** (1 nodes): `ProductReviews.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1565`** (1 nodes): `ExistingReviewMessage.tsx`
+- **Thin community `Community 1565`** (1 nodes): `ProductsNavigationBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1566`** (1 nodes): `OrderItem.test.tsx`
+- **Thin community `Community 1566`** (1 nodes): `ErrorMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1567`** (1 nodes): `ReviewForm.tsx`
+- **Thin community `Community 1567`** (1 nodes): `ExistingReviewMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1568`** (1 nodes): `SuccessMessage.tsx`
+- **Thin community `Community 1568`** (1 nodes): `OrderItem.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1569`** (1 nodes): `types.ts`
+- **Thin community `Community 1569`** (1 nodes): `ReviewForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1570`** (1 nodes): `SavedBag.tsx`
+- **Thin community `Community 1570`** (1 nodes): `SuccessMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1571`** (1 nodes): `SavedIcon.tsx`
+- **Thin community `Community 1571`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1572`** (1 nodes): `CartIcon.tsx`
+- **Thin community `Community 1572`** (1 nodes): `SavedBag.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1573`** (1 nodes): `ShoppingBag.test.tsx`
+- **Thin community `Community 1573`** (1 nodes): `SavedIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1574`** (1 nodes): `empty-state.tsx`
+- **Thin community `Community 1574`** (1 nodes): `CartIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1575`** (1 nodes): `Maintenance.test.tsx`
+- **Thin community `Community 1575`** (1 nodes): `ShoppingBag.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1576`** (1 nodes): `Maintenance.tsx`
+- **Thin community `Community 1576`** (1 nodes): `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1577`** (1 nodes): `AnimatedCard.tsx`
+- **Thin community `Community 1577`** (1 nodes): `Maintenance.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1578`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 1578`** (1 nodes): `Maintenance.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1579`** (1 nodes): `alert.tsx`
+- **Thin community `Community 1579`** (1 nodes): `AnimatedCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1580`** (1 nodes): `breadcrumb.tsx`
+- **Thin community `Community 1580`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1581`** (1 nodes): `button.tsx`
+- **Thin community `Community 1581`** (1 nodes): `alert.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1582`** (1 nodes): `card.tsx`
+- **Thin community `Community 1582`** (1 nodes): `breadcrumb.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1583`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 1583`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1584`** (1 nodes): `command.tsx`
+- **Thin community `Community 1584`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1585`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 1585`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1586`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 1586`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1587`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 1587`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1588`** (1 nodes): `form.tsx`
+- **Thin community `Community 1588`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1589`** (1 nodes): `icons.tsx`
+- **Thin community `Community 1589`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1590`** (1 nodes): `image-with-fallback.tsx`
+- **Thin community `Community 1590`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1591`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 1591`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1592`** (1 nodes): `input-with-end-button.tsx`
+- **Thin community `Community 1592`** (1 nodes): `image-with-fallback.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1593`** (1 nodes): `input.tsx`
+- **Thin community `Community 1593`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1594`** (1 nodes): `label.tsx`
+- **Thin community `Community 1594`** (1 nodes): `input-with-end-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1595`** (1 nodes): `LeaveAReviewModalForm.tsx`
+- **Thin community `Community 1595`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1596`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 1596`** (1 nodes): `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1597`** (1 nodes): `welcomeBackModalAnimations.ts`
+- **Thin community `Community 1597`** (1 nodes): `LeaveAReviewModalForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1598`** (1 nodes): `index.ts`
+- **Thin community `Community 1598`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1599`** (1 nodes): `types.ts`
+- **Thin community `Community 1599`** (1 nodes): `welcomeBackModalAnimations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1600`** (1 nodes): `navigation-menu.tsx`
+- **Thin community `Community 1600`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1601`** (1 nodes): `popover.tsx`
+- **Thin community `Community 1601`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1602`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 1602`** (1 nodes): `navigation-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1603`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 1603`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1604`** (1 nodes): `select.tsx`
+- **Thin community `Community 1604`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1605`** (1 nodes): `separator.tsx`
+- **Thin community `Community 1605`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1606`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 1606`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1607`** (1 nodes): `table.tsx`
+- **Thin community `Community 1607`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1608`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 1608`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1609`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 1609`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1610`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 1610`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1611`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 1611`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1612`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 1612`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1613`** (1 nodes): `config.ts`
+- **Thin community `Community 1613`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1614`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 1614`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1615`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 1615`** (1 nodes): `config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1616`** (1 nodes): `useQueryEnabled.test.ts`
+- **Thin community `Community 1616`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1617`** (1 nodes): `useStorefrontObservability.ts`
+- **Thin community `Community 1617`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1618`** (1 nodes): `constants.ts`
+- **Thin community `Community 1618`** (1 nodes): `useQueryEnabled.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1619`** (1 nodes): `countries.ts`
+- **Thin community `Community 1619`** (1 nodes): `useStorefrontObservability.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1620`** (1 nodes): `feeUtils.test.ts`
+- **Thin community `Community 1620`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1621`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1621`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1622`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 1622`** (1 nodes): `feeUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1623`** (1 nodes): `maintenanceUtils.test.ts`
+- **Thin community `Community 1623`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1624`** (1 nodes): `index.ts`
+- **Thin community `Community 1624`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1625`** (1 nodes): `store.ts`
+- **Thin community `Community 1625`** (1 nodes): `maintenanceUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1626`** (1 nodes): `bag.ts`
+- **Thin community `Community 1626`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1627`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1627`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1628`** (1 nodes): `category.ts`
+- **Thin community `Community 1628`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1629`** (1 nodes): `organization.ts`
+- **Thin community `Community 1629`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1630`** (1 nodes): `product.ts`
+- **Thin community `Community 1630`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1631`** (1 nodes): `store.ts`
+- **Thin community `Community 1631`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1632`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1632`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1633`** (1 nodes): `user.ts`
+- **Thin community `Community 1633`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1634`** (1 nodes): `states.ts`
+- **Thin community `Community 1634`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1635`** (1 nodes): `storefrontFailureObservability.test.ts`
+- **Thin community `Community 1635`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1636`** (1 nodes): `storefrontJourneyEvents.test.ts`
+- **Thin community `Community 1636`** (1 nodes): `states.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1637`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1637`** (1 nodes): `storefrontFailureObservability.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1638`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 1638`** (1 nodes): `storefrontJourneyEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1639`** (1 nodes): `-homePageLoader.test.ts`
+- **Thin community `Community 1639`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1640`** (1 nodes): `__root.tsx`
+- **Thin community `Community 1640`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1641`** (1 nodes): `$orderItemId.review.tsx`
+- **Thin community `Community 1641`** (1 nodes): `-homePageLoader.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1642`** (1 nodes): `index.tsx`
+- **Thin community `Community 1642`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1643`** (1 nodes): `$subcategorySlug.tsx`
+- **Thin community `Community 1643`** (1 nodes): `$orderItemId.review.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1644`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1645`** (1 nodes): `rewards.index.tsx`
+- **Thin community `Community 1645`** (1 nodes): `$subcategorySlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1646`** (1 nodes): `shop.saved.index.tsx`
+- **Thin community `Community 1646`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1647`** (1 nodes): `bag.index.tsx`
+- **Thin community `Community 1647`** (1 nodes): `rewards.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1648`** (1 nodes): `complete.tsx`
+- **Thin community `Community 1648`** (1 nodes): `shop.saved.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1649`** (1 nodes): `incomplete.tsx`
+- **Thin community `Community 1649`** (1 nodes): `bag.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1650`** (1 nodes): `index.tsx`
+- **Thin community `Community 1650`** (1 nodes): `complete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1651`** (1 nodes): `pending.tsx`
+- **Thin community `Community 1651`** (1 nodes): `incomplete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1652`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 1652`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1653`** (1 nodes): `storefront-boot.e2e.ts`
+- **Thin community `Community 1653`** (1 nodes): `pending.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1654`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 1654`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1655`** (1 nodes): `vitest.setup.ts`
+- **Thin community `Community 1655`** (1 nodes): `storefront-boot.e2e.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1656`** (1 nodes): `index.js`
+- **Thin community `Community 1656`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1657`** (1 nodes): `harness-app-registry.test.ts`
+- **Thin community `Community 1657`** (1 nodes): `vitest.setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1658`** (1 nodes): `athena-runtime-app.test.ts`
+- **Thin community `Community 1658`** (1 nodes): `index.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1659`** (1 nodes): `storefront-runtime-api.test.ts`
+- **Thin community `Community 1659`** (1 nodes): `harness-app-registry.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1660`** (1 nodes): `valkey-runtime-app.test.ts`
+- **Thin community `Community 1660`** (1 nodes): `athena-runtime-app.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1661`** (1 nodes): `harness-behavior-scenarios.test.ts`
+- **Thin community `Community 1661`** (1 nodes): `storefront-runtime-api.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1662`** (1 nodes): `harness-repo-validation.test.ts`
+- **Thin community `Community 1662`** (1 nodes): `valkey-runtime-app.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1663`** (1 nodes): `harness-behavior-scenarios.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1664`** (1 nodes): `harness-repo-validation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -7,10 +7,10 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 - [packages/AGENTS.md](../../packages/AGENTS.md) - package router plus the operational guides for each harnessed package
 
 ## Repo Summary
-- Code files discovered: 1734
-- Graph nodes: 5428
-- Graph edges: 5624
-- Communities: 1663
+- Code files discovered: 1736
+- Graph nodes: 5457
+- Graph edges: 5676
+- Communities: 1665
 
 ## Graph Hotspots
 - `DailyCloseView.tsx` (82 edges, Community 0) - [`packages/athena-webapp/src/components/operations/DailyCloseView.tsx`](../../packages/athena-webapp/src/components/operations/DailyCloseView.tsx)

--- a/graphify-out/wiki/packages/storefront-webapp.md
+++ b/graphify-out/wiki/packages/storefront-webapp.md
@@ -19,9 +19,9 @@ Landing page for packages/storefront-webapp. Use this page to orient around grap
 ## Graph Hotspots
 - `storefrontJourneyEvents.ts` (45 edges, Community 3) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
 - `createJourneyEvent()` (40 edges, Community 3) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
-- `getStoreConfigV2()` (17 edges, Community 26) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)
-- `checkoutSession.ts` (14 edges, Community 56) - [`packages/storefront-webapp/src/api/checkoutSession.ts`](../../../packages/storefront-webapp/src/api/checkoutSession.ts)
-- `storeConfig.ts` (14 edges, Community 26) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)
+- `getStoreConfigV2()` (17 edges, Community 27) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)
+- `checkoutSession.ts` (14 edges, Community 57) - [`packages/storefront-webapp/src/api/checkoutSession.ts`](../../../packages/storefront-webapp/src/api/checkoutSession.ts)
+- `storeConfig.ts` (14 edges, Community 27) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)
 
 ## Navigation
 - [wiki index](../index.md) - back to the wiki index

--- a/graphify-out/wiki/packages/valkey-proxy-server.md
+++ b/graphify-out/wiki/packages/valkey-proxy-server.md
@@ -17,11 +17,11 @@ Landing page for packages/valkey-proxy-server. Use this page to orient around gr
 - [validation-map.json](../../../packages/valkey-proxy-server/docs/agent/validation-map.json)
 
 ## Graph Hotspots
-- `app.js` (14 edges, Community 61) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
+- `app.js` (14 edges, Community 62) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
 - `app.test.js` (6 edges, Community 106) - [`packages/valkey-proxy-server/app.test.js`](../../../packages/valkey-proxy-server/app.test.js)
-- `createRedisClient()` (4 edges, Community 61) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
-- `createRedisCluster()` (3 edges, Community 61) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
-- `deleteKeysIndividually()` (3 edges, Community 61) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
+- `createRedisClient()` (4 edges, Community 62) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
+- `createRedisCluster()` (3 edges, Community 62) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
+- `deleteKeysIndividually()` (3 edges, Community 62) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
 
 ## Navigation
 - [wiki index](../index.md) - back to the wiki index

--- a/packages/athena-webapp/convex/operations/staffCredentials.test.ts
+++ b/packages/athena-webapp/convex/operations/staffCredentials.test.ts
@@ -23,6 +23,7 @@ import {
   createStaffCredentialWithCtx,
   getStaffCredentialUsernameAvailabilityWithCtx,
   listStaffCredentialsByStoreWithCtx,
+  refreshTerminalStaffAuthority,
   updateStaffCredentialWithCtx,
 } from "./staffCredentials";
 import { hashPosLocalStaffProofToken } from "../pos/application/sync/staffProof";
@@ -39,6 +40,14 @@ type TableName =
   | "staffProfile"
   | "staffRoleAssignment";
 type Row = Record<string, unknown> & { _id: string };
+
+const localPinVerifier = {
+  algorithm: "PBKDF2-SHA256",
+  hash: "local-hash",
+  iterations: 120000,
+  salt: "salt",
+  version: 1,
+};
 
 function createStaffCredentialsMutationCtx(seed?: {
   approvalProofs?: Row[];
@@ -184,7 +193,7 @@ describe("staff credential operations", () => {
   });
 
   it("reports store-scoped username availability", async () => {
-    const { ctx } = createStaffCredentialsMutationCtx({
+    const { ctx, tables } = createStaffCredentialsMutationCtx({
       credentials: [
         {
           _id: "credential-1",
@@ -192,6 +201,8 @@ describe("staff credential operations", () => {
           organizationId: "org_1" as Id<"organization">,
           storeId: "store_1" as Id<"store">,
           username: "frontdesk",
+          localPinVerifier,
+          localVerifierVersion: 1,
           pinHash: "hash-1",
           status: "active",
         },
@@ -220,7 +231,7 @@ describe("staff credential operations", () => {
   });
 
   it("lists credentials for a single store, including pending records", async () => {
-    const { ctx } = createStaffCredentialsMutationCtx({
+    const { ctx, tables } = createStaffCredentialsMutationCtx({
       credentials: [
         {
           _id: "credential-1",
@@ -237,6 +248,7 @@ describe("staff credential operations", () => {
           organizationId: "org_1" as Id<"organization">,
           storeId: "store_1" as Id<"store">,
           username: "pending-user",
+          pinHash: "pending-hash",
           status: "pending",
         },
         {
@@ -251,11 +263,11 @@ describe("staff credential operations", () => {
       ],
     });
 
-    await expect(
-      listStaffCredentialsByStoreWithCtx(ctx, {
-        storeId: "store_1" as Id<"store">,
-      })
-    ).resolves.toEqual(
+    const credentials = await listStaffCredentialsByStoreWithCtx(ctx, {
+      storeId: "store_1" as Id<"store">,
+    });
+
+    expect(credentials).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
           _id: "credential-1",
@@ -269,12 +281,17 @@ describe("staff credential operations", () => {
           username: "pending-user",
           status: "pending",
         }),
-      ])
+      ]),
     );
+    for (const credential of credentials) {
+      expect(credential).not.toHaveProperty("pinHash");
+      expect(credential).not.toHaveProperty("localPinVerifier");
+      expect(credential).not.toHaveProperty("localVerifierVersion");
+    }
   });
 
   it("keeps pending credentials from authenticating until PIN setup activates them", async () => {
-    const { ctx } = createStaffCredentialsMutationCtx({
+    const { ctx, tables } = createStaffCredentialsMutationCtx({
       credentials: [
         {
           _id: "credential-1",
@@ -346,6 +363,12 @@ describe("staff credential operations", () => {
     });
 
     expect(activated).toMatchObject({
+      status: "active",
+    });
+    expect(activated).not.toHaveProperty("pinHash");
+    expect(activated).not.toHaveProperty("localPinVerifier");
+    expect(activated).not.toHaveProperty("localVerifierVersion");
+    expect(tables.staffCredential.get("credential-1")).toMatchObject({
       pinHash: "hash-1",
       status: "active",
     });
@@ -397,6 +420,7 @@ describe("staff credential operations", () => {
       storeId: "store_1" as Id<"store">,
       username: " FrontDesk ",
       pinHash: "hash-1",
+      localPinVerifier,
     });
 
     expect(result).toMatchObject({
@@ -404,15 +428,22 @@ describe("staff credential operations", () => {
       organizationId: "org_1",
       storeId: "store_1",
       username: "frontdesk",
-      pinHash: "hash-1",
       status: "active",
     });
+    expect(result).not.toHaveProperty("pinHash");
+    expect(result).not.toHaveProperty("localPinVerifier");
+    expect(result).not.toHaveProperty("localVerifierVersion");
     expect(result?.lastAuthenticatedAt).toBeUndefined();
     expect(tables.staffCredential.size).toBe(1);
+    expect(Array.from(tables.staffCredential.values())[0]).toMatchObject({
+      pinHash: "hash-1",
+      localPinVerifier,
+      localVerifierVersion: 1,
+    });
   });
 
   it("rejects credential creation when the username is already taken", async () => {
-    const { ctx } = createStaffCredentialsMutationCtx({
+    const { ctx, tables } = createStaffCredentialsMutationCtx({
       credentials: [
         {
           _id: "credential-1",
@@ -564,11 +595,21 @@ describe("staff credential operations", () => {
       storeId: "store_1" as Id<"store">,
       username: "desk-2",
       pinHash: "hash-2",
+      localPinVerifier,
     });
 
     expect(rotated).toMatchObject({
       username: "desk-2",
+      status: "active",
+    });
+    expect(rotated).not.toHaveProperty("pinHash");
+    expect(rotated).not.toHaveProperty("localPinVerifier");
+    expect(rotated).not.toHaveProperty("localVerifierVersion");
+    expect(tables.staffCredential.get("credential-1")).toMatchObject({
+      username: "desk-2",
       pinHash: "hash-2",
+      localPinVerifier,
+      localVerifierVersion: 1,
       status: "active",
     });
 
@@ -583,6 +624,118 @@ describe("staff credential operations", () => {
       status: "suspended",
     });
     expect(tables.staffCredential.get("credential-1")?.status).toBe("suspended");
+  });
+
+  it("increments the local verifier version when a credential PIN is reset", async () => {
+    const { ctx, tables } = createStaffCredentialsMutationCtx({
+      credentials: [
+        {
+          _id: "credential-1",
+          staffProfileId: "staff_profile_1",
+          organizationId: "org_1",
+          storeId: "store_1",
+          username: "frontdesk",
+          pinHash: "hash-1",
+          localPinVerifier,
+          localVerifierVersion: 3,
+          status: "active",
+        },
+      ],
+      profiles: [
+        {
+          _id: "staff_profile_1",
+          storeId: "store_1",
+          organizationId: "org_1",
+          status: "active",
+          fullName: "Ari Mensah",
+        },
+      ],
+      roles: [
+        {
+          _id: "role_1",
+          staffProfileId: "staff_profile_1",
+          organizationId: "org_1",
+          storeId: "store_1",
+          role: "cashier",
+          isPrimary: true,
+          status: "active",
+          assignedAt: 1,
+        },
+      ],
+    });
+    const nextVerifier = { ...localPinVerifier, hash: "next-local-hash" };
+
+    await expect(
+      updateStaffCredentialWithCtx(ctx, {
+        organizationId: "org_1" as Id<"organization">,
+        pinHash: "hash-2",
+        localPinVerifier: nextVerifier,
+        staffProfileId: "staff_profile_1" as Id<"staffProfile">,
+        storeId: "store_1" as Id<"store">,
+      }),
+    ).resolves.toMatchObject({
+      status: "active",
+    });
+    expect(tables.staffCredential.get("credential-1")).toMatchObject({
+      localPinVerifier: nextVerifier,
+      localVerifierVersion: 4,
+      pinHash: "hash-2",
+    });
+  });
+
+  it("clears stale local verifier metadata when a PIN reset omits a verifier", async () => {
+    const { ctx, tables } = createStaffCredentialsMutationCtx({
+      credentials: [
+        {
+          _id: "credential-1",
+          staffProfileId: "staff_profile_1",
+          organizationId: "org_1",
+          storeId: "store_1",
+          username: "frontdesk",
+          pinHash: "hash-1",
+          localPinVerifier,
+          localVerifierVersion: 3,
+          status: "active",
+        },
+      ],
+      profiles: [
+        {
+          _id: "staff_profile_1",
+          storeId: "store_1",
+          organizationId: "org_1",
+          status: "active",
+          fullName: "Ari Mensah",
+        },
+      ],
+      roles: [
+        {
+          _id: "role_1",
+          staffProfileId: "staff_profile_1",
+          organizationId: "org_1",
+          storeId: "store_1",
+          role: "cashier",
+          isPrimary: true,
+          status: "active",
+          assignedAt: 1,
+        },
+      ],
+    });
+
+    await expect(
+      updateStaffCredentialWithCtx(ctx, {
+        organizationId: "org_1" as Id<"organization">,
+        pinHash: "hash-2",
+        staffProfileId: "staff_profile_1" as Id<"staffProfile">,
+        storeId: "store_1" as Id<"store">,
+      }),
+    ).resolves.toMatchObject({
+      status: "active",
+    });
+    expect(tables.staffCredential.get("credential-1")).toMatchObject({
+      localPinVerifier: undefined,
+      localVerifierVersion: 4,
+      pinHash: "hash-2",
+    });
   });
 
   it("authenticates only active credentials with active profiles and allowed roles", async () => {
@@ -928,6 +1081,145 @@ describe("staff credential operations", () => {
         userId: "athena-user-1",
       },
     );
+  });
+
+  it("refreshes terminal-scoped local staff authority without exposing legacy credentials", async () => {
+    const { ctx, tables } = createStaffCredentialsMutationCtx({
+      credentials: [
+        {
+          _id: "credential-1",
+          staffProfileId: "staff_profile_1",
+          organizationId: "org_1",
+          storeId: "store_1",
+          username: "frontdesk",
+          pinHash: "hash-1",
+          localPinVerifier,
+          localVerifierVersion: 2,
+          status: "active",
+        },
+        {
+          _id: "credential-2",
+          staffProfileId: "staff_profile_2",
+          organizationId: "org_1",
+          storeId: "store_1",
+          username: "legacy",
+          pinHash: "hash-2",
+          status: "active",
+        },
+      ],
+      profiles: [
+        {
+          _id: "staff_profile_1",
+          storeId: "store_1",
+          organizationId: "org_1",
+          status: "active",
+          firstName: "Ari",
+          fullName: "Ari Mensah",
+          lastName: "Mensah",
+        },
+        {
+          _id: "staff_profile_2",
+          storeId: "store_1",
+          organizationId: "org_1",
+          status: "active",
+          fullName: "Legacy Staff",
+        },
+      ],
+      roles: [
+        {
+          _id: "role_1",
+          staffProfileId: "staff_profile_1",
+          organizationId: "org_1",
+          storeId: "store_1",
+          role: "cashier",
+          isPrimary: true,
+          status: "active",
+          assignedAt: 1,
+        },
+        {
+          _id: "role_2",
+          staffProfileId: "staff_profile_2",
+          organizationId: "org_1",
+          storeId: "store_1",
+          role: "cashier",
+          isPrimary: true,
+          status: "active",
+          assignedAt: 1,
+        },
+      ],
+    });
+
+    await expect(
+      getHandler(refreshTerminalStaffAuthority)(ctx, {
+        storeId: "store_1" as Id<"store">,
+        terminalId: "terminal-1" as Id<"posTerminal">,
+      }),
+    ).resolves.toEqual({
+      kind: "ok",
+      data: [
+        expect.objectContaining({
+          activeRoles: ["cashier"],
+          credentialId: "credential-1",
+          credentialVersion: 2,
+          displayName: "Ari Mensah",
+          staffProfileId: "staff_profile_1",
+          username: "frontdesk",
+          verifier: localPinVerifier,
+        }),
+      ],
+    });
+    expect(tables.posLocalStaffProof.size).toBe(0);
+  });
+
+  it("fails staff authority refresh instead of returning a truncated snapshot", async () => {
+    const credentials = Array.from({ length: 1001 }, (_, index) => ({
+      _id: `credential-${index}`,
+      staffProfileId: `staff_profile_${index}`,
+      organizationId: "org_1",
+      storeId: "store_1",
+      username: `staff${index}`,
+      pinHash: `hash-${index}`,
+      localPinVerifier,
+      localVerifierVersion: 1,
+      status: "active",
+    }));
+    const profiles = credentials.map((credential, index) => ({
+      _id: credential.staffProfileId,
+      storeId: "store_1",
+      organizationId: "org_1",
+      status: "active",
+      fullName: `Staff ${index}`,
+    }));
+    const roles = credentials.map((credential, index) => ({
+      _id: `role_${index}`,
+      staffProfileId: credential.staffProfileId,
+      organizationId: "org_1",
+      storeId: "store_1",
+      role: "cashier",
+      isPrimary: true,
+      status: "active",
+      assignedAt: 1,
+    }));
+    const { ctx, tables } = createStaffCredentialsMutationCtx({
+      credentials,
+      profiles,
+      roles,
+    });
+
+    await expect(
+      getHandler(refreshTerminalStaffAuthority)(ctx, {
+        storeId: "store_1" as Id<"store">,
+        terminalId: "terminal-1" as Id<"posTerminal">,
+      }),
+    ).resolves.toEqual({
+      kind: "user_error",
+      error: {
+        code: "precondition_failed",
+        message:
+          "Staff sign-in list is too large to refresh safely. Contact support before using offline sign-in.",
+      },
+    });
+    expect(tables.posLocalStaffProof.size).toBe(0);
   });
 
   it("returns a precondition_failed result when the staff member is active on another terminal", async () => {

--- a/packages/athena-webapp/convex/operations/staffCredentials.ts
+++ b/packages/athena-webapp/convex/operations/staffCredentials.ts
@@ -28,16 +28,46 @@ export const STAFF_CREDENTIAL_STATUS = v.union(
   v.literal("revoked"),
 );
 
+const localPinVerifierValidator = v.object({
+  algorithm: v.string(),
+  hash: v.string(),
+  iterations: v.number(),
+  salt: v.string(),
+  version: v.number(),
+});
+
+const localStaffAuthorityRecordValidator = v.object({
+  activeRoles: v.array(v.union(v.literal("cashier"), v.literal("manager"))),
+  credentialId: v.id("staffCredential"),
+  credentialVersion: v.number(),
+  displayName: v.optional(v.union(v.string(), v.null())),
+  expiresAt: v.number(),
+  issuedAt: v.number(),
+  organizationId: v.id("organization"),
+  refreshedAt: v.number(),
+  staffProfileId: v.id("staffProfile"),
+  status: v.literal("active"),
+  storeId: v.id("store"),
+  terminalId: v.id("posTerminal"),
+  username: v.string(),
+  verifier: localPinVerifierValidator,
+});
+
 export type StaffCredentialStatus =
   | "pending"
   | "active"
   | "suspended"
   | "revoked";
 type StaffCredentialReaderCtx = Pick<QueryCtx, "db"> | Pick<MutationCtx, "db">;
+type PublicStaffCredential = Omit<
+  Doc<"staffCredential">,
+  "localPinVerifier" | "localVerifierVersion" | "pinHash"
+>;
 
 type StaffCredentialAuthenticationData = {
   activeRoles: OperationalRole[];
   credentialId: Id<"staffCredential">;
+  credentialVersion?: number;
   posLocalStaffProof?: {
     expiresAt: number;
     token: string;
@@ -56,7 +86,13 @@ type StaffCredentialApprovalAuthenticationData = {
   requestedByStaffProfileId?: Id<"staffProfile">;
 };
 
+type PosTerminalAuthorizationResult = CommandResult<{
+  store: Doc<"store">;
+  terminal: Doc<"posTerminal">;
+}>;
+
 const ACTIVE_STAFF_SESSION_LOOKUP_LIMIT = 100;
+const STAFF_AUTHORITY_REFRESH_LIMIT = 1_000;
 
 function normalizeUsername(username: string) {
   return username.trim().toLowerCase();
@@ -95,6 +131,47 @@ function staffPreconditionFailedResult(
     code: "precondition_failed",
     message,
   });
+}
+
+function terminalAuthorizationFailedResult(): PosTerminalAuthorizationResult {
+  return userError({
+    code: "authorization_failed",
+    message: "This terminal is not available for staff authentication.",
+  });
+}
+
+async function requirePosTerminalAuthorityWithCtx(
+  ctx: MutationCtx,
+  args: {
+    storeId: Id<"store">;
+    terminalId: Id<"posTerminal">;
+  },
+): Promise<PosTerminalAuthorizationResult> {
+  const terminal = await ctx.db.get("posTerminal", args.terminalId);
+  if (!terminal || terminal.storeId !== args.storeId || terminal.status !== "active") {
+    return terminalAuthorizationFailedResult();
+  }
+
+  try {
+    const store = await ctx.db.get("store", args.storeId);
+    if (!store) {
+      return terminalAuthorizationFailedResult();
+    }
+    const athenaUser = await requireAuthenticatedAthenaUserWithCtx(ctx);
+    if (terminal.registeredByUserId !== athenaUser._id) {
+      return terminalAuthorizationFailedResult();
+    }
+    await requireOrganizationMemberRoleWithCtx(ctx, {
+      allowedRoles: ["full_admin", "pos_only"],
+      failureMessage: "You do not have access to this POS terminal.",
+      organizationId: store.organizationId,
+      userId: athenaUser._id,
+    });
+
+    return ok({ store, terminal });
+  } catch {
+    return terminalAuthorizationFailedResult();
+  }
 }
 
 export async function getStaffCredentialByStaffProfileIdWithCtx(
@@ -241,7 +318,7 @@ export async function listStaffCredentialsByStoreWithCtx(
   args: {
     storeId: Id<"store">;
   },
-) {
+): Promise<PublicStaffCredential[]> {
   // Store staff rosters stay small enough for the admin credential screen to read them in full.
   const [
     pendingCredentials,
@@ -284,12 +361,31 @@ export async function listStaffCredentialsByStoreWithCtx(
     ...activeCredentials,
     ...suspendedCredentials,
     ...revokedCredentials,
-  ];
+  ].map(toPublicStaffCredential);
+}
+
+function toPublicStaffCredential(
+  credential: Doc<"staffCredential">,
+): PublicStaffCredential {
+  const {
+    localPinVerifier: _localPinVerifier,
+    localVerifierVersion: _localVerifierVersion,
+    pinHash: _pinHash,
+    ...publicCredential
+  } = credential;
+  return publicCredential;
 }
 
 export async function createStaffCredentialWithCtx(
   ctx: Pick<MutationCtx, "db">,
   args: {
+    localPinVerifier?: {
+      algorithm: string;
+      hash: string;
+      iterations: number;
+      salt: string;
+      version: number;
+    };
     organizationId: Id<"organization">;
     pinHash?: string;
     staffProfileId: Id<"staffProfile">;
@@ -322,16 +418,31 @@ export async function createStaffCredentialWithCtx(
     organizationId: args.organizationId,
     storeId: args.storeId,
     username: normalizedUsername,
+    ...(args.localPinVerifier
+      ? {
+          localPinVerifier: args.localPinVerifier,
+          localVerifierVersion: 1,
+        }
+      : {}),
     pinHash: args.pinHash,
     status: args.pinHash ? ("active" as const) : ("pending" as const),
   });
 
-  return ctx.db.get("staffCredential", credentialId);
+  const credential = await ctx.db.get("staffCredential", credentialId);
+  if (!credential) return null;
+  return toPublicStaffCredential(credential);
 }
 
 export async function updateStaffCredentialWithCtx(
   ctx: Pick<MutationCtx, "db">,
   args: {
+    localPinVerifier?: {
+      algorithm: string;
+      hash: string;
+      iterations: number;
+      salt: string;
+      version: number;
+    };
     organizationId: Id<"organization">;
     pinHash?: string;
     staffCredentialId?: Id<"staffCredential">;
@@ -394,6 +505,9 @@ export async function updateStaffCredentialWithCtx(
 
   if (args.pinHash !== undefined) {
     updates.pinHash = args.pinHash;
+    updates.localPinVerifier = args.localPinVerifier;
+    updates.localVerifierVersion =
+      (existingCredential.localVerifierVersion ?? 0) + 1;
   }
 
   const resolvedStatus =
@@ -422,7 +536,9 @@ export async function updateStaffCredentialWithCtx(
 
   await ctx.db.patch("staffCredential", existingCredential._id, updates);
 
-  return ctx.db.get("staffCredential", existingCredential._id);
+  const credential = await ctx.db.get("staffCredential", existingCredential._id);
+  if (!credential) return null;
+  return toPublicStaffCredential(credential);
 }
 
 export async function authenticateStaffCredentialWithCtx(
@@ -510,6 +626,9 @@ export async function authenticateStaffCredentialWithCtx(
   return ok({
     activeRoles: authorizedRoles.map((role) => role.role),
     credentialId: activeCredential._id,
+    ...(activeCredential.localVerifierVersion
+      ? { credentialVersion: activeCredential.localVerifierVersion }
+      : {}),
     staffProfile,
     staffProfileId: activeCredential.staffProfileId,
   });
@@ -599,26 +718,53 @@ async function withPosLocalStaffProof(
     return authentication;
   }
 
+  const credential = await ctx.db.get(
+    "staffCredential",
+    authentication.data.credentialId,
+  );
+  const proof = await issuePosLocalStaffProofWithCtx(ctx, {
+    credentialId: authentication.data.credentialId,
+    credentialVersion: credential?.localVerifierVersion,
+    staffProfileId: authentication.data.staffProfileId,
+    storeId: args.storeId,
+    terminalId: args.terminalId,
+  });
+
+  return ok({
+    ...authentication.data,
+    posLocalStaffProof: proof,
+  });
+}
+
+async function issuePosLocalStaffProofWithCtx(
+  ctx: Pick<MutationCtx, "db">,
+  args: {
+    credentialId: Id<"staffCredential">;
+    credentialVersion?: number;
+    staffProfileId: Id<"staffProfile">;
+    storeId: Id<"store">;
+    terminalId: Id<"posTerminal">;
+  },
+) {
   const now = Date.now();
   const token = createPosLocalStaffProofToken();
+  const expiresAt = now + POS_LOCAL_STAFF_PROOF_TTL_MS;
+
   await ctx.db.insert("posLocalStaffProof", {
-    credentialId: authentication.data.credentialId,
+    credentialId: args.credentialId,
+    ...(args.credentialVersion
+      ? { credentialVersion: args.credentialVersion }
+      : {}),
     createdAt: now,
-    expiresAt: now + POS_LOCAL_STAFF_PROOF_TTL_MS,
-    staffProfileId: authentication.data.staffProfileId,
+    expiresAt,
+    staffProfileId: args.staffProfileId,
     status: "active",
     storeId: args.storeId,
     terminalId: args.terminalId,
     tokenHash: await hashPosLocalStaffProofToken(token),
   });
 
-  return ok({
-    ...authentication.data,
-    posLocalStaffProof: {
-      expiresAt: now + POS_LOCAL_STAFF_PROOF_TTL_MS,
-      token,
-    },
-  });
+  return { expiresAt, token };
 }
 
 export async function authenticateStaffCredentialForApprovalWithCtx(
@@ -676,6 +822,7 @@ export const listStaffCredentialsByStore = query({
 
 export const createStaffCredential = mutation({
   args: {
+    localPinVerifier: v.optional(localPinVerifierValidator),
     organizationId: v.id("organization"),
     pinHash: v.optional(v.string()),
     staffProfileId: v.id("staffProfile"),
@@ -725,6 +872,7 @@ export const createStaffCredential = mutation({
 
 export const updateStaffCredential = mutation({
   args: {
+    localPinVerifier: v.optional(localPinVerifierValidator),
     organizationId: v.id("organization"),
     pinHash: v.optional(v.string()),
     staffCredentialId: v.optional(v.id("staffCredential")),
@@ -795,39 +943,134 @@ export const authenticateStaffCredentialForTerminal = mutation({
     username: v.string(),
   },
   handler: async (ctx, args) => {
-    const terminal = await ctx.db.get("posTerminal", args.terminalId);
-    if (!terminal || terminal.storeId !== args.storeId || terminal.status !== "active") {
-      return staffAuthorizationFailedResult(
-        "This terminal is not available for staff authentication.",
-      );
-    }
-
-    try {
-      const store = await ctx.db.get("store", args.storeId);
-      if (!store) {
-        return staffAuthorizationFailedResult(
-          "This terminal is not available for staff authentication.",
-        );
-      }
-      const athenaUser = await requireAuthenticatedAthenaUserWithCtx(ctx);
-      if (terminal.registeredByUserId !== athenaUser._id) {
-        return staffAuthorizationFailedResult(
-          "This terminal is not available for staff authentication.",
-        );
-      }
-      await requireOrganizationMemberRoleWithCtx(ctx, {
-        allowedRoles: ["full_admin", "pos_only"],
-        failureMessage: "You do not have access to this POS terminal.",
-        organizationId: store.organizationId,
-        userId: athenaUser._id,
-      });
-    } catch {
-      return staffAuthorizationFailedResult(
-        "This terminal is not available for staff authentication.",
-      );
+    const terminalAuthority = await requirePosTerminalAuthorityWithCtx(ctx, {
+      storeId: args.storeId,
+      terminalId: args.terminalId,
+    });
+    if (terminalAuthority.kind !== "ok") {
+      return terminalAuthority;
     }
 
     return authenticateStaffCredentialForTerminalWithCtx(ctx, args);
+  },
+});
+
+export const refreshTerminalStaffAuthority = mutation({
+  args: {
+    storeId: v.id("store"),
+    terminalId: v.id("posTerminal"),
+  },
+  returns: commandResultValidator(v.array(localStaffAuthorityRecordValidator)),
+  handler: async (ctx, args) => {
+    const terminalAuthority = await requirePosTerminalAuthorityWithCtx(ctx, {
+      storeId: args.storeId,
+      terminalId: args.terminalId,
+    });
+    if (terminalAuthority.kind !== "ok") {
+      return terminalAuthority;
+    }
+
+    const refreshedAt = Date.now();
+    const credentials = await ctx.db
+      .query("staffCredential")
+      .withIndex("by_storeId_status", (q) =>
+        q.eq("storeId", args.storeId).eq("status", "active"),
+      )
+      .take(STAFF_AUTHORITY_REFRESH_LIMIT + 1);
+    const [profiles, roleAssignments] = await Promise.all([
+      ctx.db
+        .query("staffProfile")
+        .withIndex("by_storeId_status", (q) =>
+          q.eq("storeId", args.storeId).eq("status", "active"),
+        )
+        .take(STAFF_AUTHORITY_REFRESH_LIMIT + 1),
+      ctx.db
+        .query("staffRoleAssignment")
+        .withIndex("by_storeId", (q) => q.eq("storeId", args.storeId))
+        .take(STAFF_AUTHORITY_REFRESH_LIMIT + 1),
+    ]);
+    if (
+      credentials.length > STAFF_AUTHORITY_REFRESH_LIMIT ||
+      profiles.length > STAFF_AUTHORITY_REFRESH_LIMIT ||
+      roleAssignments.length > STAFF_AUTHORITY_REFRESH_LIMIT
+    ) {
+      return userError({
+        code: "precondition_failed",
+        message:
+          "Staff sign-in list is too large to refresh safely. Contact support before using offline sign-in.",
+      });
+    }
+    const activeProfilesById = new Map(
+      profiles.map((profile) => [profile._id, profile]),
+    );
+    const activePosRolesByStaffProfileId = new Map<
+      Id<"staffProfile">,
+      Array<"cashier" | "manager">
+    >();
+    for (const assignment of roleAssignments) {
+      if (
+        assignment.status !== "active" ||
+        (assignment.role !== "cashier" && assignment.role !== "manager")
+      ) {
+        continue;
+      }
+      const roles = activePosRolesByStaffProfileId.get(assignment.staffProfileId) ?? [];
+      roles.push(assignment.role);
+      activePosRolesByStaffProfileId.set(assignment.staffProfileId, roles);
+    }
+    const authority = [];
+
+    for (const credential of credentials) {
+      if (
+        !credential.pinHash ||
+        !credential.localPinVerifier ||
+        !credential.localVerifierVersion
+      ) {
+        continue;
+      }
+
+      const staffProfile = activeProfilesById.get(credential.staffProfileId);
+      if (
+        !staffProfile ||
+        staffProfile.storeId !== args.storeId ||
+        staffProfile.status !== "active"
+      ) {
+        continue;
+      }
+
+      const activeRoles =
+        activePosRolesByStaffProfileId.get(credential.staffProfileId) ?? [];
+
+      if (activeRoles.length === 0) {
+        continue;
+      }
+
+      const expiresAt = refreshedAt + POS_LOCAL_STAFF_PROOF_TTL_MS;
+
+      authority.push({
+        activeRoles,
+        credentialId: credential._id,
+        credentialVersion: credential.localVerifierVersion,
+        displayName:
+          staffProfile.fullName ??
+          [staffProfile.firstName, staffProfile.lastName]
+            .filter(Boolean)
+            .join(" ") ??
+          null,
+        expiresAt,
+        issuedAt: refreshedAt,
+        organizationId: credential.organizationId,
+        refreshedAt,
+        staffProfileId: credential.staffProfileId,
+        status: credential.status,
+        storeId: args.storeId,
+        terminalId: args.terminalId,
+        username: credential.username,
+        verifier: credential.localPinVerifier,
+      });
+    }
+
+    return ok(authority);
   },
 });
 

--- a/packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.test.ts
+++ b/packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.test.ts
@@ -1385,7 +1385,7 @@ describe("createLocalSyncIngestionService", () => {
     );
   });
 
-  it("rejects held event retries when the staff proof token changed", async () => {
+  it("allows held event retries when only the staff proof token changed", async () => {
     const repository = createFakeSyncRepository();
     const service = createLocalSyncIngestionService({
       repository,
@@ -1407,14 +1407,14 @@ describe("createLocalSyncIngestionService", () => {
       }),
     );
 
-    expect(retry).toEqual({
-      kind: "user_error",
-      error: {
-        code: "validation_failed",
-        message:
-          "POS sync event retry does not match the original local event.",
-      },
-    });
+    expect(retry.kind).toBe("ok");
+    if (retry.kind !== "ok") throw new Error("Expected ok result");
+    expect(retry.data.held).toEqual([
+      expect.objectContaining({
+        localEventId: "event-sale-completed-2",
+        sequence: 2,
+      }),
+    ]);
     expect(repository.events[0]).toEqual(
       expect.objectContaining({
         staffProofTokenHash: await hashPosLocalStaffProofToken("proof-token-1"),
@@ -1806,6 +1806,46 @@ describe("createLocalSyncIngestionService", () => {
           "POS sync event retry does not match the original local event.",
       },
     });
+  });
+
+  it("accepts duplicate projected event retries when only the staff proof token changed", async () => {
+    const repository = createFakeSyncRepository();
+    const service = createLocalSyncIngestionService({
+      repository,
+      projectionRepository: repository,
+      now: () => 100,
+    });
+
+    await service.ingestBatch(
+      buildBatch({ events: [buildSaleCompletedEvent({ sequence: 1 })] }),
+    );
+    const retry = await service.ingestBatch(
+      buildBatch({
+        events: [
+          buildSaleCompletedEvent({
+            sequence: 1,
+            staffProofToken: "proof-token-2",
+          }),
+        ],
+      }),
+    );
+
+    expect(retry.kind).toBe("ok");
+    if (retry.kind !== "ok") throw new Error("Expected ok result");
+    expect(retry.data.accepted).toEqual([
+      expect.objectContaining({
+        localEventId: "event-sale-completed-1",
+        sequence: 1,
+        status: "projected",
+      }),
+    ]);
+    expect(repository.events).toHaveLength(1);
+    expect(repository.events[0]).toEqual(
+      expect.objectContaining({
+        staffProofTokenHash: await hashPosLocalStaffProofToken("proof-token-1"),
+        status: "projected",
+      }),
+    );
   });
 
   it("rejects malformed nested Convex ids before projection side effects", async () => {
@@ -2250,6 +2290,7 @@ describe("createLocalSyncIngestionService", () => {
         {
           _id: "proof-1",
           credentialId: "credential-1",
+          credentialVersion: 2,
           expiresAt: 200,
           staffProfileId: "staff-1",
           status: "active",
@@ -2261,6 +2302,7 @@ describe("createLocalSyncIngestionService", () => {
       staffCredential: [
         {
           _id: "credential-1",
+          localVerifierVersion: 2,
           staffProfileId: "staff-1",
           status: "active",
           storeId: "store-1",
@@ -2324,12 +2366,63 @@ describe("createLocalSyncIngestionService", () => {
       }),
     ).resolves.toBe(false);
 
+    await ctx.db.patch("staffCredential", "credential-1", {
+      localVerifierVersion: 3,
+    });
+    await expect(
+      repository.validateLocalStaffProof({
+        staffProfileId: "staff-1" as never,
+        storeId: "store-1" as never,
+        terminalId: "terminal-1" as never,
+        token: "proof-token-1",
+        now: 100,
+      }),
+    ).resolves.toBe(false);
+
     const proof = ctx.db
       .query("posLocalStaffProof")
       .withIndex("by_tokenHash", (q: any) => q.eq("tokenHash", tokenHash));
     await expect(proof.unique()).resolves.toEqual(
       expect.objectContaining({ lastUsedAt: 100 }),
     );
+  });
+
+  it("rejects unversioned local staff proofs once a credential has a verifier version", async () => {
+    const tokenHash = await hashPosLocalStaffProofToken("proof-token-1");
+    const ctx = createFakeConvexCtx({
+      posLocalStaffProof: [
+        {
+          _id: "proof-1",
+          credentialId: "credential-1",
+          expiresAt: 200,
+          staffProfileId: "staff-1",
+          status: "active",
+          storeId: "store-1",
+          terminalId: "terminal-1",
+          tokenHash,
+        },
+      ],
+      staffCredential: [
+        {
+          _id: "credential-1",
+          localVerifierVersion: 1,
+          staffProfileId: "staff-1",
+          status: "active",
+          storeId: "store-1",
+        },
+      ],
+    });
+    const repository = createConvexLocalSyncRepository(ctx as never);
+
+    await expect(
+      repository.validateLocalStaffProof({
+        staffProfileId: "staff-1" as never,
+        storeId: "store-1" as never,
+        terminalId: "terminal-1" as never,
+        token: "proof-token-1",
+        now: 100,
+      }),
+    ).resolves.toBe(false);
   });
 
   it("rejects production local staff proofs when the bound credential is suspended or revoked", async () => {

--- a/packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.ts
+++ b/packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.ts
@@ -824,20 +824,16 @@ function advanceAcceptedThroughSequence(
     : acceptedThroughSequence;
 }
 
-async function isSameLocalEvent(
+function isSameLocalEvent(
   existing: LocalSyncEventRecord,
   incoming: PosLocalSyncEventInput,
 ) {
-  const incomingStaffProofTokenHash = await hashPosLocalStaffProofToken(
-    incoming.staffProofToken,
-  );
   return (
     existing.localRegisterSessionId === incoming.localRegisterSessionId &&
     existing.sequence === incoming.sequence &&
     existing.eventType === incoming.eventType &&
     existing.occurredAt === incoming.occurredAt &&
     existing.staffProfileId === incoming.staffProfileId &&
-    existing.staffProofTokenHash === incomingStaffProofTokenHash &&
     canonicalJson(existing.payload) === canonicalJson(incoming.payload)
   );
 }

--- a/packages/athena-webapp/convex/pos/infrastructure/repositories/localSyncRepository.ts
+++ b/packages/athena-webapp/convex/pos/infrastructure/repositories/localSyncRepository.ts
@@ -79,7 +79,8 @@ export function createConvexLocalSyncRepository(
         !credential ||
         credential.status !== "active" ||
         credential.staffProfileId !== args.staffProfileId ||
-        credential.storeId !== args.storeId
+        credential.storeId !== args.storeId ||
+        credential.localVerifierVersion !== proof.credentialVersion
       ) {
         return false;
       }

--- a/packages/athena-webapp/convex/schemas/operations/staffCredential.ts
+++ b/packages/athena-webapp/convex/schemas/operations/staffCredential.ts
@@ -6,6 +6,16 @@ export const staffCredentialSchema = v.object({
   storeId: v.id("store"),
   username: v.string(),
   pinHash: v.optional(v.string()),
+  localPinVerifier: v.optional(
+    v.object({
+      algorithm: v.string(),
+      hash: v.string(),
+      iterations: v.number(),
+      salt: v.string(),
+      version: v.number(),
+    }),
+  ),
+  localVerifierVersion: v.optional(v.number()),
   status: v.union(
     v.literal("pending"),
     v.literal("active"),

--- a/packages/athena-webapp/convex/schemas/pos/posLocalStaffProof.ts
+++ b/packages/athena-webapp/convex/schemas/pos/posLocalStaffProof.ts
@@ -5,6 +5,7 @@ export const posLocalStaffProofSchema = v.object({
   terminalId: v.id("posTerminal"),
   staffProfileId: v.id("staffProfile"),
   credentialId: v.id("staffCredential"),
+  credentialVersion: v.optional(v.number()),
   tokenHash: v.string(),
   status: v.union(v.literal("active"), v.literal("revoked")),
   createdAt: v.number(),

--- a/packages/athena-webapp/docs/agent/key-folder-index.md
+++ b/packages/athena-webapp/docs/agent/key-folder-index.md
@@ -13,7 +13,7 @@ This key-folder index highlights the main directories agents are likely to need 
 - [`src/components/procurement`](../../src/components/procurement) — Procurement planning and receiving views for replenishment pressure and purchase-order execution. Currently 4 file(s); key children: ProcurementView.test.tsx, ProcurementView.tsx, ReceivingView.test.tsx, ReceivingView.tsx.
 - [`src/hooks`](../../src/hooks) — React hooks that fan out auth, shell, and feature state. Currently 42 file(s); key children: use-image-upload.ts, use-mobile.tsx, use-navigate-back.ts, use-navigation-keyboard-shortcuts.ts, use-pagination-persistence.ts.
 - [`src/contexts`](../../src/contexts) — Context providers for app-wide state and wiring. Currently 8 file(s); key children: AppShellFullscreenContext.tsx, ManagerElevationContext.test.tsx, ManagerElevationContext.tsx, OnlineOrderContext.tsx, PermissionsContext.tsx.
-- [`src/lib`](../../src/lib) — Shared frontend helpers, schemas, and package utilities. Currently 107 file(s); key children: access, aws.ts, behaviorUtils.ts, browserFingerprint.ts, constants.ts.
+- [`src/lib`](../../src/lib) — Shared frontend helpers, schemas, and package utilities. Currently 109 file(s); key children: access, aws.ts, behaviorUtils.ts, browserFingerprint.ts, constants.ts.
 - [`shared`](../../shared) — Browser-safe helpers shared with Convex-backed workflows. Currently 14 file(s); key children: approvalPolicy.ts, auth.ts, commandResult.test.ts, commandResult.ts, currencyFormatter.test.ts.
 - [`src/utils`](../../src/utils) — Cross-cutting browser helpers and lower-level utilities. Currently 3 file(s); key children: formatNumber.ts, index.ts, versionChecker.ts.
 

--- a/packages/athena-webapp/docs/agent/test-index.md
+++ b/packages/athena-webapp/docs/agent/test-index.md
@@ -249,6 +249,7 @@ This index enumerates the current automated test files and ties them back to the
 - [`src/lib/pos/presentation/register/useRegisterViewModel.test.ts`](../../src/lib/pos/presentation/register/useRegisterViewModel.test.ts)
 - [`src/lib/pos/presentation/syncStatusPresentation.test.ts`](../../src/lib/pos/presentation/syncStatusPresentation.test.ts)
 - [`src/lib/productUtils.test.ts`](../../src/lib/productUtils.test.ts)
+- [`src/lib/security/localPinVerifier.test.ts`](../../src/lib/security/localPinVerifier.test.ts)
 - [`src/lib/storeConfig.test.ts`](../../src/lib/storeConfig.test.ts)
 - [`src/lib/traces/createWorkflowTraceId.test.ts`](../../src/lib/traces/createWorkflowTraceId.test.ts)
 - [`src/lib/utils.test.ts`](../../src/lib/utils.test.ts)

--- a/packages/athena-webapp/src/components/pos/CashierAuthDialog.test.tsx
+++ b/packages/athena-webapp/src/components/pos/CashierAuthDialog.test.tsx
@@ -13,10 +13,31 @@ import { mapThrownError } from "~/src/lib/pos/application/results";
 import { CashierAuthDialog } from "./CashierAuthDialog";
 
 const mocks = vi.hoisted(() => ({
+  createPosLocalStore: vi.fn(),
   hashPin: vi.fn(async (pin: string) => `hashed:${pin}`),
   toastError: vi.fn(),
   toastSuccess: vi.fn(),
+  unwrapLocalStaffProofToken: vi.fn(
+    async (): Promise<{ expiresAt: number; token: string } | null> => ({
+      expiresAt: Date.now() + 10_000,
+      token: "proof-token-1",
+    }),
+  ),
   useMutation: vi.fn(),
+  verifyLocalPin: vi.fn(
+    async (): Promise<
+      | { ok: true }
+      | {
+          ok: false;
+          reason: "invalid_pin" | "malformed_verifier" | "unsupported_verifier";
+        }
+    > => ({ ok: true }),
+  ),
+  wrapLocalStaffProofToken: vi.fn(async () => ({
+    ciphertext: "wrapped-proof-token",
+    expiresAt: Date.now() + 10_000,
+    iv: "proof-iv",
+  })),
 }));
 
 vi.mock("convex/react", () => ({
@@ -32,6 +53,17 @@ vi.mock("sonner", () => ({
 
 vi.mock("~/src/lib/security/pinHash", () => ({
   hashPin: mocks.hashPin,
+}));
+
+vi.mock("@/lib/security/localPinVerifier", () => ({
+  unwrapLocalStaffProofToken: mocks.unwrapLocalStaffProofToken,
+  verifyLocalPin: mocks.verifyLocalPin,
+  wrapLocalStaffProofToken: mocks.wrapLocalStaffProofToken,
+}));
+
+vi.mock("@/lib/pos/infrastructure/local/posLocalStore", () => ({
+  createIndexedDbPosLocalStorageAdapter: vi.fn(() => ({})),
+  createPosLocalStore: mocks.createPosLocalStore,
 }));
 
 vi.mock("@/components/pos/PinInput", () => ({
@@ -77,13 +109,45 @@ const storeId = "store-1" as Id<"store">;
 const terminalId = "terminal-1" as Id<"posTerminal">;
 const staffProfileId = "staff-1" as Id<"staffProfile">;
 
+function buildLocalAuthorityRecord() {
+  return {
+    activeRoles: ["cashier"],
+    credentialId: "credential-1",
+    credentialVersion: 1,
+    displayName: "Ama Mensah",
+    expiresAt: Date.now() + 10_000,
+    issuedAt: Date.now(),
+    organizationId: "org-1",
+    refreshedAt: Date.now(),
+    staffProfileId,
+    status: "active",
+    storeId,
+    terminalId,
+    username: "frontdesk",
+    verifier: {
+      algorithm: "PBKDF2-SHA256",
+      hash: "hash",
+      iterations: 120000,
+      salt: "salt",
+      version: 1,
+    },
+    wrappedPosLocalStaffProof: {
+      ciphertext: "wrapped-proof-token",
+      expiresAt: Date.now() + 10_000,
+      iv: "proof-iv",
+    },
+  };
+}
+
 function renderDialog({
   authenticateMutation = vi.fn(),
   expireMutation = vi.fn(),
+  refreshAuthorityMutation = vi.fn().mockResolvedValue(ok([])),
   workflowMode,
 }: {
   authenticateMutation?: ReturnType<typeof vi.fn>;
   expireMutation?: ReturnType<typeof vi.fn>;
+  refreshAuthorityMutation?: ReturnType<typeof vi.fn>;
   workflowMode?: "pos" | "expense";
 } = {}) {
   mocks.useMutation.mockReset();
@@ -91,9 +155,9 @@ function renderDialog({
   mocks.useMutation.mockImplementation(() => {
     mutationCallCount += 1;
 
-    return (
-      mutationCallCount % 2 === 1 ? authenticateMutation : expireMutation
-    ) as never;
+    if (mutationCallCount === 1) return authenticateMutation as never;
+    if (mutationCallCount === 2) return refreshAuthorityMutation as never;
+    return expireMutation as never;
   });
 
   const onAuthenticated = vi.fn();
@@ -137,7 +201,32 @@ async function submitCredentials(
 describe("CashierAuthDialog", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.createPosLocalStore.mockReturnValue({
+      readStaffAuthorityForUsername: vi.fn(async () => ({
+        ok: true,
+        value: null,
+      })),
+      replaceStaffAuthoritySnapshot: vi.fn(async () => ({
+        ok: true,
+        value: [],
+      })),
+    });
+    mocks.verifyLocalPin.mockResolvedValue({ ok: true });
+    mocks.unwrapLocalStaffProofToken.mockResolvedValue({
+      expiresAt: Date.now() + 10_000,
+      token: "proof-token-1",
+    });
+    mocks.wrapLocalStaffProofToken.mockResolvedValue({
+      ciphertext: "wrapped-proof-token",
+      expiresAt: Date.now() + 10_000,
+      iv: "proof-iv",
+    });
+    Object.defineProperty(window.navigator, "onLine", {
+      configurable: true,
+      value: true,
+    });
     vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(console, "warn").mockImplementation(() => {});
   });
 
   afterEach(() => {
@@ -187,6 +276,37 @@ describe("CashierAuthDialog", () => {
     expect(onAuthenticated).not.toHaveBeenCalled();
   });
 
+  it("clears local staff authority when an online refresh is refused", async () => {
+    const replaceStaffAuthoritySnapshot = vi.fn(async () => ({
+      ok: true,
+      value: [],
+    }));
+    mocks.createPosLocalStore.mockReturnValue({
+      readStaffAuthorityForUsername: vi.fn(async () => ({
+        ok: true,
+        value: buildLocalAuthorityRecord(),
+      })),
+      replaceStaffAuthoritySnapshot,
+    });
+    const refreshAuthorityMutation = vi.fn().mockResolvedValue(
+      userError({
+        code: "precondition_failed",
+        message:
+          "Staff sign-in list is too large to refresh safely. Contact support before using offline sign-in.",
+      }),
+    );
+
+    renderDialog({ refreshAuthorityMutation });
+
+    await waitFor(() =>
+      expect(replaceStaffAuthoritySnapshot).toHaveBeenCalledWith({
+        records: [],
+        storeId,
+        terminalId,
+      }),
+    );
+  });
+
   it("uses expense session copy when signing into expense mode", () => {
     const authenticateMutation = vi.fn();
 
@@ -198,6 +318,206 @@ describe("CashierAuthDialog", () => {
     expect(
       screen.getByRole("button", { name: "Sign out from other sessions" }),
     ).toBeInTheDocument();
+  });
+
+  it("does not leave cashier sign-in pending when the browser is offline", async () => {
+    Object.defineProperty(window.navigator, "onLine", {
+      configurable: true,
+      value: false,
+    });
+    const authenticateMutation = vi.fn();
+
+    const { user, onAuthenticated } = renderDialog({ authenticateMutation });
+
+    await submitCredentials(user);
+
+    await waitFor(() =>
+      expect(mocks.toastError).toHaveBeenCalledWith(
+        "This staff sign-in is not available offline on this terminal. Reconnect, then try again.",
+      ),
+    );
+    expect(authenticateMutation).not.toHaveBeenCalled();
+    expect(onAuthenticated).not.toHaveBeenCalled();
+    await waitFor(() => expect(screen.getByLabelText(/pin/i)).toHaveValue(""));
+    expect(
+      screen.getByRole("button", { name: "Sign in" }),
+    ).toBeInTheDocument();
+  });
+
+  it("authenticates a locally authorized cashier while offline", async () => {
+    Object.defineProperty(window.navigator, "onLine", {
+      configurable: true,
+      value: false,
+    });
+    const readStaffAuthorityForUsername = vi.fn(async () => ({
+      ok: true,
+      value: buildLocalAuthorityRecord(),
+    }));
+    mocks.createPosLocalStore.mockReturnValue({
+      readStaffAuthorityForUsername,
+      replaceStaffAuthoritySnapshot: vi.fn(async () => ({
+        ok: true,
+        value: [],
+      })),
+    });
+    const authenticateMutation = vi.fn();
+
+    const { user, onAuthenticated } = renderDialog({ authenticateMutation });
+
+    await submitCredentials(user);
+
+    await waitFor(() =>
+      expect(onAuthenticated).toHaveBeenCalledWith(
+        expect.objectContaining({
+          activeRoles: ["cashier"],
+          posLocalStaffProof: {
+            expiresAt: expect.any(Number),
+            token: "proof-token-1",
+          },
+          staffProfileId,
+        }),
+      ),
+    );
+    expect(authenticateMutation).not.toHaveBeenCalled();
+    expect(mocks.verifyLocalPin).toHaveBeenCalledWith(
+      expect.objectContaining({ algorithm: "PBKDF2-SHA256" }),
+      "123456",
+    );
+    expect(mocks.unwrapLocalStaffProofToken).toHaveBeenCalledWith(
+      expect.objectContaining({ algorithm: "PBKDF2-SHA256" }),
+      "123456",
+      expect.objectContaining({ ciphertext: "wrapped-proof-token" }),
+    );
+    expect(mocks.toastSuccess).toHaveBeenCalledWith("Signed in as Ama Mensah");
+  });
+
+  it("clears the PIN when local offline authority cannot be read", async () => {
+    Object.defineProperty(window.navigator, "onLine", {
+      configurable: true,
+      value: false,
+    });
+    mocks.createPosLocalStore.mockReturnValue({
+      readStaffAuthorityForUsername: vi.fn(async () => ({
+        error: { code: "write_failed", message: "No local store" },
+        ok: false,
+      })),
+      replaceStaffAuthoritySnapshot: vi.fn(async () => ({
+        ok: true,
+        value: [],
+      })),
+    });
+    const authenticateMutation = vi.fn();
+
+    const { user, onAuthenticated } = renderDialog({ authenticateMutation });
+
+    await submitCredentials(user);
+
+    await waitFor(() =>
+      expect(mocks.toastError).toHaveBeenCalledWith(
+        "Offline staff sign-in is unavailable. Reconnect, then try again.",
+      ),
+    );
+    expect(authenticateMutation).not.toHaveBeenCalled();
+    expect(onAuthenticated).not.toHaveBeenCalled();
+    await waitFor(() => expect(screen.getByLabelText(/pin/i)).toHaveValue(""));
+  });
+
+  it("clears the PIN when offline local PIN verification fails", async () => {
+    Object.defineProperty(window.navigator, "onLine", {
+      configurable: true,
+      value: false,
+    });
+    mocks.verifyLocalPin.mockResolvedValue({
+      ok: false,
+      reason: "invalid_pin",
+    });
+    mocks.createPosLocalStore.mockReturnValue({
+      readStaffAuthorityForUsername: vi.fn(async () => ({
+        ok: true,
+        value: buildLocalAuthorityRecord(),
+      })),
+      replaceStaffAuthoritySnapshot: vi.fn(async () => ({
+        ok: true,
+        value: [],
+      })),
+    });
+    const authenticateMutation = vi.fn();
+
+    const { user, onAuthenticated } = renderDialog({ authenticateMutation });
+
+    await submitCredentials(user);
+
+    await waitFor(() =>
+      expect(mocks.toastError).toHaveBeenCalledWith(
+        "Sign-in details not recognized. Enter the username and PIN again.",
+      ),
+    );
+    expect(authenticateMutation).not.toHaveBeenCalled();
+    expect(onAuthenticated).not.toHaveBeenCalled();
+    await waitFor(() => expect(screen.getByLabelText(/pin/i)).toHaveValue(""));
+  });
+
+  it("clears the PIN when an offline staff proof cannot be unwrapped", async () => {
+    Object.defineProperty(window.navigator, "onLine", {
+      configurable: true,
+      value: false,
+    });
+    mocks.unwrapLocalStaffProofToken.mockResolvedValue(null);
+    mocks.createPosLocalStore.mockReturnValue({
+      readStaffAuthorityForUsername: vi.fn(async () => ({
+        ok: true,
+        value: buildLocalAuthorityRecord(),
+      })),
+      replaceStaffAuthoritySnapshot: vi.fn(async () => ({
+        ok: true,
+        value: [],
+      })),
+    });
+    const authenticateMutation = vi.fn();
+
+    const { user, onAuthenticated } = renderDialog({ authenticateMutation });
+
+    await submitCredentials(user);
+
+    await waitFor(() =>
+      expect(mocks.toastError).toHaveBeenCalledWith(
+        "Offline staff sign-in needs a refresh. Reconnect, then try again.",
+      ),
+    );
+    expect(authenticateMutation).not.toHaveBeenCalled();
+    expect(onAuthenticated).not.toHaveBeenCalled();
+    await waitFor(() => expect(screen.getByLabelText(/pin/i)).toHaveValue(""));
+  });
+
+  it("rejects offline recover mode without claiming other registers were signed out", async () => {
+    Object.defineProperty(window.navigator, "onLine", {
+      configurable: true,
+      value: false,
+    });
+    const authenticateMutation = vi.fn();
+    const expireMutation = vi.fn();
+
+    const { user, onAuthenticated } = renderDialog({
+      authenticateMutation,
+      expireMutation,
+    });
+
+    await user.click(
+      screen.getByRole("button", { name: "Sign out from other registers" }),
+    );
+    await submitCredentials(user);
+    await user.click(
+      screen.getByRole("button", { name: "Sign out from all registers" }),
+    );
+
+    await waitFor(() =>
+      expect(mocks.toastError).toHaveBeenCalledWith(
+        "Other register sign-outs need a connection. Reconnect, then try again.",
+      ),
+    );
+    expect(authenticateMutation).not.toHaveBeenCalled();
+    expect(expireMutation).not.toHaveBeenCalled();
+    expect(onAuthenticated).not.toHaveBeenCalled();
   });
 
   it("collapses thrown faults to generic fallback copy and clears the PIN", async () => {
@@ -266,10 +586,12 @@ describe("CashierAuthDialog", () => {
       }),
     );
     const expireMutation = vi.fn().mockResolvedValue({ success: true });
+    const refreshAuthorityMutation = vi.fn().mockResolvedValue(ok([]));
 
     const { user, onAuthenticated } = renderDialog({
       authenticateMutation,
       expireMutation,
+      refreshAuthorityMutation,
     });
 
     await user.click(

--- a/packages/athena-webapp/src/components/pos/CashierAuthDialog.tsx
+++ b/packages/athena-webapp/src/components/pos/CashierAuthDialog.tsx
@@ -1,3 +1,4 @@
+import { useCallback, useEffect, useMemo } from "react";
 import { useMutation } from "convex/react";
 
 import {
@@ -6,9 +7,20 @@ import {
   type StaffAuthMode,
 } from "@/components/staff-auth/StaffAuthenticationDialog";
 import { runCommand } from "@/lib/errors/runCommand";
+import { logger } from "@/lib/logger";
+import {
+  createIndexedDbPosLocalStorageAdapter,
+  createPosLocalStore,
+  type PosLocalStaffAuthorityRecord,
+} from "@/lib/pos/infrastructure/local/posLocalStore";
+import {
+  unwrapLocalStaffProofToken,
+  verifyLocalPin,
+  wrapLocalStaffProofToken,
+} from "@/lib/security/localPinVerifier";
 import { api } from "~/convex/_generated/api";
 import type { Id } from "~/convex/_generated/dataModel";
-import { userError } from "~/shared/commandResult";
+import { ok, userError, type CommandResult } from "~/shared/commandResult";
 import type { RegisterWorkflowMode } from "~/src/lib/pos/presentation/register/registerUiState";
 
 interface CashierAuthDialogProps {
@@ -30,6 +42,10 @@ function getStaffDisplayName(result: StaffAuthenticationResult) {
   );
 }
 
+function isBrowserOffline() {
+  return typeof navigator !== "undefined" && navigator.onLine === false;
+}
+
 export function CashierAuthDialog({
   onAuthenticated,
   onDismiss,
@@ -42,16 +58,214 @@ export function CashierAuthDialog({
   const authenticateStaffCredentialForTerminal = useMutation(
     api.operations.staffCredentials.authenticateStaffCredentialForTerminal,
   );
+  const refreshTerminalStaffAuthority = useMutation(
+    api.operations.staffCredentials.refreshTerminalStaffAuthority,
+  );
   const expireAllSessionsForStaff = useMutation(
     api.inventory.posSessions.expireAllSessionsForStaff,
   );
+  const localStore = useMemo(
+    () =>
+      createPosLocalStore({
+        adapter: createIndexedDbPosLocalStorageAdapter(),
+      }),
+    [],
+  );
   const isExpenseWorkflow = workflowMode === "expense";
+
+  const refreshLocalAuthority = useCallback(async (unlock?: {
+    pin: string;
+    posLocalStaffProof?: { expiresAt: number; token: string };
+    staffProfileId: Id<"staffProfile">;
+  }) => {
+    if (isBrowserOffline()) {
+      return;
+    }
+
+    let result: CommandResult<PosLocalStaffAuthorityRecord[]>;
+    try {
+      result = await (
+        refreshTerminalStaffAuthority as (args: {
+          storeId: Id<"store">;
+          terminalId: Id<"posTerminal">;
+        }) => Promise<CommandResult<PosLocalStaffAuthorityRecord[]>>
+      )({ storeId, terminalId });
+    } catch (error) {
+      logger.warn("[POS] Staff authority refresh failed", {
+        message: error instanceof Error ? error.message : String(error),
+        storeId,
+        terminalId,
+      });
+      return;
+    }
+
+    if (result.kind !== "ok") {
+      logger.warn("[POS] Staff authority refresh skipped", {
+        kind: result.kind,
+        storeId,
+        terminalId,
+      });
+      const clearResult = await localStore.replaceStaffAuthoritySnapshot({
+        records: [],
+        storeId,
+        terminalId,
+      });
+      if (!clearResult.ok) {
+        logger.warn("[POS] Staff authority snapshot could not be cleared", {
+          code: clearResult.error.code,
+          storeId,
+          terminalId,
+        });
+      }
+      return;
+    }
+
+    const records = await Promise.all(
+      result.data.map(async (record) => {
+        if (
+          !unlock?.posLocalStaffProof ||
+          record.staffProfileId !== unlock.staffProfileId
+        ) {
+          return record;
+        }
+
+        const wrappedProof = await wrapLocalStaffProofToken(
+          record.verifier,
+          unlock.pin,
+          unlock.posLocalStaffProof,
+        );
+        if (!wrappedProof) {
+          logger.warn("[POS] Staff authority proof could not be wrapped", {
+            staffProfileId: record.staffProfileId,
+            storeId,
+            terminalId,
+          });
+          return record;
+        }
+
+        return {
+          ...record,
+          wrappedPosLocalStaffProof: wrappedProof,
+        };
+      }),
+    );
+
+    const writeResult = await localStore.replaceStaffAuthoritySnapshot({
+      records,
+      storeId,
+      terminalId,
+    });
+    if (!writeResult.ok) {
+      logger.warn("[POS] Staff authority refresh could not be stored", {
+        code: writeResult.error.code,
+        storeId,
+        terminalId,
+      });
+    }
+  }, [localStore, refreshTerminalStaffAuthority, storeId, terminalId]);
+
+  useEffect(() => {
+    if (!open || isBrowserOffline()) {
+      return;
+    }
+
+    void refreshLocalAuthority();
+  }, [open, refreshLocalAuthority, storeId, terminalId]);
+
+  async function authenticateOfflineStaff(args: {
+    pin: string;
+    username: string;
+  }): Promise<CommandResult<StaffAuthenticationResult>> {
+    const authorityResult = await localStore.readStaffAuthorityForUsername({
+      storeId,
+      terminalId,
+      username: args.username,
+    });
+
+    if (!authorityResult.ok) {
+      logger.warn("[POS] Local staff authority read failed", {
+        code: authorityResult.error.code,
+        storeId,
+        terminalId,
+      });
+      return userError({
+        code: "precondition_failed",
+        message: "Offline staff sign-in is unavailable. Reconnect, then try again.",
+      });
+    }
+
+    const authority = authorityResult.value;
+    if (!authority) {
+      return userError({
+        code: "precondition_failed",
+        message:
+          "This staff sign-in is not available offline on this terminal. Reconnect, then try again.",
+      });
+    }
+
+    const verification = await verifyLocalPin(authority.verifier, args.pin);
+    if (!verification.ok) {
+      if (verification.reason === "invalid_pin") {
+        return userError({
+          code: "authentication_failed",
+          message: "Sign-in details not recognized. Enter the username and PIN again.",
+        });
+      }
+
+      return userError({
+        code: "precondition_failed",
+        message: "Offline staff sign-in needs a refresh. Reconnect, then try again.",
+      });
+    }
+
+    const posLocalStaffProof = await unwrapLocalStaffProofToken(
+      authority.verifier,
+      args.pin,
+      authority.wrappedPosLocalStaffProof,
+    );
+    if (!posLocalStaffProof || posLocalStaffProof.expiresAt <= Date.now()) {
+      return userError({
+        code: "precondition_failed",
+        message: "Offline staff sign-in needs a refresh. Reconnect, then try again.",
+      });
+    }
+
+    return ok({
+      activeRoles: authority.activeRoles,
+      posLocalStaffProof,
+      staffProfile: {
+        fullName: authority.displayName ?? null,
+      },
+      staffProfileId: authority.staffProfileId as Id<"staffProfile">,
+    });
+  }
 
   async function authenticateStaff(args: {
     mode: StaffAuthMode;
+    pin: string;
     pinHash: string;
     username: string;
   }) {
+    if (isBrowserOffline()) {
+      if (args.mode === "recover") {
+        return userError({
+          code: "precondition_failed",
+          message: isExpenseWorkflow
+            ? "Other session sign-outs need a connection. Reconnect, then try again."
+            : "Other register sign-outs need a connection. Reconnect, then try again.",
+        });
+      }
+
+      logger.info("[POS] Cashier authentication using local authority", {
+        mode: args.mode,
+        storeId,
+        terminalId,
+        workflowMode,
+      });
+
+      return authenticateOfflineStaff(args);
+    }
+
     const authenticationResult = await runCommand(() =>
       authenticateStaffCredentialForTerminal({
         allowedRoles: ["cashier", "manager"],
@@ -66,6 +280,12 @@ export function CashierAuthDialog({
     if (authenticationResult.kind !== "ok") {
       return authenticationResult;
     }
+
+    void refreshLocalAuthority({
+      pin: args.pin,
+      posLocalStaffProof: authenticationResult.data.posLocalStaffProof,
+      staffProfileId: authenticationResult.data.staffProfileId,
+    });
 
     if (args.mode === "authenticate") {
       return authenticationResult;
@@ -85,7 +305,7 @@ export function CashierAuthDialog({
       });
     }
 
-    return runCommand(() =>
+    const recoveryResult = await runCommand(() =>
       authenticateStaffCredentialForTerminal({
         allowedRoles: ["cashier", "manager"],
         pinHash: args.pinHash,
@@ -94,6 +314,15 @@ export function CashierAuthDialog({
         username: args.username,
       }),
     );
+    if (recoveryResult.kind === "ok") {
+      void refreshLocalAuthority({
+        pin: args.pin,
+        posLocalStaffProof: recoveryResult.data.posLocalStaffProof,
+        staffProfileId: recoveryResult.data.staffProfileId,
+      });
+    }
+
+    return recoveryResult;
   }
 
   const primaryCopy = isExpenseWorkflow

--- a/packages/athena-webapp/src/components/pos/register/POSRegisterView.test.tsx
+++ b/packages/athena-webapp/src/components/pos/register/POSRegisterView.test.tsx
@@ -268,6 +268,61 @@ describe("POSRegisterView", () => {
     expect(screen.queryByText("cashier-auth-dialog")).not.toBeInTheDocument();
   });
 
+  it("renders local-only register context with debug state instead of the blank shell", async () => {
+    mockUseRegisterViewModel.mockReturnValue({
+      hasActiveStore: true,
+      debug: {
+        activeStoreSource: "local",
+        authDialogOpen: true,
+        hasLiveActiveStore: false,
+        localEntryStatus: "ready",
+        online: false,
+        staffSignedIn: false,
+        storeId: "store-1",
+        terminalId: "terminal-1",
+        terminalSource: "local",
+      },
+      header: {
+        title: "POS",
+        isSessionActive: false,
+      },
+      registerInfo: {
+        registerLabel: "Front Counter",
+        hasTerminal: true,
+      },
+      customerPanel: {},
+      productEntry: {
+        disabled: true,
+        productSearchQuery: "",
+        setProductSearchQuery: vi.fn(),
+        onBarcodeSubmit: vi.fn(),
+      },
+      cart: {
+        items: [],
+      },
+      checkout: {
+        isTransactionCompleted: false,
+      },
+      sessionPanel: null,
+      cashierCard: null,
+      closeoutControl: null,
+      authDialog: {
+        open: true,
+      },
+      drawerGate: null,
+      onNavigateBack: vi.fn(),
+    });
+
+    const { POSRegisterView } = await import("./POSRegisterView");
+    render(<POSRegisterView />);
+
+    expect(screen.getByText("Register connection details")).toBeInTheDocument();
+    expect(screen.getByText("offline")).toBeInTheDocument();
+    expect(screen.getByText("local:store-1")).toBeInTheDocument();
+    expect(screen.getByText("local:terminal-1")).toBeInTheDocument();
+    expect(screen.getByText("cashier-auth-dialog")).toBeInTheDocument();
+  });
+
   it("shows POS sync status and schedules manual retry from the header", async () => {
     const onRetrySync = vi.fn();
     mockUseRegisterViewModel.mockReturnValue({

--- a/packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx
+++ b/packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx
@@ -245,6 +245,56 @@ function RegisterSyncStatusChip({
   );
 }
 
+function POSLocalDebugStrip({
+  debug,
+}: {
+  debug: RegisterViewModel["debug"];
+}) {
+  if (!debug || !import.meta.env.DEV) return null;
+
+  const shouldShow =
+    !debug.online ||
+    debug.activeStoreSource !== "live" ||
+    debug.terminalSource !== "live" ||
+    debug.localEntryStatus !== "ready";
+
+  if (!shouldShow) return null;
+
+  const rows = [
+    ["network", debug.online ? "online" : "offline"],
+    ["entry", debug.localEntryStatus],
+    ["authority", debug.localStaffAuthorityStatus],
+    ["store", `${debug.activeStoreSource}${debug.storeId ? `:${debug.storeId}` : ""}`],
+    [
+      "terminal",
+      `${debug.terminalSource}${debug.terminalId ? `:${debug.terminalId}` : ""}`,
+    ],
+    ["staff", debug.staffSignedIn ? "signed-in" : "not-signed-in"],
+    ["auth", debug.authDialogOpen ? "open" : "closed"],
+  ];
+
+  return (
+    <details
+      className="rounded-lg border border-warning/30 bg-warning/10 px-4 py-3 text-xs text-foreground"
+      open
+    >
+      <summary className="cursor-pointer font-medium text-warning">
+        Register connection details
+      </summary>
+      <dl className="mt-2 grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
+        {rows.map(([label, value]) => (
+          <div key={label} className="min-w-0">
+            <dt className="uppercase tracking-wide text-muted-foreground">
+              {label}
+            </dt>
+            <dd className="truncate font-mono text-foreground">{value}</dd>
+          </div>
+        ))}
+      </dl>
+    </details>
+  );
+}
+
 function LocalRegisterClosedWorkspace({
   syncStatus,
 }: {
@@ -702,6 +752,8 @@ export function POSRegisterView({
     >
       <FadeIn className={registerContentClassName}>
         <div className="flex h-full min-h-0 flex-col gap-6 overflow-hidden">
+          {isPosWorkflow ? <POSLocalDebugStrip debug={viewModel.debug} /> : null}
+
           {isPosWorkflow &&
           shouldRenderSaleSurface &&
           !shouldShowOnboarding &&

--- a/packages/athena-webapp/src/components/staff-auth/StaffAuthenticationDialog.test.tsx
+++ b/packages/athena-webapp/src/components/staff-auth/StaffAuthenticationDialog.test.tsx
@@ -1,12 +1,29 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
 import { StaffAuthenticationDialog } from "./StaffAuthenticationDialog";
 
 vi.mock("@/components/pos/PinInput", () => ({
-  PinInput: ({ value }: { value: string }) => (
-    <input aria-label="PIN" readOnly value={value} />
+  PinInput: ({
+    disabled,
+    onChange,
+    value,
+  }: {
+    disabled?: boolean;
+    onChange: (value: string) => void;
+    value: string;
+  }) => (
+    <input
+      aria-label="PIN"
+      disabled={disabled}
+      onChange={(event) => onChange(event.target.value)}
+      value={value}
+    />
   ),
+}));
+
+vi.mock("@/lib/security/pinHash", () => ({
+  hashPin: vi.fn(async (pin: string) => `hashed:${pin}`),
 }));
 
 const baseProps = {
@@ -40,5 +57,45 @@ describe("StaffAuthenticationDialog", () => {
       screen.getByRole("heading", { name: "Confirm staff credentials" }),
     ).toBeInTheDocument();
     expect(screen.getByText("Authenticate to continue.")).toBeInTheDocument();
+  });
+
+  it("does not submit again while an authentication request is already in flight", async () => {
+    const onAuthenticate = vi.fn(
+      () =>
+        new Promise<never>(() => {
+          // Keep the request pending so a parent re-render can exercise the guard.
+        }),
+    );
+
+    const { rerender } = render(
+      <StaffAuthenticationDialog
+        {...baseProps}
+        onAuthenticate={onAuthenticate}
+        onAuthenticated={vi.fn()}
+        presentation="inline"
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText(/username/i), {
+      target: { value: "frontdesk" },
+    });
+    fireEvent.change(screen.getByLabelText(/pin/i), {
+      target: { value: "123456" },
+    });
+
+    await waitFor(() => expect(onAuthenticate).toHaveBeenCalledTimes(1));
+
+    rerender(
+      <StaffAuthenticationDialog
+        {...baseProps}
+        onAuthenticate={onAuthenticate}
+        onAuthenticated={vi.fn()}
+        presentation="inline"
+      />,
+    );
+
+    await new Promise((resolve) => window.setTimeout(resolve, 0));
+
+    expect(onAuthenticate).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/athena-webapp/src/components/staff-auth/StaffAuthenticationDialog.tsx
+++ b/packages/athena-webapp/src/components/staff-auth/StaffAuthenticationDialog.tsx
@@ -56,6 +56,7 @@ export type StaffAuthenticationDialogProps = {
   ) => string | null;
   onAuthenticate: (args: {
     mode: StaffAuthMode;
+    pin: string;
     pinHash: string;
     username: string;
   }) => Promise<NormalizedCommandResult<StaffAuthenticationResult>>;
@@ -107,6 +108,10 @@ export function StaffAuthenticationDialog({
   }, [open]);
 
   const handleSubmit = useCallback(async () => {
+    if (isAuthenticating) {
+      return;
+    }
+
     if (!username.trim()) {
       toast.error("Username required. Enter a username to continue.");
       return;
@@ -128,6 +133,7 @@ export function StaffAuthenticationDialog({
 
       result = await onAuthenticate({
         mode,
+        pin,
         pinHash: submittedPinHash,
         username: submittedUsername,
       });
@@ -164,6 +170,7 @@ export function StaffAuthenticationDialog({
     setMode("authenticate");
   }, [
     getSuccessMessage,
+    isAuthenticating,
     mode,
     onAuthenticate,
     onAuthenticated,
@@ -172,10 +179,10 @@ export function StaffAuthenticationDialog({
   ]);
 
   useEffect(() => {
-    if (canSubmit && mode === "authenticate") {
+    if (canSubmit && !isAuthenticating && mode === "authenticate") {
       void handleSubmit();
     }
-  }, [canSubmit, handleSubmit, mode]);
+  }, [canSubmit, handleSubmit, isAuthenticating, mode]);
 
   function handleKeyDown(event: React.KeyboardEvent) {
     if (event.key === "Enter" && canSubmit) {

--- a/packages/athena-webapp/src/components/staff/StaffManagement.test.tsx
+++ b/packages/athena-webapp/src/components/staff/StaffManagement.test.tsx
@@ -2,7 +2,6 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useMutation, useQuery } from "convex/react";
-import { api } from "~/convex/_generated/api";
 import { Id } from "~/convex/_generated/dataModel";
 import { StaffManagement } from "./StaffManagement";
 import { ok, userError } from "~/shared/commandResult";
@@ -22,6 +21,16 @@ vi.mock("sonner", () => ({
 
 vi.mock("~/src/lib/security/pinHash", () => ({
   hashPin: vi.fn(async (pin: string) => `hashed:${pin}`),
+}));
+
+vi.mock("~/src/lib/security/localPinVerifier", () => ({
+  createLocalPinVerifier: vi.fn(async (pin: string) => ({
+    algorithm: "PBKDF2-SHA256",
+    hash: `local:${pin}`,
+    iterations: 120000,
+    salt: "salt",
+    version: 1,
+  })),
 }));
 
 vi.mock("../ui/select", () => ({
@@ -117,7 +126,8 @@ function mockConvex({
       })
     | undefined;
 } = {}) {
-  mockedUseQuery.mockImplementation((...[_reference, args]) => {
+  mockedUseQuery.mockImplementation((...callArgs) => {
+    const args = callArgs[1];
     if (args === "skip") {
       return undefined as never;
     }
@@ -294,6 +304,13 @@ describe("StaffManagement", () => {
 
     await waitFor(() => expect(updateStaffCredential).toHaveBeenCalledTimes(1));
     expect(updateStaffCredential).toHaveBeenCalledWith({
+      localPinVerifier: {
+        algorithm: "PBKDF2-SHA256",
+        hash: "local:123456",
+        iterations: 120000,
+        salt: "salt",
+        version: 1,
+      },
       organizationId: "org-1",
       pinHash: "hashed:123456",
       staffProfileId: "staff-1",

--- a/packages/athena-webapp/src/components/staff/StaffManagement.tsx
+++ b/packages/athena-webapp/src/components/staff/StaffManagement.tsx
@@ -1,10 +1,11 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useMutation, useQuery } from "convex/react";
-import { Pencil, Plus, UserMinus } from "lucide-react";
+import { Plus, UserMinus } from "lucide-react";
 import { toast } from "sonner";
 import { api } from "~/convex/_generated/api";
 import { Id } from "~/convex/_generated/dataModel";
 import { hashPin } from "~/src/lib/security/pinHash";
+import { createLocalPinVerifier } from "~/src/lib/security/localPinVerifier";
 import { presentCommandToast } from "~/src/lib/errors/presentCommandToast";
 import { runCommand } from "~/src/lib/errors/runCommand";
 import { PinInput } from "../pos/PinInput";
@@ -123,37 +124,6 @@ const formatRoleLabel = (role?: OperationalRole | null) => {
     .split("_")
     .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
     .join(" ");
-};
-
-const formatStartDate = (timestamp?: number | null) => {
-  if (!timestamp) {
-    return "—";
-  }
-
-  return new Intl.DateTimeFormat(undefined, {
-    day: "numeric",
-    month: "short",
-    year: "numeric",
-  }).format(new Date(timestamp));
-};
-
-const formatCredentialStatusLabel = (staff: StaffProfileRow) => {
-  if (staff.status !== "active") {
-    return "Inactive";
-  }
-
-  switch (staff.credentialStatus) {
-    case "pending":
-      return "Pending PIN";
-    case "active":
-      return "Active";
-    case "suspended":
-      return "Suspended";
-    case "revoked":
-      return "Revoked";
-    default:
-      return "Missing credential";
-  }
 };
 
 const CredentialStatusBadge = ({ staff }: { staff: StaffProfileRow }) => {
@@ -681,10 +651,14 @@ function CredentialPinDialog({
 
     setIsSaving(true);
     try {
-      const pinHash = await hashPin(pin);
+      const [pinHash, localPinVerifier] = await Promise.all([
+        hashPin(pin),
+        createLocalPinVerifier(pin),
+      ]);
 
       const result = await runCommand(() =>
         updateStaffCredential({
+          localPinVerifier,
           organizationId,
           pinHash,
           staffProfileId: state.staff._id,

--- a/packages/athena-webapp/src/hooks/useGetTerminal.test.ts
+++ b/packages/athena-webapp/src/hooks/useGetTerminal.test.ts
@@ -6,6 +6,7 @@ import { useGetTerminal } from "./useGetTerminal";
 const mockUseConvexTerminalByFingerprint = vi.fn();
 const mockReadStoredTerminalFingerprintHash = vi.fn();
 const mockReadProvisionedTerminalSeed = vi.fn();
+let mockActiveStore: { _id: string } | null = { _id: "store-1" };
 
 vi.mock("@/lib/pos/infrastructure/convex/registerGateway", () => ({
   useConvexTerminalByFingerprint: (...args: unknown[]) =>
@@ -26,7 +27,7 @@ vi.mock("@/lib/pos/infrastructure/local/posLocalStore", () => ({
 
 vi.mock("./useGetActiveStore", () => ({
   default: () => ({
-    activeStore: { _id: "store-1" },
+    activeStore: mockActiveStore,
   }),
 }));
 
@@ -52,6 +53,7 @@ describe("useGetTerminal", () => {
     });
     (globalThis as typeof globalThis & { indexedDB?: IDBFactory }).indexedDB =
       {} as IDBFactory;
+    mockActiveStore = { _id: "store-1" };
   });
 
   it("falls back to the provisioned local terminal seed while Convex is unavailable", async () => {
@@ -85,6 +87,23 @@ describe("useGetTerminal", () => {
       registerNumber: "2",
       status: "active",
     });
+  });
+
+  it("falls back to the provisioned local terminal seed when active store is unavailable", async () => {
+    mockActiveStore = null;
+
+    const { result } = renderHook(() => useGetTerminal());
+
+    await waitFor(() =>
+      expect(result.current).toEqual({
+        _id: "terminal-1",
+        cloudTerminalId: "terminal-1",
+        displayName: "Front Counter",
+        localTerminalId: "fingerprint-1",
+        registerNumber: "1",
+        status: "local",
+      }),
+    );
   });
 
   it("rejects a provisioned local terminal seed for another store", async () => {

--- a/packages/athena-webapp/src/hooks/useGetTerminal.ts
+++ b/packages/athena-webapp/src/hooks/useGetTerminal.ts
@@ -32,7 +32,7 @@ export const useGetTerminal = () => {
   useEffect(() => {
     let cancelled = false;
 
-    if (!activeStore?._id || !fingerprintHash || terminal) {
+    if (!fingerprintHash || terminal) {
       setLocalTerminal(null);
       return;
     }
@@ -52,12 +52,12 @@ export const useGetTerminal = () => {
       if (
         result.ok &&
         result.value &&
-        result.value.storeId === activeStore._id &&
+        (!activeStore?._id || result.value.storeId === activeStore._id) &&
         result.value.terminalId === fingerprintHash
       ) {
         setLocalTerminal({
           fingerprintHash,
-          storeId: activeStore._id,
+          storeId: result.value.storeId,
           terminal: {
             _id: result.value.cloudTerminalId as Id<"posTerminal">,
             cloudTerminalId: result.value.cloudTerminalId,
@@ -84,7 +84,7 @@ export const useGetTerminal = () => {
 
   if (
     localTerminal &&
-    localTerminal.storeId === activeStore?._id &&
+    (!activeStore?._id || localTerminal.storeId === activeStore._id) &&
     localTerminal.fingerprintHash === fingerprintHash
   ) {
     return terminal ?? localTerminal.terminal;

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.test.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.test.ts
@@ -7,6 +7,37 @@ import {
   createPosLocalStore,
 } from "./posLocalStore";
 
+function buildAuthorityRecord(overrides = {}) {
+  return {
+    activeRoles: ["cashier" as const],
+    credentialId: "credential-1",
+    credentialVersion: 1,
+    displayName: "Ama Mensah",
+    expiresAt: 2_000,
+    issuedAt: 1_000,
+    organizationId: "org-1",
+    wrappedPosLocalStaffProof: {
+      ciphertext: "wrapped-proof-token",
+      expiresAt: 2_000,
+      iv: "proof-iv",
+    },
+    refreshedAt: 1_000,
+    staffProfileId: "staff-1",
+    status: "active" as const,
+    storeId: "store-1",
+    terminalId: "terminal-1",
+    username: "FrontDesk",
+    verifier: {
+      algorithm: "PBKDF2-SHA256" as const,
+      hash: "hash",
+      iterations: 120000,
+      salt: "salt",
+      version: 1 as const,
+    },
+    ...overrides,
+  };
+}
+
 describe("posLocalStore", () => {
   it("writes and reads a provisioned terminal seed before any network call", async () => {
     const store = createPosLocalStore({
@@ -154,6 +185,47 @@ describe("posLocalStore", () => {
     );
   });
 
+  it("keeps staff proof tokens transient for upload without storing them in events", async () => {
+    const store = createPosLocalStore({
+      adapter: createMemoryPosLocalStorageAdapter(),
+      createLocalId: () => "local-event-1",
+    });
+
+    await expect(
+      store.appendEvent({
+        type: "register.opened",
+        terminalId: "local-terminal-1",
+        storeId: "store_cloud_1",
+        localRegisterSessionId: "local-register-session-1",
+        staffProfileId: "staff_cloud_1",
+        staffProofToken: "proof-token-1",
+        payload: { openingFloat: 100 },
+      }),
+    ).resolves.toEqual({
+      ok: true,
+      value: expect.not.objectContaining({
+        staffProofToken: expect.any(String),
+      }),
+    });
+
+    await expect(store.listEvents()).resolves.toEqual({
+      ok: true,
+      value: [
+        expect.not.objectContaining({
+          staffProofToken: expect.any(String),
+        }),
+      ],
+    });
+    await expect(store.listEventsForUpload()).resolves.toEqual({
+      ok: true,
+      value: [
+        expect.objectContaining({
+          staffProofToken: "proof-token-1",
+        }),
+      ],
+    });
+  });
+
   it("marks uploaded events as synced without changing unrelated pending events", async () => {
     let nextLocalId = 1;
     const store = createPosLocalStore({
@@ -231,7 +303,7 @@ describe("posLocalStore", () => {
       error: {
         code: "unsupported_schema_version",
         message:
-          "POS local store schema version 3 is newer than supported version 2.",
+          "POS local store schema version 4 is newer than supported version 3.",
       },
     });
   });
@@ -280,6 +352,103 @@ describe("posLocalStore", () => {
       ok: true,
       value: [],
     });
+  });
+
+  it("replaces and reads terminal-scoped staff authority without store bleed", async () => {
+    const store = createPosLocalStore({
+      adapter: createMemoryPosLocalStorageAdapter(),
+      clock: () => 1_500,
+    });
+
+    await expect(
+      store.replaceStaffAuthoritySnapshot({
+        storeId: "store-1",
+        terminalId: "terminal-1",
+        records: [
+          buildAuthorityRecord(),
+          buildAuthorityRecord({
+            credentialId: "credential-2",
+            staffProfileId: "staff-2",
+            storeId: "store-2",
+            username: "other",
+          }),
+        ],
+      }),
+    ).resolves.toEqual({
+      ok: true,
+      value: [
+        expect.objectContaining({
+          storeId: "store-1",
+          terminalId: "terminal-1",
+          username: "frontdesk",
+        }),
+      ],
+    });
+
+    await expect(
+      store.readStaffAuthorityForUsername({
+        storeId: "store-1",
+        terminalId: "terminal-1",
+        username: " FRONTDESK ",
+      }),
+    ).resolves.toEqual({
+      ok: true,
+      value: expect.objectContaining({
+        credentialId: "credential-1",
+        username: "frontdesk",
+      }),
+    });
+    await expect(
+      store.readStaffAuthorityForUsername({
+        storeId: "store-2",
+        terminalId: "terminal-1",
+        username: "frontdesk",
+      }),
+    ).resolves.toEqual({ ok: true, value: null });
+  });
+
+  it("ignores expired and malformed local staff authority records", async () => {
+    const adapter = createMemoryPosLocalStorageAdapter();
+    const store = createPosLocalStore({
+      adapter,
+      clock: () => 3_000,
+    });
+
+    await store.replaceStaffAuthoritySnapshot({
+      storeId: "store-1",
+      terminalId: "terminal-1",
+      records: [buildAuthorityRecord()],
+    });
+    await expect(
+      store.getStaffAuthorityReadiness({
+        storeId: "store-1",
+        terminalId: "terminal-1",
+      }),
+    ).resolves.toEqual({ ok: true, value: "expired" });
+    await expect(
+      store.readStaffAuthorityForUsername({
+        storeId: "store-1",
+        terminalId: "terminal-1",
+        username: "frontdesk",
+      }),
+    ).resolves.toEqual({ ok: true, value: null });
+
+    await adapter.transaction(
+      "readwrite",
+      ["staffAuthority"],
+      async (transaction) => {
+        await transaction.put("staffAuthority", "store-1:terminal-1:broken", {
+          username: "broken",
+        });
+      },
+    );
+    await expect(
+      store.readStaffAuthorityForUsername({
+        storeId: "store-1",
+        terminalId: "terminal-1",
+        username: "broken",
+      }),
+    ).resolves.toEqual({ ok: true, value: null });
   });
 
   it("reads local-to-cloud mappings for later events on the same local entity", async () => {

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.ts
@@ -1,4 +1,9 @@
-export const POS_LOCAL_STORE_SCHEMA_VERSION = 2;
+import type {
+  LocalPinVerifierMetadata,
+  WrappedLocalStaffProof,
+} from "@/lib/security/localPinVerifier";
+
+export const POS_LOCAL_STORE_SCHEMA_VERSION = 3;
 
 export type PosLocalEntityKind =
   | "registerSession"
@@ -81,6 +86,29 @@ export interface PosLocalStoreDayReadiness {
   closeLifecycleStatus?: "active" | "reopened" | "superseded";
 }
 
+export type PosLocalStaffAuthorityRecord = {
+  activeRoles: Array<"cashier" | "manager">;
+  credentialId: string;
+  credentialVersion: number;
+  displayName?: string | null;
+  expiresAt: number;
+  issuedAt: number;
+  organizationId: string;
+  refreshedAt: number;
+  staffProfileId: string;
+  status: "active" | "revoked";
+  storeId: string;
+  terminalId: string;
+  username: string;
+  verifier: LocalPinVerifierMetadata;
+  wrappedPosLocalStaffProof?: WrappedLocalStaffProof;
+};
+
+export type PosLocalStaffAuthorityReadiness =
+  | "missing"
+  | "expired"
+  | "ready";
+
 export type PosLocalStoreErrorCode =
   | "unsupported_schema_version"
   | "write_failed";
@@ -100,7 +128,8 @@ export type PosLocalObjectStoreName =
   | "terminalSeed"
   | "events"
   | "mappings"
-  | "readiness";
+  | "readiness"
+  | "staffAuthority";
 
 export interface PosLocalStoreTransaction {
   get<T>(
@@ -113,6 +142,7 @@ export interface PosLocalStoreTransaction {
     key: string,
     value: T,
   ): Promise<void>;
+  delete(storeName: PosLocalObjectStoreName, key: string): Promise<void>;
 }
 
 export interface PosLocalStorageAdapter {
@@ -230,9 +260,6 @@ export function createPosLocalStore(options: PosLocalStoreOptions) {
         ? { localTransactionId: input.localTransactionId }
         : {}),
       ...(input.staffProfileId ? { staffProfileId: input.staffProfileId } : {}),
-      ...(input.staffProofToken
-        ? { staffProofToken: input.staffProofToken }
-        : {}),
       payload: input.payload,
       createdAt: clock(),
       sync: { status: "pending" },
@@ -240,8 +267,13 @@ export function createPosLocalStore(options: PosLocalStoreOptions) {
 
     await transaction.put("events", String(nextSequence), event);
     await transaction.put("meta", META_SEQUENCE_KEY, nextSequence);
+    if (input.staffProofToken) {
+      transientStaffProofTokens.set(event.localEventId, input.staffProofToken);
+    }
     return event;
   }
+
+  const transientStaffProofTokens = new Map<string, string>();
 
   return {
     async writeProvisionedTerminalSeed(
@@ -337,6 +369,149 @@ export function createPosLocalStore(options: PosLocalStoreOptions) {
       }
     },
 
+    async replaceStaffAuthoritySnapshot(input: {
+      records: PosLocalStaffAuthorityRecord[];
+      storeId: string;
+      terminalId: string;
+    }): Promise<PosLocalStoreResult<PosLocalStaffAuthorityRecord[]>> {
+      try {
+        const value = await options.adapter.transaction(
+          "readwrite",
+          ["meta", "staffAuthority"],
+          async (transaction) => {
+            await ensureSupportedSchema(transaction, "readwrite");
+            const existing =
+              await transaction.getAll<unknown>("staffAuthority");
+            const existingByKey = new Map(
+              existing
+                .filter(isStaffAuthorityRecord)
+                .map((record) => [staffAuthorityKey(record), record]),
+            );
+
+            for (const record of existing) {
+              if (
+                isStaffAuthorityRecord(record) &&
+                record.storeId === input.storeId &&
+                record.terminalId === input.terminalId
+              ) {
+                await transaction.delete(
+                  "staffAuthority",
+                  staffAuthorityKey(record),
+                );
+              }
+            }
+
+            const scopedRecords = input.records
+              .filter(
+                (record) =>
+                  record.storeId === input.storeId &&
+                  record.terminalId === input.terminalId,
+              )
+              .map((record) =>
+                normalizeStaffAuthorityRecord(
+                  preserveWrappedStaffProof(record, existingByKey),
+                ),
+              );
+
+            for (const record of scopedRecords) {
+              await transaction.put(
+                "staffAuthority",
+                staffAuthorityKey(record),
+                record,
+              );
+            }
+
+            return scopedRecords;
+          },
+        );
+
+        return { ok: true, value };
+      } catch (error) {
+        return toFailure(error);
+      }
+    },
+
+    async readStaffAuthorityForUsername(input: {
+      now?: number;
+      storeId: string;
+      terminalId: string;
+      username: string;
+    }): Promise<PosLocalStoreResult<PosLocalStaffAuthorityRecord | null>> {
+      try {
+        const value = await options.adapter.transaction(
+          "readonly",
+          ["meta", "staffAuthority"],
+          async (transaction) => {
+            await ensureSupportedSchema(transaction, "readonly");
+            const record =
+              (await transaction.get<unknown>(
+                "staffAuthority",
+                staffAuthorityKey(input),
+              )) ?? null;
+
+            if (!isStaffAuthorityRecord(record)) {
+              return null;
+            }
+
+            if (
+              record.storeId !== input.storeId ||
+              record.terminalId !== input.terminalId ||
+              record.status !== "active" ||
+              record.expiresAt <= (input.now ?? clock())
+            ) {
+              return null;
+            }
+
+            return record;
+          },
+        );
+
+        return { ok: true, value };
+      } catch (error) {
+        return toFailure(error);
+      }
+    },
+
+    async getStaffAuthorityReadiness(input: {
+      now?: number;
+      storeId: string;
+      terminalId: string;
+    }): Promise<PosLocalStoreResult<PosLocalStaffAuthorityReadiness>> {
+      try {
+        const value = await options.adapter.transaction(
+          "readonly",
+          ["meta", "staffAuthority"],
+          async (transaction) => {
+            await ensureSupportedSchema(transaction, "readonly");
+            const records =
+              await transaction.getAll<unknown>("staffAuthority");
+            const scopedRecords = records.filter(
+              (record): record is PosLocalStaffAuthorityRecord =>
+                isStaffAuthorityRecord(record) &&
+                record.storeId === input.storeId &&
+                record.terminalId === input.terminalId,
+            );
+
+            if (scopedRecords.length === 0) {
+              return "missing" as const;
+            }
+
+            return scopedRecords.some(
+              (record) =>
+                record.status === "active" &&
+                record.expiresAt > (input.now ?? clock()),
+            )
+              ? ("ready" as const)
+              : ("expired" as const);
+          },
+        );
+
+        return { ok: true, value };
+      } catch (error) {
+        return toFailure(error);
+      }
+    },
+
     async appendEvent(
       input: PosLocalAppendEventInput,
     ): Promise<PosLocalStoreResult<PosLocalEventRecord>> {
@@ -373,6 +548,46 @@ export function createPosLocalStore(options: PosLocalStoreOptions) {
       } catch (error) {
         return toFailure(error);
       }
+    },
+
+    async listEventsForUpload(): Promise<PosLocalStoreResult<PosLocalEventRecord[]>> {
+      const events = await this.listEvents();
+      if (!events.ok) return events;
+
+      return {
+        ok: true,
+        value: events.value.map((event) =>
+          event.staffProofToken || !transientStaffProofTokens.has(event.localEventId)
+            ? event
+            : {
+                ...event,
+                staffProofToken: transientStaffProofTokens.get(event.localEventId),
+              },
+        ),
+      };
+    },
+
+    async attachStaffProofTokenToPendingEvents(input: {
+      staffProfileId: string;
+      staffProofToken: string;
+    }): Promise<PosLocalStoreResult<number>> {
+      const events = await this.listEvents();
+      if (!events.ok) return events;
+
+      let attachedCount = 0;
+      for (const event of events.value) {
+        if (
+          event.staffProfileId === input.staffProfileId &&
+          (event.sync.status === "pending" ||
+            event.sync.status === "syncing" ||
+            event.sync.status === "failed")
+        ) {
+          transientStaffProofTokens.set(event.localEventId, input.staffProofToken);
+          attachedCount += 1;
+        }
+      }
+
+      return { ok: true, value: attachedCount };
     },
 
     async writeLocalCloudMapping(
@@ -553,6 +768,87 @@ function readinessKey(storeId: string, operatingDate: string) {
   return `${storeId}:${operatingDate}`;
 }
 
+function normalizeUsername(username: string) {
+  return username.trim().toLowerCase();
+}
+
+function staffAuthorityKey(input: {
+  storeId: string;
+  terminalId: string;
+  username: string;
+}) {
+  return `${input.storeId}:${input.terminalId}:${normalizeUsername(input.username)}`;
+}
+
+function normalizeStaffAuthorityRecord(
+  record: PosLocalStaffAuthorityRecord,
+): PosLocalStaffAuthorityRecord {
+  return {
+    ...record,
+    username: normalizeUsername(record.username),
+  };
+}
+
+function preserveWrappedStaffProof(
+  record: PosLocalStaffAuthorityRecord,
+  existingByKey: Map<string, PosLocalStaffAuthorityRecord>,
+): PosLocalStaffAuthorityRecord {
+  if (record.wrappedPosLocalStaffProof) {
+    return record;
+  }
+
+  const existing = existingByKey.get(staffAuthorityKey(record));
+  if (
+    !existing?.wrappedPosLocalStaffProof ||
+    existing.credentialVersion !== record.credentialVersion ||
+    existing.wrappedPosLocalStaffProof.expiresAt <= Date.now()
+  ) {
+    return record;
+  }
+
+  return {
+    ...record,
+    wrappedPosLocalStaffProof: existing.wrappedPosLocalStaffProof,
+  };
+}
+
+function isStaffAuthorityRecord(
+  value: unknown,
+): value is PosLocalStaffAuthorityRecord {
+  if (!value || typeof value !== "object") return false;
+  const record = value as Record<string, unknown>;
+  const verifier = record.verifier as Record<string, unknown> | undefined;
+  const wrappedProof = record.wrappedPosLocalStaffProof as
+    | Record<string, unknown>
+    | undefined;
+
+  return (
+    Array.isArray(record.activeRoles) &&
+    record.activeRoles.every((role) => role === "cashier" || role === "manager") &&
+    typeof record.credentialId === "string" &&
+    typeof record.credentialVersion === "number" &&
+    Number.isSafeInteger(record.credentialVersion) &&
+    typeof record.expiresAt === "number" &&
+    typeof record.issuedAt === "number" &&
+    typeof record.organizationId === "string" &&
+    (record.wrappedPosLocalStaffProof === undefined ||
+      (typeof wrappedProof?.ciphertext === "string" &&
+        typeof wrappedProof.expiresAt === "number" &&
+        typeof wrappedProof.iv === "string")) &&
+    typeof record.refreshedAt === "number" &&
+    typeof record.staffProfileId === "string" &&
+    (record.status === "active" || record.status === "revoked") &&
+    typeof record.storeId === "string" &&
+    typeof record.terminalId === "string" &&
+    typeof record.username === "string" &&
+    typeof verifier?.algorithm === "string" &&
+    typeof verifier.hash === "string" &&
+    typeof verifier.iterations === "number" &&
+    typeof verifier.salt === "string" &&
+    typeof verifier.version === "number"
+  );
+}
+
 export function createIndexedDbPosLocalStorageAdapter(options?: {
   databaseName?: string;
 }): PosLocalStorageAdapter {
@@ -570,6 +866,7 @@ export function createIndexedDbPosLocalStorageAdapter(options?: {
           "events",
           "mappings",
           "readiness",
+          "staffAuthority",
         ] satisfies PosLocalObjectStoreName[]) {
           if (!database.objectStoreNames.contains(storeName)) {
             database.createObjectStore(storeName);
@@ -624,6 +921,13 @@ export function createIndexedDbPosLocalStorageAdapter(options?: {
                 const request = transaction
                   .objectStore(storeName)
                   .put(value, key);
+                request.onerror = () => innerReject(request.error);
+                request.onsuccess = () => innerResolve();
+              });
+            },
+            delete(storeName, key) {
+              return new Promise((innerResolve, innerReject) => {
+                const request = transaction.objectStore(storeName).delete(key);
                 request.onerror = () => innerReject(request.error);
                 request.onsuccess = () => innerResolve();
               });
@@ -693,6 +997,9 @@ export function createMemoryPosLocalStorageAdapter(options?: {
             }
             transactionData[storeName].set(key, cloneValue(value));
           },
+          async delete(storeName, key) {
+            transactionData[storeName].delete(key);
+          },
         };
 
         const result = await callback(transaction);
@@ -723,6 +1030,7 @@ function createEmptyMemoryStore(): MemoryStore {
     events: new Map(),
     mappings: new Map(),
     readiness: new Map(),
+    staffAuthority: new Map(),
   };
 }
 
@@ -733,6 +1041,7 @@ function cloneMemoryStore(store: MemoryStore): MemoryStore {
     events: new Map(store.events),
     mappings: new Map(store.mappings),
     readiness: new Map(store.readiness),
+    staffAuthority: new Map(store.staffAuthority),
   };
 }
 

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts
@@ -19,7 +19,10 @@ import {
 import { createPosLocalSyncScheduler } from "./syncScheduler";
 import { derivePosLocalSyncStatus } from "./syncStatus";
 import { readScopedPosLocalEvents } from "./localRegisterReader";
-import { resolvePosLocalTerminalScope } from "./terminalScope";
+import {
+  isPosLocalEventInTerminalScope,
+  resolvePosLocalTerminalScope,
+} from "./terminalScope";
 
 export type PosLocalRuntimeSyncStatusSource = {
   description?: string | null;
@@ -126,7 +129,7 @@ export function usePosLocalSyncRuntimeStatus(input: {
         isOnline: () =>
           typeof navigator === "undefined" ? true : navigator.onLine,
         loadPendingEvents: async () => {
-          const pending = await readScopedPosLocalEvents({
+          const pending = await readScopedPosLocalUploadEvents({
             store,
             storeId,
             terminalId,
@@ -160,7 +163,7 @@ export function usePosLocalSyncRuntimeStatus(input: {
           await refreshEvents();
         },
         uploadBatch: async (pendingEvents) => {
-          const latestEvents = await readScopedPosLocalEvents({
+          const latestEvents = await readScopedPosLocalUploadEvents({
             store,
             storeId,
             terminalId,
@@ -305,6 +308,37 @@ export function assertPosLocalStoreOk<T>(result: PosLocalStoreResult<T>) {
   if (!result.ok) {
     throw new Error(result.error.message);
   }
+}
+
+async function readScopedPosLocalUploadEvents(input: {
+  store: PosLocalRuntimeStore;
+  storeId?: string | null;
+  terminalId?: string | null;
+}) {
+  const [events, terminalSeed] = await Promise.all([
+    input.store.listEventsForUpload
+      ? input.store.listEventsForUpload()
+      : input.store.listEvents(),
+    input.store.readProvisionedTerminalSeed(),
+  ]);
+  if (!events.ok) return events;
+  if (!terminalSeed.ok) return terminalSeed;
+
+  const scope = resolvePosLocalTerminalScope({
+    storeId: input.storeId,
+    terminalId: input.terminalId,
+    terminalSeed: terminalSeed.value,
+  });
+
+  return {
+    ok: true as const,
+    value: {
+      events: events.value.filter((event) =>
+        isPosLocalEventInTerminalScope(event, scope),
+      ),
+      terminalSeed: scope.provisionedSeed,
+    },
+  };
 }
 
 export function collectServerSyncedLocalEventIds(

--- a/packages/athena-webapp/src/lib/pos/presentation/register/registerUiState.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/registerUiState.ts
@@ -223,6 +223,18 @@ export interface RegisterOnboardingState {
 export interface RegisterViewModel {
   workflowMode?: RegisterWorkflowMode;
   hasActiveStore: boolean;
+  debug?: {
+    activeStoreSource: "live" | "local" | "missing";
+    authDialogOpen: boolean;
+    hasLiveActiveStore: boolean;
+    localStaffAuthorityStatus: string;
+    localEntryStatus: string;
+    online: boolean;
+    staffSignedIn: boolean;
+    storeId?: string;
+    terminalId?: string;
+    terminalSource: "live" | "local" | "missing";
+  };
   header: RegisterHeaderState;
   registerInfo: RegisterInfoState;
   onboarding: RegisterOnboardingState;

--- a/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts
@@ -32,6 +32,7 @@ const mockUsePosLocalSyncRuntimeStatus = vi.fn();
 const mockAppendLocalEvent = vi.fn();
 const mockListLocalEvents = vi.fn();
 const mockReadProvisionedTerminalSeed = vi.fn();
+const mockGetStaffAuthorityReadiness = vi.fn();
 const mockMarkLocalEventsSynced = vi.fn();
 const mockWriteLocalCloudMapping = vi.fn();
 
@@ -177,6 +178,13 @@ vi.mock("sonner", () => ({
   },
 }));
 
+vi.mock("@tanstack/react-router", () => ({
+  useParams: () => ({
+    orgUrlSlug: "wigclub",
+    storeUrlSlug: "wigclub",
+  }),
+}));
+
 vi.mock("@/hooks/useGetActiveStore", () => ({
   default: () => ({
     activeStore: mockActiveStore,
@@ -250,7 +258,13 @@ vi.mock("@/lib/pos/infrastructure/local/posLocalStore", () => ({
   createIndexedDbPosLocalStorageAdapter: vi.fn(() => ({})),
   createPosLocalStore: vi.fn(() => ({
     appendEvent: mockAppendLocalEvent,
+    attachStaffProofTokenToPendingEvents: vi.fn(async () => ({
+      ok: true,
+      value: 0,
+    })),
+    getStaffAuthorityReadiness: mockGetStaffAuthorityReadiness,
     listEvents: mockListLocalEvents,
+    listEventsForUpload: mockListLocalEvents,
     readProvisionedTerminalSeed: mockReadProvisionedTerminalSeed,
     markEventsSynced: mockMarkLocalEventsSynced,
     writeLocalCloudMapping: mockWriteLocalCloudMapping,
@@ -398,6 +412,11 @@ describe("useRegisterViewModel", () => {
         storeId: "store-1",
         terminalId: "local-terminal-1",
       },
+    });
+    mockGetStaffAuthorityReadiness.mockReset();
+    mockGetStaffAuthorityReadiness.mockResolvedValue({
+      ok: true,
+      value: "ready",
     });
     mockMarkLocalEventsSynced.mockReset();
     mockMarkLocalEventsSynced.mockResolvedValue({ ok: true, value: [] });
@@ -719,6 +738,40 @@ describe("useRegisterViewModel", () => {
     expect(result.current.cashierCard).toBeNull();
   });
 
+  it("uses the local POS entry seed as store authority when the live active store is unavailable", async () => {
+    mockActiveStore = null;
+    mockRegisterState = undefined;
+    mockActiveSession = null;
+    mockTerminal = {
+      _id: "terminal-1" as Id<"posTerminal">,
+      displayName: "Front Counter",
+      registerNumber: "1",
+    };
+
+    const { useRegisterViewModel } = await import("./useRegisterViewModel");
+    const { result } = renderHook(() => useRegisterViewModel());
+
+    await waitFor(() =>
+      expect(result.current.debug?.localEntryStatus).toBe("ready"),
+    );
+
+    expect(result.current.hasActiveStore).toBe(true);
+    expect(result.current.authDialog).toEqual(
+      expect.objectContaining({
+        open: true,
+        storeId: "store-1",
+        terminalId: "terminal-1",
+      }),
+    );
+    expect(result.current.debug).toEqual(
+      expect.objectContaining({
+        activeStoreSource: "local",
+        hasLiveActiveStore: false,
+        localEntryStatus: "ready",
+      }),
+    );
+  });
+
   it("uses the short-lived local POS staff proof for local events", async () => {
     const { useRegisterViewModel } = await import("./useRegisterViewModel");
     const { result } = renderHook(() => useRegisterViewModel());
@@ -936,6 +989,40 @@ describe("useRegisterViewModel", () => {
     expect(result.current.drawerGate?.errorMessage).toBeNull();
     expect(result.current.checkout.registerNumber).toBe("1");
     expect(mockStartSession).not.toHaveBeenCalled();
+  });
+
+  it("uses offline authenticated manager roles for drawer access", async () => {
+    mockRegisterState = {
+      phase: "readyToStart",
+      terminal: { _id: "terminal-1", displayName: "Front Counter" },
+      cashier: null,
+      activeRegisterSession: null,
+      activeSession: null,
+      resumableSession: null,
+    };
+    mockActiveSession = null;
+
+    const { useRegisterViewModel } = await import("./useRegisterViewModel");
+    const { result } = renderHook(() => useRegisterViewModel());
+
+    await act(async () => {
+      result.current.authDialog?.onAuthenticated({
+        activeRoles: ["manager"],
+        staffProfileId: "staff-1" as Id<"staffProfile">,
+        staffProfile: {
+          fullName: "Offline Manager",
+        },
+        posLocalStaffProof: {
+          expiresAt: Date.now() + 60_000,
+          token: "staff-proof-token",
+        },
+      });
+    });
+
+    expect(result.current.drawerGate).not.toBeNull();
+    expect(result.current.drawerGate?.mode).toBe("initialSetup");
+    expect(result.current.drawerGate?.canOpenDrawer).toBe(true);
+    expect(result.current.cashierCard?.cashierName).toBe("Offline Manager");
   });
 
   it("holds bootstrap on a closing drawer and exposes the closeout-blocked gate", async () => {

--- a/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { FormEvent } from "react";
+import { useParams } from "@tanstack/react-router";
 import { useMutation, useQuery } from "convex/react";
 import { toast } from "sonner";
 
@@ -41,6 +42,7 @@ import {
 } from "@/lib/pos/infrastructure/local/registerReadModel";
 import { readProjectedLocalRegisterModel } from "@/lib/pos/infrastructure/local/localRegisterReader";
 import { usePosLocalSyncRuntimeStatus } from "@/lib/pos/infrastructure/local/usePosLocalSyncRuntime";
+import { useLocalPosEntryContext } from "@/lib/pos/infrastructure/local/localPosEntryContext";
 import {
   useConvexRegisterCatalog,
   useConvexRegisterCatalogAvailability,
@@ -98,6 +100,11 @@ type LocalSyncRecord = {
   syncStatus?: LocalSyncStatusSource | string | null;
 };
 
+type LocalAuthenticatedStaff = {
+  activeRoles: string[];
+  displayName: string;
+} | null;
+
 function readStaffProofFromAuthResult(
   result: StaffAuthenticationResult,
 ): string | null {
@@ -115,6 +122,15 @@ function readStaffProofFromAuthResult(
   }
 
   return token;
+}
+
+function getStaffDisplayNameFromAuthResult(result: StaffAuthenticationResult) {
+  return (
+    result.staffProfile.fullName ||
+    [result.staffProfile.firstName, result.staffProfile.lastName]
+      .filter(Boolean)
+      .join(" ")
+  );
 }
 
 function hasCustomerDetails(
@@ -590,13 +606,32 @@ export function useRegisterViewModel(): RegisterViewModel {
   const { activeStore } = useGetActiveStore();
   const { user } = useAuth();
   const terminal = useGetTerminal();
+  const routeParams = useParams({ strict: false }) as
+    | {
+        orgUrlSlug?: string;
+        storeUrlSlug?: string;
+      }
+    | undefined;
+  const localEntryContext = useLocalPosEntryContext({
+    activeStore,
+    routeParams,
+  });
+  const activeStoreId = (activeStore?._id ??
+    (localEntryContext.status === "ready"
+      ? localEntryContext.storeId
+      : undefined)) as Id<"store"> | undefined;
+  const activeStoreCurrency = activeStore?.currency ?? "GHS";
   const navigateBack = useNavigateBack();
   const [staffProfileId, setStaffProfileId] =
     useState<Id<"staffProfile"> | null>(null);
   const [staffProofToken, setStaffProofToken] = useState<string | null>(null);
+  const [localAuthenticatedStaff, setLocalAuthenticatedStaff] =
+    useState<LocalAuthenticatedStaff>(null);
   const terminalRegisterNumber = terminal?.registerNumber
     ? trimOptional(terminal.registerNumber)
     : undefined;
+  const [localStaffAuthorityStatus, setLocalStaffAuthorityStatus] =
+    useState("unknown");
   const [showCustomerPanel, setShowCustomerPanel] = useState(false);
   const [showProductEntry, setShowProductEntry] = useState(true);
   const [productSearchQuery, setProductSearchQuery] = useState("");
@@ -661,7 +696,7 @@ export function useRegisterViewModel(): RegisterViewModel {
     useState(0);
 
   const registerState = useConvexRegisterState({
-    storeId: activeStore?._id,
+    storeId: activeStoreId,
     terminalId: terminal?._id ?? null,
     staffProfileId,
     registerNumber: terminalRegisterNumber,
@@ -671,23 +706,23 @@ export function useRegisterViewModel(): RegisterViewModel {
   });
   const staffRosterResult = useQuery(
     api.operations.staffProfiles.listStaffProfiles,
-    activeStore?._id ? { storeId: activeStore._id } : "skip",
+    activeStoreId ? { storeId: activeStoreId! } : "skip",
   ) as unknown;
   const isStaffRosterLoaded =
-    !activeStore?._id || Array.isArray(staffRosterResult);
+    !activeStoreId || Array.isArray(staffRosterResult);
   const staffRoster = Array.isArray(staffRosterResult)
     ? (staffRosterResult as StaffProfileRosterRow[])
     : [];
   const activeRegisterOperatorCount =
     staffRoster.filter(canOperateRegister).length;
   const activeSession = useConvexActiveSession({
-    storeId: activeStore?._id,
+    storeId: activeStoreId,
     terminalId: terminal?._id ?? null,
     staffProfileId,
     registerNumber: terminalRegisterNumber,
   });
   const registerCatalogRows = useConvexRegisterCatalog({
-    storeId: activeStore?._id,
+    storeId: activeStoreId,
   });
   const registerCatalogIndex = useRegisterCatalogIndex(registerCatalogRows);
   const registerMetadataSearchState = useMemo(
@@ -702,7 +737,7 @@ export function useRegisterViewModel(): RegisterViewModel {
     [registerMetadataSearchState.results],
   );
   const registerCatalogAvailabilityRows = useConvexRegisterCatalogAvailability({
-    storeId: activeStore?._id,
+    storeId: activeStoreId,
     productSkuIds: registerAvailabilityProductSkuIds,
   });
   const registerCatalogAvailabilityBySkuId = useMemo(() => {
@@ -767,7 +802,7 @@ export function useRegisterViewModel(): RegisterViewModel {
       : null;
   const projectedLocalRegisterSession =
     localRegisterReadModel?.activeRegisterSession &&
-    activeStore?._id &&
+    activeStoreId &&
     terminal?._id &&
     isPosUsableRegisterSessionStatus(
       localRegisterReadModel.activeRegisterSession.status,
@@ -781,13 +816,13 @@ export function useRegisterViewModel(): RegisterViewModel {
             localRegisterReadModel.activeRegisterSession.openingFloat,
           registerNumber:
             localRegisterReadModel.activeRegisterSession.registerNumber ?? "",
-          storeId: activeStore._id,
+          storeId: activeStoreId!,
           terminalId: terminal._id,
       }
     : null;
   const projectedLocalCloseoutBlockedRegisterSession =
     localRegisterReadModel?.activeRegisterSession?.status === "closing" &&
-    activeStore?._id &&
+    activeStoreId &&
     terminal?._id
       ? {
           localRegisterSessionId:
@@ -822,7 +857,7 @@ export function useRegisterViewModel(): RegisterViewModel {
       : null;
   const locallyOperableRegisterSession =
     localOperableRegisterSession &&
-    activeStore?._id === localOperableRegisterSession.storeId &&
+    activeStoreId === localOperableRegisterSession.storeId &&
     terminal?._id === localOperableRegisterSession.terminalId
       ? localOperableRegisterSession
       : projectedLocalRegisterSession;
@@ -846,13 +881,16 @@ export function useRegisterViewModel(): RegisterViewModel {
     cloudRegisterSessionId;
   const registerNumber = activeRegisterNumber ?? terminalRegisterNumber ?? "";
   const heldSessions = useConvexHeldSessions({
-    storeId: activeStore?._id,
+    storeId: activeStoreId,
     terminalId: terminal?._id ?? null,
     staffProfileId,
     limit: 10,
   });
   const cashier = registerState?.cashier ?? null;
-  const isCashierManager = Boolean(cashier?.activeRoles?.includes("manager"));
+  const isCashierManager = Boolean(
+    cashier?.activeRoles?.includes("manager") ||
+      localAuthenticatedStaff?.activeRoles.includes("manager"),
+  );
   const activeSessionConflict = registerState?.activeSessionConflict ?? null;
 
   const { holdSession: holdSessionCommand } = useConvexCommandGateway();
@@ -870,7 +908,7 @@ export function useRegisterViewModel(): RegisterViewModel {
       subject: ApprovalRequirement["subject"];
       username: string;
     }) => {
-      if (!activeStore?._id) {
+      if (!activeStoreId) {
         return Promise.resolve(
           userError({
             code: "authentication_failed",
@@ -887,16 +925,16 @@ export function useRegisterViewModel(): RegisterViewModel {
             reason: args.reason,
             requiredRole: args.requiredRole,
             requestedByStaffProfileId: args.requestedByStaffProfileId,
-            storeId: activeStore._id,
+            storeId: activeStoreId!,
             subject: args.subject,
             username: args.username,
           }) as Promise<CommandResult<CommandApprovalProofResult>>,
       );
     },
-    [activeStore?._id, authenticateStaffCredentialForApproval],
+    [activeStoreId, authenticateStaffCredentialForApproval],
   );
   const closeoutApprovalRunner = useApprovedCommand({
-    storeId: activeStore?._id,
+    storeId: activeStoreId,
     onAuthenticateForApproval: authenticateForCloseoutApproval,
   });
   const correctRegisterSessionOpeningFloat = useMutation(
@@ -909,13 +947,18 @@ export function useRegisterViewModel(): RegisterViewModel {
     updateSession,
   } = useConvexSessionActions();
   const voidSessionRef = useRef<typeof voidSession>(voidSession);
+  const localStore = useMemo(
+    () =>
+      createPosLocalStore({
+        adapter: createIndexedDbPosLocalStorageAdapter(),
+      }),
+    [],
+  );
   const localCommandGateway = useMemo(
     () =>
       createLocalCommandGateway({
         allowExplicitRegisterSessionWithoutProjection: true,
-        store: createPosLocalStore({
-          adapter: createIndexedDbPosLocalStorageAdapter(),
-        }),
+        store: localStore,
         createLocalId: (kind) => {
           if (kind === "local-register-session" && terminal?._id) {
             return createLocalFallbackId(`local-register-${terminal._id}`);
@@ -927,10 +970,52 @@ export function useRegisterViewModel(): RegisterViewModel {
             ? (staffProofToken ?? undefined)
             : undefined,
       }),
-    [staffProfileId, staffProofToken, terminal?._id],
+    [localStore, staffProfileId, staffProofToken, terminal?._id],
   );
+  useEffect(() => {
+    if (!staffProfileId || !staffProofToken) {
+      return;
+    }
+
+    void localStore.attachStaffProofTokenToPendingEvents({
+      staffProfileId,
+      staffProofToken,
+    });
+  }, [localStore, staffProfileId, staffProofToken]);
+  useEffect(() => {
+    let cancelled = false;
+
+    async function refreshLocalStaffAuthorityStatus() {
+      if (!activeStoreId || !terminal?._id || typeof indexedDB === "undefined") {
+        setLocalStaffAuthorityStatus("unavailable");
+        return;
+      }
+
+      try {
+        const result = await localStore.getStaffAuthorityReadiness({
+          storeId: activeStoreId,
+          terminalId: terminal._id,
+        });
+        if (!cancelled) {
+          setLocalStaffAuthorityStatus(
+            result.ok ? result.value : "unavailable",
+          );
+        }
+      } catch {
+        if (!cancelled) {
+          setLocalStaffAuthorityStatus("unavailable");
+        }
+      }
+    }
+
+    void refreshLocalStaffAuthorityStatus();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [activeStoreId, localStore, terminal?._id, staffProfileId]);
   const hasProvisionedLocalSyncSeed = useCallback(async () => {
-    if (!activeStore?._id || !terminal?._id || typeof indexedDB === "undefined") {
+    if (!activeStoreId || !terminal?._id || typeof indexedDB === "undefined") {
       return false;
     }
 
@@ -941,13 +1026,13 @@ export function useRegisterViewModel(): RegisterViewModel {
     return Boolean(
       result.ok &&
         result.value &&
-        result.value.storeId === activeStore._id &&
+        result.value.storeId === activeStoreId! &&
         result.value.cloudTerminalId === terminal._id &&
         result.value.syncSecretHash,
     );
-  }, [activeStore?._id, terminal?._id]);
+  }, [activeStoreId, terminal?._id]);
   const readCurrentLocalRegisterModel = useCallback(async () => {
-    if (!activeStore?._id || !terminal?._id || typeof indexedDB === "undefined") {
+    if (!activeStoreId || !terminal?._id || typeof indexedDB === "undefined") {
       return null;
     }
 
@@ -963,12 +1048,12 @@ export function useRegisterViewModel(): RegisterViewModel {
 
     const model = await readProjectedLocalRegisterModel({
       store,
-      storeId: activeStore._id,
+      storeId: activeStoreId!,
       terminal,
       isOnline: globalThis.navigator?.onLine ?? false,
     });
     return model.ok ? model.value : null;
-  }, [activeStore?._id, terminal]);
+  }, [activeStoreId, terminal]);
 
   const refreshLocalRegisterReadModel = useCallback(async () => {
     const model = await readCurrentLocalRegisterModel();
@@ -1020,7 +1105,7 @@ export function useRegisterViewModel(): RegisterViewModel {
       return {
         _id: sale.localPosSessionId,
         _creationTime: sale.startedAt,
-        storeId: activeStore?._id as Id<"store">,
+        storeId: activeStoreId as Id<"store">,
         terminalId: sale.terminalId,
         staffProfileId: (sale.staffProfileId as Id<"staffProfile">) ?? undefined,
         status: "active",
@@ -1076,7 +1161,7 @@ export function useRegisterViewModel(): RegisterViewModel {
       },
     };
   }, [
-    activeStore?._id,
+    activeStoreId,
     localOperablePosSession,
     localRegisterReadModel,
     locallyOperableRegisterSession,
@@ -1224,7 +1309,7 @@ export function useRegisterViewModel(): RegisterViewModel {
       hasActivePosSession),
   );
   const requiresDrawerGate = Boolean(
-    activeStore?._id &&
+    activeStoreId &&
     terminal?._id &&
     staffProfileId &&
     bootstrapState &&
@@ -1321,6 +1406,7 @@ export function useRegisterViewModel(): RegisterViewModel {
       if (!options?.keepCashier) {
         setStaffProfileId(null);
         setStaffProofToken(null);
+        setLocalAuthenticatedStaff(null);
         setLocalOperableRegisterSession(null);
       }
     },
@@ -1379,7 +1465,7 @@ export function useRegisterViewModel(): RegisterViewModel {
     requestBootstrap();
   }, [
     requestBootstrap,
-    activeStore?._id,
+    activeStoreId,
     terminal?._id,
     staffProfileId,
     registerNumber,
@@ -1444,7 +1530,7 @@ export function useRegisterViewModel(): RegisterViewModel {
       if (
         !usableActiveRegisterSession ||
         usableActiveRegisterSession._id.toString() !== localRegisterSessionId ||
-        !activeStore?._id ||
+        !activeStoreId ||
         !terminal?._id ||
         !staffProfileId
       ) {
@@ -1453,7 +1539,7 @@ export function useRegisterViewModel(): RegisterViewModel {
 
       const savedLocally = await localCommandGateway.seedRegisterSession({
         terminalId: terminal._id,
-        storeId: activeStore._id,
+        storeId: activeStoreId!,
         registerNumber,
         localRegisterSessionId,
         staffProfileId,
@@ -1468,7 +1554,7 @@ export function useRegisterViewModel(): RegisterViewModel {
       return Boolean(savedLocally);
     },
     [
-      activeStore?._id,
+      activeStoreId,
       localRegisterReadModel?.activeRegisterSession?.localRegisterSessionId,
       localRegisterReadModel?.canSell,
       localCommandGateway,
@@ -1495,12 +1581,12 @@ export function useRegisterViewModel(): RegisterViewModel {
         toast.error("Drawer closed. Open the drawer before adding items.");
         return null;
       }
-      if (!activeStore?._id || !terminal?._id || !staffProfileId) {
+      if (!activeStoreId || !terminal?._id || !staffProfileId) {
         toast.error("Register sign-in required. Sign in before adding items.");
         return null;
       }
       const localSession = await localCommandGateway.startSession({
-        storeId: activeStore._id,
+        storeId: activeStoreId!,
         terminalId: terminal._id as Id<"posTerminal">,
         staffProfileId,
         registerNumber,
@@ -1524,7 +1610,7 @@ export function useRegisterViewModel(): RegisterViewModel {
       return null;
     }
 
-    if (!activeStore?._id || !terminal?._id || !staffProfileId) {
+    if (!activeStoreId || !terminal?._id || !staffProfileId) {
       toast.error("Register sign-in required. Sign in before adding items.");
       return null;
     }
@@ -1540,7 +1626,7 @@ export function useRegisterViewModel(): RegisterViewModel {
     }
 
     const result = await localCommandGateway.startSession({
-      storeId: activeStore._id,
+      storeId: activeStoreId!,
       terminalId: terminal._id as Id<"posTerminal">,
       staffProfileId,
       registerNumber,
@@ -1559,7 +1645,7 @@ export function useRegisterViewModel(): RegisterViewModel {
       localRegisterSessionId,
       registerNumber,
       startedAt: Date.now(),
-      storeId: activeStore._id,
+      storeId: activeStoreId!,
       terminalId: terminal._id,
     });
     bootstrapInitialized.current = true;
@@ -1567,7 +1653,7 @@ export function useRegisterViewModel(): RegisterViewModel {
   }, [
     operableActiveSession?._id,
     localEventRegisterSessionId,
-    activeStore?._id,
+    activeStoreId,
     ensureLocalRegisterSessionReady,
     hasProvisionedLocalSyncSeed,
     localCommandGateway,
@@ -1712,7 +1798,7 @@ export function useRegisterViewModel(): RegisterViewModel {
         return false;
       }
 
-      if (!activeStore?._id || !terminal?._id) {
+      if (!activeStoreId || !terminal?._id) {
         return false;
       }
 
@@ -1726,7 +1812,7 @@ export function useRegisterViewModel(): RegisterViewModel {
 
       const savedLocally = await localCommandGateway.appendPaymentState({
         terminalId: terminal._id,
-        storeId: activeStore._id,
+        storeId: activeStoreId!,
         registerNumber,
         localRegisterSessionId: localEventRegisterSessionId ?? registerNumber,
         localPosSessionId: operableActiveSession._id.toString(),
@@ -1753,7 +1839,7 @@ export function useRegisterViewModel(): RegisterViewModel {
       operableActiveSession?._id,
       activeSessionHasBlockedRegisterBinding,
       localEventRegisterSessionId,
-      activeStore?._id,
+      activeStoreId,
       hasProvisionedLocalSyncSeed,
       localCommandGateway,
       noteLocalRegisterEventChanged,
@@ -1875,13 +1961,13 @@ export function useRegisterViewModel(): RegisterViewModel {
       try {
         await waitForCheckoutMutationQueues();
 
-        if (!activeStore?._id || !terminal?._id) {
+        if (!activeStoreId || !terminal?._id) {
           presentOperatorError("Unable to save this cart update locally.");
           return false;
         }
         const savedLocally = await localCommandGateway.clearCart({
           terminalId: terminal._id,
-          storeId: activeStore._id,
+          storeId: activeStoreId!,
           registerNumber,
           localRegisterSessionId: localEventRegisterSessionId ?? registerNumber,
           localPosSessionId: localSaleId,
@@ -1929,7 +2015,7 @@ export function useRegisterViewModel(): RegisterViewModel {
   }, [
     activeCartItems,
     localEventRegisterSessionId,
-    activeStore?._id,
+    activeStoreId,
     localCommandGateway,
     localRegisterReadModel?.activeSale?.localPosSessionId,
     noteLocalRegisterEventChanged,
@@ -1995,7 +2081,7 @@ export function useRegisterViewModel(): RegisterViewModel {
       return;
     }
 
-    if (!activeStore?._id || !terminal?._id || !staffProfileId) {
+    if (!activeStoreId || !terminal?._id || !staffProfileId) {
       toast.error("Register sign-in required. Sign in before starting a sale.");
       return;
     }
@@ -2031,7 +2117,7 @@ export function useRegisterViewModel(): RegisterViewModel {
     }
 
     const result = await localCommandGateway.startSession({
-      storeId: activeStore._id,
+      storeId: activeStoreId!,
       terminalId: terminal._id as Id<"posTerminal">,
       staffProfileId,
       registerNumber,
@@ -2053,7 +2139,7 @@ export function useRegisterViewModel(): RegisterViewModel {
       localRegisterSessionId,
       registerNumber,
       startedAt: Date.now(),
-      storeId: activeStore._id,
+      storeId: activeStoreId!,
       terminalId: terminal._id,
     });
     bootstrapInitialized.current = true;
@@ -2061,7 +2147,7 @@ export function useRegisterViewModel(): RegisterViewModel {
   }, [
     operableActiveSession,
     localEventRegisterSessionId,
-    activeStore?._id,
+    activeStoreId,
     staffProfileId,
     guardActiveSessionConflict,
     ensureLocalRegisterSessionReady,
@@ -2076,7 +2162,7 @@ export function useRegisterViewModel(): RegisterViewModel {
   ]);
 
   const handleOpenDrawer = useCallback(async () => {
-    if (!activeStore?._id || !terminal?._id || !staffProfileId) {
+    if (!activeStoreId || !terminal?._id || !staffProfileId) {
       setDrawerErrorMessage(
         "Register sign-in required. Sign in before opening the drawer.",
       );
@@ -2103,7 +2189,7 @@ export function useRegisterViewModel(): RegisterViewModel {
     }
 
     const result = await localCommandGateway.openDrawer({
-      storeId: activeStore._id,
+      storeId: activeStoreId!,
       terminalId: terminal._id as Id<"posTerminal">,
       staffProfileId,
       registerNumber,
@@ -2126,14 +2212,14 @@ export function useRegisterViewModel(): RegisterViewModel {
       openedAt: result.data.openedAt,
       openingFloat: parsedOpeningFloat,
       registerNumber,
-      storeId: activeStore._id,
+      storeId: activeStoreId!,
       terminalId: terminal._id,
     });
     setDrawerErrorMessage(null);
     bootstrapInitialized.current = true;
     toast.success("Drawer opening saved locally. It will sync when ready.");
   }, [
-    activeStore?._id,
+    activeStoreId,
     staffProfileId,
     drawerNotes,
     drawerOpeningFloat,
@@ -2145,7 +2231,7 @@ export function useRegisterViewModel(): RegisterViewModel {
   ]);
 
   const handleSubmitRegisterCloseout = useCallback(async () => {
-    if (!activeStore?._id || !terminal?._id || !staffProfileId) {
+    if (!activeStoreId || !terminal?._id || !staffProfileId) {
       setDrawerErrorMessage(
         "Register sign-in required. Sign in before submitting closeout.",
       );
@@ -2188,7 +2274,7 @@ export function useRegisterViewModel(): RegisterViewModel {
     await waitForCheckoutMutationQueues();
     const savedLocally = await localCommandGateway.startCloseout({
       terminalId: terminal._id,
-      storeId: activeStore._id,
+      storeId: activeStoreId!,
       registerNumber,
       localRegisterSessionId: registerSessionId,
       staffProfileId,
@@ -2217,7 +2303,7 @@ export function useRegisterViewModel(): RegisterViewModel {
     requestBootstrap();
     toast.success("Register session closed locally. It will sync when ready.");
   }, [
-    activeStore?._id,
+    activeStoreId,
     activeCloseoutRegisterSession,
     closeoutCountedCash,
     closeoutNotes,
@@ -2240,7 +2326,7 @@ export function useRegisterViewModel(): RegisterViewModel {
       return;
     }
 
-    if (!activeStore?._id || !terminal?._id || !staffProfileId) {
+    if (!activeStoreId || !terminal?._id || !staffProfileId) {
       setDrawerErrorMessage(
         "Register sign-in required. Sign in before reopening the register.",
       );
@@ -2270,7 +2356,7 @@ export function useRegisterViewModel(): RegisterViewModel {
 
     const savedLocally = await localCommandGateway.reopenRegister({
       terminalId: terminal._id,
-      storeId: activeStore._id,
+      storeId: activeStoreId!,
       registerNumber,
       localRegisterSessionId: registerSessionId,
       staffProfileId,
@@ -2292,13 +2378,13 @@ export function useRegisterViewModel(): RegisterViewModel {
       openedAt: closeoutBlockedRegisterSession.openedAt,
       openingFloat: closeoutBlockedRegisterSession.openingFloat,
       registerNumber,
-      storeId: activeStore._id,
+      storeId: activeStoreId!,
       terminalId: terminal._id,
     });
     requestBootstrap();
     toast.success("Register reopened locally. It will sync when ready.");
   }, [
-    activeStore?._id,
+    activeStoreId,
     activeCloseoutRegisterSession,
     closeoutBlockedRegisterSession,
     isCashierManager,
@@ -2311,7 +2397,7 @@ export function useRegisterViewModel(): RegisterViewModel {
   ]);
 
   const handleSubmitOpeningFloatCorrection = useCallback(async () => {
-    if (!activeStore?._id || !user?._id || !staffProfileId) {
+    if (!activeStoreId || !user?._id || !staffProfileId) {
       setDrawerErrorMessage(
         "Register sign-in required. Sign in before correcting opening float.",
       );
@@ -2358,7 +2444,7 @@ export function useRegisterViewModel(): RegisterViewModel {
               correctedOpeningFloat: parsedOpeningFloat,
               reason,
               registerSessionId,
-              storeId: activeStore._id,
+              storeId: activeStoreId!,
             }),
           );
         } finally {
@@ -2388,7 +2474,7 @@ export function useRegisterViewModel(): RegisterViewModel {
     });
   }, [
     activeOpeningFloatCorrectionRegisterSession?._id,
-    activeStore?._id,
+    activeStoreId,
     closeoutApprovalRunner,
     correctedOpeningFloat,
     correctRegisterSessionOpeningFloat,
@@ -2440,7 +2526,7 @@ export function useRegisterViewModel(): RegisterViewModel {
 
   useEffect(() => {
     if (
-      !activeStore?._id ||
+      !activeStoreId ||
       !terminal?._id ||
       !staffProfileId ||
       !bootstrapState ||
@@ -2487,7 +2573,7 @@ export function useRegisterViewModel(): RegisterViewModel {
       bootstrapInitialized.current = false;
     })();
   }, [
-    activeStore?._id,
+    activeStoreId,
     activeRegisterSessionId,
     bootstrapState,
     staffProfileId,
@@ -2499,13 +2585,13 @@ export function useRegisterViewModel(): RegisterViewModel {
 
   const appendLocalCartItem = useCallback(
     async (input: { localPosSessionId: string; payload: unknown }) => {
-      if (!activeStore?._id || !terminal?._id || !staffProfileId) {
+      if (!activeStoreId || !terminal?._id || !staffProfileId) {
         return false;
       }
 
       return localCommandGateway.appendCartItem({
         terminalId: terminal._id,
-        storeId: activeStore._id,
+        storeId: activeStoreId!,
         registerNumber,
         localRegisterSessionId: localEventRegisterSessionId ?? registerNumber,
         localPosSessionId: input.localPosSessionId,
@@ -2515,7 +2601,7 @@ export function useRegisterViewModel(): RegisterViewModel {
     },
     [
       localEventRegisterSessionId,
-      activeStore?._id,
+      activeStoreId,
       localCommandGateway,
       registerNumber,
       staffProfileId,
@@ -2902,14 +2988,14 @@ export function useRegisterViewModel(): RegisterViewModel {
     try {
       await waitForCheckoutMutationQueues();
 
-      if (!activeStore?._id || !terminal?._id) {
+      if (!activeStoreId || !terminal?._id) {
         presentOperatorError("Unable to save this cart update locally.");
         return;
       }
 
       const savedLocally = await localCommandGateway.clearCart({
         terminalId: terminal._id,
-        storeId: activeStore._id,
+        storeId: activeStoreId!,
         registerNumber,
         localRegisterSessionId: localEventRegisterSessionId ?? registerNumber,
         localPosSessionId: operableActiveSession._id.toString(),
@@ -2943,7 +3029,7 @@ export function useRegisterViewModel(): RegisterViewModel {
     activeSessionHasBlockedRegisterBinding,
     localEventRegisterSessionId,
     activeCartItems,
-    activeStore?._id,
+    activeStoreId,
     localCommandGateway,
     noteLocalRegisterEventChanged,
     registerNumber,
@@ -2997,9 +3083,14 @@ export function useRegisterViewModel(): RegisterViewModel {
       if (typeof result === "string") {
         setStaffProfileId(result as Id<"staffProfile">);
         setStaffProofToken(null);
+        setLocalAuthenticatedStaff(null);
       } else {
         setStaffProfileId(result.staffProfileId);
         setStaffProofToken(readStaffProofFromAuthResult(result));
+        setLocalAuthenticatedStaff({
+          activeRoles: result.activeRoles ?? [],
+          displayName: getStaffDisplayNameFromAuthResult(result),
+        });
       }
       requestBootstrap();
     },
@@ -3148,7 +3239,7 @@ export function useRegisterViewModel(): RegisterViewModel {
         return false;
       }
 
-      if (!activeStore?._id || !terminal?._id) {
+      if (!activeStoreId || !terminal?._id) {
         presentOperatorError("Unable to save this sale locally.");
         return false;
       }
@@ -3156,7 +3247,7 @@ export function useRegisterViewModel(): RegisterViewModel {
       const localTransactionId = createLocalFallbackId("local-txn");
       const savedLocally = await localCommandGateway.completeTransaction({
         terminalId: terminal._id,
-        storeId: activeStore._id,
+        storeId: activeStoreId!,
         registerNumber,
         localRegisterSessionId: localEventRegisterSessionId ?? registerNumber,
         localPosSessionId,
@@ -3187,7 +3278,7 @@ export function useRegisterViewModel(): RegisterViewModel {
     activeSession?._id,
     activeSession?.cartItems,
     localEventRegisterSessionId,
-    activeStore?._id,
+    activeStoreId,
     activeTotals,
     operableActiveSession,
     customerInfo,
@@ -3396,7 +3487,7 @@ export function useRegisterViewModel(): RegisterViewModel {
   ]);
 
   const sessionPanel =
-    activeStore?._id && terminal?._id && staffProfileId
+    activeStoreId && terminal?._id && staffProfileId
       ? {
           activeSessionNumber: operableActiveSession?.sessionNumber ?? null,
           activeSessionTraceId: operableActiveSession?.workflowTraceId ?? null,
@@ -3447,9 +3538,10 @@ export function useRegisterViewModel(): RegisterViewModel {
       : null;
 
   const cashierCard =
-    activeStore?._id && terminal?._id && staffProfileId
+    activeStoreId && terminal?._id && staffProfileId
       ? {
-          cashierName: getCashierDisplayName(cashier),
+          cashierName:
+            cashier ? getCashierDisplayName(cashier) : localAuthenticatedStaff?.displayName ?? "",
           onSignOut: handleCashierSignOut,
         }
       : null;
@@ -3462,13 +3554,13 @@ export function useRegisterViewModel(): RegisterViewModel {
   );
 
   const drawerGate =
-    activeStore?._id && terminal?._id && staffProfileId && shouldShowDrawerGate
+    activeStoreId && terminal?._id && staffProfileId && shouldShowDrawerGate
       ? drawerGateMode === "openingFloatCorrection"
         ? {
             mode: drawerGateMode,
             registerLabel: terminal.displayName,
             registerNumber,
-            currency: activeStore.currency,
+            currency: activeStoreCurrency,
             currentOpeningFloat:
               activeOpeningFloatCorrectionRegisterSession?.openingFloat,
             correctedOpeningFloat,
@@ -3500,7 +3592,7 @@ export function useRegisterViewModel(): RegisterViewModel {
               isRecovery: closeoutBlockedGateIsRecovery,
               registerLabel: terminal.displayName,
               registerNumber,
-              currency: activeStore.currency,
+              currency: activeStoreCurrency,
               closeoutCountedCash,
               closeoutDraftVariance:
                 parsedCloseoutCountedCash !== undefined &&
@@ -3545,7 +3637,7 @@ export function useRegisterViewModel(): RegisterViewModel {
               mode: drawerGateMode,
               registerLabel: terminal.displayName,
               registerNumber,
-              currency: activeStore.currency,
+              currency: activeStoreCurrency,
               canOpenCashControls: isCashierManager,
               canOpenDrawer: isCashierManager,
               openingFloat: drawerOpeningFloat,
@@ -3569,7 +3661,7 @@ export function useRegisterViewModel(): RegisterViewModel {
             }
       : null;
   const closeoutControl =
-    activeStore?._id && terminal?._id && staffProfileId
+    activeStoreId && terminal?._id && staffProfileId
       ? {
           canCloseout: Boolean(
             (usableActiveRegisterSession ?? localCloseoutRegisterSession) &&
@@ -3615,9 +3707,10 @@ export function useRegisterViewModel(): RegisterViewModel {
         }
       : null;
   const localRuntimeSyncSource = usePosLocalSyncRuntimeStatus({
-    storeId: activeStore?._id,
+    storeId: activeStoreId,
     terminalId: terminal?._id,
     onRetrySync: requestBootstrap,
+    storeFactory: () => localStore,
   });
   const localSyncSource = readLocalSyncStatus(
     localRuntimeSyncSource
@@ -3637,7 +3730,7 @@ export function useRegisterViewModel(): RegisterViewModel {
     registerState,
   );
   const syncStatus =
-    activeStore?._id && terminal?._id
+    activeStoreId && terminal?._id
       ? {
           ...buildPosSyncStatusPresentation(localSyncSource),
           onRetrySync: () => {
@@ -3648,10 +3741,10 @@ export function useRegisterViewModel(): RegisterViewModel {
       : null;
 
   const authDialog =
-    activeStore?._id && terminal?._id
+    activeStoreId && terminal?._id
       ? {
           open: !staffProfileId,
-          storeId: activeStore._id,
+          storeId: activeStoreId!,
           terminalId: terminal._id,
 	          onAuthenticated: (
 	            result: StaffAuthenticationResult | Id<"staffProfile">,
@@ -3666,7 +3759,27 @@ export function useRegisterViewModel(): RegisterViewModel {
     closeoutApprovalRunner.approvalDialog as RegisterCommandApprovalDialogState | null;
 
   return {
-    hasActiveStore: Boolean(activeStore),
+    hasActiveStore: Boolean(activeStoreId),
+    debug: {
+      activeStoreSource: activeStore
+        ? "live"
+        : activeStoreId
+          ? "local"
+          : "missing",
+      authDialogOpen: Boolean(authDialog?.open),
+      hasLiveActiveStore: Boolean(activeStore),
+      localStaffAuthorityStatus,
+      localEntryStatus: localEntryContext.status,
+      online: globalThis.navigator?.onLine ?? true,
+      staffSignedIn: Boolean(staffProfileId),
+      ...(activeStoreId ? { storeId: activeStoreId } : {}),
+      ...(terminal?._id ? { terminalId: terminal._id } : {}),
+      terminalSource: terminal
+        ? terminal.status === "local"
+          ? "local"
+          : "live"
+        : "missing",
+    },
     header,
     registerInfo,
     onboarding,

--- a/packages/athena-webapp/src/lib/security/localPinVerifier.test.ts
+++ b/packages/athena-webapp/src/lib/security/localPinVerifier.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  createLocalPinVerifier,
+  unwrapLocalStaffProofToken,
+  verifyLocalPin,
+  wrapLocalStaffProofToken,
+} from "./localPinVerifier";
+
+describe("localPinVerifier", () => {
+  it("verifies the PIN used to create the local verifier and rejects a different PIN", async () => {
+    const verifier = await createLocalPinVerifier("123456");
+
+    expect(verifier).toEqual({
+      algorithm: "PBKDF2-SHA256",
+      hash: expect.any(String),
+      iterations: 120000,
+      salt: expect.any(String),
+      version: 1,
+    });
+    await expect(verifyLocalPin(verifier, "123456")).resolves.toEqual({
+      ok: true,
+    });
+    await expect(verifyLocalPin(verifier, "654321")).resolves.toEqual({
+      ok: false,
+      reason: "invalid_pin",
+    });
+  });
+
+  it("fails closed for malformed or unsupported verifier payloads", async () => {
+    await expect(verifyLocalPin({ hash: "missing-fields" }, "123456")).resolves.toEqual({
+      ok: false,
+      reason: "malformed_verifier",
+    });
+    await expect(
+      verifyLocalPin(
+        {
+          algorithm: "PBKDF2-SHA512",
+          hash: "hash",
+          iterations: 1,
+          salt: "salt",
+          version: 99,
+        },
+        "123456",
+      ),
+    ).resolves.toEqual({
+      ok: false,
+      reason: "unsupported_verifier",
+    });
+    await expect(
+      verifyLocalPin(
+        {
+          algorithm: "PBKDF2-SHA256",
+          hash: "hash",
+          iterations: 120000,
+          salt: "%",
+          version: 1,
+        },
+        "123456",
+      ),
+    ).resolves.toEqual({
+      ok: false,
+      reason: "malformed_verifier",
+    });
+    await expect(
+      verifyLocalPin(
+        {
+          algorithm: "PBKDF2-SHA256",
+          hash: "hash",
+          iterations: 0,
+          salt: "salt",
+          version: 1,
+        },
+        "123456",
+      ),
+    ).resolves.toEqual({
+      ok: false,
+      reason: "malformed_verifier",
+    });
+  });
+
+  it("wraps local staff proof tokens so they only unwrap with the correct PIN", async () => {
+    const verifier = await createLocalPinVerifier("123456");
+    const wrapped = await wrapLocalStaffProofToken(verifier, "123456", {
+      expiresAt: 2000,
+      token: "proof-token-1",
+    });
+
+    expect(wrapped).toEqual({
+      ciphertext: expect.any(String),
+      expiresAt: 2000,
+      iv: expect.any(String),
+    });
+    await expect(
+      unwrapLocalStaffProofToken(verifier, "123456", wrapped ?? undefined),
+    ).resolves.toEqual({
+      expiresAt: 2000,
+      token: "proof-token-1",
+    });
+    await expect(
+      unwrapLocalStaffProofToken(verifier, "654321", wrapped ?? undefined),
+    ).resolves.toBeNull();
+  });
+});

--- a/packages/athena-webapp/src/lib/security/localPinVerifier.ts
+++ b/packages/athena-webapp/src/lib/security/localPinVerifier.ts
@@ -1,0 +1,295 @@
+export const LOCAL_PIN_VERIFIER_VERSION = 1;
+export const LOCAL_PIN_VERIFIER_ALGORITHM = "PBKDF2-SHA256";
+export const LOCAL_PIN_VERIFIER_ITERATIONS = 120_000;
+
+export type LocalPinVerifierMetadata = {
+  algorithm: typeof LOCAL_PIN_VERIFIER_ALGORITHM;
+  hash: string;
+  iterations: number;
+  salt: string;
+  version: typeof LOCAL_PIN_VERIFIER_VERSION;
+};
+
+export type LocalPinVerificationResult =
+  | { ok: true }
+  | {
+      ok: false;
+      reason: "invalid_pin" | "malformed_verifier" | "unsupported_verifier";
+    };
+
+export type WrappedLocalStaffProof = {
+  ciphertext: string;
+  expiresAt: number;
+  iv: string;
+};
+
+const KEY_LENGTH_BITS = 256;
+const SALT_BYTES = 16;
+const AES_GCM_IV_BYTES = 12;
+
+function getCrypto() {
+  const cryptoRef = globalThis.crypto;
+  if (!cryptoRef?.subtle || !cryptoRef.getRandomValues) {
+    throw new Error("Local PIN verification is unavailable in this browser.");
+  }
+  return cryptoRef;
+}
+
+function bytesToBase64(bytes: Uint8Array) {
+  if (typeof btoa === "function") {
+    let binary = "";
+    bytes.forEach((byte) => {
+      binary += String.fromCharCode(byte);
+    });
+    return btoa(binary);
+  }
+
+  throw new Error("Base64 encoding is unavailable in this runtime.");
+}
+
+function base64ToBytes(value: string): Uint8Array | null {
+  try {
+    if (typeof atob === "function") {
+      const binary = atob(value);
+      return Uint8Array.from(binary, (character) => character.charCodeAt(0));
+    }
+
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function timingSafeEqual(left: string, right: string) {
+  const leftBytes = new TextEncoder().encode(left);
+  const rightBytes = new TextEncoder().encode(right);
+  const length = Math.max(leftBytes.length, rightBytes.length);
+  let diff = leftBytes.length ^ rightBytes.length;
+
+  for (let index = 0; index < length; index += 1) {
+    diff |= (leftBytes[index] ?? 0) ^ (rightBytes[index] ?? 0);
+  }
+
+  return diff === 0;
+}
+
+async function derivePinHash(input: {
+  iterations: number;
+  pin: string;
+  salt: Uint8Array;
+}) {
+  const cryptoRef = getCrypto();
+  const keyMaterial = await cryptoRef.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(input.pin),
+    "PBKDF2",
+    false,
+    ["deriveBits"],
+  );
+  const derivedBits = await cryptoRef.subtle.deriveBits(
+    {
+      name: "PBKDF2",
+      hash: "SHA-256",
+      salt: input.salt as unknown as BufferSource,
+      iterations: input.iterations,
+    },
+    keyMaterial,
+    KEY_LENGTH_BITS,
+  );
+
+  return bytesToBase64(new Uint8Array(derivedBits));
+}
+
+async function deriveWrappingKey(input: {
+  iterations: number;
+  pin: string;
+  salt: Uint8Array;
+}) {
+  const cryptoRef = getCrypto();
+  const keyMaterial = await cryptoRef.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(input.pin),
+    "PBKDF2",
+    false,
+    ["deriveKey"],
+  );
+
+  return cryptoRef.subtle.deriveKey(
+    {
+      name: "PBKDF2",
+      hash: "SHA-256",
+      salt: input.salt as unknown as BufferSource,
+      iterations: input.iterations,
+    },
+    keyMaterial,
+    { name: "AES-GCM", length: 256 },
+    false,
+    ["encrypt", "decrypt"],
+  );
+}
+
+export async function createLocalPinVerifier(
+  pin: string,
+): Promise<LocalPinVerifierMetadata> {
+  const cryptoRef = getCrypto();
+  const salt = new Uint8Array(SALT_BYTES);
+  cryptoRef.getRandomValues(salt);
+  const hash = await derivePinHash({
+    iterations: LOCAL_PIN_VERIFIER_ITERATIONS,
+    pin,
+    salt,
+  });
+
+  return {
+    algorithm: LOCAL_PIN_VERIFIER_ALGORITHM,
+    hash,
+    iterations: LOCAL_PIN_VERIFIER_ITERATIONS,
+    salt: bytesToBase64(salt),
+    version: LOCAL_PIN_VERIFIER_VERSION,
+  };
+}
+
+export async function verifyLocalPin(
+  verifier: unknown,
+  pin: string,
+): Promise<LocalPinVerificationResult> {
+  if (!isLocalPinVerifierMetadata(verifier)) {
+    return { ok: false, reason: "malformed_verifier" };
+  }
+
+  if (
+    verifier.version !== LOCAL_PIN_VERIFIER_VERSION ||
+    verifier.algorithm !== LOCAL_PIN_VERIFIER_ALGORITHM
+  ) {
+    return { ok: false, reason: "unsupported_verifier" };
+  }
+
+  const salt = base64ToBytes(verifier.salt);
+  if (!salt || salt.length === 0 || verifier.iterations <= 0) {
+    return { ok: false, reason: "malformed_verifier" };
+  }
+
+  const hash = await derivePinHash({
+    iterations: verifier.iterations,
+    pin,
+    salt,
+  });
+
+  return timingSafeEqual(hash, verifier.hash)
+    ? { ok: true }
+    : { ok: false, reason: "invalid_pin" };
+}
+
+export async function wrapLocalStaffProofToken(
+  verifier: LocalPinVerifierMetadata,
+  pin: string,
+  proof: { expiresAt: number; token: string },
+): Promise<WrappedLocalStaffProof | null> {
+  if (
+    verifier.version !== LOCAL_PIN_VERIFIER_VERSION ||
+    verifier.algorithm !== LOCAL_PIN_VERIFIER_ALGORITHM
+  ) {
+    return null;
+  }
+
+  const salt = base64ToBytes(verifier.salt);
+  if (!salt || salt.length === 0 || verifier.iterations <= 0) {
+    return null;
+  }
+
+  const cryptoRef = getCrypto();
+  const iv = new Uint8Array(AES_GCM_IV_BYTES);
+  cryptoRef.getRandomValues(iv);
+  const key = await deriveWrappingKey({
+    iterations: verifier.iterations,
+    pin,
+    salt,
+  });
+  const ciphertext = await cryptoRef.subtle.encrypt(
+    { name: "AES-GCM", iv: iv as unknown as BufferSource },
+    key,
+    new TextEncoder().encode(proof.token),
+  );
+
+  return {
+    ciphertext: bytesToBase64(new Uint8Array(ciphertext)),
+    expiresAt: proof.expiresAt,
+    iv: bytesToBase64(iv),
+  };
+}
+
+export async function unwrapLocalStaffProofToken(
+  verifier: LocalPinVerifierMetadata,
+  pin: string,
+  wrappedProof: WrappedLocalStaffProof | undefined,
+): Promise<{ expiresAt: number; token: string } | null> {
+  if (!wrappedProof) {
+    return null;
+  }
+
+  if (
+    verifier.version !== LOCAL_PIN_VERIFIER_VERSION ||
+    verifier.algorithm !== LOCAL_PIN_VERIFIER_ALGORITHM
+  ) {
+    return null;
+  }
+
+  const salt = base64ToBytes(verifier.salt);
+  const iv = base64ToBytes(wrappedProof.iv);
+  const ciphertext = base64ToBytes(wrappedProof.ciphertext);
+  if (
+    !salt ||
+    salt.length === 0 ||
+    !iv ||
+    iv.length === 0 ||
+    !ciphertext ||
+    ciphertext.length === 0 ||
+    verifier.iterations <= 0
+  ) {
+    return null;
+  }
+
+  try {
+    const key = await deriveWrappingKey({
+      iterations: verifier.iterations,
+      pin,
+      salt,
+    });
+    const plaintext = await cryptoRefDecrypt(key, iv, ciphertext);
+    return {
+      expiresAt: wrappedProof.expiresAt,
+      token: new TextDecoder().decode(plaintext),
+    };
+  } catch {
+    return null;
+  }
+}
+
+async function cryptoRefDecrypt(
+  key: CryptoKey,
+  iv: Uint8Array,
+  ciphertext: Uint8Array,
+) {
+  const cryptoRef = getCrypto();
+  return cryptoRef.subtle.decrypt(
+    { name: "AES-GCM", iv: iv as unknown as BufferSource },
+    key,
+    ciphertext as unknown as BufferSource,
+  );
+}
+
+export function isLocalPinVerifierMetadata(
+  value: unknown,
+): value is LocalPinVerifierMetadata {
+  if (!value || typeof value !== "object") return false;
+  const candidate = value as Record<string, unknown>;
+  return (
+    typeof candidate.algorithm === "string" &&
+    typeof candidate.hash === "string" &&
+    typeof candidate.iterations === "number" &&
+    Number.isSafeInteger(candidate.iterations) &&
+    typeof candidate.salt === "string" &&
+    typeof candidate.version === "number" &&
+    Number.isSafeInteger(candidate.version)
+  );
+}

--- a/packages/athena-webapp/src/routes/_authed.test.tsx
+++ b/packages/athena-webapp/src/routes/_authed.test.tsx
@@ -101,6 +101,12 @@ describe("Authed layout", () => {
   beforeEach(() => {
     mocked.OutletComponent = null;
     window.history.replaceState({}, "", "/wigclub/store/wigclub/products");
+    Object.defineProperty(window.navigator, "onLine", {
+      configurable: true,
+      value: true,
+    });
+    vi.mocked(window.localStorage.getItem).mockReset();
+    vi.mocked(window.localStorage.getItem).mockReturnValue(null);
     mocked.navigate.mockReset();
     mocked.signOut.mockClear();
     mocked.startManagerElevation.mockReset();
@@ -132,11 +138,76 @@ describe("Authed layout", () => {
     expect(mocked.navigate).not.toHaveBeenCalled();
   });
 
+  it("renders the POS shell offline when Convex auth is still reconnecting", () => {
+    Object.defineProperty(window.navigator, "onLine", {
+      configurable: true,
+      value: false,
+    });
+    vi.mocked(window.localStorage.getItem).mockImplementation((key) =>
+      key === LOGGED_IN_USER_ID_KEY ? "user-1" : null,
+    );
+    mocked.useAuth.mockReturnValue({
+      user: undefined,
+      isLoading: true,
+    });
+    mocked.useRouterState.mockImplementation(({ select }) =>
+      select({ location: { pathname: "/wigclub/store/wigclub/pos/register" } }),
+    );
+
+    render(<Layout />);
+
+    expect(screen.getByTestId("app-sidebar")).toBeInTheDocument();
+    expect(screen.getByTestId("authed-outlet")).toBeInTheDocument();
+    expect(mocked.navigate).not.toHaveBeenCalled();
+  });
+
+  it("keeps non-POS routes blocked while offline auth is still loading", () => {
+    Object.defineProperty(window.navigator, "onLine", {
+      configurable: true,
+      value: false,
+    });
+    vi.mocked(window.localStorage.getItem).mockImplementation((key) =>
+      key === LOGGED_IN_USER_ID_KEY ? "user-1" : null,
+    );
+    mocked.useAuth.mockReturnValue({
+      user: undefined,
+      isLoading: true,
+    });
+
+    const { container } = render(<Layout />);
+
+    expect(container).toBeEmptyDOMElement();
+    expect(mocked.navigate).not.toHaveBeenCalled();
+  });
+
   it("redirects to login instead of rendering the authed shell when the session is gone", async () => {
     mocked.useAuth.mockReturnValue({
       user: null,
       isLoading: false,
     });
+
+    const { container } = render(<Layout />);
+
+    expect(container).toBeEmptyDOMElement();
+    await waitFor(() => expect(mocked.navigate).toHaveBeenCalledWith({ to: "/login" }));
+    expect(screen.queryByTestId("app-sidebar")).not.toBeInTheDocument();
+  });
+
+  it("redirects instead of rendering POS offline when Convex auth settles without a user", async () => {
+    Object.defineProperty(window.navigator, "onLine", {
+      configurable: true,
+      value: false,
+    });
+    vi.mocked(window.localStorage.getItem).mockImplementation((key) =>
+      key === LOGGED_IN_USER_ID_KEY ? "user-1" : null,
+    );
+    mocked.useAuth.mockReturnValue({
+      user: null,
+      isLoading: false,
+    });
+    mocked.useRouterState.mockImplementation(({ select }) =>
+      select({ location: { pathname: "/wigclub/store/wigclub/pos/register" } }),
+    );
 
     const { container } = render(<Layout />);
 

--- a/packages/athena-webapp/src/routes/_authed.tsx
+++ b/packages/athena-webapp/src/routes/_authed.tsx
@@ -52,6 +52,18 @@ function isUnknownRouterPath(pathname?: string) {
   return !pathname || pathname === "/";
 }
 
+function isBrowserOffline() {
+  return typeof navigator !== "undefined" && navigator.onLine === false;
+}
+
+function hasStoredLocalSession() {
+  if (typeof localStorage === "undefined") {
+    return false;
+  }
+
+  return Boolean(localStorage.getItem(LOGGED_IN_USER_ID_KEY));
+}
+
 function AuthedComponent() {
   return (
     <>
@@ -166,10 +178,20 @@ export default function Layout() {
     select: (state) => state.location.pathname,
   });
   const { isLoading, user } = useAuth();
-  const userEmail = user?.email ?? "";
+  const browserPathname = getBrowserPathname();
+  const routeWantsPos =
+    isPosRegisterPath(pathname) ||
+    (isUnknownRouterPath(pathname) && isPosRegisterPath(browserPathname));
+  const canRenderOfflinePosShell =
+    routeWantsPos &&
+    isLoading &&
+    isBrowserOffline() &&
+    hasStoredLocalSession();
+  const userEmail =
+    user?.email ?? (canRenderOfflinePosShell ? "Offline POS" : "");
   const routeWantsFullscreen =
     isPosRegisterPath(pathname) ||
-    (isUnknownRouterPath(pathname) && isPosRegisterPath(getBrowserPathname()));
+    (isUnknownRouterPath(pathname) && isPosRegisterPath(browserPathname));
   const isFullscreenActive = fullscreenOverride ?? routeWantsFullscreen;
 
   // useEffect(() => {
@@ -190,16 +212,23 @@ export default function Layout() {
 
   // Don't render until we've read the cookie
   useEffect(() => {
+    if (canRenderOfflinePosShell) {
+      return;
+    }
+
     if (!isLoading && user === null) {
       navigate({ to: "/login" });
     }
-  }, [isLoading, navigate, user]);
+  }, [canRenderOfflinePosShell, isLoading, navigate, user]);
 
   useEffect(() => {
     setFullscreenOverride(null);
   }, [routeWantsFullscreen]);
 
-  if (defaultOpen === null || isLoading || user === null) {
+  if (
+    defaultOpen === null ||
+    (!canRenderOfflinePosShell && (isLoading || user === null))
+  ) {
     return null; // or a loading spinner if you prefer
   }
 


### PR DESCRIPTION
## Summary
- add terminal-scoped POS local staff authority snapshots with local PIN verifiers and wrapped offline staff proofs
- harden sync proof validation, credential DTO sanitization, and retry identity so offline events can be reauthorized safely
- wire offline cashier authentication, local manager role display, POS sync proof attachment, and narrow auth-route offline fallback
- add implementation plan, reusable solution note, tests, and refreshed generated graph/harness artifacts

## Internal reviewers
- Correctness: approved
- Data integrity: approved
- Performance: approved
- Testing: approved
- Maintainability: approved
- Security: approved
- Adversarial review: approved
- Project standards: approved

## Validation
- `bun run pr:athena`
- `bun run harness:review --base origin/main --repo-validation-provided-by pr:athena`
- `bun run --filter '@athena/webapp' test -- convex/operations/staffCredentials.test.ts convex/pos/application/sync/ingestLocalEvents.test.ts src/components/pos/CashierAuthDialog.test.tsx src/lib/pos/infrastructure/local/posLocalStore.test.ts src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.test.ts src/lib/security/localPinVerifier.test.ts`
- `bun run --filter '@athena/webapp' test:coverage -- src/components/staff-auth/StaffAuthenticationDialog.test.tsx`
- `bunx tsc --noEmit -p packages/athena-webapp/tsconfig.json`
- `bun run graphify:rebuild && bun run graphify:check`

Closes V26-578, V26-579, V26-580, V26-581, V26-582, V26-583, V26-584, V26-585, V26-586, V26-587