### PR TITLE
fix(pos): persist local sync proof evidence

### DIFF
--- a/docs/solutions/architecture/athena-pos-hub-owned-local-sync-drain-2026-05-18.md
+++ b/docs/solutions/architecture/athena-pos-hub-owned-local-sync-drain-2026-05-18.md
@@ -46,12 +46,20 @@ Make upload sequence and upload ownership terminal-local concepts:
   ordering without consuming upload sequence.
 - Keep cashier attribution on the event as actor evidence for receipts,
   transactions, payment allocation, cash controls, and workflow traces.
+- Persist the cashier's event-scoped sync proof on uploadable pending events
+  when they are appended. Upload cannot depend on the cashier proof still being
+  available in memory after a reload or staff switch.
 - Keep submission authority separate from actor attribution. The POS hub or
   provisioned terminal submits the batch with terminal-scoped authority, while
   the event payload preserves the original cashier/manager actor.
 - Treat the POS hub and provisioned terminal as the foreground sync drain owner.
   The register flow appends durable events and can show status, but it should
   not be the surface that decides whether upload runs.
+- Allow the register flow to trigger a narrow, one-shot drain immediately after
+  an uploadable local event is appended. This is an opportunistic online upload
+  hint, not a foreground scheduler: it must not make Convex upload part of the
+  cashier success path, and it must not replace hub route-entry, reconnect,
+  visibility, or interval catch-up drains.
 - Do not require the original cashier to sign in again just to drain local
   history. Permission drift should become reconciliation or review work, not a
   permanent upload blocker.
@@ -72,11 +80,17 @@ offline sequence, not just as isolated helpers:
 - `usePosLocalSyncRuntime.test.ts` should prove `drainEnabled: false` reads
   status without calling `ingestLocalEvents`, while hub-owned
   `drainEnabled: true` uploads pending rows on route entry or reconnect.
+- `usePosLocalSyncRuntime.test.ts` should also prove the register can opt into
+  a one-shot post-append drain from status-only mode without uploading on route
+  entry by default.
 - `PointOfSaleView.test.tsx` should prove opening `/pos` with a provisioned
   terminal starts a hub drain for pending uploadable events.
 - `useRegisterViewModel.test.ts` and `POSRegisterView.test.tsx` should prove the
   register can show pending/synced status without owning upload and that compact
   labels stay limited to `pending sync` and `synced`.
+- POS support diagnostics should show both browser-local event sequence and
+  upload sequence. Local event order explains the IndexedDB timeline; upload
+  sequence explains Convex cursor failures such as out-of-order held events.
 - `ingestLocalEvents.test.ts` and `public/sync.test.ts` should prove one
   terminal authority can submit ordered events for multiple actor staff profiles,
   accepted retries stay idempotent, and true missing earlier upload sequence is
@@ -96,6 +110,8 @@ JavaScript, and no remote assets.
 - Never compute POS upload sequence from a filtered set of currently syncable
   events.
 - Never make original staff proof presence the gate for preserving upload order.
+- Never keep pending upload proof only in memory; event-scoped proof must
+  survive reload until the event reaches synced or review state.
 - Keep actor staff identity separate from terminal or hub submission authority.
 - Keep the validation map pointed at every POS local sync boundary, including
   the local sync repository, shared sync contract, hub/register runtime, local

--- a/docs/solutions/architecture/athena-pos-local-staff-authority-2026-05-14.md
+++ b/docs/solutions/architecture/athena-pos-local-staff-authority-2026-05-14.md
@@ -68,6 +68,13 @@ credential, staff profile state, role eligibility, and credential version. A PIN
 reset increments the local verifier version, and older local proofs stop
 validating once that credential version drifts.
 
+When an uploadable local POS event is appended, the already-unwrapped proof is
+copied onto that event row as event-scoped sync evidence. That lets offline
+sales survive reloads and later hub drains without requiring the original
+cashier's in-memory sign-in state. The proof remains separate from the roster
+authority snapshot, and it is scrubbed from the event once the event is synced or
+moved to review.
+
 Manager elevation and command approval proofs remain separate server-side
 approval boundaries. Local cashier authority should not be treated as approval
 for manager-only commands.
@@ -76,6 +83,8 @@ for manager-only commands.
 
 - Do not use online `pinHash` as an offline verifier.
 - Do not persist plaintext `posLocalStaffProof` tokens in local staff authority.
+- Do persist event-scoped proof evidence on pending uploadable events at append
+  time, then scrub it after sync/review terminal state.
 - Keep local staff authority snapshots scoped to store and terminal ids.
 - Include credential-version evidence in local sync proofs.
 - Refresh local staff authority after online cashier authentication and during

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 5511 nodes · 5736 edges · 1673 communities detected
+- 5512 nodes · 5737 edges · 1673 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -1823,36 +1823,36 @@ Cohesion: 0.25
 Nodes (21): buildActiveCycleCountDraftsSubmissionKey(), buildCycleCountDraftSubmissionKey(), createCycleCountDraftWithCtx(), discardCycleCountDraftCommandWithCtx(), ensureCycleCountDraftCommandWithCtx(), ensureCycleCountDraftWithCtx(), findOpenCycleCountDraftWithCtx(), getActiveCycleCountDraftSummaryWithCtx() (+13 more)
 
 ### Community 28 - "Community 28"
+Cohesion: 0.12
+Nodes (9): collectAcceptedEventIdsWithLocalPrecursors(), collectReviewLocalEventIds(), collectRuntimeRelevantEvents(), collectSyncedLocalEventIds(), derivePosLocalRuntimeSyncStatus(), hasPendingLocalCloseout(), isRuntimeRelevantLocalEvent(), toLocalCloudMappingEntity() (+1 more)
+
+### Community 29 - "Community 29"
 Cohesion: 0.27
 Nodes (20): asBoolean(), asMtnMomoSetupStatus(), asNumber(), asOptionalArray(), asRecord(), asString(), cleanUndefined(), firstDefined() (+12 more)
 
-### Community 29 - "Community 29"
+### Community 30 - "Community 30"
 Cohesion: 0.17
 Nodes (17): assertRegisterSessionIdentity(), assertRegisterSessionMatchesTransaction(), assertValidRegisterSessionTransition(), buildClosedRegisterSessionPatch(), buildRegisterSession(), buildRegisterSessionCloseoutPatch(), buildRegisterSessionDepositPatch(), buildRegisterSessionOpeningFloatCorrectionPatch() (+9 more)
 
-### Community 30 - "Community 30"
+### Community 31 - "Community 31"
 Cohesion: 0.18
 Nodes (19): assertIdempotentReplayMatches(), assertProductSkuBelongsToStore(), assertSkuActivityArgs(), buildActiveReservationEntries(), buildAvailabilityWarnings(), buildSkuActivityEvent(), buildTimeline(), getImpactQuantities() (+11 more)
 
-### Community 31 - "Community 31"
+### Community 32 - "Community 32"
 Cohesion: 0.18
 Nodes (16): createDefaultSessionCommandService(), createPosSessionCommandService(), failure(), isActiveRegisterSession(), isSessionExpired(), registerSessionMatchesIdentity(), resolveRegisterSessionBinding(), runBindSessionToRegisterSessionCommand() (+8 more)
 
-### Community 32 - "Community 32"
+### Community 33 - "Community 33"
 Cohesion: 0.1
 Nodes (4): handleChange(), isSkuReserved(), parseVariantInputValue(), shouldDisable()
 
-### Community 33 - "Community 33"
+### Community 34 - "Community 34"
 Cohesion: 0.13
 Nodes (11): CashPositionSummary(), cn(), formatCashExposureSupporting(), formatCurrency(), formatStaffByline(), formatTimestamp(), getSessionActionLabel(), getSessionOpenedLine() (+3 more)
 
-### Community 34 - "Community 34"
-Cohesion: 0.12
-Nodes (7): buildMissingDraftResult(), getApprovalRequestCopy(), handleDecideApprovalRequest(), handleDiscardCycleCountDraft(), handleRefreshCycleCountDraftLineBaseline(), handleSaveCycleCountDraftLine(), handleSubmitCycleCountDraft()
-
 ### Community 35 - "Community 35"
 Cohesion: 0.12
-Nodes (9): collectAcceptedEventIdsWithLocalPrecursors(), collectReviewLocalEventIds(), collectRuntimeRelevantEvents(), collectSyncedLocalEventIds(), derivePosLocalRuntimeSyncStatus(), hasPendingLocalCloseout(), isRuntimeRelevantLocalEvent(), toLocalCloudMappingEntity() (+1 more)
+Nodes (7): buildMissingDraftResult(), getApprovalRequestCopy(), handleDecideApprovalRequest(), handleDiscardCycleCountDraft(), handleRefreshCycleCountDraftLineBaseline(), handleSaveCycleCountDraftLine(), handleSubmitCycleCountDraft()
 
 ### Community 36 - "Community 36"
 Cohesion: 0.11
@@ -2467,8 +2467,8 @@ Cohesion: 0.53
 Nodes (3): handleUpdateFees(), parseDeliveryFeeInputs(), parseOptionalDeliveryFeeInput()
 
 ### Community 189 - "Community 189"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.47
+Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
 
 ### Community 190 - "Community 190"
 Cohesion: 0.33
@@ -2491,52 +2491,52 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 195 - "Community 195"
-Cohesion: 0.53
-Nodes (4): calculatePosChange(), calculatePosRemainingDue(), calculatePosTotalPaid(), roundPosAmount()
-
-### Community 196 - "Community 196"
 Cohesion: 0.33
 Nodes (0):
+
+### Community 196 - "Community 196"
+Cohesion: 0.53
+Nodes (4): calculatePosChange(), calculatePosRemainingDue(), calculatePosTotalPaid(), roundPosAmount()
 
 ### Community 197 - "Community 197"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 198 - "Community 198"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 199 - "Community 199"
 Cohesion: 0.4
 Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 200 - "Community 200"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 201 - "Community 201"
-Cohesion: 0.47
-Nodes (4): fetchPosTransaction(), getBaseUrl(), getPosTransactionByReceiptToken(), PosTransactionReceiptError
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 202 - "Community 202"
 Cohesion: 0.47
-Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
+Nodes (4): fetchPosTransaction(), getBaseUrl(), getPosTransactionByReceiptToken(), PosTransactionReceiptError
 
 ### Community 203 - "Community 203"
+Cohesion: 0.47
+Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
+
+### Community 204 - "Community 204"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 204 - "Community 204"
+### Community 205 - "Community 205"
 Cohesion: 0.4
 Nodes (2): handleConfirm(), handlePrimaryAction()
 
-### Community 205 - "Community 205"
+### Community 206 - "Community 206"
 Cohesion: 0.33
 Nodes (0):
-
-### Community 206 - "Community 206"
-Cohesion: 0.47
-Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
 
 ### Community 207 - "Community 207"
 Cohesion: 0.53

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,8 +8,8 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 1744
-- Graph nodes: 5511
-- Graph edges: 5736
+- Graph nodes: 5512
+- Graph edges: 5737
 - Communities: 1673
 
 ## Graph Hotspots

--- a/graphify-out/wiki/packages/storefront-webapp.md
+++ b/graphify-out/wiki/packages/storefront-webapp.md
@@ -19,9 +19,9 @@ Landing page for packages/storefront-webapp. Use this page to orient around grap
 ## Graph Hotspots
 - `storefrontJourneyEvents.ts` (45 edges, Community 3) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
 - `createJourneyEvent()` (40 edges, Community 3) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
-- `getStoreConfigV2()` (17 edges, Community 28) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)
+- `getStoreConfigV2()` (17 edges, Community 29) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)
 - `checkoutSession.ts` (14 edges, Community 56) - [`packages/storefront-webapp/src/api/checkoutSession.ts`](../../../packages/storefront-webapp/src/api/checkoutSession.ts)
-- `storeConfig.ts` (14 edges, Community 28) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)
+- `storeConfig.ts` (14 edges, Community 29) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)
 
 ## Navigation
 - [wiki index](../index.md) - back to the wiki index

--- a/packages/athena-webapp/src/components/pos/register/POSRegisterView.test.tsx
+++ b/packages/athena-webapp/src/components/pos/register/POSRegisterView.test.tsx
@@ -375,6 +375,8 @@ describe("POSRegisterView", () => {
           nextPendingSequence: null,
           oldestPendingEventAt: Date.UTC(2026, 4, 15, 12, 0, 0),
           oldestPendingEventSequence: 3,
+          oldestPendingUploadSequence: 2,
+          nextPendingUploadSequence: 2,
           pendingEventCount: 0,
           pendingUploadEventCount: 0,
           schedulerBackoffUntil: null,
@@ -441,6 +443,8 @@ describe("POSRegisterView", () => {
     expect(screen.getByText("local-only events")).toBeInTheDocument();
     expect(screen.getByText("oldest pending")).toBeInTheDocument();
     expect(screen.getByText("2026-05-15T12:00:00Z")).toBeInTheDocument();
+    expect(screen.getByText("local 3 upload 2")).toBeInTheDocument();
+    expect(screen.getByText("oldest 2 next 2")).toBeInTheDocument();
     expect(screen.getByText("scheduler")).toBeInTheDocument();
     expect(screen.getByText("last failure")).toBeInTheDocument();
     expect(screen.getByText("none")).toBeInTheDocument();

--- a/packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx
+++ b/packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx
@@ -380,9 +380,17 @@ function POSLocalDebugStrip({
     ],
     [
       "oldest sequence",
-      debug.syncFlow.oldestPendingEventSequence === undefined
-        ? "n/a"
-        : String(debug.syncFlow.oldestPendingEventSequence),
+      [
+        `local ${debug.syncFlow.oldestPendingEventSequence ?? "n/a"}`,
+        `upload ${debug.syncFlow.oldestPendingUploadSequence ?? "n/a"}`,
+      ].join(" "),
+    ],
+    [
+      "upload sequence",
+      [
+        `oldest ${debug.syncFlow.oldestPendingUploadSequence ?? "n/a"}`,
+        `next ${debug.syncFlow.nextPendingUploadSequence ?? "n/a"}`,
+      ].join(" "),
     ],
     [
       "last batch",

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.test.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.test.ts
@@ -434,9 +434,10 @@ describe("posLocalStore", () => {
     );
   });
 
-  it("keeps staff proof tokens transient for upload without storing them in events", async () => {
+  it("persists upload proof on pending uploadable events so offline sync survives reload", async () => {
+    const adapter = createMemoryPosLocalStorageAdapter();
     const store = createPosLocalStore({
-      adapter: createMemoryPosLocalStorageAdapter(),
+      adapter,
       createLocalId: () => "local-event-1",
     });
 
@@ -452,20 +453,25 @@ describe("posLocalStore", () => {
       }),
     ).resolves.toEqual({
       ok: true,
-      value: expect.not.objectContaining({
-        staffProofToken: expect.any(String),
+      value: expect.objectContaining({
+        staffProofToken: "proof-token-1",
       }),
     });
 
-    await expect(store.listEvents()).resolves.toEqual({
+    const reloadedStore = createPosLocalStore({
+      adapter,
+      createLocalId: () => "unused-local-event",
+    });
+
+    await expect(reloadedStore.listEvents()).resolves.toEqual({
       ok: true,
       value: [
-        expect.not.objectContaining({
-          staffProofToken: expect.any(String),
+        expect.objectContaining({
+          staffProofToken: "proof-token-1",
         }),
       ],
     });
-    await expect(store.listEventsForUpload()).resolves.toEqual({
+    await expect(reloadedStore.listEventsForUpload()).resolves.toEqual({
       ok: true,
       value: [
         expect.objectContaining({
@@ -489,6 +495,7 @@ describe("posLocalStore", () => {
       localRegisterSessionId: "local-register-session-1",
       localPosSessionId: "local-session-1",
       staffProfileId: "staff_cloud_1",
+      staffProofToken: "proof-token-1",
       payload: { localPosSessionId: "local-session-1" },
     });
     await store.appendEvent({
@@ -507,6 +514,18 @@ describe("posLocalStore", () => {
       }),
     ).resolves.toEqual({ ok: true, value: 1 });
     await expect(store.listEventsForUpload()).resolves.toEqual({
+      ok: true,
+      value: [
+        expect.not.objectContaining({
+          staffProofToken: expect.any(String),
+        }),
+        expect.objectContaining({
+          localEventId: "local-event-2",
+          staffProofToken: "proof-token-1",
+        }),
+      ],
+    });
+    await expect(store.listEvents()).resolves.toEqual({
       ok: true,
       value: [
         expect.not.objectContaining({

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.ts
@@ -298,6 +298,9 @@ export function createPosLocalStore(options: PosLocalStoreOptions) {
         ? { localTransactionId: input.localTransactionId }
         : {}),
       ...(input.staffProfileId ? { staffProfileId: input.staffProfileId } : {}),
+      ...(shouldPersistStaffProofToken(input)
+        ? { staffProofToken: input.staffProofToken }
+        : {}),
       payload: input.payload,
       createdAt: clock(),
       sync: { status: input.initialSyncStatus ?? getInitialSyncStatus(input.type) },
@@ -305,9 +308,6 @@ export function createPosLocalStore(options: PosLocalStoreOptions) {
 
     await transaction.put("events", String(nextSequence), event);
     await transaction.put("meta", META_SEQUENCE_KEY, nextSequence);
-    if (input.staffProofToken) {
-      transientStaffProofTokens.set(event.localEventId, input.staffProofToken);
-    }
     return event;
   }
 
@@ -344,7 +344,9 @@ export function createPosLocalStore(options: PosLocalStoreOptions) {
     return canUploadPosLocalEventType(type) ? "pending" : "synced";
   }
 
-  const transientStaffProofTokens = new Map<string, string>();
+  function shouldPersistStaffProofToken(input: PosLocalAppendEventInput) {
+    return Boolean(input.staffProofToken && shouldAllocateUploadSequence(input));
+  }
 
   return {
     async writeProvisionedTerminalSeed(
@@ -730,44 +732,47 @@ export function createPosLocalStore(options: PosLocalStoreOptions) {
     },
 
     async listEventsForUpload(): Promise<PosLocalStoreResult<PosLocalEventRecord[]>> {
-      const events = await this.listEvents();
-      if (!events.ok) return events;
-
-      return {
-        ok: true,
-        value: events.value.map((event) =>
-          event.staffProofToken || !transientStaffProofTokens.has(event.localEventId)
-            ? event
-            : {
-                ...event,
-                staffProofToken: transientStaffProofTokens.get(event.localEventId),
-              },
-        ),
-      };
+      return this.listEvents();
     },
 
     async attachStaffProofTokenToPendingEvents(input: {
       staffProfileId: string;
       staffProofToken: string;
     }): Promise<PosLocalStoreResult<number>> {
-      const events = await this.listEvents();
-      if (!events.ok) return events;
+      try {
+        const value = await options.adapter.transaction(
+          "readwrite",
+          ["meta", "events"],
+          async (transaction) => {
+            await ensureSupportedSchema(transaction, "readwrite");
+            const events =
+              await transaction.getAll<PosLocalEventRecord>("events");
+            let attachedCount = 0;
 
-      let attachedCount = 0;
-      for (const event of events.value) {
-        if (
-          event.staffProfileId === input.staffProfileId &&
-          canUploadPosLocalEventType(event.type) &&
-          (event.sync.status === "pending" ||
-            event.sync.status === "syncing" ||
-            event.sync.status === "failed")
-        ) {
-          transientStaffProofTokens.set(event.localEventId, input.staffProofToken);
-          attachedCount += 1;
-        }
+            for (const event of events) {
+              if (
+                event.staffProfileId === input.staffProfileId &&
+                canUploadPosLocalEventType(event.type) &&
+                (event.sync.status === "pending" ||
+                  event.sync.status === "syncing" ||
+                  event.sync.status === "failed")
+              ) {
+                await transaction.put("events", String(event.sequence), {
+                  ...event,
+                  staffProofToken: input.staffProofToken,
+                });
+                attachedCount += 1;
+              }
+            }
+
+            return attachedCount;
+          },
+        );
+
+        return { ok: true, value };
+      } catch (error) {
+        return toFailure(error);
       }
-
-      return { ok: true, value: attachedCount };
     },
 
     async writeLocalCloudMapping(

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/syncScheduler.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/syncScheduler.ts
@@ -32,6 +32,7 @@ export interface PosLocalSyncScheduler {
   ): void;
   startForegroundTriggers(): () => void;
   getStatus(): PosLocalSyncStatus;
+  stop(): void;
 }
 
 export interface CreatePosLocalSyncSchedulerOptions {
@@ -276,6 +277,10 @@ export function createPosLocalSyncScheduler(
     },
 
     getStatus: status,
+
+    stop() {
+      clearScheduledTimer();
+    },
   };
 }
 

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.test.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.test.ts
@@ -913,6 +913,9 @@ describe("usePosLocalSyncRuntimeStatus", () => {
             localOnlyEventCount: 1,
             mode: "status-only",
             oldestPendingEventAt: 1,
+            oldestPendingEventSequence: 1,
+            oldestPendingUploadSequence: 1,
+            nextPendingUploadSequence: 1,
             pendingUploadEventCount: 1,
           }),
           pendingEventCount: 1,
@@ -931,6 +934,107 @@ describe("usePosLocalSyncRuntimeStatus", () => {
     );
     expect(mocks.ingestLocalEvents).not.toHaveBeenCalled();
     expect(store.markEventsSynced).not.toHaveBeenCalled();
+  });
+
+  it("runs one immediate upload from status-only mode after a local event append when enabled", async () => {
+    const store = {
+      listEvents: vi.fn(async () => ({
+        ok: true,
+        value: [
+          buildLocalEvent({
+            localEventId: "event-open",
+            payload: {
+              openingFloat: 100,
+              status: "open",
+            },
+            sequence: 1,
+            type: "register.opened",
+            uploadSequence: 1,
+          }),
+        ],
+      })),
+      markEventsSynced: vi.fn(async () => ({
+        ok: true,
+        value: [],
+      })),
+      readProvisionedTerminalSeed: vi.fn(async () => ({
+        ok: true,
+        value: {
+          cloudTerminalId: "terminal-cloud-1",
+          displayName: "Front",
+          provisionedAt: 1,
+          schemaVersion: 1,
+          syncSecretHash: "sync-secret-1",
+          storeId: "store-1",
+          terminalId: "local-terminal-1",
+        },
+      })),
+      writeLocalCloudMapping: vi.fn(async () => ({
+        ok: true,
+        value: {
+          cloudId: "register-session-1",
+          entity: "registerSession",
+          localId: "register-1",
+          mappedAt: 10,
+        },
+      })),
+    };
+    mocks.ingestLocalEvents.mockResolvedValue({
+      kind: "ok",
+      data: {
+        accepted: [
+          {
+            localEventId: "event-open",
+            sequence: 1,
+            status: "projected",
+          },
+        ],
+        held: [],
+        mappings: [],
+        conflicts: [],
+        syncCursor: {
+          localRegisterSessionId: "register-1",
+          acceptedThroughSequence: 1,
+        },
+      },
+    });
+    const storeFactory = () => store as never;
+
+    const { rerender } = renderHook(
+      ({ eventAppendToken }: { eventAppendToken: number }) =>
+        usePosLocalSyncRuntimeStatus({
+          drainOnAppend: true,
+          eventAppendToken,
+          mode: "status-only",
+          storeFactory,
+          storeId: "store-1",
+          terminalId: "terminal-cloud-1",
+        }),
+      {
+        initialProps: { eventAppendToken: 0 },
+      },
+    );
+
+    await waitFor(() => expect(store.listEvents).toHaveBeenCalled());
+    expect(mocks.ingestLocalEvents).not.toHaveBeenCalled();
+
+    rerender({ eventAppendToken: 1 });
+
+    await waitFor(() =>
+      expect(mocks.ingestLocalEvents).toHaveBeenCalledWith(
+        expect.objectContaining({
+          events: [
+            expect.objectContaining({
+              localEventId: "event-open",
+              sequence: 1,
+            }),
+          ],
+        }),
+      ),
+    );
+    expect(store.markEventsSynced).toHaveBeenCalledWith(["event-open"], {
+      uploaded: true,
+    });
   });
 
   it("refreshes status-only mode on connectivity changes without uploading", async () => {
@@ -995,7 +1099,7 @@ describe("usePosLocalSyncRuntimeStatus", () => {
     expect(mocks.ingestLocalEvents).not.toHaveBeenCalled();
   });
 
-  it("drains proofless multi-staff local history from the hub in stored upload order", async () => {
+  it("drains persisted-proof multi-staff local history from the hub in stored upload order", async () => {
     const store = {
       listEvents: vi.fn(async () => ({
         ok: true,
@@ -1004,7 +1108,7 @@ describe("usePosLocalSyncRuntimeStatus", () => {
             localEventId: "event-staff-a-open",
             sequence: 1,
             staffProfileId: "staff-a",
-            staffProofToken: undefined,
+            staffProofToken: "proof-token-a",
             type: "register.opened",
             uploadSequence: 1,
           }),
@@ -1097,6 +1201,7 @@ describe("usePosLocalSyncRuntimeStatus", () => {
               localEventId: "event-staff-a-open",
               sequence: 1,
               staffProfileId: "staff-a",
+              staffProofToken: "proof-token-a",
             }),
             expect.objectContaining({
               localEventId: "event-staff-b-sale",
@@ -1108,7 +1213,6 @@ describe("usePosLocalSyncRuntimeStatus", () => {
       ),
     );
     const uploadedEvents = mocks.ingestLocalEvents.mock.calls[0]?.[0].events;
-    expect(uploadedEvents[0]).not.toHaveProperty("staffProofToken");
     expect(uploadedEvents.map((event: { sequence: number }) => event.sequence))
       .toEqual([1, 2]);
   });

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts
@@ -51,6 +51,8 @@ export type PosLocalRuntimeSyncDebug = {
   oldestPendingEventAt?: number;
   oldestPendingEventId?: string;
   oldestPendingEventSequence?: number;
+  oldestPendingUploadSequence?: number;
+  nextPendingUploadSequence?: number;
   pendingUploadEventCount?: number;
   reviewEventCount?: number;
   schedulerBackoffUntil?: number | null;
@@ -68,6 +70,7 @@ type IngestLocalEventsArgs = FunctionArgs<
 export function usePosLocalSyncRuntimeStatus(input: {
   storeId?: string | null;
   terminalId?: string | null;
+  drainOnAppend?: boolean;
   eventAppendToken?: number;
   mode?: PosLocalSyncRuntimeMode;
   onLocalEventsChanged?: (() => void) | null;
@@ -87,6 +90,7 @@ export function usePosLocalSyncRuntimeStatus(input: {
   const lastEventAppendTokenRef = useRef(0);
   const lastManualRetryTokenRef = useRef(0);
   const { storeFactory, storeId, terminalId } = input;
+  const drainOnAppend = input.drainOnAppend ?? false;
   const eventAppendToken = input.eventAppendToken ?? 0;
   const mode = input.mode ?? "drain-enabled";
   const onLocalEventsChanged = input.onLocalEventsChanged;
@@ -126,7 +130,7 @@ export function usePosLocalSyncRuntimeStatus(input: {
       createPosLocalStore({
         adapter: createIndexedDbPosLocalStorageAdapter(),
       });
-    let stopScheduler: (() => void) | null = null;
+    const stopSchedulers: Array<() => void> = [];
 
     void (async () => {
       const shouldStop = () => cancelled;
@@ -207,23 +211,9 @@ export function usePosLocalSyncRuntimeStatus(input: {
         lastTriggerPriority: triggerPriority,
       }));
 
-      if (mode === "status-only") {
-        stopScheduler = startStatusOnlyRuntimeTriggers(() => {
-          setIsOnline(typeof navigator === "undefined" ? true : navigator.onLine);
-          setRefreshToken((current) => current + 1);
-        });
-        return;
-      }
-
-      if (
-        !provisionedSeed ||
-        !provisionedSeed.syncSecretHash ||
-        provisionedSeed.cloudTerminalId !== cloudTerminalId
-      ) {
-        return;
-      }
-
-      const scheduler = createPosLocalSyncScheduler({
+      const createDrainScheduler = (
+        syncSeed: NonNullable<typeof provisionedSeed>,
+      ) => createPosLocalSyncScheduler({
         isOnline: () =>
           typeof navigator === "undefined" ? true : navigator.onLine,
         loadPendingEvents: async () => {
@@ -254,12 +244,12 @@ export function usePosLocalSyncRuntimeStatus(input: {
             }));
           }
           return uploadableEvents.map((event) => ({
-              id: event.localEventId,
-              terminalId: event.terminalId,
-              localRegisterSessionId: event.localRegisterSessionId ?? "",
-              createdAt: event.createdAt,
-              sequence: event.sequence,
-            }));
+            id: event.localEventId,
+            terminalId: event.terminalId,
+            localRegisterSessionId: event.localRegisterSessionId ?? "",
+            createdAt: event.createdAt,
+            sequence: event.sequence,
+          }));
         },
         onStatusChange: (status) => {
           if (shouldStop()) {
@@ -323,8 +313,8 @@ export function usePosLocalSyncRuntimeStatus(input: {
           const result = await ingestLocalEvents(
             toIngestLocalEventsArgs({
               events: uploadedEvents,
-              storeId: provisionedSeed.storeId,
-              syncSecretHash: provisionedSeed.syncSecretHash,
+              storeId: syncSeed.storeId,
+              syncSecretHash: syncSeed.syncSecretHash,
               terminalId: cloudTerminalId,
             }),
           );
@@ -407,15 +397,52 @@ export function usePosLocalSyncRuntimeStatus(input: {
           onLocalEventsChanged?.();
         },
       });
-      stopScheduler = scheduler.startForegroundTriggers();
+
+      if (mode === "status-only") {
+        stopSchedulers.push(
+          startStatusOnlyRuntimeTriggers(() => {
+            setIsOnline(
+              typeof navigator === "undefined" ? true : navigator.onLine,
+            );
+            setRefreshToken((current) => current + 1);
+          }),
+        );
+
+        if (
+          drainOnAppend &&
+          trigger === "event-appended" &&
+          provisionedSeed &&
+          provisionedSeed.syncSecretHash &&
+          provisionedSeed.cloudTerminalId === cloudTerminalId
+        ) {
+          const scheduler = createDrainScheduler(provisionedSeed);
+          stopSchedulers.push(() => scheduler.stop());
+          scheduler.trigger("event-appended", { priority: "high" });
+        }
+        return;
+      }
+
+      if (
+        !provisionedSeed ||
+        !provisionedSeed.syncSecretHash ||
+        provisionedSeed.cloudTerminalId !== cloudTerminalId
+      ) {
+        return;
+      }
+
+      const scheduler = createDrainScheduler(provisionedSeed);
+      stopSchedulers.push(scheduler.startForegroundTriggers());
       scheduler.trigger(trigger, { priority: "high" });
     })();
 
     return () => {
       cancelled = true;
-      stopScheduler?.();
+      for (const stopScheduler of stopSchedulers) {
+        stopScheduler();
+      }
     };
   }, [
+    drainOnAppend,
     ingestLocalEvents,
     eventAppendToken,
     manualRetryToken,
@@ -547,6 +574,9 @@ function buildRuntimeSyncDebug(
   const pendingUploadableEvents = pendingUploadCandidates.filter(
     isSyncablePosLocalEvent,
   );
+  const nextPendingUploadableEvent = [...pendingUploadableEvents]
+    .sort(compareUploadableEventOrder)
+    .at(0);
   const localOnlyEvents = pendingUploadCandidates.filter(
     (event) => !isSyncablePosLocalEvent(event),
   );
@@ -566,9 +596,24 @@ function buildRuntimeSyncDebug(
     oldestPendingEventAt: oldestPendingEvent?.createdAt,
     oldestPendingEventId: oldestPendingEvent?.localEventId,
     oldestPendingEventSequence: oldestPendingEvent?.sequence,
+    oldestPendingUploadSequence: oldestPendingEvent?.uploadSequence,
+    nextPendingUploadSequence: nextPendingUploadableEvent?.uploadSequence,
     pendingUploadEventCount: pendingUploadableEvents.length,
     reviewEventCount: reviewEvents.length,
   };
+}
+
+function compareUploadableEventOrder(
+  left: PosLocalEventRecord,
+  right: PosLocalEventRecord,
+) {
+  const leftUploadSequence = left.uploadSequence ?? Number.POSITIVE_INFINITY;
+  const rightUploadSequence = right.uploadSequence ?? Number.POSITIVE_INFINITY;
+  if (leftUploadSequence !== rightUploadSequence) {
+    return leftUploadSequence - rightUploadSequence;
+  }
+
+  return left.sequence - right.sequence;
 }
 
 function isPendingUploadCandidate(event: PosLocalEventRecord) {

--- a/packages/athena-webapp/src/lib/pos/presentation/register/registerUiState.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/registerUiState.ts
@@ -252,6 +252,8 @@ export interface RegisterViewModel {
       oldestPendingEventAt?: number;
       oldestPendingEventId?: string;
       oldestPendingEventSequence?: number;
+      oldestPendingUploadSequence?: number;
+      nextPendingUploadSequence?: number;
       pendingEventCount?: number;
       pendingUploadEventCount?: number;
       reviewEventCount?: number;

--- a/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts
@@ -1243,6 +1243,7 @@ describe("useRegisterViewModel", () => {
     await waitFor(() =>
       expect(mockUsePosLocalSyncRuntimeStatus).toHaveBeenCalledWith(
         expect.objectContaining({
+          drainOnAppend: true,
           eventAppendToken: 1,
           mode: "status-only",
           onLocalEventsChanged: expect.any(Function),

--- a/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts
@@ -4219,6 +4219,7 @@ export function useRegisterViewModel(): RegisterViewModel {
         }
       : null;
   const localRuntimeSyncSource = usePosLocalSyncRuntimeStatus({
+    drainOnAppend: true,
     eventAppendToken: localSyncEventAppendToken,
     mode: "status-only",
     onLocalEventsChanged: noteLocalRegisterEventChanged,
@@ -4359,6 +4360,10 @@ export function useRegisterViewModel(): RegisterViewModel {
           localRuntimeSyncSource?.debug?.oldestPendingEventId,
         oldestPendingEventSequence:
           localRuntimeSyncSource?.debug?.oldestPendingEventSequence,
+        oldestPendingUploadSequence:
+          localRuntimeSyncSource?.debug?.oldestPendingUploadSequence,
+        nextPendingUploadSequence:
+          localRuntimeSyncSource?.debug?.nextPendingUploadSequence,
         pendingEventCount: syncStatus?.pendingEventCount ?? 0,
         pendingUploadEventCount:
           localRuntimeSyncSource?.debug?.pendingUploadEventCount,


### PR DESCRIPTION
## Summary
- persist staff proof evidence on uploadable local POS events at append time so offline-completed transactions can sync after reload
- keep immediate one-shot drain after register event append and expose local/upload sequence diagnostics
- scrub proof evidence once events reach synced or review states

## Validation
- bun run pr:athena