### PR TITLE
fix(pos): harden local-first register sync

### DIFF
--- a/docs/solutions/architecture/athena-pos-local-first-runtime-feedback-2026-05-15.md
+++ b/docs/solutions/architecture/athena-pos-local-first-runtime-feedback-2026-05-15.md
@@ -1,0 +1,102 @@
+---
+title: Athena POS Local-First Runtime Feedback Mirrors The Local Event Log
+date: 2026-05-15
+category: architecture
+module: athena-webapp
+problem_type: offline_pos_runtime_feedback
+component: pos
+symptoms:
+  - "The POS header can show pending sync even after IndexedDB events are marked synced"
+  - "Online drawer-open events can remain pending until a later route or runtime trigger"
+  - "Local-first transaction numbers can leak machine-readable local ids into cashier-facing lists"
+  - "Manager drawer-open authentication can accidentally leave the register in an unsigned-out presentation state"
+root_cause: local_first_runtime_state_was_not_refreshed_from_the_local_event_log_after_each_command
+resolution_type: runtime_read_model_contract
+severity: high
+tags:
+  - pos
+  - local-first
+  - sync
+  - diagnostics
+  - receipts
+---
+
+# Athena POS Local-First Runtime Feedback Mirrors The Local Event Log
+
+## Problem
+
+Once POS commands are always local first, the browser has two timelines to keep
+honest: the durable IndexedDB event log and the visible register runtime state.
+It is not enough for sync to mark an event as uploaded in IndexedDB if the
+header, diagnostic panel, staff indicator, or transaction list still reflect an
+older local read model.
+
+The main failure modes are subtle:
+
+- Important events such as `register.opened` look pending while the terminal is
+  online because the runtime waits for a later incidental refresh.
+- The UI can say synced while the local event row still says pending, or the
+  reverse, depending on which source last updated.
+- A local receipt identifier can leak into operator surfaces as
+  `local-txn-...` instead of the same human-readable transaction number used by
+  cloud-first POS.
+- Staff proof and manager drawer-open state can sync correctly while the
+  presentation layer still behaves as if no cashier is signed in.
+
+## Solution
+
+Treat local event append as the runtime wake-up boundary. After a POS command is
+durably appended, the runtime should refresh the local event summary, mark the
+specific trigger source, and attempt upload immediately when the browser has an
+active connection. Route entry, reconnect, manual retry, and timer triggers can
+still exist, but they are fallbacks rather than the primary feedback path.
+
+Render POS sync status from the same local event summary that upload mutates.
+When upload marks rows synced, failed, or pending review, the header and debug
+panel should observe that change without needing a page refresh. Stale async
+runtime callbacks must be ignored after the terminal, store, or local seed scope
+changes, otherwise an older upload result can overwrite the current register
+state.
+
+Keep two receipt identifiers:
+
+- `localReceiptNumber` is a durable, terminal-scoped local idempotency key for
+  sync and reconciliation.
+- `receiptNumber` is the human-readable transaction number shown to cashiers,
+  transaction history, receipts, and cloud projections.
+
+Cloud projection should use `receiptNumber` for the transaction number while
+retaining `localReceiptNumber` for local-to-cloud mapping and retry idempotency.
+
+## Diagnostics
+
+POS diagnostics are support tooling, not cashier workflow copy. They can expose
+sync source, trigger, proof, upload, and cloud-current state, but labels should
+stay operational and avoid raw backend jargon where possible. The debug panel
+must be available in all environments through the supported shortcut so a
+production support session can inspect runtime flow without shipping a separate
+build.
+
+Operator toasts should describe the completed action, not the background sync
+implementation. For example, opening a drawer should present `Drawer open`.
+Item-add, sale-started, and sale-completed success toasts are redundant when the
+cart and transaction-complete screen already show the result.
+
+## Prevention
+
+- Trigger runtime sync immediately after local event append when online.
+- Refresh header/debug status from the local event store after upload changes
+  row sync state.
+- Guard async runtime callbacks against stale terminal, store, and seed scopes.
+- Keep staff signed-in presentation derived from local-first session state, not
+  only from cloud session state.
+- Never show `local-*` ids as cashier-facing transaction numbers.
+- Test the public sync contract and projection contract whenever local event
+  payload fields are added.
+- Keep debug copy support-facing and operator toasts action-facing.
+
+## Related
+
+- [Athena POS Local-First Sync Uses Event Logs](./athena-pos-local-first-sync-2026-05-13.md)
+- [Athena POS Register Commands Are Always Local First](./athena-pos-always-local-first-register-2026-05-14.md)
+- [Athena POS Local Staff Authority Uses Terminal-Scoped Verifiers](./athena-pos-local-staff-authority-2026-05-14.md)

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 5489 nodes · 5714 edges · 1671 communities detected
+- 5496 nodes · 5724 edges · 1671 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -2041,56 +2041,56 @@ Cohesion: 0.24
 Nodes (5): formatBackendLabel(), formatInventoryNumber(), formatQuantity(), getActivityTitle(), pluralize()
 
 ### Community 83 - "Community 83"
+Cohesion: 0.2
+Nodes (2): handleKeyDown(), isDebugShortcut()
+
+### Community 84 - "Community 84"
 Cohesion: 0.31
 Nodes (7): buildCustomerCreateInput(), cancelPendingAdd(), commitCustomer(), handleAddFromSearch(), handleClearCustomer(), handleSelectCustomer(), toCustomerInfo()
 
-### Community 84 - "Community 84"
+### Community 85 - "Community 85"
 Cohesion: 0.25
 Nodes (6): handleEdit(), handleReset(), handleSubmit(), itemToFormState(), parseServiceCatalogForm(), validateServiceCatalogForm()
 
-### Community 85 - "Community 85"
-Cohesion: 0.18
-Nodes (0):
-
 ### Community 86 - "Community 86"
-Cohesion: 0.18
-Nodes (0):
+Cohesion: 0.25
+Nodes (6): mapProductByIdResult(), useConvexProductIdLookup(), useConvexRegisterCatalog(), useConvexRegisterCatalogAvailability(), useConvexRegisterCatalogAvailabilityState(), usePrewarmRegisterCatalogOfflineSnapshots()
 
 ### Community 87 - "Community 87"
+Cohesion: 0.18
+Nodes (0):
+
+### Community 88 - "Community 88"
+Cohesion: 0.18
+Nodes (0):
+
+### Community 89 - "Community 89"
 Cohesion: 0.2
 Nodes (2): diagnoseAthenaQaLiveSmoke(), stripUrlQuery()
 
-### Community 88 - "Community 88"
+### Community 90 - "Community 90"
 Cohesion: 0.31
 Nodes (6): expenseItemSuccess(), expenseSessionSuccess(), itemSuccess(), operationSuccess(), sessionSuccess(), success()
 
-### Community 89 - "Community 89"
+### Community 91 - "Community 91"
 Cohesion: 0.22
 Nodes (2): isValidEmail(), validateCustomerInfo()
 
-### Community 90 - "Community 90"
+### Community 92 - "Community 92"
 Cohesion: 0.22
 Nodes (2): listProductSkusByProductId(), readAllQueryResults()
 
-### Community 91 - "Community 91"
+### Community 93 - "Community 93"
 Cohesion: 0.22
 Nodes (2): getTerminalByFingerprint(), mapTerminalRecord()
 
-### Community 92 - "Community 92"
+### Community 94 - "Community 94"
 Cohesion: 0.31
 Nodes (7): buildVariantSkuMoneyPayload(), createVariantSku(), modifyProduct(), onSubmit(), parseVariantDisplayMoney(), saveProduct(), updateVariantSku()
 
-### Community 93 - "Community 93"
+### Community 95 - "Community 95"
 Cohesion: 0.29
 Nodes (6): handleFileSelect(), handleRevert(), handleUpload(), resetEditState(), uploadImage(), validateFile()
-
-### Community 94 - "Community 94"
-Cohesion: 0.2
-Nodes (0):
-
-### Community 95 - "Community 95"
-Cohesion: 0.24
-Nodes (4): mapProductByIdResult(), useConvexProductIdLookup(), useConvexRegisterCatalogAvailability(), useConvexRegisterCatalogAvailabilityState()
 
 ### Community 96 - "Community 96"
 Cohesion: 0.27
@@ -2357,96 +2357,96 @@ Cohesion: 0.29
 Nodes (0):
 
 ### Community 162 - "Community 162"
-Cohesion: 0.52
-Nodes (6): addItemToSavedBag(), getActiveSavedBag(), getBaseUrl(), removeItemFromSavedBag(), updateSavedBagItem(), updateSavedBagOwner()
-
-### Community 163 - "Community 163"
 Cohesion: 0.33
 Nodes (2): getProductName(), sortProduct()
 
+### Community 163 - "Community 163"
+Cohesion: 0.29
+Nodes (0):
+
 ### Community 164 - "Community 164"
+Cohesion: 0.52
+Nodes (6): addItemToSavedBag(), getActiveSavedBag(), getBaseUrl(), removeItemFromSavedBag(), updateSavedBagItem(), updateSavedBagOwner()
+
+### Community 165 - "Community 165"
 Cohesion: 0.43
 Nodes (4): createFixtureRepo(), gitEnv(), runGit(), write()
 
-### Community 165 - "Community 165"
+### Community 166 - "Community 166"
 Cohesion: 0.52
 Nodes (5): emitSignal(), handleCheckoutSessionFetch(), handleCheckoutSessionUpdate(), jsonResponse(), withCorsHeaders()
 
-### Community 166 - "Community 166"
+### Community 167 - "Community 167"
 Cohesion: 0.33
 Nodes (2): overwriteFreshGraphifyArtifacts(), write()
 
-### Community 167 - "Community 167"
+### Community 168 - "Community 168"
 Cohesion: 0.38
 Nodes (4): createFixtureRepo(), initializeGitHistory(), runGit(), write()
 
-### Community 168 - "Community 168"
-Cohesion: 0.33
-Nodes (1): ValkeyClient
-
 ### Community 169 - "Community 169"
 Cohesion: 0.33
-Nodes (0):
+Nodes (1): ValkeyClient
 
 ### Community 170 - "Community 170"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 171 - "Community 171"
-Cohesion: 0.73
-Nodes (5): buildOrderStatusMessage(), buildPickupDetails(), sendPaymentVerificationEmails(), sendPODOrderEmails(), shouldSendToAdmins()
-
-### Community 172 - "Community 172"
-Cohesion: 0.6
-Nodes (5): createVendorCommandWithCtx(), createVendorWithCtx(), mapCreateVendorError(), normalizeVendorLookupKey(), trimOptional()
-
-### Community 173 - "Community 173"
-Cohesion: 0.6
-Nodes (5): find_block_end(), list_convex_files(), main(), scan_file(), strip_code()
-
-### Community 174 - "Community 174"
 Cohesion: 0.33
 Nodes (0):
 
+### Community 172 - "Community 172"
+Cohesion: 0.73
+Nodes (5): buildOrderStatusMessage(), buildPickupDetails(), sendPaymentVerificationEmails(), sendPODOrderEmails(), shouldSendToAdmins()
+
+### Community 173 - "Community 173"
+Cohesion: 0.6
+Nodes (5): createVendorCommandWithCtx(), createVendorWithCtx(), mapCreateVendorError(), normalizeVendorLookupKey(), trimOptional()
+
+### Community 174 - "Community 174"
+Cohesion: 0.6
+Nodes (5): find_block_end(), list_convex_files(), main(), scan_file(), strip_code()
+
 ### Community 175 - "Community 175"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 176 - "Community 176"
 Cohesion: 0.53
 Nodes (4): includesRegisterSessionStatus(), isCashControlVisibleRegisterSessionStatus(), isPosUsableRegisterSessionStatus(), isRegisterSessionConflictBlockingStatus()
 
-### Community 176 - "Community 176"
+### Community 177 - "Community 177"
 Cohesion: 0.33
 Nodes (1): DataTableToolbar()
-
-### Community 177 - "Community 177"
-Cohesion: 0.53
-Nodes (2): SelectedProductsProvider(), useSelectedProducts()
 
 ### Community 178 - "Community 178"
 Cohesion: 0.4
 Nodes (2): handlePinChange(), normalizeOtpCode()
 
 ### Community 179 - "Community 179"
+Cohesion: 0.53
+Nodes (2): SelectedProductsProvider(), useSelectedProducts()
+
+### Community 180 - "Community 180"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 180 - "Community 180"
+### Community 181 - "Community 181"
 Cohesion: 0.47
 Nodes (3): historyRecord(), snapshot(), storedReportSnapshot()
 
-### Community 181 - "Community 181"
+### Community 182 - "Community 182"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 182 - "Community 182"
+### Community 183 - "Community 183"
 Cohesion: 0.4
 Nodes (2): buildApprovalRetryArgs(), getAsyncApprovalRequestId()
 
-### Community 183 - "Community 183"
+### Community 184 - "Community 184"
 Cohesion: 0.47
 Nodes (3): getSummaryAmount(), getSummaryLabel(), getSummaryPanel()
-
-### Community 184 - "Community 184"
-Cohesion: 0.33
-Nodes (0):
 
 ### Community 185 - "Community 185"
 Cohesion: 0.33
@@ -2457,16 +2457,16 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 187 - "Community 187"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 188 - "Community 188"
 Cohesion: 0.53
 Nodes (3): handleUpdateFees(), parseDeliveryFeeInputs(), parseOptionalDeliveryFeeInput()
 
-### Community 188 - "Community 188"
+### Community 189 - "Community 189"
 Cohesion: 0.47
 Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
-
-### Community 189 - "Community 189"
-Cohesion: 0.33
-Nodes (0):
 
 ### Community 190 - "Community 190"
 Cohesion: 0.33
@@ -2489,12 +2489,12 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 195 - "Community 195"
-Cohesion: 0.53
-Nodes (4): calculatePosChange(), calculatePosRemainingDue(), calculatePosTotalPaid(), roundPosAmount()
-
-### Community 196 - "Community 196"
 Cohesion: 0.33
 Nodes (0):
+
+### Community 196 - "Community 196"
+Cohesion: 0.53
+Nodes (4): calculatePosChange(), calculatePosRemainingDue(), calculatePosTotalPaid(), roundPosAmount()
 
 ### Community 197 - "Community 197"
 Cohesion: 0.33
@@ -2593,24 +2593,24 @@ Cohesion: 0.7
 Nodes (4): buildDecision(), classifyCorrectionIntent(), isSupportedCorrectionIntent(), isUnsupportedHighRiskCorrectionIntent()
 
 ### Community 221 - "Community 221"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 222 - "Community 222"
 Cohesion: 0.7
 Nodes (4): getPaystackHeaders(), initializeTransaction(), initiateRefund(), verifyTransaction()
 
-### Community 222 - "Community 222"
+### Community 223 - "Community 223"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 223 - "Community 223"
+### Community 224 - "Community 224"
 Cohesion: 0.6
 Nodes (3): buildOnlineOrderReturnExchangePlan(), getApprovalReason(), getKind()
 
-### Community 224 - "Community 224"
+### Community 225 - "Community 225"
 Cohesion: 0.5
 Nodes (2): getNonEmptyString(), normalizeStorefrontObservabilityEvent()
-
-### Community 225 - "Community 225"
-Cohesion: 0.4
-Nodes (0):
 
 ### Community 226 - "Community 226"
 Cohesion: 0.4
@@ -2629,12 +2629,12 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 230 - "Community 230"
-Cohesion: 0.5
-Nodes (2): handleFileSelect(), validateFile()
-
-### Community 231 - "Community 231"
 Cohesion: 0.4
 Nodes (0):
+
+### Community 231 - "Community 231"
+Cohesion: 0.5
+Nodes (2): handleFileSelect(), validateFile()
 
 ### Community 232 - "Community 232"
 Cohesion: 0.4
@@ -2649,16 +2649,16 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 235 - "Community 235"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 236 - "Community 236"
 Cohesion: 0.5
 Nodes (2): getBalanceDueLabel(), getBalanceDuePanel()
 
-### Community 236 - "Community 236"
+### Community 237 - "Community 237"
 Cohesion: 0.6
 Nodes (3): handleClearSearch(), handleQuickAddSubmit(), resetQuickAddForm()
-
-### Community 237 - "Community 237"
-Cohesion: 0.4
-Nodes (0):
 
 ### Community 238 - "Community 238"
 Cohesion: 0.4
@@ -2673,32 +2673,32 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 241 - "Community 241"
-Cohesion: 0.7
-Nodes (4): getRuntimeOrigin(), isLocalHost(), resolveStoreFrontUrl(), trimTrailingSlash()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 242 - "Community 242"
 Cohesion: 0.7
-Nodes (4): bufferToHex(), collectBrowserInfo(), generateBrowserFingerprint(), hashFingerprintSource()
+Nodes (4): getRuntimeOrigin(), isLocalHost(), resolveStoreFrontUrl(), trimTrailingSlash()
 
 ### Community 243 - "Community 243"
-Cohesion: 0.4
-Nodes (1): MockImage
+Cohesion: 0.7
+Nodes (4): bufferToHex(), collectBrowserInfo(), generateBrowserFingerprint(), hashFingerprintSource()
 
 ### Community 244 - "Community 244"
 Cohesion: 0.4
-Nodes (0):
+Nodes (1): MockImage
 
 ### Community 245 - "Community 245"
-Cohesion: 0.6
-Nodes (3): calculatePosCartTotals(), calculatePosItemTotal(), roundPosAmount()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 246 - "Community 246"
 Cohesion: 0.6
-Nodes (4): mapRegisterStateDto(), mapTerminalDto(), useConvexRegisterState(), useConvexTerminalByFingerprint()
+Nodes (3): calculatePosCartTotals(), calculatePosItemTotal(), roundPosAmount()
 
 ### Community 247 - "Community 247"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.6
+Nodes (4): mapRegisterStateDto(), mapTerminalDto(), useConvexRegisterState(), useConvexTerminalByFingerprint()
 
 ### Community 248 - "Community 248"
 Cohesion: 0.4
@@ -2721,88 +2721,88 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 253 - "Community 253"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 254 - "Community 254"
 Cohesion: 0.5
 Nodes (2): completePendingAuthSync(), sleep()
 
-### Community 254 - "Community 254"
+### Community 255 - "Community 255"
 Cohesion: 0.4
 Nodes (0):
-
-### Community 255 - "Community 255"
-Cohesion: 0.7
-Nodes (4): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory()
 
 ### Community 256 - "Community 256"
 Cohesion: 0.7
-Nodes (4): getBaseUrl(), getOrder(), getOrders(), updateOrdersOwner()
+Nodes (4): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory()
 
 ### Community 257 - "Community 257"
 Cohesion: 0.7
-Nodes (4): getActiveUser(), getBaseUrl(), getGuest(), updateUser()
+Nodes (4): getBaseUrl(), getOrder(), getOrders(), updateOrdersOwner()
 
 ### Community 258 - "Community 258"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.7
+Nodes (4): getActiveUser(), getBaseUrl(), getGuest(), updateUser()
 
 ### Community 259 - "Community 259"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 260 - "Community 260"
-Cohesion: 0.7
-Nodes (4): createStorefrontFailureEvent(), emitStorefrontFailure(), inferStorefrontJourneyFromRoute(), normalizeStorefrontError()
-
-### Community 261 - "Community 261"
 Cohesion: 0.4
 Nodes (0):
+
+### Community 261 - "Community 261"
+Cohesion: 0.7
+Nodes (4): createStorefrontFailureEvent(), emitStorefrontFailure(), inferStorefrontJourneyFromRoute(), normalizeStorefrontError()
 
 ### Community 262 - "Community 262"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 263 - "Community 263"
-Cohesion: 0.6
-Nodes (4): collectHarnessRepoValidationSelection(), matchesHarnessRepoValidationPath(), normalizeRepoPath(), sortUniquePaths()
-
-### Community 264 - "Community 264"
 Cohesion: 0.4
 Nodes (0):
 
+### Community 264 - "Community 264"
+Cohesion: 0.6
+Nodes (4): collectHarnessRepoValidationSelection(), matchesHarnessRepoValidationPath(), normalizeRepoPath(), sortUniquePaths()
+
 ### Community 265 - "Community 265"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 266 - "Community 266"
 Cohesion: 0.7
 Nodes (4): createFixtureRepo(), fixtureEnv(), runGit(), runWorktreeManager()
 
-### Community 266 - "Community 266"
+### Community 267 - "Community 267"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 267 - "Community 267"
+### Community 268 - "Community 268"
 Cohesion: 0.67
 Nodes (2): maskReceiptPhone(), normalizeReceiptPhone()
 
-### Community 268 - "Community 268"
+### Community 269 - "Community 269"
 Cohesion: 0.83
 Nodes (3): createReceiptShareToken(), hashReceiptShareToken(), toHex()
 
-### Community 269 - "Community 269"
+### Community 270 - "Community 270"
 Cohesion: 0.83
 Nodes (3): timingSafeEqual(), toHex(), verifyMetaWebhookSignature()
-
-### Community 270 - "Community 270"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 271 - "Community 271"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 272 - "Community 272"
-Cohesion: 0.67
-Nodes (2): createExpenseTransactionFromSessionHandler(), expenseTransactionError()
-
-### Community 273 - "Community 273"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 273 - "Community 273"
+Cohesion: 0.67
+Nodes (2): createExpenseTransactionFromSessionHandler(), expenseTransactionError()
 
 ### Community 274 - "Community 274"
 Cohesion: 0.5
@@ -2813,72 +2813,72 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 276 - "Community 276"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 277 - "Community 277"
 Cohesion: 0.67
 Nodes (2): createProductsQueryCtx(), createSkuMutationCtx()
 
-### Community 277 - "Community 277"
+### Community 278 - "Community 278"
 Cohesion: 0.83
 Nodes (3): getCachedTokenRecord(), resolveAccessTokenForStore(), resolveConfigForStore()
 
-### Community 278 - "Community 278"
+### Community 279 - "Community 279"
 Cohesion: 0.67
 Nodes (2): maskMtnPartyId(), normalizeCollectionsTransaction()
 
-### Community 279 - "Community 279"
+### Community 280 - "Community 280"
 Cohesion: 0.67
 Nodes (2): consumeApprovalProofWithCtx(), invalidApprovalProofResult()
 
-### Community 280 - "Community 280"
+### Community 281 - "Community 281"
 Cohesion: 0.67
 Nodes (2): buildOperationalEvent(), recordOperationalEventWithCtx()
 
-### Community 281 - "Community 281"
+### Community 282 - "Community 282"
 Cohesion: 0.67
 Nodes (2): buildOperationalWorkItem(), createOperationalWorkItemWithCtx()
 
-### Community 282 - "Community 282"
+### Community 283 - "Community 283"
 Cohesion: 0.67
 Nodes (2): expectIndex(), getTableIndexes()
-
-### Community 283 - "Community 283"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 284 - "Community 284"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 285 - "Community 285"
-Cohesion: 0.83
-Nodes (3): resolveServiceIntakeCustomerProfile(), splitFullName(), trimOptional()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 286 - "Community 286"
 Cohesion: 0.83
-Nodes (3): mapOpenDrawerUserError(), normalizeRegisterNumber(), openDrawer()
+Nodes (3): resolveServiceIntakeCustomerProfile(), splitFullName(), trimOptional()
 
 ### Community 287 - "Community 287"
 Cohesion: 0.83
-Nodes (3): createDbGetMock(), createDbMock(), createDbQueryMock()
+Nodes (3): mapOpenDrawerUserError(), normalizeRegisterNumber(), openDrawer()
 
 ### Community 288 - "Community 288"
 Cohesion: 0.83
-Nodes (3): buildRegisterState(), getActiveSessionConflictForRegisterState(), getRegisterState()
+Nodes (3): createDbGetMock(), createDbMock(), createDbQueryMock()
 
 ### Community 289 - "Community 289"
+Cohesion: 0.83
+Nodes (3): buildRegisterState(), getActiveSessionConflictForRegisterState(), getRegisterState()
+
+### Community 290 - "Community 290"
 Cohesion: 0.67
 Nodes (2): lookupByBarcode(), mapSkuToCatalogResult()
 
-### Community 290 - "Community 290"
+### Community 291 - "Community 291"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 291 - "Community 291"
-Cohesion: 0.83
-Nodes (3): createPosLocalStaffProofToken(), hashPosLocalStaffProofToken(), toHex()
 
 ### Community 292 - "Community 292"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): createPosLocalStaffProofToken(), hashPosLocalStaffProofToken(), toHex()
 
 ### Community 293 - "Community 293"
 Cohesion: 0.5
@@ -3057,32 +3057,32 @@ Cohesion: 0.83
 Nodes (3): derivePosLocalSyncStatus(), getContiguousSyncedSequence(), getSyncState()
 
 ### Community 337 - "Community 337"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 338 - "Community 338"
 Cohesion: 0.83
 Nodes (3): isBrowserFingerprintResult(), readStoredTerminalFingerprint(), readStoredTerminalFingerprintHash()
 
-### Community 338 - "Community 338"
+### Community 339 - "Community 339"
 Cohesion: 0.67
 Nodes (2): getCashierDisplayName(), useExpenseRegisterViewModel()
 
-### Community 339 - "Community 339"
+### Community 340 - "Community 340"
 Cohesion: 0.67
 Nodes (2): buildPosSyncStatusPresentation(), normalizeStatus()
 
-### Community 340 - "Community 340"
+### Community 341 - "Community 341"
 Cohesion: 0.83
 Nodes (3): getBaseUrl(), getUserRedeemedOffers(), submitOffer()
 
-### Community 341 - "Community 341"
+### Community 342 - "Community 342"
 Cohesion: 0.83
 Nodes (3): getAllStores(), getBaseUrl(), getStore()
 
-### Community 342 - "Community 342"
+### Community 343 - "Community 343"
 Cohesion: 0.83
 Nodes (3): getAllSubcategories(), getBaseUrl(), getSubategory()
-
-### Community 343 - "Community 343"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 344 - "Community 344"
 Cohesion: 0.5
@@ -3113,59 +3113,59 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 351 - "Community 351"
-Cohesion: 0.67
-Nodes (2): useOptionalStoreContext(), useStoreContext()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 352 - "Community 352"
 Cohesion: 0.67
-Nodes (2): clearFilters(), onMobileFiltersCloseClick()
+Nodes (2): useOptionalStoreContext(), useStoreContext()
 
 ### Community 353 - "Community 353"
+Cohesion: 0.67
+Nodes (2): clearFilters(), onMobileFiltersCloseClick()
+
+### Community 354 - "Community 354"
 Cohesion: 0.83
 Nodes (3): cancelOrder(), getErrorMessage(), placeOrder()
 
-### Community 354 - "Community 354"
+### Community 355 - "Community 355"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 355 - "Community 355"
-Cohesion: 0.83
-Nodes (3): bootstrapCheckout(), createBootstrapToken(), createMarker()
 
 ### Community 356 - "Community 356"
 Cohesion: 0.83
-Nodes (3): createFixtureRoot(), write(), writeGraphifyWikiArtifacts()
+Nodes (3): bootstrapCheckout(), createBootstrapToken(), createMarker()
 
 ### Community 357 - "Community 357"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): createFixtureRoot(), write(), writeGraphifyWikiArtifacts()
 
 ### Community 358 - "Community 358"
-Cohesion: 0.67
-Nodes (2): buildHarnessDocPaths(), buildHarnessDocPathsForArchetype()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 359 - "Community 359"
 Cohesion: 0.67
-Nodes (2): shutdown(), stopValkeyRuntimeServer()
+Nodes (2): buildHarnessDocPaths(), buildHarnessDocPathsForArchetype()
 
 ### Community 360 - "Community 360"
+Cohesion: 0.67
+Nodes (2): shutdown(), stopValkeyRuntimeServer()
+
+### Community 361 - "Community 361"
 Cohesion: 0.83
 Nodes (3): createFixtureRepo(), createInferentialArtifact(), write()
 
-### Community 361 - "Community 361"
+### Community 362 - "Community 362"
 Cohesion: 0.67
 Nodes (2): collectHarnessTestTargets(), runHarnessTest()
-
-### Community 362 - "Community 362"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 363 - "Community 363"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 364 - "Community 364"
-Cohesion: 0.67
+Cohesion: 0.5
 Nodes (0):
 
 ### Community 365 - "Community 365"
@@ -3173,12 +3173,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 366 - "Community 366"
-Cohesion: 1.0
-Nodes (2): providerErrorCategory(), sendWhatsAppReceiptTemplate()
-
-### Community 367 - "Community 367"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 367 - "Community 367"
+Cohesion: 1.0
+Nodes (2): providerErrorCategory(), sendWhatsAppReceiptTemplate()
 
 ### Community 368 - "Community 368"
 Cohesion: 0.67
@@ -3209,12 +3209,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 375 - "Community 375"
-Cohesion: 1.0
-Nodes (2): buildCtx(), createDb()
-
-### Community 376 - "Community 376"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 376 - "Community 376"
+Cohesion: 1.0
+Nodes (2): buildCtx(), createDb()
 
 ### Community 377 - "Community 377"
 Cohesion: 0.67
@@ -3237,16 +3237,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 382 - "Community 382"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 383 - "Community 383"
 Cohesion: 1.0
 Nodes (2): hashPosTerminalSyncSecret(), toHex()
 
-### Community 383 - "Community 383"
-Cohesion: 0.67
-Nodes (1): PosServerError
-
 ### Community 384 - "Community 384"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): PosServerError
 
 ### Community 385 - "Community 385"
 Cohesion: 0.67
@@ -3261,12 +3261,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 388 - "Community 388"
-Cohesion: 1.0
-Nodes (2): getActiveRegisterSessionForRegisterState(), mapRegisterSessionToCashDrawerSummary()
-
-### Community 389 - "Community 389"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 389 - "Community 389"
+Cohesion: 1.0
+Nodes (2): getActiveRegisterSessionForRegisterState(), mapRegisterSessionToCashDrawerSummary()
 
 ### Community 390 - "Community 390"
 Cohesion: 0.67
@@ -3281,16 +3281,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 393 - "Community 393"
-Cohesion: 1.0
-Nodes (2): buildServiceCatalogItem(), normalizeServiceCatalogNameKey()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 394 - "Community 394"
 Cohesion: 1.0
-Nodes (2): expectIndex(), getTableIndexes()
+Nodes (2): buildServiceCatalogItem(), normalizeServiceCatalogNameKey()
 
 ### Community 395 - "Community 395"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): expectIndex(), getTableIndexes()
 
 ### Community 396 - "Community 396"
 Cohesion: 0.67
@@ -3305,36 +3305,36 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 399 - "Community 399"
-Cohesion: 1.0
-Nodes (2): listBagItems(), loadBagWithItems()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 400 - "Community 400"
 Cohesion: 1.0
-Nodes (2): buildRegisterSessionTraceSeed(), formatRegisterSessionLabel()
+Nodes (2): listBagItems(), loadBagWithItems()
 
 ### Community 401 - "Community 401"
 Cohesion: 1.0
-Nodes (2): getWorkflowTraceViewByIdWithCtx(), getWorkflowTraceViewByLookupWithCtx()
+Nodes (2): buildRegisterSessionTraceSeed(), formatRegisterSessionLabel()
 
 ### Community 402 - "Community 402"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getWorkflowTraceViewByIdWithCtx(), getWorkflowTraceViewByLookupWithCtx()
 
 ### Community 403 - "Community 403"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 404 - "Community 404"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 405 - "Community 405"
 Cohesion: 1.0
 Nodes (2): createWorkflowTraceId(), normalizeWorkflowTraceLookupValue()
 
-### Community 405 - "Community 405"
-Cohesion: 0.67
-Nodes (1): View()
-
 ### Community 406 - "Community 406"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): View()
 
 ### Community 407 - "Community 407"
 Cohesion: 0.67
@@ -3349,12 +3349,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 410 - "Community 410"
-Cohesion: 1.0
-Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
-
-### Community 411 - "Community 411"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 411 - "Community 411"
+Cohesion: 1.0
+Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
 
 ### Community 412 - "Community 412"
 Cohesion: 0.67
@@ -3366,11 +3366,11 @@ Nodes (0):
 
 ### Community 414 - "Community 414"
 Cohesion: 0.67
-Nodes (1): FadeIn()
+Nodes (0):
 
 ### Community 415 - "Community 415"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): FadeIn()
 
 ### Community 416 - "Community 416"
 Cohesion: 0.67
@@ -3378,15 +3378,15 @@ Nodes (0):
 
 ### Community 417 - "Community 417"
 Cohesion: 0.67
-Nodes (1): VideoPlayer()
+Nodes (0):
 
 ### Community 418 - "Community 418"
-Cohesion: 1.0
-Nodes (2): handleRefundOrder(), toast()
+Cohesion: 0.67
+Nodes (1): VideoPlayer()
 
 ### Community 419 - "Community 419"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): handleRefundOrder(), toast()
 
 ### Community 420 - "Community 420"
 Cohesion: 0.67
@@ -3446,79 +3446,79 @@ Nodes (0):
 
 ### Community 434 - "Community 434"
 Cohesion: 0.67
-Nodes (1): SingleLineError()
+Nodes (0):
 
 ### Community 435 - "Community 435"
 Cohesion: 0.67
-Nodes (1): ErrorPage()
+Nodes (1): SingleLineError()
 
 ### Community 436 - "Community 436"
 Cohesion: 0.67
-Nodes (1): AppSkeleton()
+Nodes (1): ErrorPage()
 
 ### Community 437 - "Community 437"
 Cohesion: 0.67
-Nodes (1): DashboardSkeleton()
+Nodes (1): AppSkeleton()
 
 ### Community 438 - "Community 438"
 Cohesion: 0.67
-Nodes (1): TableSkeleton()
+Nodes (1): DashboardSkeleton()
 
 ### Community 439 - "Community 439"
 Cohesion: 0.67
-Nodes (1): TransactionsSkeleton()
+Nodes (1): TableSkeleton()
 
 ### Community 440 - "Community 440"
 Cohesion: 0.67
-Nodes (1): NotFound()
+Nodes (1): TransactionsSkeleton()
 
 ### Community 441 - "Community 441"
+Cohesion: 0.67
+Nodes (1): NotFound()
+
+### Community 442 - "Community 442"
 Cohesion: 1.0
 Nodes (2): getWorkflowTraceRouteTarget(), WorkflowTraceRouteLink()
 
-### Community 442 - "Community 442"
+### Community 443 - "Community 443"
 Cohesion: 0.67
 Nodes (1): AppContextMenu()
 
-### Community 443 - "Community 443"
+### Community 444 - "Community 444"
 Cohesion: 0.67
 Nodes (1): Badge()
 
-### Community 444 - "Community 444"
-Cohesion: 0.67
-Nodes (0):
-
 ### Community 445 - "Community 445"
 Cohesion: 0.67
-Nodes (1): LoadingButton()
+Nodes (0):
 
 ### Community 446 - "Community 446"
 Cohesion: 0.67
-Nodes (1): onChange()
+Nodes (1): LoadingButton()
 
 ### Community 447 - "Community 447"
 Cohesion: 0.67
-Nodes (1): AlertModal()
+Nodes (1): onChange()
 
 ### Community 448 - "Community 448"
 Cohesion: 0.67
-Nodes (1): OverlayModal()
+Nodes (1): AlertModal()
 
 ### Community 449 - "Community 449"
 Cohesion: 0.67
-Nodes (1): Skeleton()
+Nodes (1): OverlayModal()
 
 ### Community 450 - "Community 450"
 Cohesion: 0.67
-Nodes (1): Toaster()
+Nodes (1): Skeleton()
 
 ### Community 451 - "Community 451"
 Cohesion: 0.67
-Nodes (1): Spinner()
+Nodes (1): Toaster()
 
 ### Community 452 - "Community 452"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): Spinner()
 
 ### Community 453 - "Community 453"
 Cohesion: 0.67
@@ -3550,11 +3550,11 @@ Nodes (0):
 
 ### Community 460 - "Community 460"
 Cohesion: 0.67
-Nodes (1): useAuth()
+Nodes (0):
 
 ### Community 461 - "Community 461"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): useAuth()
 
 ### Community 462 - "Community 462"
 Cohesion: 0.67
@@ -3565,36 +3565,36 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 464 - "Community 464"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 465 - "Community 465"
 Cohesion: 1.0
 Nodes (2): getApprovalGuidance(), presentCommandToast()
 
-### Community 465 - "Community 465"
+### Community 466 - "Community 466"
 Cohesion: 0.67
 Nodes (1): isInMaintenanceMode()
 
-### Community 466 - "Community 466"
+### Community 467 - "Community 467"
 Cohesion: 0.67
 Nodes (0):
-
-### Community 467 - "Community 467"
-Cohesion: 1.0
-Nodes (2): createTerminalSyncSecretToken(), registerAndProvisionPosTerminal()
 
 ### Community 468 - "Community 468"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): createTerminalSyncSecretToken(), registerAndProvisionPosTerminal()
 
 ### Community 469 - "Community 469"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 470 - "Community 470"
-Cohesion: 1.0
-Nodes (2): readProjectedLocalRegisterModel(), readScopedPosLocalEvents()
-
-### Community 471 - "Community 471"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 471 - "Community 471"
+Cohesion: 1.0
+Nodes (2): readProjectedLocalRegisterModel(), readScopedPosLocalEvents()
 
 ### Community 472 - "Community 472"
 Cohesion: 0.67
@@ -8693,1231 +8693,1231 @@ Nodes (0):
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 674`** (2 nodes): `ExpenseCompletionPanel()`, `ExpenseCompletionPanel.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 675`** (2 nodes): `RegisterCustomerAttribution.test.tsx`, `makeCustomer()`
+- **Thin community `Community 675`** (2 nodes): `POSRegisterView.test.tsx`, `pressDebugPanelShortcut()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 676`** (2 nodes): `RegisterCustomerPanel.tsx`, `RegisterCustomerPanel()`
+- **Thin community `Community 676`** (2 nodes): `RegisterCustomerAttribution.test.tsx`, `makeCustomer()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 677`** (2 nodes): `RegisterDrawerGate.test.tsx`, `renderGate()`
+- **Thin community `Community 677`** (2 nodes): `RegisterCustomerPanel.tsx`, `RegisterCustomerPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 678`** (2 nodes): `RegisterSessionPanel.tsx`, `RegisterSessionPanel()`
+- **Thin community `Community 678`** (2 nodes): `RegisterDrawerGate.test.tsx`, `renderGate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 679`** (2 nodes): `transactionColumns.test.tsx`, `renderTransactionCell()`
+- **Thin community `Community 679`** (2 nodes): `RegisterSessionPanel.tsx`, `RegisterSessionPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 680`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
+- **Thin community `Community 680`** (2 nodes): `transactionColumns.test.tsx`, `renderTransactionCell()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 681`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
+- **Thin community `Community 681`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 682`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
+- **Thin community `Community 682`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 683`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
+- **Thin community `Community 683`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 684`** (2 nodes): `ProductStatus.tsx`, `ProductStatus()`
+- **Thin community `Community 684`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 685`** (2 nodes): `SKUSelector.tsx`, `SKUSelector()`
+- **Thin community `Community 685`** (2 nodes): `ProductStatus.tsx`, `ProductStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 686`** (2 nodes): `product-actions.tsx`, `useArchiveProduct()`
+- **Thin community `Community 686`** (2 nodes): `SKUSelector.tsx`, `SKUSelector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 687`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
+- **Thin community `Community 687`** (2 nodes): `product-actions.tsx`, `useArchiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 688`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
+- **Thin community `Community 688`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 689`** (2 nodes): `Products.tsx`, `Products()`
+- **Thin community `Community 689`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 690`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
+- **Thin community `Community 690`** (2 nodes): `Products.tsx`, `Products()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 691`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
+- **Thin community `Community 691`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 692`** (2 nodes): `PromoCodePreview.tsx`, `Discount()`
+- **Thin community `Community 692`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 693`** (2 nodes): `PromoCodesView.test.tsx`, `readSource()`
+- **Thin community `Community 693`** (2 nodes): `PromoCodePreview.tsx`, `Discount()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 694`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
+- **Thin community `Community 694`** (2 nodes): `PromoCodesView.test.tsx`, `readSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 695`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
+- **Thin community `Community 695`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 696`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
+- **Thin community `Community 696`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 697`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
+- **Thin community `Community 697`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 698`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
+- **Thin community `Community 698`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 699`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
+- **Thin community `Community 699`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 700`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
+- **Thin community `Community 700`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 701`** (2 nodes): `ServiceCasesView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 701`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 702`** (2 nodes): `ServiceCatalogView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 702`** (2 nodes): `ServiceCasesView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 703`** (2 nodes): `ServiceIntakeForm.tsx`, `ServiceIntakeForm()`
+- **Thin community `Community 703`** (2 nodes): `ServiceCatalogView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 704`** (2 nodes): `ServiceIntakeView.auth.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 704`** (2 nodes): `ServiceIntakeForm.tsx`, `ServiceIntakeForm()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 705`** (2 nodes): `ServiceIntakeView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 705`** (2 nodes): `ServiceIntakeView.auth.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 706`** (2 nodes): `StaffAuthenticationDialog.tsx`, `handleKeyDown()`
+- **Thin community `Community 706`** (2 nodes): `ServiceIntakeView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 707`** (2 nodes): `staffPinPolicy.ts`, `normalizeStaffPin()`
+- **Thin community `Community 707`** (2 nodes): `StaffAuthenticationDialog.tsx`, `handleKeyDown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 708`** (2 nodes): `onClick()`, `empty-state.tsx`
+- **Thin community `Community 708`** (2 nodes): `staffPinPolicy.ts`, `normalizeStaffPin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 709`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
+- **Thin community `Community 709`** (2 nodes): `onClick()`, `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 710`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
+- **Thin community `Community 710`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 711`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
+- **Thin community `Community 711`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 712`** (2 nodes): `ProtectedAdminSignInView.tsx`, `ProtectedAdminSignInView()`
+- **Thin community `Community 712`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 713`** (2 nodes): `ContactView()`, `ContactView.tsx`
+- **Thin community `Community 713`** (2 nodes): `ProtectedAdminSignInView.tsx`, `ProtectedAdminSignInView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 714`** (2 nodes): `Header()`, `Header.tsx`
+- **Thin community `Community 714`** (2 nodes): `ContactView()`, `ContactView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 715`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
+- **Thin community `Community 715`** (2 nodes): `Header()`, `Header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 716`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
+- **Thin community `Community 716`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 717`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
+- **Thin community `Community 717`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 718`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
+- **Thin community `Community 718`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 719`** (2 nodes): `useChart()`, `chart.tsx`
+- **Thin community `Community 719`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 720`** (2 nodes): `handleCopy()`, `copy-button.tsx`
+- **Thin community `Community 720`** (2 nodes): `useChart()`, `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 721`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
+- **Thin community `Community 721`** (2 nodes): `handleCopy()`, `copy-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 722`** (2 nodes): `Label()`, `label.tsx`
+- **Thin community `Community 722`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 723`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
+- **Thin community `Community 723`** (2 nodes): `Label()`, `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 724`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
+- **Thin community `Community 724`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 725`** (2 nodes): `store-modal.tsx`, `onSubmit()`
+- **Thin community `Community 725`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 726`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
+- **Thin community `Community 726`** (2 nodes): `store-modal.tsx`, `onSubmit()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 727`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
+- **Thin community `Community 727`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 728`** (2 nodes): `select-native.tsx`, `cn()`
+- **Thin community `Community 728`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 729`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
+- **Thin community `Community 729`** (2 nodes): `select-native.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 730`** (2 nodes): `webp-image.tsx`, `WebpImage()`
+- **Thin community `Community 730`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 731`** (2 nodes): `BagItems()`, `BagItems.tsx`
+- **Thin community `Community 731`** (2 nodes): `webp-image.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 732`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
+- **Thin community `Community 732`** (2 nodes): `BagItems()`, `BagItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 733`** (2 nodes): `Bags()`, `Bags.tsx`
+- **Thin community `Community 733`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 734`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
+- **Thin community `Community 734`** (2 nodes): `Bags()`, `Bags.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 735`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
+- **Thin community `Community 735`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 736`** (2 nodes): `UserBag.tsx`, `UserBag()`
+- **Thin community `Community 736`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 737`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
+- **Thin community `Community 737`** (2 nodes): `UserBag.tsx`, `UserBag()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 738`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
+- **Thin community `Community 738`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 739`** (2 nodes): `UserView.tsx`, `UserActions()`
+- **Thin community `Community 739`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 740`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
+- **Thin community `Community 740`** (2 nodes): `UserView.tsx`, `UserActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 741`** (2 nodes): `UserBehaviorInsights.tsx`, `UserBehaviorInsights()`
+- **Thin community `Community 741`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 742`** (2 nodes): `wrapper()`, `ManagerElevationContext.test.tsx`
+- **Thin community `Community 742`** (2 nodes): `UserBehaviorInsights.tsx`, `UserBehaviorInsights()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 743`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
+- **Thin community `Community 743`** (2 nodes): `wrapper()`, `ManagerElevationContext.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 744`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
+- **Thin community `Community 744`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 745`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
+- **Thin community `Community 745`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 746`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
+- **Thin community `Community 746`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 747`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
+- **Thin community `Community 747`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 748`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
+- **Thin community `Community 748`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 749`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
+- **Thin community `Community 749`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 750`** (2 nodes): `useConvexAuthIdentity.ts`, `useConvexAuthIdentity()`
+- **Thin community `Community 750`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 751`** (2 nodes): `useCopyText.ts`, `useCopyText()`
+- **Thin community `Community 751`** (2 nodes): `useConvexAuthIdentity.ts`, `useConvexAuthIdentity()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 752`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
+- **Thin community `Community 752`** (2 nodes): `useCopyText.ts`, `useCopyText()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 753`** (2 nodes): `useDebounce.ts`, `useDebounce()`
+- **Thin community `Community 753`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 754`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
+- **Thin community `Community 754`** (2 nodes): `useDebounce.ts`, `useDebounce()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 755`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
+- **Thin community `Community 755`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 756`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
+- **Thin community `Community 756`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 757`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
+- **Thin community `Community 757`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 758`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
+- **Thin community `Community 758`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 759`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
+- **Thin community `Community 759`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 760`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
+- **Thin community `Community 760`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 761`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
+- **Thin community `Community 761`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 762`** (2 nodes): `usePermissions.ts`, `usePermissions()`
+- **Thin community `Community 762`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 763`** (2 nodes): `usePrint.ts`, `usePrint()`
+- **Thin community `Community 763`** (2 nodes): `usePermissions.ts`, `usePermissions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 764`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
+- **Thin community `Community 764`** (2 nodes): `usePrint.ts`, `usePrint()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 765`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
+- **Thin community `Community 765`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 766`** (2 nodes): `useProtectedAdminPageState.ts`, `useProtectedAdminPageState()`
+- **Thin community `Community 766`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 767`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
+- **Thin community `Community 767`** (2 nodes): `useProtectedAdminPageState.ts`, `useProtectedAdminPageState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 768`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
+- **Thin community `Community 768`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 769`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
+- **Thin community `Community 769`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 770`** (2 nodes): `toOperatorMessage()`, `operatorMessages.ts`
+- **Thin community `Community 770`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 771`** (2 nodes): `presentUnexpectedErrorToast.ts`, `presentUnexpectedErrorToast()`
+- **Thin community `Community 771`** (2 nodes): `toOperatorMessage()`, `operatorMessages.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 772`** (2 nodes): `getOrigin()`, `navigationUtils.ts`
+- **Thin community `Community 772`** (2 nodes): `presentUnexpectedErrorToast.ts`, `presentUnexpectedErrorToast()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 773`** (2 nodes): `addItem()`, `addItem.ts`
+- **Thin community `Community 773`** (2 nodes): `getOrigin()`, `navigationUtils.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 774`** (2 nodes): `bootstrapRegister()`, `bootstrapRegister.ts`
+- **Thin community `Community 774`** (2 nodes): `addItem()`, `addItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 775`** (2 nodes): `holdSession()`, `holdSession.ts`
+- **Thin community `Community 775`** (2 nodes): `bootstrapRegister()`, `bootstrapRegister.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 776`** (2 nodes): `openDrawer()`, `openDrawer.ts`
+- **Thin community `Community 776`** (2 nodes): `holdSession()`, `holdSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 777`** (2 nodes): `startSession.ts`, `startSession()`
+- **Thin community `Community 777`** (2 nodes): `openDrawer()`, `openDrawer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 778`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
+- **Thin community `Community 778`** (2 nodes): `startSession.ts`, `startSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 779`** (2 nodes): `registerAvailabilitySnapshot.test.ts`, `buildAvailabilityRow()`
+- **Thin community `Community 779`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 780`** (2 nodes): `registerAvailabilitySnapshot.ts`, `readRegisterAvailabilitySnapshotState()`
+- **Thin community `Community 780`** (2 nodes): `registerAvailabilitySnapshot.test.ts`, `buildAvailabilityRow()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 781`** (2 nodes): `syncContract.test.ts`, `buildLocalEvent()`
+- **Thin community `Community 781`** (2 nodes): `registerAvailabilitySnapshot.ts`, `readRegisterAvailabilitySnapshotState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 782`** (2 nodes): `syncScheduler.test.ts`, `baseEvent()`
+- **Thin community `Community 782`** (2 nodes): `syncContract.test.ts`, `buildLocalEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 783`** (2 nodes): `syncStatus.test.ts`, `event()`
+- **Thin community `Community 783`** (2 nodes): `syncScheduler.test.ts`, `baseEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 784`** (2 nodes): `useRegisterCatalogIndex.ts`, `useRegisterCatalogIndex()`
+- **Thin community `Community 784`** (2 nodes): `syncStatus.test.ts`, `event()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 785`** (2 nodes): `pinHash.ts`, `hashPin()`
+- **Thin community `Community 785`** (2 nodes): `useRegisterCatalogIndex.ts`, `useRegisterCatalogIndex()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 786`** (2 nodes): `hasOrgNotFoundPayload()`, `index.tsx`
+- **Thin community `Community 786`** (2 nodes): `pinHash.ts`, `hashPin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 787`** (2 nodes): `$sessionId.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 787`** (2 nodes): `hasOrgNotFoundPayload()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 788`** (2 nodes): `registers.index.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 788`** (2 nodes): `$sessionId.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 789`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
+- **Thin community `Community 789`** (2 nodes): `registers.index.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 790`** (2 nodes): `ApprovalsRoute()`, `approvals.tsx`
+- **Thin community `Community 790`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 791`** (2 nodes): `DailyCloseHistoryRoute()`, `daily-close-history.tsx`
+- **Thin community `Community 791`** (2 nodes): `ApprovalsRoute()`, `approvals.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 792`** (2 nodes): `DailyCloseRoute()`, `daily-close.tsx`
+- **Thin community `Community 792`** (2 nodes): `DailyCloseHistoryRoute()`, `daily-close-history.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 793`** (2 nodes): `OpenWorkRoute()`, `open-work.tsx`
+- **Thin community `Community 793`** (2 nodes): `DailyCloseRoute()`, `daily-close.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 794`** (2 nodes): `DailyOpeningRoute()`, `opening.tsx`
+- **Thin community `Community 794`** (2 nodes): `OpenWorkRoute()`, `open-work.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 795`** (2 nodes): `stock-adjustments.tsx`, `StockAdjustmentsRoute()`
+- **Thin community `Community 795`** (2 nodes): `DailyOpeningRoute()`, `opening.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 796`** (2 nodes): `ExpenseRouteComponent()`, `expense.index.tsx`
+- **Thin community `Community 796`** (2 nodes): `stock-adjustments.tsx`, `StockAdjustmentsRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 797`** (2 nodes): `published.index.tsx`, `RouteComponent()`
+- **Thin community `Community 797`** (2 nodes): `ExpenseRouteComponent()`, `expense.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 798`** (2 nodes): `Index()`, `index.tsx`
+- **Thin community `Community 798`** (2 nodes): `published.index.tsx`, `RouteComponent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 799`** (2 nodes): `AthenaLoginReadyView()`, `_layout.index.tsx`
+- **Thin community `Community 799`** (2 nodes): `Index()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 800`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
+- **Thin community `Community 800`** (2 nodes): `AthenaLoginReadyView()`, `_layout.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 801`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 801`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 802`** (2 nodes): `view-patterns.tsx`, `cn()`
+- **Thin community `Community 802`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 803`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
+- **Thin community `Community 803`** (2 nodes): `view-patterns.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 804`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
+- **Thin community `Community 804`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 805`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
+- **Thin community `Community 805`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 806`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 806`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 807`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
+- **Thin community `Community 807`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 808`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
+- **Thin community `Community 808`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 809`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
+- **Thin community `Community 809`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 810`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 810`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 811`** (2 nodes): `usePrint.test.ts`, `setWindowOpenMock()`
+- **Thin community `Community 811`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 812`** (2 nodes): `formatNumber()`, `formatNumber.ts`
+- **Thin community `Community 812`** (2 nodes): `usePrint.test.ts`, `setWindowOpenMock()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 813`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
+- **Thin community `Community 813`** (2 nodes): `formatNumber()`, `formatNumber.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 814`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
+- **Thin community `Community 814`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 815`** (2 nodes): `updateGuest()`, `guest.ts`
+- **Thin community `Community 815`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 816`** (2 nodes): `posTransaction.test.ts`, `jsonResponse()`
+- **Thin community `Community 816`** (2 nodes): `updateGuest()`, `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 817`** (2 nodes): `storefront.ts`, `getStore()`
+- **Thin community `Community 817`** (2 nodes): `posTransaction.test.ts`, `jsonResponse()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 818`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
+- **Thin community `Community 818`** (2 nodes): `storefront.ts`, `getStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 819`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
+- **Thin community `Community 819`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 820`** (2 nodes): `AuthComponent()`, `Auth.tsx`
+- **Thin community `Community 820`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 821`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
+- **Thin community `Community 821`** (2 nodes): `AuthComponent()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 822`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
+- **Thin community `Community 822`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 823`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
+- **Thin community `Community 823`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 824`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
+- **Thin community `Community 824`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 825`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
+- **Thin community `Community 825`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 826`** (2 nodes): `PickupDetails()`, `index.tsx`
+- **Thin community `Community 826`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 827`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
+- **Thin community `Community 827`** (2 nodes): `PickupDetails()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 828`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
+- **Thin community `Community 828`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 829`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
+- **Thin community `Community 829`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 830`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
+- **Thin community `Community 830`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 831`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
+- **Thin community `Community 831`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 832`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
+- **Thin community `Community 832`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 833`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
+- **Thin community `Community 833`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 834`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
+- **Thin community `Community 834`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 835`** (2 nodes): `useCountdown()`, `hooks.ts`
+- **Thin community `Community 835`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 836`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
+- **Thin community `Community 836`** (2 nodes): `useCountdown()`, `hooks.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 837`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
+- **Thin community `Community 837`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 838`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
+- **Thin community `Community 838`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 839`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
+- **Thin community `Community 839`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 840`** (2 nodes): `resolveHomepageContent()`, `homePageContent.ts`
+- **Thin community `Community 840`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 841`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
+- **Thin community `Community 841`** (2 nodes): `resolveHomepageContent()`, `homePageContent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 842`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
+- **Thin community `Community 842`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 843`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
+- **Thin community `Community 843`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 844`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
+- **Thin community `Community 844`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 845`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
+- **Thin community `Community 845`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 846`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
+- **Thin community `Community 846`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 847`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
+- **Thin community `Community 847`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 848`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
+- **Thin community `Community 848`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 849`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
+- **Thin community `Community 849`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 850`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
+- **Thin community `Community 850`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 851`** (2 nodes): `ProductPage.test.tsx`, `makePageState()`
+- **Thin community `Community 851`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 852`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
+- **Thin community `Community 852`** (2 nodes): `ProductPage.test.tsx`, `makePageState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 853`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
+- **Thin community `Community 853`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 854`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
+- **Thin community `Community 854`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 855`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
+- **Thin community `Community 855`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 856`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
+- **Thin community `Community 856`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 857`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
+- **Thin community `Community 857`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 858`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
+- **Thin community `Community 858`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 859`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
+- **Thin community `Community 859`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 860`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
+- **Thin community `Community 860`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 861`** (2 nodes): `BagItem()`, `BagItem.tsx`
+- **Thin community `Community 861`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 862`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
+- **Thin community `Community 862`** (2 nodes): `BagItem()`, `BagItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 863`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
+- **Thin community `Community 863`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 864`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
+- **Thin community `Community 864`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 865`** (2 nodes): `CountrySelect()`, `country-select.tsx`
+- **Thin community `Community 865`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 866`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
+- **Thin community `Community 866`** (2 nodes): `CountrySelect()`, `country-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 867`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
+- **Thin community `Community 867`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 868`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
+- **Thin community `Community 868`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 869`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
+- **Thin community `Community 869`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 870`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
+- **Thin community `Community 870`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 871`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
+- **Thin community `Community 871`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 872`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
+- **Thin community `Community 872`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 873`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
+- **Thin community `Community 873`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 874`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
+- **Thin community `Community 874`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 875`** (2 nodes): `useCheckout.ts`, `useCheckout()`
+- **Thin community `Community 875`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 876`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
+- **Thin community `Community 876`** (2 nodes): `useCheckout.ts`, `useCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 877`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
+- **Thin community `Community 877`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 878`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
+- **Thin community `Community 878`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 879`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
+- **Thin community `Community 879`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 880`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
+- **Thin community `Community 880`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 881`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
+- **Thin community `Community 881`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 882`** (2 nodes): `useGetStore.ts`, `useGetStore()`
+- **Thin community `Community 882`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 883`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
+- **Thin community `Community 883`** (2 nodes): `useGetStore.ts`, `useGetStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 884`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
+- **Thin community `Community 884`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 885`** (2 nodes): `useLogout.ts`, `useLogout()`
+- **Thin community `Community 885`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 886`** (2 nodes): `useModalState.tsx`, `useModalState()`
+- **Thin community `Community 886`** (2 nodes): `useLogout.ts`, `useLogout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 887`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
+- **Thin community `Community 887`** (2 nodes): `useModalState.tsx`, `useModalState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 888`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
+- **Thin community `Community 888`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 889`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
+- **Thin community `Community 889`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 890`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
+- **Thin community `Community 890`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 891`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
+- **Thin community `Community 891`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 892`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
+- **Thin community `Community 892`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 893`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
+- **Thin community `Community 893`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 894`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
+- **Thin community `Community 894`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 895`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
+- **Thin community `Community 895`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 896`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
+- **Thin community `Community 896`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 897`** (2 nodes): `useBagQueries()`, `bag.ts`
+- **Thin community `Community 897`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 898`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
+- **Thin community `Community 898`** (2 nodes): `useBagQueries()`, `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 899`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
+- **Thin community `Community 899`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 900`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
+- **Thin community `Community 900`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 901`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
+- **Thin community `Community 901`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 902`** (2 nodes): `posTransaction.ts`, `usePosTransactionQueries()`
+- **Thin community `Community 902`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 903`** (2 nodes): `product.ts`, `useProductQueries()`
+- **Thin community `Community 903`** (2 nodes): `posTransaction.ts`, `usePosTransactionQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 904`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
+- **Thin community `Community 904`** (2 nodes): `product.ts`, `useProductQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 905`** (2 nodes): `reviews.ts`, `useReviewQueries()`
+- **Thin community `Community 905`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 906`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
+- **Thin community `Community 906`** (2 nodes): `reviews.ts`, `useReviewQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 907`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
+- **Thin community `Community 907`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 908`** (2 nodes): `user.ts`, `useUserQueries()`
+- **Thin community `Community 908`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 909`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
+- **Thin community `Community 909`** (2 nodes): `user.ts`, `useUserQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 910`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
+- **Thin community `Community 910`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 911`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
+- **Thin community `Community 911`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 912`** (2 nodes): `validateEmail()`, `email.ts`
+- **Thin community `Community 912`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 913`** (2 nodes): `router.tsx`, `createRouter()`
+- **Thin community `Community 913`** (2 nodes): `validateEmail()`, `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 914`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
+- **Thin community `Community 914`** (2 nodes): `router.tsx`, `createRouter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 915`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
+- **Thin community `Community 915`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 916`** (2 nodes): `ContactUs()`, `contact-us.tsx`
+- **Thin community `Community 916`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 917`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
+- **Thin community `Community 917`** (2 nodes): `ContactUs()`, `contact-us.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 918`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
+- **Thin community `Community 918`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 919`** (2 nodes): `tos.index.tsx`, `TosSection()`
+- **Thin community `Community 919`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 920`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
+- **Thin community `Community 920`** (2 nodes): `tos.index.tsx`, `TosSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 921`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
+- **Thin community `Community 921`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 922`** (2 nodes): `HomeRoute()`, `index.tsx`
+- **Thin community `Community 922`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 923`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
+- **Thin community `Community 923`** (2 nodes): `HomeRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 924`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
+- **Thin community `Community 924`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 925`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
+- **Thin community `Community 925`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 926`** (2 nodes): `ReceiptShareRoute()`, `index.tsx`
+- **Thin community `Community 926`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 927`** (2 nodes): `test-connection.js`, `main()`
+- **Thin community `Community 927`** (2 nodes): `ReceiptShareRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 928`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
+- **Thin community `Community 928`** (2 nodes): `test-connection.js`, `main()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 929`** (2 nodes): `run()`, `architecture-boundary-check.ts`
+- **Thin community `Community 929`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 930`** (2 nodes): `readRepoFile()`, `deploy-qa-vps.test.ts`
+- **Thin community `Community 930`** (2 nodes): `run()`, `architecture-boundary-check.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 931`** (2 nodes): `runCommand()`, `github-pr-merge.test.ts`
+- **Thin community `Community 931`** (2 nodes): `readRepoFile()`, `deploy-qa-vps.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 932`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
+- **Thin community `Community 932`** (2 nodes): `runCommand()`, `github-pr-merge.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 933`** (2 nodes): `shutdown()`, `sample-app.ts`
+- **Thin community `Community 933`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 934`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
+- **Thin community `Community 934`** (2 nodes): `shutdown()`, `sample-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 935`** (1 nodes): `api.d.ts`
+- **Thin community `Community 935`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 936`** (1 nodes): `api.js`
+- **Thin community `Community 936`** (1 nodes): `api.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 937`** (1 nodes): `dataModel.d.ts`
+- **Thin community `Community 937`** (1 nodes): `api.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 938`** (1 nodes): `server.d.ts`
+- **Thin community `Community 938`** (1 nodes): `dataModel.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 939`** (1 nodes): `server.js`
+- **Thin community `Community 939`** (1 nodes): `server.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 940`** (1 nodes): `app.ts`
+- **Thin community `Community 940`** (1 nodes): `server.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 941`** (1 nodes): `auth.config.js`
+- **Thin community `Community 941`** (1 nodes): `app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 942`** (1 nodes): `auth.ts`
+- **Thin community `Community 942`** (1 nodes): `auth.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 943`** (1 nodes): `registerSessions.test.ts`
+- **Thin community `Community 943`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 944`** (1 nodes): `r2.test.ts`
+- **Thin community `Community 944`** (1 nodes): `registerSessions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 945`** (1 nodes): `countries.ts`
+- **Thin community `Community 945`** (1 nodes): `r2.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 946`** (1 nodes): `email.ts`
+- **Thin community `Community 946`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 947`** (1 nodes): `ghana.ts`
+- **Thin community `Community 947`** (1 nodes): `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 948`** (1 nodes): `payment.ts`
+- **Thin community `Community 948`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 949`** (1 nodes): `crons.ts`
+- **Thin community `Community 949`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 950`** (1 nodes): `domain.test.ts`
+- **Thin community `Community 950`** (1 nodes): `crons.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 951`** (1 nodes): `internal.ts`
+- **Thin community `Community 951`** (1 nodes): `domain.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 952`** (1 nodes): `public.test.ts`
+- **Thin community `Community 952`** (1 nodes): `internal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 953`** (1 nodes): `token.test.ts`
+- **Thin community `Community 953`** (1 nodes): `public.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 954`** (1 nodes): `whatsappClient.test.ts`
+- **Thin community `Community 954`** (1 nodes): `token.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 955`** (1 nodes): `whatsappConfig.test.ts`
+- **Thin community `Community 955`** (1 nodes): `whatsappClient.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 956`** (1 nodes): `devPatchBadTransaction.ts`
+- **Thin community `Community 956`** (1 nodes): `whatsappConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 957`** (1 nodes): `FeedbackRequest.tsx`
+- **Thin community `Community 957`** (1 nodes): `devPatchBadTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 958`** (1 nodes): `NewOrderAdmin.tsx`
+- **Thin community `Community 958`** (1 nodes): `FeedbackRequest.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 959`** (1 nodes): `OrderEmail.tsx`
+- **Thin community `Community 959`** (1 nodes): `NewOrderAdmin.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 960`** (1 nodes): `PosReceiptEmail.tsx`
+- **Thin community `Community 960`** (1 nodes): `OrderEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 961`** (1 nodes): `env.ts`
+- **Thin community `Community 961`** (1 nodes): `PosReceiptEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 962`** (1 nodes): `analytics.ts`
+- **Thin community `Community 962`** (1 nodes): `env.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 963`** (1 nodes): `auth.ts`
+- **Thin community `Community 963`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 964`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 964`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 965`** (1 nodes): `colors.ts`
+- **Thin community `Community 965`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 966`** (1 nodes): `index.ts`
+- **Thin community `Community 966`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 967`** (1 nodes): `organizations.ts`
+- **Thin community `Community 967`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 968`** (1 nodes): `products.ts`
+- **Thin community `Community 968`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 969`** (1 nodes): `storefrontHidden.test.ts`
+- **Thin community `Community 969`** (1 nodes): `products.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 970`** (1 nodes): `stores.ts`
+- **Thin community `Community 970`** (1 nodes): `storefrontHidden.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 971`** (1 nodes): `bag.ts`
+- **Thin community `Community 971`** (1 nodes): `stores.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 972`** (1 nodes): `guest.ts`
+- **Thin community `Community 972`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 973`** (1 nodes): `index.ts`
+- **Thin community `Community 973`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 974`** (1 nodes): `me.ts`
+- **Thin community `Community 974`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 975`** (1 nodes): `offers.ts`
+- **Thin community `Community 975`** (1 nodes): `me.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 976`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 976`** (1 nodes): `offers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 977`** (1 nodes): `paystack.ts`
+- **Thin community `Community 977`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 978`** (1 nodes): `posTransaction.ts`
+- **Thin community `Community 978`** (1 nodes): `paystack.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 979`** (1 nodes): `reviews.ts`
+- **Thin community `Community 979`** (1 nodes): `posTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 980`** (1 nodes): `rewards.ts`
+- **Thin community `Community 980`** (1 nodes): `reviews.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 981`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 981`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 982`** (1 nodes): `security.test.ts`
+- **Thin community `Community 982`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 983`** (1 nodes): `storefront.ts`
+- **Thin community `Community 983`** (1 nodes): `security.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 984`** (1 nodes): `upsells.ts`
+- **Thin community `Community 984`** (1 nodes): `storefront.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 985`** (1 nodes): `user.ts`
+- **Thin community `Community 985`** (1 nodes): `upsells.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 986`** (1 nodes): `userOffers.ts`
+- **Thin community `Community 986`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 987`** (1 nodes): `index.ts`
+- **Thin community `Community 987`** (1 nodes): `userOffers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 988`** (1 nodes): `health.test.ts`
+- **Thin community `Community 988`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 989`** (1 nodes): `http.ts`
+- **Thin community `Community 989`** (1 nodes): `health.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 990`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 990`** (1 nodes): `http.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 991`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 991`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 992`** (1 nodes): `bestSeller.ts`
+- **Thin community `Community 992`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 993`** (1 nodes): `categories.ts`
+- **Thin community `Community 993`** (1 nodes): `bestSeller.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 994`** (1 nodes): `colors.ts`
+- **Thin community `Community 994`** (1 nodes): `categories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 995`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 995`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 996`** (1 nodes): `expenseTransactions.test.ts`
+- **Thin community `Community 996`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 997`** (1 nodes): `featuredItem.ts`
+- **Thin community `Community 997`** (1 nodes): `expenseTransactions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 998`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 998`** (1 nodes): `featuredItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 999`** (1 nodes): `organizationMembers.ts`
+- **Thin community `Community 999`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1000`** (1 nodes): `organizations.ts`
+- **Thin community `Community 1000`** (1 nodes): `organizationMembers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1001`** (1 nodes): `pos.ts`
+- **Thin community `Community 1001`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1002`** (1 nodes): `posCustomers.ts`
+- **Thin community `Community 1002`** (1 nodes): `pos.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1003`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 1003`** (1 nodes): `posCustomers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1004`** (1 nodes): `productSku.ts`
+- **Thin community `Community 1004`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1005`** (1 nodes): `productUtil.test.ts`
+- **Thin community `Community 1005`** (1 nodes): `productSku.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1006`** (1 nodes): `promoCode.test.ts`
+- **Thin community `Community 1006`** (1 nodes): `productUtil.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1007`** (1 nodes): `stockValidation.ts`
+- **Thin community `Community 1007`** (1 nodes): `promoCode.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1008`** (1 nodes): `storeConfigV2.test.ts`
+- **Thin community `Community 1008`** (1 nodes): `stockValidation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1009`** (1 nodes): `subcategories.ts`
+- **Thin community `Community 1009`** (1 nodes): `storeConfigV2.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1010`** (1 nodes): `commandResultValidators.test.ts`
+- **Thin community `Community 1010`** (1 nodes): `subcategories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1011`** (1 nodes): `currency.test.ts`
+- **Thin community `Community 1011`** (1 nodes): `commandResultValidators.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1012`** (1 nodes): `storeInsights.ts`
+- **Thin community `Community 1012`** (1 nodes): `currency.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1013`** (1 nodes): `userInsights.ts`
+- **Thin community `Community 1013`** (1 nodes): `storeInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1014`** (1 nodes): `migrateAmountsToPesewas.ts`
+- **Thin community `Community 1014`** (1 nodes): `userInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1015`** (1 nodes): `client.test.ts`
+- **Thin community `Community 1015`** (1 nodes): `migrateAmountsToPesewas.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1016`** (1 nodes): `config.test.ts`
+- **Thin community `Community 1016`** (1 nodes): `client.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1017`** (1 nodes): `normalize.test.ts`
+- **Thin community `Community 1017`** (1 nodes): `config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1018`** (1 nodes): `types.ts`
+- **Thin community `Community 1018`** (1 nodes): `normalize.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1019`** (1 nodes): `customerProfiles.test.ts`
+- **Thin community `Community 1019`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1020`** (1 nodes): `paymentAllocations.test.ts`
+- **Thin community `Community 1020`** (1 nodes): `customerProfiles.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1021`** (1 nodes): `EmailOTP.test.ts`
+- **Thin community `Community 1021`** (1 nodes): `paymentAllocations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1022`** (1 nodes): `correctTransactionCustomer.test.ts`
+- **Thin community `Community 1022`** (1 nodes): `EmailOTP.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1023`** (1 nodes): `correctionEvents.test.ts`
+- **Thin community `Community 1023`** (1 nodes): `correctTransactionCustomer.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1024`** (1 nodes): `correctionPolicy.test.ts`
+- **Thin community `Community 1024`** (1 nodes): `correctionEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1025`** (1 nodes): `dto.ts`
+- **Thin community `Community 1025`** (1 nodes): `correctionPolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1026`** (1 nodes): `getRegisterState.test.ts`
+- **Thin community `Community 1026`** (1 nodes): `dto.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1027`** (1 nodes): `posSessionTracing.test.ts`
+- **Thin community `Community 1027`** (1 nodes): `getRegisterState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1028`** (1 nodes): `types.ts`
+- **Thin community `Community 1028`** (1 nodes): `posSessionTracing.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1029`** (1 nodes): `terminals.test.ts`
+- **Thin community `Community 1029`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1030`** (1 nodes): `types.ts`
+- **Thin community `Community 1030`** (1 nodes): `terminals.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1031`** (1 nodes): `registerSessionRepository.test.ts`
+- **Thin community `Community 1031`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1032`** (1 nodes): `customers.ts`
+- **Thin community `Community 1032`** (1 nodes): `registerSessionRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1033`** (1 nodes): `register.ts`
+- **Thin community `Community 1033`** (1 nodes): `customers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1034`** (1 nodes): `sync.ts`
+- **Thin community `Community 1034`** (1 nodes): `register.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1035`** (1 nodes): `schema.ts`
+- **Thin community `Community 1035`** (1 nodes): `sync.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1036`** (1 nodes): `customerMessageDelivery.ts`
+- **Thin community `Community 1036`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1037`** (1 nodes): `index.ts`
+- **Thin community `Community 1037`** (1 nodes): `customerMessageDelivery.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1038`** (1 nodes): `receiptShareToken.ts`
+- **Thin community `Community 1038`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1039`** (1 nodes): `appVerificationCode.ts`
+- **Thin community `Community 1039`** (1 nodes): `receiptShareToken.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1040`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 1040`** (1 nodes): `appVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1041`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 1041`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1042`** (1 nodes): `bestSeller.ts`
+- **Thin community `Community 1042`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1043`** (1 nodes): `category.ts`
+- **Thin community `Community 1043`** (1 nodes): `bestSeller.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1044`** (1 nodes): `color.ts`
+- **Thin community `Community 1044`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1045`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 1045`** (1 nodes): `color.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1046`** (1 nodes): `featuredItem.ts`
+- **Thin community `Community 1046`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1047`** (1 nodes): `index.ts`
+- **Thin community `Community 1047`** (1 nodes): `featuredItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1048`** (1 nodes): `inventoryHold.ts`
+- **Thin community `Community 1048`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1049`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 1049`** (1 nodes): `inventoryHold.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1050`** (1 nodes): `organization.ts`
+- **Thin community `Community 1050`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1051`** (1 nodes): `organizationMember.ts`
+- **Thin community `Community 1051`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1052`** (1 nodes): `product.ts`
+- **Thin community `Community 1052`** (1 nodes): `organizationMember.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1053`** (1 nodes): `promoCode.ts`
+- **Thin community `Community 1053`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1054`** (1 nodes): `redeemedPromoCode.ts`
+- **Thin community `Community 1054`** (1 nodes): `promoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1055`** (1 nodes): `store.ts`
+- **Thin community `Community 1055`** (1 nodes): `redeemedPromoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1056`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1056`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1057`** (1 nodes): `index.ts`
+- **Thin community `Community 1057`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1058`** (1 nodes): `workflowTrace.ts`
+- **Thin community `Community 1058`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1059`** (1 nodes): `workflowTraceEvent.ts`
+- **Thin community `Community 1059`** (1 nodes): `workflowTrace.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1060`** (1 nodes): `workflowTraceLookup.ts`
+- **Thin community `Community 1060`** (1 nodes): `workflowTraceEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1061`** (1 nodes): `approvalRequest.ts`
+- **Thin community `Community 1061`** (1 nodes): `workflowTraceLookup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1062`** (1 nodes): `customerProfile.ts`
+- **Thin community `Community 1062`** (1 nodes): `approvalRequest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1063`** (1 nodes): `dailyClose.ts`
+- **Thin community `Community 1063`** (1 nodes): `customerProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1064`** (1 nodes): `dailyOpening.ts`
+- **Thin community `Community 1064`** (1 nodes): `dailyClose.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1065`** (1 nodes): `index.ts`
+- **Thin community `Community 1065`** (1 nodes): `dailyOpening.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1066`** (1 nodes): `inventoryMovement.ts`
+- **Thin community `Community 1066`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1067`** (1 nodes): `managerElevation.ts`
+- **Thin community `Community 1067`** (1 nodes): `inventoryMovement.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1068`** (1 nodes): `operationalEvent.ts`
+- **Thin community `Community 1068`** (1 nodes): `managerElevation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1069`** (1 nodes): `operationalWorkItem.ts`
+- **Thin community `Community 1069`** (1 nodes): `operationalEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1070`** (1 nodes): `paymentAllocation.ts`
+- **Thin community `Community 1070`** (1 nodes): `operationalWorkItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1071`** (1 nodes): `registerSession.ts`
+- **Thin community `Community 1071`** (1 nodes): `paymentAllocation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1072`** (1 nodes): `skuActivityEvent.ts`
+- **Thin community `Community 1072`** (1 nodes): `registerSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1073`** (1 nodes): `staffCredential.ts`
+- **Thin community `Community 1073`** (1 nodes): `skuActivityEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1074`** (1 nodes): `staffProfile.ts`
+- **Thin community `Community 1074`** (1 nodes): `staffCredential.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1075`** (1 nodes): `staffRoleAssignment.ts`
+- **Thin community `Community 1075`** (1 nodes): `staffProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1076`** (1 nodes): `mtnCollections.ts`
+- **Thin community `Community 1076`** (1 nodes): `staffRoleAssignment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1077`** (1 nodes): `customer.ts`
+- **Thin community `Community 1077`** (1 nodes): `mtnCollections.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1078`** (1 nodes): `expenseSession.ts`
+- **Thin community `Community 1078`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1079`** (1 nodes): `expenseSessionItem.ts`
+- **Thin community `Community 1079`** (1 nodes): `expenseSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1080`** (1 nodes): `expenseTransaction.ts`
+- **Thin community `Community 1080`** (1 nodes): `expenseSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1081`** (1 nodes): `expenseTransactionItem.ts`
+- **Thin community `Community 1081`** (1 nodes): `expenseTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1082`** (1 nodes): `index.ts`
+- **Thin community `Community 1082`** (1 nodes): `expenseTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1083`** (1 nodes): `posLocalStaffProof.ts`
+- **Thin community `Community 1083`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1084`** (1 nodes): `posLocalSyncConflict.ts`
+- **Thin community `Community 1084`** (1 nodes): `posLocalStaffProof.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1085`** (1 nodes): `posLocalSyncCursor.ts`
+- **Thin community `Community 1085`** (1 nodes): `posLocalSyncConflict.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1086`** (1 nodes): `posLocalSyncEvent.ts`
+- **Thin community `Community 1086`** (1 nodes): `posLocalSyncCursor.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1087`** (1 nodes): `posLocalSyncMapping.ts`
+- **Thin community `Community 1087`** (1 nodes): `posLocalSyncEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1088`** (1 nodes): `posSession.ts`
+- **Thin community `Community 1088`** (1 nodes): `posLocalSyncMapping.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1089`** (1 nodes): `posSessionItem.ts`
+- **Thin community `Community 1089`** (1 nodes): `posSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1090`** (1 nodes): `posTerminal.test.ts`
+- **Thin community `Community 1090`** (1 nodes): `posSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1091`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 1091`** (1 nodes): `posTerminal.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1092`** (1 nodes): `posTransaction.ts`
+- **Thin community `Community 1092`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1093`** (1 nodes): `posTransactionItem.ts`
+- **Thin community `Community 1093`** (1 nodes): `posTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1094`** (1 nodes): `index.ts`
+- **Thin community `Community 1094`** (1 nodes): `posTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1095`** (1 nodes): `serviceAppointment.ts`
+- **Thin community `Community 1095`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1096`** (1 nodes): `serviceCase.ts`
+- **Thin community `Community 1096`** (1 nodes): `serviceAppointment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1097`** (1 nodes): `serviceCaseLineItem.ts`
+- **Thin community `Community 1097`** (1 nodes): `serviceCase.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1098`** (1 nodes): `serviceCatalog.ts`
+- **Thin community `Community 1098`** (1 nodes): `serviceCaseLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1099`** (1 nodes): `serviceInventoryUsage.ts`
+- **Thin community `Community 1099`** (1 nodes): `serviceCatalog.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1100`** (1 nodes): `cycleCountDraft.ts`
+- **Thin community `Community 1100`** (1 nodes): `serviceInventoryUsage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1101`** (1 nodes): `index.ts`
+- **Thin community `Community 1101`** (1 nodes): `cycleCountDraft.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1102`** (1 nodes): `purchaseOrder.ts`
+- **Thin community `Community 1102`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1103`** (1 nodes): `purchaseOrderLineItem.ts`
+- **Thin community `Community 1103`** (1 nodes): `purchaseOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1104`** (1 nodes): `receivingBatch.ts`
+- **Thin community `Community 1104`** (1 nodes): `purchaseOrderLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1105`** (1 nodes): `stockAdjustmentBatch.ts`
+- **Thin community `Community 1105`** (1 nodes): `receivingBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1106`** (1 nodes): `vendor.ts`
+- **Thin community `Community 1106`** (1 nodes): `stockAdjustmentBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1107`** (1 nodes): `analytics.ts`
+- **Thin community `Community 1107`** (1 nodes): `vendor.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1108`** (1 nodes): `bag.ts`
+- **Thin community `Community 1108`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1109`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1109`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1110`** (1 nodes): `checkoutSession.ts`
+- **Thin community `Community 1110`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1111`** (1 nodes): `checkoutSessionItem.ts`
+- **Thin community `Community 1111`** (1 nodes): `checkoutSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1112`** (1 nodes): `guest.ts`
+- **Thin community `Community 1112`** (1 nodes): `checkoutSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1113`** (1 nodes): `index.ts`
+- **Thin community `Community 1113`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1114`** (1 nodes): `offer.ts`
+- **Thin community `Community 1114`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1115`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 1115`** (1 nodes): `offer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1116`** (1 nodes): `onlineOrderItem.ts`
+- **Thin community `Community 1116`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1117`** (1 nodes): `review.ts`
+- **Thin community `Community 1117`** (1 nodes): `onlineOrderItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1118`** (1 nodes): `rewards.ts`
+- **Thin community `Community 1118`** (1 nodes): `review.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1119`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 1119`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1120`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 1120`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1121`** (1 nodes): `storeFrontSession.ts`
+- **Thin community `Community 1121`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1122`** (1 nodes): `storeFrontUser.ts`
+- **Thin community `Community 1122`** (1 nodes): `storeFrontSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1123`** (1 nodes): `storeFrontVerificationCode.ts`
+- **Thin community `Community 1123`** (1 nodes): `storeFrontUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1124`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 1124`** (1 nodes): `storeFrontVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1125`** (1 nodes): `catalogAppointments.test.ts`
+- **Thin community `Community 1125`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1126`** (1 nodes): `bag.ts`
+- **Thin community `Community 1126`** (1 nodes): `catalogAppointments.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1127`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1127`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1128`** (1 nodes): `customer.ts`
+- **Thin community `Community 1128`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1129`** (1 nodes): `guest.ts`
+- **Thin community `Community 1129`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1130`** (1 nodes): `offers.test.ts`
+- **Thin community `Community 1130`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1131`** (1 nodes): `onlineOrderUtilFns.ts`
+- **Thin community `Community 1131`** (1 nodes): `offers.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1132`** (1 nodes): `orderOperations.test.ts`
+- **Thin community `Community 1132`** (1 nodes): `onlineOrderUtilFns.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1133`** (1 nodes): `payment.test.ts`
+- **Thin community `Community 1133`** (1 nodes): `orderOperations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1134`** (1 nodes): `payment.ts`
+- **Thin community `Community 1134`** (1 nodes): `payment.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1135`** (1 nodes): `paystackActions.ts`
+- **Thin community `Community 1135`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1136`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 1136`** (1 nodes): `paystackActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1137`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 1137`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1138`** (1 nodes): `users.ts`
+- **Thin community `Community 1138`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1139`** (1 nodes): `payment.ts`
+- **Thin community `Community 1139`** (1 nodes): `users.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1140`** (1 nodes): `posSession.test.ts`
+- **Thin community `Community 1140`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1141`** (1 nodes): `registerSession.test.ts`
+- **Thin community `Community 1141`** (1 nodes): `posSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1142`** (1 nodes): `presentation.test.ts`
+- **Thin community `Community 1142`** (1 nodes): `registerSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1143`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 1143`** (1 nodes): `presentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1144`** (1 nodes): `index.ts`
+- **Thin community `Community 1144`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1145`** (1 nodes): `postcss.config.js`
+- **Thin community `Community 1145`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1146`** (1 nodes): `approvalPolicy.ts`
+- **Thin community `Community 1146`** (1 nodes): `postcss.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1147`** (1 nodes): `auth.ts`
+- **Thin community `Community 1147`** (1 nodes): `approvalPolicy.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1148`** (1 nodes): `commandResult.test.ts`
+- **Thin community `Community 1148`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1149`** (1 nodes): `currencyFormatter.test.ts`
+- **Thin community `Community 1149`** (1 nodes): `commandResult.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1150`** (1 nodes): `posLocalSyncContract.ts`
+- **Thin community `Community 1150`** (1 nodes): `currencyFormatter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1151`** (1 nodes): `registerSessionStatus.test.ts`
+- **Thin community `Community 1151`** (1 nodes): `posLocalSyncContract.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1152`** (1 nodes): `staffDisplayName.test.ts`
+- **Thin community `Community 1152`** (1 nodes): `registerSessionStatus.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1153`** (1 nodes): `GenericComboBox.tsx`
+- **Thin community `Community 1153`** (1 nodes): `staffDisplayName.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1154`** (1 nodes): `StoreAccordion.tsx`
+- **Thin community `Community 1154`** (1 nodes): `GenericComboBox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1155`** (1 nodes): `StoresAccordion.tsx`
+- **Thin community `Community 1155`** (1 nodes): `StoreAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1156`** (1 nodes): `ThemeToggle.tsx`
+- **Thin community `Community 1156`** (1 nodes): `StoresAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1157`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
+- **Thin community `Community 1157`** (1 nodes): `ThemeToggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1158`** (1 nodes): `ProductAttributes.tsx`
+- **Thin community `Community 1158`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1159`** (1 nodes): `ProductAttributesView.tsx`
+- **Thin community `Community 1159`** (1 nodes): `ProductAttributes.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1160`** (1 nodes): `ProductStock.test.ts`
+- **Thin community `Community 1160`** (1 nodes): `ProductAttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1161`** (1 nodes): `ProductView.test.tsx`
+- **Thin community `Community 1161`** (1 nodes): `ProductStock.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1162`** (1 nodes): `constants.ts`
+- **Thin community `Community 1162`** (1 nodes): `ProductView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1163`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1163`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1164`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1164`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1165`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1165`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1166`** (1 nodes): `types.ts`
+- **Thin community `Community 1166`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1167`** (1 nodes): `ConversionFunnelChart.tsx`
+- **Thin community `Community 1167`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1168`** (1 nodes): `RevenueChart.tsx`
+- **Thin community `Community 1168`** (1 nodes): `ConversionFunnelChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1169`** (1 nodes): `analytics-columns.tsx`
+- **Thin community `Community 1169`** (1 nodes): `RevenueChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1170`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1170`** (1 nodes): `analytics-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1171`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1171`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1172`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1172`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1173`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1173`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1174`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1174`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1175`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1175`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1176`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1176`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1177`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1177`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1178`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1178`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1179`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1179`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1180`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1180`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1181`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1181`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1182`** (1 nodes): `chart.tsx`
+- **Thin community `Community 1182`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1183`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1183`** (1 nodes): `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1184`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1184`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1185`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1185`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1186`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1186`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1187`** (1 nodes): `constants.ts`
+- **Thin community `Community 1187`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1188`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1188`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1189`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1189`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1190`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1190`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1191`** (1 nodes): `data.ts`
+- **Thin community `Community 1191`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1192`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1192`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1193`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1193`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1194`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1194`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1195`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1195`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1196`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1196`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1197`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1197`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1198`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1198`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1199`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1199`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1200`** (1 nodes): `assetsColumns.tsx`
+- **Thin community `Community 1200`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1201`** (1 nodes): `constants.ts`
+- **Thin community `Community 1201`** (1 nodes): `assetsColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1202`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1202`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1203`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1203`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1204`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1204`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1205`** (1 nodes): `data.ts`
+- **Thin community `Community 1205`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1206`** (1 nodes): `DefaultCatchBoundary.test.tsx`
+- **Thin community `Community 1206`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1207`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 1207`** (1 nodes): `DefaultCatchBoundary.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1208`** (1 nodes): `LoginForm.test.tsx`
+- **Thin community `Community 1208`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1209`** (1 nodes): `LoginForm.tsx`
+- **Thin community `Community 1209`** (1 nodes): `LoginForm.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1210`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1210`** (1 nodes): `LoginForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1211`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1211`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1212`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1212`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1213`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1213`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1214`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1214`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1215`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1215`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1216`** (1 nodes): `constants.ts`
+- **Thin community `Community 1216`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1217`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1217`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1218`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1218`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1219`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1219`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1220`** (1 nodes): `BulkOperationsPage.tsx`
+- **Thin community `Community 1220`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1221`** (1 nodes): `CashControlsDashboard.auth.test.tsx`
+- **Thin community `Community 1221`** (1 nodes): `BulkOperationsPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1222`** (1 nodes): `CashControlsDashboard.test.tsx`
+- **Thin community `Community 1222`** (1 nodes): `CashControlsDashboard.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1223`** (1 nodes): `CashControlsWorkspaceHeader.tsx`
+- **Thin community `Community 1223`** (1 nodes): `CashControlsDashboard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1224`** (1 nodes): `RegisterSessionView.auth.test.tsx`
+- **Thin community `Community 1224`** (1 nodes): `CashControlsWorkspaceHeader.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1225`** (1 nodes): `RegisterSessionView.test.tsx`
+- **Thin community `Community 1225`** (1 nodes): `RegisterSessionView.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1226`** (1 nodes): `RegisterSessionsView.test.tsx`
+- **Thin community `Community 1226`** (1 nodes): `RegisterSessionView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1227`** (1 nodes): `formatReviewReason.test.ts`
+- **Thin community `Community 1227`** (1 nodes): `RegisterSessionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1228`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1228`** (1 nodes): `formatReviewReason.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1229`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1229`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1230`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1230`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1231`** (1 nodes): `ListPagination.tsx`
+- **Thin community `Community 1231`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1232`** (1 nodes): `PageLevelHeader.test.tsx`
+- **Thin community `Community 1232`** (1 nodes): `ListPagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1233`** (1 nodes): `PageLevelHeader.tsx`
+- **Thin community `Community 1233`** (1 nodes): `PageLevelHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1234`** (1 nodes): `MetricCard.tsx`
+- **Thin community `Community 1234`** (1 nodes): `PageLevelHeader.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1235`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 1235`** (1 nodes): `MetricCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1236`** (1 nodes): `CommandApprovalDialog.test.tsx`
+- **Thin community `Community 1236`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1237`** (1 nodes): `OperationReviewWorkspace.tsx`
+- **Thin community `Community 1237`** (1 nodes): `CommandApprovalDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1238`** (1 nodes): `OperationsQueueView.auth.test.tsx`
+- **Thin community `Community 1238`** (1 nodes): `OperationReviewWorkspace.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1239`** (1 nodes): `SkuActivityTimeline.test.tsx`
+- **Thin community `Community 1239`** (1 nodes): `OperationsQueueView.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1240`** (1 nodes): `skuActivityTimelineAdapter.test.ts`
+- **Thin community `Community 1240`** (1 nodes): `SkuActivityTimeline.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1241`** (1 nodes): `useApprovedCommand.test.tsx`
+- **Thin community `Community 1241`** (1 nodes): `skuActivityTimelineAdapter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1242`** (1 nodes): `OrderStatus.test.tsx`
+- **Thin community `Community 1242`** (1 nodes): `useApprovedCommand.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1243`** (1 nodes): `OrderStatus.tsx`
+- **Thin community `Community 1243`** (1 nodes): `OrderStatus.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1244`** (1 nodes): `OrderSummary.tsx`
+- **Thin community `Community 1244`** (1 nodes): `OrderStatus.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1245`** (1 nodes): `Orders.tsx`
+- **Thin community `Community 1245`** (1 nodes): `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1246`** (1 nodes): `RefundsView.test.tsx`
+- **Thin community `Community 1246`** (1 nodes): `Orders.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1247`** (1 nodes): `ReturnExchangeView.test.tsx`
+- **Thin community `Community 1247`** (1 nodes): `RefundsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1248`** (1 nodes): `constants.ts`
+- **Thin community `Community 1248`** (1 nodes): `ReturnExchangeView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1249`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1249`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1250`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1250`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1251`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1251`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1252`** (1 nodes): `data.ts`
+- **Thin community `Community 1252`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1253`** (1 nodes): `refundUtils.test.ts`
+- **Thin community `Community 1253`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1254`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1254`** (1 nodes): `refundUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1255`** (1 nodes): `constants.ts`
+- **Thin community `Community 1255`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1256`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1256`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1257`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1257`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1258`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1258`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1259`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1259`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1260`** (1 nodes): `data.ts`
+- **Thin community `Community 1260`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1261`** (1 nodes): `inviteColumns.tsx`
+- **Thin community `Community 1261`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1262`** (1 nodes): `constants.ts`
+- **Thin community `Community 1262`** (1 nodes): `inviteColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1263`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1263`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1264`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1264`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1265`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1265`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1266`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1266`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1267`** (1 nodes): `data.ts`
+- **Thin community `Community 1267`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1268`** (1 nodes): `membersColumns.tsx`
+- **Thin community `Community 1268`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1269`** (1 nodes): `organization-switcher.test.tsx`
+- **Thin community `Community 1269`** (1 nodes): `membersColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1270`** (1 nodes): `CashierView.tsx`
+- **Thin community `Community 1270`** (1 nodes): `organization-switcher.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1271`** (1 nodes): `POSRegisterView.tsx`
+- **Thin community `Community 1271`** (1 nodes): `CashierView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1272`** (1 nodes): `PaymentView.test.tsx`
+- **Thin community `Community 1272`** (1 nodes): `POSRegisterView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1273`** (1 nodes): `PointOfSaleView.test.tsx`
+- **Thin community `Community 1273`** (1 nodes): `PaymentView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1274`** (1 nodes): `PointOfSaleView.tsx`
+- **Thin community `Community 1274`** (1 nodes): `PointOfSaleView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1275`** (1 nodes): `ProductLookup.tsx`
+- **Thin community `Community 1275`** (1 nodes): `PointOfSaleView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1276`** (1 nodes): `RegisterActions.tsx`
+- **Thin community `Community 1276`** (1 nodes): `ProductLookup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1277`** (1 nodes): `SessionManager.test.tsx`
+- **Thin community `Community 1277`** (1 nodes): `RegisterActions.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1278`** (1 nodes): `SessionManager.tsx`
+- **Thin community `Community 1278`** (1 nodes): `SessionManager.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1279`** (1 nodes): `TotalsDisplay.test.tsx`
+- **Thin community `Community 1279`** (1 nodes): `SessionManager.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1280`** (1 nodes): `TotalsDisplay.tsx`
+- **Thin community `Community 1280`** (1 nodes): `TotalsDisplay.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1281`** (1 nodes): `ExpenseReportView.tsx`
+- **Thin community `Community 1281`** (1 nodes): `TotalsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1282`** (1 nodes): `ExpenseReportsView.test.ts`
+- **Thin community `Community 1282`** (1 nodes): `ExpenseReportView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1283`** (1 nodes): `ExpenseReportsView.test.tsx`
+- **Thin community `Community 1283`** (1 nodes): `ExpenseReportsView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1284`** (1 nodes): `expenseReportColumns.tsx`
+- **Thin community `Community 1284`** (1 nodes): `ExpenseReportsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1285`** (1 nodes): `PosReceiptShareControl.test.tsx`
+- **Thin community `Community 1285`** (1 nodes): `expenseReportColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1286`** (1 nodes): `POSRegisterOpeningGuard.test.tsx`
+- **Thin community `Community 1286`** (1 nodes): `PosReceiptShareControl.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1287`** (1 nodes): `POSRegisterView.test.tsx`
+- **Thin community `Community 1287`** (1 nodes): `POSRegisterOpeningGuard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1288`** (1 nodes): `RegisterActionBar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,8 +8,8 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 1742
-- Graph nodes: 5489
-- Graph edges: 5714
+- Graph nodes: 5496
+- Graph edges: 5724
 - Communities: 1671
 
 ## Graph Hotspots
@@ -19,7 +19,7 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 - `storefrontJourneyEvents.ts` (45 edges, Community 3) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
 - `createJourneyEvent()` (40 edges, Community 3) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
 - `ProcurementView.tsx` (39 edges, Community 4) - [`packages/athena-webapp/src/components/procurement/ProcurementView.tsx`](../../packages/athena-webapp/src/components/procurement/ProcurementView.tsx)
-- `useRegisterViewModel.ts` (37 edges, Community 5) - [`packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts`](../../packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts)
+- `useRegisterViewModel.ts` (38 edges, Community 5) - [`packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts`](../../packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts)
 - `DailyOpeningView.tsx` (35 edges, Community 7) - [`packages/athena-webapp/src/components/operations/DailyOpeningView.tsx`](../../packages/athena-webapp/src/components/operations/DailyOpeningView.tsx)
 
 ## Registered Packages

--- a/graphify-out/wiki/packages/athena-webapp.md
+++ b/graphify-out/wiki/packages/athena-webapp.md
@@ -20,7 +20,7 @@ Landing page for packages/athena-webapp. Use this page to orient around graph ho
 - `DailyCloseView.tsx` (82 edges, Community 0) - [`packages/athena-webapp/src/components/operations/DailyCloseView.tsx`](../../../packages/athena-webapp/src/components/operations/DailyCloseView.tsx)
 - `dailyClose.ts` (57 edges, Community 1) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../../packages/athena-webapp/convex/operations/dailyClose.ts)
 - `ProcurementView.tsx` (39 edges, Community 4) - [`packages/athena-webapp/src/components/procurement/ProcurementView.tsx`](../../../packages/athena-webapp/src/components/procurement/ProcurementView.tsx)
-- `useRegisterViewModel.ts` (37 edges, Community 5) - [`packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts`](../../../packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts)
+- `useRegisterViewModel.ts` (38 edges, Community 5) - [`packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts`](../../../packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts)
 - `DailyOpeningView.tsx` (35 edges, Community 7) - [`packages/athena-webapp/src/components/operations/DailyOpeningView.tsx`](../../../packages/athena-webapp/src/components/operations/DailyOpeningView.tsx)
 
 ## Navigation

--- a/packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.ts
+++ b/packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.ts
@@ -661,6 +661,7 @@ function validateSaleCompletedPayload(payload: Record<string, unknown>) {
 
   if (
     !isOptionalNonEmptyString(payload.registerNumber) ||
+    !isOptionalNonEmptyString(payload.receiptNumber) ||
     !isOptionalNonEmptyString(payload.customerProfileId)
   ) {
     return "POS sale optional identifiers are invalid.";
@@ -718,6 +719,8 @@ function parseSaleCompletedPayload(
     localPosSessionId: payload.localPosSessionId as string,
     localTransactionId: payload.localTransactionId as string,
     localReceiptNumber: payload.localReceiptNumber as string,
+    receiptNumber:
+      optionalString(payload.receiptNumber) ?? (payload.localReceiptNumber as string),
     registerNumber: optionalString(payload.registerNumber),
     customerProfileId: customerProfileId
       ? repository.normalizeCloudId("customerProfile", customerProfileId) ??

--- a/packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.test.ts
+++ b/packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.test.ts
@@ -98,6 +98,39 @@ describe("projectLocalSyncEvent", () => {
     ]);
   });
 
+  it("keeps the display receipt number separate from the local sync receipt id", async () => {
+    const repository = createProjectionRepository();
+
+    const result = await projectLocalSyncEvent(repository, {
+      storeId: "store-1" as never,
+      terminalId: "terminal-1" as never,
+      event: buildSaleCompletedEvent({
+        payload: {
+          ...buildSaleCompletedEvent().payload,
+          localReceiptNumber: "local-txn-1",
+          receiptNumber: "123456",
+        },
+      }),
+      syncEventId: "sync-event-1",
+      now: 100,
+    });
+
+    expect(result.status).toBe("projected");
+    expect(repository.createdTransactions).toEqual([
+      expect.objectContaining({
+        transactionNumber: "123456",
+      }),
+    ]);
+    expect(result.mappings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          localIdKind: "receipt",
+          localId: "local-txn-1",
+        }),
+      ]),
+    );
+  });
+
   it("projects cashier sales on admin-provisioned shared terminals", async () => {
     const repository = createProjectionRepository({
       terminalRegisteredByUserId: "admin-user-1",
@@ -2118,6 +2151,7 @@ function buildSaleCompletedEvent(
       localPosSessionId: "local-session-1",
       localTransactionId: "local-txn-1",
       localReceiptNumber: "LR-001",
+      receiptNumber: "LR-001",
       registerNumber: "1",
       totals: {
         subtotal: 25,

--- a/packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts
+++ b/packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts
@@ -910,7 +910,7 @@ async function persistSaleRecord(
 ): Promise<PersistedSale> {
   const { payments, payload, saleSession, session } = input;
   const transactionId = await repository.createTransaction({
-    transactionNumber: payload.localReceiptNumber,
+    transactionNumber: payload.receiptNumber,
     storeId: args.storeId,
     sessionId: saleSession.posSessionId,
     registerSessionId: session.registerSession._id,

--- a/packages/athena-webapp/convex/pos/application/sync/types.ts
+++ b/packages/athena-webapp/convex/pos/application/sync/types.ts
@@ -45,6 +45,7 @@ export type PosLocalSalePayload = {
   localPosSessionId: string;
   localTransactionId: string;
   localReceiptNumber: string;
+  receiptNumber: string;
   registerNumber?: string;
   customerProfileId?: Id<"customerProfile">;
   customerInfo?: {

--- a/packages/athena-webapp/convex/pos/public/sync.test.ts
+++ b/packages/athena-webapp/convex/pos/public/sync.test.ts
@@ -289,6 +289,33 @@ describe("POS local sync public mutation", () => {
       }),
     );
   });
+
+  it("passes sale completed display receipt numbers through the public sync boundary", async () => {
+    const ctx = buildCtx();
+    const event = buildSaleCompletedEvent();
+
+    await getHandler(ingestLocalEvents)(ctx as never, {
+      storeId: "store-1",
+      terminalId: "terminal-1",
+      syncSecretHash: "sync-secret-1",
+      events: [event],
+    });
+
+    expect(mocks.ingestLocalEventsWithCtx).toHaveBeenCalledWith(
+      ctx,
+      expect.objectContaining({
+        events: [
+          expect.objectContaining({
+            eventType: "sale_completed",
+            payload: expect.objectContaining({
+              localReceiptNumber: "local-txn-1",
+              receiptNumber: "123456",
+            }),
+          }),
+        ],
+      }),
+    );
+  });
 });
 
 function buildCtx(
@@ -358,6 +385,49 @@ function buildEvent() {
     payload: {
       openingFloat: 100,
       registerNumber: "1",
+    },
+  };
+}
+
+function buildSaleCompletedEvent() {
+  return {
+    localEventId: "event-sale-1",
+    localRegisterSessionId: "local-register-1",
+    sequence: 2,
+    eventType: "sale_completed",
+    occurredAt: 124,
+    staffProfileId: "staff-1",
+    staffProofToken: "proof-token-1",
+    payload: {
+      localPosSessionId: "local-session-1",
+      localTransactionId: "local-txn-1",
+      localReceiptNumber: "local-txn-1",
+      receiptNumber: "123456",
+      registerNumber: "1",
+      totals: {
+        subtotal: 25,
+        tax: 0,
+        total: 25,
+      },
+      items: [
+        {
+          localTransactionItemId: "local-item-1",
+          productId: "product-1",
+          productSkuId: "sku-1",
+          productName: "Wig Cap",
+          productSku: "CAP-1",
+          quantity: 1,
+          unitPrice: 25,
+        },
+      ],
+      payments: [
+        {
+          localPaymentId: "local-payment-1",
+          method: "cash",
+          amount: 25,
+          timestamp: 124,
+        },
+      ],
     },
   };
 }

--- a/packages/athena-webapp/convex/pos/public/sync.ts
+++ b/packages/athena-webapp/convex/pos/public/sync.ts
@@ -99,6 +99,7 @@ const posLocalSyncUploadEventValidator = v.union(
       localPosSessionId: v.string(),
       localTransactionId: v.string(),
       localReceiptNumber: v.string(),
+      receiptNumber: v.string(),
       registerNumber: v.optional(v.string()),
       customerProfileId: v.optional(v.string()),
       customerInfo: v.optional(

--- a/packages/athena-webapp/shared/posLocalSyncContract.ts
+++ b/packages/athena-webapp/shared/posLocalSyncContract.ts
@@ -49,6 +49,7 @@ export type PosLocalSyncSaleCompletedPayload = {
   localPosSessionId: string;
   localTransactionId: string;
   localReceiptNumber: string;
+  receiptNumber: string;
   registerNumber?: string;
   customerProfileId?: string;
   customerInfo?: {

--- a/packages/athena-webapp/src/components/pos/OrderSummary.tsx
+++ b/packages/athena-webapp/src/components/pos/OrderSummary.tsx
@@ -113,7 +113,7 @@ interface OrderSummaryProps {
   onRemovePayment?: (paymentId: string) => boolean | Promise<boolean>;
   onClearPayments?: () => boolean | Promise<boolean>;
   onCompleteTransaction?: () => Promise<boolean>;
-  onStartNewTransaction?: () => void;
+  onStartNewTransaction?: () => void | Promise<void>;
   onPaymentFlowChange?: (isActive: boolean) => void;
   onPaymentEntryStart?: () => void;
   onEditingPaymentChange?: (isEditing: boolean) => void;

--- a/packages/athena-webapp/src/components/pos/PointOfSaleView.test.tsx
+++ b/packages/athena-webapp/src/components/pos/PointOfSaleView.test.tsx
@@ -7,6 +7,7 @@ const useGetActiveOrganizationMock = vi.fn();
 const useGetActiveStoreMock = vi.fn();
 const useLocalPosEntryContextMock = vi.fn();
 const usePermissionsMock = vi.fn();
+const usePrewarmRegisterCatalogOfflineSnapshotsMock = vi.fn();
 const useQueryMock = vi.fn();
 
 vi.mock("@tanstack/react-router", () => ({
@@ -58,6 +59,12 @@ vi.mock("~/src/hooks/useGetTerminal", () => ({
 
 vi.mock("@/lib/pos/infrastructure/local/localPosEntryContext", () => ({
   useLocalPosEntryContext: () => useLocalPosEntryContextMock(),
+}));
+
+vi.mock("@/lib/pos/infrastructure/convex/catalogGateway", () => ({
+  usePrewarmRegisterCatalogOfflineSnapshots: (
+    input: Record<string, unknown>,
+  ) => usePrewarmRegisterCatalogOfflineSnapshotsMock(input),
 }));
 
 vi.mock("~/src/hooks/usePermissions", () => ({
@@ -122,6 +129,34 @@ describe("PointOfSaleView", () => {
     expect(
       screen.getByRole("heading", { level: 1, name: "Point of Sale" }),
     ).toBeInTheDocument();
+  });
+
+  it("prewarms POS register offline snapshots from the POS landing page", () => {
+    render(<PointOfSaleView />);
+
+    expect(usePrewarmRegisterCatalogOfflineSnapshotsMock).toHaveBeenCalledWith({
+      storeId: "store-1",
+    });
+  });
+
+  it("prewarms POS register offline snapshots from local entry context when live store context is unavailable", () => {
+    useGetActiveStoreMock.mockReturnValue({
+      activeStore: null,
+    });
+    useLocalPosEntryContextMock.mockReturnValue({
+      status: "ready",
+      orgUrlSlug: "acme",
+      storeUrlSlug: "downtown",
+      storeId: "local-store-1",
+      terminalSeed: null,
+      source: "local",
+    });
+
+    render(<PointOfSaleView />);
+
+    expect(usePrewarmRegisterCatalogOfflineSnapshotsMock).toHaveBeenCalledWith({
+      storeId: "local-store-1",
+    });
   });
 
   it("links managers to active POS session operations from the POS landing page", () => {

--- a/packages/athena-webapp/src/components/pos/PointOfSaleView.tsx
+++ b/packages/athena-webapp/src/components/pos/PointOfSaleView.tsx
@@ -29,6 +29,8 @@ import { usePermissions } from "~/src/hooks/usePermissions";
 import { toDisplayAmount } from "~/convex/lib/currency";
 import { PageLevelHeader, PageWorkspace } from "../common/PageLevelHeader";
 import { useLocalPosEntryContext } from "@/lib/pos/infrastructure/local/localPosEntryContext";
+import { usePrewarmRegisterCatalogOfflineSnapshots } from "@/lib/pos/infrastructure/convex/catalogGateway";
+import type { Id } from "~/convex/_generated/dataModel";
 
 type FeatureLinkProps = {
   children: ReactNode;
@@ -59,6 +61,12 @@ export default function PointOfSaleView() {
     activeStore,
     routeParams,
   });
+  const snapshotStoreId =
+    activeStore?._id ??
+    (localEntryContext.status === "ready"
+      ? (localEntryContext.storeId as Id<"store">)
+      : undefined);
+  usePrewarmRegisterCatalogOfflineSnapshots({ storeId: snapshotStoreId });
 
   // Get today's POS transaction summary
   const todaySummary = useQuery(

--- a/packages/athena-webapp/src/components/pos/register/POSRegisterView.test.tsx
+++ b/packages/athena-webapp/src/components/pos/register/POSRegisterView.test.tsx
@@ -1,9 +1,22 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
 import { describe, expect, it, vi } from "vitest";
 
 const mockUseRegisterViewModel = vi.fn();
+
+function pressDebugPanelShortcut() {
+  fireEvent.keyDown(document, {
+    code: "Slash",
+    key: "/",
+    metaKey: true,
+  });
+  fireEvent.keyUp(document, {
+    code: "Slash",
+    key: "/",
+    metaKey: true,
+  });
+}
 
 vi.mock("@/lib/pos/presentation/register/useRegisterViewModel", () => ({
   useRegisterViewModel: () => mockUseRegisterViewModel(),
@@ -275,10 +288,18 @@ describe("POSRegisterView", () => {
         activeStoreSource: "local",
         authDialogOpen: true,
         hasLiveActiveStore: false,
+        localStaffAuthorityStatus: "ready",
         localEntryStatus: "ready",
         online: false,
         staffSignedIn: false,
         storeId: "store-1",
+        syncFlow: {
+          eventAppendToken: 0,
+          pendingEventCount: 1,
+          source: "runtime",
+          staffProof: "missing",
+          status: "pending_sync",
+        },
         terminalId: "terminal-1",
         terminalSource: "local",
       },
@@ -316,11 +337,99 @@ describe("POSRegisterView", () => {
     const { POSRegisterView } = await import("./POSRegisterView");
     render(<POSRegisterView />);
 
-    expect(screen.getByText("Register connection details")).toBeInTheDocument();
-    expect(screen.getByText("offline")).toBeInTheDocument();
-    expect(screen.getByText("local:store-1")).toBeInTheDocument();
-    expect(screen.getByText("local:terminal-1")).toBeInTheDocument();
-    expect(screen.getByText("cashier-auth-dialog")).toBeInTheDocument();
+    expect(screen.getByLabelText("No staff signed in")).toBeInTheDocument();
+    expect(
+      screen.queryByText("Support sync diagnostics"),
+    ).not.toBeInTheDocument();
+    pressDebugPanelShortcut();
+
+    expect(screen.getByText("Support sync diagnostics")).toBeInTheDocument();
+    expect(screen.getAllByText("Offline")).not.toHaveLength(0);
+    expect(screen.getAllByText("Local")).not.toHaveLength(0);
+    expect(screen.getByText("Open")).toBeInTheDocument();
+  });
+
+  it("shows the debug strip while the register has an active connection", async () => {
+    mockUseRegisterViewModel.mockReturnValue({
+      hasActiveStore: true,
+      debug: {
+        activeStoreSource: "live",
+        authDialogOpen: false,
+        hasLiveActiveStore: true,
+        localStaffAuthorityStatus: "ready",
+        localEntryStatus: "ready",
+        online: true,
+        staffSignedIn: true,
+        storeId: "store-1",
+        syncFlow: {
+          eventAppendToken: 2,
+          lastLocalSequence: 4,
+          lastRuntimeTrigger: "event-appended",
+          lastRuntimeTriggerAt: Date.UTC(2026, 4, 15, 12, 34, 56),
+          lastRuntimeTriggerPriority: "high",
+          lastSyncedSequence: 4,
+          nextPendingSequence: null,
+          pendingEventCount: 0,
+          source: "none",
+          staffProof: "present",
+          status: "synced",
+        },
+        terminalId: "terminal-1",
+        terminalSource: "live",
+      },
+      header: {
+        title: "POS",
+        isSessionActive: false,
+      },
+      registerInfo: {
+        registerLabel: "Front Counter",
+        hasTerminal: true,
+      },
+      customerPanel: {},
+      productEntry: {
+        disabled: true,
+        productSearchQuery: "",
+        setProductSearchQuery: vi.fn(),
+        onBarcodeSubmit: vi.fn(),
+      },
+      cart: {
+        items: [],
+      },
+      checkout: {
+        isTransactionCompleted: false,
+      },
+      sessionPanel: null,
+      cashierCard: null,
+      closeoutControl: null,
+      authDialog: {
+        open: false,
+      },
+      drawerGate: null,
+      onNavigateBack: vi.fn(),
+    });
+
+    const { POSRegisterView } = await import("./POSRegisterView");
+    render(<POSRegisterView />);
+
+    expect(screen.getByLabelText("Staff signed in")).toBeInTheDocument();
+    expect(
+      screen.queryByText("Support sync diagnostics"),
+    ).not.toBeInTheDocument();
+    pressDebugPanelShortcut();
+
+    expect(screen.getByText("Support sync diagnostics")).toBeInTheDocument();
+    expect(screen.getByText("Online")).toBeInTheDocument();
+    expect(screen.getAllByText("Live")).not.toHaveLength(0);
+    expect(screen.getByText("Server current")).toBeInTheDocument();
+    expect(screen.getByText("New register activity")).toBeInTheDocument();
+    expect(screen.getByText("High")).toBeInTheDocument();
+    expect(screen.getByText("2026-05-15T12:34:56Z")).toBeInTheDocument();
+    expect(screen.getByText("local 4 synced 4 next n/a")).toBeInTheDocument();
+
+    pressDebugPanelShortcut();
+    expect(
+      screen.queryByText("Support sync diagnostics"),
+    ).not.toBeInTheDocument();
   });
 
   it("shows POS sync status and schedules manual retry from the header", async () => {
@@ -375,7 +484,9 @@ describe("POSRegisterView", () => {
     expect(screen.getByText("Pending sync")).toBeInTheDocument();
     expect(screen.getByText("2")).toBeInTheDocument();
 
-    await userEvent.click(screen.getByRole("button", { name: /retry pos sync/i }));
+    await userEvent.click(
+      screen.getByRole("button", { name: /retry pos sync: pending sync 2/i }),
+    );
 
     expect(onRetrySync).toHaveBeenCalled();
   });

--- a/packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx
+++ b/packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx
@@ -216,6 +216,39 @@ function RegisterSyncStatusChip({
         : syncStatus.tone === "warning"
           ? "border-warning/30 bg-warning/15 text-warning"
           : "border-border bg-background text-muted-foreground";
+  const canRetry = syncStatus.status !== "synced" && syncStatus.onRetrySync;
+  const content = (
+    <>
+      <Icon aria-hidden className="h-3.5 w-3.5 shrink-0" />
+      <span className="truncate">{syncStatus.label}</span>
+      {syncStatus.pendingEventCount ? (
+        <span className="font-numeric tabular-nums">
+          {syncStatus.pendingEventCount}
+        </span>
+      ) : null}
+      {canRetry ? (
+        <RefreshCw aria-hidden className="ml-1 h-3.5 w-3.5 shrink-0" />
+      ) : null}
+    </>
+  );
+
+  if (canRetry) {
+    return (
+      <button
+        aria-label={`Retry POS sync: ${syncStatus.label}${
+          syncStatus.pendingEventCount ? ` ${syncStatus.pendingEventCount}` : ""
+        }`}
+        className={cn(
+          "inline-flex max-w-full items-center gap-2 rounded-full border px-3 py-1 text-xs font-medium transition hover:bg-background/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+          className,
+        )}
+        onClick={syncStatus.onRetrySync}
+        type="button"
+      >
+        {content}
+      </button>
+    );
+  }
 
   return (
     <div
@@ -224,63 +257,229 @@ function RegisterSyncStatusChip({
         className,
       )}
     >
-      <Icon aria-hidden className="h-3.5 w-3.5 shrink-0" />
-      <span className="truncate">{syncStatus.label}</span>
-      {syncStatus.pendingEventCount ? (
-        <span className="font-numeric tabular-nums">
-          {syncStatus.pendingEventCount}
-        </span>
-      ) : null}
-      {syncStatus.status !== "synced" && syncStatus.onRetrySync ? (
-        <button
-          aria-label="Retry POS sync"
-          className="ml-1 rounded-full p-0.5 transition hover:bg-background/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-          onClick={syncStatus.onRetrySync}
-          type="button"
-        >
-          <RefreshCw className="h-3.5 w-3.5" />
-        </button>
-      ) : null}
+      {content}
     </div>
   );
 }
 
+function formatDebugTimestamp(timestamp?: number) {
+  return timestamp
+    ? new Date(timestamp).toISOString().replace(/\.\d{3}Z$/, "Z")
+    : "n/a";
+}
+
+function formatDebugStatus(value?: string | null) {
+  if (!value) return "not ready";
+
+  return value
+    .replace(/[-_]/g, " ")
+    .replace(/\b\w/g, (character) => character.toUpperCase());
+}
+
+function formatDebugSource(value?: string | null) {
+  switch (value) {
+    case "runtime":
+      return "Upload worker";
+    case "local-read-model":
+      return "Local register record";
+    case "register-state":
+      return "Register record";
+    case "none":
+    default:
+      return "No active source";
+  }
+}
+
+function formatDebugTrigger(value?: string | null) {
+  switch (value) {
+    case "event-appended":
+      return "New register activity";
+    case "route-entry":
+      return "Page opened";
+    case "visibility":
+      return "Page visible";
+    case "interval":
+      return "Scheduled retry";
+    case "online":
+      return "Connection restored";
+    case "manual":
+      return "Manual retry";
+    case "none":
+    default:
+      return "Not triggered";
+  }
+}
+
+function usePosDebugPanelToggle() {
+  const [isVisible, setIsVisible] = useState(false);
+
+  useEffect(() => {
+    function isDebugShortcut(event: KeyboardEvent) {
+      const isDebugShortcut =
+        event.key === "/" || event.code === "Slash";
+      return event.metaKey && isDebugShortcut;
+    }
+
+    function handleKeyDown(event: KeyboardEvent) {
+      if (!isDebugShortcut(event)) {
+        return;
+      }
+
+      event.preventDefault();
+      if (event.repeat) {
+        return;
+      }
+
+      setIsVisible((current) => !current);
+    }
+
+    document.addEventListener("keydown", handleKeyDown, true);
+    return () => document.removeEventListener("keydown", handleKeyDown, true);
+  }, []);
+
+  return isVisible;
+}
+
 function POSLocalDebugStrip({
   debug,
+  isVisible,
 }: {
   debug: RegisterViewModel["debug"];
+  isVisible: boolean;
 }) {
-  if (!debug || !import.meta.env.DEV) return null;
-
-  const shouldShow =
-    !debug.online ||
-    debug.activeStoreSource !== "live" ||
-    debug.terminalSource !== "live" ||
-    debug.localEntryStatus !== "ready";
-
-  if (!shouldShow) return null;
+  if (!debug || !isVisible) return null;
 
   const rows = [
-    ["network", debug.online ? "online" : "offline"],
-    ["entry", debug.localEntryStatus],
-    ["authority", debug.localStaffAuthorityStatus],
-    ["store", `${debug.activeStoreSource}${debug.storeId ? `:${debug.storeId}` : ""}`],
+    ["connection", debug.online ? "Online" : "Offline"],
+    ["register activity", formatDebugStatus(debug.localEntryStatus)],
+    ["staff access", formatDebugStatus(debug.localStaffAuthorityStatus)],
+    ["store record", formatDebugStatus(debug.activeStoreSource)],
+    ["register record", formatDebugStatus(debug.terminalSource)],
+    ["staff sign-in", debug.staffSignedIn ? "Signed in" : "Not signed in"],
     [
-      "terminal",
-      `${debug.terminalSource}${debug.terminalId ? `:${debug.terminalId}` : ""}`,
+      "staff authorization",
+      debug.syncFlow.staffProof === "present" ? "Ready" : "Needed",
     ],
-    ["staff", debug.staffSignedIn ? "signed-in" : "not-signed-in"],
-    ["auth", debug.authDialogOpen ? "open" : "closed"],
+    ["sign-in panel", debug.authDialogOpen ? "Open" : "Closed"],
+    ["sync status", formatDebugStatus(debug.syncFlow.status)],
+    ["status source", formatDebugSource(debug.syncFlow.source)],
+    ["activity signal", String(debug.syncFlow.eventAppendToken)],
+    [
+      "last sync attempt",
+      formatDebugTrigger(debug.syncFlow.lastRuntimeTrigger),
+    ],
+    [
+      "attempt priority",
+      debug.syncFlow.lastRuntimeTriggerPriority === "high" ? "High" : "Normal",
+    ],
+    ["attempted at", formatDebugTimestamp(debug.syncFlow.lastRuntimeTriggerAt)],
+    ["waiting to sync", String(debug.syncFlow.pendingEventCount ?? 0)],
+    [
+      "activity count",
+      [
+        `local ${debug.syncFlow.lastLocalSequence ?? "n/a"}`,
+        `synced ${debug.syncFlow.lastSyncedSequence ?? "n/a"}`,
+        `next ${debug.syncFlow.nextPendingSequence ?? "n/a"}`,
+      ].join(" "),
+    ],
   ];
+  const flow = [
+    {
+      label: debug.online ? "Connected" : "Offline",
+      state: debug.online ? "ready" : "blocked",
+    },
+    {
+      label:
+        debug.localEntryStatus === "ready"
+          ? "Register activity ready"
+          : "Register activity",
+      state: debug.localEntryStatus === "ready" ? "ready" : "waiting",
+    },
+    {
+      label:
+        debug.syncFlow.staffProof === "present"
+          ? "Staff authorized"
+          : "Staff authorization",
+      state: debug.syncFlow.staffProof === "present" ? "ready" : "waiting",
+    },
+    {
+      label:
+        debug.syncFlow.status === "syncing"
+          ? "Uploading"
+          : debug.syncFlow.status === "synced"
+            ? "Uploaded"
+            : "Upload",
+      state:
+        debug.syncFlow.status === "needs_review"
+          ? "blocked"
+          : debug.syncFlow.status === "synced"
+            ? "ready"
+            : debug.syncFlow.pendingEventCount
+              ? "active"
+              : "waiting",
+    },
+    {
+      label:
+        debug.syncFlow.status === "synced"
+          ? "Server current"
+          : debug.syncFlow.status === "needs_review"
+            ? "Needs review"
+            : "Server update",
+      state:
+        debug.syncFlow.status === "synced"
+          ? "ready"
+          : debug.syncFlow.status === "needs_review"
+            ? "blocked"
+            : "waiting",
+    },
+  ];
+  const tone =
+    !debug.online || debug.syncFlow.status === "needs_review"
+      ? "warning"
+      : "neutral";
 
   return (
     <details
-      className="rounded-lg border border-warning/30 bg-warning/10 px-4 py-3 text-xs text-foreground"
+      className={cn(
+        "rounded-lg border px-4 py-3 text-xs text-foreground",
+        tone === "warning"
+          ? "border-warning/30 bg-warning/10"
+          : "border-border bg-muted/25",
+      )}
       open
     >
-      <summary className="cursor-pointer font-medium text-warning">
-        Register connection details
+      <summary
+        className={cn(
+          "cursor-pointer font-medium",
+          tone === "warning" ? "text-warning" : "text-muted-foreground",
+        )}
+      >
+        Support sync diagnostics
       </summary>
+      <div className="mt-3 flex flex-wrap items-center gap-2">
+        {flow.map((step, index) => (
+          <div key={step.label} className="flex items-center gap-2">
+            <span
+              className={cn(
+                "inline-flex h-7 items-center gap-1.5 rounded-full border px-2.5 font-medium",
+                step.state === "ready"
+                  ? "border-success/25 bg-success/10 text-success"
+                  : step.state === "blocked"
+                    ? "border-warning/30 bg-warning/15 text-warning"
+                    : step.state === "active"
+                      ? "border-primary/25 bg-primary/10 text-primary"
+                      : "border-border bg-background text-muted-foreground",
+              )}
+            >
+              <Circle className="h-2 w-2 fill-current" />
+              {step.label}
+            </span>
+            {index < flow.length - 1 ? (
+              <ArrowRight className="h-3.5 w-3.5 text-muted-foreground" />
+            ) : null}
+          </div>
+        ))}
+      </div>
       <dl className="mt-2 grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
         {rows.map(([label, value]) => (
           <div key={label} className="min-w-0">
@@ -506,6 +705,7 @@ export function POSRegisterView({
   const [isPaymentsListExpanded, setIsPaymentsListExpanded] = useState(false);
   const productEntryRef = useRef<ProductEntryHandle>(null);
   const headerProductSearchInputRef = useRef<HTMLInputElement>(null);
+  const isDebugPanelVisible = usePosDebugPanelToggle();
 
   useCollapseSidebarForPosFlow();
   const isSessionActive = viewModel.header.isSessionActive;
@@ -520,6 +720,8 @@ export function POSRegisterView({
   const cartItemCount =
     viewModel.cart?.items?.reduce((sum, item) => sum + item.quantity, 0) ?? 0;
   const isAwaitingCashierAuth = Boolean(viewModel.authDialog?.open);
+  const isStaffSignedIn =
+    viewModel.debug?.staffSignedIn === true || Boolean(viewModel.cashierCard);
   const onboardingState =
     viewModel.onboarding ??
     ({
@@ -703,17 +905,19 @@ export function POSRegisterView({
           leadingContent={
             <div className="flex min-w-0 flex-1 flex-wrap items-center gap-8">
               <div className="flex shrink-0 items-center gap-3">
-                {isSessionActive ? (
-                  <FadeIn className="flex items-center gap-2">
-                    <div
-                      className={`w-2 h-2 bg-green-600 rounded-full animate-pulse`}
-                    />
-                  </FadeIn>
-                ) : (
+                <FadeIn className="flex items-center gap-2">
                   <div
-                    className={`w-2 h-2 bg-background rounded-full animate-pulse`}
+                    aria-label={
+                      isStaffSignedIn ? "Staff signed in" : "No staff signed in"
+                    }
+                    className={cn(
+                      "h-2 w-2 rounded-full",
+                      isStaffSignedIn
+                        ? "animate-pulse bg-green-600"
+                        : "bg-background",
+                    )}
                   />
-                )}
+                </FadeIn>
 
                 <p className="text-lg font-semibold text-gray-900">
                   {viewModel.header.title}
@@ -752,7 +956,12 @@ export function POSRegisterView({
     >
       <FadeIn className={registerContentClassName}>
         <div className="flex h-full min-h-0 flex-col gap-6 overflow-hidden">
-          {isPosWorkflow ? <POSLocalDebugStrip debug={viewModel.debug} /> : null}
+          {isPosWorkflow ? (
+            <POSLocalDebugStrip
+              debug={viewModel.debug}
+              isVisible={isDebugPanelVisible}
+            />
+          ) : null}
 
           {isPosWorkflow &&
           shouldRenderSaleSurface &&
@@ -908,17 +1117,6 @@ export function POSRegisterView({
           </div>
         </div>
       </FadeIn>
-
-      {viewModel.authDialog && !isAwaitingCashierAuth && (
-        <CashierAuthDialog
-          open={viewModel.authDialog.open}
-          storeId={viewModel.authDialog.storeId}
-          terminalId={viewModel.authDialog.terminalId}
-          workflowMode={viewModel.authDialog.workflowMode}
-          onAuthenticated={viewModel.authDialog.onAuthenticated}
-          onDismiss={viewModel.authDialog.onDismiss}
-        />
-      )}
 
       {viewModel.commandApprovalDialog ? (
         <CommandApprovalDialog

--- a/packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.test.tsx
+++ b/packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.test.tsx
@@ -87,4 +87,19 @@ describe("RegisterDrawerGate", () => {
     expect(screen.getByText("GH₵100.02")).toBeInTheDocument();
     expect(screen.getByText("GH₵-0.02")).toHaveClass("text-red-700");
   });
+
+  it("runs the closeout secondary action for return-to-sale states", async () => {
+    const user = userEvent.setup();
+    const onCloseoutSecondaryAction = vi.fn();
+    renderGate({
+      closeoutSecondaryActionLabel: "Return to sale",
+      expectedCash: 10002,
+      mode: "closeoutBlocked",
+      onCloseoutSecondaryAction,
+    });
+
+    await user.click(screen.getByRole("button", { name: "Return to sale" }));
+
+    expect(onCloseoutSecondaryAction).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.tsx
+++ b/packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.tsx
@@ -404,7 +404,7 @@ export function RegisterDrawerGate({
                     drawerGate.isReopeningCloseout,
                   )}
                   isLoading={Boolean(drawerGate.isReopeningCloseout)}
-                  onClick={() => void drawerGate.onReopenRegister?.()}
+                  onClick={() => void drawerGate.onCloseoutSecondaryAction?.()}
                   type="button"
                   variant="outline"
                 >

--- a/packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts
@@ -178,6 +178,17 @@ export function useConvexRegisterCatalogAvailability(
   return state.status === "ready" ? state.rows : undefined;
 }
 
+export function usePrewarmRegisterCatalogOfflineSnapshots(input: {
+  storeId?: Id<"store">;
+}) {
+  useConvexRegisterCatalog({ storeId: input.storeId });
+  useConvexRegisterCatalogAvailabilityState({
+    refreshFullAvailabilitySnapshot: true,
+    storeId: input.storeId,
+    productSkuIds: [],
+  });
+}
+
 export function useConvexRegisterCatalogAvailabilityState(
   input: PosRegisterCatalogAvailabilityInput,
 ): RegisterCatalogAvailabilityGatewayState {

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/localCommandGateway.test.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/localCommandGateway.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { createLocalCommandGateway } from "./localCommandGateway";
 import {
@@ -57,6 +57,27 @@ describe("createLocalCommandGateway", () => {
         expect.objectContaining({ type: "session.started" }),
       ],
     });
+  });
+
+  it("notifies after a local event is durably appended", async () => {
+    const store = createPosLocalStore({
+      adapter: createMemoryPosLocalStorageAdapter(),
+    });
+    const onEventAppended = vi.fn();
+    const gateway = createLocalCommandGateway({
+      store,
+      onEventAppended,
+    });
+
+    await gateway.openDrawer({
+      storeId: "store-1" as never,
+      terminalId: "terminal-1" as never,
+      staffProfileId: "staff-1" as never,
+      registerNumber: "1",
+      openingFloat: 100,
+    });
+
+    expect(onEventAppended).toHaveBeenCalledTimes(1);
   });
 
   it("refuses to start a sale from another store's local drawer", async () => {

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/localCommandGateway.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/localCommandGateway.ts
@@ -27,6 +27,7 @@ type CreateLocalCommandGatewayOptions = {
   store: PosLocalCommandStore;
   clock?: () => number;
   createLocalId?: (kind: string) => string;
+  onEventAppended?: () => void;
   staffProofToken?: string | ((staffProfileId: string) => string | undefined);
 };
 
@@ -84,6 +85,7 @@ export function createLocalCommandGateway(
   async function append(input: PosLocalAppendEventInput) {
     const result = await options.store.appendEvent(input);
     if (!result.ok) return toLocalUserError(result.error.message);
+    options.onEventAppended?.();
     return null;
   }
 

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/syncContract.test.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/syncContract.test.ts
@@ -287,7 +287,8 @@ describe("syncContract", () => {
         payload: {
           localPosSessionId: "local-session-1",
           localTransactionId: "local-txn-1",
-          receiptNumber: "LOCAL-1-000001",
+          localReceiptNumber: "local-txn-1",
+          receiptNumber: "123456",
           customerProfileId: "profile-1",
           customerName: "Efua Mensah",
           customerEmail: "efua@example.com",
@@ -308,7 +309,8 @@ describe("syncContract", () => {
         payload: expect.objectContaining({
           localPosSessionId: "local-session-1",
           localTransactionId: "local-txn-1",
-          localReceiptNumber: "LOCAL-1-000001",
+          localReceiptNumber: "local-txn-1",
+          receiptNumber: "123456",
           customerProfileId: "profile-1",
           customerInfo: {
             name: "Efua Mensah",

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/syncContract.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/syncContract.ts
@@ -92,7 +92,12 @@ function toUploadEvent(
         localPosSessionId,
         localTransactionId:
           event.localTransactionId ?? stringOrEmpty(payload.localTransactionId),
-        localReceiptNumber: stringOrEmpty(payload.receiptNumber),
+        localReceiptNumber:
+          stringOrEmpty(payload.localReceiptNumber) ||
+          stringOrEmpty(payload.receiptNumber),
+        receiptNumber:
+          stringOrEmpty(payload.receiptNumber) ||
+          stringOrEmpty(payload.localReceiptNumber),
         registerNumber: event.registerNumber,
         customerProfileId: nullableStringToOptional(payload.customerProfileId),
         customerInfo: customerInfoFromPayload(payload),

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.test.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.test.ts
@@ -26,6 +26,15 @@ import {
 } from "./usePosLocalSyncRuntime";
 import type { PosLocalEventRecord } from "./posLocalStore";
 
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((nextResolve) => {
+    resolve = nextResolve;
+  });
+
+  return { promise, resolve };
+}
+
 describe("usePosLocalSyncRuntimeStatus", () => {
   beforeEach(() => {
     vi.resetAllMocks();
@@ -211,9 +220,11 @@ describe("usePosLocalSyncRuntimeStatus", () => {
       })),
     };
     const storeFactory = () => store as never;
+    const onLocalEventsChanged = vi.fn();
 
     const { result } = renderHook(() =>
       usePosLocalSyncRuntimeStatus({
+        onLocalEventsChanged,
         onRetrySync: retry,
         storeFactory,
         storeId: "store-1",
@@ -224,6 +235,11 @@ describe("usePosLocalSyncRuntimeStatus", () => {
     await waitFor(() => {
       expect(result.current).toEqual(
         expect.objectContaining({
+          debug: expect.objectContaining({
+            lastTrigger: "route-entry",
+            lastTriggerAt: expect.any(Number),
+            lastTriggerPriority: "normal",
+          }),
           pendingEventCount: 5,
           status: "pending",
         }),
@@ -277,6 +293,354 @@ describe("usePosLocalSyncRuntimeStatus", () => {
       mappedAt: 12,
     });
     expect(store.writeLocalCloudMapping).toHaveBeenCalledTimes(3);
+    expect(onLocalEventsChanged).toHaveBeenCalledTimes(1);
+  });
+
+  it("uploads pending events after the append token changes", async () => {
+    let localEvents: PosLocalEventRecord[] = [];
+    mocks.ingestLocalEvents.mockResolvedValue({
+      kind: "ok",
+      data: {
+        accepted: [
+          {
+            localEventId: "event-open",
+            sequence: 1,
+            status: "projected",
+          },
+        ],
+        held: [],
+        mappings: [],
+        conflicts: [],
+        syncCursor: {
+          localRegisterSessionId: "register-1",
+          acceptedThroughSequence: 1,
+        },
+      },
+    });
+    const store = {
+      listEvents: vi.fn(async () => ({
+        ok: true,
+        value: localEvents,
+      })),
+      markEventsSynced: vi.fn(async () => ({
+        ok: true,
+        value: [],
+      })),
+      writeLocalCloudMapping: vi.fn(async () => ({
+        ok: true,
+        value: {
+          entity: "registerSession",
+          localId: "register-1",
+          cloudId: "register-session-1",
+          mappedAt: 10,
+        },
+      })),
+      readProvisionedTerminalSeed: vi.fn(async () => ({
+        ok: true,
+        value: {
+          cloudTerminalId: "terminal-cloud-1",
+          displayName: "Front",
+          provisionedAt: 1,
+          schemaVersion: 1,
+          syncSecretHash: "sync-secret-1",
+          storeId: "store-1",
+          terminalId: "local-terminal-1",
+        },
+      })),
+    };
+    const storeFactory = () => store as never;
+
+    const { result, rerender } = renderHook(
+      ({ eventAppendToken }: { eventAppendToken: number }) =>
+        usePosLocalSyncRuntimeStatus({
+          eventAppendToken,
+          storeFactory,
+          storeId: "store-1",
+          terminalId: "terminal-cloud-1",
+        }),
+      {
+        initialProps: { eventAppendToken: 0 },
+      },
+    );
+
+    await waitFor(() => expect(store.listEvents).toHaveBeenCalled());
+    expect(mocks.ingestLocalEvents).not.toHaveBeenCalled();
+
+    localEvents = [
+      buildLocalEvent({
+        localEventId: "event-open",
+        payload: {
+          openingFloat: 100,
+          status: "open",
+        },
+        sequence: 1,
+        type: "register.opened",
+      }),
+    ];
+
+    rerender({ eventAppendToken: 1 });
+
+    await waitFor(() =>
+      expect(result.current?.debug).toEqual(
+        expect.objectContaining({
+          lastTrigger: "event-appended",
+          lastTriggerAt: expect.any(Number),
+          lastTriggerPriority: "high",
+        }),
+      ),
+    );
+    await waitFor(() =>
+      expect(mocks.ingestLocalEvents).toHaveBeenCalledWith(
+        expect.objectContaining({
+          events: [
+            expect.objectContaining({
+              eventType: "register_opened",
+              localEventId: "event-open",
+            }),
+          ],
+        }),
+      ),
+    );
+    expect(store.markEventsSynced).toHaveBeenCalledWith(["event-open"], {
+      uploaded: true,
+    });
+  });
+
+  it("ignores stale upload results after the runtime scope changes", async () => {
+    const pendingIngest = deferred<{
+      kind: "error";
+      error: { code: string; message: string };
+    }>();
+    mocks.ingestLocalEvents.mockReturnValue(pendingIngest.promise);
+    const oldStore = {
+      listEvents: vi.fn(async () => ({
+        ok: true,
+        value: [
+          buildLocalEvent({
+            localEventId: "event-open",
+            payload: {
+              openingFloat: 100,
+              status: "open",
+            },
+            sequence: 1,
+            storeId: "store-1",
+            type: "register.opened",
+          }),
+        ],
+      })),
+      markEventsNeedsReview: vi.fn(async () => ({
+        ok: true,
+        value: undefined,
+      })),
+      markEventsSynced: vi.fn(async () => ({
+        ok: true,
+        value: [],
+      })),
+      writeLocalCloudMapping: vi.fn(async () => ({
+        ok: true,
+        value: {},
+      })),
+      readProvisionedTerminalSeed: vi.fn(async () => ({
+        ok: true,
+        value: {
+          cloudTerminalId: "terminal-cloud-1",
+          displayName: "Front",
+          provisionedAt: 1,
+          schemaVersion: 1,
+          syncSecretHash: "sync-secret-1",
+          storeId: "store-1",
+          terminalId: "local-terminal-1",
+        },
+      })),
+    };
+    const newStore = {
+      listEvents: vi.fn(async () => ({
+        ok: true,
+        value: [],
+      })),
+      markEventsNeedsReview: vi.fn(async () => ({
+        ok: true,
+        value: undefined,
+      })),
+      markEventsSynced: vi.fn(async () => ({
+        ok: true,
+        value: [],
+      })),
+      writeLocalCloudMapping: vi.fn(async () => ({
+        ok: true,
+        value: {},
+      })),
+      readProvisionedTerminalSeed: vi.fn(async () => ({
+        ok: true,
+        value: {
+          cloudTerminalId: "terminal-cloud-2",
+          displayName: "Back",
+          provisionedAt: 1,
+          schemaVersion: 1,
+          syncSecretHash: "sync-secret-2",
+          storeId: "store-2",
+          terminalId: "local-terminal-2",
+        },
+      })),
+    };
+    const onLocalEventsChanged = vi.fn();
+    let currentStore: typeof oldStore | typeof newStore = oldStore;
+    const storeFactory = () => currentStore as never;
+
+    const { result, rerender } = renderHook(
+      ({
+        eventAppendToken,
+        storeId,
+      }: {
+        eventAppendToken: number;
+        storeId: "store-1" | "store-2";
+      }) =>
+        usePosLocalSyncRuntimeStatus({
+          eventAppendToken,
+          onLocalEventsChanged,
+          storeFactory,
+          storeId,
+          terminalId: storeId === "store-1" ? "terminal-cloud-1" : "terminal-cloud-2",
+        }),
+      {
+        initialProps: {
+          eventAppendToken: 0,
+          storeId: "store-1" as "store-1" | "store-2",
+        },
+      },
+    );
+
+    await waitFor(() => {
+      expect(result.current).toEqual(
+        expect.objectContaining({
+          pendingEventCount: 1,
+          status: "pending",
+        }),
+      );
+    });
+    act(() => {
+      result.current?.onRetrySync?.();
+    });
+    await waitFor(() => expect(oldStore.listEvents).toHaveBeenCalled());
+    await waitFor(() => expect(mocks.ingestLocalEvents).toHaveBeenCalled());
+
+    currentStore = newStore;
+    rerender({ eventAppendToken: 0, storeId: "store-2" });
+    pendingIngest.resolve({
+      kind: "error",
+      error: { code: "unavailable", message: "Old upload failed." },
+    });
+
+    await waitFor(() => expect(newStore.listEvents).toHaveBeenCalled());
+    await act(async () => {
+      await pendingIngest.promise;
+    });
+
+    expect(oldStore.markEventsNeedsReview).not.toHaveBeenCalled();
+    expect(onLocalEventsChanged).not.toHaveBeenCalled();
+  });
+
+  it("treats an already-incremented append token as an immediate event trigger on first observation", async () => {
+    mocks.ingestLocalEvents.mockResolvedValue({
+      kind: "ok",
+      data: {
+        accepted: [
+          {
+            localEventId: "event-open",
+            sequence: 1,
+            status: "projected",
+          },
+        ],
+        held: [],
+        mappings: [
+          {
+            _id: "mapping-open",
+            storeId: "store-1",
+            terminalId: "terminal-cloud-1",
+            localRegisterSessionId: "register-1",
+            localEventId: "event-open",
+            localIdKind: "registerSession",
+            localId: "register-1",
+            cloudTable: "registerSession",
+            cloudId: "register-session-1",
+            createdAt: 12,
+          },
+        ],
+        conflicts: [],
+        syncCursor: {
+          localRegisterSessionId: "register-1",
+          acceptedThroughSequence: 1,
+        },
+      },
+    });
+    const store = {
+      listEvents: vi.fn(async () => ({
+        ok: true,
+        value: [
+          buildLocalEvent({
+            localEventId: "event-open",
+            payload: {
+              openingFloat: 100,
+              status: "open",
+            },
+            sequence: 1,
+            type: "register.opened",
+          }),
+        ],
+      })),
+      markEventsSynced: vi.fn(async () => ({
+        ok: true,
+        value: [],
+      })),
+      writeLocalCloudMapping: vi.fn(async () => ({
+        ok: true,
+        value: {},
+      })),
+      readProvisionedTerminalSeed: vi.fn(async () => ({
+        ok: true,
+        value: {
+          cloudTerminalId: "terminal-cloud-1",
+          displayName: "Front",
+          provisionedAt: 1,
+          schemaVersion: 1,
+          syncSecretHash: "sync-secret-1",
+          storeId: "store-1",
+          terminalId: "local-terminal-1",
+        },
+      })),
+    };
+    const storeFactory = () => store as never;
+
+    const { result } = renderHook(() =>
+      usePosLocalSyncRuntimeStatus({
+        eventAppendToken: 1,
+        storeFactory,
+        storeId: "store-1",
+        terminalId: "terminal-cloud-1",
+      }),
+    );
+
+    await waitFor(() =>
+      expect(result.current?.debug).toEqual(
+        expect.objectContaining({
+          lastTrigger: "event-appended",
+          lastTriggerAt: expect.any(Number),
+          lastTriggerPriority: "high",
+        }),
+      ),
+    );
+    await waitFor(() =>
+      expect(mocks.ingestLocalEvents).toHaveBeenCalledWith(
+        expect.objectContaining({
+          events: [
+            expect.objectContaining({
+              eventType: "register_opened",
+              localEventId: "event-open",
+            }),
+          ],
+        }),
+      ),
+    );
   });
 
   it("marks uploaded events for review when the server rejects the batch", async () => {

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useMutation } from "convex/react";
 import type { FunctionArgs } from "convex/server";
 
@@ -16,7 +16,10 @@ import {
   isSyncablePosLocalEvent,
   type PosLocalUploadEvent,
 } from "./syncContract";
-import { createPosLocalSyncScheduler } from "./syncScheduler";
+import {
+  createPosLocalSyncScheduler,
+  type PosLocalSyncTrigger,
+} from "./syncScheduler";
 import { derivePosLocalSyncStatus } from "./syncStatus";
 import { readScopedPosLocalEvents } from "./localRegisterReader";
 import {
@@ -25,11 +28,18 @@ import {
 } from "./terminalScope";
 
 export type PosLocalRuntimeSyncStatusSource = {
+  debug?: PosLocalRuntimeSyncDebug;
   description?: string | null;
   label?: string | null;
   onRetrySync?: (() => void) | null;
   pendingEventCount?: number | null;
   status?: string | null;
+};
+
+export type PosLocalRuntimeSyncDebug = {
+  lastTrigger?: PosLocalSyncTrigger;
+  lastTriggerAt?: number;
+  lastTriggerPriority?: "high" | "normal";
 };
 
 type PosLocalRuntimeStore = ReturnType<typeof createPosLocalStore>;
@@ -40,6 +50,8 @@ type IngestLocalEventsArgs = FunctionArgs<
 export function usePosLocalSyncRuntimeStatus(input: {
   storeId?: string | null;
   terminalId?: string | null;
+  eventAppendToken?: number;
+  onLocalEventsChanged?: (() => void) | null;
   onRetrySync?: (() => void) | null;
   storeFactory?: (() => PosLocalRuntimeStore) | null;
 }): PosLocalRuntimeSyncStatusSource | null {
@@ -47,7 +59,11 @@ export function usePosLocalSyncRuntimeStatus(input: {
   const [events, setEvents] = useState<PosLocalEventRecord[]>([]);
   const [readError, setReadError] = useState<string | null>(null);
   const [refreshToken, setRefreshToken] = useState(0);
+  const [debug, setDebug] = useState<PosLocalRuntimeSyncDebug>({});
+  const lastEventAppendTokenRef = useRef(0);
   const { storeFactory, storeId, terminalId } = input;
+  const eventAppendToken = input.eventAppendToken ?? 0;
+  const onLocalEventsChanged = input.onLocalEventsChanged;
   const onRetrySync = input.onRetrySync;
   const isOnline = typeof navigator === "undefined" ? true : navigator.onLine;
 
@@ -67,6 +83,7 @@ export function usePosLocalSyncRuntimeStatus(input: {
     let stopScheduler: (() => void) | null = null;
 
     void (async () => {
+      const shouldStop = () => cancelled;
       const seed = await store.readProvisionedTerminalSeed();
       if (!seed.ok) {
         if (!cancelled) {
@@ -80,6 +97,9 @@ export function usePosLocalSyncRuntimeStatus(input: {
         terminalId,
         terminalSeed: seed.value,
       });
+      if (shouldStop()) {
+        return;
+      }
       const provisionedSeed = scope.provisionedSeed;
       const cloudTerminalId = provisionedSeed?.cloudTerminalId ?? terminalId;
       if (scope.terminalIds.size === 0 || !cloudTerminalId) {
@@ -105,14 +125,18 @@ export function usePosLocalSyncRuntimeStatus(input: {
           storeId,
           terminalId,
         });
+        if (shouldStop()) {
+          return false;
+        }
         if (!refreshedEvents.ok || cancelled) {
           if (!cancelled) {
             setReadError(refreshedEvents.ok ? null : refreshedEvents.error.message);
           }
-          return;
+          return false;
         }
         setReadError(null);
         setEvents(refreshedEvents.value.events);
+        return true;
       };
       setEvents(eventsResult.value.events);
       setReadError(null);
@@ -134,6 +158,9 @@ export function usePosLocalSyncRuntimeStatus(input: {
             storeId,
             terminalId,
           });
+          if (shouldStop()) {
+            return [];
+          }
           if (!pending.ok) {
             setReadError(pending.error.message);
             throw new Error(pending.error.message);
@@ -159,8 +186,17 @@ export function usePosLocalSyncRuntimeStatus(input: {
           const result = await store.markEventsSynced(eventIds, {
             uploaded: true,
           });
+          if (shouldStop()) {
+            return;
+          }
           assertPosLocalStoreOk(result);
-          await refreshEvents();
+          if (!(await refreshEvents())) {
+            return;
+          }
+          if (shouldStop()) {
+            return;
+          }
+          onLocalEventsChanged?.();
         },
         uploadBatch: async (pendingEvents) => {
           const latestEvents = await readScopedPosLocalUploadEvents({
@@ -168,6 +204,9 @@ export function usePosLocalSyncRuntimeStatus(input: {
             storeId,
             terminalId,
           });
+          if (shouldStop()) {
+            return { syncedEventIds: [] };
+          }
           if (!latestEvents.ok) {
             setReadError(latestEvents.error.message);
             throw new Error(latestEvents.error.message);
@@ -192,6 +231,9 @@ export function usePosLocalSyncRuntimeStatus(input: {
               terminalId: cloudTerminalId,
             }),
           );
+          if (shouldStop()) {
+            return { syncedEventIds: [] };
+          }
           if (result.kind !== "ok") {
             return {
               syncedEventIds: [],
@@ -206,6 +248,9 @@ export function usePosLocalSyncRuntimeStatus(input: {
             store,
             result.data.mappings,
           );
+          if (shouldStop()) {
+            return { syncedEventIds: [] };
+          }
           if (!mappingWrite.ok) {
             setReadError(mappingWrite.message);
             return {
@@ -236,12 +281,37 @@ export function usePosLocalSyncRuntimeStatus(input: {
             "Cloud sync needs review before this local event can finish.",
             { uploaded: true },
           );
+          if (shouldStop()) {
+            return;
+          }
           assertPosLocalStoreOk(result);
-          await refreshEvents();
+          if (!(await refreshEvents())) {
+            return;
+          }
+          if (shouldStop()) {
+            return;
+          }
+          onLocalEventsChanged?.();
         },
       });
       stopScheduler = scheduler.startForegroundTriggers();
-      scheduler.trigger("route-entry");
+      const trigger: PosLocalSyncTrigger =
+        eventAppendToken !== lastEventAppendTokenRef.current
+          ? "event-appended"
+          : "route-entry";
+      const triggerPriority = trigger === "event-appended" ? "high" : "normal";
+      lastEventAppendTokenRef.current = eventAppendToken;
+      if (!cancelled) {
+        setDebug({
+          lastTrigger: trigger,
+          lastTriggerAt: Date.now(),
+          lastTriggerPriority: triggerPriority,
+        });
+      }
+      scheduler.trigger(
+        trigger,
+        triggerPriority === "high" ? { priority: "high" } : undefined,
+      );
     })();
 
     return () => {
@@ -250,6 +320,8 @@ export function usePosLocalSyncRuntimeStatus(input: {
     };
   }, [
     ingestLocalEvents,
+    eventAppendToken,
+    onLocalEventsChanged,
     storeFactory,
     storeId,
     terminalId,
@@ -261,6 +333,7 @@ export function usePosLocalSyncRuntimeStatus(input: {
       return {
         description:
           "Local register activity could not be read. Check this terminal before continuing.",
+        debug,
         label: "Local sync unavailable",
         onRetrySync: () => {
           setRefreshToken((current) => current + 1);
@@ -271,14 +344,25 @@ export function usePosLocalSyncRuntimeStatus(input: {
       };
     }
 
-    return derivePosLocalRuntimeSyncStatus(events, {
+    const source = derivePosLocalRuntimeSyncStatus(events, {
       isOnline,
       onRetrySync: () => {
         setRefreshToken((current) => current + 1);
         onRetrySync?.();
       },
     });
-  }, [events, isOnline, onRetrySync, readError]);
+    if (source) return { ...source, debug };
+
+    return debug.lastTrigger
+      ? {
+          debug,
+          onRetrySync: () => {
+            setRefreshToken((current) => current + 1);
+            onRetrySync?.();
+          },
+        }
+      : null;
+  }, [debug, events, isOnline, onRetrySync, readError]);
 }
 
 function toIngestLocalEventsArgs(input: {

--- a/packages/athena-webapp/src/lib/pos/presentation/register/registerUiState.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/registerUiState.ts
@@ -127,7 +127,7 @@ export interface RegisterCheckoutState {
   onRemovePayment: (paymentId: string) => Promise<boolean>;
   onClearPayments: () => Promise<boolean>;
   onCompleteTransaction: () => Promise<boolean>;
-  onStartNewTransaction: () => void;
+  onStartNewTransaction: () => void | Promise<void>;
 }
 
 export interface RegisterCashierCardState {
@@ -168,6 +168,7 @@ export interface RegisterDrawerGateState {
   isSubmitting?: boolean;
   onCloseoutCountedCashChange?: (value: string) => void;
   onCloseoutNotesChange?: (value: string) => void;
+  onCloseoutSecondaryAction?: () => void | Promise<void>;
   onCorrectedOpeningFloatChange?: (value: string) => void;
   onCorrectionReasonChange?: (value: string) => void;
   onOpeningFloatChange?: (value: string) => void;
@@ -232,6 +233,19 @@ export interface RegisterViewModel {
     online: boolean;
     staffSignedIn: boolean;
     storeId?: string;
+    syncFlow: {
+      eventAppendToken: number;
+      lastLocalSequence?: number;
+      lastRuntimeTrigger?: string;
+      lastRuntimeTriggerAt?: number;
+      lastRuntimeTriggerPriority?: string;
+      lastSyncedSequence?: number;
+      nextPendingSequence?: number | null;
+      pendingEventCount?: number;
+      source: string;
+      staffProof: "present" | "missing";
+      status: string;
+    };
     terminalId?: string;
     terminalSource: "live" | "local" | "missing";
   };

--- a/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts
@@ -29,7 +29,9 @@ const mockReopenRegisterSessionCloseout = vi.fn();
 const mockCorrectRegisterSessionOpeningFloat = vi.fn();
 const mockNavigateBack = vi.fn();
 const mockUsePosLocalSyncRuntimeStatus = vi.fn();
+const mockUseConvexRegisterCatalogAvailability = vi.fn();
 const mockAppendLocalEvent = vi.fn();
+const mockAttachStaffProofTokenToPendingEvents = vi.fn();
 const mockListLocalEvents = vi.fn();
 const mockReadProvisionedTerminalSeed = vi.fn();
 const mockGetStaffAuthorityReadiness = vi.fn();
@@ -214,8 +216,8 @@ vi.mock("@/hooks/usePOSProducts", () => ({
 
 vi.mock("@/lib/pos/infrastructure/convex/catalogGateway", () => ({
   useConvexRegisterCatalog: () => mockRegisterCatalogRows,
-  useConvexRegisterCatalogAvailability: () =>
-    mockRegisterCatalogAvailabilityRows,
+  useConvexRegisterCatalogAvailability: (...args: unknown[]) =>
+    mockUseConvexRegisterCatalogAvailability(...args),
 }));
 
 vi.mock("@/hooks/useDebounce", () => ({
@@ -260,10 +262,8 @@ vi.mock("@/lib/pos/infrastructure/local/posLocalStore", () => ({
   createIndexedDbPosLocalStorageAdapter: vi.fn(() => ({})),
   createPosLocalStore: vi.fn(() => ({
     appendEvent: mockAppendLocalEvent,
-    attachStaffProofTokenToPendingEvents: vi.fn(async () => ({
-      ok: true,
-      value: 0,
-    })),
+    attachStaffProofTokenToPendingEvents:
+      mockAttachStaffProofTokenToPendingEvents,
     getStaffAuthorityReadiness: mockGetStaffAuthorityReadiness,
     listEvents: mockListLocalEvents,
     listEventsForUpload: mockListLocalEvents,
@@ -340,6 +340,24 @@ function buildLocalEvent(
   };
 }
 
+function buildStaffAuthenticationResult(
+  overrides: Partial<Record<string, unknown>> = {},
+) {
+  return {
+    activeRoles: ["manager"],
+    staffProfileId: "staff-1" as Id<"staffProfile">,
+    staffProfile: {
+      firstName: "Ama",
+      lastName: "Kusi",
+    },
+    posLocalStaffProof: {
+      expiresAt: Date.now() + 60_000,
+      token: "staff-proof-token",
+    },
+    ...overrides,
+  };
+}
+
 describe("useRegisterViewModel", () => {
   beforeEach(() => {
     mockActiveStore = {
@@ -413,6 +431,10 @@ describe("useRegisterViewModel", () => {
     };
     mockRegisterCatalogRows = [];
     mockRegisterCatalogAvailabilityRows = [];
+    mockUseConvexRegisterCatalogAvailability.mockReset();
+    mockUseConvexRegisterCatalogAvailability.mockImplementation(
+      () => mockRegisterCatalogAvailabilityRows,
+    );
     localStorage.clear();
 
     mockUseQuery.mockImplementation(() => mockCashier);
@@ -422,6 +444,11 @@ describe("useRegisterViewModel", () => {
     mockAppendLocalEvent.mockResolvedValue({
       ok: true,
       value: { localEventId: "local-event-1" },
+    });
+    mockAttachStaffProofTokenToPendingEvents.mockReset();
+    mockAttachStaffProofTokenToPendingEvents.mockResolvedValue({
+      ok: true,
+      value: 0,
     });
     mockListLocalEvents.mockReset();
     mockListLocalEvents.mockResolvedValue({ ok: true, value: [] });
@@ -589,7 +616,7 @@ describe("useRegisterViewModel", () => {
 
     await act(async () => {
       result.current.authDialog?.onAuthenticated(
-        "staff-1" as Id<"staffProfile">,
+        buildStaffAuthenticationResult(),
       );
     });
 
@@ -621,7 +648,7 @@ describe("useRegisterViewModel", () => {
 
     await act(async () => {
       result.current.authDialog?.onAuthenticated(
-        "staff-1" as Id<"staffProfile">,
+        buildStaffAuthenticationResult(),
       );
     });
 
@@ -643,6 +670,106 @@ describe("useRegisterViewModel", () => {
     expect(onRetrySync).toHaveBeenCalled();
   });
 
+  it("starts a new sale after cashier sign-in when the drawer is already open", async () => {
+    mockRegisterState = {
+      phase: "readyToStart",
+      terminal: { _id: "terminal-1", displayName: "Front Counter" },
+      cashier: null,
+      activeRegisterSession: {
+        _id: "drawer-1",
+        status: "open",
+        terminalId: "terminal-1",
+        registerNumber: "1",
+        openingFloat: 5_000,
+        expectedCash: 5_000,
+        openedAt: Date.now(),
+      },
+      activeSession: null,
+      activeSessionConflict: null,
+      resumableSession: null,
+    };
+    mockActiveSession = null;
+
+    const { useRegisterViewModel } = await import("./useRegisterViewModel");
+    const { result } = renderHook(() => useRegisterViewModel());
+
+    await act(async () => {
+      await result.current.authDialog?.onAuthenticated(
+        buildStaffAuthenticationResult(),
+      );
+    });
+
+    await waitFor(() =>
+      expect(mockAppendLocalEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "session.started",
+          localRegisterSessionId: "drawer-1",
+          staffProfileId: "staff-1",
+        }),
+      ),
+    );
+    expect(result.current.checkout.isTransactionCompleted).toBe(false);
+    expect(result.current.productEntry.disabled).toBe(false);
+    expect(toast.success).not.toHaveBeenCalledWith("Sale started");
+  });
+
+  it("does not start duplicate local sales when cashier sign-in completes twice", async () => {
+    mockRegisterState = {
+      phase: "readyToStart",
+      terminal: { _id: "terminal-1", displayName: "Front Counter" },
+      cashier: null,
+      activeRegisterSession: {
+        _id: "drawer-1",
+        status: "open",
+        terminalId: "terminal-1",
+        registerNumber: "1",
+        openingFloat: 5_000,
+        expectedCash: 5_000,
+        openedAt: Date.now(),
+      },
+      activeSession: null,
+      activeSessionConflict: null,
+      resumableSession: null,
+    };
+    mockActiveSession = null;
+    const pendingStart = deferred<{
+      ok: true;
+      value: { localEventId: string };
+    }>();
+    mockAppendLocalEvent.mockImplementation((input: { type: string }) =>
+      input.type === "session.started"
+        ? pendingStart.promise
+        : Promise.resolve({
+            ok: true,
+            value: { localEventId: "local-event-1" },
+          }),
+    );
+
+    const { useRegisterViewModel } = await import("./useRegisterViewModel");
+    const { result } = renderHook(() => useRegisterViewModel());
+
+    await act(async () => {
+      result.current.authDialog?.onAuthenticated(buildStaffAuthenticationResult());
+      result.current.authDialog?.onAuthenticated(buildStaffAuthenticationResult());
+    });
+
+    await waitFor(() =>
+      expect(
+        mockAppendLocalEvent.mock.calls.filter(
+          ([event]) => event.type === "session.started",
+        ),
+      ).toHaveLength(1),
+    );
+
+    pendingStart.resolve({
+      ok: true,
+      value: { localEventId: "local-session-event-1" },
+    });
+    await act(async () => {
+      await pendingStart.promise;
+    });
+  });
+
   it("uses pending status from the local-first runtime before Convex session state", async () => {
     const onRetrySync = vi.fn();
     mockUsePosLocalSyncRuntimeStatus.mockReturnValue({
@@ -662,7 +789,7 @@ describe("useRegisterViewModel", () => {
 
     await act(async () => {
       result.current.authDialog?.onAuthenticated(
-        "staff-1" as Id<"staffProfile">,
+        buildStaffAuthenticationResult(),
       );
     });
 
@@ -688,6 +815,94 @@ describe("useRegisterViewModel", () => {
     expect(onRetrySync).toHaveBeenCalled();
   });
 
+  it("does not let debug-only runtime metadata mask pending local read-model events", async () => {
+    mockUsePosLocalSyncRuntimeStatus.mockReturnValue({
+      debug: {
+        lastTrigger: "route-entry",
+        lastTriggerAt: 1_000,
+        lastTriggerPriority: "normal",
+      },
+    });
+    mockListLocalEvents.mockResolvedValue({
+      ok: true,
+      value: [
+        buildLocalEvent({
+          sequence: 1,
+          type: "register.opened",
+          payload: {
+            expectedCash: 5_000,
+            localRegisterSessionId: "drawer-1",
+            openingFloat: 5_000,
+            status: "open",
+          },
+        }),
+      ],
+    });
+
+    const { useRegisterViewModel } = await import("./useRegisterViewModel");
+    const { result } = renderHook(() => useRegisterViewModel());
+
+    await waitFor(() =>
+      expect(result.current.debug?.syncFlow.source).toBe("local-read-model"),
+    );
+    expect(result.current.syncStatus).toEqual(
+      expect.objectContaining({
+        label: "Pending sync",
+        pendingEventCount: 1,
+        status: "pending_sync",
+      }),
+    );
+    expect(result.current.debug?.syncFlow).toEqual(
+      expect.objectContaining({
+        lastRuntimeTrigger: "route-entry",
+        pendingEventCount: 1,
+        status: "pending_sync",
+      }),
+    );
+  });
+
+  it("nudges local sync after pending events receive staff proof", async () => {
+    mockAttachStaffProofTokenToPendingEvents.mockResolvedValue({
+      ok: true,
+      value: 1,
+    });
+
+    const { useRegisterViewModel } = await import("./useRegisterViewModel");
+    const { result } = renderHook(() => useRegisterViewModel());
+    const expiresAt = Date.now() + 60_000;
+
+    await act(async () => {
+      result.current.authDialog?.onAuthenticated({
+        staffProfileId: "staff-1" as Id<"staffProfile">,
+        staffProfile: {
+          firstName: "Ama",
+          lastName: "Kusi",
+        },
+        posLocalStaffProof: {
+          expiresAt,
+          token: "staff-proof-token",
+        },
+      });
+    });
+
+    await waitFor(() =>
+      expect(mockAttachStaffProofTokenToPendingEvents).toHaveBeenCalledWith({
+        staffProfileId: "staff-1",
+        staffProofToken: "staff-proof-token",
+      }),
+    );
+    await waitFor(() =>
+      expect(mockUsePosLocalSyncRuntimeStatus).toHaveBeenCalledWith(
+        expect.objectContaining({
+          eventAppendToken: 1,
+          onLocalEventsChanged: expect.any(Function),
+          storeId: "store-1",
+          terminalId: "terminal-1",
+        }),
+      ),
+    );
+  });
+
   it("maps local reconciliation exceptions without blocking the retry callback", async () => {
     const onRetrySync = vi.fn();
     mockActiveSession = {
@@ -709,7 +924,7 @@ describe("useRegisterViewModel", () => {
 
     await act(async () => {
       result.current.authDialog?.onAuthenticated(
-        "staff-1" as Id<"staffProfile">,
+        buildStaffAuthenticationResult(),
       );
     });
 
@@ -740,7 +955,7 @@ describe("useRegisterViewModel", () => {
 
     await act(async () => {
       result.current.authDialog?.onAuthenticated(
-        "staff-1" as Id<"staffProfile">,
+        buildStaffAuthenticationResult(),
       );
     });
 
@@ -1007,7 +1222,7 @@ describe("useRegisterViewModel", () => {
 
     await act(async () => {
       result.current.authDialog?.onAuthenticated(
-        "staff-1" as Id<"staffProfile">,
+        buildStaffAuthenticationResult(),
       );
     });
 
@@ -1084,7 +1299,7 @@ describe("useRegisterViewModel", () => {
 
     await act(async () => {
       result.current.authDialog?.onAuthenticated(
-        "staff-1" as Id<"staffProfile">,
+        buildStaffAuthenticationResult(),
       );
     });
 
@@ -1137,7 +1352,7 @@ describe("useRegisterViewModel", () => {
 
     await act(async () => {
       result.current.authDialog?.onAuthenticated(
-        "staff-1" as Id<"staffProfile">,
+        buildStaffAuthenticationResult(),
       );
     });
 
@@ -1167,7 +1382,7 @@ describe("useRegisterViewModel", () => {
     );
     expect(mockMarkLocalEventsSynced).not.toHaveBeenCalled();
     expect(toast.success).toHaveBeenCalledWith(
-      "Register session closed locally. It will sync when ready.",
+      "Register closed.",
     );
   });
 
@@ -1208,7 +1423,7 @@ describe("useRegisterViewModel", () => {
 
     await act(async () => {
       result.current.authDialog?.onAuthenticated(
-        "staff-1" as Id<"staffProfile">,
+        buildStaffAuthenticationResult(),
       );
     });
 
@@ -1233,7 +1448,7 @@ describe("useRegisterViewModel", () => {
     );
     expect(mockMarkLocalEventsSynced).not.toHaveBeenCalled();
     expect(result.current.drawerGate?.errorMessage).toBe(
-      "Unable to save this closeout locally.",
+      "Unable to close this register. Try again.",
     );
   });
 
@@ -1261,7 +1476,7 @@ describe("useRegisterViewModel", () => {
 
     await act(async () => {
       result.current.authDialog?.onAuthenticated(
-        "staff-1" as Id<"staffProfile">,
+        buildStaffAuthenticationResult(),
       );
     });
 
@@ -1307,7 +1522,7 @@ describe("useRegisterViewModel", () => {
 
     await act(async () => {
       result.current.authDialog?.onAuthenticated(
-        "staff-1" as Id<"staffProfile">,
+        buildStaffAuthenticationResult(),
       );
     });
 
@@ -1345,7 +1560,7 @@ describe("useRegisterViewModel", () => {
 
     await act(async () => {
       result.current.authDialog?.onAuthenticated(
-        "staff-1" as Id<"staffProfile">,
+        buildStaffAuthenticationResult(),
       );
     });
 
@@ -1361,6 +1576,13 @@ describe("useRegisterViewModel", () => {
       "Return to sale",
     );
     expect(result.current.productEntry.disabled).toBe(true);
+
+    act(() => {
+      result.current.drawerGate?.onCloseoutSecondaryAction?.();
+    });
+
+    expect(result.current.drawerGate).toBeNull();
+    expect(result.current.productEntry.disabled).toBe(false);
   });
 
   it("routes register actions through the active-terminal conflict gate", async () => {
@@ -1605,7 +1827,7 @@ describe("useRegisterViewModel", () => {
     );
     expect(mockMarkLocalEventsSynced).not.toHaveBeenCalled();
     expect(toast.success).toHaveBeenCalledWith(
-      "Register reopened locally. It will sync when ready.",
+      "Register reopened. You can start selling.",
     );
   });
 
@@ -1698,10 +1920,10 @@ describe("useRegisterViewModel", () => {
     expect(result.current.drawerGate?.mode).toBe("closeoutBlocked");
     expect(result.current.productEntry.disabled).toBe(true);
     expect(result.current.drawerGate?.errorMessage).toBe(
-      "Unable to save this reopen locally.",
+      "Unable to reopen this register. Try again.",
     );
     expect(toast.success).not.toHaveBeenCalledWith(
-      "Register reopened locally. It will sync when ready.",
+      "Register reopened. You can start selling.",
     );
   });
 
@@ -2185,7 +2407,7 @@ describe("useRegisterViewModel", () => {
 
     await act(async () => {
       result.current.authDialog?.onAuthenticated(
-        "staff-1" as Id<"staffProfile">,
+        buildStaffAuthenticationResult(),
       );
     });
 
@@ -2230,7 +2452,7 @@ describe("useRegisterViewModel", () => {
 
     await act(async () => {
       result.current.authDialog?.onAuthenticated(
-        "staff-1" as Id<"staffProfile">,
+        buildStaffAuthenticationResult(),
       );
     });
 
@@ -2257,7 +2479,7 @@ describe("useRegisterViewModel", () => {
 
     await act(async () => {
       result.current.authDialog?.onAuthenticated(
-        "staff-1" as Id<"staffProfile">,
+        buildStaffAuthenticationResult(),
       );
     });
 
@@ -2353,7 +2575,7 @@ describe("useRegisterViewModel", () => {
 
     await act(async () => {
       result.current.authDialog?.onAuthenticated(
-        "staff-1" as Id<"staffProfile">,
+        buildStaffAuthenticationResult(),
       );
     });
 
@@ -2398,7 +2620,7 @@ describe("useRegisterViewModel", () => {
 
     await act(async () => {
       result.current.authDialog?.onAuthenticated(
-        "staff-1" as Id<"staffProfile">,
+        buildStaffAuthenticationResult(),
       );
     });
 
@@ -2478,7 +2700,7 @@ describe("useRegisterViewModel", () => {
 
     await act(async () => {
       result.current.authDialog?.onAuthenticated(
-        "staff-1" as Id<"staffProfile">,
+        buildStaffAuthenticationResult(),
       );
     });
 
@@ -2921,6 +3143,131 @@ describe("useRegisterViewModel", () => {
     );
   });
 
+  it("prioritizes cart item SKUs in the availability request before search results", async () => {
+    mockRegisterCatalogRows = Array.from({ length: 55 }, (_, index) =>
+      buildRegisterCatalogRow({
+        id: `sku-search-${index}` as Id<"productSku">,
+        productSkuId: `sku-search-${index}` as Id<"productSku">,
+        skuId: `sku-search-${index}` as Id<"productSku">,
+        productId: `product-search-${index}` as Id<"product">,
+        name: `Searchable Wave ${index}`,
+        sku: `SEARCH-${index}`,
+        barcode: `barcode-${index}`,
+      }),
+    );
+    mockUseConvexRegisterCatalogAvailability.mockImplementation(
+      (input: { productSkuIds?: Array<Id<"productSku">> }) =>
+        input.productSkuIds?.includes("sku-2" as Id<"productSku">)
+          ? [
+              buildRegisterCatalogAvailabilityRow({
+                availabilitySource: "live",
+                quantityAvailable: 5,
+              }),
+            ]
+          : [],
+    );
+
+    const localEvents = [
+      buildLocalEvent({
+        sequence: 1,
+        type: "register.opened",
+        payload: {
+          localRegisterSessionId: "drawer-1",
+          openingFloat: 5_000,
+          expectedCash: 5_000,
+          status: "open",
+        },
+        sync: { status: "synced", cloudEventId: "cloud-event-1" },
+      }),
+      buildLocalEvent({
+        sequence: 2,
+        type: "session.started",
+        localPosSessionId: "session-1",
+        payload: { localPosSessionId: "session-1", status: "active" },
+        sync: { status: "synced", cloudEventId: "cloud-event-2" },
+      }),
+      buildLocalEvent({
+        sequence: 3,
+        type: "cart.item_added",
+        localPosSessionId: "session-1",
+        payload: {
+          localItemId: "item-1",
+          productId: "product-2",
+          productSkuId: "sku-2",
+          productSku: "DW-18",
+          productName: "Deep Wave",
+          price: 100,
+          quantity: 1,
+        },
+        sync: { status: "synced", cloudEventId: "cloud-event-3" },
+      }),
+    ];
+    mockListLocalEvents.mockResolvedValue({
+      ok: true,
+      value: localEvents,
+    });
+
+    const { useRegisterViewModel } = await import("./useRegisterViewModel");
+    const { result } = renderHook(() => useRegisterViewModel());
+
+    await act(async () => {
+      result.current.authDialog?.onAuthenticated(
+        buildStaffAuthenticationResult(),
+      );
+    });
+    await waitFor(() =>
+      expect(result.current.cart.items).toEqual([
+        expect.objectContaining({
+          id: "item-1",
+          quantity: 1,
+          skuId: "sku-2",
+        }),
+      ]),
+    );
+    act(() => {
+      result.current.productEntry.setProductSearchQuery("searchable");
+    });
+    await waitFor(() => {
+      const latestInput = mockUseConvexRegisterCatalogAvailability.mock.calls.at(
+        -1,
+      )?.[0] as { productSkuIds?: Array<Id<"productSku">> } | undefined;
+      const cartSkuIndex =
+        latestInput?.productSkuIds?.indexOf("sku-2" as Id<"productSku">) ?? -1;
+      const searchSkuIndex =
+        latestInput?.productSkuIds?.indexOf(
+          "sku-search-0" as Id<"productSku">,
+        ) ?? -1;
+      expect(cartSkuIndex).toBeGreaterThanOrEqual(0);
+      expect(cartSkuIndex).toBeLessThan(50);
+      expect(searchSkuIndex).toBeGreaterThan(cartSkuIndex);
+    });
+
+    await act(async () => {
+      await result.current.cart.onUpdateQuantity(
+        "item-1" as Id<"posSessionItem">,
+        2,
+      );
+    });
+
+    expect(mockUseConvexRegisterCatalogAvailability).toHaveBeenCalledWith(
+      expect.objectContaining({
+        productSkuIds: expect.arrayContaining(["sku-2"]),
+      }),
+    );
+    expect(toast.error).not.toHaveBeenCalledWith(
+      "Availability not ready. Reconnect or refresh this terminal before selling this item.",
+    );
+    expect(mockAppendLocalEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "cart.item_added",
+        payload: expect.objectContaining({
+          productSkuId: "sku-2",
+          quantity: 2,
+        }),
+      }),
+    );
+  });
+
   it("adds an exact in-stock SKU match on submit without auto-adding first", async () => {
     mockRegisterCatalogRows = [buildRegisterCatalogRow()];
     mockRegisterCatalogAvailabilityRows = [
@@ -3106,9 +3453,17 @@ describe("useRegisterViewModel", () => {
     const { result, rerender } = renderHook(() => useRegisterViewModel());
 
     await act(async () => {
-      result.current.authDialog?.onAuthenticated(
-        "staff-1" as Id<"staffProfile">,
-      );
+      result.current.authDialog?.onAuthenticated({
+        staffProfileId: "staff-1" as Id<"staffProfile">,
+        staffProfile: {
+          firstName: "Ama",
+          lastName: "Kusi",
+        },
+        posLocalStaffProof: {
+          expiresAt: Date.now() + 60_000,
+          token: "staff-proof-token",
+        },
+      });
     });
 
     act(() => {
@@ -3131,6 +3486,7 @@ describe("useRegisterViewModel", () => {
           openingFloat: 5_000,
           notes: "Opening float ready",
         }),
+        staffProofToken: "staff-proof-token",
       }),
     );
     expect(mockStartSession).not.toHaveBeenCalled();
@@ -3157,6 +3513,103 @@ describe("useRegisterViewModel", () => {
     });
 
     expect(mockStartSession).not.toHaveBeenCalled();
+  });
+
+  it("requires a fresh staff proof before appending an online drawer opening", async () => {
+    mockRegisterState = {
+      phase: "readyToStart",
+      terminal: { _id: "terminal-1", displayName: "Front Counter" },
+      cashier: { _id: "staff-1", firstName: "Ama", lastName: "Kusi" },
+      activeRegisterSession: null,
+      activeSession: null,
+      resumableSession: null,
+    };
+    mockActiveSession = null;
+
+    const { useRegisterViewModel } = await import("./useRegisterViewModel");
+    const { result } = renderHook(() => useRegisterViewModel());
+
+    await act(async () => {
+      result.current.authDialog?.onAuthenticated(
+        "staff-1" as Id<"staffProfile">,
+      );
+    });
+
+    act(() => {
+      result.current.drawerGate?.onOpeningFloatChange?.("50.00");
+      result.current.drawerGate?.onNotesChange?.("Opening float ready");
+    });
+
+    await act(async () => {
+      await result.current.drawerGate?.onSubmit?.();
+    });
+
+    expect(mockAppendLocalEvent).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "register.opened",
+      }),
+    );
+    expect(result.current.authDialog?.open).toBe(false);
+    expect(result.current.drawerGate).toEqual(
+      expect.objectContaining({
+        errorMessage: "Sign in again before opening the drawer.",
+      }),
+    );
+    expect(toast.error).toHaveBeenCalledWith(
+      "Sign out, then sign in again before opening the drawer.",
+    );
+  });
+
+  it("allows offline drawer opening without a fresh staff proof", async () => {
+    Object.defineProperty(globalThis.navigator, "onLine", {
+      configurable: true,
+      value: false,
+    });
+    mockRegisterState = {
+      phase: "readyToStart",
+      terminal: { _id: "terminal-1", displayName: "Front Counter" },
+      cashier: {
+        _id: "staff-1",
+        activeRoles: ["manager"],
+        firstName: "Ama",
+        lastName: "Kusi",
+      },
+      activeRegisterSession: null,
+      activeSession: null,
+      resumableSession: null,
+    };
+    mockActiveSession = null;
+
+    const { useRegisterViewModel } = await import("./useRegisterViewModel");
+    const { result } = renderHook(() => useRegisterViewModel());
+
+    await act(async () => {
+      result.current.authDialog?.onAuthenticated(
+        "staff-1" as Id<"staffProfile">,
+      );
+    });
+
+    act(() => {
+      result.current.drawerGate?.onOpeningFloatChange?.("50.00");
+      result.current.drawerGate?.onNotesChange?.("Opening float ready");
+    });
+
+    await act(async () => {
+      await result.current.drawerGate?.onSubmit?.();
+    });
+
+    expect(mockAppendLocalEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "register.opened",
+        staffProofToken: undefined,
+      }),
+    );
+    expect(result.current.drawerGate?.errorMessage).not.toBe(
+      "Sign in again before opening the drawer.",
+    );
+    expect(toast.error).not.toHaveBeenCalledWith(
+      "Sign out, then sign in again before opening the drawer.",
+    );
   });
 
   it("marks drawer opening unavailable for non-manager cashier sign-ins", async () => {
@@ -3214,7 +3667,7 @@ describe("useRegisterViewModel", () => {
 
     await act(async () => {
       result.current.authDialog?.onAuthenticated(
-        "staff-1" as Id<"staffProfile">,
+        buildStaffAuthenticationResult(),
       );
     });
 
@@ -3282,7 +3735,7 @@ describe("useRegisterViewModel", () => {
 
     await act(async () => {
       result.current.authDialog?.onAuthenticated(
-        "staff-1" as Id<"staffProfile">,
+        buildStaffAuthenticationResult(),
       );
     });
 
@@ -3342,7 +3795,7 @@ describe("useRegisterViewModel", () => {
 
     await act(async () => {
       result.current.authDialog?.onAuthenticated(
-        "staff-1" as Id<"staffProfile">,
+        buildStaffAuthenticationResult(),
       );
     });
 
@@ -3356,7 +3809,7 @@ describe("useRegisterViewModel", () => {
 
     expect(result.current.drawerGate).not.toBeNull();
     expect(result.current.drawerGate?.errorMessage).toBe(
-      "Unable to save this drawer opening locally.",
+      "Unable to open the drawer. Try again.",
     );
     expect(toast.error).not.toHaveBeenCalled();
     expect(mockStartSession).not.toHaveBeenCalled();
@@ -3383,7 +3836,7 @@ describe("useRegisterViewModel", () => {
 
     await act(async () => {
       result.current.authDialog?.onAuthenticated(
-        "staff-1" as Id<"staffProfile">,
+        buildStaffAuthenticationResult(),
       );
     });
 
@@ -3425,7 +3878,7 @@ describe("useRegisterViewModel", () => {
 
     await act(async () => {
       result.current.authDialog?.onAuthenticated(
-        "staff-1" as Id<"staffProfile">,
+        buildStaffAuthenticationResult(),
       );
     });
 
@@ -3456,7 +3909,7 @@ describe("useRegisterViewModel", () => {
 
     await act(async () => {
       result.current.authDialog?.onAuthenticated(
-        "staff-1" as Id<"staffProfile">,
+        buildStaffAuthenticationResult(),
       );
     });
 
@@ -3505,7 +3958,7 @@ describe("useRegisterViewModel", () => {
 
     await act(async () => {
       result.current.authDialog?.onAuthenticated(
-        "staff-1" as Id<"staffProfile">,
+        buildStaffAuthenticationResult(),
       );
     });
 
@@ -4051,9 +4504,8 @@ describe("useRegisterViewModel", () => {
     );
     expect(mockMarkLocalEventsSynced).not.toHaveBeenCalled();
     expect(toast.success).toHaveBeenCalledWith(
-      "Drawer opening saved locally. It will sync when ready.",
+      "Drawer open",
     );
-    expect(toast.success).not.toHaveBeenCalledWith("Drawer open");
     await waitFor(() => expect(result.current.drawerGate).toBeNull());
     expect(result.current.productEntry.disabled).toBe(false);
     expect(result.current.syncStatus).toEqual(
@@ -4063,6 +4515,40 @@ describe("useRegisterViewModel", () => {
       }),
     );
     expect(mockStartSession).not.toHaveBeenCalled();
+
+    const registerOpenedEvent = mockAppendLocalEvent.mock.calls.find(
+      ([event]) => event.type === "register.opened",
+    )?.[0];
+    expect(registerOpenedEvent).toBeDefined();
+    mockListLocalEvents.mockResolvedValue({
+      ok: true,
+      value: [
+        buildLocalEvent({
+          localEventId: "event-opened",
+          localRegisterSessionId: registerOpenedEvent.localRegisterSessionId,
+          payload: registerOpenedEvent.payload,
+          sequence: 1,
+          sync: { status: "synced", uploaded: true },
+          type: "register.opened",
+        }),
+      ],
+    });
+
+    const runtimeInput = mockUsePosLocalSyncRuntimeStatus.mock.calls.at(-1)?.[0] as
+      | { onLocalEventsChanged?: () => void }
+      | undefined;
+    await act(async () => {
+      runtimeInput?.onLocalEventsChanged?.();
+    });
+
+    await waitFor(() =>
+      expect(result.current.syncStatus).toEqual(
+        expect.objectContaining({
+          status: "synced",
+          label: "Synced",
+        }),
+      ),
+    );
 
     let added = false;
     await act(async () => {
@@ -4210,7 +4696,7 @@ describe("useRegisterViewModel", () => {
     expect(mockUpdateSession).not.toHaveBeenCalled();
     expect(mockCompleteTransaction).not.toHaveBeenCalled();
     expect(result.current.checkout.completedOrderNumber).toMatch(
-      /^local-txn-/,
+      /^\d{6}$/,
     );
     expect(mockAppendLocalEvent).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -4222,6 +4708,7 @@ describe("useRegisterViewModel", () => {
         localTransactionId: expect.stringMatching(/^local-txn-/),
         staffProofToken: "staff-proof-token",
         payload: expect.objectContaining({
+          receiptNumber: expect.stringMatching(/^\d{6}$/),
           total: 200,
           items: [
             expect.objectContaining({
@@ -5270,7 +5757,7 @@ describe("useRegisterViewModel", () => {
     expect(result.current.cart.items[0].quantity).toBe(1);
     expect(result.current.checkout.cartItems[0].quantity).toBe(1);
     expect(toast.error).toHaveBeenCalledWith(
-      "Unable to save this cart update locally.",
+      "Unable to update this sale. Try again.",
     );
   });
 
@@ -5340,7 +5827,7 @@ describe("useRegisterViewModel", () => {
       ]),
     );
     expect(toast.error).toHaveBeenCalledWith(
-      "Unable to save this item locally.",
+      "Unable to add this item. Try again.",
     );
   });
 
@@ -5362,6 +5849,7 @@ describe("useRegisterViewModel", () => {
       });
     });
 
+    vi.mocked(toast.success).mockClear();
     let added = false;
     await act(async () => {
       added = await result.current.productEntry.onAddProduct({
@@ -5399,9 +5887,7 @@ describe("useRegisterViewModel", () => {
     );
     expect(mockMarkLocalEventsSynced).not.toHaveBeenCalled();
     expect(toast.error).not.toHaveBeenCalledWith("Connection unavailable.");
-    expect(toast.success).toHaveBeenCalledWith(
-      "Item added to local sale. Complete the sale to sync it.",
-    );
+    expect(toast.success).not.toHaveBeenCalled();
   });
 
   it("snapshots optimistic cart items into a pending local sale on completion", async () => {
@@ -5573,7 +6059,7 @@ describe("useRegisterViewModel", () => {
     );
     expect(result.current.cart.items).toEqual([]);
     expect(toast.error).toHaveBeenCalledWith(
-      "Unable to save this sale locally. Try again.",
+      "Unable to start this sale. Try again.",
     );
   });
 
@@ -5631,7 +6117,7 @@ describe("useRegisterViewModel", () => {
     expect(result.current.cart.items[0].quantity).toBe(1);
     expect(result.current.checkout.cartItems[0].quantity).toBe(1);
     expect(toast.error).toHaveBeenCalledWith(
-      "Unable to save this item locally.",
+      "Unable to add this item. Try again.",
     );
   });
 
@@ -5674,7 +6160,7 @@ describe("useRegisterViewModel", () => {
     expect(result.current.cart.items[0].quantity).toBe(1);
     expect(result.current.checkout.cartItems).toHaveLength(1);
     expect(toast.error).toHaveBeenCalledWith(
-      "Unable to save this cart update locally.",
+      "Unable to update this sale. Try again.",
     );
   });
 
@@ -5870,7 +6356,7 @@ describe("useRegisterViewModel", () => {
     expect(result.current.cart.items[0].quantity).toBe(1);
     expect(result.current.checkout.cartItems).toHaveLength(1);
     expect(toast.error).toHaveBeenCalledWith(
-      "Unable to save this cart update locally.",
+      "Unable to update this sale. Try again.",
     );
   });
 
@@ -5943,7 +6429,7 @@ describe("useRegisterViewModel", () => {
     expect(result.current.cart.items[0].quantity).toBe(1);
     expect(result.current.checkout.cartItems).toHaveLength(1);
     expect(toast.error).toHaveBeenCalledWith(
-      "Unable to save this cart update locally.",
+      "Unable to update this sale. Try again.",
     );
   });
 
@@ -6010,7 +6496,7 @@ describe("useRegisterViewModel", () => {
 
     expect(result.current.checkout.payments).toEqual([]);
     expect(toast.error).toHaveBeenCalledWith(
-      "Unable to save this payment locally.",
+      "Unable to update this payment. Try again.",
     );
 
     let completed = true;
@@ -6566,7 +7052,7 @@ describe("useRegisterViewModel", () => {
           localRegisterSessionId: "drawer-1",
           localPosSessionId: "session-1",
           payload: expect.objectContaining({
-            receiptNumber: expect.stringMatching(/^local-txn-/),
+            receiptNumber: expect.stringMatching(/^\d{6}$/),
             items: [
               expect.objectContaining({
                 localItemId: "item-1",
@@ -6610,6 +7096,7 @@ describe("useRegisterViewModel", () => {
       await result.current.checkout.onAddPayment("cash", 120);
     });
 
+    vi.mocked(toast.success).mockClear();
     let completed = true;
     await act(async () => {
       completed = await result.current.checkout.onCompleteTransaction();
@@ -6617,7 +7104,7 @@ describe("useRegisterViewModel", () => {
 
     expect(completed).toBe(true);
     expect(result.current.checkout.isTransactionCompleted).toBe(true);
-    expect(result.current.checkout.completedOrderNumber).toMatch(/^local-txn-/);
+    expect(result.current.checkout.completedOrderNumber).toMatch(/^\d{6}$/);
     await waitFor(() =>
       expect(mockAppendLocalEvent).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -6626,16 +7113,24 @@ describe("useRegisterViewModel", () => {
           localPosSessionId: "session-1",
           staffProfileId: "staff-1",
           payload: expect.objectContaining({
+            localReceiptNumber: expect.stringMatching(/^local-txn-/),
+            receiptNumber: expect.stringMatching(/^\d{6}$/),
             items: [expect.objectContaining({ localItemId: "item-1" })],
             payments: [expect.objectContaining({ method: "cash", amount: 120 })],
           }),
         }),
       ),
     );
-    expect(mockMarkLocalEventsSynced).not.toHaveBeenCalled();
-    expect(toast.success).toHaveBeenCalledWith(
-      "Sale completed locally. It will sync when ready.",
+    const completedEvent = mockAppendLocalEvent.mock.calls.find(
+      ([event]) => event.type === "transaction.completed",
+    )?.[0];
+    expect(completedEvent?.payload).toEqual(
+      expect.objectContaining({
+        localReceiptNumber: completedEvent?.localTransactionId,
+      }),
     );
+    expect(mockMarkLocalEventsSynced).not.toHaveBeenCalled();
+    expect(toast.success).not.toHaveBeenCalled();
   });
 
   it("does not resurrect a cloud-backed sale after completing it locally", async () => {
@@ -6663,13 +7158,23 @@ describe("useRegisterViewModel", () => {
       await result.current.checkout.onCompleteTransaction();
     });
 
-    act(() => {
-      result.current.checkout.onStartNewTransaction();
+    mockAppendLocalEvent.mockClear();
+    await act(async () => {
+      await result.current.checkout.onStartNewTransaction();
     });
 
+    await waitFor(() =>
+      expect(mockAppendLocalEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "session.started",
+          localRegisterSessionId: "drawer-1",
+          staffProfileId: "staff-1",
+        }),
+      ),
+    );
     await waitFor(() => expect(result.current.checkout.cartItems).toEqual([]));
     expect(result.current.checkout.total).toBe(0);
-    expect(result.current.sessionPanel?.activeSessionNumber).toBeNull();
+    expect(result.current.checkout.isTransactionCompleted).toBe(false);
   });
 
   it("does not resurrect a cloud-backed sale after a reload replays local completion", async () => {
@@ -6724,7 +7229,7 @@ describe("useRegisterViewModel", () => {
           payload: {
             localPosSessionId: "session-1",
             localTransactionId: "local-txn-1",
-            receiptNumber: "local-txn-1",
+            receiptNumber: "123456",
             subtotal: 120,
             tax: 0,
             total: 120,
@@ -6864,7 +7369,7 @@ describe("useRegisterViewModel", () => {
     expect(result.current.checkout.completedOrderNumber).toBeNull();
     expect(result.current.checkout.completedTransactionData).toBeNull();
     expect(toast.error).toHaveBeenCalledWith(
-      "Unable to save this sale locally.",
+      "Unable to complete this sale. Try again.",
     );
   });
 

--- a/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts
@@ -6,6 +6,7 @@ import { toast } from "sonner";
 
 import { api } from "~/convex/_generated/api";
 import type { Id } from "~/convex/_generated/dataModel";
+import { generateTransactionNumber } from "~/convex/utils";
 
 import type {
   CartItem,
@@ -217,6 +218,10 @@ function createLocalFallbackId(prefix: string): string {
   return `${prefix}-${uniqueId}`;
 }
 
+function buildLocalReceiptNumber() {
+  return generateTransactionNumber();
+}
+
 function getCloseoutLocalRegisterSessionId(
   session:
     | { _id?: Id<"registerSession"> | string; localRegisterSessionId?: string }
@@ -356,6 +361,7 @@ function getProductAvailabilityStatus(product: Product) {
 function buildCompletedSalePayload(input: {
   cartItems: CartItem[];
   customerInfo: CustomerInfo;
+  localReceiptNumber: string;
   localPosSessionId: string;
   localTransactionId: string;
   payments: Payment[];
@@ -369,6 +375,7 @@ function buildCompletedSalePayload(input: {
   return {
     localPosSessionId: input.localPosSessionId,
     localTransactionId: input.localTransactionId,
+    localReceiptNumber: input.localReceiptNumber,
     receiptNumber: input.receiptNumber,
     customerProfileId: customer?.customerProfileId,
     customerName: customer?.name || undefined,
@@ -776,6 +783,10 @@ export function useRegisterViewModel(): RegisterViewModel {
   const [staffProfileId, setStaffProfileId] =
     useState<Id<"staffProfile"> | null>(null);
   const [staffProofToken, setStaffProofToken] = useState<string | null>(null);
+  const staffProfileIdRef = useRef<Id<"staffProfile"> | null>(staffProfileId);
+  const staffProofTokenRef = useRef<string | null>(staffProofToken);
+  staffProfileIdRef.current = staffProfileId;
+  staffProofTokenRef.current = staffProofToken;
   const [localAuthenticatedStaff, setLocalAuthenticatedStaff] =
     useState<LocalAuthenticatedStaff>(null);
   const terminalRegisterNumber = terminal?.registerNumber
@@ -831,6 +842,8 @@ export function useRegisterViewModel(): RegisterViewModel {
   const unmountSessionRef = useRef<Id<"posSession"> | null>(null);
   const unmountSessionCartItemCountRef = useRef(0);
   const exactAddKeyRef = useRef<string | null>(null);
+  const pendingSessionStartKeyRef = useRef<string | null>(null);
+  const seededRegisterSessionIdsRef = useRef<Set<string>>(new Set());
   const [optimisticCartQuantities, setOptimisticCartQuantities] = useState<
     Record<string, number>
   >({});
@@ -845,6 +858,7 @@ export function useRegisterViewModel(): RegisterViewModel {
     useState<PosLocalRegisterReadModel | null>(null);
   const [localRegisterReadModelVersion, setLocalRegisterReadModelVersion] =
     useState(0);
+  const [localSyncEventAppendToken, setLocalSyncEventAppendToken] = useState(0);
 
   const registerState = useConvexRegisterState({
     storeId: activeStoreId,
@@ -884,13 +898,34 @@ export function useRegisterViewModel(): RegisterViewModel {
     () => searchRegisterCatalog(registerCatalogIndex, productSearchQuery),
     [productSearchQuery, registerCatalogIndex],
   );
-  const registerAvailabilityProductSkuIds = useMemo(
-    () =>
-      registerMetadataSearchState.results.map(
-        (row) => row.productSkuId as Id<"productSku">,
-      ),
-    [registerMetadataSearchState.results],
-  );
+  const registerAvailabilityProductSkuIds = useMemo(() => {
+    const productSkuIds = new Set<Id<"productSku">>();
+
+    for (const item of activeSession?.cartItems ?? []) {
+      if (item.skuId) {
+        productSkuIds.add(item.skuId);
+      }
+    }
+
+    for (const item of localRegisterReadModel?.activeSale?.items ?? []) {
+      productSkuIds.add(item.productSkuId as Id<"productSku">);
+    }
+
+    for (const productSkuId of Object.keys(optimisticCartProducts)) {
+      productSkuIds.add(productSkuId as Id<"productSku">);
+    }
+
+    for (const row of registerMetadataSearchState.results) {
+      productSkuIds.add(row.productSkuId as Id<"productSku">);
+    }
+
+    return Array.from(productSkuIds);
+  }, [
+    activeSession?.cartItems,
+    localRegisterReadModel?.activeSale?.items,
+    optimisticCartProducts,
+    registerMetadataSearchState.results,
+  ]);
   const registerCatalogAvailabilityRows = useConvexRegisterCatalogAvailability({
     refreshFullAvailabilitySnapshot: true,
     storeId: activeStoreId,
@@ -1083,22 +1118,32 @@ export function useRegisterViewModel(): RegisterViewModel {
           }
           return createLocalFallbackId(kind);
         },
+        onEventAppended: () => {
+          setLocalSyncEventAppendToken((current) => current + 1);
+        },
         staffProofToken: (requestedStaffProfileId) =>
-          requestedStaffProfileId === staffProfileId
-            ? (staffProofToken ?? undefined)
+          requestedStaffProfileId === staffProfileIdRef.current
+            ? (staffProofTokenRef.current ?? undefined)
             : undefined,
       }),
-    [localStore, staffProfileId, staffProofToken, terminal?._id],
+    [localStore, terminal?._id],
   );
+  const localRuntimeStoreFactory = useCallback(() => localStore, [localStore]);
   useEffect(() => {
     if (!staffProfileId || !staffProofToken) {
       return;
     }
 
-    void localStore.attachStaffProofTokenToPendingEvents({
-      staffProfileId,
-      staffProofToken,
-    });
+    void localStore
+      .attachStaffProofTokenToPendingEvents({
+        staffProfileId,
+        staffProofToken,
+      })
+      .then((result) => {
+        if (result.ok && result.value > 0) {
+          setLocalSyncEventAppendToken((current) => current + 1);
+        }
+      });
   }, [localStore, staffProfileId, staffProofToken]);
   useEffect(() => {
     let cancelled = false;
@@ -1301,6 +1346,11 @@ export function useRegisterViewModel(): RegisterViewModel {
   );
   const operableActiveSession: OperableActiveSession | null =
     localActiveSession ?? visibleActiveSession;
+  useEffect(() => {
+    if (operableActiveSession) {
+      pendingSessionStartKeyRef.current = null;
+    }
+  }, [operableActiveSession]);
   const serverCartItems = useMemo(
     () => operableActiveSession?.cartItems ?? [],
     [operableActiveSession?.cartItems],
@@ -1706,8 +1756,14 @@ export function useRegisterViewModel(): RegisterViewModel {
   ]);
 
   const ensureLocalRegisterSessionReady = useCallback(
-    async (localRegisterSessionId: string) => {
+    async (
+      localRegisterSessionId: string,
+      options?: { staffProfileId?: Id<"staffProfile"> },
+    ) => {
+      const actingStaffProfileId = options?.staffProfileId ?? staffProfileId;
+
       if (
+        seededRegisterSessionIdsRef.current.has(localRegisterSessionId) ||
         locallyOperableRegisterSession?.localRegisterSessionId ===
           localRegisterSessionId ||
         (localRegisterReadModel?.canSell &&
@@ -1722,7 +1778,7 @@ export function useRegisterViewModel(): RegisterViewModel {
         usableActiveRegisterSession._id.toString() !== localRegisterSessionId ||
         !activeStoreId ||
         !terminal?._id ||
-        !staffProfileId
+        !actingStaffProfileId
       ) {
         return false;
       }
@@ -1732,13 +1788,14 @@ export function useRegisterViewModel(): RegisterViewModel {
         storeId: activeStoreId!,
         registerNumber,
         localRegisterSessionId,
-        staffProfileId,
+        staffProfileId: actingStaffProfileId,
         openingFloat: usableActiveRegisterSession.openingFloat,
         expectedCash: usableActiveRegisterSession.expectedCash,
         notes: usableActiveRegisterSession.notes ?? null,
         status: usableActiveRegisterSession.status,
       });
       if (savedLocally) {
+        seededRegisterSessionIdsRef.current.add(localRegisterSessionId);
         noteLocalRegisterEventChanged();
       }
       return Boolean(savedLocally);
@@ -1784,7 +1841,7 @@ export function useRegisterViewModel(): RegisterViewModel {
         localPosSessionId: operableActiveSession._id.toString(),
       });
       if (localSession.kind !== "ok") {
-        toast.error("Unable to save this sale locally. Try again.");
+        toast.error("Unable to start this sale. Try again.");
         return null;
       }
       noteLocalRegisterEventChanged();
@@ -1824,7 +1881,7 @@ export function useRegisterViewModel(): RegisterViewModel {
     });
 
     if (result.kind !== "ok") {
-      toast.error("Unable to save this sale locally. Try again.");
+      toast.error("Unable to start this sale. Try again.");
       return null;
     }
 
@@ -2152,7 +2209,7 @@ export function useRegisterViewModel(): RegisterViewModel {
         await waitForCheckoutMutationQueues();
 
         if (!activeStoreId || !terminal?._id) {
-          presentOperatorError("Unable to save this cart update locally.");
+          presentOperatorError("Unable to update this sale. Try again.");
           return false;
         }
         const savedLocally = await localCommandGateway.clearCart({
@@ -2166,7 +2223,7 @@ export function useRegisterViewModel(): RegisterViewModel {
         });
 
         if (!savedLocally) {
-          presentOperatorError("Unable to save this cart update locally.");
+          presentOperatorError("Unable to update this sale. Try again.");
           return false;
         }
         noteLocalRegisterEventChanged();
@@ -2266,12 +2323,17 @@ export function useRegisterViewModel(): RegisterViewModel {
     ],
   );
 
-  const handleStartNewSession = useCallback(async () => {
+  const handleStartNewSession = useCallback(async (options?: {
+    force?: boolean;
+    staffProfileId?: Id<"staffProfile">;
+  }) => {
     if (guardActiveSessionConflict()) {
       return;
     }
 
-    if (!activeStoreId || !terminal?._id || !staffProfileId) {
+    const actingStaffProfileId = options?.staffProfileId ?? staffProfileId;
+
+    if (!activeStoreId || !terminal?._id || !actingStaffProfileId) {
       toast.error("Register sign-in required. Sign in before starting a sale.");
       return;
     }
@@ -2285,55 +2347,75 @@ export function useRegisterViewModel(): RegisterViewModel {
       return;
     }
 
-    if (!(await hasProvisionedLocalSyncSeed())) {
-      toast.error("Terminal setup required. Register this terminal before selling.");
+    const sessionStartKey = `${localRegisterSessionId}:${actingStaffProfileId}`;
+    if (pendingSessionStartKeyRef.current === sessionStartKey) {
       return;
     }
+    pendingSessionStartKeyRef.current = sessionStartKey;
+    let keepSessionStartGuard = false;
 
-    if (!(await ensureLocalRegisterSessionReady(localRegisterSessionId))) {
-      toast.error("Drawer closed. Open the drawer before starting a sale.");
-      return;
-    }
-
-    if (operableActiveSession) {
-      const hasDraftState = operableActiveSession.cartItems.length > 0;
-      const handled = hasDraftState
-        ? await holdCurrentSession("Auto-held for new session")
-        : true;
-
-      if (!handled) {
+    try {
+      if (!(await hasProvisionedLocalSyncSeed())) {
+        toast.error("Terminal setup required. Register this terminal before selling.");
         return;
       }
+
+      if (
+        !(await ensureLocalRegisterSessionReady(localRegisterSessionId, {
+          staffProfileId: actingStaffProfileId,
+        }))
+      ) {
+        toast.error("Drawer closed. Open the drawer before starting a sale.");
+        return;
+      }
+
+      if (operableActiveSession) {
+        const hasDraftState = operableActiveSession.cartItems.length > 0;
+        const handled = hasDraftState
+          ? await holdCurrentSession("Auto-held for new session")
+          : true;
+
+        if (!handled) {
+          return;
+        }
+      }
+
+      const result = await localCommandGateway.startSession({
+        storeId: activeStoreId!,
+        terminalId: terminal._id as Id<"posTerminal">,
+        staffProfileId: actingStaffProfileId,
+        registerNumber,
+        localRegisterSessionId,
+      });
+
+      if (result.kind !== "ok") {
+        presentOperatorError("Unable to start this sale. Try again.");
+        return;
+      }
+
+      const localPosSessionId = result.data.localPosSessionId;
+      keepSessionStartGuard = true;
+      noteLocalRegisterEventChanged();
+      resetDraftState({
+        keepCashier: true,
+      });
+      setLocalOperablePosSession({
+        localPosSessionId,
+        localRegisterSessionId,
+        registerNumber,
+        startedAt: Date.now(),
+        storeId: activeStoreId!,
+        terminalId: terminal._id,
+      });
+      bootstrapInitialized.current = true;
+    } finally {
+      if (
+        !keepSessionStartGuard &&
+        pendingSessionStartKeyRef.current === sessionStartKey
+      ) {
+        pendingSessionStartKeyRef.current = null;
+      }
     }
-
-    const result = await localCommandGateway.startSession({
-      storeId: activeStoreId!,
-      terminalId: terminal._id as Id<"posTerminal">,
-      staffProfileId,
-      registerNumber,
-      localRegisterSessionId,
-    });
-
-    if (result.kind !== "ok") {
-      presentOperatorError("Unable to save this sale locally.");
-      return;
-    }
-
-    const localPosSessionId = result.data.localPosSessionId;
-    noteLocalRegisterEventChanged();
-    resetDraftState({
-      keepCashier: true,
-    });
-    setLocalOperablePosSession({
-      localPosSessionId,
-      localRegisterSessionId,
-      registerNumber,
-      startedAt: Date.now(),
-      storeId: activeStoreId!,
-      terminalId: terminal._id,
-    });
-    bootstrapInitialized.current = true;
-    toast.success("Sale started");
   }, [
     operableActiveSession,
     localEventRegisterSessionId,
@@ -2356,6 +2438,16 @@ export function useRegisterViewModel(): RegisterViewModel {
       setDrawerErrorMessage(
         "Register sign-in required. Sign in before opening the drawer.",
       );
+      return;
+    }
+
+    const isOnline = globalThis.navigator?.onLine ?? true;
+
+    if (isOnline && !staffProofToken) {
+      setDrawerErrorMessage(
+        "Sign in again before opening the drawer.",
+      );
+      toast.error("Sign out, then sign in again before opening the drawer.");
       return;
     }
 
@@ -2390,7 +2482,7 @@ export function useRegisterViewModel(): RegisterViewModel {
     setIsOpeningDrawer(false);
 
     if (result.kind !== "ok" || !result.data) {
-      setDrawerErrorMessage("Unable to save this drawer opening locally.");
+      setDrawerErrorMessage("Unable to open the drawer. Try again.");
       return;
     }
 
@@ -2407,10 +2499,11 @@ export function useRegisterViewModel(): RegisterViewModel {
     });
     setDrawerErrorMessage(null);
     bootstrapInitialized.current = true;
-    toast.success("Drawer opening saved locally. It will sync when ready.");
+    toast.success("Drawer open");
   }, [
     activeStoreId,
     staffProfileId,
+    staffProofToken,
     drawerNotes,
     drawerOpeningFloat,
     hasProvisionedLocalSyncSeed,
@@ -2474,7 +2567,7 @@ export function useRegisterViewModel(): RegisterViewModel {
     setIsSubmittingCloseout(false);
 
     if (!savedLocally) {
-      setDrawerErrorMessage("Unable to save this closeout locally.");
+      setDrawerErrorMessage("Unable to close this register. Try again.");
       return;
     }
 
@@ -2491,7 +2584,7 @@ export function useRegisterViewModel(): RegisterViewModel {
       setLocalOperableRegisterSession(null);
     }
     requestBootstrap();
-    toast.success("Register session closed locally. It will sync when ready.");
+    toast.success("Register closed.");
   }, [
     activeStoreId,
     activeCloseoutRegisterSession,
@@ -2506,6 +2599,13 @@ export function useRegisterViewModel(): RegisterViewModel {
     terminal?._id,
     waitForCheckoutMutationQueues,
   ]);
+
+  const handleCancelRegisterCloseout = useCallback(() => {
+    setIsCloseoutRequested(false);
+    setCloseoutCountedCash("");
+    setCloseoutNotes("");
+    setDrawerErrorMessage(null);
+  }, []);
 
   const handleReopenRegisterCloseout = useCallback(async () => {
     if (!closeoutBlockedRegisterSession) {
@@ -2555,7 +2655,7 @@ export function useRegisterViewModel(): RegisterViewModel {
     setIsReopeningCloseout(false);
 
     if (!savedLocally) {
-      setDrawerErrorMessage("Unable to save this reopen locally.");
+      setDrawerErrorMessage("Unable to reopen this register. Try again.");
       return;
     }
 
@@ -2572,7 +2672,7 @@ export function useRegisterViewModel(): RegisterViewModel {
       terminalId: terminal._id,
     });
     requestBootstrap();
-    toast.success("Register reopened locally. It will sync when ready.");
+    toast.success("Register reopened. You can start selling.");
   }, [
     activeStoreId,
     activeCloseoutRegisterSession,
@@ -2920,13 +3020,12 @@ export function useRegisterViewModel(): RegisterViewModel {
             return next;
           });
         }
-        presentOperatorError("Unable to save this item locally.");
+        presentOperatorError("Unable to add this item. Try again.");
         return false;
       }
 
       noteLocalRegisterEventChanged();
       setProductSearchQuery("");
-      toast.success("Item added to local sale. Complete the sale to sync it.");
       return true;
       });
     },
@@ -3058,7 +3157,7 @@ export function useRegisterViewModel(): RegisterViewModel {
             }),
           });
           if (!savedLocally) {
-            presentOperatorError("Unable to save this cart update locally.");
+            presentOperatorError("Unable to update this sale. Try again.");
             return;
           }
           noteLocalRegisterEventChanged();
@@ -3079,7 +3178,7 @@ export function useRegisterViewModel(): RegisterViewModel {
           }),
         });
         if (!savedLocally) {
-          presentOperatorError("Unable to save this cart update locally.");
+          presentOperatorError("Unable to update this sale. Try again.");
           return;
         }
         noteLocalRegisterEventChanged();
@@ -3104,7 +3203,7 @@ export function useRegisterViewModel(): RegisterViewModel {
         });
 
         if (!savedLocally) {
-          presentOperatorError("Unable to save this cart update locally.");
+          presentOperatorError("Unable to update this sale. Try again.");
           return;
         }
 
@@ -3141,7 +3240,7 @@ export function useRegisterViewModel(): RegisterViewModel {
           delete next[itemId];
           return next;
         });
-        presentOperatorError("Unable to save this cart update locally.");
+        presentOperatorError("Unable to update this sale. Try again.");
         return;
       }
       noteLocalRegisterEventChanged();
@@ -3191,7 +3290,7 @@ export function useRegisterViewModel(): RegisterViewModel {
           }),
         });
         if (!savedLocally) {
-          presentOperatorError("Unable to save this cart update locally.");
+          presentOperatorError("Unable to update this sale. Try again.");
           return;
         }
         noteLocalRegisterEventChanged();
@@ -3213,7 +3312,7 @@ export function useRegisterViewModel(): RegisterViewModel {
       });
 
       if (!savedLocally) {
-        presentOperatorError("Unable to save this cart update locally.");
+        presentOperatorError("Unable to update this sale. Try again.");
         return;
       }
 
@@ -3255,7 +3354,7 @@ export function useRegisterViewModel(): RegisterViewModel {
       await waitForCheckoutMutationQueues();
 
       if (!activeStoreId || !terminal?._id) {
-        presentOperatorError("Unable to save this cart update locally.");
+        presentOperatorError("Unable to update this sale. Try again.");
         return;
       }
 
@@ -3270,7 +3369,7 @@ export function useRegisterViewModel(): RegisterViewModel {
       });
 
       if (!savedLocally) {
-        presentOperatorError("Unable to save this cart update locally.");
+        presentOperatorError("Unable to update this sale. Try again.");
         return;
       }
 
@@ -3362,21 +3461,56 @@ export function useRegisterViewModel(): RegisterViewModel {
 
   const handleCashierAuthenticated = useCallback(
     (result: StaffAuthenticationResult | Id<"staffProfile">) => {
+      let authenticatedStaffProfileId: Id<"staffProfile">;
+      let canAutoStartSale = false;
       if (typeof result === "string") {
-        setStaffProfileId(result as Id<"staffProfile">);
+        authenticatedStaffProfileId = result as Id<"staffProfile">;
+        staffProfileIdRef.current = authenticatedStaffProfileId;
+        staffProofTokenRef.current = null;
+        setStaffProfileId(authenticatedStaffProfileId);
         setStaffProofToken(null);
         setLocalAuthenticatedStaff(null);
       } else {
-        setStaffProfileId(result.staffProfileId);
-        setStaffProofToken(readStaffProofFromAuthResult(result));
+        canAutoStartSale = true;
+        authenticatedStaffProfileId = result.staffProfileId;
+        const authenticatedStaffProofToken = readStaffProofFromAuthResult(result);
+        staffProfileIdRef.current = authenticatedStaffProfileId;
+        staffProofTokenRef.current = authenticatedStaffProofToken;
+        setStaffProfileId(authenticatedStaffProfileId);
+        setStaffProofToken(authenticatedStaffProofToken);
         setLocalAuthenticatedStaff({
           activeRoles: result.activeRoles ?? [],
           displayName: getStaffDisplayNameFromAuthResult(result),
         });
       }
       requestBootstrap();
+
+      if (
+        canAutoStartSale &&
+        activeStoreId &&
+        terminal?._id &&
+        localEventRegisterSessionId &&
+        !operableActiveSession &&
+        !registerState?.activeSession &&
+        !activeSessionConflict &&
+        !isTransactionCompleted
+      ) {
+        void handleStartNewSession({
+          staffProfileId: authenticatedStaffProfileId,
+        });
+      }
     },
-    [requestBootstrap],
+    [
+      activeSessionConflict,
+      activeStoreId,
+      handleStartNewSession,
+      isTransactionCompleted,
+      localEventRegisterSessionId,
+      operableActiveSession,
+      registerState?.activeSession,
+      requestBootstrap,
+      terminal?._id,
+    ],
   );
 
   const handleNavigateBack = useCallback(async () => {
@@ -3497,7 +3631,6 @@ export function useRegisterViewModel(): RegisterViewModel {
       }
       const finishCompletedSale = (input: {
         orderNumber: string;
-        successMessage: string;
         transactionId?: Id<"posTransaction">;
       }) => {
         setIsTransactionCompleted(true);
@@ -3513,7 +3646,6 @@ export function useRegisterViewModel(): RegisterViewModel {
           total: saleTotals.total,
           customerInfo: completedCustomerInfo(customerInfo),
         });
-        toast.success(input.successMessage);
       };
       const buildSalePayload = (input: {
         localTransactionId: string;
@@ -3524,6 +3656,7 @@ export function useRegisterViewModel(): RegisterViewModel {
           customerInfo,
           localPosSessionId,
           localTransactionId: input.localTransactionId,
+          localReceiptNumber: input.localTransactionId,
           payments: currentPayments,
           receiptNumber: input.receiptNumber,
           totals: saleTotals,
@@ -3535,11 +3668,12 @@ export function useRegisterViewModel(): RegisterViewModel {
       }
 
       if (!activeStoreId || !terminal?._id) {
-        presentOperatorError("Unable to save this sale locally.");
+        presentOperatorError("Unable to complete this sale. Try again.");
         return false;
       }
 
       const localTransactionId = createLocalFallbackId("local-txn");
+      const receiptNumber = buildLocalReceiptNumber();
       const savedLocally = await localCommandGateway.completeTransaction({
         terminalId: terminal._id,
         storeId: activeStoreId!,
@@ -3550,19 +3684,18 @@ export function useRegisterViewModel(): RegisterViewModel {
         staffProfileId,
         payload: buildSalePayload({
           localTransactionId,
-          receiptNumber: localTransactionId,
+          receiptNumber,
         }),
       });
       if (!savedLocally) {
-        presentOperatorError("Unable to save this sale locally.");
+        presentOperatorError("Unable to complete this sale. Try again.");
         return false;
       }
 
       noteLocalRegisterEventChanged();
       locallyCompletedSessionIdsRef.current.add(localPosSessionId);
       finishCompletedSale({
-        orderNumber: localTransactionId,
-        successMessage: "Sale completed locally. It will sync when ready.",
+        orderNumber: receiptNumber,
       });
       return true;
     } finally {
@@ -3587,12 +3720,13 @@ export function useRegisterViewModel(): RegisterViewModel {
     waitForCheckoutMutationQueues,
   ]);
 
-  const handleStartNewTransaction = useCallback(() => {
+  const handleStartNewTransaction = useCallback(async () => {
     resetDraftState({
       keepCashier: true,
     });
     requestBootstrap();
-  }, [requestBootstrap, resetDraftState]);
+    await handleStartNewSession({ force: true });
+  }, [handleStartNewSession, requestBootstrap, resetDraftState]);
 
   const enqueuePaymentMutation = useCallback(
     (
@@ -3628,7 +3762,7 @@ export function useRegisterViewModel(): RegisterViewModel {
         });
 
         if (!saved) {
-          toast.error("Unable to save this payment locally.");
+          toast.error("Unable to update this payment. Try again.");
           return false;
         }
 
@@ -3903,6 +4037,11 @@ export function useRegisterViewModel(): RegisterViewModel {
               closeoutSecondaryActionLabel: closeoutBlockedRegisterSession
                 ? "Reopen register"
                 : "Return to sale",
+              onCloseoutSecondaryAction: closeoutBlockedRegisterSession
+                ? isCashierManager
+                  ? handleReopenRegisterCloseout
+                  : undefined
+                : handleCancelRegisterCloseout,
               expectedCash: activeCloseoutRegisterSession?.expectedCash,
               canOpenCashControls: isCashierManager,
               cashControlsRegisterSessionId: getCloseoutCloudRegisterSessionId(
@@ -4002,24 +4141,56 @@ export function useRegisterViewModel(): RegisterViewModel {
         }
       : null;
   const localRuntimeSyncSource = usePosLocalSyncRuntimeStatus({
+    eventAppendToken: localSyncEventAppendToken,
+    onLocalEventsChanged: noteLocalRegisterEventChanged,
     storeId: activeStoreId,
     terminalId: terminal?._id,
     onRetrySync: requestBootstrap,
-    storeFactory: () => localStore,
+    storeFactory: localRuntimeStoreFactory,
   });
-  const localSyncSource = readLocalSyncStatus(
-    localRuntimeSyncSource
-      ? { localSyncStatus: localRuntimeSyncSource }
-      : null,
-    operableActiveSession,
-    locallyOperableRegisterSession
+  const localRuntimeStatusSource = localRuntimeSyncSource?.status
+    ? localRuntimeSyncSource
+    : null;
+  const localReadModelSyncSource =
+    localRegisterReadModel &&
+    localRegisterReadModel.syncStatus.state !== "synced"
+      ? {
+          localSyncStatus: {
+            status:
+              localRegisterReadModel.syncStatus.state === "needs_review" ||
+              localRegisterReadModel.syncStatus.state === "failed"
+                ? "needs_review"
+                : localRegisterReadModel.activeRegisterSession?.status ===
+                    "closing"
+                  ? "locally_closed_pending_sync"
+                  : "pending_sync",
+            pendingEventCount:
+              localRegisterReadModel.syncStatus.pendingCount +
+              localRegisterReadModel.syncStatus.failedCount,
+          },
+        }
+      : null;
+  const localOperableRegisterSyncSource =
+    locallyOperableRegisterSession &&
+    !(
+      localRegisterReadModel?.activeRegisterSession?.localRegisterSessionId ===
+        locallyOperableRegisterSession.localRegisterSessionId &&
+      localRegisterReadModel.syncStatus.state === "synced"
+    )
       ? {
           localSyncStatus: {
             status: "pending_sync",
             pendingEventCount: 1,
           },
         }
+      : null;
+  const localSyncSource = readLocalSyncStatus(
+    localRuntimeStatusSource
+      ? { localSyncStatus: localRuntimeStatusSource }
       : null,
+    operableActiveSession,
+    localReadModelSyncSource,
+    localOperableRegisterSyncSource,
     activeCloseoutRegisterSession,
     registerState?.activeRegisterSession,
     registerState,
@@ -4068,6 +4239,29 @@ export function useRegisterViewModel(): RegisterViewModel {
       online: globalThis.navigator?.onLine ?? true,
       staffSignedIn: Boolean(staffProfileId),
       ...(activeStoreId ? { storeId: activeStoreId } : {}),
+      syncFlow: {
+        eventAppendToken: localSyncEventAppendToken,
+        lastLocalSequence: localRegisterReadModel?.syncStatus.lastLocalSequence,
+        lastRuntimeTrigger:
+          localRuntimeSyncSource?.debug?.lastTrigger ?? "none",
+        lastRuntimeTriggerAt: localRuntimeSyncSource?.debug?.lastTriggerAt,
+        lastRuntimeTriggerPriority:
+          localRuntimeSyncSource?.debug?.lastTriggerPriority ?? "normal",
+        lastSyncedSequence:
+          localRegisterReadModel?.syncStatus.lastSyncedSequence,
+        nextPendingSequence:
+          localRegisterReadModel?.syncStatus.nextPendingSequence,
+        pendingEventCount: syncStatus?.pendingEventCount ?? 0,
+        source: localRuntimeStatusSource
+          ? "runtime"
+          : localReadModelSyncSource
+            ? "local-read-model"
+          : localSyncSource
+            ? "register-state"
+            : "none",
+        staffProof: staffProofToken ? "present" : "missing",
+        status: syncStatus?.status ?? "synced",
+      },
       ...(terminal?._id ? { terminalId: terminal._id } : {}),
       terminalSource: terminal
         ? terminal.status === "local"


### PR DESCRIPTION
## Summary
- harden local-first POS register sync so important events retry immediately and stale runtime work cannot update the active register scope
- keep cashier-facing transaction numbers human-readable while retaining durable local ids for sync idempotency
- clean up POS operator messaging, debug diagnostics, staff-session indicator behavior, and sale-start flow details from the migrated local work

## Validation
- `bunx tsc --noEmit -p packages/athena-webapp/tsconfig.json`
- `bun run --filter '@athena/webapp' lint:frontend:changed`
- `bunx vitest run --maxWorkers=1 ...` affected POS + Convex sync suite: 14 files, 366 tests
- `bun run graphify:rebuild && bun run graphify:check`
- `bun run pre-push:review` via push hook: full @athena/webapp test run, build, selected harness behavior scenarios, graphify, architecture, convex audit/lint

## Review
- Correctness, testing, project standards, and frontend race subagents approved the final diff.
- Visual validation intentionally left to the operator per request.
