### PR TITLE
fix(pos): make local sync drain from hub

### DIFF
--- a/.agents/skills/ce-plan/SKILL.md
+++ b/.agents/skills/ce-plan/SKILL.md
@@ -800,10 +800,9 @@ HTML rules:
 - Keep styling restrained and review-focused; optimize for reading dense plan content, not marketing presentation
 - Use repo-relative links inside the artifact when linking to repo files or sibling artifacts
 - Escape ampersands and other HTML-sensitive characters
-- Include `meta http-equiv="Content-Type" content="text/html; charset=utf-8"` and use `style type="text/css"` for compatibility with local validators
-- If tables are used, add a concise `summary` attribute when doing so helps older HTML validators
-- Avoid validator-noisy semantic HTML if the local repo tooling is old; simple `div` structure with classes is acceptable
-- If `tidy` is installed, run `tidy -errors -quiet <html_path>` after writing the artifact and fix real errors. If `tidy` is unavailable, inspect the HTML manually and note that validation was not run.
+- Use normal semantic HTML5 structure when it improves readability, such as `main`, `header`, `section`, `nav`, and `article`
+- Include `<!doctype html>`, `<meta charset="utf-8">`, and a non-empty `<title>`
+- If this repo has `scripts/validate-plan-html.ts`, run `bun scripts/validate-plan-html.ts <html_path>` after writing the artifact and fix reported issues. Fall back to manual inspection only when the repo-local validator is unavailable.
 - If the markdown plan changes materially after confidence deepening, document review, Proof HITL review, or a requested revision, regenerate or update the HTML artifact before handoff.
 
 ### Phase 5: Final Review, Write File, and Handoff

--- a/docs/solutions/architecture/athena-pos-hub-owned-local-sync-drain-2026-05-18.md
+++ b/docs/solutions/architecture/athena-pos-hub-owned-local-sync-drain-2026-05-18.md
@@ -1,0 +1,75 @@
+---
+title: Athena POS Local Sync Drains From The Hub
+date: 2026-05-18
+category: architecture
+module: athena-webapp
+problem_type: offline_pos_sync_ordering
+component: pos
+symptoms:
+  - "Offline POS events remain pending after reconnect until the original cashier signs in"
+  - "Later cashier events can sync before earlier local history"
+  - "POS sync diagnostics show out-of-order holds for history that exists locally"
+root_cause: upload_order_was_derived_from_currently_syncable_staff_proof_state
+resolution_type: terminal_owned_sync_drain
+severity: high
+tags:
+  - pos
+  - local-first
+  - offline
+  - sync
+  - reconciliation
+---
+
+# Athena POS Local Sync Drains From The Hub
+
+## Problem
+
+POS local sync order must be stable even when multiple cashiers use the same
+provisioned terminal offline. The broken pattern is to decide which events are
+syncable by checking for the currently signed-in cashier's transient proof and
+then deriving upload sequence from that filtered set.
+
+That makes local history mutable at upload time. If Staff A creates earlier
+offline events, signs out, and Staff B later completes a sale, Staff A's events
+can disappear from the upload set while Staff B's events receive lower upload
+sequence numbers. The backend correctly enforces contiguous local register
+history, so the omitted earlier events are later held as out of order.
+
+## Solution
+
+Make upload sequence and upload ownership terminal-local concepts:
+
+- Assign upload ordering when uploadable local POS events are written, not when
+  they are uploaded.
+- Keep cashier attribution on the event as actor evidence for receipts,
+  transactions, payment allocation, cash controls, and workflow traces.
+- Treat the POS hub and provisioned terminal as the foreground sync drain owner.
+  The register flow appends durable events and can show status, but it should
+  not be the surface that decides whether upload runs.
+- Do not require the original cashier to sign in again just to drain local
+  history. Permission drift should become reconciliation or review work, not a
+  permanent upload blocker.
+- Keep local-only precursor events, such as no-item `session.started` records,
+  out of the upload sequence so they cannot strand sync.
+
+For plan HTML review artifacts, use the repo-local HTML validator rather than
+system `tidy`. The local validator accepts semantic HTML5 review artifacts while
+still enforcing the important constraints: static HTML, a charset, a title, no
+JavaScript, and no remote assets.
+
+## Prevention
+
+- Never compute POS upload sequence from a filtered set of currently syncable
+  events.
+- Never make original staff proof presence the gate for preserving upload order.
+- Keep actor staff identity separate from terminal or hub submission authority.
+- Run `bun run plan-html:check` for plan HTML review artifacts instead of
+  falling back to system `tidy`.
+- Update `docs/solutions` whenever POS local sync ownership, ordering, or
+  reconciliation behavior changes substantially.
+
+## Related
+
+- [Athena POS Local-First Sync Uses Event Logs](./athena-pos-local-first-sync-2026-05-13.md)
+- [Athena POS Local Staff Authority Uses Terminal-Scoped Verifiers](./athena-pos-local-staff-authority-2026-05-14.md)
+- [Athena POS Local-First Runtime Feedback Mirrors The Local Event Log](./athena-pos-local-first-runtime-feedback-2026-05-15.md)

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,11 +1,11 @@
 # Graph Report - .
 
 ## Corpus Check
-- 1742 files · ~0 words
+- 1744 files · ~0 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 5496 nodes · 5724 edges · 1671 communities detected
+- 5508 nodes · 5739 edges · 1673 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -1681,6 +1681,8 @@
 - [[_COMMUNITY_Community 1668|Community 1668]]
 - [[_COMMUNITY_Community 1669|Community 1669]]
 - [[_COMMUNITY_Community 1670|Community 1670]]
+- [[_COMMUNITY_Community 1671|Community 1671]]
+- [[_COMMUNITY_Community 1672|Community 1672]]
 
 ## God Nodes (most connected - your core abstractions)
 1. `createJourneyEvent()` - 40 edges
@@ -1725,12 +1727,12 @@ Cohesion: 0.09
 Nodes (45): compactContext(), createAuthEntryViewedEvent(), createAuthRequestStartedEvent(), createAuthVerificationSucceededEvent(), createAuthVerificationViewedEvent(), createBagAddSucceededEvent(), createBagMoveToSavedEvent(), createBagRemoveSucceededEvent() (+37 more)
 
 ### Community 4 - "Community 4"
-Cohesion: 0.07
-Nodes (18): formatStatus(), formatUnitCount(), getPurchaseOrderMode(), getRecommendationForPurchaseOrder(), getRecommendationStateNote(), getRecommendationUrlSku(), handleAdvancePurchaseOrderToOrdered(), handleCreateDraftPurchaseOrders() (+10 more)
+Cohesion: 0.08
+Nodes (22): addLocalAvailabilityConsumption(), addLocalAvailabilityDeltaConsumption(), asCloudOperableSession(), buildCompletedSalePayload(), buildLocalAvailabilityEventIndex(), cartItemsFromLocalRegisterModel(), completedCustomerInfo(), countPendingSyncableLocalEventsForStaff() (+14 more)
 
 ### Community 5 - "Community 5"
-Cohesion: 0.08
-Nodes (20): addLocalAvailabilityConsumption(), addLocalAvailabilityDeltaConsumption(), asCloudOperableSession(), buildCompletedSalePayload(), buildLocalAvailabilityEventIndex(), cartItemsFromLocalRegisterModel(), completedCustomerInfo(), createPaymentId() (+12 more)
+Cohesion: 0.07
+Nodes (18): formatStatus(), formatUnitCount(), getPurchaseOrderMode(), getRecommendationForPurchaseOrder(), getRecommendationStateNote(), getRecommendationUrlSku(), handleAdvancePurchaseOrderToOrdered(), handleCreateDraftPurchaseOrders() (+10 more)
 
 ### Community 6 - "Community 6"
 Cohesion: 0.16
@@ -1881,20 +1883,20 @@ Cohesion: 0.17
 Nodes (13): buildSkuContinuityContextById(), deriveContinuityStatus(), getPlannedActionAt(), getStartOfCurrentDay(), hasLateInbound(), hasRelatedPurchaseOrderContext(), hasStalePlannedAction(), isInboundStatus() (+5 more)
 
 ### Community 43 - "Community 43"
+Cohesion: 0.13
+Nodes (7): createEmptyMemoryStore(), createMemoryPosLocalStorageAdapter(), normalizeStaffAuthorityRecord(), normalizeUsername(), PosLocalStoreSchemaError, preserveWrappedStaffProof(), staffAuthorityKey()
+
+### Community 44 - "Community 44"
 Cohesion: 0.19
 Nodes (16): bestFuzzyTokenScore(), extractIdentifierFromUrl(), findExactMatches(), firstNonEmpty(), isProbablySameToken(), levenshteinDistance(), normalizeIdentifier(), normalizeSearchText() (+8 more)
 
-### Community 44 - "Community 44"
+### Community 45 - "Community 45"
 Cohesion: 0.23
 Nodes (14): buildCompleteTransactionResult(), calculateCanonicalTransactionTotals(), calculateTotalPaid(), completeTransaction(), createTransactionFromSessionHandler(), isUsableRegisterSession(), recordRegisterSessionSale(), recordRegisterSessionVoid() (+6 more)
 
-### Community 45 - "Community 45"
+### Community 46 - "Community 46"
 Cohesion: 0.11
 Nodes (0):
-
-### Community 46 - "Community 46"
-Cohesion: 0.14
-Nodes (7): createEmptyMemoryStore(), createMemoryPosLocalStorageAdapter(), normalizeStaffAuthorityRecord(), normalizeUsername(), PosLocalStoreSchemaError, preserveWrappedStaffProof(), staffAuthorityKey()
 
 ### Community 47 - "Community 47"
 Cohesion: 0.22
@@ -2029,36 +2031,36 @@ Cohesion: 0.18
 Nodes (2): formatBlockerList(), runPrePushReview()
 
 ### Community 80 - "Community 80"
-Cohesion: 0.29
-Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
-
-### Community 81 - "Community 81"
 Cohesion: 0.33
 Nodes (2): OrdersTableToolbarProvider(), useOrdersTableToolbar()
 
-### Community 82 - "Community 82"
+### Community 81 - "Community 81"
 Cohesion: 0.24
 Nodes (5): formatBackendLabel(), formatInventoryNumber(), formatQuantity(), getActivityTitle(), pluralize()
 
-### Community 83 - "Community 83"
+### Community 82 - "Community 82"
 Cohesion: 0.2
 Nodes (2): handleKeyDown(), isDebugShortcut()
 
-### Community 84 - "Community 84"
+### Community 83 - "Community 83"
 Cohesion: 0.31
 Nodes (7): buildCustomerCreateInput(), cancelPendingAdd(), commitCustomer(), handleAddFromSearch(), handleClearCustomer(), handleSelectCustomer(), toCustomerInfo()
 
-### Community 85 - "Community 85"
+### Community 84 - "Community 84"
 Cohesion: 0.25
 Nodes (6): handleEdit(), handleReset(), handleSubmit(), itemToFormState(), parseServiceCatalogForm(), validateServiceCatalogForm()
 
-### Community 86 - "Community 86"
+### Community 85 - "Community 85"
 Cohesion: 0.25
 Nodes (6): mapProductByIdResult(), useConvexProductIdLookup(), useConvexRegisterCatalog(), useConvexRegisterCatalogAvailability(), useConvexRegisterCatalogAvailabilityState(), usePrewarmRegisterCatalogOfflineSnapshots()
 
-### Community 87 - "Community 87"
+### Community 86 - "Community 86"
 Cohesion: 0.18
 Nodes (0):
+
+### Community 87 - "Community 87"
+Cohesion: 0.29
+Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
 
 ### Community 88 - "Community 88"
 Cohesion: 0.18
@@ -2357,16 +2359,16 @@ Cohesion: 0.29
 Nodes (0):
 
 ### Community 162 - "Community 162"
-Cohesion: 0.33
-Nodes (2): getProductName(), sortProduct()
-
-### Community 163 - "Community 163"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 164 - "Community 164"
+### Community 163 - "Community 163"
 Cohesion: 0.52
 Nodes (6): addItemToSavedBag(), getActiveSavedBag(), getBaseUrl(), removeItemFromSavedBag(), updateSavedBagItem(), updateSavedBagOwner()
+
+### Community 164 - "Community 164"
+Cohesion: 0.33
+Nodes (2): getProductName(), sortProduct()
 
 ### Community 165 - "Community 165"
 Cohesion: 0.43
@@ -2421,12 +2423,12 @@ Cohesion: 0.33
 Nodes (1): DataTableToolbar()
 
 ### Community 178 - "Community 178"
-Cohesion: 0.4
-Nodes (2): handlePinChange(), normalizeOtpCode()
-
-### Community 179 - "Community 179"
 Cohesion: 0.53
 Nodes (2): SelectedProductsProvider(), useSelectedProducts()
+
+### Community 179 - "Community 179"
+Cohesion: 0.4
+Nodes (2): handlePinChange(), normalizeOtpCode()
 
 ### Community 180 - "Community 180"
 Cohesion: 0.33
@@ -2557,64 +2559,64 @@ Cohesion: 0.4
 Nodes (2): createFixtureRoot(), write()
 
 ### Community 212 - "Community 212"
+Cohesion: 0.53
+Nodes (4): collectDefaultPlanHtmlFiles(), collectPlanHtmlFindings(), hasRemoteReference(), runPlanHtmlValidation()
+
+### Community 213 - "Community 213"
 Cohesion: 0.5
 Nodes (2): createAuthorizedRegisterDepositCtx(), createQueryCtx()
 
-### Community 213 - "Community 213"
+### Community 214 - "Community 214"
 Cohesion: 0.6
 Nodes (4): buildInStorePaymentAllocations(), normalizeInStorePayments(), resolveRegisterSessionForInStoreCollectionWithCtx(), selectRegisterSessionForAttribution()
-
-### Community 214 - "Community 214"
-Cohesion: 0.4
-Nodes (0):
 
 ### Community 215 - "Community 215"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 216 - "Community 216"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 217 - "Community 217"
 Cohesion: 0.6
 Nodes (3): formatStoredAmount(), toDisplayAmount(), toPesewas()
 
-### Community 217 - "Community 217"
+### Community 218 - "Community 218"
 Cohesion: 0.7
 Nodes (4): compactRecord(), ensureCustomerProfileFromSourcesWithCtx(), findExistingProfile(), loadCustomerSources()
-
-### Community 218 - "Community 218"
-Cohesion: 0.4
-Nodes (0):
 
 ### Community 219 - "Community 219"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 220 - "Community 220"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 221 - "Community 221"
 Cohesion: 0.7
 Nodes (4): buildDecision(), classifyCorrectionIntent(), isSupportedCorrectionIntent(), isUnsupportedHighRiskCorrectionIntent()
 
-### Community 221 - "Community 221"
+### Community 222 - "Community 222"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 222 - "Community 222"
+### Community 223 - "Community 223"
 Cohesion: 0.7
 Nodes (4): getPaystackHeaders(), initializeTransaction(), initiateRefund(), verifyTransaction()
 
-### Community 223 - "Community 223"
+### Community 224 - "Community 224"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 224 - "Community 224"
+### Community 225 - "Community 225"
 Cohesion: 0.6
 Nodes (3): buildOnlineOrderReturnExchangePlan(), getApprovalReason(), getKind()
 
-### Community 225 - "Community 225"
+### Community 226 - "Community 226"
 Cohesion: 0.5
 Nodes (2): getNonEmptyString(), normalizeStorefrontObservabilityEvent()
-
-### Community 226 - "Community 226"
-Cohesion: 0.4
-Nodes (0):
 
 ### Community 227 - "Community 227"
 Cohesion: 0.4
@@ -2633,12 +2635,12 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 231 - "Community 231"
-Cohesion: 0.5
-Nodes (2): handleFileSelect(), validateFile()
-
-### Community 232 - "Community 232"
 Cohesion: 0.4
 Nodes (0):
+
+### Community 232 - "Community 232"
+Cohesion: 0.5
+Nodes (2): handleFileSelect(), validateFile()
 
 ### Community 233 - "Community 233"
 Cohesion: 0.4
@@ -2653,16 +2655,16 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 236 - "Community 236"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 237 - "Community 237"
 Cohesion: 0.5
 Nodes (2): getBalanceDueLabel(), getBalanceDuePanel()
 
-### Community 237 - "Community 237"
+### Community 238 - "Community 238"
 Cohesion: 0.6
 Nodes (3): handleClearSearch(), handleQuickAddSubmit(), resetQuickAddForm()
-
-### Community 238 - "Community 238"
-Cohesion: 0.4
-Nodes (0):
 
 ### Community 239 - "Community 239"
 Cohesion: 0.4
@@ -2677,32 +2679,32 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 242 - "Community 242"
-Cohesion: 0.7
-Nodes (4): getRuntimeOrigin(), isLocalHost(), resolveStoreFrontUrl(), trimTrailingSlash()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 243 - "Community 243"
 Cohesion: 0.7
-Nodes (4): bufferToHex(), collectBrowserInfo(), generateBrowserFingerprint(), hashFingerprintSource()
+Nodes (4): getRuntimeOrigin(), isLocalHost(), resolveStoreFrontUrl(), trimTrailingSlash()
 
 ### Community 244 - "Community 244"
-Cohesion: 0.4
-Nodes (1): MockImage
+Cohesion: 0.7
+Nodes (4): bufferToHex(), collectBrowserInfo(), generateBrowserFingerprint(), hashFingerprintSource()
 
 ### Community 245 - "Community 245"
 Cohesion: 0.4
-Nodes (0):
+Nodes (1): MockImage
 
 ### Community 246 - "Community 246"
-Cohesion: 0.6
-Nodes (3): calculatePosCartTotals(), calculatePosItemTotal(), roundPosAmount()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 247 - "Community 247"
 Cohesion: 0.6
-Nodes (4): mapRegisterStateDto(), mapTerminalDto(), useConvexRegisterState(), useConvexTerminalByFingerprint()
+Nodes (3): calculatePosCartTotals(), calculatePosItemTotal(), roundPosAmount()
 
 ### Community 248 - "Community 248"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.6
+Nodes (4): mapRegisterStateDto(), mapTerminalDto(), useConvexRegisterState(), useConvexTerminalByFingerprint()
 
 ### Community 249 - "Community 249"
 Cohesion: 0.4
@@ -2725,196 +2727,196 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 254 - "Community 254"
-Cohesion: 0.5
-Nodes (2): completePendingAuthSync(), sleep()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 255 - "Community 255"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 256 - "Community 256"
-Cohesion: 0.7
-Nodes (4): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory()
+Cohesion: 0.5
+Nodes (2): completePendingAuthSync(), sleep()
 
 ### Community 257 - "Community 257"
-Cohesion: 0.7
-Nodes (4): getBaseUrl(), getOrder(), getOrders(), updateOrdersOwner()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 258 - "Community 258"
 Cohesion: 0.7
-Nodes (4): getActiveUser(), getBaseUrl(), getGuest(), updateUser()
+Nodes (4): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory()
 
 ### Community 259 - "Community 259"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.7
+Nodes (4): getBaseUrl(), getOrder(), getOrders(), updateOrdersOwner()
 
 ### Community 260 - "Community 260"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.7
+Nodes (4): getActiveUser(), getBaseUrl(), getGuest(), updateUser()
 
 ### Community 261 - "Community 261"
-Cohesion: 0.7
-Nodes (4): createStorefrontFailureEvent(), emitStorefrontFailure(), inferStorefrontJourneyFromRoute(), normalizeStorefrontError()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 262 - "Community 262"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 263 - "Community 263"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.7
+Nodes (4): createStorefrontFailureEvent(), emitStorefrontFailure(), inferStorefrontJourneyFromRoute(), normalizeStorefrontError()
 
 ### Community 264 - "Community 264"
-Cohesion: 0.6
-Nodes (4): collectHarnessRepoValidationSelection(), matchesHarnessRepoValidationPath(), normalizeRepoPath(), sortUniquePaths()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 265 - "Community 265"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 266 - "Community 266"
-Cohesion: 0.7
-Nodes (4): createFixtureRepo(), fixtureEnv(), runGit(), runWorktreeManager()
+Cohesion: 0.6
+Nodes (4): collectHarnessRepoValidationSelection(), matchesHarnessRepoValidationPath(), normalizeRepoPath(), sortUniquePaths()
 
 ### Community 267 - "Community 267"
-Cohesion: 0.5
+Cohesion: 0.4
 Nodes (0):
 
 ### Community 268 - "Community 268"
+Cohesion: 0.7
+Nodes (4): createFixtureRepo(), fixtureEnv(), runGit(), runWorktreeManager()
+
+### Community 269 - "Community 269"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 270 - "Community 270"
 Cohesion: 0.67
 Nodes (2): maskReceiptPhone(), normalizeReceiptPhone()
 
-### Community 269 - "Community 269"
+### Community 271 - "Community 271"
 Cohesion: 0.83
 Nodes (3): createReceiptShareToken(), hashReceiptShareToken(), toHex()
 
-### Community 270 - "Community 270"
+### Community 272 - "Community 272"
 Cohesion: 0.83
 Nodes (3): timingSafeEqual(), toHex(), verifyMetaWebhookSignature()
 
-### Community 271 - "Community 271"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 272 - "Community 272"
-Cohesion: 0.5
-Nodes (0):
-
 ### Community 273 - "Community 273"
-Cohesion: 0.67
-Nodes (2): createExpenseTransactionFromSessionHandler(), expenseTransactionError()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 274 - "Community 274"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 275 - "Community 275"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): createExpenseTransactionFromSessionHandler(), expenseTransactionError()
 
 ### Community 276 - "Community 276"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 277 - "Community 277"
-Cohesion: 0.67
-Nodes (2): createProductsQueryCtx(), createSkuMutationCtx()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 278 - "Community 278"
-Cohesion: 0.83
-Nodes (3): getCachedTokenRecord(), resolveAccessTokenForStore(), resolveConfigForStore()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 279 - "Community 279"
 Cohesion: 0.67
-Nodes (2): maskMtnPartyId(), normalizeCollectionsTransaction()
+Nodes (2): createProductsQueryCtx(), createSkuMutationCtx()
 
 ### Community 280 - "Community 280"
-Cohesion: 0.67
-Nodes (2): consumeApprovalProofWithCtx(), invalidApprovalProofResult()
+Cohesion: 0.83
+Nodes (3): getCachedTokenRecord(), resolveAccessTokenForStore(), resolveConfigForStore()
 
 ### Community 281 - "Community 281"
 Cohesion: 0.67
-Nodes (2): buildOperationalEvent(), recordOperationalEventWithCtx()
+Nodes (2): maskMtnPartyId(), normalizeCollectionsTransaction()
 
 ### Community 282 - "Community 282"
 Cohesion: 0.67
-Nodes (2): buildOperationalWorkItem(), createOperationalWorkItemWithCtx()
+Nodes (2): consumeApprovalProofWithCtx(), invalidApprovalProofResult()
 
 ### Community 283 - "Community 283"
 Cohesion: 0.67
-Nodes (2): expectIndex(), getTableIndexes()
+Nodes (2): buildOperationalEvent(), recordOperationalEventWithCtx()
 
 ### Community 284 - "Community 284"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): buildOperationalWorkItem(), createOperationalWorkItemWithCtx()
 
 ### Community 285 - "Community 285"
+Cohesion: 0.67
+Nodes (2): expectIndex(), getTableIndexes()
+
+### Community 286 - "Community 286"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 286 - "Community 286"
-Cohesion: 0.83
-Nodes (3): resolveServiceIntakeCustomerProfile(), splitFullName(), trimOptional()
-
 ### Community 287 - "Community 287"
-Cohesion: 0.83
-Nodes (3): mapOpenDrawerUserError(), normalizeRegisterNumber(), openDrawer()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 288 - "Community 288"
 Cohesion: 0.83
-Nodes (3): createDbGetMock(), createDbMock(), createDbQueryMock()
+Nodes (3): resolveServiceIntakeCustomerProfile(), splitFullName(), trimOptional()
 
 ### Community 289 - "Community 289"
 Cohesion: 0.83
-Nodes (3): buildRegisterState(), getActiveSessionConflictForRegisterState(), getRegisterState()
+Nodes (3): mapOpenDrawerUserError(), normalizeRegisterNumber(), openDrawer()
 
 ### Community 290 - "Community 290"
-Cohesion: 0.67
-Nodes (2): lookupByBarcode(), mapSkuToCatalogResult()
+Cohesion: 0.83
+Nodes (3): createDbGetMock(), createDbMock(), createDbQueryMock()
 
 ### Community 291 - "Community 291"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): buildRegisterState(), getActiveSessionConflictForRegisterState(), getRegisterState()
 
 ### Community 292 - "Community 292"
-Cohesion: 0.83
-Nodes (3): createPosLocalStaffProofToken(), hashPosLocalStaffProofToken(), toHex()
+Cohesion: 0.67
+Nodes (2): lookupByBarcode(), mapSkuToCatalogResult()
 
 ### Community 293 - "Community 293"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 294 - "Community 294"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): createPosLocalStaffProofToken(), hashPosLocalStaffProofToken(), toHex()
 
 ### Community 295 - "Community 295"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 296 - "Community 296"
-Cohesion: 0.67
-Nodes (2): expectIndex(), getTableIndexes()
-
-### Community 297 - "Community 297"
-Cohesion: 0.83
-Nodes (3): findExistingCustomerProfileId(), getStoreOrganizationId(), recordStoreFrontCustomerMilestone()
-
-### Community 298 - "Community 298"
 Cohesion: 0.5
 Nodes (0):
 
+### Community 297 - "Community 297"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 298 - "Community 298"
+Cohesion: 0.67
+Nodes (2): expectIndex(), getTableIndexes()
+
 ### Community 299 - "Community 299"
 Cohesion: 0.83
-Nodes (3): formatStaffDisplayName(), formatStaffDisplayNameOrFallback(), normalizeNamePart()
+Nodes (3): findExistingCustomerProfileId(), getStoreOrganizationId(), recordStoreFrontCustomerMilestone()
 
 ### Community 300 - "Community 300"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 301 - "Community 301"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): formatStaffDisplayName(), formatStaffDisplayNameOrFallback(), normalizeNamePart()
 
 ### Community 302 - "Community 302"
 Cohesion: 0.5
@@ -2925,16 +2927,16 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 304 - "Community 304"
-Cohesion: 0.67
-Nodes (2): countGroupedAnalytics(), groupAnalytics()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 305 - "Community 305"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 306 - "Community 306"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): countGroupedAnalytics(), groupAnalytics()
 
 ### Community 307 - "Community 307"
 Cohesion: 0.5
@@ -2953,28 +2955,28 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 311 - "Community 311"
-Cohesion: 0.67
-Nodes (2): handleSubmit(), resetReplacementFields()
-
-### Community 312 - "Community 312"
-Cohesion: 0.67
-Nodes (2): CashierAuthDialog(), getStaffDisplayName()
-
-### Community 313 - "Community 313"
 Cohesion: 0.5
 Nodes (0):
 
+### Community 312 - "Community 312"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 313 - "Community 313"
+Cohesion: 0.67
+Nodes (2): handleSubmit(), resetReplacementFields()
+
 ### Community 314 - "Community 314"
 Cohesion: 0.67
-Nodes (2): getLocalOperatingDate(), getLocalOperatingDateRange()
+Nodes (2): CashierAuthDialog(), getStaffDisplayName()
 
 ### Community 315 - "Community 315"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 316 - "Community 316"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): getLocalOperatingDate(), getLocalOperatingDateRange()
 
 ### Community 317 - "Community 317"
 Cohesion: 0.5
@@ -2989,20 +2991,20 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 320 - "Community 320"
-Cohesion: 0.67
-Nodes (2): applyCommandResult(), handleCreateCase()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 321 - "Community 321"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 322 - "Community 322"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): applyCommandResult(), handleCreateCase()
 
 ### Community 323 - "Community 323"
-Cohesion: 0.67
-Nodes (2): getRiskStyles(), RiskIndicators()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 324 - "Community 324"
 Cohesion: 0.5
@@ -3010,19 +3012,19 @@ Nodes (0):
 
 ### Community 325 - "Community 325"
 Cohesion: 0.67
-Nodes (2): useGetArchivedProducts(), useGetProducts()
+Nodes (2): getRiskStyles(), RiskIndicators()
 
 ### Community 326 - "Community 326"
-Cohesion: 1.0
-Nodes (3): canAccessFullAdminSurface(), canAccessStoreDaySurface(), getSurfaceAccess()
-
-### Community 327 - "Community 327"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 328 - "Community 328"
+### Community 327 - "Community 327"
 Cohesion: 0.67
-Nodes (2): extractTraceId(), runCommand()
+Nodes (2): useGetArchivedProducts(), useGetProducts()
+
+### Community 328 - "Community 328"
+Cohesion: 1.0
+Nodes (3): canAccessFullAdminSurface(), canAccessStoreDaySurface(), getSurfaceAccess()
 
 ### Community 329 - "Community 329"
 Cohesion: 0.5
@@ -3030,7 +3032,7 @@ Nodes (0):
 
 ### Community 330 - "Community 330"
 Cohesion: 0.67
-Nodes (2): formatStoredAmount(), formatStoredCurrencyAmount()
+Nodes (2): extractTraceId(), runCommand()
 
 ### Community 331 - "Community 331"
 Cohesion: 0.5
@@ -3038,55 +3040,55 @@ Nodes (0):
 
 ### Community 332 - "Community 332"
 Cohesion: 0.67
-Nodes (2): mapActiveSessionDto(), normalizeCartItems()
+Nodes (2): formatStoredAmount(), formatStoredCurrencyAmount()
 
 ### Community 333 - "Community 333"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 334 - "Community 334"
+Cohesion: 0.67
+Nodes (2): mapActiveSessionDto(), normalizeCartItems()
+
+### Community 335 - "Community 335"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 335 - "Community 335"
+### Community 336 - "Community 336"
 Cohesion: 0.67
 Nodes (2): isSeedReadLoading(), resolveLocalPosEntryContext()
 
-### Community 336 - "Community 336"
+### Community 337 - "Community 337"
 Cohesion: 0.83
 Nodes (3): derivePosLocalSyncStatus(), getContiguousSyncedSequence(), getSyncState()
 
-### Community 337 - "Community 337"
+### Community 338 - "Community 338"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 338 - "Community 338"
+### Community 339 - "Community 339"
 Cohesion: 0.83
 Nodes (3): isBrowserFingerprintResult(), readStoredTerminalFingerprint(), readStoredTerminalFingerprintHash()
 
-### Community 339 - "Community 339"
+### Community 340 - "Community 340"
 Cohesion: 0.67
 Nodes (2): getCashierDisplayName(), useExpenseRegisterViewModel()
 
-### Community 340 - "Community 340"
+### Community 341 - "Community 341"
 Cohesion: 0.67
 Nodes (2): buildPosSyncStatusPresentation(), normalizeStatus()
 
-### Community 341 - "Community 341"
+### Community 342 - "Community 342"
 Cohesion: 0.83
 Nodes (3): getBaseUrl(), getUserRedeemedOffers(), submitOffer()
 
-### Community 342 - "Community 342"
+### Community 343 - "Community 343"
 Cohesion: 0.83
 Nodes (3): getAllStores(), getBaseUrl(), getStore()
 
-### Community 343 - "Community 343"
+### Community 344 - "Community 344"
 Cohesion: 0.83
 Nodes (3): getAllSubcategories(), getBaseUrl(), getSubategory()
-
-### Community 344 - "Community 344"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 345 - "Community 345"
 Cohesion: 0.5
@@ -3117,59 +3119,59 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 352 - "Community 352"
-Cohesion: 0.67
-Nodes (2): useOptionalStoreContext(), useStoreContext()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 353 - "Community 353"
 Cohesion: 0.67
-Nodes (2): clearFilters(), onMobileFiltersCloseClick()
+Nodes (2): useOptionalStoreContext(), useStoreContext()
 
 ### Community 354 - "Community 354"
+Cohesion: 0.67
+Nodes (2): clearFilters(), onMobileFiltersCloseClick()
+
+### Community 355 - "Community 355"
 Cohesion: 0.83
 Nodes (3): cancelOrder(), getErrorMessage(), placeOrder()
 
-### Community 355 - "Community 355"
+### Community 356 - "Community 356"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 356 - "Community 356"
-Cohesion: 0.83
-Nodes (3): bootstrapCheckout(), createBootstrapToken(), createMarker()
 
 ### Community 357 - "Community 357"
 Cohesion: 0.83
-Nodes (3): createFixtureRoot(), write(), writeGraphifyWikiArtifacts()
+Nodes (3): bootstrapCheckout(), createBootstrapToken(), createMarker()
 
 ### Community 358 - "Community 358"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): createFixtureRoot(), write(), writeGraphifyWikiArtifacts()
 
 ### Community 359 - "Community 359"
-Cohesion: 0.67
-Nodes (2): buildHarnessDocPaths(), buildHarnessDocPathsForArchetype()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 360 - "Community 360"
 Cohesion: 0.67
-Nodes (2): shutdown(), stopValkeyRuntimeServer()
+Nodes (2): buildHarnessDocPaths(), buildHarnessDocPathsForArchetype()
 
 ### Community 361 - "Community 361"
+Cohesion: 0.67
+Nodes (2): shutdown(), stopValkeyRuntimeServer()
+
+### Community 362 - "Community 362"
 Cohesion: 0.83
 Nodes (3): createFixtureRepo(), createInferentialArtifact(), write()
 
-### Community 362 - "Community 362"
+### Community 363 - "Community 363"
 Cohesion: 0.67
 Nodes (2): collectHarnessTestTargets(), runHarnessTest()
-
-### Community 363 - "Community 363"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 364 - "Community 364"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 365 - "Community 365"
-Cohesion: 0.67
+Cohesion: 0.5
 Nodes (0):
 
 ### Community 366 - "Community 366"
@@ -3177,12 +3179,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 367 - "Community 367"
-Cohesion: 1.0
-Nodes (2): providerErrorCategory(), sendWhatsAppReceiptTemplate()
-
-### Community 368 - "Community 368"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 368 - "Community 368"
+Cohesion: 1.0
+Nodes (2): providerErrorCategory(), sendWhatsAppReceiptTemplate()
 
 ### Community 369 - "Community 369"
 Cohesion: 0.67
@@ -3213,12 +3215,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 376 - "Community 376"
-Cohesion: 1.0
-Nodes (2): buildCtx(), createDb()
-
-### Community 377 - "Community 377"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 377 - "Community 377"
+Cohesion: 1.0
+Nodes (2): buildCtx(), createDb()
 
 ### Community 378 - "Community 378"
 Cohesion: 0.67
@@ -3241,16 +3243,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 383 - "Community 383"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 384 - "Community 384"
 Cohesion: 1.0
 Nodes (2): hashPosTerminalSyncSecret(), toHex()
 
-### Community 384 - "Community 384"
-Cohesion: 0.67
-Nodes (1): PosServerError
-
 ### Community 385 - "Community 385"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): PosServerError
 
 ### Community 386 - "Community 386"
 Cohesion: 0.67
@@ -3265,12 +3267,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 389 - "Community 389"
-Cohesion: 1.0
-Nodes (2): getActiveRegisterSessionForRegisterState(), mapRegisterSessionToCashDrawerSummary()
-
-### Community 390 - "Community 390"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 390 - "Community 390"
+Cohesion: 1.0
+Nodes (2): getActiveRegisterSessionForRegisterState(), mapRegisterSessionToCashDrawerSummary()
 
 ### Community 391 - "Community 391"
 Cohesion: 0.67
@@ -3285,16 +3287,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 394 - "Community 394"
-Cohesion: 1.0
-Nodes (2): buildServiceCatalogItem(), normalizeServiceCatalogNameKey()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 395 - "Community 395"
 Cohesion: 1.0
-Nodes (2): expectIndex(), getTableIndexes()
+Nodes (2): buildServiceCatalogItem(), normalizeServiceCatalogNameKey()
 
 ### Community 396 - "Community 396"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): expectIndex(), getTableIndexes()
 
 ### Community 397 - "Community 397"
 Cohesion: 0.67
@@ -3309,36 +3311,36 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 400 - "Community 400"
-Cohesion: 1.0
-Nodes (2): listBagItems(), loadBagWithItems()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 401 - "Community 401"
 Cohesion: 1.0
-Nodes (2): buildRegisterSessionTraceSeed(), formatRegisterSessionLabel()
+Nodes (2): listBagItems(), loadBagWithItems()
 
 ### Community 402 - "Community 402"
 Cohesion: 1.0
-Nodes (2): getWorkflowTraceViewByIdWithCtx(), getWorkflowTraceViewByLookupWithCtx()
+Nodes (2): buildRegisterSessionTraceSeed(), formatRegisterSessionLabel()
 
 ### Community 403 - "Community 403"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getWorkflowTraceViewByIdWithCtx(), getWorkflowTraceViewByLookupWithCtx()
 
 ### Community 404 - "Community 404"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 405 - "Community 405"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 406 - "Community 406"
 Cohesion: 1.0
 Nodes (2): createWorkflowTraceId(), normalizeWorkflowTraceLookupValue()
 
-### Community 406 - "Community 406"
-Cohesion: 0.67
-Nodes (1): View()
-
 ### Community 407 - "Community 407"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): View()
 
 ### Community 408 - "Community 408"
 Cohesion: 0.67
@@ -3353,12 +3355,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 411 - "Community 411"
-Cohesion: 1.0
-Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
-
-### Community 412 - "Community 412"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 412 - "Community 412"
+Cohesion: 1.0
+Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
 
 ### Community 413 - "Community 413"
 Cohesion: 0.67
@@ -3370,11 +3372,11 @@ Nodes (0):
 
 ### Community 415 - "Community 415"
 Cohesion: 0.67
-Nodes (1): FadeIn()
+Nodes (0):
 
 ### Community 416 - "Community 416"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): FadeIn()
 
 ### Community 417 - "Community 417"
 Cohesion: 0.67
@@ -3382,15 +3384,15 @@ Nodes (0):
 
 ### Community 418 - "Community 418"
 Cohesion: 0.67
-Nodes (1): VideoPlayer()
+Nodes (0):
 
 ### Community 419 - "Community 419"
-Cohesion: 1.0
-Nodes (2): handleRefundOrder(), toast()
+Cohesion: 0.67
+Nodes (1): VideoPlayer()
 
 ### Community 420 - "Community 420"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): handleRefundOrder(), toast()
 
 ### Community 421 - "Community 421"
 Cohesion: 0.67
@@ -3450,79 +3452,79 @@ Nodes (0):
 
 ### Community 435 - "Community 435"
 Cohesion: 0.67
-Nodes (1): SingleLineError()
+Nodes (0):
 
 ### Community 436 - "Community 436"
 Cohesion: 0.67
-Nodes (1): ErrorPage()
+Nodes (1): SingleLineError()
 
 ### Community 437 - "Community 437"
 Cohesion: 0.67
-Nodes (1): AppSkeleton()
+Nodes (1): ErrorPage()
 
 ### Community 438 - "Community 438"
 Cohesion: 0.67
-Nodes (1): DashboardSkeleton()
+Nodes (1): AppSkeleton()
 
 ### Community 439 - "Community 439"
 Cohesion: 0.67
-Nodes (1): TableSkeleton()
+Nodes (1): DashboardSkeleton()
 
 ### Community 440 - "Community 440"
 Cohesion: 0.67
-Nodes (1): TransactionsSkeleton()
+Nodes (1): TableSkeleton()
 
 ### Community 441 - "Community 441"
 Cohesion: 0.67
-Nodes (1): NotFound()
+Nodes (1): TransactionsSkeleton()
 
 ### Community 442 - "Community 442"
+Cohesion: 0.67
+Nodes (1): NotFound()
+
+### Community 443 - "Community 443"
 Cohesion: 1.0
 Nodes (2): getWorkflowTraceRouteTarget(), WorkflowTraceRouteLink()
 
-### Community 443 - "Community 443"
+### Community 444 - "Community 444"
 Cohesion: 0.67
 Nodes (1): AppContextMenu()
 
-### Community 444 - "Community 444"
+### Community 445 - "Community 445"
 Cohesion: 0.67
 Nodes (1): Badge()
 
-### Community 445 - "Community 445"
-Cohesion: 0.67
-Nodes (0):
-
 ### Community 446 - "Community 446"
 Cohesion: 0.67
-Nodes (1): LoadingButton()
+Nodes (0):
 
 ### Community 447 - "Community 447"
 Cohesion: 0.67
-Nodes (1): onChange()
+Nodes (1): LoadingButton()
 
 ### Community 448 - "Community 448"
 Cohesion: 0.67
-Nodes (1): AlertModal()
+Nodes (1): onChange()
 
 ### Community 449 - "Community 449"
 Cohesion: 0.67
-Nodes (1): OverlayModal()
+Nodes (1): AlertModal()
 
 ### Community 450 - "Community 450"
 Cohesion: 0.67
-Nodes (1): Skeleton()
+Nodes (1): OverlayModal()
 
 ### Community 451 - "Community 451"
 Cohesion: 0.67
-Nodes (1): Toaster()
+Nodes (1): Skeleton()
 
 ### Community 452 - "Community 452"
 Cohesion: 0.67
-Nodes (1): Spinner()
+Nodes (1): Toaster()
 
 ### Community 453 - "Community 453"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): Spinner()
 
 ### Community 454 - "Community 454"
 Cohesion: 0.67
@@ -3554,11 +3556,11 @@ Nodes (0):
 
 ### Community 461 - "Community 461"
 Cohesion: 0.67
-Nodes (1): useAuth()
+Nodes (0):
 
 ### Community 462 - "Community 462"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): useAuth()
 
 ### Community 463 - "Community 463"
 Cohesion: 0.67
@@ -3569,36 +3571,36 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 465 - "Community 465"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 466 - "Community 466"
 Cohesion: 1.0
 Nodes (2): getApprovalGuidance(), presentCommandToast()
 
-### Community 466 - "Community 466"
+### Community 467 - "Community 467"
 Cohesion: 0.67
 Nodes (1): isInMaintenanceMode()
 
-### Community 467 - "Community 467"
+### Community 468 - "Community 468"
 Cohesion: 0.67
 Nodes (0):
-
-### Community 468 - "Community 468"
-Cohesion: 1.0
-Nodes (2): createTerminalSyncSecretToken(), registerAndProvisionPosTerminal()
 
 ### Community 469 - "Community 469"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): createTerminalSyncSecretToken(), registerAndProvisionPosTerminal()
 
 ### Community 470 - "Community 470"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 471 - "Community 471"
-Cohesion: 1.0
-Nodes (2): readProjectedLocalRegisterModel(), readScopedPosLocalEvents()
-
-### Community 472 - "Community 472"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 472 - "Community 472"
+Cohesion: 1.0
+Nodes (2): readProjectedLocalRegisterModel(), readScopedPosLocalEvents()
 
 ### Community 473 - "Community 473"
 Cohesion: 0.67
@@ -3610,67 +3612,67 @@ Nodes (0):
 
 ### Community 475 - "Community 475"
 Cohesion: 0.67
-Nodes (1): App()
+Nodes (0):
 
 ### Community 476 - "Community 476"
-Cohesion: 1.0
-Nodes (2): collectSourceFiles(), findIllegalConvexImports()
+Cohesion: 0.67
+Nodes (1): App()
 
 ### Community 477 - "Community 477"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): collectSourceFiles(), findIllegalConvexImports()
 
 ### Community 478 - "Community 478"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 479 - "Community 479"
-Cohesion: 1.0
-Nodes (2): getAthenaDesignTokenStyle(), withAthenaTheme()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 480 - "Community 480"
 Cohesion: 1.0
-Nodes (2): mockGetSku(), validateInventoryForTransaction()
+Nodes (2): getAthenaDesignTokenStyle(), withAthenaTheme()
 
 ### Community 481 - "Community 481"
-Cohesion: 0.67
-Nodes (1): hashPassword()
+Cohesion: 1.0
+Nodes (2): mockGetSku(), validateInventoryForTransaction()
 
 ### Community 482 - "Community 482"
 Cohesion: 0.67
-Nodes (1): createVersionChecker()
+Nodes (1): hashPassword()
 
 ### Community 483 - "Community 483"
 Cohesion: 0.67
-Nodes (1): manualChunks()
+Nodes (1): createVersionChecker()
 
 ### Community 484 - "Community 484"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): manualChunks()
 
 ### Community 485 - "Community 485"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 486 - "Community 486"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 487 - "Community 487"
 Cohesion: 1.0
 Nodes (2): getAllColors(), getBaseUrl()
 
-### Community 487 - "Community 487"
+### Community 488 - "Community 488"
 Cohesion: 0.67
 Nodes (0):
-
-### Community 488 - "Community 488"
-Cohesion: 1.0
-Nodes (2): getBaseUrl(), getLastViewedProduct()
 
 ### Community 489 - "Community 489"
 Cohesion: 1.0
-Nodes (2): getBaseUrl(), getUserOffersEligibility()
+Nodes (2): getBaseUrl(), getLastViewedProduct()
 
 ### Community 490 - "Community 490"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getBaseUrl(), getUserOffersEligibility()
 
 ### Community 491 - "Community 491"
 Cohesion: 0.67
@@ -3685,12 +3687,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 494 - "Community 494"
-Cohesion: 1.0
-Nodes (2): handleKeyDown(), handleRedeemPromoCode()
-
-### Community 495 - "Community 495"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 495 - "Community 495"
+Cohesion: 1.0
+Nodes (2): handleKeyDown(), handleRedeemPromoCode()
 
 ### Community 496 - "Community 496"
 Cohesion: 0.67
@@ -3701,12 +3703,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 498 - "Community 498"
-Cohesion: 1.0
-Nodes (2): getPromoAlertCopy(), PromoAlert()
-
-### Community 499 - "Community 499"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 499 - "Community 499"
+Cohesion: 1.0
+Nodes (2): getPromoAlertCopy(), PromoAlert()
 
 ### Community 500 - "Community 500"
 Cohesion: 0.67
@@ -3773,16 +3775,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 516 - "Community 516"
-Cohesion: 1.0
-Nodes (2): collectWorkflowFiles(), runWorkflowCheck()
-
-### Community 517 - "Community 517"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 518 - "Community 518"
+### Community 517 - "Community 517"
 Cohesion: 1.0
-Nodes (2): createFixtureRepo(), write()
+Nodes (2): collectWorkflowFiles(), runWorkflowCheck()
+
+### Community 518 - "Community 518"
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 519 - "Community 519"
 Cohesion: 1.0
@@ -3801,20 +3803,20 @@ Cohesion: 1.0
 Nodes (2): createFixtureRepo(), write()
 
 ### Community 523 - "Community 523"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): createFixtureRepo(), write()
 
 ### Community 524 - "Community 524"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 525 - "Community 525"
-Cohesion: 1.0
-Nodes (2): collectRootScriptTestFiles(), runRootScriptsCoverage()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 526 - "Community 526"
 Cohesion: 1.0
-Nodes (0):
+Nodes (2): collectRootScriptTestFiles(), runRootScriptsCoverage()
 
 ### Community 527 - "Community 527"
 Cohesion: 1.0
@@ -8392,2298 +8394,2308 @@ Nodes (0):
 Cohesion: 1.0
 Nodes (0):
 
+### Community 1671 - "Community 1671"
+Cohesion: 1.0
+Nodes (0):
+
+### Community 1672 - "Community 1672"
+Cohesion: 1.0
+Nodes (0):
+
 ## Knowledge Gaps
 - **1 isolated node(s):** `HelpRequested`
   These have ≤1 connection - possible missing edges or undocumented components.
-- **Thin community `Community 526`** (2 nodes): `paymentAllocationAttribution.test.ts`, `readProjectFile()`
+- **Thin community `Community 527`** (2 nodes): `paymentAllocationAttribution.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 527`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
+- **Thin community `Community 528`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 528`** (2 nodes): `createCommandShimBin()`, `convexAuditScript.test.ts`
+- **Thin community `Community 529`** (2 nodes): `createCommandShimBin()`, `convexAuditScript.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 529`** (2 nodes): `policy.ts`, `assertSupportedCustomerMessagePolicy()`
+- **Thin community `Community 530`** (2 nodes): `policy.ts`, `assertSupportedCustomerMessagePolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 530`** (2 nodes): `repository.test.ts`, `queryResult()`
+- **Thin community `Community 531`** (2 nodes): `repository.test.ts`, `queryResult()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 531`** (2 nodes): `webhookSecurity.test.ts`, `sign()`
+- **Thin community `Community 532`** (2 nodes): `webhookSecurity.test.ts`, `sign()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 532`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
+- **Thin community `Community 533`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 533`** (2 nodes): `subcategories.ts`, `removeStorefrontHiddenSubcategoryList()`
+- **Thin community `Community 534`** (2 nodes): `subcategories.ts`, `removeStorefrontHiddenSubcategoryList()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 534`** (2 nodes): `storefrontCors.test.ts`, `readRouteFile()`
+- **Thin community `Community 535`** (2 nodes): `storefrontCors.test.ts`, `readRouteFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 535`** (2 nodes): `whatsapp.ts`, `mapWebhookStatus()`
+- **Thin community `Community 536`** (2 nodes): `whatsapp.ts`, `mapWebhookStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 536`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
+- **Thin community `Community 537`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 537`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
+- **Thin community `Community 538`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 538`** (2 nodes): `mapAthenaAuthSyncError()`, `auth.ts`
+- **Thin community `Community 539`** (2 nodes): `mapAthenaAuthSyncError()`, `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 539`** (2 nodes): `getHandler()`, `bestSeller.test.ts`
+- **Thin community `Community 540`** (2 nodes): `getHandler()`, `bestSeller.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 540`** (2 nodes): `userErrorFromExpenseItemCommandFailure()`, `expenseSessionItems.ts`
+- **Thin community `Community 541`** (2 nodes): `userErrorFromExpenseItemCommandFailure()`, `expenseSessionItems.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 541`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
+- **Thin community `Community 542`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 542`** (2 nodes): `posSessionItems.ts`, `userErrorFromSessionItemFailure()`
+- **Thin community `Community 543`** (2 nodes): `posSessionItems.ts`, `userErrorFromSessionItemFailure()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 543`** (2 nodes): `productUtil.ts`, `buildAllProductsCacheKey()`
+- **Thin community `Community 544`** (2 nodes): `productUtil.ts`, `buildAllProductsCacheKey()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 544`** (2 nodes): `promoCode.ts`, `calculateSelectedProductPromoDiscount()`
+- **Thin community `Community 545`** (2 nodes): `promoCode.ts`, `calculateSelectedProductPromoDiscount()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 545`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
+- **Thin community `Community 546`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 546`** (2 nodes): `commandResultValidator()`, `commandResultValidators.ts`
+- **Thin community `Community 547`** (2 nodes): `commandResultValidator()`, `commandResultValidators.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 547`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
+- **Thin community `Community 548`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 548`** (2 nodes): `callAnthropic()`, `anthropic.ts`
+- **Thin community `Community 549`** (2 nodes): `callAnthropic()`, `anthropic.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 549`** (2 nodes): `callOpenAi()`, `openai.ts`
+- **Thin community `Community 550`** (2 nodes): `callOpenAi()`, `openai.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 550`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
+- **Thin community `Community 551`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 551`** (2 nodes): `consumeCommandApprovalProofWithCtx()`, `approvalActions.ts`
+- **Thin community `Community 552`** (2 nodes): `consumeCommandApprovalProofWithCtx()`, `approvalActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 552`** (2 nodes): `createOperationalEventCtx()`, `approvalAuditEvents.test.ts`
+- **Thin community `Community 553`** (2 nodes): `createOperationalEventCtx()`, `approvalAuditEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 553`** (2 nodes): `createApprovalProofMutationCtx()`, `approvalProofs.test.ts`
+- **Thin community `Community 554`** (2 nodes): `createApprovalProofMutationCtx()`, `approvalProofs.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 554`** (2 nodes): `buildApprovalRequest()`, `approvalRequestHelpers.ts`
+- **Thin community `Community 555`** (2 nodes): `buildApprovalRequest()`, `approvalRequestHelpers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 555`** (2 nodes): `createApprovalRequestMutationCtx()`, `approvalRequests.test.ts`
+- **Thin community `Community 556`** (2 nodes): `createApprovalRequestMutationCtx()`, `approvalRequests.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 556`** (2 nodes): `buildOperationalEventMessage()`, `eventBuilders.ts`
+- **Thin community `Community 557`** (2 nodes): `buildOperationalEventMessage()`, `eventBuilders.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 557`** (2 nodes): `createInventoryMovementCtx()`, `inventoryMovements.test.ts`
+- **Thin community `Community 558`** (2 nodes): `createInventoryMovementCtx()`, `inventoryMovements.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 558`** (2 nodes): `skuActivity.test.ts`, `createIndexedDb()`
+- **Thin community `Community 559`** (2 nodes): `skuActivity.test.ts`, `createIndexedDb()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 559`** (2 nodes): `formatValidTime()`, `EmailOTP.ts`
+- **Thin community `Community 560`** (2 nodes): `formatValidTime()`, `EmailOTP.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 560`** (2 nodes): `quickAddCatalogItem.test.ts`, `createQuickAddCtx()`
+- **Thin community `Community 561`** (2 nodes): `quickAddCatalogItem.test.ts`, `createQuickAddCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 561`** (2 nodes): `expectNoCompletionSideEffects()`, `completeTransaction.test.ts`
+- **Thin community `Community 562`** (2 nodes): `expectNoCompletionSideEffects()`, `completeTransaction.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 562`** (2 nodes): `createMutationCtx()`, `correctTransactionPaymentMethod.test.ts`
+- **Thin community `Community 563`** (2 nodes): `createMutationCtx()`, `correctTransactionPaymentMethod.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 563`** (2 nodes): `buildCorrectionOperationalEvent()`, `correctionEvents.ts`
+- **Thin community `Community 564`** (2 nodes): `buildCorrectionOperationalEvent()`, `correctionEvents.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 564`** (2 nodes): `mockCorrectionHistoryDb()`, `getTransactions.test.ts`
+- **Thin community `Community 565`** (2 nodes): `mockCorrectionHistoryDb()`, `getTransactions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 565`** (2 nodes): `createRegisterCatalogCtx()`, `listRegisterCatalog.test.ts`
+- **Thin community `Community 566`** (2 nodes): `createRegisterCatalogCtx()`, `listRegisterCatalog.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 566`** (2 nodes): `getCashierForRegisterState()`, `cashierRepository.ts`
+- **Thin community `Community 567`** (2 nodes): `getCashierForRegisterState()`, `cashierRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 567`** (2 nodes): `createExpenseSessionCommandRepository()`, `expenseSessionCommandRepository.ts`
+- **Thin community `Community 568`** (2 nodes): `createExpenseSessionCommandRepository()`, `expenseSessionCommandRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 568`** (2 nodes): `createConvexLocalSyncRepository()`, `localSyncRepository.ts`
+- **Thin community `Community 569`** (2 nodes): `createConvexLocalSyncRepository()`, `localSyncRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 569`** (2 nodes): `sessionCommandRepository.test.ts`, `readProjectFile()`
+- **Thin community `Community 570`** (2 nodes): `sessionCommandRepository.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 570`** (2 nodes): `sessionRepository.test.ts`, `buildSession()`
+- **Thin community `Community 571`** (2 nodes): `sessionRepository.test.ts`, `buildSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 571`** (2 nodes): `requireRegisterCatalogStoreAccess()`, `catalog.ts`
+- **Thin community `Community 572`** (2 nodes): `requireRegisterCatalogStoreAccess()`, `catalog.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 572`** (2 nodes): `transactions.ts`, `mapCorrectionError()`
+- **Thin community `Community 573`** (2 nodes): `transactions.ts`, `mapCorrectionError()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 573`** (2 nodes): `getSource()`, `moduleWiring.test.ts`
+- **Thin community `Community 574`** (2 nodes): `getSource()`, `moduleWiring.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 574`** (2 nodes): `createStockOpsAccessQueryCtx()`, `access.test.ts`
+- **Thin community `Community 575`** (2 nodes): `createStockOpsAccessQueryCtx()`, `access.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 575`** (2 nodes): `requireStoreFullAdminAccess()`, `access.ts`
+- **Thin community `Community 576`** (2 nodes): `requireStoreFullAdminAccess()`, `access.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 576`** (2 nodes): `createCycleCountDraftCtx()`, `cycleCountDrafts.test.ts`
+- **Thin community `Community 577`** (2 nodes): `createCycleCountDraftCtx()`, `cycleCountDrafts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 577`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
+- **Thin community `Community 578`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 578`** (2 nodes): `createReservationActivityCtx()`, `checkoutSession.test.ts`
+- **Thin community `Community 579`** (2 nodes): `createReservationActivityCtx()`, `checkoutSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 579`** (2 nodes): `createQueryCtx()`, `customerBehaviorTimeline.test.ts`
+- **Thin community `Community 580`** (2 nodes): `createQueryCtx()`, `customerBehaviorTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 580`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
+- **Thin community `Community 581`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 581`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
+- **Thin community `Community 582`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 582`** (2 nodes): `createMutationCtx()`, `customerEngagementEvents.test.ts`
+- **Thin community `Community 583`** (2 nodes): `createMutationCtx()`, `customerEngagementEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 583`** (2 nodes): `getSource()`, `onlineOrder.test.ts`
+- **Thin community `Community 584`** (2 nodes): `getSource()`, `onlineOrder.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 584`** (2 nodes): `updateOnlineOrderItem()`, `onlineOrderItem.ts`
+- **Thin community `Community 585`** (2 nodes): `updateOnlineOrderItem()`, `onlineOrderItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 585`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
+- **Thin community `Community 586`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 586`** (2 nodes): `rewards.ts`, `formatPointsLabel()`
+- **Thin community `Community 587`** (2 nodes): `rewards.ts`, `formatPointsLabel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 587`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
+- **Thin community `Community 588`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 588`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
+- **Thin community `Community 589`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 589`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
+- **Thin community `Community 590`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 590`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
+- **Thin community `Community 591`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 591`** (2 nodes): `user.ts`, `getStoreFrontActorById()`
+- **Thin community `Community 592`** (2 nodes): `user.ts`, `getStoreFrontActorById()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 592`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
+- **Thin community `Community 593`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 593`** (2 nodes): `buildExpenseSessionTraceSeed()`, `expenseSession.ts`
+- **Thin community `Community 594`** (2 nodes): `buildExpenseSessionTraceSeed()`, `expenseSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 594`** (2 nodes): `posSession.ts`, `buildPosSessionTraceSeed()`
+- **Thin community `Community 595`** (2 nodes): `posSession.ts`, `buildPosSessionTraceSeed()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 595`** (2 nodes): `presentation.ts`, `buildWorkflowTraceViewModel()`
+- **Thin community `Community 596`** (2 nodes): `presentation.ts`, `buildWorkflowTraceViewModel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 596`** (2 nodes): `schemaIndexes.test.ts`, `getTableIndexes()`
+- **Thin community `Community 597`** (2 nodes): `schemaIndexes.test.ts`, `getTableIndexes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 597`** (2 nodes): `serviceIntake.ts`, `validateServiceIntakeInput()`
+- **Thin community `Community 598`** (2 nodes): `serviceIntake.ts`, `validateServiceIntakeInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 598`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
+- **Thin community `Community 599`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 599`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
+- **Thin community `Community 600`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 600`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
+- **Thin community `Community 601`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 601`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
+- **Thin community `Community 602`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 602`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
+- **Thin community `Community 603`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 603`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
+- **Thin community `Community 604`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 604`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
+- **Thin community `Community 605`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 605`** (2 nodes): `StoreView.tsx`, `Navigation()`
+- **Thin community `Community 606`** (2 nodes): `StoreView.tsx`, `Navigation()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 606`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
+- **Thin community `Community 607`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 607`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
+- **Thin community `Community 608`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 608`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
+- **Thin community `Community 609`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 609`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
+- **Thin community `Community 610`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 610`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
+- **Thin community `Community 611`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 611`** (2 nodes): `ProductImages.tsx`, `Header()`
+- **Thin community `Community 612`** (2 nodes): `ProductImages.tsx`, `Header()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 612`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
+- **Thin community `Community 613`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 613`** (2 nodes): `setIsUpdatingSku()`, `CopyImagesView.tsx`
+- **Thin community `Community 614`** (2 nodes): `setIsUpdatingSku()`, `CopyImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 614`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
+- **Thin community `Community 615`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 615`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
+- **Thin community `Community 616`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 616`** (2 nodes): `AnalyticsCombinedUsers()`, `AnalyticsCombinedUsers.tsx`
+- **Thin community `Community 617`** (2 nodes): `AnalyticsCombinedUsers()`, `AnalyticsCombinedUsers.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 617`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
+- **Thin community `Community 618`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 618`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
+- **Thin community `Community 619`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 619`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
+- **Thin community `Community 620`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 620`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
+- **Thin community `Community 621`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 621`** (2 nodes): `StoreInsights.tsx`, `getTrendIcon()`
+- **Thin community `Community 622`** (2 nodes): `StoreInsights.tsx`, `getTrendIcon()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 622`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
+- **Thin community `Community 623`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 623`** (2 nodes): `readSource()`, `analyticsWorkspaceEfficiency.test.ts`
+- **Thin community `Community 624`** (2 nodes): `readSource()`, `analyticsWorkspaceEfficiency.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 624`** (2 nodes): `LogItems()`, `LogItems.tsx`
+- **Thin community `Community 625`** (2 nodes): `LogItems()`, `LogItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 625`** (2 nodes): `Header()`, `LogView.tsx`
+- **Thin community `Community 626`** (2 nodes): `Header()`, `LogView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 626`** (2 nodes): `Navigation()`, `LogsView.tsx`
+- **Thin community `Community 627`** (2 nodes): `Navigation()`, `LogsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 627`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
+- **Thin community `Community 628`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 628`** (2 nodes): `Passthrough()`, `app-sidebar.test.tsx`
+- **Thin community `Community 629`** (2 nodes): `Passthrough()`, `app-sidebar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 629`** (2 nodes): `SidebarMenuCollapsible()`, `app-sidebar.tsx`
+- **Thin community `Community 630`** (2 nodes): `SidebarMenuCollapsible()`, `app-sidebar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 630`** (2 nodes): `Auth()`, `Auth.tsx`
+- **Thin community `Community 631`** (2 nodes): `Auth()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 631`** (2 nodes): `resolveSignIn()`, `InputOTP.test.tsx`
+- **Thin community `Community 632`** (2 nodes): `resolveSignIn()`, `InputOTP.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 632`** (2 nodes): `Login()`, `index.tsx`
+- **Thin community `Community 633`** (2 nodes): `Login()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 633`** (2 nodes): `DataTableColumnHeader()`, `data-table-column-header.tsx`
+- **Thin community `Community 634`** (2 nodes): `DataTableColumnHeader()`, `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 634`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
+- **Thin community `Community 635`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 635`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
+- **Thin community `Community 636`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 636`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
+- **Thin community `Community 637`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 637`** (2 nodes): `formatReviewReason()`, `formatReviewReason.ts`
+- **Thin community `Community 638`** (2 nodes): `formatReviewReason()`, `formatReviewReason.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 638`** (2 nodes): `registerSessionColumns.tsx`, `RegisterSessionLink()`
+- **Thin community `Community 639`** (2 nodes): `registerSessionColumns.tsx`, `RegisterSessionLink()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 639`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
+- **Thin community `Community 640`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 640`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
+- **Thin community `Community 641`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 641`** (2 nodes): `ExpenseCompletion()`, `ExpenseCompletion.tsx`
+- **Thin community `Community 642`** (2 nodes): `ExpenseCompletion()`, `ExpenseCompletion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 642`** (2 nodes): `ExpenseView()`, `ExpenseView.tsx`
+- **Thin community `Community 643`** (2 nodes): `ExpenseView()`, `ExpenseView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 643`** (2 nodes): `handleAddBestSeller()`, `BestSellersDialog.tsx`
+- **Thin community `Community 644`** (2 nodes): `handleAddBestSeller()`, `BestSellersDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 644`** (2 nodes): `handleAddFeaturedItem()`, `FeaturedSectionDialog.tsx`
+- **Thin community `Community 645`** (2 nodes): `handleAddFeaturedItem()`, `FeaturedSectionDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 645`** (2 nodes): `Navigation()`, `Home.tsx`
+- **Thin community `Community 646`** (2 nodes): `Navigation()`, `Home.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 646`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
+- **Thin community `Community 647`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 647`** (2 nodes): `ShopLookDialog.tsx`, `handleAddFeaturedItem()`
+- **Thin community `Community 648`** (2 nodes): `ShopLookDialog.tsx`, `handleAddFeaturedItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 648`** (2 nodes): `ShopLookImageUploader.tsx`, `ShopLookImageUploader()`
+- **Thin community `Community 649`** (2 nodes): `ShopLookImageUploader.tsx`, `ShopLookImageUploader()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 649`** (2 nodes): `JoinTeam()`, `index.tsx`
+- **Thin community `Community 650`** (2 nodes): `JoinTeam()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 650`** (2 nodes): `Reveal()`, `AthenaLandingPage.tsx`
+- **Thin community `Community 651`** (2 nodes): `Reveal()`, `AthenaLandingPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 651`** (2 nodes): `cn()`, `OperationReviewItemCard.tsx`
+- **Thin community `Community 652`** (2 nodes): `cn()`, `OperationReviewItemCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 652`** (2 nodes): `buildParams()`, `OperationsSummaryMetric.tsx`
+- **Thin community `Community 653`** (2 nodes): `buildParams()`, `OperationsSummaryMetric.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 653`** (2 nodes): `StockAdjustmentWorkspace.test.tsx`, `renderStockAdjustmentWorkspace()`
+- **Thin community `Community 654`** (2 nodes): `StockAdjustmentWorkspace.test.tsx`, `renderStockAdjustmentWorkspace()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 654`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
+- **Thin community `Community 655`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 655`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
+- **Thin community `Community 656`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 656`** (2 nodes): `OrderMetricsPanel()`, `OrderMetricsPanel.tsx`
+- **Thin community `Community 657`** (2 nodes): `OrderMetricsPanel()`, `OrderMetricsPanel.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 657`** (2 nodes): `getTimeFilter()`, `OrdersView.tsx`
+- **Thin community `Community 658`** (2 nodes): `getTimeFilter()`, `OrdersView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 658`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
+- **Thin community `Community 659`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 659`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
+- **Thin community `Community 660`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 660`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
+- **Thin community `Community 661`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 661`** (2 nodes): `if()`, `orderColumns.tsx`
+- **Thin community `Community 662`** (2 nodes): `if()`, `orderColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 662`** (2 nodes): `OrganizationSwitcher()`, `organization-switcher.tsx`
+- **Thin community `Community 663`** (2 nodes): `OrganizationSwitcher()`, `organization-switcher.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 663`** (2 nodes): `cn()`, `CartItems.tsx`
+- **Thin community `Community 664`** (2 nodes): `cn()`, `CartItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 664`** (2 nodes): `buildLocalAuthorityRecord()`, `CashierAuthDialog.test.tsx`
+- **Thin community `Community 665`** (2 nodes): `buildLocalAuthorityRecord()`, `CashierAuthDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 665`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
+- **Thin community `Community 666`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 666`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
+- **Thin community `Community 667`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 667`** (2 nodes): `PinInput.tsx`, `PinInput()`
+- **Thin community `Community 668`** (2 nodes): `PinInput.tsx`, `PinInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 668`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
+- **Thin community `Community 669`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 669`** (2 nodes): `ProductCard.tsx`, `handleClick()`
+- **Thin community `Community 670`** (2 nodes): `ProductCard.tsx`, `handleClick()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 670`** (2 nodes): `SearchResultsSection.test.tsx`, `buildProduct()`
+- **Thin community `Community 671`** (2 nodes): `SearchResultsSection.test.tsx`, `buildProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 671`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
+- **Thin community `Community 672`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 672`** (2 nodes): `isToday()`, `ExpenseReportsView.tsx`
+- **Thin community `Community 673`** (2 nodes): `isToday()`, `ExpenseReportsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 673`** (2 nodes): `toExpenseReportRows()`, `expenseReportRows.ts`
+- **Thin community `Community 674`** (2 nodes): `toExpenseReportRows()`, `expenseReportRows.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 674`** (2 nodes): `ExpenseCompletionPanel()`, `ExpenseCompletionPanel.tsx`
+- **Thin community `Community 675`** (2 nodes): `ExpenseCompletionPanel()`, `ExpenseCompletionPanel.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 675`** (2 nodes): `POSRegisterView.test.tsx`, `pressDebugPanelShortcut()`
+- **Thin community `Community 676`** (2 nodes): `POSRegisterView.test.tsx`, `pressDebugPanelShortcut()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 676`** (2 nodes): `RegisterCustomerAttribution.test.tsx`, `makeCustomer()`
+- **Thin community `Community 677`** (2 nodes): `RegisterCustomerAttribution.test.tsx`, `makeCustomer()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 677`** (2 nodes): `RegisterCustomerPanel.tsx`, `RegisterCustomerPanel()`
+- **Thin community `Community 678`** (2 nodes): `RegisterCustomerPanel.tsx`, `RegisterCustomerPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 678`** (2 nodes): `RegisterDrawerGate.test.tsx`, `renderGate()`
+- **Thin community `Community 679`** (2 nodes): `RegisterDrawerGate.test.tsx`, `renderGate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 679`** (2 nodes): `RegisterSessionPanel.tsx`, `RegisterSessionPanel()`
+- **Thin community `Community 680`** (2 nodes): `RegisterSessionPanel.tsx`, `RegisterSessionPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 680`** (2 nodes): `transactionColumns.test.tsx`, `renderTransactionCell()`
+- **Thin community `Community 681`** (2 nodes): `transactionColumns.test.tsx`, `renderTransactionCell()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 681`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
+- **Thin community `Community 682`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 682`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
+- **Thin community `Community 683`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 683`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
+- **Thin community `Community 684`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 684`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
+- **Thin community `Community 685`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 685`** (2 nodes): `ProductStatus.tsx`, `ProductStatus()`
+- **Thin community `Community 686`** (2 nodes): `ProductStatus.tsx`, `ProductStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 686`** (2 nodes): `SKUSelector.tsx`, `SKUSelector()`
+- **Thin community `Community 687`** (2 nodes): `SKUSelector.tsx`, `SKUSelector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 687`** (2 nodes): `product-actions.tsx`, `useArchiveProduct()`
+- **Thin community `Community 688`** (2 nodes): `product-actions.tsx`, `useArchiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 688`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
+- **Thin community `Community 689`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 689`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
+- **Thin community `Community 690`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 690`** (2 nodes): `Products.tsx`, `Products()`
+- **Thin community `Community 691`** (2 nodes): `Products.tsx`, `Products()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 691`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
+- **Thin community `Community 692`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 692`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
+- **Thin community `Community 693`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 693`** (2 nodes): `PromoCodePreview.tsx`, `Discount()`
+- **Thin community `Community 694`** (2 nodes): `PromoCodePreview.tsx`, `Discount()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 694`** (2 nodes): `PromoCodesView.test.tsx`, `readSource()`
+- **Thin community `Community 695`** (2 nodes): `PromoCodesView.test.tsx`, `readSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 695`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
+- **Thin community `Community 696`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 696`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
+- **Thin community `Community 697`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 697`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
+- **Thin community `Community 698`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 698`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
+- **Thin community `Community 699`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 699`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
+- **Thin community `Community 700`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 700`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
+- **Thin community `Community 701`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 701`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
+- **Thin community `Community 702`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 702`** (2 nodes): `ServiceCasesView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 703`** (2 nodes): `ServiceCasesView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 703`** (2 nodes): `ServiceCatalogView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 704`** (2 nodes): `ServiceCatalogView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 704`** (2 nodes): `ServiceIntakeForm.tsx`, `ServiceIntakeForm()`
+- **Thin community `Community 705`** (2 nodes): `ServiceIntakeForm.tsx`, `ServiceIntakeForm()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 705`** (2 nodes): `ServiceIntakeView.auth.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 706`** (2 nodes): `ServiceIntakeView.auth.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 706`** (2 nodes): `ServiceIntakeView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 707`** (2 nodes): `ServiceIntakeView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 707`** (2 nodes): `StaffAuthenticationDialog.tsx`, `handleKeyDown()`
+- **Thin community `Community 708`** (2 nodes): `StaffAuthenticationDialog.tsx`, `handleKeyDown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 708`** (2 nodes): `staffPinPolicy.ts`, `normalizeStaffPin()`
+- **Thin community `Community 709`** (2 nodes): `staffPinPolicy.ts`, `normalizeStaffPin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 709`** (2 nodes): `onClick()`, `empty-state.tsx`
+- **Thin community `Community 710`** (2 nodes): `onClick()`, `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 710`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
+- **Thin community `Community 711`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 711`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
+- **Thin community `Community 712`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 712`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
+- **Thin community `Community 713`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 713`** (2 nodes): `ProtectedAdminSignInView.tsx`, `ProtectedAdminSignInView()`
+- **Thin community `Community 714`** (2 nodes): `ProtectedAdminSignInView.tsx`, `ProtectedAdminSignInView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 714`** (2 nodes): `ContactView()`, `ContactView.tsx`
+- **Thin community `Community 715`** (2 nodes): `ContactView()`, `ContactView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 715`** (2 nodes): `Header()`, `Header.tsx`
+- **Thin community `Community 716`** (2 nodes): `Header()`, `Header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 716`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
+- **Thin community `Community 717`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 717`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
+- **Thin community `Community 718`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 718`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
+- **Thin community `Community 719`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 719`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
+- **Thin community `Community 720`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 720`** (2 nodes): `useChart()`, `chart.tsx`
+- **Thin community `Community 721`** (2 nodes): `useChart()`, `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 721`** (2 nodes): `handleCopy()`, `copy-button.tsx`
+- **Thin community `Community 722`** (2 nodes): `handleCopy()`, `copy-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 722`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
+- **Thin community `Community 723`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 723`** (2 nodes): `Label()`, `label.tsx`
+- **Thin community `Community 724`** (2 nodes): `Label()`, `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 724`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
+- **Thin community `Community 725`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 725`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
+- **Thin community `Community 726`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 726`** (2 nodes): `store-modal.tsx`, `onSubmit()`
+- **Thin community `Community 727`** (2 nodes): `store-modal.tsx`, `onSubmit()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 727`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
+- **Thin community `Community 728`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 728`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
+- **Thin community `Community 729`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 729`** (2 nodes): `select-native.tsx`, `cn()`
+- **Thin community `Community 730`** (2 nodes): `select-native.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 730`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
+- **Thin community `Community 731`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 731`** (2 nodes): `webp-image.tsx`, `WebpImage()`
+- **Thin community `Community 732`** (2 nodes): `webp-image.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 732`** (2 nodes): `BagItems()`, `BagItems.tsx`
+- **Thin community `Community 733`** (2 nodes): `BagItems()`, `BagItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 733`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
+- **Thin community `Community 734`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 734`** (2 nodes): `Bags()`, `Bags.tsx`
+- **Thin community `Community 735`** (2 nodes): `Bags()`, `Bags.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 735`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
+- **Thin community `Community 736`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 736`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
+- **Thin community `Community 737`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 737`** (2 nodes): `UserBag.tsx`, `UserBag()`
+- **Thin community `Community 738`** (2 nodes): `UserBag.tsx`, `UserBag()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 738`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
+- **Thin community `Community 739`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 739`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
+- **Thin community `Community 740`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 740`** (2 nodes): `UserView.tsx`, `UserActions()`
+- **Thin community `Community 741`** (2 nodes): `UserView.tsx`, `UserActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 741`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
+- **Thin community `Community 742`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 742`** (2 nodes): `UserBehaviorInsights.tsx`, `UserBehaviorInsights()`
+- **Thin community `Community 743`** (2 nodes): `UserBehaviorInsights.tsx`, `UserBehaviorInsights()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 743`** (2 nodes): `wrapper()`, `ManagerElevationContext.test.tsx`
+- **Thin community `Community 744`** (2 nodes): `wrapper()`, `ManagerElevationContext.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 744`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
+- **Thin community `Community 745`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 745`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
+- **Thin community `Community 746`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 746`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
+- **Thin community `Community 747`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 747`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
+- **Thin community `Community 748`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 748`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
+- **Thin community `Community 749`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 749`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
+- **Thin community `Community 750`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 750`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
+- **Thin community `Community 751`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 751`** (2 nodes): `useConvexAuthIdentity.ts`, `useConvexAuthIdentity()`
+- **Thin community `Community 752`** (2 nodes): `useConvexAuthIdentity.ts`, `useConvexAuthIdentity()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 752`** (2 nodes): `useCopyText.ts`, `useCopyText()`
+- **Thin community `Community 753`** (2 nodes): `useCopyText.ts`, `useCopyText()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 753`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
+- **Thin community `Community 754`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 754`** (2 nodes): `useDebounce.ts`, `useDebounce()`
+- **Thin community `Community 755`** (2 nodes): `useDebounce.ts`, `useDebounce()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 755`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
+- **Thin community `Community 756`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 756`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
+- **Thin community `Community 757`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 757`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
+- **Thin community `Community 758`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 758`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
+- **Thin community `Community 759`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 759`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
+- **Thin community `Community 760`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 760`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
+- **Thin community `Community 761`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 761`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
+- **Thin community `Community 762`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 762`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
+- **Thin community `Community 763`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 763`** (2 nodes): `usePermissions.ts`, `usePermissions()`
+- **Thin community `Community 764`** (2 nodes): `usePermissions.ts`, `usePermissions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 764`** (2 nodes): `usePrint.ts`, `usePrint()`
+- **Thin community `Community 765`** (2 nodes): `usePrint.ts`, `usePrint()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 765`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
+- **Thin community `Community 766`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 766`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
+- **Thin community `Community 767`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 767`** (2 nodes): `useProtectedAdminPageState.ts`, `useProtectedAdminPageState()`
+- **Thin community `Community 768`** (2 nodes): `useProtectedAdminPageState.ts`, `useProtectedAdminPageState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 768`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
+- **Thin community `Community 769`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 769`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
+- **Thin community `Community 770`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 770`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
+- **Thin community `Community 771`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 771`** (2 nodes): `toOperatorMessage()`, `operatorMessages.ts`
+- **Thin community `Community 772`** (2 nodes): `toOperatorMessage()`, `operatorMessages.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 772`** (2 nodes): `presentUnexpectedErrorToast.ts`, `presentUnexpectedErrorToast()`
+- **Thin community `Community 773`** (2 nodes): `presentUnexpectedErrorToast.ts`, `presentUnexpectedErrorToast()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 773`** (2 nodes): `getOrigin()`, `navigationUtils.ts`
+- **Thin community `Community 774`** (2 nodes): `getOrigin()`, `navigationUtils.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 774`** (2 nodes): `addItem()`, `addItem.ts`
+- **Thin community `Community 775`** (2 nodes): `addItem()`, `addItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 775`** (2 nodes): `bootstrapRegister()`, `bootstrapRegister.ts`
+- **Thin community `Community 776`** (2 nodes): `bootstrapRegister()`, `bootstrapRegister.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 776`** (2 nodes): `holdSession()`, `holdSession.ts`
+- **Thin community `Community 777`** (2 nodes): `holdSession()`, `holdSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 777`** (2 nodes): `openDrawer()`, `openDrawer.ts`
+- **Thin community `Community 778`** (2 nodes): `openDrawer()`, `openDrawer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 778`** (2 nodes): `startSession.ts`, `startSession()`
+- **Thin community `Community 779`** (2 nodes): `startSession.ts`, `startSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 779`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
+- **Thin community `Community 780`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 780`** (2 nodes): `registerAvailabilitySnapshot.test.ts`, `buildAvailabilityRow()`
+- **Thin community `Community 781`** (2 nodes): `registerAvailabilitySnapshot.test.ts`, `buildAvailabilityRow()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 781`** (2 nodes): `registerAvailabilitySnapshot.ts`, `readRegisterAvailabilitySnapshotState()`
+- **Thin community `Community 782`** (2 nodes): `registerAvailabilitySnapshot.ts`, `readRegisterAvailabilitySnapshotState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 782`** (2 nodes): `syncContract.test.ts`, `buildLocalEvent()`
+- **Thin community `Community 783`** (2 nodes): `syncContract.test.ts`, `buildLocalEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 783`** (2 nodes): `syncScheduler.test.ts`, `baseEvent()`
+- **Thin community `Community 784`** (2 nodes): `syncScheduler.test.ts`, `baseEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 784`** (2 nodes): `syncStatus.test.ts`, `event()`
+- **Thin community `Community 785`** (2 nodes): `syncStatus.test.ts`, `event()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 785`** (2 nodes): `useRegisterCatalogIndex.ts`, `useRegisterCatalogIndex()`
+- **Thin community `Community 786`** (2 nodes): `useRegisterCatalogIndex.ts`, `useRegisterCatalogIndex()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 786`** (2 nodes): `pinHash.ts`, `hashPin()`
+- **Thin community `Community 787`** (2 nodes): `pinHash.ts`, `hashPin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 787`** (2 nodes): `hasOrgNotFoundPayload()`, `index.tsx`
+- **Thin community `Community 788`** (2 nodes): `hasOrgNotFoundPayload()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 788`** (2 nodes): `$sessionId.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 789`** (2 nodes): `$sessionId.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 789`** (2 nodes): `registers.index.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 790`** (2 nodes): `registers.index.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 790`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
+- **Thin community `Community 791`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 791`** (2 nodes): `ApprovalsRoute()`, `approvals.tsx`
+- **Thin community `Community 792`** (2 nodes): `ApprovalsRoute()`, `approvals.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 792`** (2 nodes): `DailyCloseHistoryRoute()`, `daily-close-history.tsx`
+- **Thin community `Community 793`** (2 nodes): `DailyCloseHistoryRoute()`, `daily-close-history.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 793`** (2 nodes): `DailyCloseRoute()`, `daily-close.tsx`
+- **Thin community `Community 794`** (2 nodes): `DailyCloseRoute()`, `daily-close.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 794`** (2 nodes): `OpenWorkRoute()`, `open-work.tsx`
+- **Thin community `Community 795`** (2 nodes): `OpenWorkRoute()`, `open-work.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 795`** (2 nodes): `DailyOpeningRoute()`, `opening.tsx`
+- **Thin community `Community 796`** (2 nodes): `DailyOpeningRoute()`, `opening.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 796`** (2 nodes): `stock-adjustments.tsx`, `StockAdjustmentsRoute()`
+- **Thin community `Community 797`** (2 nodes): `stock-adjustments.tsx`, `StockAdjustmentsRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 797`** (2 nodes): `ExpenseRouteComponent()`, `expense.index.tsx`
+- **Thin community `Community 798`** (2 nodes): `ExpenseRouteComponent()`, `expense.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 798`** (2 nodes): `published.index.tsx`, `RouteComponent()`
+- **Thin community `Community 799`** (2 nodes): `published.index.tsx`, `RouteComponent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 799`** (2 nodes): `Index()`, `index.tsx`
+- **Thin community `Community 800`** (2 nodes): `Index()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 800`** (2 nodes): `AthenaLoginReadyView()`, `_layout.index.tsx`
+- **Thin community `Community 801`** (2 nodes): `AthenaLoginReadyView()`, `_layout.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 801`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
+- **Thin community `Community 802`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 802`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 803`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 803`** (2 nodes): `view-patterns.tsx`, `cn()`
+- **Thin community `Community 804`** (2 nodes): `view-patterns.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 804`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
+- **Thin community `Community 805`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 805`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
+- **Thin community `Community 806`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 806`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
+- **Thin community `Community 807`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 807`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 808`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 808`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
+- **Thin community `Community 809`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 809`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
+- **Thin community `Community 810`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 810`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
+- **Thin community `Community 811`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 811`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 812`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 812`** (2 nodes): `usePrint.test.ts`, `setWindowOpenMock()`
+- **Thin community `Community 813`** (2 nodes): `usePrint.test.ts`, `setWindowOpenMock()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 813`** (2 nodes): `formatNumber()`, `formatNumber.ts`
+- **Thin community `Community 814`** (2 nodes): `formatNumber()`, `formatNumber.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 814`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
+- **Thin community `Community 815`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 815`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
+- **Thin community `Community 816`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 816`** (2 nodes): `updateGuest()`, `guest.ts`
+- **Thin community `Community 817`** (2 nodes): `updateGuest()`, `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 817`** (2 nodes): `posTransaction.test.ts`, `jsonResponse()`
+- **Thin community `Community 818`** (2 nodes): `posTransaction.test.ts`, `jsonResponse()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 818`** (2 nodes): `storefront.ts`, `getStore()`
+- **Thin community `Community 819`** (2 nodes): `storefront.ts`, `getStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 819`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
+- **Thin community `Community 820`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 820`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
+- **Thin community `Community 821`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 821`** (2 nodes): `AuthComponent()`, `Auth.tsx`
+- **Thin community `Community 822`** (2 nodes): `AuthComponent()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 822`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
+- **Thin community `Community 823`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 823`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
+- **Thin community `Community 824`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 824`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
+- **Thin community `Community 825`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 825`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
+- **Thin community `Community 826`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 826`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
+- **Thin community `Community 827`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 827`** (2 nodes): `PickupDetails()`, `index.tsx`
+- **Thin community `Community 828`** (2 nodes): `PickupDetails()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 828`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
+- **Thin community `Community 829`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 829`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
+- **Thin community `Community 830`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 830`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
+- **Thin community `Community 831`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 831`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
+- **Thin community `Community 832`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 832`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
+- **Thin community `Community 833`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 833`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
+- **Thin community `Community 834`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 834`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
+- **Thin community `Community 835`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 835`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
+- **Thin community `Community 836`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 836`** (2 nodes): `useCountdown()`, `hooks.ts`
+- **Thin community `Community 837`** (2 nodes): `useCountdown()`, `hooks.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 837`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
+- **Thin community `Community 838`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 838`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
+- **Thin community `Community 839`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 839`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
+- **Thin community `Community 840`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 840`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
+- **Thin community `Community 841`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 841`** (2 nodes): `resolveHomepageContent()`, `homePageContent.ts`
+- **Thin community `Community 842`** (2 nodes): `resolveHomepageContent()`, `homePageContent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 842`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
+- **Thin community `Community 843`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 843`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
+- **Thin community `Community 844`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 844`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
+- **Thin community `Community 845`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 845`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
+- **Thin community `Community 846`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 846`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
+- **Thin community `Community 847`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 847`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
+- **Thin community `Community 848`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 848`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
+- **Thin community `Community 849`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 849`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
+- **Thin community `Community 850`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 850`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
+- **Thin community `Community 851`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 851`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
+- **Thin community `Community 852`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 852`** (2 nodes): `ProductPage.test.tsx`, `makePageState()`
+- **Thin community `Community 853`** (2 nodes): `ProductPage.test.tsx`, `makePageState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 853`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
+- **Thin community `Community 854`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 854`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
+- **Thin community `Community 855`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 855`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
+- **Thin community `Community 856`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 856`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
+- **Thin community `Community 857`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 857`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
+- **Thin community `Community 858`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 858`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
+- **Thin community `Community 859`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 859`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
+- **Thin community `Community 860`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 860`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
+- **Thin community `Community 861`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 861`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
+- **Thin community `Community 862`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 862`** (2 nodes): `BagItem()`, `BagItem.tsx`
+- **Thin community `Community 863`** (2 nodes): `BagItem()`, `BagItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 863`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
+- **Thin community `Community 864`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 864`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
+- **Thin community `Community 865`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 865`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
+- **Thin community `Community 866`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 866`** (2 nodes): `CountrySelect()`, `country-select.tsx`
+- **Thin community `Community 867`** (2 nodes): `CountrySelect()`, `country-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 867`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
+- **Thin community `Community 868`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 868`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
+- **Thin community `Community 869`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 869`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
+- **Thin community `Community 870`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 870`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
+- **Thin community `Community 871`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 871`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
+- **Thin community `Community 872`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 872`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
+- **Thin community `Community 873`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 873`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
+- **Thin community `Community 874`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 874`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
+- **Thin community `Community 875`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 875`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
+- **Thin community `Community 876`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 876`** (2 nodes): `useCheckout.ts`, `useCheckout()`
+- **Thin community `Community 877`** (2 nodes): `useCheckout.ts`, `useCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 877`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
+- **Thin community `Community 878`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 878`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
+- **Thin community `Community 879`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 879`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
+- **Thin community `Community 880`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 880`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
+- **Thin community `Community 881`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 881`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
+- **Thin community `Community 882`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 882`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
+- **Thin community `Community 883`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 883`** (2 nodes): `useGetStore.ts`, `useGetStore()`
+- **Thin community `Community 884`** (2 nodes): `useGetStore.ts`, `useGetStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 884`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
+- **Thin community `Community 885`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 885`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
+- **Thin community `Community 886`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 886`** (2 nodes): `useLogout.ts`, `useLogout()`
+- **Thin community `Community 887`** (2 nodes): `useLogout.ts`, `useLogout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 887`** (2 nodes): `useModalState.tsx`, `useModalState()`
+- **Thin community `Community 888`** (2 nodes): `useModalState.tsx`, `useModalState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 888`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
+- **Thin community `Community 889`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 889`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
+- **Thin community `Community 890`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 890`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
+- **Thin community `Community 891`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 891`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
+- **Thin community `Community 892`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 892`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
+- **Thin community `Community 893`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 893`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
+- **Thin community `Community 894`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 894`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
+- **Thin community `Community 895`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 895`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
+- **Thin community `Community 896`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 896`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
+- **Thin community `Community 897`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 897`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
+- **Thin community `Community 898`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 898`** (2 nodes): `useBagQueries()`, `bag.ts`
+- **Thin community `Community 899`** (2 nodes): `useBagQueries()`, `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 899`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
+- **Thin community `Community 900`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 900`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
+- **Thin community `Community 901`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 901`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
+- **Thin community `Community 902`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 902`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
+- **Thin community `Community 903`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 903`** (2 nodes): `posTransaction.ts`, `usePosTransactionQueries()`
+- **Thin community `Community 904`** (2 nodes): `posTransaction.ts`, `usePosTransactionQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 904`** (2 nodes): `product.ts`, `useProductQueries()`
+- **Thin community `Community 905`** (2 nodes): `product.ts`, `useProductQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 905`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
+- **Thin community `Community 906`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 906`** (2 nodes): `reviews.ts`, `useReviewQueries()`
+- **Thin community `Community 907`** (2 nodes): `reviews.ts`, `useReviewQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 907`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
+- **Thin community `Community 908`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 908`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
+- **Thin community `Community 909`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 909`** (2 nodes): `user.ts`, `useUserQueries()`
+- **Thin community `Community 910`** (2 nodes): `user.ts`, `useUserQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 910`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
+- **Thin community `Community 911`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 911`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
+- **Thin community `Community 912`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 912`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
+- **Thin community `Community 913`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 913`** (2 nodes): `validateEmail()`, `email.ts`
+- **Thin community `Community 914`** (2 nodes): `validateEmail()`, `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 914`** (2 nodes): `router.tsx`, `createRouter()`
+- **Thin community `Community 915`** (2 nodes): `router.tsx`, `createRouter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 915`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
+- **Thin community `Community 916`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 916`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
+- **Thin community `Community 917`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 917`** (2 nodes): `ContactUs()`, `contact-us.tsx`
+- **Thin community `Community 918`** (2 nodes): `ContactUs()`, `contact-us.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 918`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
+- **Thin community `Community 919`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 919`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
+- **Thin community `Community 920`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 920`** (2 nodes): `tos.index.tsx`, `TosSection()`
+- **Thin community `Community 921`** (2 nodes): `tos.index.tsx`, `TosSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 921`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
+- **Thin community `Community 922`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 922`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
+- **Thin community `Community 923`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 923`** (2 nodes): `HomeRoute()`, `index.tsx`
+- **Thin community `Community 924`** (2 nodes): `HomeRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 924`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
+- **Thin community `Community 925`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 925`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
+- **Thin community `Community 926`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 926`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
+- **Thin community `Community 927`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 927`** (2 nodes): `ReceiptShareRoute()`, `index.tsx`
+- **Thin community `Community 928`** (2 nodes): `ReceiptShareRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 928`** (2 nodes): `test-connection.js`, `main()`
+- **Thin community `Community 929`** (2 nodes): `test-connection.js`, `main()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 929`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
+- **Thin community `Community 930`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 930`** (2 nodes): `run()`, `architecture-boundary-check.ts`
+- **Thin community `Community 931`** (2 nodes): `run()`, `architecture-boundary-check.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 931`** (2 nodes): `readRepoFile()`, `deploy-qa-vps.test.ts`
+- **Thin community `Community 932`** (2 nodes): `readRepoFile()`, `deploy-qa-vps.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 932`** (2 nodes): `runCommand()`, `github-pr-merge.test.ts`
+- **Thin community `Community 933`** (2 nodes): `runCommand()`, `github-pr-merge.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 933`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
+- **Thin community `Community 934`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 934`** (2 nodes): `shutdown()`, `sample-app.ts`
+- **Thin community `Community 935`** (2 nodes): `shutdown()`, `sample-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 935`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
+- **Thin community `Community 936`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 936`** (1 nodes): `api.d.ts`
+- **Thin community `Community 937`** (2 nodes): `validate-plan-html.test.ts`, `createTempRepo()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 937`** (1 nodes): `api.js`
+- **Thin community `Community 938`** (1 nodes): `api.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 938`** (1 nodes): `dataModel.d.ts`
+- **Thin community `Community 939`** (1 nodes): `api.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 939`** (1 nodes): `server.d.ts`
+- **Thin community `Community 940`** (1 nodes): `dataModel.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 940`** (1 nodes): `server.js`
+- **Thin community `Community 941`** (1 nodes): `server.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 941`** (1 nodes): `app.ts`
+- **Thin community `Community 942`** (1 nodes): `server.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 942`** (1 nodes): `auth.config.js`
+- **Thin community `Community 943`** (1 nodes): `app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 943`** (1 nodes): `auth.ts`
+- **Thin community `Community 944`** (1 nodes): `auth.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 944`** (1 nodes): `registerSessions.test.ts`
+- **Thin community `Community 945`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 945`** (1 nodes): `r2.test.ts`
+- **Thin community `Community 946`** (1 nodes): `registerSessions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 946`** (1 nodes): `countries.ts`
+- **Thin community `Community 947`** (1 nodes): `r2.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 947`** (1 nodes): `email.ts`
+- **Thin community `Community 948`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 948`** (1 nodes): `ghana.ts`
+- **Thin community `Community 949`** (1 nodes): `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 949`** (1 nodes): `payment.ts`
+- **Thin community `Community 950`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 950`** (1 nodes): `crons.ts`
+- **Thin community `Community 951`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 951`** (1 nodes): `domain.test.ts`
+- **Thin community `Community 952`** (1 nodes): `crons.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 952`** (1 nodes): `internal.ts`
+- **Thin community `Community 953`** (1 nodes): `domain.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 953`** (1 nodes): `public.test.ts`
+- **Thin community `Community 954`** (1 nodes): `internal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 954`** (1 nodes): `token.test.ts`
+- **Thin community `Community 955`** (1 nodes): `public.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 955`** (1 nodes): `whatsappClient.test.ts`
+- **Thin community `Community 956`** (1 nodes): `token.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 956`** (1 nodes): `whatsappConfig.test.ts`
+- **Thin community `Community 957`** (1 nodes): `whatsappClient.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 957`** (1 nodes): `devPatchBadTransaction.ts`
+- **Thin community `Community 958`** (1 nodes): `whatsappConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 958`** (1 nodes): `FeedbackRequest.tsx`
+- **Thin community `Community 959`** (1 nodes): `devPatchBadTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 959`** (1 nodes): `NewOrderAdmin.tsx`
+- **Thin community `Community 960`** (1 nodes): `FeedbackRequest.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 960`** (1 nodes): `OrderEmail.tsx`
+- **Thin community `Community 961`** (1 nodes): `NewOrderAdmin.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 961`** (1 nodes): `PosReceiptEmail.tsx`
+- **Thin community `Community 962`** (1 nodes): `OrderEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 962`** (1 nodes): `env.ts`
+- **Thin community `Community 963`** (1 nodes): `PosReceiptEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 963`** (1 nodes): `analytics.ts`
+- **Thin community `Community 964`** (1 nodes): `env.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 964`** (1 nodes): `auth.ts`
+- **Thin community `Community 965`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 965`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 966`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 966`** (1 nodes): `colors.ts`
+- **Thin community `Community 967`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 967`** (1 nodes): `index.ts`
+- **Thin community `Community 968`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 968`** (1 nodes): `organizations.ts`
+- **Thin community `Community 969`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 969`** (1 nodes): `products.ts`
+- **Thin community `Community 970`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 970`** (1 nodes): `storefrontHidden.test.ts`
+- **Thin community `Community 971`** (1 nodes): `products.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 971`** (1 nodes): `stores.ts`
+- **Thin community `Community 972`** (1 nodes): `storefrontHidden.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 972`** (1 nodes): `bag.ts`
+- **Thin community `Community 973`** (1 nodes): `stores.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 973`** (1 nodes): `guest.ts`
+- **Thin community `Community 974`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 974`** (1 nodes): `index.ts`
+- **Thin community `Community 975`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 975`** (1 nodes): `me.ts`
+- **Thin community `Community 976`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 976`** (1 nodes): `offers.ts`
+- **Thin community `Community 977`** (1 nodes): `me.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 977`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 978`** (1 nodes): `offers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 978`** (1 nodes): `paystack.ts`
+- **Thin community `Community 979`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 979`** (1 nodes): `posTransaction.ts`
+- **Thin community `Community 980`** (1 nodes): `paystack.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 980`** (1 nodes): `reviews.ts`
+- **Thin community `Community 981`** (1 nodes): `posTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 981`** (1 nodes): `rewards.ts`
+- **Thin community `Community 982`** (1 nodes): `reviews.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 982`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 983`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 983`** (1 nodes): `security.test.ts`
+- **Thin community `Community 984`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 984`** (1 nodes): `storefront.ts`
+- **Thin community `Community 985`** (1 nodes): `security.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 985`** (1 nodes): `upsells.ts`
+- **Thin community `Community 986`** (1 nodes): `storefront.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 986`** (1 nodes): `user.ts`
+- **Thin community `Community 987`** (1 nodes): `upsells.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 987`** (1 nodes): `userOffers.ts`
+- **Thin community `Community 988`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 988`** (1 nodes): `index.ts`
+- **Thin community `Community 989`** (1 nodes): `userOffers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 989`** (1 nodes): `health.test.ts`
+- **Thin community `Community 990`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 990`** (1 nodes): `http.ts`
+- **Thin community `Community 991`** (1 nodes): `health.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 991`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 992`** (1 nodes): `http.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 992`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 993`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 993`** (1 nodes): `bestSeller.ts`
+- **Thin community `Community 994`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 994`** (1 nodes): `categories.ts`
+- **Thin community `Community 995`** (1 nodes): `bestSeller.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 995`** (1 nodes): `colors.ts`
+- **Thin community `Community 996`** (1 nodes): `categories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 996`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 997`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 997`** (1 nodes): `expenseTransactions.test.ts`
+- **Thin community `Community 998`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 998`** (1 nodes): `featuredItem.ts`
+- **Thin community `Community 999`** (1 nodes): `expenseTransactions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 999`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 1000`** (1 nodes): `featuredItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1000`** (1 nodes): `organizationMembers.ts`
+- **Thin community `Community 1001`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1001`** (1 nodes): `organizations.ts`
+- **Thin community `Community 1002`** (1 nodes): `organizationMembers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1002`** (1 nodes): `pos.ts`
+- **Thin community `Community 1003`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1003`** (1 nodes): `posCustomers.ts`
+- **Thin community `Community 1004`** (1 nodes): `pos.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1004`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 1005`** (1 nodes): `posCustomers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1005`** (1 nodes): `productSku.ts`
+- **Thin community `Community 1006`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1006`** (1 nodes): `productUtil.test.ts`
+- **Thin community `Community 1007`** (1 nodes): `productSku.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1007`** (1 nodes): `promoCode.test.ts`
+- **Thin community `Community 1008`** (1 nodes): `productUtil.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1008`** (1 nodes): `stockValidation.ts`
+- **Thin community `Community 1009`** (1 nodes): `promoCode.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1009`** (1 nodes): `storeConfigV2.test.ts`
+- **Thin community `Community 1010`** (1 nodes): `stockValidation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1010`** (1 nodes): `subcategories.ts`
+- **Thin community `Community 1011`** (1 nodes): `storeConfigV2.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1011`** (1 nodes): `commandResultValidators.test.ts`
+- **Thin community `Community 1012`** (1 nodes): `subcategories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1012`** (1 nodes): `currency.test.ts`
+- **Thin community `Community 1013`** (1 nodes): `commandResultValidators.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1013`** (1 nodes): `storeInsights.ts`
+- **Thin community `Community 1014`** (1 nodes): `currency.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1014`** (1 nodes): `userInsights.ts`
+- **Thin community `Community 1015`** (1 nodes): `storeInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1015`** (1 nodes): `migrateAmountsToPesewas.ts`
+- **Thin community `Community 1016`** (1 nodes): `userInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1016`** (1 nodes): `client.test.ts`
+- **Thin community `Community 1017`** (1 nodes): `migrateAmountsToPesewas.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1017`** (1 nodes): `config.test.ts`
+- **Thin community `Community 1018`** (1 nodes): `client.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1018`** (1 nodes): `normalize.test.ts`
+- **Thin community `Community 1019`** (1 nodes): `config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1019`** (1 nodes): `types.ts`
+- **Thin community `Community 1020`** (1 nodes): `normalize.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1020`** (1 nodes): `customerProfiles.test.ts`
+- **Thin community `Community 1021`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1021`** (1 nodes): `paymentAllocations.test.ts`
+- **Thin community `Community 1022`** (1 nodes): `customerProfiles.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1022`** (1 nodes): `EmailOTP.test.ts`
+- **Thin community `Community 1023`** (1 nodes): `paymentAllocations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1023`** (1 nodes): `correctTransactionCustomer.test.ts`
+- **Thin community `Community 1024`** (1 nodes): `EmailOTP.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1024`** (1 nodes): `correctionEvents.test.ts`
+- **Thin community `Community 1025`** (1 nodes): `correctTransactionCustomer.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1025`** (1 nodes): `correctionPolicy.test.ts`
+- **Thin community `Community 1026`** (1 nodes): `correctionEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1026`** (1 nodes): `dto.ts`
+- **Thin community `Community 1027`** (1 nodes): `correctionPolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1027`** (1 nodes): `getRegisterState.test.ts`
+- **Thin community `Community 1028`** (1 nodes): `dto.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1028`** (1 nodes): `posSessionTracing.test.ts`
+- **Thin community `Community 1029`** (1 nodes): `getRegisterState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1029`** (1 nodes): `types.ts`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1030`** (1 nodes): `terminals.test.ts`
+- **Thin community `Community 1030`** (1 nodes): `posSessionTracing.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1031`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1032`** (1 nodes): `registerSessionRepository.test.ts`
+- **Thin community `Community 1032`** (1 nodes): `terminals.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1033`** (1 nodes): `customers.ts`
+- **Thin community `Community 1033`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1034`** (1 nodes): `register.ts`
+- **Thin community `Community 1034`** (1 nodes): `registerSessionRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1035`** (1 nodes): `sync.ts`
+- **Thin community `Community 1035`** (1 nodes): `customers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1036`** (1 nodes): `schema.ts`
+- **Thin community `Community 1036`** (1 nodes): `register.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1037`** (1 nodes): `customerMessageDelivery.ts`
+- **Thin community `Community 1037`** (1 nodes): `sync.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1038`** (1 nodes): `index.ts`
+- **Thin community `Community 1038`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1039`** (1 nodes): `receiptShareToken.ts`
+- **Thin community `Community 1039`** (1 nodes): `customerMessageDelivery.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1040`** (1 nodes): `appVerificationCode.ts`
+- **Thin community `Community 1040`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1041`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 1041`** (1 nodes): `receiptShareToken.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1042`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 1042`** (1 nodes): `appVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1043`** (1 nodes): `bestSeller.ts`
+- **Thin community `Community 1043`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1044`** (1 nodes): `category.ts`
+- **Thin community `Community 1044`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1045`** (1 nodes): `color.ts`
+- **Thin community `Community 1045`** (1 nodes): `bestSeller.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1046`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 1046`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1047`** (1 nodes): `featuredItem.ts`
+- **Thin community `Community 1047`** (1 nodes): `color.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1048`** (1 nodes): `index.ts`
+- **Thin community `Community 1048`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1049`** (1 nodes): `inventoryHold.ts`
+- **Thin community `Community 1049`** (1 nodes): `featuredItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1050`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 1050`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1051`** (1 nodes): `organization.ts`
+- **Thin community `Community 1051`** (1 nodes): `inventoryHold.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1052`** (1 nodes): `organizationMember.ts`
+- **Thin community `Community 1052`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1053`** (1 nodes): `product.ts`
+- **Thin community `Community 1053`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1054`** (1 nodes): `promoCode.ts`
+- **Thin community `Community 1054`** (1 nodes): `organizationMember.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1055`** (1 nodes): `redeemedPromoCode.ts`
+- **Thin community `Community 1055`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1056`** (1 nodes): `store.ts`
+- **Thin community `Community 1056`** (1 nodes): `promoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1057`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1057`** (1 nodes): `redeemedPromoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1058`** (1 nodes): `index.ts`
+- **Thin community `Community 1058`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1059`** (1 nodes): `workflowTrace.ts`
+- **Thin community `Community 1059`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1060`** (1 nodes): `workflowTraceEvent.ts`
+- **Thin community `Community 1060`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1061`** (1 nodes): `workflowTraceLookup.ts`
+- **Thin community `Community 1061`** (1 nodes): `workflowTrace.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1062`** (1 nodes): `approvalRequest.ts`
+- **Thin community `Community 1062`** (1 nodes): `workflowTraceEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1063`** (1 nodes): `customerProfile.ts`
+- **Thin community `Community 1063`** (1 nodes): `workflowTraceLookup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1064`** (1 nodes): `dailyClose.ts`
+- **Thin community `Community 1064`** (1 nodes): `approvalRequest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1065`** (1 nodes): `dailyOpening.ts`
+- **Thin community `Community 1065`** (1 nodes): `customerProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1066`** (1 nodes): `index.ts`
+- **Thin community `Community 1066`** (1 nodes): `dailyClose.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1067`** (1 nodes): `inventoryMovement.ts`
+- **Thin community `Community 1067`** (1 nodes): `dailyOpening.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1068`** (1 nodes): `managerElevation.ts`
+- **Thin community `Community 1068`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1069`** (1 nodes): `operationalEvent.ts`
+- **Thin community `Community 1069`** (1 nodes): `inventoryMovement.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1070`** (1 nodes): `operationalWorkItem.ts`
+- **Thin community `Community 1070`** (1 nodes): `managerElevation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1071`** (1 nodes): `paymentAllocation.ts`
+- **Thin community `Community 1071`** (1 nodes): `operationalEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1072`** (1 nodes): `registerSession.ts`
+- **Thin community `Community 1072`** (1 nodes): `operationalWorkItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1073`** (1 nodes): `skuActivityEvent.ts`
+- **Thin community `Community 1073`** (1 nodes): `paymentAllocation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1074`** (1 nodes): `staffCredential.ts`
+- **Thin community `Community 1074`** (1 nodes): `registerSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1075`** (1 nodes): `staffProfile.ts`
+- **Thin community `Community 1075`** (1 nodes): `skuActivityEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1076`** (1 nodes): `staffRoleAssignment.ts`
+- **Thin community `Community 1076`** (1 nodes): `staffCredential.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1077`** (1 nodes): `mtnCollections.ts`
+- **Thin community `Community 1077`** (1 nodes): `staffProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1078`** (1 nodes): `customer.ts`
+- **Thin community `Community 1078`** (1 nodes): `staffRoleAssignment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1079`** (1 nodes): `expenseSession.ts`
+- **Thin community `Community 1079`** (1 nodes): `mtnCollections.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1080`** (1 nodes): `expenseSessionItem.ts`
+- **Thin community `Community 1080`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1081`** (1 nodes): `expenseTransaction.ts`
+- **Thin community `Community 1081`** (1 nodes): `expenseSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1082`** (1 nodes): `expenseTransactionItem.ts`
+- **Thin community `Community 1082`** (1 nodes): `expenseSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1083`** (1 nodes): `index.ts`
+- **Thin community `Community 1083`** (1 nodes): `expenseTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1084`** (1 nodes): `posLocalStaffProof.ts`
+- **Thin community `Community 1084`** (1 nodes): `expenseTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1085`** (1 nodes): `posLocalSyncConflict.ts`
+- **Thin community `Community 1085`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1086`** (1 nodes): `posLocalSyncCursor.ts`
+- **Thin community `Community 1086`** (1 nodes): `posLocalStaffProof.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1087`** (1 nodes): `posLocalSyncEvent.ts`
+- **Thin community `Community 1087`** (1 nodes): `posLocalSyncConflict.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1088`** (1 nodes): `posLocalSyncMapping.ts`
+- **Thin community `Community 1088`** (1 nodes): `posLocalSyncCursor.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1089`** (1 nodes): `posSession.ts`
+- **Thin community `Community 1089`** (1 nodes): `posLocalSyncEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1090`** (1 nodes): `posSessionItem.ts`
+- **Thin community `Community 1090`** (1 nodes): `posLocalSyncMapping.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1091`** (1 nodes): `posTerminal.test.ts`
+- **Thin community `Community 1091`** (1 nodes): `posSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1092`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 1092`** (1 nodes): `posSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1093`** (1 nodes): `posTransaction.ts`
+- **Thin community `Community 1093`** (1 nodes): `posTerminal.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1094`** (1 nodes): `posTransactionItem.ts`
+- **Thin community `Community 1094`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1095`** (1 nodes): `index.ts`
+- **Thin community `Community 1095`** (1 nodes): `posTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1096`** (1 nodes): `serviceAppointment.ts`
+- **Thin community `Community 1096`** (1 nodes): `posTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1097`** (1 nodes): `serviceCase.ts`
+- **Thin community `Community 1097`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1098`** (1 nodes): `serviceCaseLineItem.ts`
+- **Thin community `Community 1098`** (1 nodes): `serviceAppointment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1099`** (1 nodes): `serviceCatalog.ts`
+- **Thin community `Community 1099`** (1 nodes): `serviceCase.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1100`** (1 nodes): `serviceInventoryUsage.ts`
+- **Thin community `Community 1100`** (1 nodes): `serviceCaseLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1101`** (1 nodes): `cycleCountDraft.ts`
+- **Thin community `Community 1101`** (1 nodes): `serviceCatalog.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1102`** (1 nodes): `index.ts`
+- **Thin community `Community 1102`** (1 nodes): `serviceInventoryUsage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1103`** (1 nodes): `purchaseOrder.ts`
+- **Thin community `Community 1103`** (1 nodes): `cycleCountDraft.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1104`** (1 nodes): `purchaseOrderLineItem.ts`
+- **Thin community `Community 1104`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1105`** (1 nodes): `receivingBatch.ts`
+- **Thin community `Community 1105`** (1 nodes): `purchaseOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1106`** (1 nodes): `stockAdjustmentBatch.ts`
+- **Thin community `Community 1106`** (1 nodes): `purchaseOrderLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1107`** (1 nodes): `vendor.ts`
+- **Thin community `Community 1107`** (1 nodes): `receivingBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1108`** (1 nodes): `analytics.ts`
+- **Thin community `Community 1108`** (1 nodes): `stockAdjustmentBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1109`** (1 nodes): `bag.ts`
+- **Thin community `Community 1109`** (1 nodes): `vendor.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1110`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1110`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1111`** (1 nodes): `checkoutSession.ts`
+- **Thin community `Community 1111`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1112`** (1 nodes): `checkoutSessionItem.ts`
+- **Thin community `Community 1112`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1113`** (1 nodes): `guest.ts`
+- **Thin community `Community 1113`** (1 nodes): `checkoutSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1114`** (1 nodes): `index.ts`
+- **Thin community `Community 1114`** (1 nodes): `checkoutSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1115`** (1 nodes): `offer.ts`
+- **Thin community `Community 1115`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1116`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 1116`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1117`** (1 nodes): `onlineOrderItem.ts`
+- **Thin community `Community 1117`** (1 nodes): `offer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1118`** (1 nodes): `review.ts`
+- **Thin community `Community 1118`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1119`** (1 nodes): `rewards.ts`
+- **Thin community `Community 1119`** (1 nodes): `onlineOrderItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1120`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 1120`** (1 nodes): `review.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1121`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 1121`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1122`** (1 nodes): `storeFrontSession.ts`
+- **Thin community `Community 1122`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1123`** (1 nodes): `storeFrontUser.ts`
+- **Thin community `Community 1123`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1124`** (1 nodes): `storeFrontVerificationCode.ts`
+- **Thin community `Community 1124`** (1 nodes): `storeFrontSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1125`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 1125`** (1 nodes): `storeFrontUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1126`** (1 nodes): `catalogAppointments.test.ts`
+- **Thin community `Community 1126`** (1 nodes): `storeFrontVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1127`** (1 nodes): `bag.ts`
+- **Thin community `Community 1127`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1128`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1128`** (1 nodes): `catalogAppointments.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1129`** (1 nodes): `customer.ts`
+- **Thin community `Community 1129`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1130`** (1 nodes): `guest.ts`
+- **Thin community `Community 1130`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1131`** (1 nodes): `offers.test.ts`
+- **Thin community `Community 1131`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1132`** (1 nodes): `onlineOrderUtilFns.ts`
+- **Thin community `Community 1132`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1133`** (1 nodes): `orderOperations.test.ts`
+- **Thin community `Community 1133`** (1 nodes): `offers.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1134`** (1 nodes): `payment.test.ts`
+- **Thin community `Community 1134`** (1 nodes): `onlineOrderUtilFns.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1135`** (1 nodes): `payment.ts`
+- **Thin community `Community 1135`** (1 nodes): `orderOperations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1136`** (1 nodes): `paystackActions.ts`
+- **Thin community `Community 1136`** (1 nodes): `payment.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1137`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 1137`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1138`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 1138`** (1 nodes): `paystackActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1139`** (1 nodes): `users.ts`
+- **Thin community `Community 1139`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1140`** (1 nodes): `payment.ts`
+- **Thin community `Community 1140`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1141`** (1 nodes): `posSession.test.ts`
+- **Thin community `Community 1141`** (1 nodes): `users.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1142`** (1 nodes): `registerSession.test.ts`
+- **Thin community `Community 1142`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1143`** (1 nodes): `presentation.test.ts`
+- **Thin community `Community 1143`** (1 nodes): `posSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1144`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 1144`** (1 nodes): `registerSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1145`** (1 nodes): `index.ts`
+- **Thin community `Community 1145`** (1 nodes): `presentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1146`** (1 nodes): `postcss.config.js`
+- **Thin community `Community 1146`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1147`** (1 nodes): `approvalPolicy.ts`
+- **Thin community `Community 1147`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1148`** (1 nodes): `auth.ts`
+- **Thin community `Community 1148`** (1 nodes): `postcss.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1149`** (1 nodes): `commandResult.test.ts`
+- **Thin community `Community 1149`** (1 nodes): `approvalPolicy.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1150`** (1 nodes): `currencyFormatter.test.ts`
+- **Thin community `Community 1150`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1151`** (1 nodes): `posLocalSyncContract.ts`
+- **Thin community `Community 1151`** (1 nodes): `commandResult.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1152`** (1 nodes): `registerSessionStatus.test.ts`
+- **Thin community `Community 1152`** (1 nodes): `currencyFormatter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1153`** (1 nodes): `staffDisplayName.test.ts`
+- **Thin community `Community 1153`** (1 nodes): `posLocalSyncContract.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1154`** (1 nodes): `GenericComboBox.tsx`
+- **Thin community `Community 1154`** (1 nodes): `registerSessionStatus.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1155`** (1 nodes): `StoreAccordion.tsx`
+- **Thin community `Community 1155`** (1 nodes): `staffDisplayName.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1156`** (1 nodes): `StoresAccordion.tsx`
+- **Thin community `Community 1156`** (1 nodes): `GenericComboBox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1157`** (1 nodes): `ThemeToggle.tsx`
+- **Thin community `Community 1157`** (1 nodes): `StoreAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1158`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
+- **Thin community `Community 1158`** (1 nodes): `StoresAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1159`** (1 nodes): `ProductAttributes.tsx`
+- **Thin community `Community 1159`** (1 nodes): `ThemeToggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1160`** (1 nodes): `ProductAttributesView.tsx`
+- **Thin community `Community 1160`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1161`** (1 nodes): `ProductStock.test.ts`
+- **Thin community `Community 1161`** (1 nodes): `ProductAttributes.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1162`** (1 nodes): `ProductView.test.tsx`
+- **Thin community `Community 1162`** (1 nodes): `ProductAttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1163`** (1 nodes): `constants.ts`
+- **Thin community `Community 1163`** (1 nodes): `ProductStock.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1164`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1164`** (1 nodes): `ProductView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1165`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1165`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1166`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1166`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1167`** (1 nodes): `types.ts`
+- **Thin community `Community 1167`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1168`** (1 nodes): `ConversionFunnelChart.tsx`
+- **Thin community `Community 1168`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1169`** (1 nodes): `RevenueChart.tsx`
+- **Thin community `Community 1169`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1170`** (1 nodes): `analytics-columns.tsx`
+- **Thin community `Community 1170`** (1 nodes): `ConversionFunnelChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1171`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1171`** (1 nodes): `RevenueChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1172`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1172`** (1 nodes): `analytics-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1173`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1173`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1174`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1174`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1175`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1175`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1176`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1176`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1177`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1177`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1178`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1178`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1179`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1179`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1180`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1180`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1181`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1181`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1182`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1182`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1183`** (1 nodes): `chart.tsx`
+- **Thin community `Community 1183`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1184`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1184`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1185`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1185`** (1 nodes): `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1186`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1186`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1187`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1187`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1188`** (1 nodes): `constants.ts`
+- **Thin community `Community 1188`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1189`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1189`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1190`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1190`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1191`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1191`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1192`** (1 nodes): `data.ts`
+- **Thin community `Community 1192`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1193`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1193`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1194`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1194`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1195`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1195`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1196`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1196`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1197`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1197`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1198`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1198`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1199`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1199`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1200`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1200`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1201`** (1 nodes): `assetsColumns.tsx`
+- **Thin community `Community 1201`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1202`** (1 nodes): `constants.ts`
+- **Thin community `Community 1202`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1203`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1203`** (1 nodes): `assetsColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1204`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1204`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1205`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1205`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1206`** (1 nodes): `data.ts`
+- **Thin community `Community 1206`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1207`** (1 nodes): `DefaultCatchBoundary.test.tsx`
+- **Thin community `Community 1207`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1208`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 1208`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1209`** (1 nodes): `LoginForm.test.tsx`
+- **Thin community `Community 1209`** (1 nodes): `DefaultCatchBoundary.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1210`** (1 nodes): `LoginForm.tsx`
+- **Thin community `Community 1210`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1211`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1211`** (1 nodes): `LoginForm.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1212`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1212`** (1 nodes): `LoginForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1213`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1213`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1214`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1214`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1215`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1215`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1216`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1216`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1217`** (1 nodes): `constants.ts`
+- **Thin community `Community 1217`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1218`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1218`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1219`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1219`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1220`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1220`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1221`** (1 nodes): `BulkOperationsPage.tsx`
+- **Thin community `Community 1221`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1222`** (1 nodes): `CashControlsDashboard.auth.test.tsx`
+- **Thin community `Community 1222`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1223`** (1 nodes): `CashControlsDashboard.test.tsx`
+- **Thin community `Community 1223`** (1 nodes): `BulkOperationsPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1224`** (1 nodes): `CashControlsWorkspaceHeader.tsx`
+- **Thin community `Community 1224`** (1 nodes): `CashControlsDashboard.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1225`** (1 nodes): `RegisterSessionView.auth.test.tsx`
+- **Thin community `Community 1225`** (1 nodes): `CashControlsDashboard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1226`** (1 nodes): `RegisterSessionView.test.tsx`
+- **Thin community `Community 1226`** (1 nodes): `CashControlsWorkspaceHeader.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1227`** (1 nodes): `RegisterSessionsView.test.tsx`
+- **Thin community `Community 1227`** (1 nodes): `RegisterSessionView.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1228`** (1 nodes): `formatReviewReason.test.ts`
+- **Thin community `Community 1228`** (1 nodes): `RegisterSessionView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1229`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1229`** (1 nodes): `RegisterSessionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1230`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1230`** (1 nodes): `formatReviewReason.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1231`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1231`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1232`** (1 nodes): `ListPagination.tsx`
+- **Thin community `Community 1232`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1233`** (1 nodes): `PageLevelHeader.test.tsx`
+- **Thin community `Community 1233`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1234`** (1 nodes): `PageLevelHeader.tsx`
+- **Thin community `Community 1234`** (1 nodes): `ListPagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1235`** (1 nodes): `MetricCard.tsx`
+- **Thin community `Community 1235`** (1 nodes): `PageLevelHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1236`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 1236`** (1 nodes): `PageLevelHeader.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1237`** (1 nodes): `CommandApprovalDialog.test.tsx`
+- **Thin community `Community 1237`** (1 nodes): `MetricCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1238`** (1 nodes): `OperationReviewWorkspace.tsx`
+- **Thin community `Community 1238`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1239`** (1 nodes): `OperationsQueueView.auth.test.tsx`
+- **Thin community `Community 1239`** (1 nodes): `CommandApprovalDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1240`** (1 nodes): `SkuActivityTimeline.test.tsx`
+- **Thin community `Community 1240`** (1 nodes): `OperationReviewWorkspace.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1241`** (1 nodes): `skuActivityTimelineAdapter.test.ts`
+- **Thin community `Community 1241`** (1 nodes): `OperationsQueueView.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1242`** (1 nodes): `useApprovedCommand.test.tsx`
+- **Thin community `Community 1242`** (1 nodes): `SkuActivityTimeline.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1243`** (1 nodes): `OrderStatus.test.tsx`
+- **Thin community `Community 1243`** (1 nodes): `skuActivityTimelineAdapter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1244`** (1 nodes): `OrderStatus.tsx`
+- **Thin community `Community 1244`** (1 nodes): `useApprovedCommand.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1245`** (1 nodes): `OrderSummary.tsx`
+- **Thin community `Community 1245`** (1 nodes): `OrderStatus.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1246`** (1 nodes): `Orders.tsx`
+- **Thin community `Community 1246`** (1 nodes): `OrderStatus.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1247`** (1 nodes): `RefundsView.test.tsx`
+- **Thin community `Community 1247`** (1 nodes): `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1248`** (1 nodes): `ReturnExchangeView.test.tsx`
+- **Thin community `Community 1248`** (1 nodes): `Orders.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1249`** (1 nodes): `constants.ts`
+- **Thin community `Community 1249`** (1 nodes): `RefundsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1250`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1250`** (1 nodes): `ReturnExchangeView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1251`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1251`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1252`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1252`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1253`** (1 nodes): `data.ts`
+- **Thin community `Community 1253`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1254`** (1 nodes): `refundUtils.test.ts`
+- **Thin community `Community 1254`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1255`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1255`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1256`** (1 nodes): `constants.ts`
+- **Thin community `Community 1256`** (1 nodes): `refundUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1257`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1257`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1258`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1258`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1259`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1259`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1260`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1260`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1261`** (1 nodes): `data.ts`
+- **Thin community `Community 1261`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1262`** (1 nodes): `inviteColumns.tsx`
+- **Thin community `Community 1262`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1263`** (1 nodes): `constants.ts`
+- **Thin community `Community 1263`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1264`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1264`** (1 nodes): `inviteColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1265`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1265`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1266`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1266`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1267`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1267`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1268`** (1 nodes): `data.ts`
+- **Thin community `Community 1268`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1269`** (1 nodes): `membersColumns.tsx`
+- **Thin community `Community 1269`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1270`** (1 nodes): `organization-switcher.test.tsx`
+- **Thin community `Community 1270`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1271`** (1 nodes): `CashierView.tsx`
+- **Thin community `Community 1271`** (1 nodes): `membersColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1272`** (1 nodes): `POSRegisterView.tsx`
+- **Thin community `Community 1272`** (1 nodes): `organization-switcher.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1273`** (1 nodes): `PaymentView.test.tsx`
+- **Thin community `Community 1273`** (1 nodes): `CashierView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1274`** (1 nodes): `PointOfSaleView.test.tsx`
+- **Thin community `Community 1274`** (1 nodes): `POSRegisterView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1275`** (1 nodes): `PointOfSaleView.tsx`
+- **Thin community `Community 1275`** (1 nodes): `PaymentView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1276`** (1 nodes): `ProductLookup.tsx`
+- **Thin community `Community 1276`** (1 nodes): `PointOfSaleView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1277`** (1 nodes): `RegisterActions.tsx`
+- **Thin community `Community 1277`** (1 nodes): `PointOfSaleView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1278`** (1 nodes): `SessionManager.test.tsx`
+- **Thin community `Community 1278`** (1 nodes): `ProductLookup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1279`** (1 nodes): `SessionManager.tsx`
+- **Thin community `Community 1279`** (1 nodes): `RegisterActions.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1280`** (1 nodes): `TotalsDisplay.test.tsx`
+- **Thin community `Community 1280`** (1 nodes): `SessionManager.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1281`** (1 nodes): `TotalsDisplay.tsx`
+- **Thin community `Community 1281`** (1 nodes): `SessionManager.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1282`** (1 nodes): `ExpenseReportView.tsx`
+- **Thin community `Community 1282`** (1 nodes): `TotalsDisplay.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1283`** (1 nodes): `ExpenseReportsView.test.ts`
+- **Thin community `Community 1283`** (1 nodes): `TotalsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1284`** (1 nodes): `ExpenseReportsView.test.tsx`
+- **Thin community `Community 1284`** (1 nodes): `ExpenseReportView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1285`** (1 nodes): `expenseReportColumns.tsx`
+- **Thin community `Community 1285`** (1 nodes): `ExpenseReportsView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1286`** (1 nodes): `PosReceiptShareControl.test.tsx`
+- **Thin community `Community 1286`** (1 nodes): `ExpenseReportsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1287`** (1 nodes): `POSRegisterOpeningGuard.test.tsx`
+- **Thin community `Community 1287`** (1 nodes): `expenseReportColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1288`** (1 nodes): `RegisterActionBar.test.tsx`
+- **Thin community `Community 1288`** (1 nodes): `PosReceiptShareControl.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1289`** (1 nodes): `RegisterActionBar.tsx`
+- **Thin community `Community 1289`** (1 nodes): `POSRegisterOpeningGuard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1290`** (1 nodes): `RegisterCheckoutPanel.tsx`
+- **Thin community `Community 1290`** (1 nodes): `RegisterActionBar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1291`** (1 nodes): `HeldSessionsList.test.tsx`
+- **Thin community `Community 1291`** (1 nodes): `RegisterActionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1292`** (1 nodes): `POSSessionsView.test.tsx`
+- **Thin community `Community 1292`** (1 nodes): `RegisterCheckoutPanel.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1293`** (1 nodes): `posSessionColumns.tsx`
+- **Thin community `Community 1293`** (1 nodes): `HeldSessionsList.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1294`** (1 nodes): `POSSettingsView.test.tsx`
+- **Thin community `Community 1294`** (1 nodes): `POSSessionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1295`** (1 nodes): `TransactionsView.test.tsx`
+- **Thin community `Community 1295`** (1 nodes): `posSessionColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1296`** (1 nodes): `types.ts`
+- **Thin community `Community 1296`** (1 nodes): `POSSettingsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1297`** (1 nodes): `ReceivingView.test.tsx`
+- **Thin community `Community 1297`** (1 nodes): `TransactionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1298`** (1 nodes): `AnalyticsInsights.tsx`
+- **Thin community `Community 1298`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1299`** (1 nodes): `AttributesView.tsx`
+- **Thin community `Community 1299`** (1 nodes): `ReceivingView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1300`** (1 nodes): `DetailsView.tsx`
+- **Thin community `Community 1300`** (1 nodes): `AnalyticsInsights.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1301`** (1 nodes): `ProductDetailView.tsx`
+- **Thin community `Community 1301`** (1 nodes): `AttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1302`** (1 nodes): `ArchivedProducts.tsx`
+- **Thin community `Community 1302`** (1 nodes): `DetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1303`** (1 nodes): `CategoryListView.tsx`
+- **Thin community `Community 1303`** (1 nodes): `ProductDetailView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1304`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
+- **Thin community `Community 1304`** (1 nodes): `ArchivedProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1305`** (1 nodes): `Products.tsx`
+- **Thin community `Community 1305`** (1 nodes): `CategoryListView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1306`** (1 nodes): `StoreProducts.tsx`
+- **Thin community `Community 1306`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1307`** (1 nodes): `UnresolvedProducts.tsx`
+- **Thin community `Community 1307`** (1 nodes): `Products.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1308`** (1 nodes): `ComplimentaryProducts.tsx`
+- **Thin community `Community 1308`** (1 nodes): `StoreProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1309`** (1 nodes): `complimentaryProductsColumn.tsx`
+- **Thin community `Community 1309`** (1 nodes): `UnresolvedProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1310`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1310`** (1 nodes): `ComplimentaryProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1311`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1311`** (1 nodes): `complimentaryProductsColumn.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1312`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1312`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1313`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1313`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1314`** (1 nodes): `data.ts`
+- **Thin community `Community 1314`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1315`** (1 nodes): `productColumns.tsx`
+- **Thin community `Community 1315`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1316`** (1 nodes): `PromoCodeHeader.test.tsx`
+- **Thin community `Community 1316`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1317`** (1 nodes): `PromoCodes.tsx`
+- **Thin community `Community 1317`** (1 nodes): `productColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1318`** (1 nodes): `PromoCodeAnalytics.tsx`
+- **Thin community `Community 1318`** (1 nodes): `PromoCodeHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1319`** (1 nodes): `captured-emails-columns.tsx`
+- **Thin community `Community 1319`** (1 nodes): `PromoCodes.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1320`** (1 nodes): `promoCodeMoney.test.ts`
+- **Thin community `Community 1320`** (1 nodes): `PromoCodeAnalytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1321`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1321`** (1 nodes): `captured-emails-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1322`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1322`** (1 nodes): `promoCodeMoney.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1323`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1323`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1324`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1324`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1325`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1325`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1326`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1326`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1327`** (1 nodes): `constants.ts`
+- **Thin community `Community 1327`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1328`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1328`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1329`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1329`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1330`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1330`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1331`** (1 nodes): `data.ts`
+- **Thin community `Community 1331`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1332`** (1 nodes): `types.ts`
+- **Thin community `Community 1332`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1333`** (1 nodes): `welcome-offer-card.tsx`
+- **Thin community `Community 1333`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1334`** (1 nodes): `RatingStars.tsx`
+- **Thin community `Community 1334`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1335`** (1 nodes): `ReviewCard.tsx`
+- **Thin community `Community 1335`** (1 nodes): `welcome-offer-card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1336`** (1 nodes): `ReviewMetadata.tsx`
+- **Thin community `Community 1336`** (1 nodes): `RatingStars.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1337`** (1 nodes): `ServicesWorkspaceView.test.tsx`
+- **Thin community `Community 1337`** (1 nodes): `ReviewCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1338`** (1 nodes): `index.tsx`
+- **Thin community `Community 1338`** (1 nodes): `ReviewMetadata.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1339`** (1 nodes): `StaffAuthenticationDialog.test.tsx`
+- **Thin community `Community 1339`** (1 nodes): `ServicesWorkspaceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1340`** (1 nodes): `StaffPinInput.tsx`
+- **Thin community `Community 1340`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1341`** (1 nodes): `FeesView.test.ts`
+- **Thin community `Community 1341`** (1 nodes): `StaffAuthenticationDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1342`** (1 nodes): `FulfillmentView.test.tsx`
+- **Thin community `Community 1342`** (1 nodes): `StaffPinInput.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1343`** (1 nodes): `MaintenanceView.test.tsx`
+- **Thin community `Community 1343`** (1 nodes): `FeesView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1344`** (1 nodes): `MtnMomoView.test.tsx`
+- **Thin community `Community 1344`** (1 nodes): `FulfillmentView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1345`** (1 nodes): `useStoreConfigUpdate.test.tsx`
+- **Thin community `Community 1345`** (1 nodes): `MaintenanceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1346`** (1 nodes): `index.tsx`
+- **Thin community `Community 1346`** (1 nodes): `MtnMomoView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1347`** (1 nodes): `WorkflowTraceView.test.tsx`
+- **Thin community `Community 1347`** (1 nodes): `useStoreConfigUpdate.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1348`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 1348`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1349`** (1 nodes): `button.test.tsx`
+- **Thin community `Community 1349`** (1 nodes): `WorkflowTraceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1350`** (1 nodes): `button.tsx`
+- **Thin community `Community 1350`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1351`** (1 nodes): `calendar.test.tsx`
+- **Thin community `Community 1351`** (1 nodes): `button.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1352`** (1 nodes): `card.tsx`
+- **Thin community `Community 1352`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1353`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 1353`** (1 nodes): `calendar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1354`** (1 nodes): `collapsible.tsx`
+- **Thin community `Community 1354`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1355`** (1 nodes): `command.tsx`
+- **Thin community `Community 1355`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1356`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 1356`** (1 nodes): `collapsible.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1357`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 1357`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1358`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 1358`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1359`** (1 nodes): `form.tsx`
+- **Thin community `Community 1359`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1360`** (1 nodes): `icons.tsx`
+- **Thin community `Community 1360`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1361`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 1361`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1362`** (1 nodes): `input.tsx`
+- **Thin community `Community 1362`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1363`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 1363`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1364`** (1 nodes): `panel-header.tsx`
+- **Thin community `Community 1364`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1365`** (1 nodes): `popover.tsx`
+- **Thin community `Community 1365`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1366`** (1 nodes): `primitives.test.tsx`
+- **Thin community `Community 1366`** (1 nodes): `panel-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1367`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 1367`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1368`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 1368`** (1 nodes): `primitives.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1369`** (1 nodes): `select.tsx`
+- **Thin community `Community 1369`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1370`** (1 nodes): `separator.tsx`
+- **Thin community `Community 1370`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1371`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 1371`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1372`** (1 nodes): `switch.tsx`
+- **Thin community `Community 1372`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1373`** (1 nodes): `table.tsx`
+- **Thin community `Community 1373`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1374`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 1374`** (1 nodes): `switch.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1375`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 1375`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1376`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 1376`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1377`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 1377`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1378`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 1378`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1379`** (1 nodes): `upload-button.tsx`
+- **Thin community `Community 1379`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1380`** (1 nodes): `BagView.tsx`
+- **Thin community `Community 1380`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1381`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1381`** (1 nodes): `upload-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1382`** (1 nodes): `constants.ts`
+- **Thin community `Community 1382`** (1 nodes): `BagView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1383`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1383`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1384`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1384`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1385`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1385`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1386`** (1 nodes): `data.ts`
+- **Thin community `Community 1386`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1387`** (1 nodes): `bag-columns.tsx`
+- **Thin community `Community 1387`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1388`** (1 nodes): `bags-table.tsx`
+- **Thin community `Community 1388`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1389`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1389`** (1 nodes): `bag-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1390`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1390`** (1 nodes): `bags-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1391`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1391`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1392`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1392`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1393`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1393`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1394`** (1 nodes): `LinkedAccounts.tsx`
+- **Thin community `Community 1394`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1395`** (1 nodes): `TimelineEventCard.test.tsx`
+- **Thin community `Community 1395`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1396`** (1 nodes): `UserCheckoutSession.tsx`
+- **Thin community `Community 1396`** (1 nodes): `LinkedAccounts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1397`** (1 nodes): `UserInsightsSection.tsx`
+- **Thin community `Community 1397`** (1 nodes): `TimelineEventCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1398`** (1 nodes): `index.ts`
+- **Thin community `Community 1398`** (1 nodes): `UserCheckoutSession.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1399`** (1 nodes): `config.test.ts`
+- **Thin community `Community 1399`** (1 nodes): `UserInsightsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1400`** (1 nodes): `ThemeContext.tsx`
+- **Thin community `Community 1400`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1401`** (1 nodes): `design-system-build-config.test.ts`
+- **Thin community `Community 1401`** (1 nodes): `config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1402`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 1402`** (1 nodes): `ThemeContext.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1403`** (1 nodes): `useAuth.test.tsx`
+- **Thin community `Community 1403`** (1 nodes): `design-system-build-config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1404`** (1 nodes): `useExpenseSessions.test.ts`
+- **Thin community `Community 1404`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1405`** (1 nodes): `useGetTerminal.test.ts`
+- **Thin community `Community 1405`** (1 nodes): `useAuth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1406`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 1406`** (1 nodes): `useExpenseSessions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1407`** (1 nodes): `useProtectedAdminPageState.test.tsx`
+- **Thin community `Community 1407`** (1 nodes): `useGetTerminal.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1408`** (1 nodes): `capabilities.test.ts`
+- **Thin community `Community 1408`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1409`** (1 nodes): `aws.ts`
+- **Thin community `Community 1409`** (1 nodes): `useProtectedAdminPageState.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1410`** (1 nodes): `constants.ts`
+- **Thin community `Community 1410`** (1 nodes): `capabilities.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1411`** (1 nodes): `countries.ts`
+- **Thin community `Community 1411`** (1 nodes): `aws.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1412`** (1 nodes): `operatorMessages.test.ts`
+- **Thin community `Community 1412`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1413`** (1 nodes): `presentCommandToast.test.ts`
+- **Thin community `Community 1413`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1414`** (1 nodes): `presentUnexpectedErrorToast.test.ts`
+- **Thin community `Community 1414`** (1 nodes): `operatorMessages.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1415`** (1 nodes): `runCommand.test.ts`
+- **Thin community `Community 1415`** (1 nodes): `presentCommandToast.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1416`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1416`** (1 nodes): `presentUnexpectedErrorToast.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1417`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 1417`** (1 nodes): `runCommand.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1418`** (1 nodes): `dto.ts`
+- **Thin community `Community 1418`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1419`** (1 nodes): `ports.ts`
+- **Thin community `Community 1419`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1420`** (1 nodes): `constants.ts`
+- **Thin community `Community 1420`** (1 nodes): `dto.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1421`** (1 nodes): `displayAmounts.test.ts`
+- **Thin community `Community 1421`** (1 nodes): `ports.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1422`** (1 nodes): `cart.test.ts`
+- **Thin community `Community 1422`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1423`** (1 nodes): `index.ts`
+- **Thin community `Community 1423`** (1 nodes): `displayAmounts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1424`** (1 nodes): `session.test.ts`
+- **Thin community `Community 1424`** (1 nodes): `cart.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1425`** (1 nodes): `types.ts`
+- **Thin community `Community 1425`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1426`** (1 nodes): `registerGateway.test.ts`
+- **Thin community `Community 1426`** (1 nodes): `session.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1427`** (1 nodes): `sessionGateway.test.ts`
+- **Thin community `Community 1427`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1428`** (1 nodes): `localCommandGateway.test.ts`
+- **Thin community `Community 1428`** (1 nodes): `registerGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1429`** (1 nodes): `localPosEntryContext.test.ts`
+- **Thin community `Community 1429`** (1 nodes): `sessionGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1430`** (1 nodes): `localPosReadiness.test.ts`
+- **Thin community `Community 1430`** (1 nodes): `localCommandGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1431`** (1 nodes): `loggerGateway.ts`
+- **Thin community `Community 1431`** (1 nodes): `localPosEntryContext.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1432`** (1 nodes): `catalogSearch.test.ts`
+- **Thin community `Community 1432`** (1 nodes): `localPosReadiness.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1433`** (1 nodes): `registerUiState.ts`
+- **Thin community `Community 1433`** (1 nodes): `loggerGateway.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1434`** (1 nodes): `syncStatusPresentation.test.ts`
+- **Thin community `Community 1434`** (1 nodes): `catalogSearch.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1435`** (1 nodes): `productUtils.test.ts`
+- **Thin community `Community 1435`** (1 nodes): `registerUiState.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1436`** (1 nodes): `category.ts`
+- **Thin community `Community 1436`** (1 nodes): `syncStatusPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1437`** (1 nodes): `product.ts`
+- **Thin community `Community 1437`** (1 nodes): `productUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1438`** (1 nodes): `store.ts`
+- **Thin community `Community 1438`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1439`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1439`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1440`** (1 nodes): `user.ts`
+- **Thin community `Community 1440`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1441`** (1 nodes): `localPinVerifier.test.ts`
+- **Thin community `Community 1441`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1442`** (1 nodes): `storeConfig.test.ts`
+- **Thin community `Community 1442`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1443`** (1 nodes): `createWorkflowTraceId.test.ts`
+- **Thin community `Community 1443`** (1 nodes): `localPinVerifier.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1444`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1444`** (1 nodes): `storeConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1445`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 1445`** (1 nodes): `createWorkflowTraceId.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1446`** (1 nodes): `__root.tsx`
+- **Thin community `Community 1446`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1447`** (1 nodes): `index.tsx`
+- **Thin community `Community 1447`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1448`** (1 nodes): `index.tsx`
+- **Thin community `Community 1448`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1449`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1450`** (1 nodes): `$storeUrlSlug.tsx`
+- **Thin community `Community 1450`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1451`** (1 nodes): `analytics.tsx`
+- **Thin community `Community 1451`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1452`** (1 nodes): `assets.index.tsx`
+- **Thin community `Community 1452`** (1 nodes): `$storeUrlSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1453`** (1 nodes): `bags.$bagId.tsx`
+- **Thin community `Community 1453`** (1 nodes): `analytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1454`** (1 nodes): `bags.index.tsx`
+- **Thin community `Community 1454`** (1 nodes): `assets.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1455`** (1 nodes): `index.tsx`
+- **Thin community `Community 1455`** (1 nodes): `bags.$bagId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1456`** (1 nodes): `checkout-sessions.index.tsx`
+- **Thin community `Community 1456`** (1 nodes): `bags.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1457`** (1 nodes): `configuration.index.tsx`
+- **Thin community `Community 1457`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1458`** (1 nodes): `dashboard.index.tsx`
+- **Thin community `Community 1458`** (1 nodes): `checkout-sessions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1459`** (1 nodes): `home.tsx`
+- **Thin community `Community 1459`** (1 nodes): `configuration.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1460`** (1 nodes): `logs.$logId.tsx`
+- **Thin community `Community 1460`** (1 nodes): `dashboard.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1461`** (1 nodes): `logs.index.tsx`
+- **Thin community `Community 1461`** (1 nodes): `home.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1462`** (1 nodes): `members.index.tsx`
+- **Thin community `Community 1462`** (1 nodes): `logs.$logId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1463`** (1 nodes): `index.tsx`
+- **Thin community `Community 1463`** (1 nodes): `logs.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1464`** (1 nodes): `sku-activity.test.tsx`
+- **Thin community `Community 1464`** (1 nodes): `members.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1465`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1466`** (1 nodes): `all.index.tsx`
+- **Thin community `Community 1466`** (1 nodes): `sku-activity.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1467`** (1 nodes): `cancelled.index.tsx`
+- **Thin community `Community 1467`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1468`** (1 nodes): `completed.index.tsx`
+- **Thin community `Community 1468`** (1 nodes): `all.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1469`** (1 nodes): `index.tsx`
+- **Thin community `Community 1469`** (1 nodes): `cancelled.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1470`** (1 nodes): `open.index.tsx`
+- **Thin community `Community 1470`** (1 nodes): `completed.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1471`** (1 nodes): `out-for-delivery.index.tsx`
+- **Thin community `Community 1471`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1472`** (1 nodes): `ready.index.tsx`
+- **Thin community `Community 1472`** (1 nodes): `open.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1473`** (1 nodes): `refunded.index.tsx`
+- **Thin community `Community 1473`** (1 nodes): `out-for-delivery.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1474`** (1 nodes): `$reportId.tsx`
+- **Thin community `Community 1474`** (1 nodes): `ready.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1475`** (1 nodes): `expense-reports.index.tsx`
+- **Thin community `Community 1475`** (1 nodes): `refunded.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1476`** (1 nodes): `index.tsx`
+- **Thin community `Community 1476`** (1 nodes): `$reportId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1477`** (1 nodes): `register.index.tsx`
+- **Thin community `Community 1477`** (1 nodes): `expense-reports.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1478`** (1 nodes): `sessions.index.tsx`
+- **Thin community `Community 1478`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1479`** (1 nodes): `settings.index.tsx`
+- **Thin community `Community 1479`** (1 nodes): `register.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1480`** (1 nodes): `$transactionId.tsx`
+- **Thin community `Community 1480`** (1 nodes): `sessions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1481`** (1 nodes): `transactions.index.tsx`
+- **Thin community `Community 1481`** (1 nodes): `settings.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1482`** (1 nodes): `procurement.index.test.ts`
+- **Thin community `Community 1482`** (1 nodes): `$transactionId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1483`** (1 nodes): `edit.tsx`
+- **Thin community `Community 1483`** (1 nodes): `transactions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1484`** (1 nodes): `index.tsx`
+- **Thin community `Community 1484`** (1 nodes): `procurement.index.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1485`** (1 nodes): `archived.tsx`
+- **Thin community `Community 1485`** (1 nodes): `edit.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1486`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1487`** (1 nodes): `new.tsx`
+- **Thin community `Community 1487`** (1 nodes): `archived.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1488`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1489`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1490`** (1 nodes): `unresolved.tsx`
+- **Thin community `Community 1490`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1491`** (1 nodes): `$promoCodeSlug.tsx`
+- **Thin community `Community 1491`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1492`** (1 nodes): `index.tsx`
+- **Thin community `Community 1492`** (1 nodes): `unresolved.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1493`** (1 nodes): `new.tsx`
+- **Thin community `Community 1493`** (1 nodes): `$promoCodeSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1494`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1495`** (1 nodes): `new.index.tsx`
+- **Thin community `Community 1495`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1496`** (1 nodes): `active-cases.index.tsx`
+- **Thin community `Community 1496`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1497`** (1 nodes): `appointments.index.tsx`
+- **Thin community `Community 1497`** (1 nodes): `new.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1498`** (1 nodes): `catalog-management.index.tsx`
+- **Thin community `Community 1498`** (1 nodes): `active-cases.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1499`** (1 nodes): `index.tsx`
+- **Thin community `Community 1499`** (1 nodes): `appointments.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1500`** (1 nodes): `intake.index.tsx`
+- **Thin community `Community 1500`** (1 nodes): `catalog-management.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1501`** (1 nodes): `$traceId.test.tsx`
+- **Thin community `Community 1501`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1502`** (1 nodes): `users.$userId.tsx`
+- **Thin community `Community 1502`** (1 nodes): `intake.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1503`** (1 nodes): `index.tsx`
+- **Thin community `Community 1503`** (1 nodes): `$traceId.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1504`** (1 nodes): `_authed.test.tsx`
+- **Thin community `Community 1504`** (1 nodes): `users.$userId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1505`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 1505`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1506`** (1 nodes): `join-team.index.tsx`
+- **Thin community `Community 1506`** (1 nodes): `_authed.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1507`** (1 nodes): `landing.tsx`
+- **Thin community `Community 1507`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1508`** (1 nodes): `_layout.index.test.tsx`
+- **Thin community `Community 1508`** (1 nodes): `join-team.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1509`** (1 nodes): `_layout.test.tsx`
+- **Thin community `Community 1509`** (1 nodes): `landing.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1510`** (1 nodes): `StoresSettingsAccordion.tsx`
+- **Thin community `Community 1510`** (1 nodes): `_layout.index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1511`** (1 nodes): `expenseStore.ts`
+- **Thin community `Community 1511`** (1 nodes): `_layout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1512`** (1 nodes): `Overview.stories.tsx`
+- **Thin community `Community 1512`** (1 nodes): `StoresSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1513`** (1 nodes): `foundations-content.test.tsx`
+- **Thin community `Community 1513`** (1 nodes): `expenseStore.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1514`** (1 nodes): `Introduction.stories.tsx`
+- **Thin community `Community 1514`** (1 nodes): `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1515`** (1 nodes): `introduction-content.test.tsx`
+- **Thin community `Community 1515`** (1 nodes): `foundations-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1516`** (1 nodes): `introduction-content.tsx`
+- **Thin community `Community 1516`** (1 nodes): `Introduction.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1517`** (1 nodes): `AdminShell.stories.tsx`
+- **Thin community `Community 1517`** (1 nodes): `introduction-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1518`** (1 nodes): `View.stories.tsx`
+- **Thin community `Community 1518`** (1 nodes): `introduction-content.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1519`** (1 nodes): `admin-shell-patterns.test.tsx`
+- **Thin community `Community 1519`** (1 nodes): `AdminShell.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1520`** (1 nodes): `view-patterns.test.tsx`
+- **Thin community `Community 1520`** (1 nodes): `View.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1521`** (1 nodes): `Surfaces.stories.tsx`
+- **Thin community `Community 1521`** (1 nodes): `admin-shell-patterns.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1522`** (1 nodes): `DashboardWorkspace.stories.tsx`
+- **Thin community `Community 1522`** (1 nodes): `view-patterns.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1523`** (1 nodes): `DataWorkspace.stories.tsx`
+- **Thin community `Community 1523`** (1 nodes): `Surfaces.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1524`** (1 nodes): `SettingsWorkspace.stories.tsx`
+- **Thin community `Community 1524`** (1 nodes): `DashboardWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1525`** (1 nodes): `reference-fixtures.test.tsx`
+- **Thin community `Community 1525`** (1 nodes): `DataWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1526`** (1 nodes): `storybook-config.test.ts`
+- **Thin community `Community 1526`** (1 nodes): `SettingsWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1527`** (1 nodes): `storybook-theme-decorator.test.ts`
+- **Thin community `Community 1527`** (1 nodes): `reference-fixtures.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1528`** (1 nodes): `setup.ts`
+- **Thin community `Community 1528`** (1 nodes): `storybook-config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1529`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 1529`** (1 nodes): `storybook-theme-decorator.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1530`** (1 nodes): `types.ts`
+- **Thin community `Community 1530`** (1 nodes): `setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1531`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 1531`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1532`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 1532`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1533`** (1 nodes): `global.d.ts`
+- **Thin community `Community 1533`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1534`** (1 nodes): `playwright.config.ts`
+- **Thin community `Community 1534`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1535`** (1 nodes): `analytics.test.ts`
+- **Thin community `Community 1535`** (1 nodes): `global.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1536`** (1 nodes): `types.ts`
+- **Thin community `Community 1536`** (1 nodes): `playwright.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1537`** (1 nodes): `HeartIconFilled.tsx`
+- **Thin community `Community 1537`** (1 nodes): `analytics.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1538`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 1538`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1539`** (1 nodes): `HomePage.test.tsx`
+- **Thin community `Community 1539`** (1 nodes): `HeartIconFilled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1540`** (1 nodes): `ProductCard.test.tsx`
+- **Thin community `Community 1540`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1541`** (1 nodes): `ProductCard.tsx`
+- **Thin community `Community 1541`** (1 nodes): `HomePage.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1542`** (1 nodes): `Upsell.tsx`
+- **Thin community `Community 1542`** (1 nodes): `ProductCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1543`** (1 nodes): `Checkout.test.tsx`
+- **Thin community `Community 1543`** (1 nodes): `ProductCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1544`** (1 nodes): `Checkout.tsx`
+- **Thin community `Community 1544`** (1 nodes): `Upsell.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1545`** (1 nodes): `CustomerInfoSection.tsx`
+- **Thin community `Community 1545`** (1 nodes): `Checkout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1546`** (1 nodes): `schema.ts`
+- **Thin community `Community 1546`** (1 nodes): `Checkout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1547`** (1 nodes): `DeliveryDetailsSection.tsx`
+- **Thin community `Community 1547`** (1 nodes): `CustomerInfoSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1548`** (1 nodes): `checkoutStorage.test.ts`
+- **Thin community `Community 1548`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1549`** (1 nodes): `deliveryFees.test.ts`
+- **Thin community `Community 1549`** (1 nodes): `DeliveryDetailsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1550`** (1 nodes): `deriveCheckoutState.test.ts`
+- **Thin community `Community 1550`** (1 nodes): `checkoutStorage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1551`** (1 nodes): `billingDetailsSchema.ts`
+- **Thin community `Community 1551`** (1 nodes): `deliveryFees.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1552`** (1 nodes): `checkoutFormSchema.ts`
+- **Thin community `Community 1552`** (1 nodes): `deriveCheckoutState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1553`** (1 nodes): `customerDetailsSchema.ts`
+- **Thin community `Community 1553`** (1 nodes): `billingDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1554`** (1 nodes): `deliveryDetailsSchema.ts`
+- **Thin community `Community 1554`** (1 nodes): `checkoutFormSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1555`** (1 nodes): `webOrderSchema.ts`
+- **Thin community `Community 1555`** (1 nodes): `customerDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1556`** (1 nodes): `types.ts`
+- **Thin community `Community 1556`** (1 nodes): `deliveryDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1557`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1557`** (1 nodes): `webOrderSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1558`** (1 nodes): `ProductFilterBar.tsx`
+- **Thin community `Community 1558`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1559`** (1 nodes): `BestSellersSection.test.tsx`
+- **Thin community `Community 1559`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1560`** (1 nodes): `HomeHero.tsx`
+- **Thin community `Community 1560`** (1 nodes): `ProductFilterBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1561`** (1 nodes): `HomeHeroSection.tsx`
+- **Thin community `Community 1561`** (1 nodes): `BestSellersSection.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1562`** (1 nodes): `homePageContent.test.ts`
+- **Thin community `Community 1562`** (1 nodes): `HomeHero.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1563`** (1 nodes): `MobileMenu.tsx`
+- **Thin community `Community 1563`** (1 nodes): `HomeHeroSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1564`** (1 nodes): `constants.ts`
+- **Thin community `Community 1564`** (1 nodes): `homePageContent.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1565`** (1 nodes): `navBarConstants.ts`
+- **Thin community `Community 1565`** (1 nodes): `MobileMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1566`** (1 nodes): `About.tsx`
+- **Thin community `Community 1566`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1567`** (1 nodes): `AboutProduct.tsx`
+- **Thin community `Community 1567`** (1 nodes): `navBarConstants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1568`** (1 nodes): `ProductActions.test.tsx`
+- **Thin community `Community 1568`** (1 nodes): `About.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1569`** (1 nodes): `ProductInfo.tsx`
+- **Thin community `Community 1569`** (1 nodes): `AboutProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1570`** (1 nodes): `ProductReviews.tsx`
+- **Thin community `Community 1570`** (1 nodes): `ProductActions.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1571`** (1 nodes): `ProductsNavigationBar.tsx`
+- **Thin community `Community 1571`** (1 nodes): `ProductInfo.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1572`** (1 nodes): `ErrorMessage.tsx`
+- **Thin community `Community 1572`** (1 nodes): `ProductReviews.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1573`** (1 nodes): `ExistingReviewMessage.tsx`
+- **Thin community `Community 1573`** (1 nodes): `ProductsNavigationBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1574`** (1 nodes): `OrderItem.test.tsx`
+- **Thin community `Community 1574`** (1 nodes): `ErrorMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1575`** (1 nodes): `ReviewForm.tsx`
+- **Thin community `Community 1575`** (1 nodes): `ExistingReviewMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1576`** (1 nodes): `SuccessMessage.tsx`
+- **Thin community `Community 1576`** (1 nodes): `OrderItem.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1577`** (1 nodes): `types.ts`
+- **Thin community `Community 1577`** (1 nodes): `ReviewForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1578`** (1 nodes): `SavedBag.tsx`
+- **Thin community `Community 1578`** (1 nodes): `SuccessMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1579`** (1 nodes): `SavedIcon.tsx`
+- **Thin community `Community 1579`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1580`** (1 nodes): `CartIcon.tsx`
+- **Thin community `Community 1580`** (1 nodes): `SavedBag.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1581`** (1 nodes): `ShoppingBag.test.tsx`
+- **Thin community `Community 1581`** (1 nodes): `SavedIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1582`** (1 nodes): `empty-state.tsx`
+- **Thin community `Community 1582`** (1 nodes): `CartIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1583`** (1 nodes): `Maintenance.test.tsx`
+- **Thin community `Community 1583`** (1 nodes): `ShoppingBag.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1584`** (1 nodes): `Maintenance.tsx`
+- **Thin community `Community 1584`** (1 nodes): `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1585`** (1 nodes): `AnimatedCard.tsx`
+- **Thin community `Community 1585`** (1 nodes): `Maintenance.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1586`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 1586`** (1 nodes): `Maintenance.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1587`** (1 nodes): `alert.tsx`
+- **Thin community `Community 1587`** (1 nodes): `AnimatedCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1588`** (1 nodes): `breadcrumb.tsx`
+- **Thin community `Community 1588`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1589`** (1 nodes): `button.tsx`
+- **Thin community `Community 1589`** (1 nodes): `alert.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1590`** (1 nodes): `card.tsx`
+- **Thin community `Community 1590`** (1 nodes): `breadcrumb.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1591`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 1591`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1592`** (1 nodes): `command.tsx`
+- **Thin community `Community 1592`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1593`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 1593`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1594`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 1594`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1595`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 1595`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1596`** (1 nodes): `form.tsx`
+- **Thin community `Community 1596`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1597`** (1 nodes): `icons.tsx`
+- **Thin community `Community 1597`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1598`** (1 nodes): `image-with-fallback.tsx`
+- **Thin community `Community 1598`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1599`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 1599`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1600`** (1 nodes): `input-with-end-button.tsx`
+- **Thin community `Community 1600`** (1 nodes): `image-with-fallback.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1601`** (1 nodes): `input.tsx`
+- **Thin community `Community 1601`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1602`** (1 nodes): `label.tsx`
+- **Thin community `Community 1602`** (1 nodes): `input-with-end-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1603`** (1 nodes): `LeaveAReviewModalForm.tsx`
+- **Thin community `Community 1603`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1604`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 1604`** (1 nodes): `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1605`** (1 nodes): `welcomeBackModalAnimations.ts`
+- **Thin community `Community 1605`** (1 nodes): `LeaveAReviewModalForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1606`** (1 nodes): `index.ts`
+- **Thin community `Community 1606`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1607`** (1 nodes): `types.ts`
+- **Thin community `Community 1607`** (1 nodes): `welcomeBackModalAnimations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1608`** (1 nodes): `navigation-menu.tsx`
+- **Thin community `Community 1608`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1609`** (1 nodes): `popover.tsx`
+- **Thin community `Community 1609`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1610`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 1610`** (1 nodes): `navigation-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1611`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 1611`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1612`** (1 nodes): `select.tsx`
+- **Thin community `Community 1612`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1613`** (1 nodes): `separator.tsx`
+- **Thin community `Community 1613`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1614`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 1614`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1615`** (1 nodes): `table.tsx`
+- **Thin community `Community 1615`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1616`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 1616`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1617`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 1617`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1618`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 1618`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1619`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 1619`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1620`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 1620`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1621`** (1 nodes): `config.ts`
+- **Thin community `Community 1621`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1622`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 1622`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1623`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 1623`** (1 nodes): `config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1624`** (1 nodes): `useQueryEnabled.test.ts`
+- **Thin community `Community 1624`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1625`** (1 nodes): `useStorefrontObservability.ts`
+- **Thin community `Community 1625`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1626`** (1 nodes): `constants.ts`
+- **Thin community `Community 1626`** (1 nodes): `useQueryEnabled.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1627`** (1 nodes): `countries.ts`
+- **Thin community `Community 1627`** (1 nodes): `useStorefrontObservability.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1628`** (1 nodes): `feeUtils.test.ts`
+- **Thin community `Community 1628`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1629`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1629`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1630`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 1630`** (1 nodes): `feeUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1631`** (1 nodes): `maintenanceUtils.test.ts`
+- **Thin community `Community 1631`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1632`** (1 nodes): `index.ts`
+- **Thin community `Community 1632`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1633`** (1 nodes): `store.ts`
+- **Thin community `Community 1633`** (1 nodes): `maintenanceUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1634`** (1 nodes): `bag.ts`
+- **Thin community `Community 1634`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1635`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1635`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1636`** (1 nodes): `category.ts`
+- **Thin community `Community 1636`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1637`** (1 nodes): `organization.ts`
+- **Thin community `Community 1637`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1638`** (1 nodes): `product.ts`
+- **Thin community `Community 1638`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1639`** (1 nodes): `store.ts`
+- **Thin community `Community 1639`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1640`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1640`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1641`** (1 nodes): `user.ts`
+- **Thin community `Community 1641`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1642`** (1 nodes): `states.ts`
+- **Thin community `Community 1642`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1643`** (1 nodes): `storefrontFailureObservability.test.ts`
+- **Thin community `Community 1643`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1644`** (1 nodes): `storefrontJourneyEvents.test.ts`
+- **Thin community `Community 1644`** (1 nodes): `states.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1645`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1645`** (1 nodes): `storefrontFailureObservability.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1646`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 1646`** (1 nodes): `storefrontJourneyEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1647`** (1 nodes): `-homePageLoader.test.ts`
+- **Thin community `Community 1647`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1648`** (1 nodes): `__root.tsx`
+- **Thin community `Community 1648`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1649`** (1 nodes): `$orderItemId.review.tsx`
+- **Thin community `Community 1649`** (1 nodes): `-homePageLoader.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1650`** (1 nodes): `index.tsx`
+- **Thin community `Community 1650`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1651`** (1 nodes): `$subcategorySlug.tsx`
+- **Thin community `Community 1651`** (1 nodes): `$orderItemId.review.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1652`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1653`** (1 nodes): `rewards.index.tsx`
+- **Thin community `Community 1653`** (1 nodes): `$subcategorySlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1654`** (1 nodes): `shop.saved.index.tsx`
+- **Thin community `Community 1654`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1655`** (1 nodes): `bag.index.tsx`
+- **Thin community `Community 1655`** (1 nodes): `rewards.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1656`** (1 nodes): `complete.tsx`
+- **Thin community `Community 1656`** (1 nodes): `shop.saved.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1657`** (1 nodes): `incomplete.tsx`
+- **Thin community `Community 1657`** (1 nodes): `bag.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1658`** (1 nodes): `index.tsx`
+- **Thin community `Community 1658`** (1 nodes): `complete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1659`** (1 nodes): `pending.tsx`
+- **Thin community `Community 1659`** (1 nodes): `incomplete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1660`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 1660`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1661`** (1 nodes): `storefront-boot.e2e.ts`
+- **Thin community `Community 1661`** (1 nodes): `pending.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1662`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 1662`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1663`** (1 nodes): `vitest.setup.ts`
+- **Thin community `Community 1663`** (1 nodes): `storefront-boot.e2e.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1664`** (1 nodes): `index.js`
+- **Thin community `Community 1664`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1665`** (1 nodes): `harness-app-registry.test.ts`
+- **Thin community `Community 1665`** (1 nodes): `vitest.setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1666`** (1 nodes): `athena-runtime-app.test.ts`
+- **Thin community `Community 1666`** (1 nodes): `index.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1667`** (1 nodes): `storefront-runtime-api.test.ts`
+- **Thin community `Community 1667`** (1 nodes): `harness-app-registry.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1668`** (1 nodes): `valkey-runtime-app.test.ts`
+- **Thin community `Community 1668`** (1 nodes): `athena-runtime-app.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1669`** (1 nodes): `harness-behavior-scenarios.test.ts`
+- **Thin community `Community 1669`** (1 nodes): `storefront-runtime-api.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1670`** (1 nodes): `harness-repo-validation.test.ts`
+- **Thin community `Community 1670`** (1 nodes): `valkey-runtime-app.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1671`** (1 nodes): `harness-behavior-scenarios.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1672`** (1 nodes): `harness-repo-validation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions
@@ -10700,6 +10712,6 @@ _Questions this graph is uniquely positioned to answer:_
 - **Should `Community 3` be split into smaller, more focused modules?**
   _Cohesion score 0.09 - nodes in this community are weakly interconnected._
 - **Should `Community 4` be split into smaller, more focused modules?**
-  _Cohesion score 0.07 - nodes in this community are weakly interconnected._
-- **Should `Community 5` be split into smaller, more focused modules?**
   _Cohesion score 0.08 - nodes in this community are weakly interconnected._
+- **Should `Community 5` be split into smaller, more focused modules?**
+  _Cohesion score 0.07 - nodes in this community are weakly interconnected._

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -7,10 +7,10 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 - [packages/AGENTS.md](../../packages/AGENTS.md) - package router plus the operational guides for each harnessed package
 
 ## Repo Summary
-- Code files discovered: 1742
-- Graph nodes: 5496
-- Graph edges: 5724
-- Communities: 1671
+- Code files discovered: 1744
+- Graph nodes: 5508
+- Graph edges: 5739
+- Communities: 1673
 
 ## Graph Hotspots
 - `DailyCloseView.tsx` (82 edges, Community 0) - [`packages/athena-webapp/src/components/operations/DailyCloseView.tsx`](../../packages/athena-webapp/src/components/operations/DailyCloseView.tsx)
@@ -18,8 +18,8 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 - `harness-inferential-review.ts` (46 edges, Community 2) - [`scripts/harness-inferential-review.ts`](../../scripts/harness-inferential-review.ts)
 - `storefrontJourneyEvents.ts` (45 edges, Community 3) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
 - `createJourneyEvent()` (40 edges, Community 3) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
-- `ProcurementView.tsx` (39 edges, Community 4) - [`packages/athena-webapp/src/components/procurement/ProcurementView.tsx`](../../packages/athena-webapp/src/components/procurement/ProcurementView.tsx)
-- `useRegisterViewModel.ts` (38 edges, Community 5) - [`packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts`](../../packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts)
+- `useRegisterViewModel.ts` (40 edges, Community 4) - [`packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts`](../../packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts)
+- `ProcurementView.tsx` (39 edges, Community 5) - [`packages/athena-webapp/src/components/procurement/ProcurementView.tsx`](../../packages/athena-webapp/src/components/procurement/ProcurementView.tsx)
 - `DailyOpeningView.tsx` (35 edges, Community 7) - [`packages/athena-webapp/src/components/operations/DailyOpeningView.tsx`](../../packages/athena-webapp/src/components/operations/DailyOpeningView.tsx)
 
 ## Registered Packages

--- a/graphify-out/wiki/packages/athena-webapp.md
+++ b/graphify-out/wiki/packages/athena-webapp.md
@@ -19,8 +19,8 @@ Landing page for packages/athena-webapp. Use this page to orient around graph ho
 ## Graph Hotspots
 - `DailyCloseView.tsx` (82 edges, Community 0) - [`packages/athena-webapp/src/components/operations/DailyCloseView.tsx`](../../../packages/athena-webapp/src/components/operations/DailyCloseView.tsx)
 - `dailyClose.ts` (57 edges, Community 1) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../../packages/athena-webapp/convex/operations/dailyClose.ts)
-- `ProcurementView.tsx` (39 edges, Community 4) - [`packages/athena-webapp/src/components/procurement/ProcurementView.tsx`](../../../packages/athena-webapp/src/components/procurement/ProcurementView.tsx)
-- `useRegisterViewModel.ts` (38 edges, Community 5) - [`packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts`](../../../packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts)
+- `useRegisterViewModel.ts` (40 edges, Community 4) - [`packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts`](../../../packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts)
+- `ProcurementView.tsx` (39 edges, Community 5) - [`packages/athena-webapp/src/components/procurement/ProcurementView.tsx`](../../../packages/athena-webapp/src/components/procurement/ProcurementView.tsx)
 - `DailyOpeningView.tsx` (35 edges, Community 7) - [`packages/athena-webapp/src/components/operations/DailyOpeningView.tsx`](../../../packages/athena-webapp/src/components/operations/DailyOpeningView.tsx)
 
 ## Navigation

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "harness:self-review": "bun scripts/harness-self-review.ts",
     "harness:review": "bun scripts/harness-review.ts",
     "harness:test": "bun scripts/harness-test.ts",
+    "plan-html:check": "bun scripts/validate-plan-html.ts",
     "github:pr-merge": "bun scripts/github-pr-merge.ts",
     "workflow:check": "bun scripts/github-workflows-check.ts",
     "pre-commit:generated-artifacts": "bun scripts/pre-commit-generated-artifacts.ts",

--- a/packages/athena-webapp/src/components/pos/PinInput.tsx
+++ b/packages/athena-webapp/src/components/pos/PinInput.tsx
@@ -8,6 +8,7 @@ interface PinInputProps {
   onKeyDown: (e: React.KeyboardEvent) => void;
   maxLength: number;
   size?: "sm" | "md" | "lg";
+  showSeparator?: boolean;
 }
 
 export const PinInput = ({
@@ -17,6 +18,7 @@ export const PinInput = ({
   onKeyDown,
   maxLength,
   size = "md",
+  showSeparator = true,
 }: PinInputProps) => {
   const slotSizeClass = SLOT_SIZE_CLASSES[size];
   return (
@@ -29,21 +31,29 @@ export const PinInput = ({
       pushPasswordManagerStrategy="none"
       containerClassName="group flex items-center has-[:disabled]:opacity-30"
       render={({ slots }) => (
-        <>
+        showSeparator ? (
+          <>
+            <div className="flex">
+              {slots.slice(0, 3).map((slot, idx) => (
+                <Slot key={idx} {...slot} sizeClass={slotSizeClass} />
+              ))}
+            </div>
+
+            <FakeDash />
+
+            <div className="flex">
+              {slots.slice(3).map((slot, idx) => (
+                <Slot key={idx} {...slot} sizeClass={slotSizeClass} />
+              ))}
+            </div>
+          </>
+        ) : (
           <div className="flex">
-            {slots.slice(0, 3).map((slot, idx) => (
+            {slots.map((slot, idx) => (
               <Slot key={idx} {...slot} sizeClass={slotSizeClass} />
             ))}
           </div>
-
-          <FakeDash />
-
-          <div className="flex">
-            {slots.slice(3).map((slot, idx) => (
-              <Slot key={idx} {...slot} sizeClass={slotSizeClass} />
-            ))}
-          </div>
-        </>
+        )
       )}
     />
   );
@@ -71,15 +81,6 @@ function Slot({ sizeClass, ...props }: SlotProps & { sizeClass: string }) {
       )}
     >
       {props.char !== null && <div>•</div>}
-    </div>
-  );
-}
-
-// You can emulate a fake textbox caret!
-function FakeCaret() {
-  return (
-    <div className="absolute pointer-events-none inset-0 flex items-center justify-center animate-caret-blink">
-      <div className="w-px h-8 bg-white" />
     </div>
   );
 }

--- a/packages/athena-webapp/src/components/pos/register/POSRegisterView.test.tsx
+++ b/packages/athena-webapp/src/components/pos/register/POSRegisterView.test.tsx
@@ -363,6 +363,8 @@ describe("POSRegisterView", () => {
         storeId: "store-1",
         syncFlow: {
           eventAppendToken: 2,
+          failureCount: 0,
+          lastFailure: null,
           lastLocalSequence: 4,
           lastRuntimeTrigger: "event-appended",
           lastRuntimeTriggerAt: Date.UTC(2026, 4, 15, 12, 34, 56),
@@ -370,6 +372,10 @@ describe("POSRegisterView", () => {
           lastSyncedSequence: 4,
           nextPendingSequence: null,
           pendingEventCount: 0,
+          pendingUploadEventCount: 0,
+          schedulerBackoffUntil: null,
+          schedulerRunning: false,
+          schedulerScheduled: false,
           source: "none",
           staffProof: "present",
           status: "synced",
@@ -425,6 +431,10 @@ describe("POSRegisterView", () => {
     expect(screen.getByText("High")).toBeInTheDocument();
     expect(screen.getByText("2026-05-15T12:34:56Z")).toBeInTheDocument();
     expect(screen.getByText("local 4 synced 4 next n/a")).toBeInTheDocument();
+    expect(screen.getByText("eligible uploads")).toBeInTheDocument();
+    expect(screen.getByText("scheduler")).toBeInTheDocument();
+    expect(screen.getByText("last failure")).toBeInTheDocument();
+    expect(screen.getByText("none")).toBeInTheDocument();
 
     pressDebugPanelShortcut();
     expect(
@@ -481,12 +491,14 @@ describe("POSRegisterView", () => {
     const { POSRegisterView } = await import("./POSRegisterView");
     render(<POSRegisterView />);
 
-    expect(screen.getByText("Pending sync")).toBeInTheDocument();
-    expect(screen.getByText("2")).toBeInTheDocument();
+    const retrySyncButton = screen.getByRole("button", {
+      name: /retry pos sync: pending sync/i,
+    });
 
-    await userEvent.click(
-      screen.getByRole("button", { name: /retry pos sync: pending sync 2/i }),
-    );
+    expect(retrySyncButton).toHaveTextContent("pending sync");
+    expect(retrySyncButton).not.toHaveTextContent("2");
+
+    await userEvent.click(retrySyncButton);
 
     expect(onRetrySync).toHaveBeenCalled();
   });
@@ -546,7 +558,11 @@ describe("POSRegisterView", () => {
     render(<POSRegisterView />);
 
     expect(screen.getByText("Register closed locally")).toBeInTheDocument();
-    expect(screen.getByText("Locally closed")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "This register was closed locally. Athena will reconcile the closeout after sync.",
+      ),
+    ).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /retry sync/i })).toBeInTheDocument();
     expect(screen.queryByText("register-customer-panel")).not.toBeInTheDocument();
     expect(screen.queryByText("register-action-bar")).not.toBeInTheDocument();

--- a/packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx
+++ b/packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx
@@ -14,11 +14,9 @@ import View from "@/components/View";
 import { cn } from "~/src/lib/utils";
 import {
   ArrowRight,
-  AlertTriangle,
   CheckCircle2,
   Circle,
   Cloud,
-  CloudUpload,
   RefreshCw,
   ScanBarcode,
   Search,
@@ -200,46 +198,24 @@ function RegisterSyncStatusChip({
     return null;
   }
 
-  const Icon =
-    syncStatus.status === "needs_review"
-      ? AlertTriangle
-      : syncStatus.status === "syncing"
-        ? CloudUpload
-        : syncStatus.status === "synced"
-          ? CheckCircle2
-          : Cloud;
   const className =
     syncStatus.tone === "success"
-      ? "border-success/25 bg-success/10 text-success"
+      ? "text-success"
       : syncStatus.tone === "danger"
-        ? "border-danger/25 bg-danger/10 text-danger"
+        ? "text-danger"
         : syncStatus.tone === "warning"
-          ? "border-warning/30 bg-warning/15 text-warning"
-          : "border-border bg-background text-muted-foreground";
+          ? "text-warning"
+          : "text-muted-foreground";
   const canRetry = syncStatus.status !== "synced" && syncStatus.onRetrySync;
-  const content = (
-    <>
-      <Icon aria-hidden className="h-3.5 w-3.5 shrink-0" />
-      <span className="truncate">{syncStatus.label}</span>
-      {syncStatus.pendingEventCount ? (
-        <span className="font-numeric tabular-nums">
-          {syncStatus.pendingEventCount}
-        </span>
-      ) : null}
-      {canRetry ? (
-        <RefreshCw aria-hidden className="ml-1 h-3.5 w-3.5 shrink-0" />
-      ) : null}
-    </>
-  );
+  const label = syncStatus.status === "synced" ? "synced" : "pending sync";
+  const content = <span className="truncate">{label}</span>;
 
   if (canRetry) {
     return (
       <button
-        aria-label={`Retry POS sync: ${syncStatus.label}${
-          syncStatus.pendingEventCount ? ` ${syncStatus.pendingEventCount}` : ""
-        }`}
+        aria-label={`Retry POS sync: ${label}`}
         className={cn(
-          "inline-flex max-w-full items-center gap-2 rounded-full border px-3 py-1 text-xs font-medium transition hover:bg-background/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+          "inline-flex max-w-full items-baseline gap-1 font-mono text-xs leading-none transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
           className,
         )}
         onClick={syncStatus.onRetrySync}
@@ -253,7 +229,7 @@ function RegisterSyncStatusChip({
   return (
     <div
       className={cn(
-        "inline-flex max-w-full items-center gap-2 rounded-full border px-3 py-1 text-xs font-medium",
+        "inline-flex max-w-full items-baseline gap-1 font-mono text-xs leading-none",
         className,
       )}
     >
@@ -374,6 +350,27 @@ function POSLocalDebugStrip({
     ],
     ["attempted at", formatDebugTimestamp(debug.syncFlow.lastRuntimeTriggerAt)],
     ["waiting to sync", String(debug.syncFlow.pendingEventCount ?? 0)],
+    [
+      "eligible uploads",
+      debug.syncFlow.pendingUploadEventCount === undefined
+        ? "n/a"
+        : String(debug.syncFlow.pendingUploadEventCount),
+    ],
+    [
+      "scheduler",
+      [
+        debug.syncFlow.schedulerRunning ? "running" : "idle",
+        debug.syncFlow.schedulerScheduled ? "scheduled" : null,
+      ]
+        .filter(Boolean)
+        .join(" "),
+    ],
+    [
+      "backoff until",
+      formatDebugTimestamp(debug.syncFlow.schedulerBackoffUntil ?? undefined),
+    ],
+    ["failure count", String(debug.syncFlow.failureCount ?? 0)],
+    ["last failure", debug.syncFlow.lastFailure ?? "none"],
     [
       "activity count",
       [
@@ -904,8 +901,8 @@ export function POSRegisterView({
           onNavigateBack={viewModel.onNavigateBack}
           leadingContent={
             <div className="flex min-w-0 flex-1 flex-wrap items-center gap-8">
-              <div className="flex shrink-0 items-center gap-3">
-                <FadeIn className="flex items-center gap-2">
+              <div className="flex shrink-0 items-baseline gap-3">
+                <FadeIn className="flex items-center gap-2 self-center">
                   <div
                     aria-label={
                       isStaffSignedIn ? "Staff signed in" : "No staff signed in"
@@ -919,7 +916,7 @@ export function POSRegisterView({
                   />
                 </FadeIn>
 
-                <p className="text-lg font-semibold text-gray-900">
+                <p className="text-lg font-semibold leading-none text-gray-900">
                   {viewModel.header.title}
                 </p>
                 {isPosWorkflow ? (

--- a/packages/athena-webapp/src/components/staff-auth/StaffPinInput.tsx
+++ b/packages/athena-webapp/src/components/staff-auth/StaffPinInput.tsx
@@ -24,6 +24,7 @@ export function StaffPinInput({
       onKeyDown={onKeyDown}
       maxLength={STAFF_PIN_LENGTH}
       size="sm"
+      showSeparator={false}
     />
   );
 }

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/localCommandGateway.test.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/localCommandGateway.test.ts
@@ -391,12 +391,81 @@ describe("createLocalCommandGateway", () => {
           localRegisterSessionId: "drawer-1",
           localPosSessionId: "session-1",
           staffProfileId: "staff-1",
+          sync: { status: "synced" },
           payload: {
             localPosSessionId: "session-1",
             reason: "Cart cleared",
           },
         }),
       ],
+    });
+  });
+
+  it("keeps clear events uploadable when the local sale had cart activity", async () => {
+    const store = createPosLocalStore({
+      adapter: createMemoryPosLocalStorageAdapter(),
+      createLocalId: (kind) => `${kind}-1`,
+    });
+    const gateway = createLocalCommandGateway({
+      store,
+      staffProofToken: "proof-token-1",
+    });
+
+    await store.appendEvent({
+      type: "register.opened",
+      terminalId: "terminal-1",
+      storeId: "store-1",
+      localRegisterSessionId: "drawer-1",
+      staffProfileId: "staff-1",
+      payload: { openingFloat: 100 },
+    });
+    await store.appendEvent({
+      type: "session.started",
+      terminalId: "terminal-1",
+      storeId: "store-1",
+      localRegisterSessionId: "drawer-1",
+      localPosSessionId: "session-1",
+      staffProfileId: "staff-1",
+      payload: { localPosSessionId: "session-1" },
+    });
+    await store.appendEvent({
+      type: "cart.item_added",
+      terminalId: "terminal-1",
+      storeId: "store-1",
+      localRegisterSessionId: "drawer-1",
+      localPosSessionId: "session-1",
+      staffProfileId: "staff-1",
+      payload: {
+        localItemId: "item-1",
+        productId: "product-1",
+        productName: "Body Wave",
+        productSkuId: "sku-1",
+        quantity: 1,
+        price: 120,
+      },
+    });
+
+    await expect(
+      gateway.clearCart({
+        terminalId: "terminal-1",
+        storeId: "store-1",
+        registerNumber: "1",
+        localRegisterSessionId: "drawer-1",
+        localPosSessionId: "session-1",
+        staffProfileId: "staff-1",
+        reason: "Cart cleared",
+      }),
+    ).resolves.toBe(true);
+
+    await expect(store.listEventsForUpload()).resolves.toMatchObject({
+      ok: true,
+      value: expect.arrayContaining([
+        expect.objectContaining({
+          type: "cart.cleared",
+          staffProofToken: "proof-token-1",
+          sync: { status: "pending" },
+        }),
+      ]),
     });
   });
 

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/localCommandGateway.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/localCommandGateway.ts
@@ -133,7 +133,17 @@ export function createLocalCommandGateway(
       });
     },
 
-    clearCart(input: ClearLocalCartInput) {
+    async clearCart(input: ClearLocalCartInput) {
+      const model = await readModel({
+        storeId: input.storeId,
+        terminalId: input.terminalId,
+      });
+      if (!model.ok) return false;
+      const hasPriorSaleActivity = hasLocalSaleActivity(
+        model.value.sourceEvents,
+        input,
+      );
+
       return appendBoolean({
         type: "cart.cleared",
         terminalId: input.terminalId,
@@ -142,10 +152,14 @@ export function createLocalCommandGateway(
         localRegisterSessionId: input.localRegisterSessionId,
         localPosSessionId: input.localPosSessionId,
         staffProfileId: input.staffProfileId,
-        staffProofToken: resolveStaffProofToken(
-          options.staffProofToken,
-          input.staffProfileId,
-        ),
+        ...(hasPriorSaleActivity
+          ? {
+              staffProofToken: resolveStaffProofToken(
+                options.staffProofToken,
+                input.staffProfileId,
+              ),
+            }
+          : { initialSyncStatus: "synced" as const }),
         payload: {
           localPosSessionId: input.localPosSessionId,
           reason: input.reason ?? null,
@@ -345,6 +359,26 @@ function resolveStaffProofToken(
   return typeof staffProofToken === "function"
     ? staffProofToken(staffProfileId)
     : staffProofToken;
+}
+
+function hasLocalSaleActivity(
+  events: PosLocalEventRecord[],
+  input: ClearLocalCartInput,
+) {
+  return events.some((event) => {
+    if (
+      event.localRegisterSessionId !== input.localRegisterSessionId ||
+      event.localPosSessionId !== input.localPosSessionId
+    ) {
+      return false;
+    }
+
+    return (
+      event.type === "cart.item_added" ||
+      event.type === "session.payments_updated" ||
+      event.type === "transaction.completed"
+    );
+  });
 }
 
 function toLocalUserError(message: string) {

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.test.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.test.ts
@@ -288,9 +288,14 @@ describe("posLocalStore", () => {
       1, 2, 3, 4, 5, 6,
     ]);
     expect(events.value.map((event) => event.type)).toEqual(eventTypes);
-    expect(events.value.every((event) => event.sync.status === "pending")).toBe(
-      true,
-    );
+    expect(events.value.map((event) => event.sync.status)).toEqual([
+      "pending",
+      "synced",
+      "pending",
+      "pending",
+      "pending",
+      "pending",
+    ]);
   });
 
   it("does not advance the local sequence cursor when an event write fails", async () => {
@@ -399,6 +404,51 @@ describe("posLocalStore", () => {
       ok: true,
       value: [
         expect.objectContaining({
+          staffProofToken: "proof-token-1",
+        }),
+      ],
+    });
+  });
+
+  it("does not attach upload proof to local-only session events", async () => {
+    let nextLocalId = 1;
+    const store = createPosLocalStore({
+      adapter: createMemoryPosLocalStorageAdapter(),
+      createLocalId: () => `local-event-${nextLocalId++}`,
+    });
+
+    await store.appendEvent({
+      type: "session.started",
+      terminalId: "local-terminal-1",
+      storeId: "store_cloud_1",
+      localRegisterSessionId: "local-register-session-1",
+      localPosSessionId: "local-session-1",
+      staffProfileId: "staff_cloud_1",
+      payload: { localPosSessionId: "local-session-1" },
+    });
+    await store.appendEvent({
+      type: "register.opened",
+      terminalId: "local-terminal-1",
+      storeId: "store_cloud_1",
+      localRegisterSessionId: "local-register-session-1",
+      staffProfileId: "staff_cloud_1",
+      payload: { openingFloat: 100 },
+    });
+
+    await expect(
+      store.attachStaffProofTokenToPendingEvents({
+        staffProfileId: "staff_cloud_1",
+        staffProofToken: "proof-token-1",
+      }),
+    ).resolves.toEqual({ ok: true, value: 1 });
+    await expect(store.listEventsForUpload()).resolves.toEqual({
+      ok: true,
+      value: [
+        expect.not.objectContaining({
+          staffProofToken: expect.any(String),
+        }),
+        expect.objectContaining({
+          localEventId: "local-event-2",
           staffProofToken: "proof-token-1",
         }),
       ],

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.ts
@@ -33,6 +33,16 @@ export type PosLocalSyncEventStatus =
   | "needs_review"
   | "failed";
 
+function canUploadPosLocalEventType(type: PosLocalEventType): boolean {
+  return (
+    type === "register.opened" ||
+    type === "transaction.completed" ||
+    type === "cart.cleared" ||
+    type === "register.closeout_started" ||
+    type === "register.reopened"
+  );
+}
+
 export interface PosProvisionedTerminalSeed {
   terminalId: string;
   cloudTerminalId: string;
@@ -189,6 +199,7 @@ export type PosLocalAppendEventInput = {
   localTransactionId?: string;
   staffProfileId?: string;
   staffProofToken?: string;
+  initialSyncStatus?: PosLocalSyncEventStatus;
   payload: unknown;
 };
 
@@ -282,7 +293,7 @@ export function createPosLocalStore(options: PosLocalStoreOptions) {
       ...(input.staffProfileId ? { staffProfileId: input.staffProfileId } : {}),
       payload: input.payload,
       createdAt: clock(),
-      sync: { status: "pending" },
+      sync: { status: input.initialSyncStatus ?? getInitialSyncStatus(input.type) },
     };
 
     await transaction.put("events", String(nextSequence), event);
@@ -291,6 +302,10 @@ export function createPosLocalStore(options: PosLocalStoreOptions) {
       transientStaffProofTokens.set(event.localEventId, input.staffProofToken);
     }
     return event;
+  }
+
+  function getInitialSyncStatus(type: PosLocalEventType): PosLocalSyncEventStatus {
+    return type === "session.started" ? "synced" : "pending";
   }
 
   const transientStaffProofTokens = new Map<string, string>();
@@ -706,6 +721,7 @@ export function createPosLocalStore(options: PosLocalStoreOptions) {
       for (const event of events.value) {
         if (
           event.staffProfileId === input.staffProfileId &&
+          canUploadPosLocalEventType(event.type) &&
           (event.sync.status === "pending" ||
             event.sync.status === "syncing" ||
             event.sync.status === "failed")

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/syncScheduler.test.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/syncScheduler.test.ts
@@ -145,6 +145,45 @@ describe("syncScheduler", () => {
     expect(scheduler.getStatus().lastFailure).toBeNull();
   });
 
+  it("keeps an event-appended rerun immediate when it arrives during a failed sync", async () => {
+    const timers: Array<{ callback: () => void; delay: number }> = [];
+    let rejectSync: ((error: Error) => void) | undefined;
+    const uploadBatch = vi.fn(
+      () =>
+        new Promise<{ syncedEventIds: string[] }>((_resolve, reject) => {
+          rejectSync = reject;
+        }),
+    );
+    const scheduler = createPosLocalSyncScheduler({
+      loadPendingEvents: vi.fn().mockResolvedValue([baseEvent({})]),
+      uploadBatch,
+      markSynced: vi.fn().mockResolvedValue(undefined),
+      isOnline: () => true,
+      now: () => 0,
+      baseBackoffMs: 30_000,
+      setTimeoutFn: ((callback: () => void, delay: number) => {
+        timers.push({ callback, delay });
+        return timers.length as unknown as ReturnType<typeof setTimeout>;
+      }) as typeof setTimeout,
+      clearTimeoutFn: vi.fn() as unknown as typeof clearTimeout,
+    });
+
+    scheduler.trigger("route-entry");
+    const initialTimer = timers.shift();
+    expect(initialTimer?.delay).toBe(250);
+    initialTimer?.callback();
+    await vi.waitFor(() => {
+      expect(uploadBatch).toHaveBeenCalledTimes(1);
+    });
+    scheduler.trigger("event-appended", { priority: "high" });
+    rejectSync?.(new Error("held history"));
+    await vi.waitFor(() => {
+      expect(scheduler.getStatus().scheduled).toBe(true);
+    });
+
+    expect(timers.at(-1)?.delay).toBe(0);
+  });
+
   it("treats mark-synced failures as sync failures with backoff", async () => {
     const markSynced = vi.fn().mockRejectedValue(new Error("local write failed"));
     const scheduler = createPosLocalSyncScheduler({
@@ -239,18 +278,29 @@ describe("syncScheduler", () => {
     );
   });
 
-  it("clears accepted history before backing off held events in mixed responses", async () => {
+  it("immediately retries held events when the same response made sync progress", async () => {
     const markNeedsReview = vi.fn().mockResolvedValue(undefined);
     const markSynced = vi.fn().mockResolvedValue(undefined);
-    const scheduler = createPosLocalSyncScheduler({
-      loadPendingEvents: vi.fn().mockResolvedValue([
+    const loadPendingEvents = vi
+      .fn()
+      .mockResolvedValueOnce([
         baseEvent({ id: "event-accepted", sequence: 1 }),
         baseEvent({ id: "event-held", sequence: 2 }),
-      ]),
-      uploadBatch: vi.fn().mockResolvedValue({
+      ])
+      .mockResolvedValueOnce([baseEvent({ id: "event-held", sequence: 2 })])
+      .mockResolvedValueOnce([]);
+    const uploadBatch = vi
+      .fn()
+      .mockResolvedValueOnce({
         heldEventIds: ["event-held"],
         syncedEventIds: ["event-accepted"],
-      }),
+      })
+      .mockResolvedValueOnce({
+        syncedEventIds: ["event-held"],
+      });
+    const scheduler = createPosLocalSyncScheduler({
+      loadPendingEvents,
+      uploadBatch,
       markNeedsReview,
       markSynced,
       isOnline: () => true,
@@ -262,11 +312,13 @@ describe("syncScheduler", () => {
     await vi.runAllTimersAsync();
 
     expect(markNeedsReview).not.toHaveBeenCalled();
-    expect(markSynced).toHaveBeenCalledWith(["event-accepted"]);
+    expect(uploadBatch).toHaveBeenCalledTimes(2);
+    expect(markSynced).toHaveBeenNthCalledWith(1, ["event-accepted"]);
+    expect(markSynced).toHaveBeenNthCalledWith(2, ["event-held"]);
     expect(scheduler.getStatus()).toEqual(
       expect.objectContaining({
-        lastFailure: "Earlier POS history must sync before this event.",
-        backoffUntil: 30_000,
+        lastFailure: null,
+        backoffUntil: null,
       }),
     );
   });

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/syncScheduler.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/syncScheduler.ts
@@ -63,6 +63,7 @@ export interface CreatePosLocalSyncSchedulerOptions {
   clearTimeoutFn?: typeof clearTimeout;
   setIntervalFn?: typeof setInterval;
   clearIntervalFn?: typeof clearInterval;
+  onStatusChange?(status: PosLocalSyncStatus): void;
 }
 
 export function createPosLocalSyncScheduler(
@@ -82,6 +83,7 @@ export function createPosLocalSyncScheduler(
   let running = false;
   let scheduled = false;
   let rerunRequested = false;
+  let rerunPriority: "normal" | "high" = "normal";
   let timer: ReturnType<typeof setTimeout> | null = null;
   let foregroundInterval: ReturnType<typeof setInterval> | null = null;
   let backoffUntil: number | null = null;
@@ -97,6 +99,9 @@ export function createPosLocalSyncScheduler(
     lastFailure,
     lastTrigger,
   });
+  const notifyStatusChange = () => {
+    options.onStatusChange?.(status());
+  };
 
   const clearScheduledTimer = () => {
     if (timer) {
@@ -104,6 +109,7 @@ export function createPosLocalSyncScheduler(
       timer = null;
     }
     scheduled = false;
+    notifyStatusChange();
   };
 
   const schedule = (
@@ -115,6 +121,10 @@ export function createPosLocalSyncScheduler(
 
     if (running) {
       rerunRequested = true;
+      if (forceImmediate) {
+        rerunPriority = "high";
+      }
+      notifyStatusChange();
       return;
     }
 
@@ -125,9 +135,11 @@ export function createPosLocalSyncScheduler(
     }
 
     scheduled = true;
+    notifyStatusChange();
     timer = setTimeoutFn(() => {
       timer = null;
       scheduled = false;
+      notifyStatusChange();
       void run(trigger);
     }, delayMs);
   };
@@ -135,14 +147,17 @@ export function createPosLocalSyncScheduler(
   const run = async (trigger: PosLocalSyncTrigger): Promise<void> => {
     if (running) {
       rerunRequested = true;
+      notifyStatusChange();
       return;
     }
 
     if (!options.isOnline()) {
+      notifyStatusChange();
       return;
     }
 
     running = true;
+    notifyStatusChange();
 
     try {
       const pendingEvents = await options.loadPendingEvents();
@@ -152,6 +167,7 @@ export function createPosLocalSyncScheduler(
         lastFailure = null;
         backoffUntil = null;
         failureCount = 0;
+        notifyStatusChange();
         return;
       }
 
@@ -164,6 +180,13 @@ export function createPosLocalSyncScheduler(
           await options.markSynced(result.syncedEventIds);
         }
         if (result.heldEventIds?.length) {
+          if (
+            result.syncedEventIds.length > 0 ||
+            (result.reviewEventIds?.length ?? 0) > 0
+          ) {
+            rerunRequested = true;
+            return;
+          }
           throw new Error("Earlier POS history must sync before this event.");
         }
       }
@@ -171,6 +194,7 @@ export function createPosLocalSyncScheduler(
       lastFailure = null;
       backoffUntil = null;
       failureCount = 0;
+      notifyStatusChange();
     } catch (error) {
       failureCount += 1;
       lastFailure = getErrorMessage(error);
@@ -178,14 +202,19 @@ export function createPosLocalSyncScheduler(
         now() +
         Math.min(
           maxBackoffMs,
-          baseBackoffMs * Math.max(1, 2 ** (failureCount - 1)),
+            baseBackoffMs * Math.max(1, 2 ** (failureCount - 1)),
         );
+      notifyStatusChange();
     } finally {
       running = false;
+      notifyStatusChange();
 
       if (rerunRequested) {
+        const priority = rerunPriority;
         rerunRequested = false;
-        const delay = getCurrentBackoffDelay(now(), backoffUntil);
+        rerunPriority = "normal";
+        const delay =
+          priority === "high" ? 0 : getCurrentBackoffDelay(now(), backoffUntil);
         schedule(lastTrigger ?? trigger, delay, true);
       }
     }
@@ -200,6 +229,7 @@ export function createPosLocalSyncScheduler(
       }
 
       if (!options.isOnline()) {
+        notifyStatusChange();
         return;
       }
 

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.test.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.test.ts
@@ -17,6 +17,7 @@ vi.mock("~/convex/_generated/api", () => ({
 
 import {
   assertPosLocalStoreOk,
+  collectSyncedLocalEventIds,
   collectServerHeldLocalEventIds,
   collectServerReviewLocalEventIds,
   collectServerSyncedLocalEventIds,
@@ -873,6 +874,46 @@ describe("usePosLocalSyncRuntimeStatus", () => {
     ).toEqual(["event-held", "event-held-later"]);
   });
 
+  it("marks cleared-sale local precursors synced when the clear event uploads", () => {
+    expect(
+      collectSyncedLocalEventIds(
+        [
+          buildLocalEvent({
+            localEventId: "event-session",
+            localPosSessionId: "local-session-1",
+            sequence: 1,
+            type: "session.started",
+          }),
+          buildLocalEvent({
+            localEventId: "event-cart",
+            localPosSessionId: "local-session-1",
+            sequence: 2,
+            type: "cart.item_added",
+          }),
+          buildLocalEvent({
+            localEventId: "event-payment",
+            localPosSessionId: "local-session-1",
+            sequence: 3,
+            type: "session.payments_updated",
+          }),
+          buildLocalEvent({
+            localEventId: "event-clear",
+            localPosSessionId: "local-session-1",
+            payload: {
+              localPosSessionId: "local-session-1",
+              reason: "Sale cleared",
+            },
+            sequence: 4,
+            type: "cart.cleared",
+          }),
+        ],
+        ["event-clear"],
+      ),
+    ).toEqual(
+      ["event-clear", "event-session", "event-cart", "event-payment"],
+    );
+  });
+
   it("marks rejected runtime sale responses and embedded local events for review", async () => {
     mocks.ingestLocalEvents.mockResolvedValue({
       kind: "ok",
@@ -1059,6 +1100,39 @@ describe("usePosLocalSyncRuntimeStatus", () => {
         { isOnline: true },
       ),
     ).toBeNull();
+  });
+
+  it("scopes presented pending upload counts to the signed-in staff profile", () => {
+    expect(
+      derivePosLocalRuntimeSyncStatus(
+        [
+          buildLocalEvent({
+            localEventId: "event-other-staff",
+            staffProfileId: "staff-2",
+            type: "register.opened",
+          }),
+        ],
+        { isOnline: true, staffProfileId: "staff-1" },
+      ),
+    ).toBeNull();
+
+    expect(
+      derivePosLocalRuntimeSyncStatus(
+        [
+          buildLocalEvent({
+            localEventId: "event-current-staff",
+            staffProfileId: "staff-1",
+            type: "register.opened",
+          }),
+        ],
+        { isOnline: true, staffProfileId: "staff-1" },
+      ),
+    ).toEqual(
+      expect.objectContaining({
+        pendingEventCount: 1,
+        status: "pending",
+      }),
+    );
   });
 
   it("does not present a reopened local closeout as pending reconciliation", () => {

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts
@@ -37,9 +37,15 @@ export type PosLocalRuntimeSyncStatusSource = {
 };
 
 export type PosLocalRuntimeSyncDebug = {
+  failureCount?: number;
+  lastFailure?: string | null;
   lastTrigger?: PosLocalSyncTrigger;
   lastTriggerAt?: number;
   lastTriggerPriority?: "high" | "normal";
+  pendingUploadEventCount?: number;
+  schedulerBackoffUntil?: number | null;
+  schedulerRunning?: boolean;
+  schedulerScheduled?: boolean;
 };
 
 type PosLocalRuntimeStore = ReturnType<typeof createPosLocalStore>;
@@ -53,6 +59,7 @@ export function usePosLocalSyncRuntimeStatus(input: {
   eventAppendToken?: number;
   onLocalEventsChanged?: (() => void) | null;
   onRetrySync?: (() => void) | null;
+  staffProfileId?: string | null;
   storeFactory?: (() => PosLocalRuntimeStore) | null;
 }): PosLocalRuntimeSyncStatusSource | null {
   const ingestLocalEvents = useMutation(api.pos.public.sync.ingestLocalEvents);
@@ -65,6 +72,7 @@ export function usePosLocalSyncRuntimeStatus(input: {
   const eventAppendToken = input.eventAppendToken ?? 0;
   const onLocalEventsChanged = input.onLocalEventsChanged;
   const onRetrySync = input.onRetrySync;
+  const staffProfileId = input.staffProfileId;
   const isOnline = typeof navigator === "undefined" ? true : navigator.onLine;
 
   useEffect(() => {
@@ -165,21 +173,40 @@ export function usePosLocalSyncRuntimeStatus(input: {
             setReadError(pending.error.message);
             throw new Error(pending.error.message);
           }
-          return pending.value.events
+          const uploadableEvents = pending.value.events
             .filter(
               (event) =>
                 event.sync.status === "pending" ||
                   event.sync.status === "syncing" ||
                   event.sync.status === "failed",
             )
-            .filter((event) => isSyncablePosLocalEvent(event))
-            .map((event) => ({
+            .filter((event) => isSyncablePosLocalEvent(event));
+          if (!shouldStop()) {
+            setDebug((current) => ({
+              ...current,
+              pendingUploadEventCount: uploadableEvents.length,
+            }));
+          }
+          return uploadableEvents.map((event) => ({
               id: event.localEventId,
               terminalId: event.terminalId,
               localRegisterSessionId: event.localRegisterSessionId ?? "",
               createdAt: event.createdAt,
               sequence: event.sequence,
             }));
+        },
+        onStatusChange: (status) => {
+          if (shouldStop()) {
+            return;
+          }
+          setDebug((current) => ({
+            ...current,
+            failureCount: status.failureCount,
+            lastFailure: status.lastFailure,
+            schedulerBackoffUntil: status.backoffUntil,
+            schedulerRunning: status.running,
+            schedulerScheduled: status.scheduled,
+          }));
         },
         markSynced: async (eventIds) => {
           if (eventIds.length === 0) return;
@@ -350,6 +377,7 @@ export function usePosLocalSyncRuntimeStatus(input: {
         setRefreshToken((current) => current + 1);
         onRetrySync?.();
       },
+      staffProfileId,
     });
     if (source) return { ...source, debug };
 
@@ -362,7 +390,7 @@ export function usePosLocalSyncRuntimeStatus(input: {
           },
         }
       : null;
-  }, [debug, events, isOnline, onRetrySync, readError]);
+  }, [debug, events, isOnline, onRetrySync, readError, staffProfileId]);
 }
 
 function toIngestLocalEventsArgs(input: {
@@ -491,7 +519,7 @@ function toLocalCloudMappingEntity(
   return null;
 }
 
-function collectSyncedLocalEventIds(
+export function collectSyncedLocalEventIds(
   events: PosLocalEventRecord[],
   acceptedUploadEventIds: string[],
 ) {
@@ -514,7 +542,9 @@ function collectAcceptedEventIdsWithLocalPrecursors(
 
   for (const event of events) {
     if (!accepted.has(event.localEventId)) continue;
-    if (event.type !== "transaction.completed") continue;
+    if (event.type !== "transaction.completed" && event.type !== "cart.cleared") {
+      continue;
+    }
 
     for (const candidate of events) {
       if (
@@ -539,9 +569,16 @@ export function derivePosLocalRuntimeSyncStatus(
   options: {
     isOnline: boolean;
     onRetrySync?: (() => void) | null;
+    staffProfileId?: string | null;
   },
 ): PosLocalRuntimeSyncStatusSource | null {
-  const relevantEvents = collectRuntimeRelevantEvents(events);
+  const scopedEvents =
+    options.staffProfileId === undefined
+      ? events
+      : options.staffProfileId
+        ? events.filter((event) => event.staffProfileId === options.staffProfileId)
+        : [];
+  const relevantEvents = collectRuntimeRelevantEvents(scopedEvents);
   const status = derivePosLocalSyncStatus({
     events: relevantEvents,
     isOnline: options.isOnline,
@@ -573,7 +610,7 @@ function collectRuntimeRelevantEvents(events: PosLocalEventRecord[]) {
 
   for (const event of events) {
     if (
-      event.type !== "transaction.completed" ||
+      (event.type !== "transaction.completed" && event.type !== "cart.cleared") ||
       event.sync.status === "synced"
     ) {
       continue;

--- a/packages/athena-webapp/src/lib/pos/presentation/register/registerUiState.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/registerUiState.ts
@@ -235,6 +235,8 @@ export interface RegisterViewModel {
     storeId?: string;
     syncFlow: {
       eventAppendToken: number;
+      failureCount?: number;
+      lastFailure?: string | null;
       lastLocalSequence?: number;
       lastRuntimeTrigger?: string;
       lastRuntimeTriggerAt?: number;
@@ -242,6 +244,10 @@ export interface RegisterViewModel {
       lastSyncedSequence?: number;
       nextPendingSequence?: number | null;
       pendingEventCount?: number;
+      pendingUploadEventCount?: number;
+      schedulerBackoffUntil?: number | null;
+      schedulerRunning?: boolean;
+      schedulerScheduled?: boolean;
       source: string;
       staffProof: "present" | "missing";
       status: string;

--- a/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts
@@ -629,7 +629,7 @@ describe("useRegisterViewModel", () => {
     expect(result.current.cashierCard?.cashierName).toBe("Ama K.");
     expect(result.current.productEntry.canQuickAddProduct).toBe(true);
     expect(result.current.authDialog?.open).toBe(false);
-    expect(result.current.syncStatus?.status).toBe("synced");
+    expect(result.current.syncStatus).toBeNull();
   });
 
   it("maps local pending-sync status into POS presentation state", async () => {
@@ -828,6 +828,7 @@ describe("useRegisterViewModel", () => {
       value: [
         buildLocalEvent({
           sequence: 1,
+          staffProofToken: "staff-proof-token",
           type: "register.opened",
           payload: {
             expectedCash: 5_000,
@@ -841,6 +842,12 @@ describe("useRegisterViewModel", () => {
 
     const { useRegisterViewModel } = await import("./useRegisterViewModel");
     const { result } = renderHook(() => useRegisterViewModel());
+
+    await act(async () => {
+      result.current.authDialog?.onAuthenticated(
+        buildStaffAuthenticationResult(),
+      );
+    });
 
     await waitFor(() =>
       expect(result.current.debug?.syncFlow.source).toBe("local-read-model"),
@@ -859,6 +866,340 @@ describe("useRegisterViewModel", () => {
         status: "pending_sync",
       }),
     );
+  });
+
+  it("does not show pending sync for local session-start records that cannot upload alone", async () => {
+    mockUsePosLocalSyncRuntimeStatus.mockReturnValue({
+      debug: {
+        lastTrigger: "event-appended",
+        lastTriggerAt: 1_000,
+        lastTriggerPriority: "high",
+      },
+    });
+    mockListLocalEvents.mockResolvedValue({
+      ok: true,
+      value: [
+        buildLocalEvent({
+          localPosSessionId: "local-pos-session-1",
+          payload: {
+            localPosSessionId: "local-pos-session-1",
+            localRegisterSessionId: "drawer-1",
+            status: "active",
+          },
+          sequence: 1,
+          type: "session.started",
+        }),
+      ],
+    });
+
+    const { useRegisterViewModel } = await import("./useRegisterViewModel");
+    const { result } = renderHook(() => useRegisterViewModel());
+
+    await waitFor(() =>
+      expect(result.current.debug?.syncFlow.source).toBe("none"),
+    );
+    expect(result.current.syncStatus).toBeNull();
+    expect(result.current.debug?.syncFlow).toEqual(
+      expect.objectContaining({
+        lastRuntimeTrigger: "event-appended",
+        pendingEventCount: 0,
+        status: "synced",
+      }),
+    );
+  });
+
+  it("shows synced after uploaded local history when only local-only records remain", async () => {
+    mockUsePosLocalSyncRuntimeStatus.mockReturnValue({
+      debug: {
+        lastTrigger: "event-appended",
+        lastTriggerAt: 1_000,
+        lastTriggerPriority: "high",
+      },
+    });
+    mockListLocalEvents.mockResolvedValue({
+      ok: true,
+      value: [
+        buildLocalEvent({
+          sequence: 1,
+          sync: { status: "synced", uploaded: true },
+          type: "register.opened",
+        }),
+        buildLocalEvent({
+          localPosSessionId: "local-pos-session-1",
+          sequence: 2,
+          sync: { status: "synced", uploaded: true },
+          type: "session.started",
+        }),
+        buildLocalEvent({
+          localPosSessionId: "local-pos-session-1",
+          sequence: 3,
+          sync: { status: "synced", uploaded: true },
+          type: "transaction.completed",
+        }),
+        buildLocalEvent({
+          localPosSessionId: "local-pos-session-1",
+          sequence: 4,
+          staffProofToken: undefined,
+          type: "cart.cleared",
+        }),
+      ],
+    });
+
+    const { useRegisterViewModel } = await import("./useRegisterViewModel");
+    const { result } = renderHook(() => useRegisterViewModel());
+
+    await act(async () => {
+      result.current.authDialog?.onAuthenticated(
+        buildStaffAuthenticationResult(),
+      );
+    });
+
+    await waitFor(() =>
+      expect(result.current.syncStatus).toEqual(
+        expect.objectContaining({
+          label: "Synced",
+          status: "synced",
+        }),
+      ),
+    );
+  });
+
+  it("does not show another staff member's pending local upload count", async () => {
+    mockUsePosLocalSyncRuntimeStatus.mockReturnValue({
+      debug: {
+        lastTrigger: "route-entry",
+        lastTriggerAt: 1_000,
+        lastTriggerPriority: "normal",
+      },
+    });
+    mockListLocalEvents.mockResolvedValue({
+      ok: true,
+      value: [
+        buildLocalEvent({
+          sequence: 1,
+          staffProfileId: "staff-2",
+          staffProofToken: "staff-2-proof-token",
+          type: "register.opened",
+          payload: {
+            expectedCash: 5_000,
+            localRegisterSessionId: "drawer-1",
+            openingFloat: 5_000,
+            status: "open",
+          },
+        }),
+      ],
+    });
+
+    const { useRegisterViewModel } = await import("./useRegisterViewModel");
+    const { result } = renderHook(() => useRegisterViewModel());
+
+    await waitFor(() =>
+      expect(result.current.debug?.syncFlow.source).toBe("none"),
+    );
+    expect(result.current.syncStatus).toBeNull();
+
+    await act(async () => {
+      result.current.authDialog?.onAuthenticated(
+        buildStaffAuthenticationResult({
+          staffProfileId: "staff-1" as Id<"staffProfile">,
+        }),
+      );
+    });
+
+    expect(result.current.syncStatus).toBeNull();
+    expect(result.current.debug?.syncFlow).toEqual(
+      expect.objectContaining({
+        pendingEventCount: 0,
+        status: "synced",
+      }),
+    );
+  });
+
+  it("keeps a reloaded local cart hidden until its staff owner signs back in", async () => {
+    mockRegisterState = {
+      phase: "readyToStart",
+      terminal: { _id: "terminal-1", displayName: "Front Counter" },
+      cashier: null,
+      activeRegisterSession: {
+        _id: "drawer-1",
+        status: "open",
+        terminalId: "terminal-1",
+        registerNumber: "1",
+        openingFloat: 5_000,
+        expectedCash: 5_000,
+        openedAt: Date.now(),
+      },
+      activeSession: null,
+      activeSessionConflict: null,
+      resumableSession: null,
+    };
+    mockActiveSession = null;
+    mockListLocalEvents.mockResolvedValue({
+      ok: true,
+      value: [
+        buildLocalEvent({
+          sequence: 1,
+          type: "register.opened",
+          payload: {
+            expectedCash: 5_000,
+            localRegisterSessionId: "drawer-1",
+            openingFloat: 5_000,
+            status: "open",
+          },
+        }),
+        buildLocalEvent({
+          localPosSessionId: "local-sale-1",
+          payload: {
+            localPosSessionId: "local-sale-1",
+            localRegisterSessionId: "drawer-1",
+            status: "active",
+          },
+          sequence: 2,
+          staffProfileId: "staff-1",
+          type: "session.started",
+        }),
+        buildLocalEvent({
+          localPosSessionId: "local-sale-1",
+          payload: {
+            localItemId: "local-item-1",
+            localPosSessionId: "local-sale-1",
+            productId: "product-1",
+            productName: "Nicca",
+            productSku: "6N2Y-WMA-EAW",
+            productSkuId: "sku-1",
+            quantity: 2,
+            price: 6_500,
+          },
+          sequence: 3,
+          staffProfileId: "staff-1",
+          type: "cart.item_added",
+        }),
+      ],
+    });
+
+    const { useRegisterViewModel } = await import("./useRegisterViewModel");
+    const { result } = renderHook(() => useRegisterViewModel());
+
+    await waitFor(() =>
+      expect(result.current.debug?.syncFlow.lastLocalSequence).toBe(3),
+    );
+
+    expect(result.current.authDialog?.open).toBe(true);
+    expect(result.current.cart.items).toEqual([]);
+    expect(result.current.checkout.total).toBe(0);
+
+    await act(async () => {
+      result.current.authDialog?.onAuthenticated(
+        buildStaffAuthenticationResult({
+          staffProfileId: "staff-2" as Id<"staffProfile">,
+        }),
+      );
+    });
+
+    expect(result.current.cart.items).toEqual([]);
+    expect(result.current.checkout.total).toBe(0);
+    expect(result.current.productEntry.disabled).toBe(true);
+    expect(
+      mockAppendLocalEvent.mock.calls.filter(
+        ([event]) => event.type === "session.started",
+      ),
+    ).toHaveLength(0);
+
+    await act(async () => {
+      await result.current.sessionPanel?.onStartNewSession();
+    });
+
+    expect(toast.error).toHaveBeenCalledWith(
+      "This local sale belongs to another signed-in staff member.",
+    );
+    expect(
+      mockAppendLocalEvent.mock.calls.filter(
+        ([event]) => event.type === "session.started",
+      ),
+    ).toHaveLength(0);
+  });
+
+  it("restores a reloaded local cart for the staff member who started it", async () => {
+    mockRegisterState = {
+      phase: "readyToStart",
+      terminal: { _id: "terminal-1", displayName: "Front Counter" },
+      cashier: null,
+      activeRegisterSession: {
+        _id: "drawer-1",
+        status: "open",
+        terminalId: "terminal-1",
+        registerNumber: "1",
+        openingFloat: 5_000,
+        expectedCash: 5_000,
+        openedAt: Date.now(),
+      },
+      activeSession: null,
+      activeSessionConflict: null,
+      resumableSession: null,
+    };
+    mockActiveSession = null;
+    mockListLocalEvents.mockResolvedValue({
+      ok: true,
+      value: [
+        buildLocalEvent({
+          sequence: 1,
+          type: "register.opened",
+          payload: {
+            expectedCash: 5_000,
+            localRegisterSessionId: "drawer-1",
+            openingFloat: 5_000,
+            status: "open",
+          },
+        }),
+        buildLocalEvent({
+          localPosSessionId: "local-sale-1",
+          payload: {
+            localPosSessionId: "local-sale-1",
+            localRegisterSessionId: "drawer-1",
+            status: "active",
+          },
+          sequence: 2,
+          staffProfileId: "staff-1",
+          type: "session.started",
+        }),
+        buildLocalEvent({
+          localPosSessionId: "local-sale-1",
+          payload: {
+            localItemId: "local-item-1",
+            localPosSessionId: "local-sale-1",
+            productId: "product-1",
+            productName: "Nicca",
+            productSku: "6N2Y-WMA-EAW",
+            productSkuId: "sku-1",
+            quantity: 2,
+            price: 6_500,
+          },
+          sequence: 3,
+          staffProfileId: "staff-1",
+          type: "cart.item_added",
+        }),
+      ],
+    });
+
+    const { useRegisterViewModel } = await import("./useRegisterViewModel");
+    const { result } = renderHook(() => useRegisterViewModel());
+
+    await waitFor(() =>
+      expect(result.current.debug?.syncFlow.lastLocalSequence).toBe(3),
+    );
+
+    await act(async () => {
+      result.current.authDialog?.onAuthenticated(buildStaffAuthenticationResult());
+    });
+
+    expect(result.current.cart.items).toHaveLength(1);
+    expect(result.current.cart.items[0]).toEqual(
+      expect.objectContaining({
+        name: "Nicca",
+        quantity: 2,
+      }),
+    );
+    expect(result.current.checkout.total).toBe(13_000);
   });
 
   it("nudges local sync after pending events receive staff proof", async () => {
@@ -2250,6 +2591,7 @@ describe("useRegisterViewModel", () => {
         type: "cart.cleared",
         localRegisterSessionId: "drawer-1",
         localPosSessionId: "local-pos-session-1",
+        initialSyncStatus: "synced",
       }),
     );
 

--- a/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts
@@ -35,6 +35,7 @@ import { useConvexCommandGateway } from "@/lib/pos/infrastructure/convex/command
 import {
   createIndexedDbPosLocalStorageAdapter,
   createPosLocalStore,
+  type PosLocalEventRecord,
 } from "@/lib/pos/infrastructure/local/posLocalStore";
 import { createLocalCommandGateway } from "@/lib/pos/infrastructure/local/localCommandGateway";
 import {
@@ -42,6 +43,7 @@ import {
   type PosLocalRegisterReadModel,
 } from "@/lib/pos/infrastructure/local/registerReadModel";
 import { readProjectedLocalRegisterModel } from "@/lib/pos/infrastructure/local/localRegisterReader";
+import { isSyncablePosLocalEvent } from "@/lib/pos/infrastructure/local/syncContract";
 import { usePosLocalSyncRuntimeStatus } from "@/lib/pos/infrastructure/local/usePosLocalSyncRuntime";
 import { useLocalPosEntryContext } from "@/lib/pos/infrastructure/local/localPosEntryContext";
 import {
@@ -274,6 +276,37 @@ function readLocalSyncStatus(
   }
 
   return null;
+}
+
+function countPendingSyncableLocalEventsForStaff(
+  events: PosLocalEventRecord[],
+  staffProfileId: Id<"staffProfile"> | string | null | undefined,
+) {
+  if (!staffProfileId) {
+    return 0;
+  }
+
+  return events.filter(
+    (event) =>
+      event.staffProfileId === staffProfileId &&
+      isSyncablePosLocalEvent(event) &&
+      (event.sync.status === "pending" ||
+        event.sync.status === "syncing" ||
+        event.sync.status === "failed"),
+  ).length;
+}
+
+function hasUploadedLocalEventsForStaff(
+  events: PosLocalEventRecord[],
+  staffProfileId: Id<"staffProfile"> | string | null | undefined,
+) {
+  if (!staffProfileId) {
+    return false;
+  }
+
+  return events.some(
+    (event) => event.staffProfileId === staffProfileId && event.sync.uploaded,
+  );
 }
 
 function mapProductToOptimisticCartItem(
@@ -953,6 +986,14 @@ export function useRegisterViewModel(): RegisterViewModel {
     isPosUsableRegisterSessionStatus(registerState.activeRegisterSession.status)
       ? registerState.activeRegisterSession
       : null;
+  const localStaffPendingUploadCount = countPendingSyncableLocalEventsForStaff(
+    localRegisterReadModel?.sourceEvents ?? [],
+    staffProfileId,
+  );
+  const localStaffHasUploadedEvents = hasUploadedLocalEventsForStaff(
+    localRegisterReadModel?.sourceEvents ?? [],
+    staffProfileId,
+  );
   const projectedLocalRegisterSession =
     localRegisterReadModel?.activeRegisterSession &&
     activeStoreId &&
@@ -1002,9 +1043,7 @@ export function useRegisterViewModel(): RegisterViewModel {
               localRegisterReadModel.syncStatus.state === "failed"
                 ? "needs_review"
                 : "locally_closed_pending_sync",
-            pendingEventCount:
-              localRegisterReadModel.syncStatus.pendingCount +
-              localRegisterReadModel.syncStatus.failedCount,
+            pendingEventCount: localStaffPendingUploadCount,
           },
         }
       : null;
@@ -1032,6 +1071,18 @@ export function useRegisterViewModel(): RegisterViewModel {
     locallyOperableRegisterSession?.localRegisterSessionId ??
     projectedLocalRegisterSession?.localRegisterSessionId ??
     cloudRegisterSessionId;
+  const projectedLocalActiveSale = localRegisterReadModel?.activeSale ?? null;
+  const projectedLocalActiveSaleStaffProfileId =
+    projectedLocalActiveSale?.staffProfileId ?? null;
+  const isProjectedLocalActiveSaleOwnedByCurrentStaff = Boolean(
+    projectedLocalActiveSale &&
+      staffProfileId &&
+      projectedLocalActiveSaleStaffProfileId === staffProfileId,
+  );
+  const isProjectedLocalActiveSaleLockedToAnotherStaff = Boolean(
+    projectedLocalActiveSale &&
+      (!staffProfileId || projectedLocalActiveSaleStaffProfileId !== staffProfileId),
+  );
   const registerNumber = activeRegisterNumber ?? terminalRegisterNumber ?? "";
   const heldSessions = useConvexHeldSessions({
     storeId: activeStoreId,
@@ -1259,8 +1310,12 @@ export function useRegisterViewModel(): RegisterViewModel {
   }, []);
 
   const localActiveSession = useMemo<LocalOperableActiveSession | null>(() => {
-    if (localRegisterReadModel?.activeSale) {
-      const sale = localRegisterReadModel.activeSale;
+    if (projectedLocalActiveSale) {
+      if (!isProjectedLocalActiveSaleOwnedByCurrentStaff) {
+        return null;
+      }
+
+      const sale = projectedLocalActiveSale;
       if (locallyCompletedSessionIdsRef.current.has(sale.localPosSessionId)) {
         return null;
       }
@@ -1284,7 +1339,7 @@ export function useRegisterViewModel(): RegisterViewModel {
         customer: null,
         localSyncStatus: {
           status: "pending_sync",
-          pendingEventCount: localRegisterReadModel.syncStatus.pendingCount,
+          pendingEventCount: localStaffPendingUploadCount,
         },
       };
     }
@@ -1325,9 +1380,11 @@ export function useRegisterViewModel(): RegisterViewModel {
     };
   }, [
     activeStoreId,
+    isProjectedLocalActiveSaleOwnedByCurrentStaff,
+    localStaffPendingUploadCount,
     localOperablePosSession,
-    localRegisterReadModel,
     locallyOperableRegisterSession,
+    projectedLocalActiveSale,
     staffProfileId,
   ]);
   const visibleActiveSession = asCloudOperableSession(
@@ -1832,6 +1889,10 @@ export function useRegisterViewModel(): RegisterViewModel {
         toast.error("Register sign-in required. Sign in before adding items.");
         return null;
       }
+      if (isProjectedLocalActiveSaleLockedToAnotherStaff) {
+        toast.error("This local sale belongs to another signed-in staff member.");
+        return null;
+      }
       const localSession = await localCommandGateway.startSession({
         storeId: activeStoreId!,
         terminalId: terminal._id as Id<"posTerminal">,
@@ -1859,6 +1920,11 @@ export function useRegisterViewModel(): RegisterViewModel {
 
     if (!activeStoreId || !terminal?._id || !staffProfileId) {
       toast.error("Register sign-in required. Sign in before adding items.");
+      return null;
+    }
+
+    if (isProjectedLocalActiveSaleLockedToAnotherStaff) {
+      toast.error("This local sale belongs to another signed-in staff member.");
       return null;
     }
 
@@ -1903,6 +1969,7 @@ export function useRegisterViewModel(): RegisterViewModel {
     activeStoreId,
     ensureLocalRegisterSessionReady,
     hasProvisionedLocalSyncSeed,
+    isProjectedLocalActiveSaleLockedToAnotherStaff,
     localCommandGateway,
     locallyOperableRegisterSession,
     noteLocalRegisterEventChanged,
@@ -2338,6 +2405,14 @@ export function useRegisterViewModel(): RegisterViewModel {
       return;
     }
 
+    if (
+      projectedLocalActiveSale &&
+      projectedLocalActiveSale.staffProfileId !== actingStaffProfileId
+    ) {
+      toast.error("This local sale belongs to another signed-in staff member.");
+      return;
+    }
+
     const localRegisterSessionId =
       locallyOperableRegisterSession?.localRegisterSessionId ??
       localEventRegisterSessionId;
@@ -2428,6 +2503,7 @@ export function useRegisterViewModel(): RegisterViewModel {
     localCommandGateway,
     locallyOperableRegisterSession?.localRegisterSessionId,
     noteLocalRegisterEventChanged,
+    projectedLocalActiveSale,
     registerNumber,
     resetDraftState,
     terminal?._id,
@@ -3490,6 +3566,7 @@ export function useRegisterViewModel(): RegisterViewModel {
         activeStoreId &&
         terminal?._id &&
         localEventRegisterSessionId &&
+        !projectedLocalActiveSale &&
         !operableActiveSession &&
         !registerState?.activeSession &&
         !activeSessionConflict &&
@@ -3507,6 +3584,7 @@ export function useRegisterViewModel(): RegisterViewModel {
       isTransactionCompleted,
       localEventRegisterSessionId,
       operableActiveSession,
+      projectedLocalActiveSale,
       registerState?.activeSession,
       requestBootstrap,
       terminal?._id,
@@ -4144,6 +4222,7 @@ export function useRegisterViewModel(): RegisterViewModel {
     eventAppendToken: localSyncEventAppendToken,
     onLocalEventsChanged: noteLocalRegisterEventChanged,
     storeId: activeStoreId,
+    staffProfileId,
     terminalId: terminal?._id,
     onRetrySync: requestBootstrap,
     storeFactory: localRuntimeStoreFactory,
@@ -4151,9 +4230,19 @@ export function useRegisterViewModel(): RegisterViewModel {
   const localRuntimeStatusSource = localRuntimeSyncSource?.status
     ? localRuntimeSyncSource
     : null;
+  const localReadModelPendingUploadCount = localStaffPendingUploadCount;
+  const localOperableRegisterPendingCount =
+    localReadModelPendingUploadCount > 0
+      ? localReadModelPendingUploadCount
+      : localRegisterReadModel?.sourceEvents.length
+        ? 0
+        : staffProfileId
+          ? 1
+          : 0;
   const localReadModelSyncSource =
     localRegisterReadModel &&
-    localRegisterReadModel.syncStatus.state !== "synced"
+    localRegisterReadModel.syncStatus.state !== "synced" &&
+    localReadModelPendingUploadCount > 0
       ? {
           localSyncStatus: {
             status:
@@ -4164,14 +4253,13 @@ export function useRegisterViewModel(): RegisterViewModel {
                     "closing"
                   ? "locally_closed_pending_sync"
                   : "pending_sync",
-            pendingEventCount:
-              localRegisterReadModel.syncStatus.pendingCount +
-              localRegisterReadModel.syncStatus.failedCount,
+            pendingEventCount: localReadModelPendingUploadCount,
           },
         }
       : null;
   const localOperableRegisterSyncSource =
     locallyOperableRegisterSession &&
+    localOperableRegisterPendingCount > 0 &&
     !(
       localRegisterReadModel?.activeRegisterSession?.localRegisterSessionId ===
         locallyOperableRegisterSession.localRegisterSessionId &&
@@ -4180,7 +4268,7 @@ export function useRegisterViewModel(): RegisterViewModel {
       ? {
           localSyncStatus: {
             status: "pending_sync",
-            pendingEventCount: 1,
+            pendingEventCount: localOperableRegisterPendingCount,
           },
         }
       : null;
@@ -4195,8 +4283,13 @@ export function useRegisterViewModel(): RegisterViewModel {
     registerState?.activeRegisterSession,
     registerState,
   );
+  const hasSyncedLocalEvents =
+    localStaffHasUploadedEvents &&
+    localReadModelPendingUploadCount === 0 &&
+    !localRuntimeStatusSource;
+  const shouldShowSyncStatus = Boolean(localSyncSource || hasSyncedLocalEvents);
   const syncStatus =
-    activeStoreId && terminal?._id
+    activeStoreId && terminal?._id && shouldShowSyncStatus
       ? {
           ...buildPosSyncStatusPresentation(localSyncSource),
           onRetrySync: () => {
@@ -4241,6 +4334,8 @@ export function useRegisterViewModel(): RegisterViewModel {
       ...(activeStoreId ? { storeId: activeStoreId } : {}),
       syncFlow: {
         eventAppendToken: localSyncEventAppendToken,
+        failureCount: localRuntimeSyncSource?.debug?.failureCount,
+        lastFailure: localRuntimeSyncSource?.debug?.lastFailure,
         lastLocalSequence: localRegisterReadModel?.syncStatus.lastLocalSequence,
         lastRuntimeTrigger:
           localRuntimeSyncSource?.debug?.lastTrigger ?? "none",
@@ -4252,6 +4347,12 @@ export function useRegisterViewModel(): RegisterViewModel {
         nextPendingSequence:
           localRegisterReadModel?.syncStatus.nextPendingSequence,
         pendingEventCount: syncStatus?.pendingEventCount ?? 0,
+        pendingUploadEventCount:
+          localRuntimeSyncSource?.debug?.pendingUploadEventCount,
+        schedulerBackoffUntil:
+          localRuntimeSyncSource?.debug?.schedulerBackoffUntil,
+        schedulerRunning: localRuntimeSyncSource?.debug?.schedulerRunning,
+        schedulerScheduled: localRuntimeSyncSource?.debug?.schedulerScheduled,
         source: localRuntimeStatusSource
           ? "runtime"
           : localReadModelSyncSource
@@ -4283,6 +4384,7 @@ export function useRegisterViewModel(): RegisterViewModel {
       disabled:
         !terminal ||
         !staffProfileId ||
+        isProjectedLocalActiveSaleLockedToAnotherStaff ||
         shouldShowDrawerGate ||
         activeSessionHasBlockedRegisterBinding ||
         isOpeningDrawer,

--- a/scripts/validate-plan-html.test.ts
+++ b/scripts/validate-plan-html.test.ts
@@ -1,0 +1,102 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { collectPlanHtmlFindings } from "./validate-plan-html";
+
+const tempDirs: string[] = [];
+
+async function createTempRepo() {
+  const dir = await mkdtemp(path.join(tmpdir(), "athena-plan-html-test-"));
+  tempDirs.push(dir);
+  await mkdir(path.join(dir, "docs/plans"), { recursive: true });
+  return dir;
+}
+
+describe("validate-plan-html", () => {
+  afterEach(async () => {
+    await Promise.all(
+      tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })),
+    );
+  });
+
+  it("accepts static semantic HTML5 plan artifacts", async () => {
+    const rootDir = await createTempRepo();
+    await writeFile(
+      path.join(rootDir, "docs/plans/plan.html"),
+      [
+        "<!doctype html>",
+        '<html lang="en">',
+        "<head>",
+        '  <meta charset="utf-8">',
+        "  <title>Plan</title>",
+        "  <style>main { max-width: 64rem; }</style>",
+        "</head>",
+        "<body>",
+        "  <main>",
+        "    <header><h1>Plan</h1></header>",
+        "    <section><h2>Summary</h2><p>Review artifact.</p></section>",
+        "  </main>",
+        "</body>",
+        "</html>",
+      ].join("\n"),
+    );
+
+    await expect(
+      collectPlanHtmlFindings(rootDir, ["docs/plans/plan.html"]),
+    ).resolves.toEqual([]);
+  });
+
+  it("rejects JavaScript and remote assets", async () => {
+    const rootDir = await createTempRepo();
+    await writeFile(
+      path.join(rootDir, "docs/plans/plan.html"),
+      [
+        "<!doctype html>",
+        '<html lang="en">',
+        "<head>",
+        '  <meta charset="utf-8">',
+        "  <title>Plan</title>",
+        '  <link rel="stylesheet" href="https://example.com/plan.css">',
+        "</head>",
+        "<body>",
+        "  <main><h1>Plan</h1></main>",
+        "  <script>console.log('no');</script>",
+        "</body>",
+        "</html>",
+      ].join("\n"),
+    );
+
+    const findings = await collectPlanHtmlFindings(rootDir, [
+      "docs/plans/plan.html",
+    ]);
+
+    expect(findings.map((finding) => finding.message)).toContain(
+      "Plan HTML artifacts must not include JavaScript.",
+    );
+    expect(findings.map((finding) => finding.message)).toContain(
+      "Plan HTML artifacts must not reference remote assets: https://example.com/plan.css",
+    );
+  });
+
+  it("accepts the older http-equiv charset form for existing artifacts", async () => {
+    const rootDir = await createTempRepo();
+    await writeFile(
+      path.join(rootDir, "docs/plans/plan.html"),
+      [
+        "<!doctype html>",
+        '<html lang="en">',
+        "<head>",
+        '  <meta http-equiv="Content-Type" content="text/html; charset=utf-8">',
+        "  <title>Plan</title>",
+        "</head>",
+        "<body><main><h1>Plan</h1></main></body>",
+        "</html>",
+      ].join("\n"),
+    );
+
+    await expect(
+      collectPlanHtmlFindings(rootDir, ["docs/plans/plan.html"]),
+    ).resolves.toEqual([]);
+  });
+});

--- a/scripts/validate-plan-html.ts
+++ b/scripts/validate-plan-html.ts
@@ -1,0 +1,144 @@
+import { readdir, readFile } from "node:fs/promises";
+import path from "node:path";
+import { JSDOM, VirtualConsole } from "jsdom";
+
+type PlanHtmlFinding = {
+  filePath: string;
+  message: string;
+};
+
+const PLAN_HTML_DIR = "docs/plans";
+
+function normalizeRepoPath(filePath: string) {
+  return filePath.replaceAll("\\", "/").replace(/^\.\//, "");
+}
+
+async function collectDefaultPlanHtmlFiles(rootDir: string) {
+  const entries = await readdir(path.join(rootDir, PLAN_HTML_DIR), {
+    withFileTypes: true,
+  });
+
+  return entries
+    .filter((entry) => entry.isFile() && entry.name.endsWith(".html"))
+    .map((entry) => path.join(PLAN_HTML_DIR, entry.name))
+    .sort((left, right) => left.localeCompare(right));
+}
+
+function hasRemoteReference(value: string) {
+  return /^https?:\/\//i.test(value) || /^\/\//.test(value);
+}
+
+export async function collectPlanHtmlFindings(
+  rootDir: string,
+  filePaths: string[],
+) {
+  const findings: PlanHtmlFinding[] = [];
+
+  for (const repoPath of filePaths.map(normalizeRepoPath)) {
+    const absolutePath = path.join(rootDir, repoPath);
+    const html = await readFile(absolutePath, "utf8");
+    const parseErrors: string[] = [];
+    const virtualConsole = new VirtualConsole();
+    virtualConsole.on("jsdomError", (error) => {
+      parseErrors.push(error.message);
+    });
+
+    const dom = new JSDOM(html, {
+      contentType: "text/html",
+      includeNodeLocations: true,
+      url: `file://${absolutePath}`,
+      virtualConsole,
+    });
+    const document = dom.window.document;
+
+    for (const parseError of parseErrors) {
+      findings.push({
+        filePath: repoPath,
+        message: `HTML parser reported: ${parseError}`,
+      });
+    }
+
+    if (!/^<!doctype html>/i.test(html.trimStart())) {
+      findings.push({
+        filePath: repoPath,
+        message: "Use the HTML5 doctype: <!doctype html>.",
+      });
+    }
+
+    const hasCharsetMeta = Boolean(
+      document.querySelector('meta[charset="utf-8" i]') ??
+        document.querySelector(
+          'meta[http-equiv="Content-Type" i][content*="charset=utf-8" i]',
+        ),
+    );
+    if (!hasCharsetMeta) {
+      findings.push({
+        filePath: repoPath,
+        message: 'Include a UTF-8 charset meta tag, preferably <meta charset="utf-8">.',
+      });
+    }
+
+    if (!document.title.trim()) {
+      findings.push({
+        filePath: repoPath,
+        message: "Include a non-empty <title>.",
+      });
+    }
+
+    if (!document.body?.textContent?.trim()) {
+      findings.push({
+        filePath: repoPath,
+        message: "The HTML artifact body is empty.",
+      });
+    }
+
+    if (document.querySelector("script")) {
+      findings.push({
+        filePath: repoPath,
+        message: "Plan HTML artifacts must not include JavaScript.",
+      });
+    }
+
+    for (const element of Array.from(
+      document.querySelectorAll("[src], link[href]"),
+    )) {
+      const reference =
+        element.getAttribute("src") ?? element.getAttribute("href");
+      if (reference && hasRemoteReference(reference)) {
+        findings.push({
+          filePath: repoPath,
+          message: `Plan HTML artifacts must not reference remote assets: ${reference}`,
+        });
+      }
+    }
+  }
+
+  return findings;
+}
+
+export async function runPlanHtmlValidation(rootDir: string, args: string[]) {
+  const filePaths =
+    args.length > 0 ? args : await collectDefaultPlanHtmlFiles(rootDir);
+  const findings = await collectPlanHtmlFindings(rootDir, filePaths);
+
+  if (findings.length === 0) {
+    console.log(
+      `[plan html check] Validated ${filePaths.length} HTML review artifact(s).`,
+    );
+    return;
+  }
+
+  throw new Error(
+    [
+      "[plan html check] HTML review artifact validation failed:",
+      ...findings.map((finding) => `- ${finding.filePath}: ${finding.message}`),
+    ].join("\n"),
+  );
+}
+
+if (import.meta.main) {
+  runPlanHtmlValidation(process.cwd(), process.argv.slice(2)).catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Summary
- drain locally saved POS events from the POS hub once connectivity is stable, without requiring the original offline cashier to sign back in
- keep POS sync labels compact while adding diagnostics for upload eligibility, backoff, and failures
- clean up shared PIN input rendering and add a repo-local HTML plan artifact validator for HTML5 structural tags
- document the POS hub-owned sync drain pattern in docs/solutions

## Validation
- bun run plan-html:check
- bun test scripts/validate-plan-html.test.ts
- (cd packages/athena-webapp && bun run test src/components/pos/register/POSRegisterView.test.tsx src/lib/pos/infrastructure/local/localCommandGateway.test.ts src/lib/pos/infrastructure/local/posLocalStore.test.ts src/lib/pos/infrastructure/local/syncScheduler.test.ts src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.test.ts src/lib/pos/presentation/register/useRegisterViewModel.test.ts)
- bun run pre-commit:generated-artifacts
- bun run graphify:check
- bun run compound:check
- git push pre-push validation suite

Production deploy not run.