### PR TITLE
Require four-digit staff PINs

### DIFF
--- a/docs/plans/2026-05-15-002-feat-four-digit-staff-pins-plan.html
+++ b/docs/plans/2026-05-15-002-feat-four-digit-staff-pins-plan.html
@@ -1,0 +1,96 @@
+<!doctype html>
+<html>
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+  <title>feat: Move staff PIN collection to four digits</title>
+  <style type="text/css">
+    body { margin: 0; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; color: #17202a; background: #f7f8fa; }
+    .page { max-width: 980px; margin: 0 auto; padding: 40px 24px 64px; }
+    .panel { background: #fff; border: 1px solid #d9dee7; border-radius: 8px; padding: 28px; }
+    h1 { margin: 0 0 8px; font-size: 30px; line-height: 1.2; }
+    h2 { margin: 32px 0 12px; font-size: 20px; }
+    h3 { margin: 20px 0 8px; font-size: 16px; }
+    p, li { line-height: 1.55; }
+    .meta { color: #5b6675; margin-bottom: 24px; }
+    .callout { border-left: 4px solid #2454d6; background: #f1f5ff; padding: 12px 16px; margin: 18px 0; }
+    .unit { border: 1px solid #e2e6ee; border-radius: 8px; padding: 16px; margin: 16px 0; }
+    table { border-collapse: collapse; width: 100%; margin: 12px 0; }
+    th, td { border: 1px solid #d9dee7; padding: 10px; text-align: left; vertical-align: top; }
+    th { background: #f3f5f8; }
+    code { background: #f3f5f8; padding: 1px 4px; border-radius: 4px; }
+    a { color: #2454d6; }
+  </style>
+</head>
+<body>
+  <div class="page">
+    <div class="panel">
+      <h1>feat: Move staff PIN collection to four digits</h1>
+      <div class="meta">Created 2026-05-15 | Type: feat | Status: active | Source: <a href="2026-05-15-002-feat-four-digit-staff-pins-plan.md">markdown plan</a></div>
+
+      <div class="callout">
+        Athena will require four-digit staff PIN entry in organization members, staff authentication, and manager elevation/approval flows. The plan centralizes the staff PIN policy in one reusable component and adds credential-level throttling at the server authentication boundary.
+      </div>
+
+      <h2>Scope</h2>
+      <ul>
+        <li>Accept and save exactly four digits for staff PIN setup and reset.</li>
+        <li>Collect exactly four digits in shared staff authentication and inherited manager auth surfaces.</li>
+        <li>Throttle repeated failed staff PIN authentication attempts on the credential record.</li>
+        <li>Do not migrate existing credential hashes or local verifier records.</li>
+        <li>Do not change roles, approval policy, audit behavior, or local staff authority proof semantics.</li>
+      </ul>
+
+      <h2>Key Decisions</h2>
+      <ul>
+        <li>Add a staff-specific PIN component that wraps the existing visual <code>PinInput</code>.</li>
+        <li>Use that component in both <code>StaffAuthenticationDialog</code> and organization members PIN setup/reset.</li>
+        <li>Keep <code>pinHash</code>, <code>localPinVerifier</code>, manager elevation, and approval proof contracts unchanged.</li>
+        <li>Add failed-attempt and lockout metadata to staff credentials, and require full-admin access before public create/update mutations can reset PIN or lockout state.</li>
+      </ul>
+
+      <h2>Implementation Units</h2>
+      <div class="unit">
+        <h3>U1. Create shared four-digit staff PIN collection</h3>
+        <p>Add <code>packages/athena-webapp/src/components/staff-auth/StaffPinInput.tsx</code> to centralize numeric sanitization, four-digit length, and slot rendering.</p>
+        <p><strong>Tests:</strong> authentication dialog coverage for four-digit submit, incomplete PIN, and pasted mixed input.</p>
+      </div>
+      <div class="unit">
+        <h3>U2. Apply four-digit collection to staff and manager authentication</h3>
+        <p>Update <code>StaffAuthenticationDialog</code> to remove six-digit assumptions so cashier, staff, command approval, and manager elevation surfaces inherit the new rule.</p>
+        <p><strong>Tests:</strong> staff auth four-digit submission, four-digit error copy, manager elevation credential forwarding.</p>
+      </div>
+      <div class="unit">
+        <h3>U3. Apply four-digit setup/reset in organization members</h3>
+        <p>Update <code>StaffManagement.tsx</code> setup/reset dialog to collect and confirm four digits using the shared component.</p>
+        <p><strong>Tests:</strong> save <code>1234</code> to both server hash and local verifier paths, mismatch handling, incomplete PIN error.</p>
+      </div>
+      <div class="unit">
+        <h3>U4. Protect four-digit staff authentication with credential throttling</h3>
+        <p>Update <code>staffCredentials.ts</code> and the staff credential schema so failed PIN attempts lock the active credential temporarily, authorized resets clear the lockout, and public authentication mutations require authenticated store access.</p>
+        <p><strong>Tests:</strong> repeated wrong attempts, success reset, authorized reset clear, unauthorized reset block, unauthorized public auth block, and manager approval proof lockout.</p>
+      </div>
+
+      <h2>Risks</h2>
+      <table summary="Risks and mitigations for the four-digit staff PIN plan">
+        <tr><th>Risk</th><th>Mitigation</th></tr>
+        <tr><td>Existing six-digit PIN users cannot enter old PINs after deploy.</td><td>Accept as part of the policy change; reset affected staff PINs through organization members.</td></tr>
+        <tr><td>A caller keeps a six-digit assumption.</td><td>Search for hard-coded six-digit PIN checks before final validation.</td></tr>
+        <tr><td>Four-digit PINs increase brute-force feasibility.</td><td>Enforce credential-level failed-attempt lockout across staff authentication and manager approval proof paths.</td></tr>
+        <tr><td>PIN reset clears lockout without authorization.</td><td>Require full-admin organization membership before public staff credential create/update mutations can create, reset, or clear credential state.</td></tr>
+        <tr><td>Public authentication creates denial-of-service lockouts or out-of-band approval proofs.</td><td>Require authenticated store access before public staff authentication and approval-proof mutations can compare PIN hashes.</td></tr>
+        <tr><td>Four-slot layout looks awkward.</td><td>Keep the low-level visual primitive responsive and browser-check affected dialogs when possible.</td></tr>
+      </table>
+
+      <h2>Verification Strategy</h2>
+      <ul>
+        <li>Focused staff authentication tests.</li>
+        <li>Focused staff management tests.</li>
+        <li>Staff credential mutation and lockout tests.</li>
+        <li>Manager elevation context test where credential forwarding is at risk.</li>
+        <li><code>bun run graphify:rebuild</code> after code changes.</li>
+        <li><code>bun run pr:athena</code> before push/merge.</li>
+      </ul>
+    </div>
+  </div>
+</body>
+</html>

--- a/docs/plans/2026-05-15-002-feat-four-digit-staff-pins-plan.md
+++ b/docs/plans/2026-05-15-002-feat-four-digit-staff-pins-plan.md
@@ -1,0 +1,258 @@
+---
+title: feat: Move staff PIN collection to four digits
+type: feat
+status: active
+date: 2026-05-15
+---
+
+# feat: Move staff PIN collection to four digits
+
+## Summary
+
+Athena should require four-digit staff PINs everywhere staff credentials are collected: initial/reset PIN setup in the organization members workspace, staff authentication, and manager elevation/approval flows. The implementation should introduce a reusable staff PIN collection component so the four-digit rule is expressed once at the UI boundary instead of repeated across each surface.
+
+---
+
+## Requirements
+
+- R1. Staff PIN setup in organization members must accept and save exactly four digits.
+- R2. Staff authentication surfaces must collect exactly four PIN digits before submitting credentials.
+- R3. Manager authentication/elevation surfaces must inherit the same four-digit collection behavior through the shared staff authentication dialog.
+- R4. The PIN input UI should be reusable and should not require each caller to hand-code length, sanitization, grouping, and validation copy.
+- R5. Existing server-side hashing, local verifier creation, offline staff authority, and manager approval proof boundaries must stay unchanged except for the raw PIN length accepted by the client.
+- R6. Four-digit PIN authentication must be protected by server-side failed-attempt throttling and authorized PIN reset controls.
+
+---
+
+## Scope Boundaries
+
+- This plan changes the required length for newly entered PINs from six digits to four digits.
+- This plan does not migrate existing stored PIN hashes or local verifier records.
+- This plan does not change staff roles, manager approval policy, audit events, or POS local staff authority proof semantics.
+- This plan does not add a new password/PIN complexity policy beyond numeric four-digit collection.
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `packages/athena-webapp/src/components/pos/PinInput.tsx` wraps `input-otp` and renders the current grouped PIN slots.
+- `packages/athena-webapp/src/components/staff-auth/StaffAuthenticationDialog.tsx` collects username/PIN and is reused by cashier authentication, manager elevation, command approval, operations, transactions, and cash controls.
+- `packages/athena-webapp/src/components/staff/StaffManagement.tsx` owns deferred staff PIN setup/reset in the organization members workspace.
+- `packages/athena-webapp/src/components/staff-auth/StaffAuthenticationDialog.test.tsx`, `packages/athena-webapp/src/components/staff/StaffManagement.test.tsx`, and `packages/athena-webapp/src/contexts/ManagerElevationContext.test.tsx` cover the closest client behaviors.
+
+### Institutional Learnings
+
+- `docs/solutions/architecture/athena-pos-local-staff-authority-2026-05-14.md` says online PIN hashes are compatibility data while local staff authority uses terminal-scoped verifier metadata. Keep the hashing/verifier boundary intact.
+- `docs/solutions/logic-errors/athena-command-approval-manager-fast-path-2026-05-02.md` says manager fast-path approval should pass fresh same-submission credentials and must not store or reuse PIN hashes. The reusable component must only collect the current raw PIN for submission.
+- `docs/solutions/logic-errors/athena-staff-pin-length-throttling-2026-05-15.md` says shorter staff PIN policies require server-side failed-attempt throttling at the credential boundary, including manager approval proof paths.
+
+---
+
+## Key Technical Decisions
+
+- Introduce a staff-specific PIN collection component near the staff authentication surface: this keeps generic slot rendering in `PinInput` while centralizing staff PIN length, numeric sanitization, submit-readiness, helper copy, and test selectors for staff credentials.
+- Route both authentication and setup through that staff PIN component: `StaffAuthenticationDialog` should stop hard-coding six digits, and `CredentialPinDialog` should stop duplicating length checks and slicing.
+- Keep server contracts unchanged: `pinHash`, `localPinVerifier`, and manager elevation mutations receive the same values they already receive, now derived from a four-digit raw PIN.
+- Add lockout metadata to staff credentials instead of introducing a separate auth-attempt table: the shared credential row is the narrowest server boundary that protects base auth, terminal auth, and approval auth together.
+
+---
+
+## Open Questions
+
+### Resolved During Planning
+
+- Should existing credential hashes be migrated? No. Hashes/verifiers are opaque and validated from the submitted raw PIN; changing client input length only affects future authentication/setup submissions.
+- Should manager auth get a separate component? No. Manager auth uses `StaffAuthenticationDialog`, so it should inherit the shared staff PIN collector.
+- Should four-digit PINs ship without server throttling? No. The server credential boundary must count failed attempts and return `rate_limited` while locked.
+
+### Deferred to Implementation
+
+- Exact component name/location: choose the smallest path that matches local imports after implementation starts.
+
+---
+
+## Implementation Units
+
+- U1. **Create shared four-digit staff PIN collection**
+
+**Goal:** Add a reusable component for staff PIN entry that wraps the existing slot input with a four-digit numeric policy.
+
+**Requirements:** R2, R3, R4
+
+**Dependencies:** None
+
+**Files:**
+- Create: `packages/athena-webapp/src/components/staff-auth/StaffPinInput.tsx`
+- Test: `packages/athena-webapp/src/components/staff-auth/StaffAuthenticationDialog.test.tsx`
+
+**Approach:**
+- Keep `PinInput` as the low-level visual primitive.
+- Add a staff PIN component that sanitizes non-digits, caps input at four digits, exposes completion/readiness behavior through normal React props, and uses four slots.
+- Preserve keyboard filtering and enter-submit behavior at the parent form/dialog level where it already exists.
+
+**Execution note:** Implement test-first by updating authentication tests to demonstrate four-digit auto-submit and rejection of incomplete PINs before changing the component.
+
+**Patterns to follow:**
+- `packages/athena-webapp/src/components/pos/PinInput.tsx`
+- `packages/athena-webapp/src/components/staff-auth/StaffAuthenticationDialog.tsx`
+
+**Test scenarios:**
+- Happy path: enter username `frontdesk` and PIN `1234`; authentication submits once with raw PIN `1234` and hash `hashed:1234`.
+- Edge case: enter username and only `123`; authentication does not submit and the submit button stays disabled.
+- Edge case: paste `12ab3456`; the shared staff PIN component stores only `1234`.
+
+**Verification:**
+- Authentication surfaces no longer reference a six-digit PIN length.
+
+---
+
+- U2. **Apply four-digit collection to staff and manager authentication**
+
+**Goal:** Update `StaffAuthenticationDialog` so staff auth, cashier auth, manager elevation, command approval, operations, transactions, and cash controls all collect four-digit PINs through the shared component.
+
+**Requirements:** R2, R3, R5
+
+**Dependencies:** U1
+
+**Files:**
+- Modify: `packages/athena-webapp/src/components/staff-auth/StaffAuthenticationDialog.tsx`
+- Modify: `packages/athena-webapp/src/contexts/ManagerElevationContext.test.tsx`
+- Test: `packages/athena-webapp/src/components/staff-auth/StaffAuthenticationDialog.test.tsx`
+
+**Approach:**
+- Replace hard-coded `pin.length === 6`, `pin.length !== 6`, `maxLength={6}`, and six-digit error copy with the shared staff PIN policy.
+- Keep the submitted credential object shape unchanged.
+- Manager elevation should need no separate runtime change beyond inherited dialog behavior; tests should prove the manager path still forwards the submitted hash and username.
+
+**Execution note:** Test-first: update dialog tests before implementation and add manager coverage only where it catches a real integration risk.
+
+**Patterns to follow:**
+- `packages/athena-webapp/src/contexts/ManagerElevationContext.tsx`
+- `docs/solutions/logic-errors/athena-command-approval-manager-fast-path-2026-05-02.md`
+
+**Test scenarios:**
+- Happy path: four-digit staff auth auto-submits in authenticate mode.
+- Error path: clicking submit with fewer than four digits shows copy that says four digits, not six.
+- Integration: manager elevation continues to pass the submitted username and PIN hash into `startManagerElevation`.
+
+**Verification:**
+- All staff-auth dialog users inherit the four-digit policy without caller-specific length props.
+
+---
+
+- U3. **Apply four-digit setup/reset in organization members**
+
+**Goal:** Update the organization members staff PIN setup/reset dialog to collect, confirm, hash, and save exactly four digits.
+
+**Requirements:** R1, R4, R5
+
+**Dependencies:** U1
+
+**Files:**
+- Modify: `packages/athena-webapp/src/components/staff/StaffManagement.tsx`
+- Test: `packages/athena-webapp/src/components/staff/StaffManagement.test.tsx`
+
+**Approach:**
+- Replace setup/reset dialog use of `PinInput` with the shared staff PIN component.
+- Replace six-digit validation, slicing, disabled-state logic, and toast copy with the four-digit policy.
+- Keep `hashPin(pin)` and `createLocalPinVerifier(pin)` as-is so persistence behavior stays the same.
+
+**Execution note:** Test-first: update staff management tests to save `1234` and verify both `pinHash` and `localPinVerifier` receive `1234`.
+
+**Patterns to follow:**
+- `packages/athena-webapp/src/components/staff/StaffManagement.tsx`
+- `docs/solutions/architecture/athena-pos-local-staff-authority-2026-05-14.md`
+
+**Test scenarios:**
+- Happy path: pending credential setup accepts `1234`, saves `pinHash: "hashed:1234"`, and stores local verifier metadata for `1234`.
+- Edge case: setup with mismatched `1234` and `4321` keeps the save action disabled and shows mismatch copy.
+- Error path: direct submit with fewer than four digits shows `PIN must be exactly 4 digits`.
+
+**Verification:**
+- Organization members staff PIN setup/reset has no remaining six-digit UI validation.
+
+---
+
+- U4. **Protect four-digit staff authentication with credential throttling**
+
+**Goal:** Add server-side failed-attempt tracking so the shorter PIN policy does not weaken staff authentication or manager approval proof minting.
+
+**Requirements:** R6
+
+**Dependencies:** U1, U2, U3
+
+**Files:**
+- Modify: `packages/athena-webapp/convex/operations/staffCredentials.ts`
+- Modify: `packages/athena-webapp/convex/schemas/operations/staffCredential.ts`
+- Test: `packages/athena-webapp/convex/operations/staffCredentials.test.ts`
+
+**Approach:**
+- Track failed attempts and lockout expiry on the staff credential row.
+- Count failed hash comparisons in `authenticateStaffCredentialWithCtx`.
+- Return `rate_limited` while the credential is locked.
+- Reset failed attempts after a successful authentication or authorized PIN reset.
+- Require authenticated store access before public staff authentication can mutate lockout state or mint approval proofs.
+- Require full-admin organization membership before public credential create/update mutations can create, reset, or clear lockout state.
+
+**Execution note:** Add tests around base authentication, terminal authentication inherited behavior, approval proof authentication, and unauthorized reset attempts.
+
+**Patterns to follow:**
+- `packages/athena-webapp/convex/operations/staffCredentials.ts`
+- `docs/solutions/logic-errors/athena-staff-pin-length-throttling-2026-05-15.md`
+
+**Test scenarios:**
+- Error path: five wrong PIN hashes lock the active credential and return `rate_limited` on the next attempt.
+- Recovery path: successful authentication resets failed-attempt counters.
+- Recovery path: authorized PIN reset clears lockout state.
+- Authorization path: public credential create/update requires full-admin access before mutating credential state.
+- Authorization path: public staff authentication and approval-proof mutations require authenticated store access before mutating credential state.
+- Integration: manager approval proof authentication cannot mint a proof while the credential is locked.
+
+**Verification:**
+- All public staff credential mutation paths that can reset PINs or lockout state are authorization-gated.
+
+---
+
+## System-Wide Impact
+
+- **Interaction graph:** `StaffAuthenticationDialog` is the shared auth entry for POS cashier auth, manager elevation, command approval, operations, transactions, and cash controls. Changing it updates all those PIN collection surfaces together.
+- **Error propagation:** Existing `presentCommandToast` behavior stays unchanged; local pre-submit copy changes from six digits to four, and server lockout returns the existing command-result `rate_limited` shape.
+- **State lifecycle risks:** Stored hashes/verifiers are not migrated, so existing staff whose current PIN is six digits may need a reset to comply with the new UI length.
+- **API surface parity:** Convex mutations keep the same argument names and types, with optional credential lockout metadata added to the stored row.
+- **Integration coverage:** Staff setup, manager elevation, credential mutation, lockout, and approval proof tests prove setup and auth routes still forward credentials correctly while enforcing attempt limits.
+- **Unchanged invariants:** Manager approval proofs, local staff authority proof wrapping, and credential version checks remain server-owned.
+
+---
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Existing staff with six-digit PINs cannot enter their old PIN after deploy | Treat as accepted behavior for the policy change; operators can reset staff PINs through organization members. |
+| A caller bypasses the shared component and keeps six-digit assumptions | Search for `pin.length`, `maxLength={6}`, `slice(0, 6)`, and six-digit PIN copy before final validation. |
+| Four-digit PINs increase brute-force feasibility | Enforce credential-level failed-attempt lockout across shared staff authentication and manager approval proof paths. |
+| PIN reset could clear lockout without authorization | Require full-admin organization membership before public staff credential create/update mutations can create, reset, or clear credential state. |
+| Public authentication could be used for denial-of-service lockouts or out-of-band approval proofs | Require authenticated store access before public staff authentication and approval-proof mutations can compare PIN hashes. |
+| PIN UI grouping looks awkward with four slots | Keep the low-level primitive responsive and let the staff component choose four slots; browser-test the affected dialogs if local runtime is available. |
+
+---
+
+## Documentation / Operational Notes
+
+- No product docs are required unless Athena has operator-facing staff onboarding documentation outside this repo.
+- Production deploy should use the Athena local-build path after merge because this changes `packages/athena-webapp` browser runtime.
+- Production deploy should also publish Convex changes because staff credential schema and mutation behavior changed.
+
+---
+
+## Sources & References
+
+- Related code: `packages/athena-webapp/src/components/pos/PinInput.tsx`
+- Related code: `packages/athena-webapp/src/components/staff-auth/StaffAuthenticationDialog.tsx`
+- Related code: `packages/athena-webapp/src/components/staff/StaffManagement.tsx`
+- Related code: `packages/athena-webapp/convex/operations/staffCredentials.ts`
+- Related learning: `docs/solutions/architecture/athena-pos-local-staff-authority-2026-05-14.md`
+- Related learning: `docs/solutions/logic-errors/athena-command-approval-manager-fast-path-2026-05-02.md`
+- Related learning: `docs/solutions/logic-errors/athena-staff-pin-length-throttling-2026-05-15.md`

--- a/docs/solutions/logic-errors/athena-staff-pin-length-throttling-2026-05-15.md
+++ b/docs/solutions/logic-errors/athena-staff-pin-length-throttling-2026-05-15.md
@@ -1,0 +1,69 @@
+---
+title: Athena Staff PIN Length Changes Need Server Throttling
+date: 2026-05-15
+category: logic-errors
+module: athena-webapp
+problem_type: staff_pin_authentication_policy
+component: staff-auth
+symptoms:
+  - "A shorter staff PIN policy increases brute-force risk"
+  - "Client-side PIN length validation can be mistaken for an authentication control"
+  - "Manager approval proof minting can inherit staff-auth brute-force exposure"
+root_cause: staff_pin_length_changed_without_server_side_attempt_control
+resolution_type: credential_level_lockout
+severity: high
+tags:
+  - staff-auth
+  - manager-approval
+  - security
+---
+
+# Athena Staff PIN Length Changes Need Server Throttling
+
+## Problem
+
+Staff PIN entry is a UI workflow, but staff PIN verification is a server
+authentication boundary. When the PIN policy gets shorter, the server-side
+credential path must absorb the increased guessing risk. A four-digit PIN has
+only 10,000 combinations, so relying on client validation or deterministic hash
+comparison alone leaves cashier sign-in and manager approval proof minting too
+easy to brute-force.
+
+## Solution
+
+Keep the reusable PIN input as the client policy boundary, but enforce failed
+attempt tracking on the server credential record. The shared
+`authenticateStaffCredentialWithCtx` path should count bad PIN hashes, lock the
+matching active credential after repeated failures, return `rate_limited` while
+locked, and reset the counter on successful authentication or authorized PIN
+reset.
+
+That placement protects every caller that goes through the staff credential
+boundary, including terminal authentication and manager approval proof minting.
+The public staff credential mutation must also require full-admin organization
+access; otherwise an attacker could reset the PIN and clear lockout state.
+Browser-facing staff authentication mutations must require an authenticated
+account with store access before comparing PIN hashes; otherwise unauthenticated
+callers can trigger lockouts or mint approval proofs through public mutations.
+
+## Prevention
+
+- Treat staff PIN length reductions as security-sensitive, even when the UI
+  change looks small.
+- Put throttling at `authenticateStaffCredentialWithCtx`, not in individual
+  React dialogs.
+- Guard public credential create/update mutations with full-admin organization
+  membership before they can reset PINs or clear lockout state.
+- Guard public staff authentication and approval-proof mutations with
+  authenticated store access before they can mutate lockout state or create
+  approval proofs.
+- Include approval proof authentication in the test matrix, because manager
+  approval has higher blast radius than cashier sign-in.
+- Reset lockout state only on successful authentication or authorized PIN reset.
+- Keep tests for wrong attempts, active lockout, success reset, reset clear,
+  unauthorized reset, and approval proof lockout.
+
+## Related
+
+- [Athena POS Local Staff Authority Uses Terminal-Scoped Verifiers](../architecture/athena-pos-local-staff-authority-2026-05-14.md)
+- [Athena command approval manager fast path](./athena-command-approval-manager-fast-path-2026-05-02.md)

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,11 +1,11 @@
 # Graph Report - .
 
 ## Corpus Check
-- 1740 files · ~0 words
+- 1742 files · ~0 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 5481 nodes · 5707 edges · 1669 communities detected
+- 5489 nodes · 5714 edges · 1671 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -1679,6 +1679,8 @@
 - [[_COMMUNITY_Community 1666|Community 1666]]
 - [[_COMMUNITY_Community 1667|Community 1667]]
 - [[_COMMUNITY_Community 1668|Community 1668]]
+- [[_COMMUNITY_Community 1669|Community 1669]]
+- [[_COMMUNITY_Community 1670|Community 1670]]
 
 ## God Nodes (most connected - your core abstractions)
 1. `createJourneyEvent()` - 40 edges
@@ -1775,32 +1777,32 @@ Cohesion: 0.15
 Nodes (22): buildDocumentationStatus(), buildEmptyHistoryMetric(), buildGraphifyStatus(), buildInferentialSummaryNote(), buildSummary(), collectHarnessScorecard(), countMissingSnippets(), createFileSystem() (+14 more)
 
 ### Community 17 - "Community 17"
+Cohesion: 0.15
+Nodes (22): assertStaffProfileReadyForCredential(), authenticateStaffCredentialForApprovalWithCtx(), authenticateStaffCredentialForTerminalWithCtx(), authenticateStaffCredentialWithCtx(), createStaffCredentialWithCtx(), getActiveRolesForStaffProfile(), getCredentialById(), getCredentialByUsername() (+14 more)
+
+### Community 18 - "Community 18"
 Cohesion: 0.12
 Nodes (18): ancestorChain(), collectRawMoneyParses(), collectRawMoneyParsesFromSource(), collectRawNumericHelperNames(), collectSourceFiles(), collectStorefrontDirectMoneyFormats(), containsDisallowedRawNumericParse(), containsTerm() (+10 more)
 
-### Community 18 - "Community 18"
+### Community 19 - "Community 19"
 Cohesion: 0.19
 Nodes (23): assertCompoundSolutionCheck(), collectChangedFiles(), collectCompoundSolutionFindings(), collectExistingFiles(), collectMarkdownContents(), collectSourceLineChanges(), countFileLines(), extractFrontmatter() (+15 more)
 
-### Community 19 - "Community 19"
+### Community 20 - "Community 20"
 Cohesion: 0.15
 Nodes (19): appendListSection(), buildMarkdownBundle(), collectCoverage(), evaluateGraphifyFreshness(), fileExists(), formatValidationCommand(), getChangedFilesFromGit(), isLocalGeneratedArtifactPath() (+11 more)
 
-### Community 20 - "Community 20"
+### Community 21 - "Community 21"
 Cohesion: 0.13
 Nodes (18): buildCartSummary(), buildSessionOperationsRow(), expirePosSessionNow(), hasCustomerSnapshotValue(), isUsableRegisterSession(), loadPosSessionItems(), loadSessionCustomer(), loadSessionOperator() (+10 more)
 
-### Community 21 - "Community 21"
+### Community 22 - "Community 22"
 Cohesion: 0.16
 Nodes (22): attentionSeverity(), buildDailyOperationsSnapshotWithCtx(), buildLanes(), buildWeekMetricForDate(), buildWeekMetrics(), emptyCloseSummary(), getCloseItemCounts(), getDailyCloseRecordForDate() (+14 more)
 
-### Community 22 - "Community 22"
+### Community 23 - "Community 23"
 Cohesion: 0.15
 Nodes (19): acquireExpenseQuantityPatchHold(), adjustExpenseQuantityPatchHold(), createDefaultExpenseSessionCommandService(), createExpenseInventoryHoldGateway(), createExpenseSessionCommandService(), failure(), isActiveRegisterSession(), isSessionExpired() (+11 more)
-
-### Community 23 - "Community 23"
-Cohesion: 0.19
-Nodes (21): assertStaffProfileReadyForCredential(), authenticateStaffCredentialForApprovalWithCtx(), authenticateStaffCredentialForTerminalWithCtx(), authenticateStaffCredentialWithCtx(), createStaffCredentialWithCtx(), getActiveRolesForStaffProfile(), getCredentialById(), getCredentialByUsername() (+13 more)
 
 ### Community 24 - "Community 24"
 Cohesion: 0.24
@@ -1855,12 +1857,12 @@ Cohesion: 0.15
 Nodes (11): checkIfItemsHaveChanged(), createOnlineOrder(), createPatchObject(), findBestValuePromoCode(), handleExistingSession(), handleOrderCreation(), handlePlaceOrder(), listSessionItems() (+3 more)
 
 ### Community 37 - "Community 37"
-Cohesion: 0.15
-Nodes (10): capitalizeFirstLetter(), capitalizeWords(), cn(), currencyFormatter(), formatDate(), getErrorForField(), getProductName(), getRelativeTime() (+2 more)
-
-### Community 38 - "Community 38"
 Cohesion: 0.13
 Nodes (8): formatInventoryNumber(), formatReservationSourceSummary(), getInventoryItemDisplayName(), getReservationLabels(), getSkuDetailEntries(), handleDraftChange(), rowMatchesStockAdjustmentSearch(), setDraftValue()
+
+### Community 38 - "Community 38"
+Cohesion: 0.15
+Nodes (10): capitalizeFirstLetter(), capitalizeWords(), cn(), currencyFormatter(), formatDate(), getErrorForField(), getProductName(), getRelativeTime() (+2 more)
 
 ### Community 39 - "Community 39"
 Cohesion: 0.21
@@ -2127,96 +2129,96 @@ Cohesion: 0.39
 Nodes (7): calculateRefundAmount(), getAmountRefunded(), getAvailableItems(), getItemsToRefund(), getNetAmount(), shouldShowReturnToStock(), validateRefund()
 
 ### Community 105 - "Community 105"
+Cohesion: 0.25
+Nodes (2): buildUsername(), normalizeNameSegment()
+
+### Community 106 - "Community 106"
 Cohesion: 0.39
 Nodes (6): handleDeliveryRestrictionToggle(), handlePickupRestrictionToggle(), handleSaveDeliveryRestriction(), handleSavePickupRestriction(), saveDeliveryRestriction(), savePickupRestriction()
 
-### Community 106 - "Community 106"
+### Community 107 - "Community 107"
 Cohesion: 0.44
 Nodes (1): Logger
 
-### Community 107 - "Community 107"
+### Community 108 - "Community 108"
 Cohesion: 0.22
 Nodes (0):
 
-### Community 108 - "Community 108"
+### Community 109 - "Community 109"
 Cohesion: 0.22
 Nodes (2): ClusterRedis, StandaloneRedis
 
-### Community 109 - "Community 109"
+### Community 110 - "Community 110"
 Cohesion: 0.42
 Nodes (8): assertCoverageToolchainParity(), checkCoverageToolchainParity(), collectCoverageToolchainFailures(), declaredVersion(), formatFailureMessage(), installedVersion(), readManifest(), runFrozenInstall()
 
-### Community 110 - "Community 110"
+### Community 111 - "Community 111"
 Cohesion: 0.46
 Nodes (7): deleteDirectoryInR2(), deleteFileInR2(), getR2(), listItemsInR2Directory(), readEnvValue(), resolveR2ConfigFromEnv(), uploadFileToR2()
 
-### Community 111 - "Community 111"
+### Community 112 - "Community 112"
 Cohesion: 0.25
 Nodes (0):
 
-### Community 112 - "Community 112"
+### Community 113 - "Community 113"
 Cohesion: 0.5
 Nodes (6): findAthenaUserByEmailWithCtx(), getAuthenticatedAthenaUserWithCtx(), getAuthenticatedUserRecord(), normalizeEmail(), requireAuthenticatedAthenaUserWithCtx(), syncAuthenticatedAthenaUserWithCtx()
 
-### Community 113 - "Community 113"
+### Community 114 - "Community 114"
 Cohesion: 0.43
 Nodes (6): sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
 
-### Community 114 - "Community 114"
+### Community 115 - "Community 115"
 Cohesion: 0.43
 Nodes (6): buildMtnCollectionsLookupPrefixes(), isTargetEnvironment(), readScopedValue(), resolveConfigForPrefix(), resolveMtnCollectionsConfigFromEnv(), toEnvSegment()
 
-### Community 115 - "Community 115"
+### Community 116 - "Community 116"
 Cohesion: 0.46
 Nodes (7): recordApprovalAuditEventWithCtx(), recordApprovalDecisionRecordedAuditEventWithCtx(), recordApprovalProofConsumedAuditEventWithCtx(), recordApprovalRequiredAuditEventWithCtx(), recordApprovedCommandAppliedAuditEventWithCtx(), recordAsyncApprovalRequestCreatedAuditEventWithCtx(), recordManagerApprovalGrantedAuditEventWithCtx()
 
-### Community 116 - "Community 116"
+### Community 117 - "Community 117"
 Cohesion: 0.5
 Nodes (7): buildApprovalDecisionRequirement(), buildApprovalDecisionSubject(), consumeApprovalDecisionProofWithCtx(), decideApprovalRequestAsAuthenticatedUserWithCtx(), decideApprovalRequestAsCommandWithCtx(), decideApprovalRequestWithCtx(), mapDecideApprovalRequestError()
 
-### Community 117 - "Community 117"
+### Community 118 - "Community 118"
 Cohesion: 0.39
 Nodes (5): buildInventoryMovement(), buildSkuActivityForInventoryMovement(), getSkuActivityTypeForMovement(), recordInventoryMovementWithCtx(), recordSkuActivityForInventoryMovementWithCtx()
 
-### Community 118 - "Community 118"
+### Community 119 - "Community 119"
 Cohesion: 0.43
 Nodes (6): assertActiveTerminal(), getActiveManagerElevationWithCtx(), getCandidateElevations(), getStaffDisplayName(), startManagerElevationWithCtx(), toActiveElevation()
 
-### Community 119 - "Community 119"
+### Community 120 - "Community 120"
 Cohesion: 0.36
 Nodes (5): buildPaymentAllocation(), correctSameAmountSinglePaymentAllocationWithCtx(), findSameAmountSinglePaymentAllocation(), listPaymentAllocationsForTargetWithCtx(), recordPaymentAllocationWithCtx()
 
-### Community 120 - "Community 120"
+### Community 121 - "Community 121"
 Cohesion: 0.43
 Nodes (6): buildPosSessionTraceEvent(), buildPosSessionTraceRecord(), buildTraceSummary(), formatPaymentMethod(), recordPosSessionTraceBestEffort(), safeTraceWrite()
 
-### Community 121 - "Community 121"
+### Community 122 - "Community 122"
 Cohesion: 0.5
 Nodes (7): findExistingSku(), findOrCreateQuickAddCategory(), findOrCreateQuickAddSubcategory(), generateSKU(), isBarcodeLike(), mapSkuToCatalogResult(), quickAddCatalogItem()
-
-### Community 122 - "Community 122"
-Cohesion: 0.25
-Nodes (0):
 
 ### Community 123 - "Community 123"
 Cohesion: 0.25
 Nodes (0):
 
 ### Community 124 - "Community 124"
+Cohesion: 0.25
+Nodes (0):
+
+### Community 125 - "Community 125"
 Cohesion: 0.39
 Nodes (6): buildOfferProductEmailItem(), createOffer(), formatOfferProductPrice(), getDiscountedOfferProductPrice(), isDuplicate(), updateStoreFrontActorEmail()
 
-### Community 125 - "Community 125"
+### Community 126 - "Community 126"
 Cohesion: 0.25
 Nodes (1): DataTableRowActions()
 
-### Community 126 - "Community 126"
+### Community 127 - "Community 127"
 Cohesion: 0.32
 Nodes (3): handleCreateCustomer(), handleSaveEdit(), showCommandError()
-
-### Community 127 - "Community 127"
-Cohesion: 0.25
-Nodes (0):
 
 ### Community 128 - "Community 128"
 Cohesion: 0.25
@@ -2227,8 +2229,8 @@ Cohesion: 0.25
 Nodes (0):
 
 ### Community 130 - "Community 130"
-Cohesion: 0.29
-Nodes (2): buildUsername(), normalizeNameSegment()
+Cohesion: 0.25
+Nodes (0):
 
 ### Community 131 - "Community 131"
 Cohesion: 0.39
@@ -2351,16 +2353,16 @@ Cohesion: 0.29
 Nodes (0):
 
 ### Community 161 - "Community 161"
-Cohesion: 0.33
-Nodes (2): getProductName(), sortProduct()
-
-### Community 162 - "Community 162"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 163 - "Community 163"
+### Community 162 - "Community 162"
 Cohesion: 0.52
 Nodes (6): addItemToSavedBag(), getActiveSavedBag(), getBaseUrl(), removeItemFromSavedBag(), updateSavedBagItem(), updateSavedBagOwner()
+
+### Community 163 - "Community 163"
+Cohesion: 0.33
+Nodes (2): getProductName(), sortProduct()
 
 ### Community 164 - "Community 164"
 Cohesion: 0.43
@@ -8382,6 +8384,14 @@ Nodes (0):
 Cohesion: 1.0
 Nodes (0):
 
+### Community 1669 - "Community 1669"
+Cohesion: 1.0
+Nodes (0):
+
+### Community 1670 - "Community 1670"
+Cohesion: 1.0
+Nodes (0):
+
 ## Knowledge Gaps
 - **1 isolated node(s):** `HelpRequested`
   These have ≤1 connection - possible missing edges or undocumented components.
@@ -8747,1929 +8757,1933 @@ Nodes (0):
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 706`** (2 nodes): `StaffAuthenticationDialog.tsx`, `handleKeyDown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 707`** (2 nodes): `onClick()`, `empty-state.tsx`
+- **Thin community `Community 707`** (2 nodes): `staffPinPolicy.ts`, `normalizeStaffPin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 708`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
+- **Thin community `Community 708`** (2 nodes): `onClick()`, `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 709`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
+- **Thin community `Community 709`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 710`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
+- **Thin community `Community 710`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 711`** (2 nodes): `ProtectedAdminSignInView.tsx`, `ProtectedAdminSignInView()`
+- **Thin community `Community 711`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 712`** (2 nodes): `ContactView()`, `ContactView.tsx`
+- **Thin community `Community 712`** (2 nodes): `ProtectedAdminSignInView.tsx`, `ProtectedAdminSignInView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 713`** (2 nodes): `Header()`, `Header.tsx`
+- **Thin community `Community 713`** (2 nodes): `ContactView()`, `ContactView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 714`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
+- **Thin community `Community 714`** (2 nodes): `Header()`, `Header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 715`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
+- **Thin community `Community 715`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 716`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
+- **Thin community `Community 716`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 717`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
+- **Thin community `Community 717`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 718`** (2 nodes): `useChart()`, `chart.tsx`
+- **Thin community `Community 718`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 719`** (2 nodes): `handleCopy()`, `copy-button.tsx`
+- **Thin community `Community 719`** (2 nodes): `useChart()`, `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 720`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
+- **Thin community `Community 720`** (2 nodes): `handleCopy()`, `copy-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 721`** (2 nodes): `Label()`, `label.tsx`
+- **Thin community `Community 721`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 722`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
+- **Thin community `Community 722`** (2 nodes): `Label()`, `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 723`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
+- **Thin community `Community 723`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 724`** (2 nodes): `store-modal.tsx`, `onSubmit()`
+- **Thin community `Community 724`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 725`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
+- **Thin community `Community 725`** (2 nodes): `store-modal.tsx`, `onSubmit()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 726`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
+- **Thin community `Community 726`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 727`** (2 nodes): `select-native.tsx`, `cn()`
+- **Thin community `Community 727`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 728`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
+- **Thin community `Community 728`** (2 nodes): `select-native.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 729`** (2 nodes): `webp-image.tsx`, `WebpImage()`
+- **Thin community `Community 729`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 730`** (2 nodes): `BagItems()`, `BagItems.tsx`
+- **Thin community `Community 730`** (2 nodes): `webp-image.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 731`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
+- **Thin community `Community 731`** (2 nodes): `BagItems()`, `BagItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 732`** (2 nodes): `Bags()`, `Bags.tsx`
+- **Thin community `Community 732`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 733`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
+- **Thin community `Community 733`** (2 nodes): `Bags()`, `Bags.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 734`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
+- **Thin community `Community 734`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 735`** (2 nodes): `UserBag.tsx`, `UserBag()`
+- **Thin community `Community 735`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 736`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
+- **Thin community `Community 736`** (2 nodes): `UserBag.tsx`, `UserBag()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 737`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
+- **Thin community `Community 737`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 738`** (2 nodes): `UserView.tsx`, `UserActions()`
+- **Thin community `Community 738`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 739`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
+- **Thin community `Community 739`** (2 nodes): `UserView.tsx`, `UserActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 740`** (2 nodes): `UserBehaviorInsights.tsx`, `UserBehaviorInsights()`
+- **Thin community `Community 740`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 741`** (2 nodes): `wrapper()`, `ManagerElevationContext.test.tsx`
+- **Thin community `Community 741`** (2 nodes): `UserBehaviorInsights.tsx`, `UserBehaviorInsights()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 742`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
+- **Thin community `Community 742`** (2 nodes): `wrapper()`, `ManagerElevationContext.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 743`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
+- **Thin community `Community 743`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 744`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
+- **Thin community `Community 744`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 745`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
+- **Thin community `Community 745`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 746`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
+- **Thin community `Community 746`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 747`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
+- **Thin community `Community 747`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 748`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
+- **Thin community `Community 748`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 749`** (2 nodes): `useConvexAuthIdentity.ts`, `useConvexAuthIdentity()`
+- **Thin community `Community 749`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 750`** (2 nodes): `useCopyText.ts`, `useCopyText()`
+- **Thin community `Community 750`** (2 nodes): `useConvexAuthIdentity.ts`, `useConvexAuthIdentity()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 751`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
+- **Thin community `Community 751`** (2 nodes): `useCopyText.ts`, `useCopyText()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 752`** (2 nodes): `useDebounce.ts`, `useDebounce()`
+- **Thin community `Community 752`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 753`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
+- **Thin community `Community 753`** (2 nodes): `useDebounce.ts`, `useDebounce()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 754`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
+- **Thin community `Community 754`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 755`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
+- **Thin community `Community 755`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 756`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
+- **Thin community `Community 756`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 757`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
+- **Thin community `Community 757`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 758`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
+- **Thin community `Community 758`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 759`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
+- **Thin community `Community 759`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 760`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
+- **Thin community `Community 760`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 761`** (2 nodes): `usePermissions.ts`, `usePermissions()`
+- **Thin community `Community 761`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 762`** (2 nodes): `usePrint.ts`, `usePrint()`
+- **Thin community `Community 762`** (2 nodes): `usePermissions.ts`, `usePermissions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 763`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
+- **Thin community `Community 763`** (2 nodes): `usePrint.ts`, `usePrint()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 764`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
+- **Thin community `Community 764`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 765`** (2 nodes): `useProtectedAdminPageState.ts`, `useProtectedAdminPageState()`
+- **Thin community `Community 765`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 766`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
+- **Thin community `Community 766`** (2 nodes): `useProtectedAdminPageState.ts`, `useProtectedAdminPageState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 767`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
+- **Thin community `Community 767`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 768`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
+- **Thin community `Community 768`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 769`** (2 nodes): `toOperatorMessage()`, `operatorMessages.ts`
+- **Thin community `Community 769`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 770`** (2 nodes): `presentUnexpectedErrorToast.ts`, `presentUnexpectedErrorToast()`
+- **Thin community `Community 770`** (2 nodes): `toOperatorMessage()`, `operatorMessages.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 771`** (2 nodes): `getOrigin()`, `navigationUtils.ts`
+- **Thin community `Community 771`** (2 nodes): `presentUnexpectedErrorToast.ts`, `presentUnexpectedErrorToast()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 772`** (2 nodes): `addItem()`, `addItem.ts`
+- **Thin community `Community 772`** (2 nodes): `getOrigin()`, `navigationUtils.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 773`** (2 nodes): `bootstrapRegister()`, `bootstrapRegister.ts`
+- **Thin community `Community 773`** (2 nodes): `addItem()`, `addItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 774`** (2 nodes): `holdSession()`, `holdSession.ts`
+- **Thin community `Community 774`** (2 nodes): `bootstrapRegister()`, `bootstrapRegister.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 775`** (2 nodes): `openDrawer()`, `openDrawer.ts`
+- **Thin community `Community 775`** (2 nodes): `holdSession()`, `holdSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 776`** (2 nodes): `startSession.ts`, `startSession()`
+- **Thin community `Community 776`** (2 nodes): `openDrawer()`, `openDrawer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 777`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
+- **Thin community `Community 777`** (2 nodes): `startSession.ts`, `startSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 778`** (2 nodes): `registerAvailabilitySnapshot.test.ts`, `buildAvailabilityRow()`
+- **Thin community `Community 778`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 779`** (2 nodes): `registerAvailabilitySnapshot.ts`, `readRegisterAvailabilitySnapshotState()`
+- **Thin community `Community 779`** (2 nodes): `registerAvailabilitySnapshot.test.ts`, `buildAvailabilityRow()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 780`** (2 nodes): `syncContract.test.ts`, `buildLocalEvent()`
+- **Thin community `Community 780`** (2 nodes): `registerAvailabilitySnapshot.ts`, `readRegisterAvailabilitySnapshotState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 781`** (2 nodes): `syncScheduler.test.ts`, `baseEvent()`
+- **Thin community `Community 781`** (2 nodes): `syncContract.test.ts`, `buildLocalEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 782`** (2 nodes): `syncStatus.test.ts`, `event()`
+- **Thin community `Community 782`** (2 nodes): `syncScheduler.test.ts`, `baseEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 783`** (2 nodes): `useRegisterCatalogIndex.ts`, `useRegisterCatalogIndex()`
+- **Thin community `Community 783`** (2 nodes): `syncStatus.test.ts`, `event()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 784`** (2 nodes): `pinHash.ts`, `hashPin()`
+- **Thin community `Community 784`** (2 nodes): `useRegisterCatalogIndex.ts`, `useRegisterCatalogIndex()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 785`** (2 nodes): `hasOrgNotFoundPayload()`, `index.tsx`
+- **Thin community `Community 785`** (2 nodes): `pinHash.ts`, `hashPin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 786`** (2 nodes): `$sessionId.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 786`** (2 nodes): `hasOrgNotFoundPayload()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 787`** (2 nodes): `registers.index.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 787`** (2 nodes): `$sessionId.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 788`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
+- **Thin community `Community 788`** (2 nodes): `registers.index.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 789`** (2 nodes): `ApprovalsRoute()`, `approvals.tsx`
+- **Thin community `Community 789`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 790`** (2 nodes): `DailyCloseHistoryRoute()`, `daily-close-history.tsx`
+- **Thin community `Community 790`** (2 nodes): `ApprovalsRoute()`, `approvals.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 791`** (2 nodes): `DailyCloseRoute()`, `daily-close.tsx`
+- **Thin community `Community 791`** (2 nodes): `DailyCloseHistoryRoute()`, `daily-close-history.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 792`** (2 nodes): `OpenWorkRoute()`, `open-work.tsx`
+- **Thin community `Community 792`** (2 nodes): `DailyCloseRoute()`, `daily-close.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 793`** (2 nodes): `DailyOpeningRoute()`, `opening.tsx`
+- **Thin community `Community 793`** (2 nodes): `OpenWorkRoute()`, `open-work.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 794`** (2 nodes): `stock-adjustments.tsx`, `StockAdjustmentsRoute()`
+- **Thin community `Community 794`** (2 nodes): `DailyOpeningRoute()`, `opening.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 795`** (2 nodes): `ExpenseRouteComponent()`, `expense.index.tsx`
+- **Thin community `Community 795`** (2 nodes): `stock-adjustments.tsx`, `StockAdjustmentsRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 796`** (2 nodes): `published.index.tsx`, `RouteComponent()`
+- **Thin community `Community 796`** (2 nodes): `ExpenseRouteComponent()`, `expense.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 797`** (2 nodes): `Index()`, `index.tsx`
+- **Thin community `Community 797`** (2 nodes): `published.index.tsx`, `RouteComponent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 798`** (2 nodes): `AthenaLoginReadyView()`, `_layout.index.tsx`
+- **Thin community `Community 798`** (2 nodes): `Index()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 799`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
+- **Thin community `Community 799`** (2 nodes): `AthenaLoginReadyView()`, `_layout.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 800`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 800`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 801`** (2 nodes): `view-patterns.tsx`, `cn()`
+- **Thin community `Community 801`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 802`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
+- **Thin community `Community 802`** (2 nodes): `view-patterns.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 803`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
+- **Thin community `Community 803`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 804`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
+- **Thin community `Community 804`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 805`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 805`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 806`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
+- **Thin community `Community 806`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 807`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
+- **Thin community `Community 807`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 808`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
+- **Thin community `Community 808`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 809`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 809`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 810`** (2 nodes): `usePrint.test.ts`, `setWindowOpenMock()`
+- **Thin community `Community 810`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 811`** (2 nodes): `formatNumber()`, `formatNumber.ts`
+- **Thin community `Community 811`** (2 nodes): `usePrint.test.ts`, `setWindowOpenMock()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 812`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
+- **Thin community `Community 812`** (2 nodes): `formatNumber()`, `formatNumber.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 813`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
+- **Thin community `Community 813`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 814`** (2 nodes): `updateGuest()`, `guest.ts`
+- **Thin community `Community 814`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 815`** (2 nodes): `posTransaction.test.ts`, `jsonResponse()`
+- **Thin community `Community 815`** (2 nodes): `updateGuest()`, `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 816`** (2 nodes): `storefront.ts`, `getStore()`
+- **Thin community `Community 816`** (2 nodes): `posTransaction.test.ts`, `jsonResponse()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 817`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
+- **Thin community `Community 817`** (2 nodes): `storefront.ts`, `getStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 818`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
+- **Thin community `Community 818`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 819`** (2 nodes): `AuthComponent()`, `Auth.tsx`
+- **Thin community `Community 819`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 820`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
+- **Thin community `Community 820`** (2 nodes): `AuthComponent()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 821`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
+- **Thin community `Community 821`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 822`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
+- **Thin community `Community 822`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 823`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
+- **Thin community `Community 823`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 824`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
+- **Thin community `Community 824`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 825`** (2 nodes): `PickupDetails()`, `index.tsx`
+- **Thin community `Community 825`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 826`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
+- **Thin community `Community 826`** (2 nodes): `PickupDetails()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 827`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
+- **Thin community `Community 827`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 828`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
+- **Thin community `Community 828`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 829`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
+- **Thin community `Community 829`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 830`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
+- **Thin community `Community 830`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 831`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
+- **Thin community `Community 831`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 832`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
+- **Thin community `Community 832`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 833`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
+- **Thin community `Community 833`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 834`** (2 nodes): `useCountdown()`, `hooks.ts`
+- **Thin community `Community 834`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 835`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
+- **Thin community `Community 835`** (2 nodes): `useCountdown()`, `hooks.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 836`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
+- **Thin community `Community 836`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 837`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
+- **Thin community `Community 837`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 838`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
+- **Thin community `Community 838`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 839`** (2 nodes): `resolveHomepageContent()`, `homePageContent.ts`
+- **Thin community `Community 839`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 840`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
+- **Thin community `Community 840`** (2 nodes): `resolveHomepageContent()`, `homePageContent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 841`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
+- **Thin community `Community 841`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 842`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
+- **Thin community `Community 842`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 843`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
+- **Thin community `Community 843`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 844`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
+- **Thin community `Community 844`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 845`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
+- **Thin community `Community 845`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 846`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
+- **Thin community `Community 846`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 847`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
+- **Thin community `Community 847`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 848`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
+- **Thin community `Community 848`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 849`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
+- **Thin community `Community 849`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 850`** (2 nodes): `ProductPage.test.tsx`, `makePageState()`
+- **Thin community `Community 850`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 851`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
+- **Thin community `Community 851`** (2 nodes): `ProductPage.test.tsx`, `makePageState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 852`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
+- **Thin community `Community 852`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 853`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
+- **Thin community `Community 853`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 854`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
+- **Thin community `Community 854`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 855`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
+- **Thin community `Community 855`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 856`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
+- **Thin community `Community 856`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 857`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
+- **Thin community `Community 857`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 858`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
+- **Thin community `Community 858`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 859`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
+- **Thin community `Community 859`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 860`** (2 nodes): `BagItem()`, `BagItem.tsx`
+- **Thin community `Community 860`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 861`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
+- **Thin community `Community 861`** (2 nodes): `BagItem()`, `BagItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 862`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
+- **Thin community `Community 862`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 863`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
+- **Thin community `Community 863`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 864`** (2 nodes): `CountrySelect()`, `country-select.tsx`
+- **Thin community `Community 864`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 865`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
+- **Thin community `Community 865`** (2 nodes): `CountrySelect()`, `country-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 866`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
+- **Thin community `Community 866`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 867`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
+- **Thin community `Community 867`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 868`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
+- **Thin community `Community 868`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 869`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
+- **Thin community `Community 869`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 870`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
+- **Thin community `Community 870`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 871`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
+- **Thin community `Community 871`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 872`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
+- **Thin community `Community 872`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 873`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
+- **Thin community `Community 873`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 874`** (2 nodes): `useCheckout.ts`, `useCheckout()`
+- **Thin community `Community 874`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 875`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
+- **Thin community `Community 875`** (2 nodes): `useCheckout.ts`, `useCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 876`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
+- **Thin community `Community 876`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 877`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
+- **Thin community `Community 877`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 878`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
+- **Thin community `Community 878`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 879`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
+- **Thin community `Community 879`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 880`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
+- **Thin community `Community 880`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 881`** (2 nodes): `useGetStore.ts`, `useGetStore()`
+- **Thin community `Community 881`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 882`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
+- **Thin community `Community 882`** (2 nodes): `useGetStore.ts`, `useGetStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 883`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
+- **Thin community `Community 883`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 884`** (2 nodes): `useLogout.ts`, `useLogout()`
+- **Thin community `Community 884`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 885`** (2 nodes): `useModalState.tsx`, `useModalState()`
+- **Thin community `Community 885`** (2 nodes): `useLogout.ts`, `useLogout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 886`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
+- **Thin community `Community 886`** (2 nodes): `useModalState.tsx`, `useModalState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 887`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
+- **Thin community `Community 887`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 888`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
+- **Thin community `Community 888`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 889`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
+- **Thin community `Community 889`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 890`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
+- **Thin community `Community 890`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 891`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
+- **Thin community `Community 891`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 892`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
+- **Thin community `Community 892`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 893`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
+- **Thin community `Community 893`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 894`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
+- **Thin community `Community 894`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 895`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
+- **Thin community `Community 895`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 896`** (2 nodes): `useBagQueries()`, `bag.ts`
+- **Thin community `Community 896`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 897`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
+- **Thin community `Community 897`** (2 nodes): `useBagQueries()`, `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 898`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
+- **Thin community `Community 898`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 899`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
+- **Thin community `Community 899`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 900`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
+- **Thin community `Community 900`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 901`** (2 nodes): `posTransaction.ts`, `usePosTransactionQueries()`
+- **Thin community `Community 901`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 902`** (2 nodes): `product.ts`, `useProductQueries()`
+- **Thin community `Community 902`** (2 nodes): `posTransaction.ts`, `usePosTransactionQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 903`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
+- **Thin community `Community 903`** (2 nodes): `product.ts`, `useProductQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 904`** (2 nodes): `reviews.ts`, `useReviewQueries()`
+- **Thin community `Community 904`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 905`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
+- **Thin community `Community 905`** (2 nodes): `reviews.ts`, `useReviewQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 906`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
+- **Thin community `Community 906`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 907`** (2 nodes): `user.ts`, `useUserQueries()`
+- **Thin community `Community 907`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 908`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
+- **Thin community `Community 908`** (2 nodes): `user.ts`, `useUserQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 909`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
+- **Thin community `Community 909`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 910`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
+- **Thin community `Community 910`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 911`** (2 nodes): `validateEmail()`, `email.ts`
+- **Thin community `Community 911`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 912`** (2 nodes): `router.tsx`, `createRouter()`
+- **Thin community `Community 912`** (2 nodes): `validateEmail()`, `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 913`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
+- **Thin community `Community 913`** (2 nodes): `router.tsx`, `createRouter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 914`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
+- **Thin community `Community 914`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 915`** (2 nodes): `ContactUs()`, `contact-us.tsx`
+- **Thin community `Community 915`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 916`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
+- **Thin community `Community 916`** (2 nodes): `ContactUs()`, `contact-us.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 917`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
+- **Thin community `Community 917`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 918`** (2 nodes): `tos.index.tsx`, `TosSection()`
+- **Thin community `Community 918`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 919`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
+- **Thin community `Community 919`** (2 nodes): `tos.index.tsx`, `TosSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 920`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
+- **Thin community `Community 920`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 921`** (2 nodes): `HomeRoute()`, `index.tsx`
+- **Thin community `Community 921`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 922`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
+- **Thin community `Community 922`** (2 nodes): `HomeRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 923`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
+- **Thin community `Community 923`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 924`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
+- **Thin community `Community 924`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 925`** (2 nodes): `ReceiptShareRoute()`, `index.tsx`
+- **Thin community `Community 925`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 926`** (2 nodes): `test-connection.js`, `main()`
+- **Thin community `Community 926`** (2 nodes): `ReceiptShareRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 927`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
+- **Thin community `Community 927`** (2 nodes): `test-connection.js`, `main()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 928`** (2 nodes): `run()`, `architecture-boundary-check.ts`
+- **Thin community `Community 928`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 929`** (2 nodes): `readRepoFile()`, `deploy-qa-vps.test.ts`
+- **Thin community `Community 929`** (2 nodes): `run()`, `architecture-boundary-check.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 930`** (2 nodes): `runCommand()`, `github-pr-merge.test.ts`
+- **Thin community `Community 930`** (2 nodes): `readRepoFile()`, `deploy-qa-vps.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 931`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
+- **Thin community `Community 931`** (2 nodes): `runCommand()`, `github-pr-merge.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 932`** (2 nodes): `shutdown()`, `sample-app.ts`
+- **Thin community `Community 932`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 933`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
+- **Thin community `Community 933`** (2 nodes): `shutdown()`, `sample-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 934`** (1 nodes): `api.d.ts`
+- **Thin community `Community 934`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 935`** (1 nodes): `api.js`
+- **Thin community `Community 935`** (1 nodes): `api.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 936`** (1 nodes): `dataModel.d.ts`
+- **Thin community `Community 936`** (1 nodes): `api.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 937`** (1 nodes): `server.d.ts`
+- **Thin community `Community 937`** (1 nodes): `dataModel.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 938`** (1 nodes): `server.js`
+- **Thin community `Community 938`** (1 nodes): `server.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 939`** (1 nodes): `app.ts`
+- **Thin community `Community 939`** (1 nodes): `server.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 940`** (1 nodes): `auth.config.js`
+- **Thin community `Community 940`** (1 nodes): `app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 941`** (1 nodes): `auth.ts`
+- **Thin community `Community 941`** (1 nodes): `auth.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 942`** (1 nodes): `registerSessions.test.ts`
+- **Thin community `Community 942`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 943`** (1 nodes): `r2.test.ts`
+- **Thin community `Community 943`** (1 nodes): `registerSessions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 944`** (1 nodes): `countries.ts`
+- **Thin community `Community 944`** (1 nodes): `r2.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 945`** (1 nodes): `email.ts`
+- **Thin community `Community 945`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 946`** (1 nodes): `ghana.ts`
+- **Thin community `Community 946`** (1 nodes): `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 947`** (1 nodes): `payment.ts`
+- **Thin community `Community 947`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 948`** (1 nodes): `crons.ts`
+- **Thin community `Community 948`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 949`** (1 nodes): `domain.test.ts`
+- **Thin community `Community 949`** (1 nodes): `crons.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 950`** (1 nodes): `internal.ts`
+- **Thin community `Community 950`** (1 nodes): `domain.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 951`** (1 nodes): `public.test.ts`
+- **Thin community `Community 951`** (1 nodes): `internal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 952`** (1 nodes): `token.test.ts`
+- **Thin community `Community 952`** (1 nodes): `public.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 953`** (1 nodes): `whatsappClient.test.ts`
+- **Thin community `Community 953`** (1 nodes): `token.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 954`** (1 nodes): `whatsappConfig.test.ts`
+- **Thin community `Community 954`** (1 nodes): `whatsappClient.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 955`** (1 nodes): `devPatchBadTransaction.ts`
+- **Thin community `Community 955`** (1 nodes): `whatsappConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 956`** (1 nodes): `FeedbackRequest.tsx`
+- **Thin community `Community 956`** (1 nodes): `devPatchBadTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 957`** (1 nodes): `NewOrderAdmin.tsx`
+- **Thin community `Community 957`** (1 nodes): `FeedbackRequest.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 958`** (1 nodes): `OrderEmail.tsx`
+- **Thin community `Community 958`** (1 nodes): `NewOrderAdmin.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 959`** (1 nodes): `PosReceiptEmail.tsx`
+- **Thin community `Community 959`** (1 nodes): `OrderEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 960`** (1 nodes): `env.ts`
+- **Thin community `Community 960`** (1 nodes): `PosReceiptEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 961`** (1 nodes): `analytics.ts`
+- **Thin community `Community 961`** (1 nodes): `env.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 962`** (1 nodes): `auth.ts`
+- **Thin community `Community 962`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 963`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 963`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 964`** (1 nodes): `colors.ts`
+- **Thin community `Community 964`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 965`** (1 nodes): `index.ts`
+- **Thin community `Community 965`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 966`** (1 nodes): `organizations.ts`
+- **Thin community `Community 966`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 967`** (1 nodes): `products.ts`
+- **Thin community `Community 967`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 968`** (1 nodes): `storefrontHidden.test.ts`
+- **Thin community `Community 968`** (1 nodes): `products.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 969`** (1 nodes): `stores.ts`
+- **Thin community `Community 969`** (1 nodes): `storefrontHidden.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 970`** (1 nodes): `bag.ts`
+- **Thin community `Community 970`** (1 nodes): `stores.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 971`** (1 nodes): `guest.ts`
+- **Thin community `Community 971`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 972`** (1 nodes): `index.ts`
+- **Thin community `Community 972`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 973`** (1 nodes): `me.ts`
+- **Thin community `Community 973`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 974`** (1 nodes): `offers.ts`
+- **Thin community `Community 974`** (1 nodes): `me.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 975`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 975`** (1 nodes): `offers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 976`** (1 nodes): `paystack.ts`
+- **Thin community `Community 976`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 977`** (1 nodes): `posTransaction.ts`
+- **Thin community `Community 977`** (1 nodes): `paystack.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 978`** (1 nodes): `reviews.ts`
+- **Thin community `Community 978`** (1 nodes): `posTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 979`** (1 nodes): `rewards.ts`
+- **Thin community `Community 979`** (1 nodes): `reviews.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 980`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 980`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 981`** (1 nodes): `security.test.ts`
+- **Thin community `Community 981`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 982`** (1 nodes): `storefront.ts`
+- **Thin community `Community 982`** (1 nodes): `security.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 983`** (1 nodes): `upsells.ts`
+- **Thin community `Community 983`** (1 nodes): `storefront.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 984`** (1 nodes): `user.ts`
+- **Thin community `Community 984`** (1 nodes): `upsells.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 985`** (1 nodes): `userOffers.ts`
+- **Thin community `Community 985`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 986`** (1 nodes): `index.ts`
+- **Thin community `Community 986`** (1 nodes): `userOffers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 987`** (1 nodes): `health.test.ts`
+- **Thin community `Community 987`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 988`** (1 nodes): `http.ts`
+- **Thin community `Community 988`** (1 nodes): `health.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 989`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 989`** (1 nodes): `http.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 990`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 990`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 991`** (1 nodes): `bestSeller.ts`
+- **Thin community `Community 991`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 992`** (1 nodes): `categories.ts`
+- **Thin community `Community 992`** (1 nodes): `bestSeller.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 993`** (1 nodes): `colors.ts`
+- **Thin community `Community 993`** (1 nodes): `categories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 994`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 994`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 995`** (1 nodes): `expenseTransactions.test.ts`
+- **Thin community `Community 995`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 996`** (1 nodes): `featuredItem.ts`
+- **Thin community `Community 996`** (1 nodes): `expenseTransactions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 997`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 997`** (1 nodes): `featuredItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 998`** (1 nodes): `organizationMembers.ts`
+- **Thin community `Community 998`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 999`** (1 nodes): `organizations.ts`
+- **Thin community `Community 999`** (1 nodes): `organizationMembers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1000`** (1 nodes): `pos.ts`
+- **Thin community `Community 1000`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1001`** (1 nodes): `posCustomers.ts`
+- **Thin community `Community 1001`** (1 nodes): `pos.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1002`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 1002`** (1 nodes): `posCustomers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1003`** (1 nodes): `productSku.ts`
+- **Thin community `Community 1003`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1004`** (1 nodes): `productUtil.test.ts`
+- **Thin community `Community 1004`** (1 nodes): `productSku.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1005`** (1 nodes): `promoCode.test.ts`
+- **Thin community `Community 1005`** (1 nodes): `productUtil.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1006`** (1 nodes): `stockValidation.ts`
+- **Thin community `Community 1006`** (1 nodes): `promoCode.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1007`** (1 nodes): `storeConfigV2.test.ts`
+- **Thin community `Community 1007`** (1 nodes): `stockValidation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1008`** (1 nodes): `subcategories.ts`
+- **Thin community `Community 1008`** (1 nodes): `storeConfigV2.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1009`** (1 nodes): `commandResultValidators.test.ts`
+- **Thin community `Community 1009`** (1 nodes): `subcategories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1010`** (1 nodes): `currency.test.ts`
+- **Thin community `Community 1010`** (1 nodes): `commandResultValidators.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1011`** (1 nodes): `storeInsights.ts`
+- **Thin community `Community 1011`** (1 nodes): `currency.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1012`** (1 nodes): `userInsights.ts`
+- **Thin community `Community 1012`** (1 nodes): `storeInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1013`** (1 nodes): `migrateAmountsToPesewas.ts`
+- **Thin community `Community 1013`** (1 nodes): `userInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1014`** (1 nodes): `client.test.ts`
+- **Thin community `Community 1014`** (1 nodes): `migrateAmountsToPesewas.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1015`** (1 nodes): `config.test.ts`
+- **Thin community `Community 1015`** (1 nodes): `client.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1016`** (1 nodes): `normalize.test.ts`
+- **Thin community `Community 1016`** (1 nodes): `config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1017`** (1 nodes): `types.ts`
+- **Thin community `Community 1017`** (1 nodes): `normalize.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1018`** (1 nodes): `customerProfiles.test.ts`
+- **Thin community `Community 1018`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1019`** (1 nodes): `paymentAllocations.test.ts`
+- **Thin community `Community 1019`** (1 nodes): `customerProfiles.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1020`** (1 nodes): `EmailOTP.test.ts`
+- **Thin community `Community 1020`** (1 nodes): `paymentAllocations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1021`** (1 nodes): `correctTransactionCustomer.test.ts`
+- **Thin community `Community 1021`** (1 nodes): `EmailOTP.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1022`** (1 nodes): `correctionEvents.test.ts`
+- **Thin community `Community 1022`** (1 nodes): `correctTransactionCustomer.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1023`** (1 nodes): `correctionPolicy.test.ts`
+- **Thin community `Community 1023`** (1 nodes): `correctionEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1024`** (1 nodes): `dto.ts`
+- **Thin community `Community 1024`** (1 nodes): `correctionPolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1025`** (1 nodes): `getRegisterState.test.ts`
+- **Thin community `Community 1025`** (1 nodes): `dto.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1026`** (1 nodes): `posSessionTracing.test.ts`
+- **Thin community `Community 1026`** (1 nodes): `getRegisterState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1027`** (1 nodes): `types.ts`
+- **Thin community `Community 1027`** (1 nodes): `posSessionTracing.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1028`** (1 nodes): `terminals.test.ts`
+- **Thin community `Community 1028`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1029`** (1 nodes): `types.ts`
+- **Thin community `Community 1029`** (1 nodes): `terminals.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1030`** (1 nodes): `registerSessionRepository.test.ts`
+- **Thin community `Community 1030`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1031`** (1 nodes): `customers.ts`
+- **Thin community `Community 1031`** (1 nodes): `registerSessionRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1032`** (1 nodes): `register.ts`
+- **Thin community `Community 1032`** (1 nodes): `customers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1033`** (1 nodes): `sync.ts`
+- **Thin community `Community 1033`** (1 nodes): `register.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1034`** (1 nodes): `schema.ts`
+- **Thin community `Community 1034`** (1 nodes): `sync.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1035`** (1 nodes): `customerMessageDelivery.ts`
+- **Thin community `Community 1035`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1036`** (1 nodes): `index.ts`
+- **Thin community `Community 1036`** (1 nodes): `customerMessageDelivery.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1037`** (1 nodes): `receiptShareToken.ts`
+- **Thin community `Community 1037`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1038`** (1 nodes): `appVerificationCode.ts`
+- **Thin community `Community 1038`** (1 nodes): `receiptShareToken.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1039`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 1039`** (1 nodes): `appVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1040`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 1040`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1041`** (1 nodes): `bestSeller.ts`
+- **Thin community `Community 1041`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1042`** (1 nodes): `category.ts`
+- **Thin community `Community 1042`** (1 nodes): `bestSeller.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1043`** (1 nodes): `color.ts`
+- **Thin community `Community 1043`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1044`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 1044`** (1 nodes): `color.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1045`** (1 nodes): `featuredItem.ts`
+- **Thin community `Community 1045`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1046`** (1 nodes): `index.ts`
+- **Thin community `Community 1046`** (1 nodes): `featuredItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1047`** (1 nodes): `inventoryHold.ts`
+- **Thin community `Community 1047`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1048`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 1048`** (1 nodes): `inventoryHold.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1049`** (1 nodes): `organization.ts`
+- **Thin community `Community 1049`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1050`** (1 nodes): `organizationMember.ts`
+- **Thin community `Community 1050`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1051`** (1 nodes): `product.ts`
+- **Thin community `Community 1051`** (1 nodes): `organizationMember.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1052`** (1 nodes): `promoCode.ts`
+- **Thin community `Community 1052`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1053`** (1 nodes): `redeemedPromoCode.ts`
+- **Thin community `Community 1053`** (1 nodes): `promoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1054`** (1 nodes): `store.ts`
+- **Thin community `Community 1054`** (1 nodes): `redeemedPromoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1055`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1055`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1056`** (1 nodes): `index.ts`
+- **Thin community `Community 1056`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1057`** (1 nodes): `workflowTrace.ts`
+- **Thin community `Community 1057`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1058`** (1 nodes): `workflowTraceEvent.ts`
+- **Thin community `Community 1058`** (1 nodes): `workflowTrace.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1059`** (1 nodes): `workflowTraceLookup.ts`
+- **Thin community `Community 1059`** (1 nodes): `workflowTraceEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1060`** (1 nodes): `approvalRequest.ts`
+- **Thin community `Community 1060`** (1 nodes): `workflowTraceLookup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1061`** (1 nodes): `customerProfile.ts`
+- **Thin community `Community 1061`** (1 nodes): `approvalRequest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1062`** (1 nodes): `dailyClose.ts`
+- **Thin community `Community 1062`** (1 nodes): `customerProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1063`** (1 nodes): `dailyOpening.ts`
+- **Thin community `Community 1063`** (1 nodes): `dailyClose.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1064`** (1 nodes): `index.ts`
+- **Thin community `Community 1064`** (1 nodes): `dailyOpening.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1065`** (1 nodes): `inventoryMovement.ts`
+- **Thin community `Community 1065`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1066`** (1 nodes): `managerElevation.ts`
+- **Thin community `Community 1066`** (1 nodes): `inventoryMovement.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1067`** (1 nodes): `operationalEvent.ts`
+- **Thin community `Community 1067`** (1 nodes): `managerElevation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1068`** (1 nodes): `operationalWorkItem.ts`
+- **Thin community `Community 1068`** (1 nodes): `operationalEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1069`** (1 nodes): `paymentAllocation.ts`
+- **Thin community `Community 1069`** (1 nodes): `operationalWorkItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1070`** (1 nodes): `registerSession.ts`
+- **Thin community `Community 1070`** (1 nodes): `paymentAllocation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1071`** (1 nodes): `skuActivityEvent.ts`
+- **Thin community `Community 1071`** (1 nodes): `registerSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1072`** (1 nodes): `staffCredential.ts`
+- **Thin community `Community 1072`** (1 nodes): `skuActivityEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1073`** (1 nodes): `staffProfile.ts`
+- **Thin community `Community 1073`** (1 nodes): `staffCredential.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1074`** (1 nodes): `staffRoleAssignment.ts`
+- **Thin community `Community 1074`** (1 nodes): `staffProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1075`** (1 nodes): `mtnCollections.ts`
+- **Thin community `Community 1075`** (1 nodes): `staffRoleAssignment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1076`** (1 nodes): `customer.ts`
+- **Thin community `Community 1076`** (1 nodes): `mtnCollections.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1077`** (1 nodes): `expenseSession.ts`
+- **Thin community `Community 1077`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1078`** (1 nodes): `expenseSessionItem.ts`
+- **Thin community `Community 1078`** (1 nodes): `expenseSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1079`** (1 nodes): `expenseTransaction.ts`
+- **Thin community `Community 1079`** (1 nodes): `expenseSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1080`** (1 nodes): `expenseTransactionItem.ts`
+- **Thin community `Community 1080`** (1 nodes): `expenseTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1081`** (1 nodes): `index.ts`
+- **Thin community `Community 1081`** (1 nodes): `expenseTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1082`** (1 nodes): `posLocalStaffProof.ts`
+- **Thin community `Community 1082`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1083`** (1 nodes): `posLocalSyncConflict.ts`
+- **Thin community `Community 1083`** (1 nodes): `posLocalStaffProof.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1084`** (1 nodes): `posLocalSyncCursor.ts`
+- **Thin community `Community 1084`** (1 nodes): `posLocalSyncConflict.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1085`** (1 nodes): `posLocalSyncEvent.ts`
+- **Thin community `Community 1085`** (1 nodes): `posLocalSyncCursor.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1086`** (1 nodes): `posLocalSyncMapping.ts`
+- **Thin community `Community 1086`** (1 nodes): `posLocalSyncEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1087`** (1 nodes): `posSession.ts`
+- **Thin community `Community 1087`** (1 nodes): `posLocalSyncMapping.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1088`** (1 nodes): `posSessionItem.ts`
+- **Thin community `Community 1088`** (1 nodes): `posSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1089`** (1 nodes): `posTerminal.test.ts`
+- **Thin community `Community 1089`** (1 nodes): `posSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1090`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 1090`** (1 nodes): `posTerminal.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1091`** (1 nodes): `posTransaction.ts`
+- **Thin community `Community 1091`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1092`** (1 nodes): `posTransactionItem.ts`
+- **Thin community `Community 1092`** (1 nodes): `posTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1093`** (1 nodes): `index.ts`
+- **Thin community `Community 1093`** (1 nodes): `posTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1094`** (1 nodes): `serviceAppointment.ts`
+- **Thin community `Community 1094`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1095`** (1 nodes): `serviceCase.ts`
+- **Thin community `Community 1095`** (1 nodes): `serviceAppointment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1096`** (1 nodes): `serviceCaseLineItem.ts`
+- **Thin community `Community 1096`** (1 nodes): `serviceCase.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1097`** (1 nodes): `serviceCatalog.ts`
+- **Thin community `Community 1097`** (1 nodes): `serviceCaseLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1098`** (1 nodes): `serviceInventoryUsage.ts`
+- **Thin community `Community 1098`** (1 nodes): `serviceCatalog.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1099`** (1 nodes): `cycleCountDraft.ts`
+- **Thin community `Community 1099`** (1 nodes): `serviceInventoryUsage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1100`** (1 nodes): `index.ts`
+- **Thin community `Community 1100`** (1 nodes): `cycleCountDraft.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1101`** (1 nodes): `purchaseOrder.ts`
+- **Thin community `Community 1101`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1102`** (1 nodes): `purchaseOrderLineItem.ts`
+- **Thin community `Community 1102`** (1 nodes): `purchaseOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1103`** (1 nodes): `receivingBatch.ts`
+- **Thin community `Community 1103`** (1 nodes): `purchaseOrderLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1104`** (1 nodes): `stockAdjustmentBatch.ts`
+- **Thin community `Community 1104`** (1 nodes): `receivingBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1105`** (1 nodes): `vendor.ts`
+- **Thin community `Community 1105`** (1 nodes): `stockAdjustmentBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1106`** (1 nodes): `analytics.ts`
+- **Thin community `Community 1106`** (1 nodes): `vendor.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1107`** (1 nodes): `bag.ts`
+- **Thin community `Community 1107`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1108`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1108`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1109`** (1 nodes): `checkoutSession.ts`
+- **Thin community `Community 1109`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1110`** (1 nodes): `checkoutSessionItem.ts`
+- **Thin community `Community 1110`** (1 nodes): `checkoutSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1111`** (1 nodes): `guest.ts`
+- **Thin community `Community 1111`** (1 nodes): `checkoutSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1112`** (1 nodes): `index.ts`
+- **Thin community `Community 1112`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1113`** (1 nodes): `offer.ts`
+- **Thin community `Community 1113`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1114`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 1114`** (1 nodes): `offer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1115`** (1 nodes): `onlineOrderItem.ts`
+- **Thin community `Community 1115`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1116`** (1 nodes): `review.ts`
+- **Thin community `Community 1116`** (1 nodes): `onlineOrderItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1117`** (1 nodes): `rewards.ts`
+- **Thin community `Community 1117`** (1 nodes): `review.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1118`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 1118`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1119`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 1119`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1120`** (1 nodes): `storeFrontSession.ts`
+- **Thin community `Community 1120`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1121`** (1 nodes): `storeFrontUser.ts`
+- **Thin community `Community 1121`** (1 nodes): `storeFrontSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1122`** (1 nodes): `storeFrontVerificationCode.ts`
+- **Thin community `Community 1122`** (1 nodes): `storeFrontUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1123`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 1123`** (1 nodes): `storeFrontVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1124`** (1 nodes): `catalogAppointments.test.ts`
+- **Thin community `Community 1124`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1125`** (1 nodes): `bag.ts`
+- **Thin community `Community 1125`** (1 nodes): `catalogAppointments.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1126`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1126`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1127`** (1 nodes): `customer.ts`
+- **Thin community `Community 1127`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1128`** (1 nodes): `guest.ts`
+- **Thin community `Community 1128`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1129`** (1 nodes): `offers.test.ts`
+- **Thin community `Community 1129`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1130`** (1 nodes): `onlineOrderUtilFns.ts`
+- **Thin community `Community 1130`** (1 nodes): `offers.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1131`** (1 nodes): `orderOperations.test.ts`
+- **Thin community `Community 1131`** (1 nodes): `onlineOrderUtilFns.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1132`** (1 nodes): `payment.test.ts`
+- **Thin community `Community 1132`** (1 nodes): `orderOperations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1133`** (1 nodes): `payment.ts`
+- **Thin community `Community 1133`** (1 nodes): `payment.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1134`** (1 nodes): `paystackActions.ts`
+- **Thin community `Community 1134`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1135`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 1135`** (1 nodes): `paystackActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1136`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 1136`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1137`** (1 nodes): `users.ts`
+- **Thin community `Community 1137`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1138`** (1 nodes): `payment.ts`
+- **Thin community `Community 1138`** (1 nodes): `users.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1139`** (1 nodes): `posSession.test.ts`
+- **Thin community `Community 1139`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1140`** (1 nodes): `registerSession.test.ts`
+- **Thin community `Community 1140`** (1 nodes): `posSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1141`** (1 nodes): `presentation.test.ts`
+- **Thin community `Community 1141`** (1 nodes): `registerSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1142`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 1142`** (1 nodes): `presentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1143`** (1 nodes): `index.ts`
+- **Thin community `Community 1143`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1144`** (1 nodes): `postcss.config.js`
+- **Thin community `Community 1144`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1145`** (1 nodes): `approvalPolicy.ts`
+- **Thin community `Community 1145`** (1 nodes): `postcss.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1146`** (1 nodes): `auth.ts`
+- **Thin community `Community 1146`** (1 nodes): `approvalPolicy.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1147`** (1 nodes): `commandResult.test.ts`
+- **Thin community `Community 1147`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1148`** (1 nodes): `currencyFormatter.test.ts`
+- **Thin community `Community 1148`** (1 nodes): `commandResult.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1149`** (1 nodes): `posLocalSyncContract.ts`
+- **Thin community `Community 1149`** (1 nodes): `currencyFormatter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1150`** (1 nodes): `registerSessionStatus.test.ts`
+- **Thin community `Community 1150`** (1 nodes): `posLocalSyncContract.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1151`** (1 nodes): `staffDisplayName.test.ts`
+- **Thin community `Community 1151`** (1 nodes): `registerSessionStatus.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1152`** (1 nodes): `GenericComboBox.tsx`
+- **Thin community `Community 1152`** (1 nodes): `staffDisplayName.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1153`** (1 nodes): `StoreAccordion.tsx`
+- **Thin community `Community 1153`** (1 nodes): `GenericComboBox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1154`** (1 nodes): `StoresAccordion.tsx`
+- **Thin community `Community 1154`** (1 nodes): `StoreAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1155`** (1 nodes): `ThemeToggle.tsx`
+- **Thin community `Community 1155`** (1 nodes): `StoresAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1156`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
+- **Thin community `Community 1156`** (1 nodes): `ThemeToggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1157`** (1 nodes): `ProductAttributes.tsx`
+- **Thin community `Community 1157`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1158`** (1 nodes): `ProductAttributesView.tsx`
+- **Thin community `Community 1158`** (1 nodes): `ProductAttributes.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1159`** (1 nodes): `ProductStock.test.ts`
+- **Thin community `Community 1159`** (1 nodes): `ProductAttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1160`** (1 nodes): `ProductView.test.tsx`
+- **Thin community `Community 1160`** (1 nodes): `ProductStock.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1161`** (1 nodes): `constants.ts`
+- **Thin community `Community 1161`** (1 nodes): `ProductView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1162`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1162`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1163`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1163`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1164`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1164`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1165`** (1 nodes): `types.ts`
+- **Thin community `Community 1165`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1166`** (1 nodes): `ConversionFunnelChart.tsx`
+- **Thin community `Community 1166`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1167`** (1 nodes): `RevenueChart.tsx`
+- **Thin community `Community 1167`** (1 nodes): `ConversionFunnelChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1168`** (1 nodes): `analytics-columns.tsx`
+- **Thin community `Community 1168`** (1 nodes): `RevenueChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1169`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1169`** (1 nodes): `analytics-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1170`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1170`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1171`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1171`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1172`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1172`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1173`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1173`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1174`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1174`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1175`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1175`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1176`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1176`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1177`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1177`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1178`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1178`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1179`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1179`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1180`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1180`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1181`** (1 nodes): `chart.tsx`
+- **Thin community `Community 1181`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1182`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1182`** (1 nodes): `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1183`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1183`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1184`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1184`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1185`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1185`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1186`** (1 nodes): `constants.ts`
+- **Thin community `Community 1186`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1187`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1187`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1188`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1188`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1189`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1189`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1190`** (1 nodes): `data.ts`
+- **Thin community `Community 1190`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1191`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1191`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1192`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1192`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1193`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1193`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1194`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1194`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1195`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1195`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1196`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1196`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1197`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1197`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1198`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1198`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1199`** (1 nodes): `assetsColumns.tsx`
+- **Thin community `Community 1199`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1200`** (1 nodes): `constants.ts`
+- **Thin community `Community 1200`** (1 nodes): `assetsColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1201`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1201`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1202`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1202`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1203`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1203`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1204`** (1 nodes): `data.ts`
+- **Thin community `Community 1204`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1205`** (1 nodes): `DefaultCatchBoundary.test.tsx`
+- **Thin community `Community 1205`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1206`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 1206`** (1 nodes): `DefaultCatchBoundary.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1207`** (1 nodes): `LoginForm.test.tsx`
+- **Thin community `Community 1207`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1208`** (1 nodes): `LoginForm.tsx`
+- **Thin community `Community 1208`** (1 nodes): `LoginForm.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1209`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1209`** (1 nodes): `LoginForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1210`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1210`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1211`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1211`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1212`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1212`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1213`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1213`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1214`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1214`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1215`** (1 nodes): `constants.ts`
+- **Thin community `Community 1215`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1216`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1216`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1217`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1217`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1218`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1218`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1219`** (1 nodes): `BulkOperationsPage.tsx`
+- **Thin community `Community 1219`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1220`** (1 nodes): `CashControlsDashboard.auth.test.tsx`
+- **Thin community `Community 1220`** (1 nodes): `BulkOperationsPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1221`** (1 nodes): `CashControlsDashboard.test.tsx`
+- **Thin community `Community 1221`** (1 nodes): `CashControlsDashboard.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1222`** (1 nodes): `CashControlsWorkspaceHeader.tsx`
+- **Thin community `Community 1222`** (1 nodes): `CashControlsDashboard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1223`** (1 nodes): `RegisterSessionView.auth.test.tsx`
+- **Thin community `Community 1223`** (1 nodes): `CashControlsWorkspaceHeader.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1224`** (1 nodes): `RegisterSessionView.test.tsx`
+- **Thin community `Community 1224`** (1 nodes): `RegisterSessionView.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1225`** (1 nodes): `RegisterSessionsView.test.tsx`
+- **Thin community `Community 1225`** (1 nodes): `RegisterSessionView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1226`** (1 nodes): `formatReviewReason.test.ts`
+- **Thin community `Community 1226`** (1 nodes): `RegisterSessionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1227`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1227`** (1 nodes): `formatReviewReason.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1228`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1228`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1229`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1229`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1230`** (1 nodes): `ListPagination.tsx`
+- **Thin community `Community 1230`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1231`** (1 nodes): `PageLevelHeader.test.tsx`
+- **Thin community `Community 1231`** (1 nodes): `ListPagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1232`** (1 nodes): `PageLevelHeader.tsx`
+- **Thin community `Community 1232`** (1 nodes): `PageLevelHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1233`** (1 nodes): `MetricCard.tsx`
+- **Thin community `Community 1233`** (1 nodes): `PageLevelHeader.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1234`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 1234`** (1 nodes): `MetricCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1235`** (1 nodes): `CommandApprovalDialog.test.tsx`
+- **Thin community `Community 1235`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1236`** (1 nodes): `OperationReviewWorkspace.tsx`
+- **Thin community `Community 1236`** (1 nodes): `CommandApprovalDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1237`** (1 nodes): `OperationsQueueView.auth.test.tsx`
+- **Thin community `Community 1237`** (1 nodes): `OperationReviewWorkspace.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1238`** (1 nodes): `SkuActivityTimeline.test.tsx`
+- **Thin community `Community 1238`** (1 nodes): `OperationsQueueView.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1239`** (1 nodes): `skuActivityTimelineAdapter.test.ts`
+- **Thin community `Community 1239`** (1 nodes): `SkuActivityTimeline.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1240`** (1 nodes): `useApprovedCommand.test.tsx`
+- **Thin community `Community 1240`** (1 nodes): `skuActivityTimelineAdapter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1241`** (1 nodes): `OrderStatus.test.tsx`
+- **Thin community `Community 1241`** (1 nodes): `useApprovedCommand.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1242`** (1 nodes): `OrderStatus.tsx`
+- **Thin community `Community 1242`** (1 nodes): `OrderStatus.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1243`** (1 nodes): `OrderSummary.tsx`
+- **Thin community `Community 1243`** (1 nodes): `OrderStatus.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1244`** (1 nodes): `Orders.tsx`
+- **Thin community `Community 1244`** (1 nodes): `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1245`** (1 nodes): `RefundsView.test.tsx`
+- **Thin community `Community 1245`** (1 nodes): `Orders.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1246`** (1 nodes): `ReturnExchangeView.test.tsx`
+- **Thin community `Community 1246`** (1 nodes): `RefundsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1247`** (1 nodes): `constants.ts`
+- **Thin community `Community 1247`** (1 nodes): `ReturnExchangeView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1248`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1248`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1249`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1249`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1250`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1250`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1251`** (1 nodes): `data.ts`
+- **Thin community `Community 1251`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1252`** (1 nodes): `refundUtils.test.ts`
+- **Thin community `Community 1252`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1253`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1253`** (1 nodes): `refundUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1254`** (1 nodes): `constants.ts`
+- **Thin community `Community 1254`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1255`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1255`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1256`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1256`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1257`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1257`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1258`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1258`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1259`** (1 nodes): `data.ts`
+- **Thin community `Community 1259`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1260`** (1 nodes): `inviteColumns.tsx`
+- **Thin community `Community 1260`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1261`** (1 nodes): `constants.ts`
+- **Thin community `Community 1261`** (1 nodes): `inviteColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1262`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1262`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1263`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1263`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1264`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1264`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1265`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1265`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1266`** (1 nodes): `data.ts`
+- **Thin community `Community 1266`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1267`** (1 nodes): `membersColumns.tsx`
+- **Thin community `Community 1267`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1268`** (1 nodes): `organization-switcher.test.tsx`
+- **Thin community `Community 1268`** (1 nodes): `membersColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1269`** (1 nodes): `CashierView.tsx`
+- **Thin community `Community 1269`** (1 nodes): `organization-switcher.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1270`** (1 nodes): `POSRegisterView.tsx`
+- **Thin community `Community 1270`** (1 nodes): `CashierView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1271`** (1 nodes): `PaymentView.test.tsx`
+- **Thin community `Community 1271`** (1 nodes): `POSRegisterView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1272`** (1 nodes): `PointOfSaleView.test.tsx`
+- **Thin community `Community 1272`** (1 nodes): `PaymentView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1273`** (1 nodes): `PointOfSaleView.tsx`
+- **Thin community `Community 1273`** (1 nodes): `PointOfSaleView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1274`** (1 nodes): `ProductLookup.tsx`
+- **Thin community `Community 1274`** (1 nodes): `PointOfSaleView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1275`** (1 nodes): `RegisterActions.tsx`
+- **Thin community `Community 1275`** (1 nodes): `ProductLookup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1276`** (1 nodes): `SessionManager.test.tsx`
+- **Thin community `Community 1276`** (1 nodes): `RegisterActions.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1277`** (1 nodes): `SessionManager.tsx`
+- **Thin community `Community 1277`** (1 nodes): `SessionManager.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1278`** (1 nodes): `TotalsDisplay.test.tsx`
+- **Thin community `Community 1278`** (1 nodes): `SessionManager.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1279`** (1 nodes): `TotalsDisplay.tsx`
+- **Thin community `Community 1279`** (1 nodes): `TotalsDisplay.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1280`** (1 nodes): `ExpenseReportView.tsx`
+- **Thin community `Community 1280`** (1 nodes): `TotalsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1281`** (1 nodes): `ExpenseReportsView.test.ts`
+- **Thin community `Community 1281`** (1 nodes): `ExpenseReportView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1282`** (1 nodes): `ExpenseReportsView.test.tsx`
+- **Thin community `Community 1282`** (1 nodes): `ExpenseReportsView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1283`** (1 nodes): `expenseReportColumns.tsx`
+- **Thin community `Community 1283`** (1 nodes): `ExpenseReportsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1284`** (1 nodes): `PosReceiptShareControl.test.tsx`
+- **Thin community `Community 1284`** (1 nodes): `expenseReportColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1285`** (1 nodes): `POSRegisterOpeningGuard.test.tsx`
+- **Thin community `Community 1285`** (1 nodes): `PosReceiptShareControl.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1286`** (1 nodes): `POSRegisterView.test.tsx`
+- **Thin community `Community 1286`** (1 nodes): `POSRegisterOpeningGuard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1287`** (1 nodes): `RegisterActionBar.test.tsx`
+- **Thin community `Community 1287`** (1 nodes): `POSRegisterView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1288`** (1 nodes): `RegisterActionBar.tsx`
+- **Thin community `Community 1288`** (1 nodes): `RegisterActionBar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1289`** (1 nodes): `RegisterCheckoutPanel.tsx`
+- **Thin community `Community 1289`** (1 nodes): `RegisterActionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1290`** (1 nodes): `HeldSessionsList.test.tsx`
+- **Thin community `Community 1290`** (1 nodes): `RegisterCheckoutPanel.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1291`** (1 nodes): `POSSessionsView.test.tsx`
+- **Thin community `Community 1291`** (1 nodes): `HeldSessionsList.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1292`** (1 nodes): `posSessionColumns.tsx`
+- **Thin community `Community 1292`** (1 nodes): `POSSessionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1293`** (1 nodes): `POSSettingsView.test.tsx`
+- **Thin community `Community 1293`** (1 nodes): `posSessionColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1294`** (1 nodes): `TransactionsView.test.tsx`
+- **Thin community `Community 1294`** (1 nodes): `POSSettingsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1295`** (1 nodes): `types.ts`
+- **Thin community `Community 1295`** (1 nodes): `TransactionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1296`** (1 nodes): `ReceivingView.test.tsx`
+- **Thin community `Community 1296`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1297`** (1 nodes): `AnalyticsInsights.tsx`
+- **Thin community `Community 1297`** (1 nodes): `ReceivingView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1298`** (1 nodes): `AttributesView.tsx`
+- **Thin community `Community 1298`** (1 nodes): `AnalyticsInsights.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1299`** (1 nodes): `DetailsView.tsx`
+- **Thin community `Community 1299`** (1 nodes): `AttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1300`** (1 nodes): `ProductDetailView.tsx`
+- **Thin community `Community 1300`** (1 nodes): `DetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1301`** (1 nodes): `ArchivedProducts.tsx`
+- **Thin community `Community 1301`** (1 nodes): `ProductDetailView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1302`** (1 nodes): `CategoryListView.tsx`
+- **Thin community `Community 1302`** (1 nodes): `ArchivedProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1303`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
+- **Thin community `Community 1303`** (1 nodes): `CategoryListView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1304`** (1 nodes): `Products.tsx`
+- **Thin community `Community 1304`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1305`** (1 nodes): `StoreProducts.tsx`
+- **Thin community `Community 1305`** (1 nodes): `Products.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1306`** (1 nodes): `UnresolvedProducts.tsx`
+- **Thin community `Community 1306`** (1 nodes): `StoreProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1307`** (1 nodes): `ComplimentaryProducts.tsx`
+- **Thin community `Community 1307`** (1 nodes): `UnresolvedProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1308`** (1 nodes): `complimentaryProductsColumn.tsx`
+- **Thin community `Community 1308`** (1 nodes): `ComplimentaryProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1309`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1309`** (1 nodes): `complimentaryProductsColumn.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1310`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1310`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1311`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1311`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1312`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1312`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1313`** (1 nodes): `data.ts`
+- **Thin community `Community 1313`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1314`** (1 nodes): `productColumns.tsx`
+- **Thin community `Community 1314`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1315`** (1 nodes): `PromoCodeHeader.test.tsx`
+- **Thin community `Community 1315`** (1 nodes): `productColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1316`** (1 nodes): `PromoCodes.tsx`
+- **Thin community `Community 1316`** (1 nodes): `PromoCodeHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1317`** (1 nodes): `PromoCodeAnalytics.tsx`
+- **Thin community `Community 1317`** (1 nodes): `PromoCodes.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1318`** (1 nodes): `captured-emails-columns.tsx`
+- **Thin community `Community 1318`** (1 nodes): `PromoCodeAnalytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1319`** (1 nodes): `promoCodeMoney.test.ts`
+- **Thin community `Community 1319`** (1 nodes): `captured-emails-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1320`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1320`** (1 nodes): `promoCodeMoney.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1321`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1321`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1322`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1322`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1323`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1323`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1324`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1324`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1325`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1325`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1326`** (1 nodes): `constants.ts`
+- **Thin community `Community 1326`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1327`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1327`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1328`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1328`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1329`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1329`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1330`** (1 nodes): `data.ts`
+- **Thin community `Community 1330`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1331`** (1 nodes): `types.ts`
+- **Thin community `Community 1331`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1332`** (1 nodes): `welcome-offer-card.tsx`
+- **Thin community `Community 1332`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1333`** (1 nodes): `RatingStars.tsx`
+- **Thin community `Community 1333`** (1 nodes): `welcome-offer-card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1334`** (1 nodes): `ReviewCard.tsx`
+- **Thin community `Community 1334`** (1 nodes): `RatingStars.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1335`** (1 nodes): `ReviewMetadata.tsx`
+- **Thin community `Community 1335`** (1 nodes): `ReviewCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1336`** (1 nodes): `ServicesWorkspaceView.test.tsx`
+- **Thin community `Community 1336`** (1 nodes): `ReviewMetadata.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1337`** (1 nodes): `index.tsx`
+- **Thin community `Community 1337`** (1 nodes): `ServicesWorkspaceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1338`** (1 nodes): `StaffAuthenticationDialog.test.tsx`
+- **Thin community `Community 1338`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1339`** (1 nodes): `FeesView.test.ts`
+- **Thin community `Community 1339`** (1 nodes): `StaffAuthenticationDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1340`** (1 nodes): `FulfillmentView.test.tsx`
+- **Thin community `Community 1340`** (1 nodes): `StaffPinInput.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1341`** (1 nodes): `MaintenanceView.test.tsx`
+- **Thin community `Community 1341`** (1 nodes): `FeesView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1342`** (1 nodes): `MtnMomoView.test.tsx`
+- **Thin community `Community 1342`** (1 nodes): `FulfillmentView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1343`** (1 nodes): `useStoreConfigUpdate.test.tsx`
+- **Thin community `Community 1343`** (1 nodes): `MaintenanceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1344`** (1 nodes): `index.tsx`
+- **Thin community `Community 1344`** (1 nodes): `MtnMomoView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1345`** (1 nodes): `WorkflowTraceView.test.tsx`
+- **Thin community `Community 1345`** (1 nodes): `useStoreConfigUpdate.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1346`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 1346`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1347`** (1 nodes): `button.test.tsx`
+- **Thin community `Community 1347`** (1 nodes): `WorkflowTraceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1348`** (1 nodes): `button.tsx`
+- **Thin community `Community 1348`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1349`** (1 nodes): `calendar.test.tsx`
+- **Thin community `Community 1349`** (1 nodes): `button.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1350`** (1 nodes): `card.tsx`
+- **Thin community `Community 1350`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1351`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 1351`** (1 nodes): `calendar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1352`** (1 nodes): `collapsible.tsx`
+- **Thin community `Community 1352`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1353`** (1 nodes): `command.tsx`
+- **Thin community `Community 1353`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1354`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 1354`** (1 nodes): `collapsible.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1355`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 1355`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1356`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 1356`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1357`** (1 nodes): `form.tsx`
+- **Thin community `Community 1357`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1358`** (1 nodes): `icons.tsx`
+- **Thin community `Community 1358`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1359`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 1359`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1360`** (1 nodes): `input.tsx`
+- **Thin community `Community 1360`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1361`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 1361`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1362`** (1 nodes): `panel-header.tsx`
+- **Thin community `Community 1362`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1363`** (1 nodes): `popover.tsx`
+- **Thin community `Community 1363`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1364`** (1 nodes): `primitives.test.tsx`
+- **Thin community `Community 1364`** (1 nodes): `panel-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1365`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 1365`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1366`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 1366`** (1 nodes): `primitives.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1367`** (1 nodes): `select.tsx`
+- **Thin community `Community 1367`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1368`** (1 nodes): `separator.tsx`
+- **Thin community `Community 1368`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1369`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 1369`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1370`** (1 nodes): `switch.tsx`
+- **Thin community `Community 1370`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1371`** (1 nodes): `table.tsx`
+- **Thin community `Community 1371`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1372`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 1372`** (1 nodes): `switch.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1373`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 1373`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1374`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 1374`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1375`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 1375`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1376`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 1376`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1377`** (1 nodes): `upload-button.tsx`
+- **Thin community `Community 1377`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1378`** (1 nodes): `BagView.tsx`
+- **Thin community `Community 1378`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1379`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1379`** (1 nodes): `upload-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1380`** (1 nodes): `constants.ts`
+- **Thin community `Community 1380`** (1 nodes): `BagView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1381`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1381`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1382`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1382`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1383`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1383`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1384`** (1 nodes): `data.ts`
+- **Thin community `Community 1384`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1385`** (1 nodes): `bag-columns.tsx`
+- **Thin community `Community 1385`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1386`** (1 nodes): `bags-table.tsx`
+- **Thin community `Community 1386`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1387`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1387`** (1 nodes): `bag-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1388`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1388`** (1 nodes): `bags-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1389`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1389`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1390`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1390`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1391`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1391`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1392`** (1 nodes): `LinkedAccounts.tsx`
+- **Thin community `Community 1392`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1393`** (1 nodes): `TimelineEventCard.test.tsx`
+- **Thin community `Community 1393`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1394`** (1 nodes): `UserCheckoutSession.tsx`
+- **Thin community `Community 1394`** (1 nodes): `LinkedAccounts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1395`** (1 nodes): `UserInsightsSection.tsx`
+- **Thin community `Community 1395`** (1 nodes): `TimelineEventCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1396`** (1 nodes): `index.ts`
+- **Thin community `Community 1396`** (1 nodes): `UserCheckoutSession.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1397`** (1 nodes): `config.test.ts`
+- **Thin community `Community 1397`** (1 nodes): `UserInsightsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1398`** (1 nodes): `ThemeContext.tsx`
+- **Thin community `Community 1398`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1399`** (1 nodes): `design-system-build-config.test.ts`
+- **Thin community `Community 1399`** (1 nodes): `config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1400`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 1400`** (1 nodes): `ThemeContext.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1401`** (1 nodes): `useAuth.test.tsx`
+- **Thin community `Community 1401`** (1 nodes): `design-system-build-config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1402`** (1 nodes): `useExpenseSessions.test.ts`
+- **Thin community `Community 1402`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1403`** (1 nodes): `useGetTerminal.test.ts`
+- **Thin community `Community 1403`** (1 nodes): `useAuth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1404`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 1404`** (1 nodes): `useExpenseSessions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1405`** (1 nodes): `useProtectedAdminPageState.test.tsx`
+- **Thin community `Community 1405`** (1 nodes): `useGetTerminal.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1406`** (1 nodes): `capabilities.test.ts`
+- **Thin community `Community 1406`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1407`** (1 nodes): `aws.ts`
+- **Thin community `Community 1407`** (1 nodes): `useProtectedAdminPageState.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1408`** (1 nodes): `constants.ts`
+- **Thin community `Community 1408`** (1 nodes): `capabilities.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1409`** (1 nodes): `countries.ts`
+- **Thin community `Community 1409`** (1 nodes): `aws.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1410`** (1 nodes): `operatorMessages.test.ts`
+- **Thin community `Community 1410`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1411`** (1 nodes): `presentCommandToast.test.ts`
+- **Thin community `Community 1411`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1412`** (1 nodes): `presentUnexpectedErrorToast.test.ts`
+- **Thin community `Community 1412`** (1 nodes): `operatorMessages.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1413`** (1 nodes): `runCommand.test.ts`
+- **Thin community `Community 1413`** (1 nodes): `presentCommandToast.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1414`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1414`** (1 nodes): `presentUnexpectedErrorToast.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1415`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 1415`** (1 nodes): `runCommand.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1416`** (1 nodes): `dto.ts`
+- **Thin community `Community 1416`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1417`** (1 nodes): `ports.ts`
+- **Thin community `Community 1417`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1418`** (1 nodes): `constants.ts`
+- **Thin community `Community 1418`** (1 nodes): `dto.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1419`** (1 nodes): `displayAmounts.test.ts`
+- **Thin community `Community 1419`** (1 nodes): `ports.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1420`** (1 nodes): `cart.test.ts`
+- **Thin community `Community 1420`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1421`** (1 nodes): `index.ts`
+- **Thin community `Community 1421`** (1 nodes): `displayAmounts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1422`** (1 nodes): `session.test.ts`
+- **Thin community `Community 1422`** (1 nodes): `cart.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1423`** (1 nodes): `types.ts`
+- **Thin community `Community 1423`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1424`** (1 nodes): `registerGateway.test.ts`
+- **Thin community `Community 1424`** (1 nodes): `session.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1425`** (1 nodes): `sessionGateway.test.ts`
+- **Thin community `Community 1425`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1426`** (1 nodes): `localCommandGateway.test.ts`
+- **Thin community `Community 1426`** (1 nodes): `registerGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1427`** (1 nodes): `localPosEntryContext.test.ts`
+- **Thin community `Community 1427`** (1 nodes): `sessionGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1428`** (1 nodes): `localPosReadiness.test.ts`
+- **Thin community `Community 1428`** (1 nodes): `localCommandGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1429`** (1 nodes): `loggerGateway.ts`
+- **Thin community `Community 1429`** (1 nodes): `localPosEntryContext.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1430`** (1 nodes): `catalogSearch.test.ts`
+- **Thin community `Community 1430`** (1 nodes): `localPosReadiness.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1431`** (1 nodes): `registerUiState.ts`
+- **Thin community `Community 1431`** (1 nodes): `loggerGateway.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1432`** (1 nodes): `syncStatusPresentation.test.ts`
+- **Thin community `Community 1432`** (1 nodes): `catalogSearch.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1433`** (1 nodes): `productUtils.test.ts`
+- **Thin community `Community 1433`** (1 nodes): `registerUiState.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1434`** (1 nodes): `category.ts`
+- **Thin community `Community 1434`** (1 nodes): `syncStatusPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1435`** (1 nodes): `product.ts`
+- **Thin community `Community 1435`** (1 nodes): `productUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1436`** (1 nodes): `store.ts`
+- **Thin community `Community 1436`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1437`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1437`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1438`** (1 nodes): `user.ts`
+- **Thin community `Community 1438`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1439`** (1 nodes): `localPinVerifier.test.ts`
+- **Thin community `Community 1439`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1440`** (1 nodes): `storeConfig.test.ts`
+- **Thin community `Community 1440`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1441`** (1 nodes): `createWorkflowTraceId.test.ts`
+- **Thin community `Community 1441`** (1 nodes): `localPinVerifier.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1442`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1442`** (1 nodes): `storeConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1443`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 1443`** (1 nodes): `createWorkflowTraceId.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1444`** (1 nodes): `__root.tsx`
+- **Thin community `Community 1444`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1445`** (1 nodes): `index.tsx`
+- **Thin community `Community 1445`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1446`** (1 nodes): `index.tsx`
+- **Thin community `Community 1446`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1447`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1448`** (1 nodes): `$storeUrlSlug.tsx`
+- **Thin community `Community 1448`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1449`** (1 nodes): `analytics.tsx`
+- **Thin community `Community 1449`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1450`** (1 nodes): `assets.index.tsx`
+- **Thin community `Community 1450`** (1 nodes): `$storeUrlSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1451`** (1 nodes): `bags.$bagId.tsx`
+- **Thin community `Community 1451`** (1 nodes): `analytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1452`** (1 nodes): `bags.index.tsx`
+- **Thin community `Community 1452`** (1 nodes): `assets.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1453`** (1 nodes): `index.tsx`
+- **Thin community `Community 1453`** (1 nodes): `bags.$bagId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1454`** (1 nodes): `checkout-sessions.index.tsx`
+- **Thin community `Community 1454`** (1 nodes): `bags.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1455`** (1 nodes): `configuration.index.tsx`
+- **Thin community `Community 1455`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1456`** (1 nodes): `dashboard.index.tsx`
+- **Thin community `Community 1456`** (1 nodes): `checkout-sessions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1457`** (1 nodes): `home.tsx`
+- **Thin community `Community 1457`** (1 nodes): `configuration.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1458`** (1 nodes): `logs.$logId.tsx`
+- **Thin community `Community 1458`** (1 nodes): `dashboard.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1459`** (1 nodes): `logs.index.tsx`
+- **Thin community `Community 1459`** (1 nodes): `home.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1460`** (1 nodes): `members.index.tsx`
+- **Thin community `Community 1460`** (1 nodes): `logs.$logId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1461`** (1 nodes): `index.tsx`
+- **Thin community `Community 1461`** (1 nodes): `logs.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1462`** (1 nodes): `sku-activity.test.tsx`
+- **Thin community `Community 1462`** (1 nodes): `members.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1463`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1464`** (1 nodes): `all.index.tsx`
+- **Thin community `Community 1464`** (1 nodes): `sku-activity.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1465`** (1 nodes): `cancelled.index.tsx`
+- **Thin community `Community 1465`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1466`** (1 nodes): `completed.index.tsx`
+- **Thin community `Community 1466`** (1 nodes): `all.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1467`** (1 nodes): `index.tsx`
+- **Thin community `Community 1467`** (1 nodes): `cancelled.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1468`** (1 nodes): `open.index.tsx`
+- **Thin community `Community 1468`** (1 nodes): `completed.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1469`** (1 nodes): `out-for-delivery.index.tsx`
+- **Thin community `Community 1469`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1470`** (1 nodes): `ready.index.tsx`
+- **Thin community `Community 1470`** (1 nodes): `open.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1471`** (1 nodes): `refunded.index.tsx`
+- **Thin community `Community 1471`** (1 nodes): `out-for-delivery.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1472`** (1 nodes): `$reportId.tsx`
+- **Thin community `Community 1472`** (1 nodes): `ready.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1473`** (1 nodes): `expense-reports.index.tsx`
+- **Thin community `Community 1473`** (1 nodes): `refunded.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1474`** (1 nodes): `index.tsx`
+- **Thin community `Community 1474`** (1 nodes): `$reportId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1475`** (1 nodes): `register.index.tsx`
+- **Thin community `Community 1475`** (1 nodes): `expense-reports.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1476`** (1 nodes): `sessions.index.tsx`
+- **Thin community `Community 1476`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1477`** (1 nodes): `settings.index.tsx`
+- **Thin community `Community 1477`** (1 nodes): `register.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1478`** (1 nodes): `$transactionId.tsx`
+- **Thin community `Community 1478`** (1 nodes): `sessions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1479`** (1 nodes): `transactions.index.tsx`
+- **Thin community `Community 1479`** (1 nodes): `settings.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1480`** (1 nodes): `procurement.index.test.ts`
+- **Thin community `Community 1480`** (1 nodes): `$transactionId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1481`** (1 nodes): `edit.tsx`
+- **Thin community `Community 1481`** (1 nodes): `transactions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1482`** (1 nodes): `index.tsx`
+- **Thin community `Community 1482`** (1 nodes): `procurement.index.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1483`** (1 nodes): `archived.tsx`
+- **Thin community `Community 1483`** (1 nodes): `edit.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1484`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1485`** (1 nodes): `new.tsx`
+- **Thin community `Community 1485`** (1 nodes): `archived.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1486`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1487`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1488`** (1 nodes): `unresolved.tsx`
+- **Thin community `Community 1488`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1489`** (1 nodes): `$promoCodeSlug.tsx`
+- **Thin community `Community 1489`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1490`** (1 nodes): `index.tsx`
+- **Thin community `Community 1490`** (1 nodes): `unresolved.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1491`** (1 nodes): `new.tsx`
+- **Thin community `Community 1491`** (1 nodes): `$promoCodeSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1492`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1493`** (1 nodes): `new.index.tsx`
+- **Thin community `Community 1493`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1494`** (1 nodes): `active-cases.index.tsx`
+- **Thin community `Community 1494`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1495`** (1 nodes): `appointments.index.tsx`
+- **Thin community `Community 1495`** (1 nodes): `new.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1496`** (1 nodes): `catalog-management.index.tsx`
+- **Thin community `Community 1496`** (1 nodes): `active-cases.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1497`** (1 nodes): `index.tsx`
+- **Thin community `Community 1497`** (1 nodes): `appointments.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1498`** (1 nodes): `intake.index.tsx`
+- **Thin community `Community 1498`** (1 nodes): `catalog-management.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1499`** (1 nodes): `$traceId.test.tsx`
+- **Thin community `Community 1499`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1500`** (1 nodes): `users.$userId.tsx`
+- **Thin community `Community 1500`** (1 nodes): `intake.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1501`** (1 nodes): `index.tsx`
+- **Thin community `Community 1501`** (1 nodes): `$traceId.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1502`** (1 nodes): `_authed.test.tsx`
+- **Thin community `Community 1502`** (1 nodes): `users.$userId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1503`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 1503`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1504`** (1 nodes): `join-team.index.tsx`
+- **Thin community `Community 1504`** (1 nodes): `_authed.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1505`** (1 nodes): `landing.tsx`
+- **Thin community `Community 1505`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1506`** (1 nodes): `_layout.index.test.tsx`
+- **Thin community `Community 1506`** (1 nodes): `join-team.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1507`** (1 nodes): `_layout.test.tsx`
+- **Thin community `Community 1507`** (1 nodes): `landing.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1508`** (1 nodes): `StoresSettingsAccordion.tsx`
+- **Thin community `Community 1508`** (1 nodes): `_layout.index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1509`** (1 nodes): `expenseStore.ts`
+- **Thin community `Community 1509`** (1 nodes): `_layout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1510`** (1 nodes): `Overview.stories.tsx`
+- **Thin community `Community 1510`** (1 nodes): `StoresSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1511`** (1 nodes): `foundations-content.test.tsx`
+- **Thin community `Community 1511`** (1 nodes): `expenseStore.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1512`** (1 nodes): `Introduction.stories.tsx`
+- **Thin community `Community 1512`** (1 nodes): `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1513`** (1 nodes): `introduction-content.test.tsx`
+- **Thin community `Community 1513`** (1 nodes): `foundations-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1514`** (1 nodes): `introduction-content.tsx`
+- **Thin community `Community 1514`** (1 nodes): `Introduction.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1515`** (1 nodes): `AdminShell.stories.tsx`
+- **Thin community `Community 1515`** (1 nodes): `introduction-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1516`** (1 nodes): `View.stories.tsx`
+- **Thin community `Community 1516`** (1 nodes): `introduction-content.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1517`** (1 nodes): `admin-shell-patterns.test.tsx`
+- **Thin community `Community 1517`** (1 nodes): `AdminShell.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1518`** (1 nodes): `view-patterns.test.tsx`
+- **Thin community `Community 1518`** (1 nodes): `View.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1519`** (1 nodes): `Surfaces.stories.tsx`
+- **Thin community `Community 1519`** (1 nodes): `admin-shell-patterns.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1520`** (1 nodes): `DashboardWorkspace.stories.tsx`
+- **Thin community `Community 1520`** (1 nodes): `view-patterns.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1521`** (1 nodes): `DataWorkspace.stories.tsx`
+- **Thin community `Community 1521`** (1 nodes): `Surfaces.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1522`** (1 nodes): `SettingsWorkspace.stories.tsx`
+- **Thin community `Community 1522`** (1 nodes): `DashboardWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1523`** (1 nodes): `reference-fixtures.test.tsx`
+- **Thin community `Community 1523`** (1 nodes): `DataWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1524`** (1 nodes): `storybook-config.test.ts`
+- **Thin community `Community 1524`** (1 nodes): `SettingsWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1525`** (1 nodes): `storybook-theme-decorator.test.ts`
+- **Thin community `Community 1525`** (1 nodes): `reference-fixtures.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1526`** (1 nodes): `setup.ts`
+- **Thin community `Community 1526`** (1 nodes): `storybook-config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1527`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 1527`** (1 nodes): `storybook-theme-decorator.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1528`** (1 nodes): `types.ts`
+- **Thin community `Community 1528`** (1 nodes): `setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1529`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 1529`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1530`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 1530`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1531`** (1 nodes): `global.d.ts`
+- **Thin community `Community 1531`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1532`** (1 nodes): `playwright.config.ts`
+- **Thin community `Community 1532`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1533`** (1 nodes): `analytics.test.ts`
+- **Thin community `Community 1533`** (1 nodes): `global.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1534`** (1 nodes): `types.ts`
+- **Thin community `Community 1534`** (1 nodes): `playwright.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1535`** (1 nodes): `HeartIconFilled.tsx`
+- **Thin community `Community 1535`** (1 nodes): `analytics.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1536`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 1536`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1537`** (1 nodes): `HomePage.test.tsx`
+- **Thin community `Community 1537`** (1 nodes): `HeartIconFilled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1538`** (1 nodes): `ProductCard.test.tsx`
+- **Thin community `Community 1538`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1539`** (1 nodes): `ProductCard.tsx`
+- **Thin community `Community 1539`** (1 nodes): `HomePage.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1540`** (1 nodes): `Upsell.tsx`
+- **Thin community `Community 1540`** (1 nodes): `ProductCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1541`** (1 nodes): `Checkout.test.tsx`
+- **Thin community `Community 1541`** (1 nodes): `ProductCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1542`** (1 nodes): `Checkout.tsx`
+- **Thin community `Community 1542`** (1 nodes): `Upsell.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1543`** (1 nodes): `CustomerInfoSection.tsx`
+- **Thin community `Community 1543`** (1 nodes): `Checkout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1544`** (1 nodes): `schema.ts`
+- **Thin community `Community 1544`** (1 nodes): `Checkout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1545`** (1 nodes): `DeliveryDetailsSection.tsx`
+- **Thin community `Community 1545`** (1 nodes): `CustomerInfoSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1546`** (1 nodes): `checkoutStorage.test.ts`
+- **Thin community `Community 1546`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1547`** (1 nodes): `deliveryFees.test.ts`
+- **Thin community `Community 1547`** (1 nodes): `DeliveryDetailsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1548`** (1 nodes): `deriveCheckoutState.test.ts`
+- **Thin community `Community 1548`** (1 nodes): `checkoutStorage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1549`** (1 nodes): `billingDetailsSchema.ts`
+- **Thin community `Community 1549`** (1 nodes): `deliveryFees.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1550`** (1 nodes): `checkoutFormSchema.ts`
+- **Thin community `Community 1550`** (1 nodes): `deriveCheckoutState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1551`** (1 nodes): `customerDetailsSchema.ts`
+- **Thin community `Community 1551`** (1 nodes): `billingDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1552`** (1 nodes): `deliveryDetailsSchema.ts`
+- **Thin community `Community 1552`** (1 nodes): `checkoutFormSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1553`** (1 nodes): `webOrderSchema.ts`
+- **Thin community `Community 1553`** (1 nodes): `customerDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1554`** (1 nodes): `types.ts`
+- **Thin community `Community 1554`** (1 nodes): `deliveryDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1555`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1555`** (1 nodes): `webOrderSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1556`** (1 nodes): `ProductFilterBar.tsx`
+- **Thin community `Community 1556`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1557`** (1 nodes): `BestSellersSection.test.tsx`
+- **Thin community `Community 1557`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1558`** (1 nodes): `HomeHero.tsx`
+- **Thin community `Community 1558`** (1 nodes): `ProductFilterBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1559`** (1 nodes): `HomeHeroSection.tsx`
+- **Thin community `Community 1559`** (1 nodes): `BestSellersSection.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1560`** (1 nodes): `homePageContent.test.ts`
+- **Thin community `Community 1560`** (1 nodes): `HomeHero.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1561`** (1 nodes): `MobileMenu.tsx`
+- **Thin community `Community 1561`** (1 nodes): `HomeHeroSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1562`** (1 nodes): `constants.ts`
+- **Thin community `Community 1562`** (1 nodes): `homePageContent.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1563`** (1 nodes): `navBarConstants.ts`
+- **Thin community `Community 1563`** (1 nodes): `MobileMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1564`** (1 nodes): `About.tsx`
+- **Thin community `Community 1564`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1565`** (1 nodes): `AboutProduct.tsx`
+- **Thin community `Community 1565`** (1 nodes): `navBarConstants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1566`** (1 nodes): `ProductActions.test.tsx`
+- **Thin community `Community 1566`** (1 nodes): `About.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1567`** (1 nodes): `ProductInfo.tsx`
+- **Thin community `Community 1567`** (1 nodes): `AboutProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1568`** (1 nodes): `ProductReviews.tsx`
+- **Thin community `Community 1568`** (1 nodes): `ProductActions.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1569`** (1 nodes): `ProductsNavigationBar.tsx`
+- **Thin community `Community 1569`** (1 nodes): `ProductInfo.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1570`** (1 nodes): `ErrorMessage.tsx`
+- **Thin community `Community 1570`** (1 nodes): `ProductReviews.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1571`** (1 nodes): `ExistingReviewMessage.tsx`
+- **Thin community `Community 1571`** (1 nodes): `ProductsNavigationBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1572`** (1 nodes): `OrderItem.test.tsx`
+- **Thin community `Community 1572`** (1 nodes): `ErrorMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1573`** (1 nodes): `ReviewForm.tsx`
+- **Thin community `Community 1573`** (1 nodes): `ExistingReviewMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1574`** (1 nodes): `SuccessMessage.tsx`
+- **Thin community `Community 1574`** (1 nodes): `OrderItem.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1575`** (1 nodes): `types.ts`
+- **Thin community `Community 1575`** (1 nodes): `ReviewForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1576`** (1 nodes): `SavedBag.tsx`
+- **Thin community `Community 1576`** (1 nodes): `SuccessMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1577`** (1 nodes): `SavedIcon.tsx`
+- **Thin community `Community 1577`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1578`** (1 nodes): `CartIcon.tsx`
+- **Thin community `Community 1578`** (1 nodes): `SavedBag.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1579`** (1 nodes): `ShoppingBag.test.tsx`
+- **Thin community `Community 1579`** (1 nodes): `SavedIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1580`** (1 nodes): `empty-state.tsx`
+- **Thin community `Community 1580`** (1 nodes): `CartIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1581`** (1 nodes): `Maintenance.test.tsx`
+- **Thin community `Community 1581`** (1 nodes): `ShoppingBag.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1582`** (1 nodes): `Maintenance.tsx`
+- **Thin community `Community 1582`** (1 nodes): `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1583`** (1 nodes): `AnimatedCard.tsx`
+- **Thin community `Community 1583`** (1 nodes): `Maintenance.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1584`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 1584`** (1 nodes): `Maintenance.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1585`** (1 nodes): `alert.tsx`
+- **Thin community `Community 1585`** (1 nodes): `AnimatedCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1586`** (1 nodes): `breadcrumb.tsx`
+- **Thin community `Community 1586`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1587`** (1 nodes): `button.tsx`
+- **Thin community `Community 1587`** (1 nodes): `alert.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1588`** (1 nodes): `card.tsx`
+- **Thin community `Community 1588`** (1 nodes): `breadcrumb.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1589`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 1589`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1590`** (1 nodes): `command.tsx`
+- **Thin community `Community 1590`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1591`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 1591`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1592`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 1592`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1593`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 1593`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1594`** (1 nodes): `form.tsx`
+- **Thin community `Community 1594`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1595`** (1 nodes): `icons.tsx`
+- **Thin community `Community 1595`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1596`** (1 nodes): `image-with-fallback.tsx`
+- **Thin community `Community 1596`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1597`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 1597`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1598`** (1 nodes): `input-with-end-button.tsx`
+- **Thin community `Community 1598`** (1 nodes): `image-with-fallback.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1599`** (1 nodes): `input.tsx`
+- **Thin community `Community 1599`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1600`** (1 nodes): `label.tsx`
+- **Thin community `Community 1600`** (1 nodes): `input-with-end-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1601`** (1 nodes): `LeaveAReviewModalForm.tsx`
+- **Thin community `Community 1601`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1602`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 1602`** (1 nodes): `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1603`** (1 nodes): `welcomeBackModalAnimations.ts`
+- **Thin community `Community 1603`** (1 nodes): `LeaveAReviewModalForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1604`** (1 nodes): `index.ts`
+- **Thin community `Community 1604`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1605`** (1 nodes): `types.ts`
+- **Thin community `Community 1605`** (1 nodes): `welcomeBackModalAnimations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1606`** (1 nodes): `navigation-menu.tsx`
+- **Thin community `Community 1606`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1607`** (1 nodes): `popover.tsx`
+- **Thin community `Community 1607`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1608`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 1608`** (1 nodes): `navigation-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1609`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 1609`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1610`** (1 nodes): `select.tsx`
+- **Thin community `Community 1610`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1611`** (1 nodes): `separator.tsx`
+- **Thin community `Community 1611`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1612`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 1612`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1613`** (1 nodes): `table.tsx`
+- **Thin community `Community 1613`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1614`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 1614`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1615`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 1615`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1616`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 1616`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1617`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 1617`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1618`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 1618`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1619`** (1 nodes): `config.ts`
+- **Thin community `Community 1619`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1620`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 1620`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1621`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 1621`** (1 nodes): `config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1622`** (1 nodes): `useQueryEnabled.test.ts`
+- **Thin community `Community 1622`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1623`** (1 nodes): `useStorefrontObservability.ts`
+- **Thin community `Community 1623`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1624`** (1 nodes): `constants.ts`
+- **Thin community `Community 1624`** (1 nodes): `useQueryEnabled.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1625`** (1 nodes): `countries.ts`
+- **Thin community `Community 1625`** (1 nodes): `useStorefrontObservability.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1626`** (1 nodes): `feeUtils.test.ts`
+- **Thin community `Community 1626`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1627`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1627`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1628`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 1628`** (1 nodes): `feeUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1629`** (1 nodes): `maintenanceUtils.test.ts`
+- **Thin community `Community 1629`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1630`** (1 nodes): `index.ts`
+- **Thin community `Community 1630`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1631`** (1 nodes): `store.ts`
+- **Thin community `Community 1631`** (1 nodes): `maintenanceUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1632`** (1 nodes): `bag.ts`
+- **Thin community `Community 1632`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1633`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1633`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1634`** (1 nodes): `category.ts`
+- **Thin community `Community 1634`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1635`** (1 nodes): `organization.ts`
+- **Thin community `Community 1635`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1636`** (1 nodes): `product.ts`
+- **Thin community `Community 1636`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1637`** (1 nodes): `store.ts`
+- **Thin community `Community 1637`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1638`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1638`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1639`** (1 nodes): `user.ts`
+- **Thin community `Community 1639`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1640`** (1 nodes): `states.ts`
+- **Thin community `Community 1640`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1641`** (1 nodes): `storefrontFailureObservability.test.ts`
+- **Thin community `Community 1641`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1642`** (1 nodes): `storefrontJourneyEvents.test.ts`
+- **Thin community `Community 1642`** (1 nodes): `states.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1643`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1643`** (1 nodes): `storefrontFailureObservability.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1644`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 1644`** (1 nodes): `storefrontJourneyEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1645`** (1 nodes): `-homePageLoader.test.ts`
+- **Thin community `Community 1645`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1646`** (1 nodes): `__root.tsx`
+- **Thin community `Community 1646`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1647`** (1 nodes): `$orderItemId.review.tsx`
+- **Thin community `Community 1647`** (1 nodes): `-homePageLoader.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1648`** (1 nodes): `index.tsx`
+- **Thin community `Community 1648`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1649`** (1 nodes): `$subcategorySlug.tsx`
+- **Thin community `Community 1649`** (1 nodes): `$orderItemId.review.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1650`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1651`** (1 nodes): `rewards.index.tsx`
+- **Thin community `Community 1651`** (1 nodes): `$subcategorySlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1652`** (1 nodes): `shop.saved.index.tsx`
+- **Thin community `Community 1652`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1653`** (1 nodes): `bag.index.tsx`
+- **Thin community `Community 1653`** (1 nodes): `rewards.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1654`** (1 nodes): `complete.tsx`
+- **Thin community `Community 1654`** (1 nodes): `shop.saved.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1655`** (1 nodes): `incomplete.tsx`
+- **Thin community `Community 1655`** (1 nodes): `bag.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1656`** (1 nodes): `index.tsx`
+- **Thin community `Community 1656`** (1 nodes): `complete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1657`** (1 nodes): `pending.tsx`
+- **Thin community `Community 1657`** (1 nodes): `incomplete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1658`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 1658`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1659`** (1 nodes): `storefront-boot.e2e.ts`
+- **Thin community `Community 1659`** (1 nodes): `pending.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1660`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 1660`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1661`** (1 nodes): `vitest.setup.ts`
+- **Thin community `Community 1661`** (1 nodes): `storefront-boot.e2e.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1662`** (1 nodes): `index.js`
+- **Thin community `Community 1662`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1663`** (1 nodes): `harness-app-registry.test.ts`
+- **Thin community `Community 1663`** (1 nodes): `vitest.setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1664`** (1 nodes): `athena-runtime-app.test.ts`
+- **Thin community `Community 1664`** (1 nodes): `index.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1665`** (1 nodes): `storefront-runtime-api.test.ts`
+- **Thin community `Community 1665`** (1 nodes): `harness-app-registry.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1666`** (1 nodes): `valkey-runtime-app.test.ts`
+- **Thin community `Community 1666`** (1 nodes): `athena-runtime-app.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1667`** (1 nodes): `harness-behavior-scenarios.test.ts`
+- **Thin community `Community 1667`** (1 nodes): `storefront-runtime-api.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1668`** (1 nodes): `harness-repo-validation.test.ts`
+- **Thin community `Community 1668`** (1 nodes): `valkey-runtime-app.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1669`** (1 nodes): `harness-behavior-scenarios.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1670`** (1 nodes): `harness-repo-validation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -7,10 +7,10 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 - [packages/AGENTS.md](../../packages/AGENTS.md) - package router plus the operational guides for each harnessed package
 
 ## Repo Summary
-- Code files discovered: 1740
-- Graph nodes: 5481
-- Graph edges: 5707
-- Communities: 1669
+- Code files discovered: 1742
+- Graph nodes: 5489
+- Graph edges: 5714
+- Communities: 1671
 
 ## Graph Hotspots
 - `DailyCloseView.tsx` (82 edges, Community 0) - [`packages/athena-webapp/src/components/operations/DailyCloseView.tsx`](../../packages/athena-webapp/src/components/operations/DailyCloseView.tsx)

--- a/graphify-out/wiki/packages/valkey-proxy-server.md
+++ b/graphify-out/wiki/packages/valkey-proxy-server.md
@@ -18,7 +18,7 @@ Landing page for packages/valkey-proxy-server. Use this page to orient around gr
 
 ## Graph Hotspots
 - `app.js` (14 edges, Community 62) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
-- `app.test.js` (6 edges, Community 108) - [`packages/valkey-proxy-server/app.test.js`](../../../packages/valkey-proxy-server/app.test.js)
+- `app.test.js` (6 edges, Community 109) - [`packages/valkey-proxy-server/app.test.js`](../../../packages/valkey-proxy-server/app.test.js)
 - `createRedisClient()` (4 edges, Community 62) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
 - `createRedisCluster()` (3 edges, Community 62) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
 - `deleteKeysIndividually()` (3 edges, Community 62) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)

--- a/packages/athena-webapp/convex/operations/staffCredentials.test.ts
+++ b/packages/athena-webapp/convex/operations/staffCredentials.test.ts
@@ -16,14 +16,17 @@ vi.mock("../lib/athenaUserAuth", () => ({
 
 import {
   authenticateStaffCredential,
+  authenticateStaffCredentialForApproval,
   authenticateStaffCredentialForApprovalWithCtx,
   authenticateStaffCredentialForTerminal,
   authenticateStaffCredentialWithCtx,
   authenticateStaffCredentialForTerminalWithCtx,
+  createStaffCredential,
   createStaffCredentialWithCtx,
   getStaffCredentialUsernameAvailabilityWithCtx,
   listStaffCredentialsByStoreWithCtx,
   refreshTerminalStaffAuthority,
+  updateStaffCredential,
   updateStaffCredentialWithCtx,
 } from "./staffCredentials";
 import { hashPosLocalStaffProofToken } from "../pos/application/sync/staffProof";
@@ -227,6 +230,254 @@ describe("staff credential operations", () => {
     ).resolves.toEqual({
       available: true,
       normalizedUsername: "new-user",
+    });
+  });
+
+  it("requires store access before public staff authentication can affect lockout state", async () => {
+    const { ctx, tables } = createStaffCredentialsMutationCtx({
+      credentials: [
+        {
+          _id: "credential-1",
+          staffProfileId: "staff_profile_1",
+          organizationId: "org_1",
+          storeId: "store_1",
+          username: "frontdesk",
+          pinHash: "hash-1",
+          status: "active",
+        },
+      ],
+      profiles: [
+        {
+          _id: "staff_profile_1",
+          storeId: "store_1",
+          organizationId: "org_1",
+          status: "active",
+          fullName: "Ari Mensah",
+        },
+      ],
+      roles: [
+        {
+          _id: "role_1",
+          staffProfileId: "staff_profile_1",
+          organizationId: "org_1",
+          storeId: "store_1",
+          role: "cashier",
+          isPrimary: true,
+          status: "active",
+          assignedAt: 1,
+        },
+      ],
+    });
+    authMocks.requireAuthenticatedAthenaUserWithCtx.mockRejectedValueOnce(
+      new Error("Sign in again to continue."),
+    );
+
+    const result = await getHandler(authenticateStaffCredential)(ctx, {
+      allowedRoles: ["cashier"],
+      storeId: "store_1" as Id<"store">,
+      username: "frontdesk",
+      pinHash: "wrong-hash",
+    });
+
+    expect(result).toEqual({
+      kind: "user_error",
+      error: {
+        code: "authorization_failed",
+        message: "You do not have access to authenticate staff for this store.",
+      },
+    });
+    expect(tables.staffCredential.get("credential-1")).not.toHaveProperty(
+      "failedAuthenticationAttempts",
+    );
+    expect(tables.staffCredential.get("credential-1")).not.toHaveProperty(
+      "authenticationLockedUntil",
+    );
+  });
+
+  it("requires store access before public manager approval authentication can mint proofs", async () => {
+    const { ctx, tables } = createStaffCredentialsMutationCtx({
+      credentials: [
+        {
+          _id: "credential-1",
+          staffProfileId: "manager-1",
+          organizationId: "org_1",
+          storeId: "store_1",
+          username: "manager",
+          pinHash: "hash-1",
+          status: "active",
+        },
+      ],
+      profiles: [
+        {
+          _id: "manager-1",
+          storeId: "store_1",
+          organizationId: "org_1",
+          status: "active",
+          fullName: "Ari Mensah",
+        },
+      ],
+      roles: [
+        {
+          _id: "role_1",
+          staffProfileId: "manager-1",
+          organizationId: "org_1",
+          storeId: "store_1",
+          role: "manager",
+          isPrimary: true,
+          status: "active",
+          assignedAt: 1,
+        },
+      ],
+    });
+    authMocks.requireOrganizationMemberRoleWithCtx.mockRejectedValueOnce(
+      new Error("You do not have access to authenticate staff for this store."),
+    );
+
+    const result = await getHandler(authenticateStaffCredentialForApproval)(
+      ctx,
+      {
+        actionKey: "pos.transaction.payment_method.correct",
+        pinHash: "hash-1",
+        reason: "Completed transactions require manager approval.",
+        requiredRole: "manager",
+        requestedByStaffProfileId: "cashier-1" as Id<"staffProfile">,
+        storeId: "store_1" as Id<"store">,
+        subject: {
+          type: "pos_transaction",
+          id: "transaction-1",
+          label: "Receipt 1001",
+        },
+        username: "manager",
+      },
+    );
+
+    expect(result).toEqual({
+      kind: "user_error",
+      error: {
+        code: "authorization_failed",
+        message: "You do not have access to authenticate staff for this store.",
+      },
+    });
+    expect(tables.approvalProof.size).toBe(0);
+    expect(tables.staffCredential.get("credential-1")).not.toHaveProperty(
+      "lastAuthenticatedAt",
+    );
+  });
+
+  it("requires full admin access before creating staff credentials through the public mutation", async () => {
+    const { ctx, tables } = createStaffCredentialsMutationCtx({
+      profiles: [
+        {
+          _id: "staff_profile_1",
+          storeId: "store_1",
+          organizationId: "org_1",
+          status: "active",
+          fullName: "Ari Mensah",
+        },
+      ],
+      roles: [
+        {
+          _id: "role_1",
+          staffProfileId: "staff_profile_1",
+          organizationId: "org_1",
+          storeId: "store_1",
+          role: "cashier",
+          isPrimary: true,
+          status: "active",
+          assignedAt: 1,
+        },
+      ],
+    });
+    authMocks.requireOrganizationMemberRoleWithCtx.mockRejectedValueOnce(
+      new Error("You do not have access to manage staff credentials."),
+    );
+
+    await expect(
+      getHandler(createStaffCredential)(ctx, {
+        organizationId: "org_1" as Id<"organization">,
+        pinHash: "hash-1",
+        staffProfileId: "staff_profile_1" as Id<"staffProfile">,
+        storeId: "store_1" as Id<"store">,
+        username: "frontdesk",
+      }),
+    ).resolves.toEqual({
+      kind: "user_error",
+      error: {
+        code: "authorization_failed",
+        message: "You do not have access to manage staff credentials.",
+      },
+    });
+    expect(tables.staffCredential.size).toBe(0);
+    expect(authMocks.requireOrganizationMemberRoleWithCtx).toHaveBeenCalledWith(
+      ctx,
+      {
+        allowedRoles: ["full_admin"],
+        failureMessage: "You do not have access to manage staff credentials.",
+        organizationId: "org_1",
+        userId: "athena-user-1",
+      },
+    );
+  });
+
+  it("requires full admin access before public credential updates can reset PINs or clear lockout", async () => {
+    const { ctx, tables } = createStaffCredentialsMutationCtx({
+      credentials: [
+        {
+          _id: "credential-1",
+          authenticationLockedUntil: Date.now() + 300_000,
+          failedAuthenticationAttempts: 5,
+          staffProfileId: "staff_profile_1",
+          organizationId: "org_1",
+          storeId: "store_1",
+          username: "frontdesk",
+          pinHash: "hash-1",
+          status: "active",
+        },
+      ],
+      profiles: [
+        {
+          _id: "staff_profile_1",
+          storeId: "store_1",
+          organizationId: "org_1",
+          status: "active",
+          fullName: "Ari Mensah",
+        },
+      ],
+      roles: [
+        {
+          _id: "role_1",
+          staffProfileId: "staff_profile_1",
+          organizationId: "org_1",
+          storeId: "store_1",
+          role: "cashier",
+          isPrimary: true,
+          status: "active",
+          assignedAt: 1,
+        },
+      ],
+    });
+    authMocks.requireOrganizationMemberRoleWithCtx.mockRejectedValueOnce(
+      new Error("You do not have access to manage staff credentials."),
+    );
+
+    await expect(
+      getHandler(updateStaffCredential)(ctx, {
+        organizationId: "org_1" as Id<"organization">,
+        pinHash: "hash-2",
+        staffProfileId: "staff_profile_1" as Id<"staffProfile">,
+        storeId: "store_1" as Id<"store">,
+      }),
+    ).resolves.toEqual({
+      kind: "user_error",
+      error: {
+        code: "authorization_failed",
+        message: "You do not have access to manage staff credentials.",
+      },
+    });
+    expect(tables.staffCredential.get("credential-1")).toMatchObject({
+      authenticationLockedUntil: expect.any(Number),
+      failedAuthenticationAttempts: 5,
+      pinHash: "hash-1",
     });
   });
 
@@ -809,6 +1060,216 @@ describe("staff credential operations", () => {
     expect(tables.staffCredential.get("credential-1")?.lastAuthenticatedAt).toEqual(
       expect.any(Number)
     );
+  });
+
+  it("locks staff authentication after repeated failed PIN attempts and resets on PIN reset", async () => {
+    const beforeAttempts = Date.now();
+    const { ctx, tables } = createStaffCredentialsMutationCtx({
+      credentials: [
+        {
+          _id: "credential-1",
+          staffProfileId: "staff_profile_1",
+          organizationId: "org_1",
+          storeId: "store_1",
+          username: "frontdesk",
+          pinHash: "hash-1",
+          status: "active",
+        },
+      ],
+      profiles: [
+        {
+          _id: "staff_profile_1",
+          storeId: "store_1",
+          organizationId: "org_1",
+          status: "active",
+          fullName: "Ari Mensah",
+        },
+      ],
+      roles: [
+        {
+          _id: "role_1",
+          staffProfileId: "staff_profile_1",
+          organizationId: "org_1",
+          storeId: "store_1",
+          role: "cashier",
+          isPrimary: true,
+          status: "active",
+          assignedAt: 1,
+        },
+      ],
+    });
+
+    for (let attempt = 1; attempt <= 5; attempt += 1) {
+      await expect(
+        authenticateStaffCredentialWithCtx(ctx, {
+          allowedRoles: ["cashier"],
+          storeId: "store_1" as Id<"store">,
+          username: "frontdesk",
+          pinHash: `wrong-${attempt}`,
+        }),
+      ).resolves.toEqual({
+        kind: "user_error",
+        error: {
+          code: "authentication_failed",
+          message: "Invalid staff credentials.",
+        },
+      });
+    }
+
+    expect(tables.staffCredential.get("credential-1")).toMatchObject({
+      failedAuthenticationAttempts: 5,
+    });
+    expect(
+      tables.staffCredential.get("credential-1")?.authenticationLockedUntil,
+    ).toBeGreaterThan(beforeAttempts);
+
+    await expect(
+      authenticateStaffCredentialWithCtx(ctx, {
+        allowedRoles: ["cashier"],
+        storeId: "store_1" as Id<"store">,
+        username: "frontdesk",
+        pinHash: "hash-1",
+      }),
+    ).resolves.toEqual({
+      kind: "user_error",
+      error: {
+        code: "rate_limited",
+        message: "Too many failed staff PIN attempts. Try again later.",
+      },
+    });
+
+    await expect(
+      updateStaffCredentialWithCtx(ctx, {
+        organizationId: "org_1" as Id<"organization">,
+        pinHash: "hash-2",
+        localPinVerifier,
+        staffProfileId: "staff_profile_1" as Id<"staffProfile">,
+        storeId: "store_1" as Id<"store">,
+      }),
+    ).resolves.toMatchObject({
+      status: "active",
+    });
+
+    expect(tables.staffCredential.get("credential-1")).toMatchObject({
+      authenticationLockedUntil: undefined,
+      failedAuthenticationAttempts: 0,
+      pinHash: "hash-2",
+    });
+  });
+
+  it("resets failed staff authentication attempts after a successful login", async () => {
+    const { ctx, tables } = createStaffCredentialsMutationCtx({
+      credentials: [
+        {
+          _id: "credential-1",
+          authenticationLockedUntil: 1,
+          failedAuthenticationAttempts: 4,
+          staffProfileId: "staff_profile_1",
+          organizationId: "org_1",
+          storeId: "store_1",
+          username: "frontdesk",
+          pinHash: "hash-1",
+          status: "active",
+        },
+      ],
+      profiles: [
+        {
+          _id: "staff_profile_1",
+          storeId: "store_1",
+          organizationId: "org_1",
+          status: "active",
+          fullName: "Ari Mensah",
+        },
+      ],
+      roles: [
+        {
+          _id: "role_1",
+          staffProfileId: "staff_profile_1",
+          organizationId: "org_1",
+          storeId: "store_1",
+          role: "cashier",
+          isPrimary: true,
+          status: "active",
+          assignedAt: 1,
+        },
+      ],
+    });
+
+    await expect(
+      authenticateStaffCredentialWithCtx(ctx, {
+        allowedRoles: ["cashier"],
+        storeId: "store_1" as Id<"store">,
+        username: "frontdesk",
+        pinHash: "hash-1",
+      }),
+    ).resolves.toMatchObject({
+      kind: "ok",
+    });
+
+    expect(tables.staffCredential.get("credential-1")).toMatchObject({
+      authenticationLockedUntil: undefined,
+      failedAuthenticationAttempts: 0,
+      lastAuthenticatedAt: expect.any(Number),
+    });
+  });
+
+  it("prevents approval proof minting while staff authentication is locked", async () => {
+    const { ctx } = createStaffCredentialsMutationCtx({
+      credentials: [
+        {
+          _id: "credential-1",
+          authenticationLockedUntil: Date.now() + 300_000,
+          failedAuthenticationAttempts: 5,
+          staffProfileId: "staff_profile_1",
+          organizationId: "org_1",
+          storeId: "store_1",
+          username: "manager",
+          pinHash: "hash-1",
+          status: "active",
+        },
+      ],
+      profiles: [
+        {
+          _id: "staff_profile_1",
+          storeId: "store_1",
+          organizationId: "org_1",
+          status: "active",
+          fullName: "Ari Mensah",
+        },
+      ],
+      roles: [
+        {
+          _id: "role_1",
+          staffProfileId: "staff_profile_1",
+          organizationId: "org_1",
+          storeId: "store_1",
+          role: "manager",
+          isPrimary: true,
+          status: "active",
+          assignedAt: 1,
+        },
+      ],
+    });
+
+    await expect(
+      authenticateStaffCredentialForApprovalWithCtx(ctx, {
+        actionKey: "operations.approval_request.decide",
+        pinHash: "hash-1",
+        requiredRole: "manager",
+        storeId: "store_1" as Id<"store">,
+        subject: {
+          id: "approval-1",
+          type: "approval_request",
+        },
+        username: "manager",
+      }),
+    ).resolves.toEqual({
+      kind: "user_error",
+      error: {
+        code: "rate_limited",
+        message: "Too many failed staff PIN attempts. Try again later.",
+      },
+    });
   });
 
   it("mints and persists a scoped local staff proof after terminal authentication", async () => {

--- a/packages/athena-webapp/convex/operations/staffCredentials.ts
+++ b/packages/athena-webapp/convex/operations/staffCredentials.ts
@@ -93,6 +93,8 @@ type PosTerminalAuthorizationResult = CommandResult<{
 
 const ACTIVE_STAFF_SESSION_LOOKUP_LIMIT = 100;
 const STAFF_AUTHORITY_REFRESH_LIMIT = 1_000;
+const STAFF_AUTH_FAILURE_LIMIT = 5;
+const STAFF_AUTH_LOCKOUT_MS = 5 * 60 * 1_000;
 
 function normalizeUsername(username: string) {
   return username.trim().toLowerCase();
@@ -112,6 +114,13 @@ function invalidStaffCredentialsResult(): StaffCredentialAuthenticationResult {
   return userError({
     code: "authentication_failed",
     message: "Invalid staff credentials.",
+  });
+}
+
+function staffCredentialsRateLimitedResult(): StaffCredentialAuthenticationResult {
+  return userError({
+    code: "rate_limited",
+    message: "Too many failed staff PIN attempts. Try again later.",
   });
 }
 
@@ -137,6 +146,46 @@ function terminalAuthorizationFailedResult(): PosTerminalAuthorizationResult {
   return userError({
     code: "authorization_failed",
     message: "This terminal is not available for staff authentication.",
+  });
+}
+
+function staffStoreAuthorizationFailedResult(): StaffCredentialAuthenticationResult {
+  return userError({
+    code: "authorization_failed",
+    message: "You do not have access to authenticate staff for this store.",
+  });
+}
+
+async function requireStaffCredentialManagementAccessWithCtx(
+  ctx: MutationCtx,
+  organizationId: Id<"organization">,
+) {
+  const athenaUser = await requireAuthenticatedAthenaUserWithCtx(ctx);
+
+  await requireOrganizationMemberRoleWithCtx(ctx, {
+    allowedRoles: ["full_admin"],
+    failureMessage: "You do not have access to manage staff credentials.",
+    organizationId,
+    userId: athenaUser._id,
+  });
+}
+
+async function requireStaffAuthenticationStoreAccessWithCtx(
+  ctx: MutationCtx,
+  storeId: Id<"store">,
+) {
+  const store = await ctx.db.get("store", storeId);
+  if (!store) {
+    throw new Error("You do not have access to authenticate staff for this store.");
+  }
+
+  const athenaUser = await requireAuthenticatedAthenaUserWithCtx(ctx);
+  await requireOrganizationMemberRoleWithCtx(ctx, {
+    allowedRoles: ["full_admin", "pos_only"],
+    failureMessage:
+      "You do not have access to authenticate staff for this store.",
+    organizationId: store.organizationId,
+    userId: athenaUser._id,
   });
 }
 
@@ -508,6 +557,8 @@ export async function updateStaffCredentialWithCtx(
     updates.localPinVerifier = args.localPinVerifier;
     updates.localVerifierVersion =
       (existingCredential.localVerifierVersion ?? 0) + 1;
+    updates.failedAuthenticationAttempts = 0;
+    updates.authenticationLockedUntil = undefined;
   }
 
   const resolvedStatus =
@@ -575,7 +626,28 @@ export async function authenticateStaffCredentialWithCtx(
     throw new Error("Multiple staff credentials match this username.");
   }
 
+  const now = Date.now();
+
+  if (
+    activeCredential.authenticationLockedUntil &&
+    activeCredential.authenticationLockedUntil > now
+  ) {
+    return staffCredentialsRateLimitedResult();
+  }
+
   if (!activeCredential.pinHash || activeCredential.pinHash !== args.pinHash) {
+    const failedAuthenticationAttempts =
+      (activeCredential.failedAuthenticationAttempts ?? 0) + 1;
+    const shouldLock =
+      failedAuthenticationAttempts >= STAFF_AUTH_FAILURE_LIMIT;
+
+    await ctx.db.patch("staffCredential", activeCredential._id, {
+      failedAuthenticationAttempts,
+      ...(shouldLock
+        ? { authenticationLockedUntil: now + STAFF_AUTH_LOCKOUT_MS }
+        : {}),
+    });
+
     return invalidStaffCredentialsResult();
   }
 
@@ -620,7 +692,9 @@ export async function authenticateStaffCredentialWithCtx(
   }
 
   await ctx.db.patch("staffCredential", activeCredential._id, {
-    lastAuthenticatedAt: Date.now(),
+    authenticationLockedUntil: undefined,
+    failedAuthenticationAttempts: 0,
+    lastAuthenticatedAt: now,
   });
 
   return ok({
@@ -832,9 +906,24 @@ export const createStaffCredential = mutation({
   returns: commandResultValidator(v.any()),
   handler: async (ctx, args) => {
     try {
+      await requireStaffCredentialManagementAccessWithCtx(
+        ctx,
+        args.organizationId,
+      );
+
       return ok(await createStaffCredentialWithCtx(ctx, args));
     } catch (error) {
       const message = error instanceof Error ? error.message : "";
+
+      if (
+        message === "Sign in again to continue." ||
+        message === "You do not have access to manage staff credentials."
+      ) {
+        return userError({
+          code: "authorization_failed",
+          message,
+        });
+      }
 
       if (message === "Staff profile not found.") {
         return userError({
@@ -884,9 +973,24 @@ export const updateStaffCredential = mutation({
   returns: commandResultValidator(v.any()),
   handler: async (ctx, args) => {
     try {
+      await requireStaffCredentialManagementAccessWithCtx(
+        ctx,
+        args.organizationId,
+      );
+
       return ok(await updateStaffCredentialWithCtx(ctx, args));
     } catch (error) {
       const message = error instanceof Error ? error.message : "";
+
+      if (
+        message === "Sign in again to continue." ||
+        message === "You do not have access to manage staff credentials."
+      ) {
+        return userError({
+          code: "authorization_failed",
+          message,
+        });
+      }
 
       if (message === "Staff credential not found.") {
         return userError({
@@ -930,7 +1034,15 @@ export const authenticateStaffCredential = mutation({
     storeId: v.id("store"),
     username: v.string(),
   },
-  handler: (ctx, args) => authenticateStaffCredentialWithCtx(ctx, args),
+  handler: async (ctx, args) => {
+    try {
+      await requireStaffAuthenticationStoreAccessWithCtx(ctx, args.storeId);
+    } catch {
+      return staffStoreAuthorizationFailedResult();
+    }
+
+    return authenticateStaffCredentialWithCtx(ctx, args);
+  },
 });
 
 export const authenticateStaffCredentialForTerminal = mutation({
@@ -1097,6 +1209,16 @@ export const authenticateStaffCredentialForApproval = mutation({
       requestedByStaffProfileId: v.optional(v.id("staffProfile")),
     }),
   ),
-  handler: (ctx, args) =>
-    authenticateStaffCredentialForApprovalWithCtx(ctx, args),
+  handler: async (ctx, args) => {
+    try {
+      await requireStaffAuthenticationStoreAccessWithCtx(ctx, args.storeId);
+    } catch {
+      return userError({
+        code: "authorization_failed",
+        message: "You do not have access to authenticate staff for this store.",
+      });
+    }
+
+    return authenticateStaffCredentialForApprovalWithCtx(ctx, args);
+  },
 });

--- a/packages/athena-webapp/convex/schemas/operations/staffCredential.ts
+++ b/packages/athena-webapp/convex/schemas/operations/staffCredential.ts
@@ -22,5 +22,7 @@ export const staffCredentialSchema = v.object({
     v.literal("suspended"),
     v.literal("revoked")
   ),
+  failedAuthenticationAttempts: v.optional(v.number()),
+  authenticationLockedUntil: v.optional(v.number()),
   lastAuthenticatedAt: v.optional(v.number()),
 });

--- a/packages/athena-webapp/docs/agent/key-folder-index.md
+++ b/packages/athena-webapp/docs/agent/key-folder-index.md
@@ -7,7 +7,7 @@ This key-folder index highlights the main directories agents are likely to need 
 ## Core app surfaces
 
 - [`src/routes`](../../src/routes) — TanStack route entrypoints and authenticated shells. Currently 83 file(s); key children: __root.tsx, _authed, _authed.test.tsx, _authed.tsx, index.test.tsx.
-- [`src/components`](../../src/components) — UI components, views, and package-local feature widgets. Currently 565 file(s); key children: GenericComboBox.tsx, Navbar.tsx, OrganizationView.tsx, OrganizationsView.tsx, PermissionGate.tsx.
+- [`src/components`](../../src/components) — UI components, views, and package-local feature widgets. Currently 567 file(s); key children: GenericComboBox.tsx, Navbar.tsx, OrganizationView.tsx, OrganizationsView.tsx, PermissionGate.tsx.
 - [`src/components/traces`](../../src/components/traces) — Shared workflow trace screens, ordered timelines, and trace detail primitives. Currently 3 file(s); key children: WorkflowTraceRouteLink.tsx, WorkflowTraceView.test.tsx, WorkflowTraceView.tsx.
 - [`src/components/operations`](../../src/components/operations) — Manager-queue and stock-adjustment workflows that share approval rails with other operational surfaces. Currently 24 file(s); key children: CommandApprovalDialog.test.tsx, CommandApprovalDialog.tsx, DailyCloseHistoryView.test.tsx, DailyCloseHistoryView.tsx, DailyCloseView.test.tsx.
 - [`src/components/procurement`](../../src/components/procurement) — Procurement planning and receiving views for replenishment pressure and purchase-order execution. Currently 4 file(s); key children: ProcurementView.test.tsx, ProcurementView.tsx, ReceivingView.test.tsx, ReceivingView.tsx.

--- a/packages/athena-webapp/src/components/operations/CommandApprovalDialog.test.tsx
+++ b/packages/athena-webapp/src/components/operations/CommandApprovalDialog.test.tsx
@@ -160,7 +160,7 @@ function renderDialog(
 async function submitCredentials(user: ReturnType<typeof userEvent.setup>) {
   await waitFor(() => expect(screen.getByLabelText(/username/i)).toHaveFocus());
   await user.type(screen.getByLabelText(/username/i), "manager");
-  await user.type(screen.getByLabelText(/pin/i), "123456");
+  await user.type(screen.getByLabelText(/pin/i), "1234");
 }
 
 describe("CommandApprovalDialog", () => {
@@ -237,7 +237,7 @@ describe("CommandApprovalDialog", () => {
     await waitFor(() =>
       expect(onAuthenticateForApproval).toHaveBeenCalledWith({
         actionKey: "transaction.payment_method_correction",
-        pinHash: "hashed:123456",
+        pinHash: "hashed:1234",
         reason: "Payment method changes need manager approval.",
         requiredRole: "manager",
         requestedByStaffProfileId: undefined,

--- a/packages/athena-webapp/src/components/operations/OperationsQueueView.test.tsx
+++ b/packages/athena-webapp/src/components/operations/OperationsQueueView.test.tsx
@@ -119,7 +119,7 @@ vi.mock("@/components/staff-auth/StaffAuthenticationDialog", () => ({
           type="button"
           onClick={async () => {
             const credentials = {
-              pinHash: "hashed:123456",
+              pinHash: "hashed:1234",
               username: "manager",
             };
             const result = await onAuthenticate({
@@ -643,7 +643,7 @@ describe("OperationsQueueViewContent", () => {
     await waitFor(() =>
       expect(authenticateStaffCredential).toHaveBeenCalledWith({
         allowedRoles: ["manager"],
-        pinHash: "hashed:123456",
+        pinHash: "hashed:1234",
         storeId: "store-1",
         username: "manager",
       }),
@@ -654,7 +654,7 @@ describe("OperationsQueueViewContent", () => {
     await waitFor(() =>
       expect(authenticateStaffCredentialForApproval).toHaveBeenCalledWith({
         actionKey: "operations.approval_request.decide",
-        pinHash: "hashed:123456",
+        pinHash: "hashed:1234",
         reason: "Resolve pending approval request.",
         requiredRole: "manager",
         storeId: "store-1",

--- a/packages/athena-webapp/src/components/pos/CashierAuthDialog.test.tsx
+++ b/packages/athena-webapp/src/components/pos/CashierAuthDialog.test.tsx
@@ -186,7 +186,7 @@ function renderDialog({
 async function submitCredentials(
   user: ReturnType<typeof userEvent.setup>,
   {
-    pin = "123456",
+    pin = "1234",
     username = "frontdesk",
   }: {
     pin?: string;
@@ -381,11 +381,11 @@ describe("CashierAuthDialog", () => {
     expect(authenticateMutation).not.toHaveBeenCalled();
     expect(mocks.verifyLocalPin).toHaveBeenCalledWith(
       expect.objectContaining({ algorithm: "PBKDF2-SHA256" }),
-      "123456",
+      "1234",
     );
     expect(mocks.unwrapLocalStaffProofToken).toHaveBeenCalledWith(
       expect.objectContaining({ algorithm: "PBKDF2-SHA256" }),
-      "123456",
+      "1234",
       expect.objectContaining({ ciphertext: "wrapped-proof-token" }),
     );
     expect(mocks.toastSuccess).toHaveBeenCalledWith("Signed in as Ama Mensah");
@@ -613,7 +613,7 @@ describe("CashierAuthDialog", () => {
       expect(authenticateMutation).toHaveBeenNthCalledWith(1, {
         allowedRoles: ["cashier", "manager"],
         allowActiveSessionsOnOtherTerminals: true,
-        pinHash: "hashed:123456",
+        pinHash: "hashed:1234",
         storeId,
         terminalId,
         username: "frontdesk",
@@ -628,7 +628,7 @@ describe("CashierAuthDialog", () => {
     await waitFor(() =>
       expect(authenticateMutation).toHaveBeenNthCalledWith(2, {
         allowedRoles: ["cashier", "manager"],
-        pinHash: "hashed:123456",
+        pinHash: "hashed:1234",
         storeId,
         terminalId,
         username: "frontdesk",

--- a/packages/athena-webapp/src/components/pos/transactions/TransactionView.test.tsx
+++ b/packages/athena-webapp/src/components/pos/transactions/TransactionView.test.tsx
@@ -163,7 +163,7 @@ vi.mock("../../staff-auth/StaffAuthenticationDialog", () => ({
         <button
           onClick={async () => {
             const result = await onAuthenticate({
-              pinHash: "123456",
+              pinHash: "hashed:1234",
               username: "manager",
             });
             if (
@@ -174,7 +174,7 @@ vi.mock("../../staff-auth/StaffAuthenticationDialog", () => ({
               "data" in result
             ) {
               onAuthenticated(result.data as never, "authenticate", {
-                pinHash: "123456",
+                pinHash: "hashed:1234",
                 username: "manager",
               });
             }
@@ -243,7 +243,7 @@ vi.mock("../../operations/CommandApprovalDialog", () => ({
             onClick={async () => {
               const result = await onAuthenticateForApproval({
                 actionKey: approval.action.key,
-                pinHash: "123456",
+                pinHash: "hashed:1234",
                 reason: approval.reason,
                 requiredRole: approval.requiredRole,
                 requestedByStaffProfileId,
@@ -973,7 +973,7 @@ describe("TransactionView", () => {
     expect(approvalMutation).not.toHaveBeenCalled();
     expect(authMutation).toHaveBeenCalledWith({
       allowedRoles: ["cashier", "manager"],
-      pinHash: "123456",
+      pinHash: "hashed:1234",
       storeId: "store_1",
       username: "manager",
     });
@@ -1041,7 +1041,7 @@ describe("TransactionView", () => {
     await waitFor(() => {
       expect(approvalMutation).toHaveBeenCalledWith({
         actionKey: "pos.transaction.correct_payment_method",
-        pinHash: "123456",
+        pinHash: "hashed:1234",
         reason:
           "Manager approval is required to correct a completed transaction payment method.",
         requiredRole: "manager",

--- a/packages/athena-webapp/src/components/staff-auth/StaffAuthenticationDialog.test.tsx
+++ b/packages/athena-webapp/src/components/staff-auth/StaffAuthenticationDialog.test.tsx
@@ -1,21 +1,25 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { StaffAuthenticationDialog } from "./StaffAuthenticationDialog";
 
 vi.mock("@/components/pos/PinInput", () => ({
   PinInput: ({
     disabled,
+    maxLength,
     onChange,
     value,
   }: {
     disabled?: boolean;
+    maxLength: number;
     onChange: (value: string) => void;
     value: string;
   }) => (
     <input
       aria-label="PIN"
       disabled={disabled}
+      maxLength={maxLength}
       onChange={(event) => onChange(event.target.value)}
       value={value}
     />
@@ -39,6 +43,12 @@ const baseProps = {
 };
 
 describe("StaffAuthenticationDialog", () => {
+  beforeEach(() => {
+    baseProps.onAuthenticate.mockReset();
+    baseProps.onAuthenticated.mockReset();
+    baseProps.onDismiss.mockReset();
+  });
+
   it("renders inline presentation without requiring a Dialog provider", () => {
     render(<StaffAuthenticationDialog {...baseProps} presentation="inline" />);
 
@@ -80,7 +90,7 @@ describe("StaffAuthenticationDialog", () => {
       target: { value: "frontdesk" },
     });
     fireEvent.change(screen.getByLabelText(/pin/i), {
-      target: { value: "123456" },
+      target: { value: "1234" },
     });
 
     await waitFor(() => expect(onAuthenticate).toHaveBeenCalledTimes(1));
@@ -97,5 +107,106 @@ describe("StaffAuthenticationDialog", () => {
     await new Promise((resolve) => window.setTimeout(resolve, 0));
 
     expect(onAuthenticate).toHaveBeenCalledTimes(1);
+  });
+
+  it("submits staff credentials when a four-digit PIN is entered", async () => {
+    const onAuthenticate = vi.fn().mockResolvedValue({
+      data: {
+        staffProfile: { fullName: "Front Desk" },
+        staffProfileId: "staff-profile-id",
+      },
+      kind: "ok",
+    });
+    const onAuthenticated = vi.fn();
+
+    render(
+      <StaffAuthenticationDialog
+        {...baseProps}
+        onAuthenticate={onAuthenticate}
+        onAuthenticated={onAuthenticated}
+        presentation="inline"
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText(/username/i), {
+      target: { value: " frontdesk " },
+    });
+    fireEvent.change(screen.getByLabelText(/pin/i), {
+      target: { value: "1234" },
+    });
+
+    await waitFor(() =>
+      expect(onAuthenticate).toHaveBeenCalledWith({
+        mode: "authenticate",
+        pin: "1234",
+        pinHash: "hashed:1234",
+        username: "frontdesk",
+      }),
+    );
+    await waitFor(() =>
+      expect(onAuthenticated).toHaveBeenCalledWith(
+        {
+          staffProfile: { fullName: "Front Desk" },
+          staffProfileId: "staff-profile-id",
+        },
+        "authenticate",
+        { pinHash: "hashed:1234", username: "frontdesk" },
+      ),
+    );
+  });
+
+  it("does not submit an incomplete staff PIN", async () => {
+    const user = userEvent.setup();
+    const onAuthenticate = vi.fn();
+
+    render(
+      <StaffAuthenticationDialog
+        {...baseProps}
+        onAuthenticate={onAuthenticate}
+        onAuthenticated={vi.fn()}
+        presentation="inline"
+      />,
+    );
+
+    await user.type(screen.getByLabelText(/username/i), "frontdesk");
+    await user.type(screen.getByLabelText(/pin/i), "123");
+
+    expect(screen.getByRole("button", { name: /continue/i })).toBeDisabled();
+    expect(onAuthenticate).not.toHaveBeenCalled();
+  });
+
+  it("sanitizes pasted mixed staff PIN input before authenticating", async () => {
+    const onAuthenticate = vi.fn().mockResolvedValue({
+      data: {
+        staffProfile: { fullName: "Front Desk" },
+        staffProfileId: "staff-profile-id",
+      },
+      kind: "ok",
+    });
+
+    render(
+      <StaffAuthenticationDialog
+        {...baseProps}
+        onAuthenticate={onAuthenticate}
+        onAuthenticated={vi.fn()}
+        presentation="inline"
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText(/username/i), {
+      target: { value: "frontdesk" },
+    });
+    fireEvent.change(screen.getByLabelText(/pin/i), {
+      target: { value: "12 a3-4z9" },
+    });
+
+    await waitFor(() =>
+      expect(onAuthenticate).toHaveBeenCalledWith({
+        mode: "authenticate",
+        pin: "1234",
+        pinHash: "hashed:1234",
+        username: "frontdesk",
+      }),
+    );
   });
 });

--- a/packages/athena-webapp/src/components/staff-auth/StaffAuthenticationDialog.tsx
+++ b/packages/athena-webapp/src/components/staff-auth/StaffAuthenticationDialog.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 
-import { PinInput } from "@/components/pos/PinInput";
 import {
   Dialog,
   DialogContent,
@@ -19,6 +18,8 @@ import {
   GENERIC_UNEXPECTED_ERROR_MESSAGE,
   GENERIC_UNEXPECTED_ERROR_TITLE,
 } from "~/shared/commandResult";
+import { StaffPinInput } from "./StaffPinInput";
+import { STAFF_PIN_LENGTH } from "./staffPinPolicy";
 
 export type StaffAuthMode = "authenticate" | "recover";
 
@@ -90,7 +91,8 @@ export function StaffAuthenticationDialog({
   const usernameInputRef = useRef<HTMLInputElement>(null);
 
   const activeCopy = mode === "recover" && alternateCopy ? alternateCopy : copy;
-  const canSubmit = username.trim().length > 0 && pin.length === 6;
+  const canSubmit =
+    username.trim().length > 0 && pin.length === STAFF_PIN_LENGTH;
 
   useEffect(() => {
     if (!open) {
@@ -117,8 +119,8 @@ export function StaffAuthenticationDialog({
       return;
     }
 
-    if (pin.length !== 6) {
-      toast.error("PIN required. Enter all 6 digits to continue.");
+    if (pin.length !== STAFF_PIN_LENGTH) {
+      toast.error("PIN required. Enter all 4 digits to continue.");
       return;
     }
 
@@ -233,13 +235,11 @@ export function StaffAuthenticationDialog({
 
         <div className="space-y-layout-xs">
           <Label htmlFor="staff-auth-pin">PIN</Label>
-          <PinInput
+          <StaffPinInput
             value={pin}
             onChange={setPin}
             disabled={isAuthenticating}
             onKeyDown={handleKeyDown}
-            maxLength={6}
-            size="sm"
           />
         </div>
       </div>

--- a/packages/athena-webapp/src/components/staff-auth/StaffPinInput.tsx
+++ b/packages/athena-webapp/src/components/staff-auth/StaffPinInput.tsx
@@ -1,0 +1,29 @@
+import { PinInput } from "@/components/pos/PinInput";
+import { STAFF_PIN_LENGTH, normalizeStaffPin } from "./staffPinPolicy";
+
+type StaffPinInputProps = {
+  "aria-label"?: string;
+  disabled: boolean;
+  id?: string;
+  onChange: (value: string) => void;
+  onKeyDown: (event: React.KeyboardEvent) => void;
+  value: string;
+};
+
+export function StaffPinInput({
+  disabled,
+  onChange,
+  onKeyDown,
+  value,
+}: StaffPinInputProps) {
+  return (
+    <PinInput
+      value={value}
+      onChange={(nextValue) => onChange(normalizeStaffPin(nextValue))}
+      disabled={disabled}
+      onKeyDown={onKeyDown}
+      maxLength={STAFF_PIN_LENGTH}
+      size="sm"
+    />
+  );
+}

--- a/packages/athena-webapp/src/components/staff-auth/staffPinPolicy.ts
+++ b/packages/athena-webapp/src/components/staff-auth/staffPinPolicy.ts
@@ -1,0 +1,5 @@
+export const STAFF_PIN_LENGTH = 4;
+
+export function normalizeStaffPin(value: string) {
+  return value.normalize("NFKC").replace(/\D/g, "").slice(0, STAFF_PIN_LENGTH);
+}

--- a/packages/athena-webapp/src/components/staff/StaffManagement.test.tsx
+++ b/packages/athena-webapp/src/components/staff/StaffManagement.test.tsx
@@ -69,14 +69,21 @@ vi.mock("../ui/select", () => ({
   ),
 }));
 
-vi.mock("../pos/PinInput", () => ({
-  PinInput: ({
+vi.mock("../staff-auth/staffPinPolicy", () => ({
+  STAFF_PIN_LENGTH: 4,
+  normalizeStaffPin: (value: string) => value.replace(/\D/g, "").slice(0, 4),
+}));
+
+vi.mock("../staff-auth/StaffPinInput", () => ({
+  StaffPinInput: ({
     disabled,
     onChange,
+    onKeyDown,
     value,
   }: {
     disabled: boolean;
     onChange: (value: string) => void;
+    onKeyDown: (event: React.KeyboardEvent) => void;
     value: string;
   }) => (
     <input
@@ -84,6 +91,7 @@ vi.mock("../pos/PinInput", () => ({
       disabled={disabled}
       value={value}
       onChange={(event) => onChange(event.target.value)}
+      onKeyDown={onKeyDown}
     />
   ),
 }));
@@ -285,7 +293,7 @@ describe("StaffManagement", () => {
     );
   });
 
-  it("sets a PIN for a pending credential", async () => {
+  it("sets a four-digit PIN for a pending credential", async () => {
     mockConvex();
     const user = userEvent.setup();
 
@@ -298,25 +306,66 @@ describe("StaffManagement", () => {
 
     await user.click(screen.getByRole("button", { name: /set pin/i }));
     const pinInputs = screen.getAllByLabelText(/pin input/i);
-    await user.type(pinInputs[0]!, "123456");
-    await user.type(pinInputs[1]!, "123456");
+    await user.type(pinInputs[0]!, "1234");
+    await user.type(pinInputs[1]!, "1234");
     await user.click(screen.getByRole("button", { name: /save pin/i }));
 
     await waitFor(() => expect(updateStaffCredential).toHaveBeenCalledTimes(1));
     expect(updateStaffCredential).toHaveBeenCalledWith({
       localPinVerifier: {
         algorithm: "PBKDF2-SHA256",
-        hash: "local:123456",
+        hash: "local:1234",
         iterations: 120000,
         salt: "salt",
         version: 1,
       },
       organizationId: "org-1",
-      pinHash: "hashed:123456",
+      pinHash: "hashed:1234",
       staffProfileId: "staff-1",
       status: "active",
       storeId: "store-1",
     });
+  });
+
+  it("does not save an incomplete staff PIN", async () => {
+    mockConvex();
+    const user = userEvent.setup();
+
+    render(
+      <StaffManagement
+        organizationId={"org-1" as Id<"organization">}
+        storeId={"store-1" as Id<"store">}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /set pin/i }));
+    const pinInputs = screen.getAllByLabelText(/pin input/i);
+    await user.type(pinInputs[0]!, "123");
+    await user.type(pinInputs[1]!, "123");
+
+    expect(screen.getByRole("button", { name: /save pin/i })).toBeDisabled();
+    expect(updateStaffCredential).not.toHaveBeenCalled();
+  });
+
+  it("blocks staff PIN saves when confirmation does not match", async () => {
+    mockConvex();
+    const user = userEvent.setup();
+
+    render(
+      <StaffManagement
+        organizationId={"org-1" as Id<"organization">}
+        storeId={"store-1" as Id<"store">}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /set pin/i }));
+    const pinInputs = screen.getAllByLabelText(/pin input/i);
+    await user.type(pinInputs[0]!, "1234");
+    await user.type(pinInputs[1]!, "1235");
+
+    expect(screen.getByText("PINs don't match")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /save pin/i })).toBeDisabled();
+    expect(updateStaffCredential).not.toHaveBeenCalled();
   });
 
   it("surfaces staff provisioning command errors from the shared toast path", async () => {

--- a/packages/athena-webapp/src/components/staff/StaffManagement.tsx
+++ b/packages/athena-webapp/src/components/staff/StaffManagement.tsx
@@ -8,7 +8,11 @@ import { hashPin } from "~/src/lib/security/pinHash";
 import { createLocalPinVerifier } from "~/src/lib/security/localPinVerifier";
 import { presentCommandToast } from "~/src/lib/errors/presentCommandToast";
 import { runCommand } from "~/src/lib/errors/runCommand";
-import { PinInput } from "../pos/PinInput";
+import { StaffPinInput } from "../staff-auth/StaffPinInput";
+import {
+  STAFF_PIN_LENGTH,
+  normalizeStaffPin,
+} from "../staff-auth/staffPinPolicy";
 import { Badge } from "../ui/badge";
 import { Button } from "../ui/button";
 import {
@@ -612,6 +616,9 @@ function CredentialPinDialog({
     }
   }, [state]);
 
+  const isPinComplete =
+    pin.length === STAFF_PIN_LENGTH && confirmPin.length === STAFF_PIN_LENGTH;
+
   const showMismatch = Boolean(
     pin.length > 0 && pin.length === confirmPin.length && pin !== confirmPin,
   );
@@ -639,8 +646,8 @@ function CredentialPinDialog({
       return;
     }
 
-    if (!/^\d{6}$/.test(pin)) {
-      toast.error("PIN must be exactly 6 digits");
+    if (pin.length !== STAFF_PIN_LENGTH || !/^\d+$/.test(pin)) {
+      toast.error(`PIN must be exactly ${STAFF_PIN_LENGTH} digits`);
       return;
     }
 
@@ -703,27 +710,21 @@ function CredentialPinDialog({
         <div className="space-y-6">
           <div className="space-y-2">
             <Label htmlFor="staff-pin">PIN</Label>
-            <PinInput
+            <StaffPinInput
               value={pin}
-              onChange={(value) => setPin(value.replace(/\D/g, "").slice(0, 6))}
+              onChange={(value) => setPin(normalizeStaffPin(value))}
               disabled={isSaving}
               onKeyDown={handlePinKeyDown}
-              maxLength={6}
-              size="sm"
             />
           </div>
 
           <div className="space-y-2">
             <Label htmlFor="staff-confirm-pin">Confirm PIN</Label>
-            <PinInput
+            <StaffPinInput
               value={confirmPin}
-              onChange={(value) =>
-                setConfirmPin(value.replace(/\D/g, "").slice(0, 6))
-              }
+              onChange={(value) => setConfirmPin(normalizeStaffPin(value))}
               disabled={isSaving}
               onKeyDown={handlePinKeyDown}
-              maxLength={6}
-              size="sm"
             />
           </div>
 
@@ -741,9 +742,7 @@ function CredentialPinDialog({
           <LoadingButton
             onClick={handleSubmit}
             isLoading={isSaving}
-            disabled={
-              pin.length !== 6 || confirmPin.length !== 6 || pin !== confirmPin
-            }
+            disabled={!isPinComplete || pin !== confirmPin}
           >
             {state?.mode === "set" ? "Save PIN" : "Reset PIN"}
           </LoadingButton>

--- a/packages/athena-webapp/src/lib/security/pinHash.ts
+++ b/packages/athena-webapp/src/lib/security/pinHash.ts
@@ -6,7 +6,7 @@ const PIN_SALT = "athena-pos-cashier-pin-salt-v1";
 
 /**
  * Hash a PIN using SHA-256 with a fixed salt
- * @param pin - The plaintext PIN (should be validated as 6 digits before calling)
+ * @param pin - The plaintext PIN (should be validated before calling)
  * @returns The SHA-256 hash of the PIN as a hex string
  */
 export async function hashPin(pin: string): Promise<string> {


### PR DESCRIPTION
## Summary
- centralize staff PIN entry in a reusable four-digit StaffPinInput
- update staff auth, manager auth, cashier auth coverage, and organization members PIN setup/reset to use four-digit PINs
- add credential-level failed-attempt lockout and require authenticated store access before public staff auth can mutate lockout state or mint approval proofs

## Validation
- bun run --filter '@athena/webapp' test -- convex/operations/staffCredentials.test.ts\n- bunx tsc --noEmit -p packages/athena-webapp/tsconfig.json\n- bun run pr:athena\n- final security reviewer: no findings\n\nRefs V26-595 V26-596 V26-597 V26-598