### PR TITLE
Fix POS register review and adjustment projections

### DIFF
--- a/docs/solutions/logic-errors/athena-pos-register-review-and-adjusted-sale-projection-2026-05-21.md
+++ b/docs/solutions/logic-errors/athena-pos-register-review-and-adjusted-sale-projection-2026-05-21.md
@@ -1,0 +1,46 @@
+---
+title: Athena POS Register Review and Adjusted Sale Projection
+date: 2026-05-21
+category: logic-errors
+module: athena-webapp
+problem_type: logic_error
+component: pos
+symptoms:
+  - "Offline synced sales can be attached to a closed register session but remain invisible to closeout totals"
+  - "Register review banners can explain that activity needs review without showing which local events are unresolved"
+  - "Adjusted transaction detail views can continue showing original item quantities and totals after an approved correction"
+root_cause: review_state_without_explicit_projection
+resolution_type: code_fix
+severity: high
+tags:
+  - pos
+  - cash-controls
+  - register-session
+  - local-sync
+  - item-adjustments
+---
+
+# Athena POS Register Review and Adjusted Sale Projection
+
+## Problem
+
+POS review states must not stop at flags. When local register activity syncs after a drawer has closed, the session needs a manager-visible review item and a way to project the reviewed sale into register totals. When a completed sale receives an approved item adjustment, the transaction detail view needs to show the adjusted operational truth first while keeping the original sale as audit context.
+
+If either path only stores the review or adjustment event, operators see stale totals: cash controls can omit reviewed sales, and transaction detail can keep presenting the original item count and receipt total as if no adjustment was applied.
+
+## Solution
+
+Treat review and adjustment records as explicit projections:
+
+- Register sync events that need manager review should expose the unresolved event count, readable event context, and a manager action that applies reviewed sales into the register session totals.
+- The projection command should be idempotent and should only settle reviewed sale events that still need projection.
+- Completed transaction detail should derive display items from applied adjustment lines when they exist, filtering removed lines and recalculating the read-only item totals.
+- The summary rail should label adjusted financial truth directly: adjusted sale total, original sale total, item adjustment delta, and settlement movement.
+- Original sale fields remain audit context. Do not silently reinterpret original receipt totals as adjusted totals.
+
+## Prevention
+
+- Keep tests for both pending and applied adjustment records so pending review does not alter displayed adjusted items or closeout totals.
+- Test register review projection at the command boundary and the UI boundary: review item visibility, action availability, and projected sale totals.
+- For completed transaction detail, assert the right rail receives adjusted item quantities and adjusted net total after approval.
+- Use calm operator-facing copy for review states. Backend event IDs and queue details are useful evidence, but the primary labels should describe what needs manager attention.

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 5672 nodes · 5948 edges · 1702 communities detected
+- 5680 nodes · 5963 edges · 1702 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -1757,7 +1757,7 @@ Nodes (45): compactContext(), createAuthEntryViewedEvent(), createAuthRequestSta
 
 ### Community 4 - "Community 4"
 Cohesion: 0.07
-Nodes (24): addLocalAvailabilityConsumption(), addLocalAvailabilityDeltaConsumption(), asCloudOperableSession(), buildCompletedSalePayload(), buildLocalAvailabilityEventIndex(), cartItemsFromLocalRegisterModel(), completedCustomerInfo(), countPendingSyncableLocalEventsForStaff() (+16 more)
+Nodes (25): addLocalAvailabilityConsumption(), addLocalAvailabilityDeltaConsumption(), asCloudOperableSession(), buildCompletedSalePayload(), buildLocalAvailabilityEventIndex(), cartItemsFromLocalRegisterModel(), completedCustomerInfo(), countPendingSyncableLocalEventsForStaff() (+17 more)
 
 ### Community 5 - "Community 5"
 Cohesion: 0.07
@@ -1769,15 +1769,15 @@ Nodes (36): assertNever(), calculateSalePayments(), canMapExistingCloudRegisterS
 
 ### Community 7 - "Community 7"
 Cohesion: 0.08
-Nodes (20): cn(), formatMetadataDisplayValue(), formatMetadataValue(), formatOperatingDate(), formatTimestamp(), getAcknowledgementKey(), getArrayMetadataStringValue(), getBucketConfigs() (+12 more)
+Nodes (21): applyCloseoutCommandResult(), applyCommandResult(), buildDepositSubmissionKey(), formatRegisterHeaderName(), formatRegisterName(), formatReviewItemTimestamp(), formatTimestamp(), handleAuthenticatedCloseoutStaff() (+13 more)
 
 ### Community 8 - "Community 8"
-Cohesion: 0.12
-Nodes (31): approvalMetadataEntries(), approvalRequestTypeLabel(), buildDailyOpeningSnapshotWithCtx(), buildReadiness(), compactMetadataEntries(), formatPaymentMethodLabel(), getDailyOpeningForDate(), getMissingCarryForwardItems() (+23 more)
+Cohesion: 0.08
+Nodes (20): cn(), formatMetadataDisplayValue(), formatMetadataValue(), formatOperatingDate(), formatTimestamp(), getAcknowledgementKey(), getArrayMetadataStringValue(), getBucketConfigs() (+12 more)
 
 ### Community 9 - "Community 9"
-Cohesion: 0.08
-Nodes (19): applyCloseoutCommandResult(), applyCommandResult(), buildDepositSubmissionKey(), formatRegisterHeaderName(), formatRegisterName(), handleAuthenticatedCloseoutStaff(), handleOpeningFloatApprovalApproved(), handleRecordDeposit() (+11 more)
+Cohesion: 0.12
+Nodes (31): approvalMetadataEntries(), approvalRequestTypeLabel(), buildDailyOpeningSnapshotWithCtx(), buildReadiness(), compactMetadataEntries(), formatPaymentMethodLabel(), getDailyOpeningForDate(), getMissingCarryForwardItems() (+23 more)
 
 ### Community 10 - "Community 10"
 Cohesion: 0.15
@@ -1796,8 +1796,8 @@ Cohesion: 0.15
 Nodes (27): buildDiscoveryIndex(), buildGeneratedDoc(), buildKeyFolderIndex(), buildTestIndex(), buildValidationGuide(), buildValidationMap(), collectFolderFacts(), collectRouteGroups() (+19 more)
 
 ### Community 14 - "Community 14"
-Cohesion: 0.15
-Nodes (22): canonicalize(), canonicalJson(), createLocalSyncIngestionService(), ingestLocalEventsWithCtx(), isNonEmptyString(), isNonNegativeFiniteNumber(), isOptionalNonEmptyString(), isRecord() (+14 more)
+Cohesion: 0.14
+Nodes (23): canonicalize(), canonicalJson(), createLocalSyncIngestionService(), ingestLocalEventsWithCtx(), isNonEmptyString(), isNonNegativeFiniteNumber(), isOptionalNonEmptyString(), isRecord() (+15 more)
 
 ### Community 15 - "Community 15"
 Cohesion: 0.16
@@ -1844,56 +1844,56 @@ Cohesion: 0.23
 Nodes (23): asRecord(), createMappingIndex(), errorFor(), errorMessage(), getCompletedSale(), getExpectedCashDelta(), getOrCreateSale(), getPhase() (+15 more)
 
 ### Community 26 - "Community 26"
+Cohesion: 0.09
+Nodes (2): buildCashControlsDashboardSnapshot(), sumDepositsBySession()
+
+### Community 27 - "Community 27"
 Cohesion: 0.1
 Nodes (4): listCompletedTransactionsForDay(), listSessionItems(), listTransactionItems(), readAllQueryResults()
 
-### Community 27 - "Community 27"
+### Community 28 - "Community 28"
 Cohesion: 0.15
 Nodes (16): buildGitProcessEnv(), collectCommandsForChangedFiles(), fileExists(), formatMissingPathPrefixError(), getChangedFilesForHarnessReview(), hasAnyHarnessDocs(), loadReviewTarget(), loadReviewTargets() (+8 more)
-
-### Community 28 - "Community 28"
-Cohesion: 0.1
-Nodes (2): buildCashControlsDashboardSnapshot(), sumDepositsBySession()
 
 ### Community 29 - "Community 29"
 Cohesion: 0.2
 Nodes (18): acquireInventoryHold(), acquireInventoryHoldsBatch(), adjustInventoryHold(), buildSkuActivityIdempotencyKey(), consumeInventoryHoldsForSession(), getActiveHoldForSessionSku(), listActiveSessionHolds(), markHoldExpired() (+10 more)
 
 ### Community 30 - "Community 30"
+Cohesion: 0.2
+Nodes (21): adjustRegisterSessionExpectedCashForSettlement(), adjustTransactionItems(), applyApprovedAdjustment(), applyInventoryDeltas(), assertPayloadMatchesPlan(), buildAdjustmentApprovalRequirement(), buildServerAdjustmentPlan(), consumeItemAdjustmentApprovalProof() (+13 more)
+
+### Community 31 - "Community 31"
 Cohesion: 0.25
 Nodes (21): buildActiveCycleCountDraftsSubmissionKey(), buildCycleCountDraftSubmissionKey(), createCycleCountDraftWithCtx(), discardCycleCountDraftCommandWithCtx(), ensureCycleCountDraftCommandWithCtx(), ensureCycleCountDraftWithCtx(), findOpenCycleCountDraftWithCtx(), getActiveCycleCountDraftSummaryWithCtx() (+13 more)
 
-### Community 31 - "Community 31"
+### Community 32 - "Community 32"
 Cohesion: 0.11
 Nodes (7): buildMissingDraftResult(), getApprovalRequestCopy(), handleDecideApprovalRequest(), handleDiscardCycleCountDraft(), handleRefreshCycleCountDraftLineBaseline(), handleSaveCycleCountDraftLine(), handleSubmitCycleCountDraft()
 
-### Community 32 - "Community 32"
+### Community 33 - "Community 33"
 Cohesion: 0.27
 Nodes (20): asBoolean(), asMtnMomoSetupStatus(), asNumber(), asOptionalArray(), asRecord(), asString(), cleanUndefined(), firstDefined() (+12 more)
 
-### Community 33 - "Community 33"
+### Community 34 - "Community 34"
 Cohesion: 0.17
 Nodes (17): assertRegisterSessionIdentity(), assertRegisterSessionMatchesTransaction(), assertValidRegisterSessionTransition(), buildClosedRegisterSessionPatch(), buildRegisterSession(), buildRegisterSessionCloseoutPatch(), buildRegisterSessionDepositPatch(), buildRegisterSessionOpeningFloatCorrectionPatch() (+9 more)
 
-### Community 34 - "Community 34"
+### Community 35 - "Community 35"
 Cohesion: 0.18
 Nodes (19): assertIdempotentReplayMatches(), assertProductSkuBelongsToStore(), assertSkuActivityArgs(), buildActiveReservationEntries(), buildAvailabilityWarnings(), buildSkuActivityEvent(), buildTimeline(), getImpactQuantities() (+11 more)
 
-### Community 35 - "Community 35"
+### Community 36 - "Community 36"
 Cohesion: 0.18
 Nodes (16): createDefaultSessionCommandService(), createPosSessionCommandService(), failure(), isActiveRegisterSession(), isSessionExpired(), registerSessionMatchesIdentity(), resolveRegisterSessionBinding(), runBindSessionToRegisterSessionCommand() (+8 more)
 
-### Community 36 - "Community 36"
+### Community 37 - "Community 37"
 Cohesion: 0.1
 Nodes (4): handleChange(), isSkuReserved(), parseVariantInputValue(), shouldDisable()
 
-### Community 37 - "Community 37"
+### Community 38 - "Community 38"
 Cohesion: 0.13
 Nodes (11): CashPositionSummary(), cn(), formatCashExposureSupporting(), formatCurrency(), formatStaffByline(), formatTimestamp(), getSessionActionLabel(), getSessionOpenedLine() (+3 more)
-
-### Community 38 - "Community 38"
-Cohesion: 0.22
-Nodes (19): adjustRegisterSessionExpectedCashForSettlement(), adjustTransactionItems(), applyApprovedAdjustment(), applyInventoryDeltas(), assertPayloadMatchesPlan(), buildAdjustmentApprovalRequirement(), buildServerAdjustmentPlan(), consumeItemAdjustmentApprovalProof() (+11 more)
 
 ### Community 39 - "Community 39"
 Cohesion: 0.15
@@ -1928,16 +1928,16 @@ Cohesion: 0.17
 Nodes (13): buildSkuContinuityContextById(), deriveContinuityStatus(), getPlannedActionAt(), getStartOfCurrentDay(), hasLateInbound(), hasRelatedPurchaseOrderContext(), hasStalePlannedAction(), isInboundStatus() (+5 more)
 
 ### Community 47 - "Community 47"
+Cohesion: 0.15
+Nodes (12): cancelItemAdjustmentWorkflow(), exitCorrectionWorkflow(), formatCorrectionEventType(), formatCorrectionHistoryChange(), formatCorrectionHistoryTitle(), formatPaymentMethodLabel(), getCorrectionHistoryChangeParts(), isManagerStaff() (+4 more)
+
+### Community 48 - "Community 48"
 Cohesion: 0.23
 Nodes (14): buildCompleteTransactionResult(), calculateCanonicalTransactionTotals(), calculateTotalPaid(), completeTransaction(), createTransactionFromSessionHandler(), isUsableRegisterSession(), recordRegisterSessionSale(), recordRegisterSessionVoid() (+6 more)
 
-### Community 48 - "Community 48"
+### Community 49 - "Community 49"
 Cohesion: 0.11
 Nodes (0):
-
-### Community 49 - "Community 49"
-Cohesion: 0.15
-Nodes (10): exitCorrectionWorkflow(), formatCorrectionEventType(), formatCorrectionHistoryChange(), formatCorrectionHistoryTitle(), formatPaymentMethodLabel(), getCorrectionHistoryChangeParts(), isManagerStaff(), runCustomerCorrection() (+2 more)
 
 ### Community 50 - "Community 50"
 Cohesion: 0.22
@@ -2080,32 +2080,32 @@ Cohesion: 0.18
 Nodes (2): formatBlockerList(), runPrePushReview()
 
 ### Community 85 - "Community 85"
+Cohesion: 0.29
+Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
+
+### Community 86 - "Community 86"
 Cohesion: 0.33
 Nodes (2): OrdersTableToolbarProvider(), useOrdersTableToolbar()
 
-### Community 86 - "Community 86"
+### Community 87 - "Community 87"
 Cohesion: 0.24
 Nodes (5): formatBackendLabel(), formatInventoryNumber(), formatQuantity(), getActivityTitle(), pluralize()
 
-### Community 87 - "Community 87"
+### Community 88 - "Community 88"
 Cohesion: 0.31
 Nodes (7): buildCustomerCreateInput(), cancelPendingAdd(), commitCustomer(), handleAddFromSearch(), handleClearCustomer(), handleSelectCustomer(), toCustomerInfo()
 
-### Community 88 - "Community 88"
+### Community 89 - "Community 89"
 Cohesion: 0.25
 Nodes (6): handleEdit(), handleReset(), handleSubmit(), itemToFormState(), parseServiceCatalogForm(), validateServiceCatalogForm()
 
-### Community 89 - "Community 89"
+### Community 90 - "Community 90"
 Cohesion: 0.25
 Nodes (6): mapProductByIdResult(), useConvexProductIdLookup(), useConvexRegisterCatalog(), useConvexRegisterCatalogAvailability(), useConvexRegisterCatalogAvailabilityState(), usePrewarmRegisterCatalogOfflineSnapshots()
 
-### Community 90 - "Community 90"
+### Community 91 - "Community 91"
 Cohesion: 0.18
 Nodes (0):
-
-### Community 91 - "Community 91"
-Cohesion: 0.29
-Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
 
 ### Community 92 - "Community 92"
 Cohesion: 0.18
@@ -2412,16 +2412,16 @@ Cohesion: 0.29
 Nodes (0):
 
 ### Community 168 - "Community 168"
-Cohesion: 0.33
-Nodes (2): getProductName(), sortProduct()
-
-### Community 169 - "Community 169"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 170 - "Community 170"
+### Community 169 - "Community 169"
 Cohesion: 0.52
 Nodes (6): addItemToSavedBag(), getActiveSavedBag(), getBaseUrl(), removeItemFromSavedBag(), updateSavedBagItem(), updateSavedBagOwner()
+
+### Community 170 - "Community 170"
+Cohesion: 0.33
+Nodes (2): getProductName(), sortProduct()
 
 ### Community 171 - "Community 171"
 Cohesion: 0.43
@@ -2524,8 +2524,8 @@ Cohesion: 0.53
 Nodes (3): handleUpdateFees(), parseDeliveryFeeInputs(), parseOptionalDeliveryFeeInput()
 
 ### Community 196 - "Community 196"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.47
+Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
 
 ### Community 197 - "Community 197"
 Cohesion: 0.33
@@ -2548,52 +2548,52 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 202 - "Community 202"
-Cohesion: 0.53
-Nodes (4): calculatePosChange(), calculatePosRemainingDue(), calculatePosTotalPaid(), roundPosAmount()
-
-### Community 203 - "Community 203"
 Cohesion: 0.33
 Nodes (0):
+
+### Community 203 - "Community 203"
+Cohesion: 0.53
+Nodes (4): calculatePosChange(), calculatePosRemainingDue(), calculatePosTotalPaid(), roundPosAmount()
 
 ### Community 204 - "Community 204"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 205 - "Community 205"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 206 - "Community 206"
 Cohesion: 0.4
 Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 207 - "Community 207"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 208 - "Community 208"
-Cohesion: 0.47
-Nodes (4): fetchPosTransaction(), getBaseUrl(), getPosTransactionByReceiptToken(), PosTransactionReceiptError
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 209 - "Community 209"
 Cohesion: 0.47
-Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
+Nodes (4): fetchPosTransaction(), getBaseUrl(), getPosTransactionByReceiptToken(), PosTransactionReceiptError
 
 ### Community 210 - "Community 210"
+Cohesion: 0.47
+Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
+
+### Community 211 - "Community 211"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 211 - "Community 211"
+### Community 212 - "Community 212"
 Cohesion: 0.4
 Nodes (2): handleConfirm(), handlePrimaryAction()
 
-### Community 212 - "Community 212"
+### Community 213 - "Community 213"
 Cohesion: 0.33
 Nodes (0):
-
-### Community 213 - "Community 213"
-Cohesion: 0.47
-Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
 
 ### Community 214 - "Community 214"
 Cohesion: 0.53

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,8 +8,8 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 1774
-- Graph nodes: 5672
-- Graph edges: 5948
+- Graph nodes: 5680
+- Graph edges: 5963
 - Communities: 1702
 
 ## Graph Hotspots
@@ -17,7 +17,7 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 - `dailyClose.ts` (65 edges, Community 1) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../packages/athena-webapp/convex/operations/dailyClose.ts)
 - `harness-inferential-review.ts` (46 edges, Community 2) - [`scripts/harness-inferential-review.ts`](../../scripts/harness-inferential-review.ts)
 - `storefrontJourneyEvents.ts` (45 edges, Community 3) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
-- `useRegisterViewModel.ts` (42 edges, Community 4) - [`packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts`](../../packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts)
+- `useRegisterViewModel.ts` (43 edges, Community 4) - [`packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts`](../../packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts)
 - `createJourneyEvent()` (40 edges, Community 3) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
 - `ProcurementView.tsx` (39 edges, Community 5) - [`packages/athena-webapp/src/components/procurement/ProcurementView.tsx`](../../packages/athena-webapp/src/components/procurement/ProcurementView.tsx)
 - `projectLocalEvents.ts` (37 edges, Community 6) - [`packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts`](../../packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts)

--- a/graphify-out/wiki/packages/athena-webapp.md
+++ b/graphify-out/wiki/packages/athena-webapp.md
@@ -19,7 +19,7 @@ Landing page for packages/athena-webapp. Use this page to orient around graph ho
 ## Graph Hotspots
 - `DailyCloseView.tsx` (82 edges, Community 0) - [`packages/athena-webapp/src/components/operations/DailyCloseView.tsx`](../../../packages/athena-webapp/src/components/operations/DailyCloseView.tsx)
 - `dailyClose.ts` (65 edges, Community 1) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../../packages/athena-webapp/convex/operations/dailyClose.ts)
-- `useRegisterViewModel.ts` (42 edges, Community 4) - [`packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts`](../../../packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts)
+- `useRegisterViewModel.ts` (43 edges, Community 4) - [`packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts`](../../../packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts)
 - `ProcurementView.tsx` (39 edges, Community 5) - [`packages/athena-webapp/src/components/procurement/ProcurementView.tsx`](../../../packages/athena-webapp/src/components/procurement/ProcurementView.tsx)
 - `projectLocalEvents.ts` (37 edges, Community 6) - [`packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts`](../../../packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts)
 

--- a/graphify-out/wiki/packages/storefront-webapp.md
+++ b/graphify-out/wiki/packages/storefront-webapp.md
@@ -19,9 +19,9 @@ Landing page for packages/storefront-webapp. Use this page to orient around grap
 ## Graph Hotspots
 - `storefrontJourneyEvents.ts` (45 edges, Community 3) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
 - `createJourneyEvent()` (40 edges, Community 3) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
-- `getStoreConfigV2()` (17 edges, Community 32) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)
+- `getStoreConfigV2()` (17 edges, Community 33) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)
 - `checkoutSession.ts` (14 edges, Community 58) - [`packages/storefront-webapp/src/api/checkoutSession.ts`](../../../packages/storefront-webapp/src/api/checkoutSession.ts)
-- `storeConfig.ts` (14 edges, Community 32) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)
+- `storeConfig.ts` (14 edges, Community 33) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)
 
 ## Navigation
 - [wiki index](../index.md) - back to the wiki index

--- a/packages/athena-webapp/convex/cashControls/deposits.test.ts
+++ b/packages/athena-webapp/convex/cashControls/deposits.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { readFileSync } from "node:fs";
 import type { Id } from "../_generated/dataModel";
+import { ok, userError } from "../../shared/commandResult";
 
 const mockedAuthServer = vi.hoisted(() => ({
   getAuthUserId: vi.fn(),
@@ -17,6 +18,7 @@ import {
   getRegisterSessionSnapshot,
   listOpenLocalSyncConflictsByRegisterSession,
   recordRegisterSessionDeposit,
+  resolveRegisterSessionSyncReview,
 } from "./deposits";
 
 function getSource(relativePath: string) {
@@ -112,6 +114,14 @@ function createQueryCtx(seed: Record<string, Array<Record<string, unknown>>>) {
                   (row) =>
                     typeof row[field] === "number" &&
                     row[field] >= (value as number),
+                );
+                return indexQuery;
+              },
+              gt(field: string, value: unknown) {
+                predicateFilters.push(
+                  (row) =>
+                    typeof row[field] === "number" &&
+                    row[field] > (value as number),
                 );
                 return indexQuery;
               },
@@ -233,6 +243,9 @@ describe("cash control deposits", () => {
             {
               _id: "sync_conflict_1" as Id<"posLocalSyncConflict">,
               conflictType: "permission",
+              createdAt: 20,
+              localEventId: "event-register-closeout-1",
+              sequence: 7,
               status: "needs_review",
               summary:
                 "Register closeout variance requires manager review before synced closeout can be applied.",
@@ -317,7 +330,10 @@ describe("cash control deposits", () => {
         status: "needs_review",
         reconciliationItems: [
           {
+            createdAt: 20,
             id: "sync_conflict_1",
+            localEventId: "event-register-closeout-1",
+            sequence: 7,
             status: "needs_review",
             summary:
               "Register closeout variance requires manager review before synced closeout can be applied.",
@@ -470,6 +486,285 @@ describe("cash control deposits", () => {
         "store_1" as Id<"store">,
       ),
     ).resolves.toEqual(new Map());
+  });
+
+  it("resolves register-session sync review conflicts with manager staff", async () => {
+    const ctx = createAuthorizedRegisterDepositCtx({
+      operationalEvent: [],
+      posLocalSyncConflict: [
+        {
+          _id: "sync_conflict_1",
+          storeId: "store_1",
+          terminalId: "terminal_1",
+          localRegisterSessionId: "local-register-1",
+          localEventId: "event_1",
+          sequence: 1,
+          conflictType: "permission",
+          status: "needs_review",
+          summary: "Register was not open before this sale synced.",
+          details: {},
+          createdAt: 1,
+        },
+      ],
+      posLocalSyncEvent: [
+        {
+          _id: "sync_event_1",
+          storeId: "store_1",
+          terminalId: "terminal_1",
+          localRegisterSessionId: "local-register-1",
+          localEventId: "event_1",
+          sequence: 1,
+          eventType: "sale_completed",
+          occurredAt: 2,
+          staffProfileId: "staff_1",
+          payload: {
+            localPosSessionId: "local-pos-session-1",
+            localTransactionId: "local-transaction-1",
+            localReceiptNumber: "885447",
+            receiptNumber: "885447",
+            registerNumber: "1",
+            totals: {
+              subtotal: 15000,
+              tax: 0,
+              total: 15000,
+            },
+            items: [
+              {
+                localTransactionItemId: "local-item-1",
+                productId: "product_1",
+                productSkuId: "product_sku_1",
+                productName: "Wig Cap",
+                productSku: "CAP-1",
+                quantity: 1,
+                unitPrice: 15000,
+              },
+            ],
+            payments: [
+              {
+                localPaymentId: "local-payment-1",
+                method: "cash",
+                amount: 15000,
+                timestamp: 3,
+              },
+            ],
+          },
+          status: "conflicted",
+          submittedAt: 4,
+          acceptedAt: 4,
+        },
+      ],
+      posLocalSyncMapping: [
+        {
+          _id: "sync_mapping_1",
+          storeId: "store_1",
+          terminalId: "terminal_1",
+          localRegisterSessionId: "local-register-1",
+          localIdKind: "registerSession",
+          localId: "local-register-1",
+          cloudTable: "registerSession",
+          cloudId: "session_open",
+        },
+      ],
+      registerSession: [
+        {
+          _id: "session_open",
+          expectedCash: 50000,
+          openedAt: 1,
+          openingFloat: 10000,
+          organizationId: "org_1",
+          registerNumber: "1",
+          status: "closed",
+          storeId: "store_1",
+          terminalId: "terminal_1",
+        },
+      ],
+      posTerminal: [
+        {
+          _id: "terminal_1",
+          registerNumber: "1",
+          registeredByUserId: "athena_user_1",
+          status: "active",
+          storeId: "store_1",
+        },
+      ],
+      product: [
+        {
+          _id: "product_1",
+          storeId: "store_1",
+        },
+      ],
+      productSku: [
+        {
+          _id: "product_sku_1",
+          images: [],
+          inventoryCount: 10,
+          price: 15000,
+          productId: "product_1",
+          quantityAvailable: 10,
+          sku: "CAP-1",
+          storeId: "store_1",
+        },
+      ],
+      staffProfile: [
+        {
+          _id: "manager_1",
+          organizationId: "org_1",
+          status: "active",
+          storeId: "store_1",
+        },
+        {
+          _id: "staff_1",
+          organizationId: "org_1",
+          status: "active",
+          storeId: "store_1",
+        },
+      ],
+      staffRoleAssignment: [
+        {
+          _id: "role_1",
+          organizationId: "org_1",
+          role: "manager",
+          staffProfileId: "manager_1",
+          status: "active",
+          storeId: "store_1",
+        },
+        {
+          _id: "role_2",
+          organizationId: "org_1",
+          role: "cashier",
+          staffProfileId: "staff_1",
+          status: "active",
+          storeId: "store_1",
+        },
+      ],
+    });
+
+    const result = await getHandler(resolveRegisterSessionSyncReview)(
+      ctx as never,
+      {
+        actorStaffProfileId: "manager_1" as Id<"staffProfile">,
+        registerSessionId: "session_open" as Id<"registerSession">,
+        storeId: "store_1" as Id<"store">,
+      },
+    );
+
+    expect(result).toEqual(
+      ok({
+        action: "resolved",
+        projectedCount: 1,
+        registerSession: expect.objectContaining({ _id: "session_open" }),
+        resolvedCount: 1,
+      }),
+    );
+    expect(ctx.tables.get("posLocalSyncConflict")).toEqual([
+      expect.objectContaining({
+        _id: "sync_conflict_1",
+        resolvedByStaffProfileId: "manager_1",
+        status: "resolved",
+      }),
+    ]);
+    expect(ctx.tables.get("posLocalSyncEvent")).toEqual([
+      expect.objectContaining({
+        _id: "sync_event_1",
+        projectedAt: expect.any(Number),
+        status: "projected",
+      }),
+    ]);
+    expect(ctx.tables.get("posTransaction")).toEqual([
+      expect.objectContaining({
+        registerSessionId: "session_open",
+        total: 15000,
+        transactionNumber: "885447",
+      }),
+    ]);
+    expect(ctx.tables.get("registerSession")).toEqual([
+      expect.objectContaining({
+        _id: "session_open",
+        expectedCash: 65000,
+      }),
+    ]);
+    expect(ctx.tables.get("operationalEvent")).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          actorStaffProfileId: "manager_1",
+          eventType: "register_session_sync_review_resolved",
+          metadata: expect.objectContaining({
+            projectedTransactionIds: ["posTransaction_1"],
+          }),
+          registerSessionId: "session_open",
+        }),
+      ]),
+    );
+  });
+
+  it("rejects sync review resolution from non-manager staff", async () => {
+    const ctx = createAuthorizedRegisterDepositCtx({
+      posLocalSyncConflict: [
+        {
+          _id: "sync_conflict_1",
+          storeId: "store_1",
+          terminalId: "terminal_1",
+          localRegisterSessionId: "session_open",
+          localEventId: "event_1",
+          sequence: 1,
+          conflictType: "permission",
+          status: "needs_review",
+          summary: "Register was not open before this sale synced.",
+          details: {},
+          createdAt: 1,
+        },
+      ],
+      registerSession: [
+        {
+          _id: "session_open",
+          expectedCash: 50000,
+          openedAt: 1,
+          openingFloat: 10000,
+          organizationId: "org_1",
+          registerNumber: "1",
+          status: "closed",
+          storeId: "store_1",
+          terminalId: "terminal_1",
+        },
+      ],
+      staffProfile: [
+        {
+          _id: "staff_1",
+          organizationId: "org_1",
+          status: "active",
+          storeId: "store_1",
+        },
+      ],
+      staffRoleAssignment: [
+        {
+          _id: "role_1",
+          organizationId: "org_1",
+          role: "cashier",
+          staffProfileId: "staff_1",
+          status: "active",
+          storeId: "store_1",
+        },
+      ],
+    });
+
+    await expect(
+      getHandler(resolveRegisterSessionSyncReview)(ctx as never, {
+        actorStaffProfileId: "staff_1" as Id<"staffProfile">,
+        registerSessionId: "session_open" as Id<"registerSession">,
+        storeId: "store_1" as Id<"store">,
+      }),
+    ).resolves.toEqual(
+      userError({
+        code: "authorization_failed",
+        message: "Only managers can resolve synced register reviews.",
+      }),
+    );
+    expect(ctx.tables.get("posLocalSyncConflict")).toEqual([
+      expect.objectContaining({
+        _id: "sync_conflict_1",
+        status: "needs_review",
+      }),
+    ]);
   });
 
   it("ignores unmapped local register ids that are not valid cloud session ids", async () => {

--- a/packages/athena-webapp/convex/cashControls/deposits.ts
+++ b/packages/athena-webapp/convex/cashControls/deposits.ts
@@ -11,6 +11,9 @@ import {
   listCompletedTransactions,
   listTransactionItems,
 } from "../pos/infrastructure/repositories/transactionRepository";
+import { createConvexLocalSyncRepository } from "../pos/infrastructure/repositories/localSyncRepository";
+import { parseStoredLocalSyncEvent } from "../pos/application/sync/ingestLocalEvents";
+import { projectLocalSyncEvent } from "../pos/application/sync/projectLocalEvents";
 import {
   requireAuthenticatedAthenaUserWithCtx,
   requireOrganizationMemberRoleWithCtx,
@@ -23,6 +26,7 @@ const CASH_DEPOSIT_ALLOCATION_TYPE = "cash_deposit";
 const CASH_DEPOSIT_SUBJECT_TYPE = "register_cash_deposit";
 const RECENT_DEPOSIT_LIMIT = 10;
 const SESSION_LIMIT = 100;
+const STAFF_ROLE_LOOKUP_LIMIT = 20;
 const SYNC_CONFLICT_LIMIT = 500;
 const TIMELINE_LIMIT = 200;
 
@@ -52,6 +56,22 @@ const registerSessionDepositResultValidator = v.union(
       action: v.union(v.literal("duplicate"), v.literal("recorded")),
       deposit: v.union(v.null(), v.any()),
       registerSession: v.union(v.null(), v.any()),
+    }),
+  }),
+  v.object({
+    kind: v.literal("user_error"),
+    error: userErrorValidator,
+  }),
+);
+
+const registerSessionSyncReviewResultValidator = v.union(
+  v.object({
+    kind: v.literal("ok"),
+    data: v.object({
+      action: v.union(v.literal("already_resolved"), v.literal("resolved")),
+      projectedCount: v.optional(v.number()),
+      registerSession: v.union(v.null(), v.any()),
+      resolvedCount: v.number(),
     }),
   }),
   v.object({
@@ -101,8 +121,17 @@ type CashControlRegisterSession = Pick<
 
 type CashControlSyncConflict = Pick<
   Doc<"posLocalSyncConflict">,
-  "_id" | "conflictType" | "status" | "summary"
->;
+  | "_id"
+  | "conflictType"
+  | "createdAt"
+  | "localEventId"
+  | "sequence"
+  | "status"
+  | "summary"
+> &
+  Partial<
+    Pick<Doc<"posLocalSyncConflict">, "localRegisterSessionId" | "terminalId">
+  >;
 
 type CashControlTransaction = Pick<
   Doc<"posTransaction">,
@@ -122,6 +151,13 @@ type RecordRegisterSessionDepositResult = {
   action: "duplicate" | "recorded";
   deposit: Doc<"paymentAllocation"> | null;
   registerSession: Doc<"registerSession"> | null;
+};
+
+type ResolveRegisterSessionSyncReviewResult = {
+  action: "already_resolved" | "resolved";
+  projectedCount?: number;
+  registerSession: Doc<"registerSession"> | null;
+  resolvedCount: number;
 };
 
 async function requireCashControlsStoreAccess(
@@ -167,6 +203,40 @@ async function resolveDepositActorStaffProfileId(
   }
 
   return staffProfile._id;
+}
+
+async function staffProfileCanResolveSyncReview(
+  ctx: Pick<QueryCtx, "db">,
+  args: {
+    organizationId: Id<"organization">;
+    staffProfileId: Id<"staffProfile">;
+    storeId: Id<"store">;
+  },
+) {
+  const staffProfile = await ctx.db.get("staffProfile", args.staffProfileId);
+  if (
+    !staffProfile ||
+    staffProfile.status !== "active" ||
+    staffProfile.organizationId !== args.organizationId ||
+    staffProfile.storeId !== args.storeId
+  ) {
+    return false;
+  }
+
+  const assignments = await ctx.db
+    .query("staffRoleAssignment")
+    .withIndex("by_staffProfileId", (q) =>
+      q.eq("staffProfileId", args.staffProfileId),
+    )
+    .take(STAFF_ROLE_LOOKUP_LIMIT);
+
+  return assignments.some(
+    (assignment) =>
+      assignment.role === "manager" &&
+      assignment.status === "active" &&
+      assignment.organizationId === args.organizationId &&
+      assignment.storeId === args.storeId,
+  );
 }
 
 function trimOptional(value?: string | null) {
@@ -283,7 +353,10 @@ function buildRegisterSessionSummary(args: {
         ? {
             status: "needs_review",
             reconciliationItems: syncConflicts.map((conflict) => ({
+              createdAt: conflict.createdAt,
               id: conflict._id,
+              localEventId: conflict.localEventId,
+              sequence: conflict.sequence,
               status: conflict.status,
               summary: conflict.summary,
               type: conflict.conflictType,
@@ -1029,6 +1102,201 @@ export const recordRegisterSessionDeposit = mutation({
       action: "recorded" as const,
       deposit,
       registerSession: updatedRegisterSession,
+    });
+  },
+});
+
+export const resolveRegisterSessionSyncReview = mutation({
+  args: {
+    actorStaffProfileId: v.id("staffProfile"),
+    registerSessionId: v.id("registerSession"),
+    storeId: v.id("store"),
+  },
+  returns: registerSessionSyncReviewResultValidator,
+  handler: async (
+    ctx,
+    args,
+  ): Promise<CommandResult<ResolveRegisterSessionSyncReviewResult>> => {
+    const { athenaUser, store } = await requireCashControlsStoreAccess(
+      ctx,
+      args.storeId,
+    );
+    const registerSession = await ctx.db.get(
+      "registerSession",
+      args.registerSessionId,
+    );
+    if (!registerSession || registerSession.storeId !== args.storeId) {
+      return userError({
+        code: "not_found",
+        message: "Register session not found for this store.",
+      });
+    }
+
+    const canResolveReview = await staffProfileCanResolveSyncReview(ctx, {
+      organizationId: store.organizationId,
+      staffProfileId: args.actorStaffProfileId,
+      storeId: args.storeId,
+    });
+    if (!canResolveReview) {
+      return userError({
+        code: "authorization_failed",
+        message: "Only managers can resolve synced register reviews.",
+      });
+    }
+
+    const conflictsBySessionId =
+      await listOpenLocalSyncConflictsByRegisterSession(ctx, args.storeId);
+    const conflicts = conflictsBySessionId.get(args.registerSessionId) ?? [];
+    if (conflicts.length === 0) {
+      return ok({
+        action: "already_resolved",
+        registerSession,
+        projectedCount: 0,
+        resolvedCount: 0,
+      });
+    }
+
+    const resolvedAt = Date.now();
+    const localSyncRepository = createConvexLocalSyncRepository(ctx);
+    const projectedTransactionIds: string[] = [];
+
+    for (const conflict of conflicts) {
+      const terminalId = conflict.terminalId ?? registerSession.terminalId;
+      if (!terminalId) {
+        return userError({
+          code: "precondition_failed",
+          message:
+            "This register review can no longer be applied because the terminal link was not found.",
+        });
+      }
+      const syncEvent = await localSyncRepository.findEvent({
+        storeId: args.storeId,
+        terminalId,
+        localEventId: conflict.localEventId,
+      });
+      if (!syncEvent) {
+        return userError({
+          code: "precondition_failed",
+          message:
+            "This register review can no longer be applied because the synced activity was not found.",
+        });
+      }
+
+      const shouldApplyReviewedSale =
+        syncEvent.eventType === "sale_completed" &&
+        (!conflict.localRegisterSessionId ||
+          syncEvent.localRegisterSessionId === conflict.localRegisterSessionId) &&
+        conflict.conflictType === "permission" &&
+        conflict.summary === "Register was not open before this sale synced.";
+
+      if (!shouldApplyReviewedSale) {
+        continue;
+      }
+
+      if (syncEvent.status === "projected") {
+        continue;
+      }
+
+      if (syncEvent.status !== "conflicted") {
+        return userError({
+          code: "precondition_failed",
+          message:
+            "This register review is not ready to apply. Refresh the register session and try again.",
+        });
+      }
+
+      const parsedEvent = parseStoredLocalSyncEvent(
+        localSyncRepository,
+        syncEvent,
+      );
+      if (!parsedEvent.ok || parsedEvent.event.eventType !== "sale_completed") {
+        return userError({
+          code: "precondition_failed",
+          message:
+            "This register review could not be applied because the synced sale details are incomplete.",
+        });
+      }
+
+      const projection = await projectLocalSyncEvent(localSyncRepository, {
+        storeId: args.storeId,
+        terminalId,
+        event: parsedEvent.event,
+        syncEventId: syncEvent._id,
+        submittedByUserId: athenaUser._id,
+        now: resolvedAt,
+        options: {
+          allowClosedRegisterSaleProjection: true,
+          trustStoredStaffProof: true,
+        },
+      });
+      if (projection.status !== "projected") {
+        return userError({
+          code: "precondition_failed",
+          message:
+            "This register review still needs attention before the synced sales can be applied.",
+          metadata: {
+            conflictSummaries: projection.conflicts.map(
+              (projectionConflict) => projectionConflict.summary,
+            ),
+          },
+        });
+      }
+
+      await localSyncRepository.patchEvent(syncEvent._id, {
+        status: "projected",
+        projectedAt: resolvedAt,
+      });
+      projectedTransactionIds.push(
+        ...projection.mappings
+          .filter(
+            (mapping) =>
+              mapping.localIdKind === "transaction" &&
+              mapping.cloudTable === "posTransaction",
+          )
+          .map((mapping) => mapping.cloudId),
+      );
+    }
+
+    await Promise.all(
+      conflicts.map((conflict) =>
+        ctx.db.patch("posLocalSyncConflict", conflict._id, {
+          resolvedAt,
+          resolvedByStaffProfileId: args.actorStaffProfileId,
+          status: "resolved",
+        }),
+      ),
+    );
+
+    await recordOperationalEventWithCtx(ctx, {
+      actorStaffProfileId: args.actorStaffProfileId,
+      actorUserId: athenaUser._id,
+      eventType: "register_session_sync_review_resolved",
+      message:
+        projectedTransactionIds.length === 0
+          ? conflicts.length === 1
+            ? "Resolved synced register review."
+            : `Resolved ${conflicts.length} synced register reviews.`
+          : projectedTransactionIds.length === 1
+            ? "Applied reviewed synced register sale."
+            : `Applied ${projectedTransactionIds.length} reviewed synced register sales.`,
+      metadata: {
+        conflictIds: conflicts.map((conflict) => conflict._id),
+        conflictTypes: conflicts.map((conflict) => conflict.conflictType),
+        projectedTransactionIds,
+      },
+      organizationId: store.organizationId,
+      registerSessionId: args.registerSessionId,
+      storeId: args.storeId,
+      subjectId: args.registerSessionId,
+      subjectLabel: registerSession.registerNumber,
+      subjectType: "register_session",
+    });
+
+    return ok({
+      action: "resolved",
+      registerSession: await ctx.db.get("registerSession", args.registerSessionId),
+      projectedCount: projectedTransactionIds.length,
+      resolvedCount: conflicts.length,
     });
   },
 });

--- a/packages/athena-webapp/convex/operations/approvalRequests.test.ts
+++ b/packages/athena-webapp/convex/operations/approvalRequests.test.ts
@@ -520,4 +520,85 @@ describe("approval request helpers", () => {
       },
     });
   });
+
+  it("returns item adjustment settlement invariant failures as user errors", async () => {
+    const { ctx, tables } = createApprovalRequestMutationCtx({
+      authUserId: "auth-user-1",
+      role: "full_admin",
+    });
+    tables.approvalRequest.set("approval-item-1", {
+      _id: "approval-item-1",
+      organizationId: "org-1",
+      requestType: "pos_item_adjustment",
+      status: "pending",
+      storeId: "store-1",
+      subjectId: "pos_transaction_item_adjustment:txn-1:fingerprint",
+      subjectType: "pos_transaction_item_adjustment",
+    });
+    tables.approvalProof.set("proof-1", {
+      ...tables.approvalProof.get("proof-1"),
+      subjectId: "approval-item-1",
+      subjectLabel: "pos_item_adjustment",
+    });
+    vi.mocked(resolveTransactionItemAdjustmentApprovalDecisionWithCtx)
+      .mockRejectedValueOnce(
+        new Error("Register session expected cash cannot be negative."),
+      );
+
+    await expect(
+      decideApprovalRequestAsCommandWithCtx(ctx, {
+        approvalRequestId: "approval-item-1" as Id<"approvalRequest">,
+        approvalProofId: "proof-1" as Id<"approvalProof">,
+        decision: "approved",
+      }),
+    ).resolves.toMatchObject({
+      kind: "user_error",
+      error: {
+        code: "precondition_failed",
+        message: "Register session expected cash cannot be negative.",
+      },
+    });
+  });
+
+  it("returns duplicate pending item adjustment failures as user errors", async () => {
+    const { ctx, tables } = createApprovalRequestMutationCtx({
+      authUserId: "auth-user-1",
+      role: "full_admin",
+    });
+    tables.approvalRequest.set("approval-item-1", {
+      _id: "approval-item-1",
+      organizationId: "org-1",
+      requestType: "pos_item_adjustment",
+      status: "pending",
+      storeId: "store-1",
+      subjectId: "pos_transaction_item_adjustment:txn-1:fingerprint",
+      subjectType: "pos_transaction_item_adjustment",
+    });
+    tables.approvalProof.set("proof-1", {
+      ...tables.approvalProof.get("proof-1"),
+      subjectId: "approval-item-1",
+      subjectLabel: "pos_item_adjustment",
+    });
+    vi.mocked(resolveTransactionItemAdjustmentApprovalDecisionWithCtx)
+      .mockRejectedValueOnce(
+        new Error(
+          "This transaction already has an item adjustment waiting for approval.",
+        ),
+      );
+
+    await expect(
+      decideApprovalRequestAsCommandWithCtx(ctx, {
+        approvalRequestId: "approval-item-1" as Id<"approvalRequest">,
+        approvalProofId: "proof-1" as Id<"approvalProof">,
+        decision: "approved",
+      }),
+    ).resolves.toMatchObject({
+      kind: "user_error",
+      error: {
+        code: "precondition_failed",
+        message:
+          "This transaction already has an item adjustment waiting for approval.",
+      },
+    });
+  });
 });

--- a/packages/athena-webapp/convex/operations/approvalRequests.ts
+++ b/packages/athena-webapp/convex/operations/approvalRequests.ts
@@ -281,6 +281,9 @@ function mapDecideApprovalRequestError(
     message === "Item adjustment approval request does not match this payload." ||
     message === "Item adjustment payload is stale for this transaction." ||
     message === "Item adjustment cannot reduce inventory below zero." ||
+    message ===
+      "This transaction already has an item adjustment waiting for approval." ||
+    message === "Register session expected cash cannot be negative." ||
     message === "Only single-payment transactions can be corrected." ||
     message === "Only same-amount payment method corrections are supported." ||
     message === "Payment allocation must be a same-amount single payment."

--- a/packages/athena-webapp/convex/operations/registerSessions.trace.test.ts
+++ b/packages/athena-webapp/convex/operations/registerSessions.trace.test.ts
@@ -415,7 +415,7 @@ describe("register session workflow trace handlers", () => {
     );
   });
 
-  it("does not return a closed register session for POS register-state gate display", async () => {
+  it("returns a closed register session for POS register-state stale-local detection", async () => {
     const ctx = createMutationCtx({
       sessions: [
         buildRegisterSession({
@@ -434,7 +434,9 @@ describe("register session workflow trace handlers", () => {
       },
     );
 
-    expect(session).toBeNull();
+    expect(session).toEqual(
+      expect.objectContaining({ _id: "session-1", status: "closed" }),
+    );
   });
 
   it("does not return POS register-state session without terminal identity", async () => {

--- a/packages/athena-webapp/convex/operations/registerSessions.ts
+++ b/packages/athena-webapp/convex/operations/registerSessions.ts
@@ -574,10 +574,15 @@ export const getRegisterSessionForRegisterState = internalQuery({
 
       if (
         latestByRegisterNumber &&
-        isPosUsableRegisterSessionStatus(latestByRegisterNumber.status) &&
         latestByRegisterNumber.terminalId === args.terminalId
       ) {
-        return latestByRegisterNumber;
+        if (isPosUsableRegisterSessionStatus(latestByRegisterNumber.status)) {
+          return latestByRegisterNumber;
+        }
+
+        if (latestByRegisterNumber.status === "closed") {
+          return latestByRegisterNumber;
+        }
       }
     }
 
@@ -587,11 +592,19 @@ export const getRegisterSessionForRegisterState = internalQuery({
       .order("desc")
       .first();
 
-    if (!latestByTerminal || !isRegisterSessionConflictBlockingStatus(latestByTerminal.status)) {
+    if (!latestByTerminal) {
       return null;
     }
 
-    return latestByTerminal;
+    if (isRegisterSessionConflictBlockingStatus(latestByTerminal.status)) {
+      return latestByTerminal;
+    }
+
+    if (latestByTerminal.status === "closed" && !registerNumber) {
+      return latestByTerminal;
+    }
+
+    return null;
   },
 });
 

--- a/packages/athena-webapp/convex/operations/staffCredentials.test.ts
+++ b/packages/athena-webapp/convex/operations/staffCredentials.test.ts
@@ -1685,7 +1685,7 @@ describe("staff credential operations", () => {
 
   it("returns a precondition_failed result when the staff member is active on another terminal", async () => {
     const now = Date.now();
-    const { ctx } = createStaffCredentialsMutationCtx({
+    const { ctx, tables } = createStaffCredentialsMutationCtx({
       credentials: [
         {
           _id: "credential-1",
@@ -1773,10 +1773,15 @@ describe("staff credential operations", () => {
     ).resolves.toEqual({
       kind: "ok",
       data: expect.objectContaining({
-        staffProfileId: "staff_profile_1",
         activeRoles: ["cashier"],
+        posLocalStaffProof: {
+          expiresAt: expect.any(Number),
+          token: expect.any(String),
+        },
+        staffProfileId: "staff_profile_1",
       }),
     });
+    expect(tables.posLocalStaffProof.size).toBe(1);
 
     await expect(
       authenticateStaffCredentialForTerminalWithCtx(ctx, {

--- a/packages/athena-webapp/convex/operations/staffCredentials.ts
+++ b/packages/athena-webapp/convex/operations/staffCredentials.ts
@@ -736,45 +736,44 @@ export async function authenticateStaffCredentialForTerminalWithCtx(
     return authentication;
   }
 
-  if (args.allowActiveSessionsOnOtherTerminals) {
-    return authentication;
-  }
-
-  // A staff member can only have a small number of live sessions, so reading them in full is safe.
-  // eslint-disable-next-line @convex-dev/no-collect-in-query
-  const activeSessions = await ctx.db
-    .query("posSession")
-    .withIndex("by_staffProfileId", (q) =>
-      q.eq("staffProfileId", authentication.data.staffProfileId),
-    )
-    .collect();
-  const activeExpenseSessions = await ctx.db
-    .query("expenseSession")
-    .withIndex("by_staffProfileId_and_status", (q) =>
-      q
-        .eq("staffProfileId", authentication.data.staffProfileId)
-        .eq("status", "active"),
-    )
-    .take(ACTIVE_STAFF_SESSION_LOOKUP_LIMIT);
-  const now = Date.now();
-  const activeSessionsOnOtherTerminals = activeSessions.filter(
-    (session) =>
-      session.status === "active" &&
-      session.expiresAt > now &&
-      session.terminalId !== args.terminalId,
-  );
-  const activeExpenseSessionsOnOtherTerminals = activeExpenseSessions.filter(
-    (session) =>
-      session.expiresAt > now && session.terminalId !== args.terminalId,
-  );
-
-  if (
-    activeSessionsOnOtherTerminals.length > 0 ||
-    activeExpenseSessionsOnOtherTerminals.length > 0
-  ) {
-    return staffPreconditionFailedResult(
-      "This staff member has an active session on another terminal.",
+  if (!args.allowActiveSessionsOnOtherTerminals) {
+    // A staff member can only have a small number of live sessions, so reading them in full is safe.
+    // eslint-disable-next-line @convex-dev/no-collect-in-query
+    const activeSessions = await ctx.db
+      .query("posSession")
+      .withIndex("by_staffProfileId", (q) =>
+        q.eq("staffProfileId", authentication.data.staffProfileId),
+      )
+      .collect();
+    const activeExpenseSessions = await ctx.db
+      .query("expenseSession")
+      .withIndex("by_staffProfileId_and_status", (q) =>
+        q
+          .eq("staffProfileId", authentication.data.staffProfileId)
+          .eq("status", "active"),
+      )
+      .take(ACTIVE_STAFF_SESSION_LOOKUP_LIMIT);
+    const now = Date.now();
+    const activeSessionsOnOtherTerminals = activeSessions.filter(
+      (session) =>
+        session.status === "active" &&
+        session.expiresAt > now &&
+        session.terminalId !== args.terminalId,
     );
+    const activeExpenseSessionsOnOtherTerminals =
+      activeExpenseSessions.filter(
+        (session) =>
+          session.expiresAt > now && session.terminalId !== args.terminalId,
+      );
+
+    if (
+      activeSessionsOnOtherTerminals.length > 0 ||
+      activeExpenseSessionsOnOtherTerminals.length > 0
+    ) {
+      return staffPreconditionFailedResult(
+        "This staff member has an active session on another terminal.",
+      );
+    }
   }
 
   return withPosLocalStaffProof(ctx, authentication, args);

--- a/packages/athena-webapp/convex/pos/application/adjustTransactionItems.test.ts
+++ b/packages/athena-webapp/convex/pos/application/adjustTransactionItems.test.ts
@@ -570,6 +570,104 @@ describe("adjustTransactionItems", () => {
     expect(tables.approvalRequest.size).toBe(1);
   });
 
+  it("marks pending adjustment rows rejected when an async approval is rejected", async () => {
+    const { ctx, tables } = createFakeCtx();
+    tables.approvalRequest.set("approval-1", {
+      _id: "approval-1",
+      metadata: {
+        payloadFingerprint: "pending-fingerprint",
+        transactionId: "txn-1",
+      },
+      requestType: "pos_item_adjustment",
+      status: "pending",
+      storeId: "store-1",
+      subjectId: "pos_transaction_item_adjustment:txn-1:pending-fingerprint",
+      subjectType: "pos_transaction_item_adjustment",
+    });
+    tables.posTransactionAdjustment.set("adjustment-1", {
+      _id: "adjustment-1",
+      approvalRequestId: "approval-1",
+      payloadFingerprint: "pending-fingerprint",
+      status: "pending_approval",
+      storeId: "store-1",
+      transactionId: "txn-1",
+    });
+
+    await resolveTransactionItemAdjustmentApprovalDecisionWithCtx(ctx as never, {
+      approvalRequestId: "approval-1" as Id<"approvalRequest">,
+      decision: "rejected",
+      decisionNotes: "Not enough evidence",
+      reviewedByStaffProfileId: "manager-1" as Id<"staffProfile">,
+      reviewedByUserId: "manager-user-1" as Id<"athenaUser">,
+    });
+
+    expect(tables.posTransactionAdjustment.get("adjustment-1")).toMatchObject({
+      decidedAt: expect.any(Number),
+      status: "rejected",
+      updatedAt: expect.any(Number),
+    });
+    expect(recordOperationalEventWithCtx).toHaveBeenCalledWith(
+      ctx as never,
+      expect.objectContaining({
+        eventType: "pos_transaction_item_adjustment_approval_rejected",
+      }),
+    );
+
+    tables.approvalRequest.set("approval-1", {
+      ...(tables.approvalRequest.get("approval-1") ?? {}),
+      status: "rejected",
+    });
+
+    const next = await adjustTransactionItems(ctx as never, {
+      actorStaffProfileId: "cashier-1" as Id<"staffProfile">,
+      payload: basePayload(),
+      reason: "Try another adjustment after rejection",
+      transactionId: "txn-1" as Id<"posTransaction">,
+    });
+
+    expect(next).toMatchObject({ action: "approval_required" });
+  });
+
+  it("does not block new submissions on pending adjustment rows whose approval was rejected", async () => {
+    const { ctx, tables } = createFakeCtx();
+    tables.approvalRequest.set("approval-1", {
+      _id: "approval-1",
+      decidedAt: 123,
+      metadata: {
+        payloadFingerprint: "rejected-fingerprint",
+        transactionId: "txn-1",
+      },
+      requestType: "pos_item_adjustment",
+      status: "rejected",
+      storeId: "store-1",
+      subjectId: "pos_transaction_item_adjustment:txn-1:rejected-fingerprint",
+      subjectType: "pos_transaction_item_adjustment",
+    });
+    tables.posTransactionAdjustment.set("adjustment-1", {
+      _id: "adjustment-1",
+      approvalRequestId: "approval-1",
+      payloadFingerprint: "rejected-fingerprint",
+      status: "pending_approval",
+      storeId: "store-1",
+      transactionId: "txn-1",
+    });
+
+    const result = await adjustTransactionItems(ctx as never, {
+      actorStaffProfileId: "cashier-1" as Id<"staffProfile">,
+      payload: basePayload(),
+      reason: "Try another adjustment after rejection",
+      transactionId: "txn-1" as Id<"posTransaction">,
+    });
+
+    expect(result).toMatchObject({ action: "approval_required" });
+    expect(tables.posTransactionAdjustment.get("adjustment-1")).toMatchObject({
+      decidedAt: 123,
+      status: "rejected",
+      updatedAt: expect.any(Number),
+    });
+    expect(tables.approvalRequest.size).toBe(2);
+  });
+
   it("skips payment allocation when corrected total is unchanged", async () => {
     const { ctx } = createFakeCtx();
     vi.mocked(consumeCommandApprovalProofWithCtx).mockResolvedValue({

--- a/packages/athena-webapp/convex/pos/application/commands/adjustTransactionItems.ts
+++ b/packages/athena-webapp/convex/pos/application/commands/adjustTransactionItems.ts
@@ -111,6 +111,36 @@ function assertPayloadMatchesPlan(args: {
   }
 }
 
+async function reconcileStalePendingAdjustment(
+  ctx: MutationCtx,
+  activeAdjustment: Awaited<ReturnType<typeof getActiveTransactionAdjustment>>,
+) {
+  if (!activeAdjustment?.approvalRequestId) {
+    return activeAdjustment;
+  }
+
+  const approvalRequest = await ctx.db.get(
+    "approvalRequest",
+    activeAdjustment.approvalRequestId,
+  );
+  if (!approvalRequest || approvalRequest.status === "pending") {
+    return activeAdjustment;
+  }
+
+  const status =
+    approvalRequest.status === "rejected" || approvalRequest.status === "cancelled"
+      ? approvalRequest.status
+      : "stale";
+  const now = Date.now();
+  await (ctx.db as any).patch("posTransactionAdjustment", activeAdjustment._id, {
+    decidedAt: activeAdjustment.decidedAt ?? approvalRequest.decidedAt ?? now,
+    status,
+    updatedAt: now,
+  });
+
+  return null;
+}
+
 async function buildServerAdjustmentPlan(
   ctx: MutationCtx,
   args: {
@@ -150,8 +180,12 @@ async function buildServerAdjustmentPlan(
     storeId: args.transaction.storeId,
     transactionId: args.transaction._id,
   });
-  const planned = planTransactionAdjustment({
+  const effectiveActiveAdjustment = await reconcileStalePendingAdjustment(
+    ctx,
     activeAdjustment,
+  );
+  const planned = planTransactionAdjustment({
+    activeAdjustment: effectiveActiveAdjustment,
     draft: {
       existingLines: args.payload.lines.flatMap((line) =>
         line.originalTransactionItemId
@@ -429,6 +463,32 @@ async function findAppliedAdjustmentForTransaction(
         .eq("status", "applied"),
     )
     .first();
+}
+
+async function markPendingAdjustmentDecisionForApprovalRequest(
+  ctx: MutationCtx,
+  args: {
+    approvalRequestId: Id<"approvalRequest">;
+    decision: "rejected" | "cancelled";
+    now: number;
+  },
+) {
+  const pendingAdjustment = await (ctx.db as any)
+    .query("posTransactionAdjustment")
+    .withIndex("by_approvalRequestId", (q: any) =>
+      q.eq("approvalRequestId", args.approvalRequestId),
+    )
+    .first();
+
+  if (!pendingAdjustment || pendingAdjustment.status !== "pending_approval") {
+    return;
+  }
+
+  await (ctx.db as any).patch("posTransactionAdjustment", pendingAdjustment._id, {
+    decidedAt: args.now,
+    status: args.decision,
+    updatedAt: args.now,
+  });
 }
 
 async function requireMatchingPendingItemAdjustmentApprovalRequest(
@@ -1012,6 +1072,13 @@ export async function resolveTransactionItemAdjustmentApprovalDecisionWithCtx(
   }
 
   if (args.decision !== "approved") {
+    const decidedAt = Date.now();
+    await markPendingAdjustmentDecisionForApprovalRequest(ctx, {
+      approvalRequestId: args.approvalRequestId,
+      decision: args.decision,
+      now: decidedAt,
+    });
+
     await recordOperationalEventWithCtx(ctx, {
       actorStaffProfileId: args.reviewedByStaffProfileId,
       actorUserId: args.reviewedByUserId,

--- a/packages/athena-webapp/convex/pos/application/queries/getTransactions.ts
+++ b/packages/athena-webapp/convex/pos/application/queries/getTransactions.ts
@@ -320,6 +320,8 @@ export async function getTransactionById(
     transaction.registerNumber ??
     session?.registerNumber ??
     registerSession?.registerNumber;
+  const terminalId =
+    transaction.terminalId ?? session?.terminalId ?? registerSession?.terminalId;
   const items = await listTransactionItems(ctx, transaction._id);
   const sessionTraceId = session?.workflowTraceId ?? null;
   const customerProfileId =
@@ -416,6 +418,7 @@ export async function getTransactionById(
     registerNumber,
     registerSessionId,
     registerSessionStatus: registerSession?.status,
+    terminalId,
     paymentMethod: transaction.paymentMethod,
     payments: transaction.payments,
     totalPaid: transaction.totalPaid ?? transaction.total,

--- a/packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.ts
+++ b/packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.ts
@@ -469,6 +469,28 @@ function parseLocalSyncEvent(
   };
 }
 
+export function parseStoredLocalSyncEvent(
+  repository: LocalSyncIngestionRepository,
+  event: LocalSyncEventRecord,
+):
+  | { ok: true; event: ParsedPosLocalSyncEventInput }
+  | { ok: false; message: string } {
+  const envelopeMessage = validateLocalSyncEventEnvelope(event);
+  if (envelopeMessage) {
+    return { ok: false, message: envelopeMessage };
+  }
+
+  return parseLocalSyncEvent(repository, {
+    localEventId: event.localEventId,
+    localRegisterSessionId: event.localRegisterSessionId,
+    sequence: event.sequence,
+    eventType: event.eventType,
+    occurredAt: event.occurredAt,
+    staffProfileId: event.staffProfileId,
+    payload: event.payload,
+  });
+}
+
 function validateLocalSyncEventPayload(event: PosLocalSyncEventInput): string | null {
   if (event.eventType === "register_opened") {
     return validateRegisterOpenedPayload(event.payload);

--- a/packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.test.ts
+++ b/packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.test.ts
@@ -2129,6 +2129,62 @@ describe("projectLocalSyncEvent", () => {
     ]);
   });
 
+  it("projects a manager-reviewed sale against a closed register session", async () => {
+    const repository = createProjectionRepository({
+      registerSession: {
+        _id: "register-session-1",
+        expectedCash: 100,
+        closeoutRecords: [],
+        countedCash: 100,
+        registerNumber: "1",
+        status: "closed",
+        variance: 0,
+      },
+    });
+
+    const result = await projectLocalSyncEvent(repository, {
+      storeId: "store-1" as never,
+      terminalId: "terminal-1" as never,
+      event: {
+        ...buildSaleCompletedEvent(),
+        staffProofToken: undefined,
+      },
+      syncEventId: "sync-event-1",
+      now: 100,
+      options: {
+        allowClosedRegisterSaleProjection: true,
+        trustStoredStaffProof: true,
+      },
+    });
+
+    expect(result.status).toBe("projected");
+    expect(repository.createdTransactions).toEqual([
+      expect.objectContaining({
+        registerSessionId: "register-session-1",
+        total: 25,
+      }),
+    ]);
+    expect(repository.registerSessionPatches).toEqual(
+      expect.arrayContaining([
+        {
+          registerSessionId: "register-session-1",
+          patch: expect.objectContaining({
+            expectedCash: 125,
+            variance: -25,
+          }),
+        },
+      ]),
+    );
+    expect(result.mappings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          cloudTable: "posTransaction",
+          localId: "local-txn-1",
+        }),
+      ]),
+    );
+  });
+
   it("conflicts duplicate closeout attempts against an already closed register session", async () => {
     const repository = createProjectionRepository({
       registerSession: {

--- a/packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts
+++ b/packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts
@@ -28,6 +28,10 @@ type ProjectEventArgs = {
   syncEventId: string;
   submittedByUserId?: Id<"athenaUser">;
   now: number;
+  options?: {
+    allowClosedRegisterSaleProjection?: boolean;
+    trustStoredStaffProof?: boolean;
+  };
 };
 
 type SaleCompletedArgs = ProjectEventArgsFor<"sale_completed">;
@@ -208,13 +212,20 @@ async function validateProjectionPermission(
         now: args.now,
       })
     : false;
+  const hasTrustedStoredStaffProof =
+    args.options?.trustStoredStaffProof === true &&
+    Boolean(staff) &&
+    staff?.storeId === args.storeId &&
+    staff?.status === "active" &&
+    hasActivePosRole &&
+    hasTerminalAccess;
   const hasTerminalStaffProof =
     Boolean(staff) &&
     staff?.storeId === args.storeId &&
     staff?.status === "active" &&
     hasActivePosRole &&
     hasTerminalAccess &&
-    hasValidStaffProof;
+    (hasValidStaffProof || hasTrustedStoredStaffProof);
   const requiresManagerProof =
     args.event.eventType === "register_reopened" &&
     allowedRoles.length === 1 &&
@@ -233,13 +244,20 @@ async function validateProjectionPermission(
           allowedRoles: ["cashier", "manager"],
         })
       : false;
+  const hasTrustedStoredCashierOrManagerProof =
+    args.options?.trustStoredStaffProof === true &&
+    Boolean(staff) &&
+    staff?.storeId === args.storeId &&
+    staff?.status === "active" &&
+    hasActiveCashierOrManagerRole &&
+    hasTerminalAccess;
   const hasTerminalCashierOrManagerProof =
     Boolean(staff) &&
     staff?.storeId === args.storeId &&
     staff?.status === "active" &&
     hasActiveCashierOrManagerRole &&
     hasTerminalAccess &&
-    hasValidStaffProof;
+    (hasValidStaffProof || hasTrustedStoredCashierOrManagerProof);
   if (
     hasTerminalCashierOrManagerProof &&
     args.event.eventType === "register_opened" &&
@@ -620,6 +638,22 @@ async function resolveSaleRegisterAndSession(
   }
 
   if (!isPosUsableRegisterSession(registerSession)) {
+    if (
+      args.options?.allowClosedRegisterSaleProjection === true &&
+      registerSession.status === "closed"
+    ) {
+      return {
+        registerSession,
+        existingPosSession: null,
+        existingPosSessionMapping: null,
+        resolvedRegisterNumber:
+          payload.registerNumber ??
+          registerSession.registerNumber ??
+          terminal?.registerNumber ??
+          "",
+      };
+    }
+
     const conflict = await createConflict(repository, args, {
       conflictType: "permission",
       summary: "Register was not open before this sale synced.",
@@ -1151,9 +1185,16 @@ async function persistPaymentAllocations(
   }
 
   if (payments.expectedCashDelta > 0) {
+    const expectedCash =
+      session.registerSession.expectedCash + payments.expectedCashDelta;
+    const variance =
+      session.registerSession.status === "closed" &&
+      typeof session.registerSession.countedCash === "number"
+        ? session.registerSession.countedCash - expectedCash
+        : undefined;
     await repository.patchRegisterSession(session.registerSession._id, {
-      expectedCash:
-        session.registerSession.expectedCash + payments.expectedCashDelta,
+      expectedCash,
+      ...(variance === undefined ? {} : { variance }),
     });
   }
 

--- a/packages/athena-webapp/convex/pos/public/transactions.test.ts
+++ b/packages/athena-webapp/convex/pos/public/transactions.test.ts
@@ -90,7 +90,7 @@ describe("POS public transaction query validators", () => {
     });
   });
 
-  it("exposes session trace ids for transaction details", () => {
+  it("exposes session trace and terminal ids for transaction details", () => {
     const validator = parseValidator(exportReturns(getTransactionById));
 
     expect(validator.type).toBe("union");
@@ -99,6 +99,7 @@ describe("POS public transaction query validators", () => {
       type: "object",
       value: {
         sessionTraceId: expect.any(Object),
+        terminalId: expect.any(Object),
       },
     });
   });

--- a/packages/athena-webapp/convex/pos/public/transactions.ts
+++ b/packages/athena-webapp/convex/pos/public/transactions.ts
@@ -284,6 +284,7 @@ export const getTransactionById = query({
       registerNumber: v.optional(v.string()),
       registerSessionId: v.optional(v.id("registerSession")),
       registerSessionStatus: v.optional(v.string()),
+      terminalId: v.optional(v.id("posTerminal")),
       paymentMethod: v.optional(v.string()),
       payments: v.array(paymentValidator),
       totalPaid: v.number(),

--- a/packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx
+++ b/packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx
@@ -390,7 +390,9 @@ function DrawerSessionCard({
   const showCountedCash = variance !== 0 && session.countedCash !== undefined;
   const showDeposited = session.totalDeposited > 0;
   const syncStatus = getSessionSyncStatus(session);
-  const showSyncBadge = syncStatus.status !== "synced";
+  const showSyncBadge =
+    syncStatus.status !== "synced" && syncStatus.status !== "needs_review";
+  const showSyncDescription = syncStatus.status !== "synced";
   const firstReconciliationItem = syncStatus.reconciliationItems[0];
   const metricColumnCount =
     1 +
@@ -523,7 +525,7 @@ function DrawerSessionCard({
         {getSessionActionLabel(session)}
         <ArrowRight aria-hidden className="h-4 w-4" />
       </span>
-      {showSyncBadge ? (
+      {showSyncDescription ? (
         <p className="mt-layout-xs text-xs leading-5 text-muted-foreground">
           {syncStatus.description}
         </p>

--- a/packages/athena-webapp/src/components/cash-controls/RegisterSessionView.test.tsx
+++ b/packages/athena-webapp/src/components/cash-controls/RegisterSessionView.test.tsx
@@ -446,11 +446,138 @@ describe("RegisterSessionViewContent", () => {
     );
 
     expect(screen.getAllByText("Needs review")[0]).toBeInTheDocument();
+    expect(screen.getByText("1 review item")).toBeInTheDocument();
+    expect(screen.getByText("Reconciliation review")).toBeInTheDocument();
+    expect(
+      screen.getByText("Review synced register activity."),
+    ).toBeInTheDocument();
+  });
+
+  it("lists each synced register review item with safe event evidence", () => {
+    const createdAt = new Date("2026-05-20T14:30:00.000Z").getTime();
+
+    render(
+      <RegisterSessionViewContent
+        currency="GHS"
+        isLoading={false}
+        onRecordDeposit={vi.fn()}
+        {...closeoutHandlers}
+        registerSessionSnapshot={{
+          ...baseSnapshot,
+          registerSession: {
+            ...baseSnapshot.registerSession,
+            localSyncStatus: {
+              status: "needs_review",
+              reconciliationItems: [
+                {
+                  createdAt,
+                  id: "sync_conflict_permission",
+                  localEventId: "event-sale-completed-2",
+                  sequence: 12,
+                  status: "needs_review",
+                  summary: "Register was not open before this sale synced.",
+                  type: "permission",
+                },
+                {
+                  createdAt,
+                  id: "sync_conflict_payment",
+                  localEventId: "event-payment-1",
+                  sequence: 13,
+                  status: "needs_review",
+                  summary: "Payment allocation needs manager review.",
+                  type: "payment",
+                },
+              ],
+            },
+          },
+        }}
+      />,
+    );
+
+    expect(screen.getByText("2 review items")).toBeInTheDocument();
+    expect(screen.getByText("Permission review")).toBeInTheDocument();
+    expect(screen.getByText("Payment review")).toBeInTheDocument();
+    expect(
+      screen.getByText("Register was not open before this sale synced."),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Payment allocation needs manager review."),
+    ).toBeInTheDocument();
     expect(
       screen.getByText(
-        /Reconciliation review: Review synced register activity./i,
+        "Sale completed while Athena did not have this register open.",
       ),
     ).toBeInTheDocument();
+    expect(
+      screen.getByText("Payment update came from local register activity."),
+    ).toBeInTheDocument();
+    expect(screen.getByText("#12 in local queue")).toBeInTheDocument();
+    expect(screen.getByText("#13 in local queue")).toBeInTheDocument();
+  });
+
+  it("resolves synced register review items after manager sign-in", async () => {
+    const user = userEvent.setup();
+    const onAuthenticateStaff = vi.fn().mockResolvedValue(
+      ok({
+        activeRoles: ["manager"],
+        staffProfile: { fullName: "Ato Kofi" },
+        staffProfileId: "manager-1",
+      }),
+    );
+    const onResolveSyncReview = vi
+      .fn()
+      .mockResolvedValue(
+        ok({ action: "resolved", projectedCount: 1, resolvedCount: 1 }),
+      );
+
+    render(
+      <RegisterSessionViewContent
+        currency="GHS"
+        isLoading={false}
+        onRecordDeposit={vi.fn()}
+        {...closeoutHandlers}
+        onAuthenticateStaff={onAuthenticateStaff}
+        onResolveSyncReview={onResolveSyncReview}
+        registerSessionSnapshot={{
+          ...baseSnapshot,
+          registerSession: {
+            ...baseSnapshot.registerSession,
+            localSyncStatus: {
+              status: "needs_review",
+              reconciliationItems: [
+                {
+                  id: "sync_conflict_1",
+                  status: "needs_review",
+                  summary: "Register was not open before this sale synced.",
+                  type: "permission",
+                },
+              ],
+            },
+          },
+        }}
+      />,
+    );
+
+    await user.click(
+      screen.getByRole("button", { name: "Apply reviewed sales" }),
+    );
+    await user.click(
+      screen.getByRole("button", {
+        name: "Confirm staff for Apply reviewed sales",
+      }),
+    );
+
+    await waitFor(() =>
+      expect(onAuthenticateStaff).toHaveBeenCalledWith({
+        allowedRoles: ["manager"],
+        pinHash: "hashed-pin",
+        username: "ato",
+      }),
+    );
+    expect(onResolveSyncReview).toHaveBeenCalledWith({
+      actorStaffProfileId: "manager-1",
+      registerSessionId: "session-1",
+    });
   });
 
   it("communicates when a register session has closed", () => {

--- a/packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx
+++ b/packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx
@@ -206,6 +206,17 @@ type RegisterCloseoutCommandPayload = {
 type RegisterCloseoutCommandResult =
   NormalizedApprovalCommandResult<RegisterCloseoutCommandPayload>;
 
+type ResolveSyncReviewArgs = {
+  actorStaffProfileId: string;
+  registerSessionId: string;
+};
+
+type ResolveSyncReviewResult = NormalizedCommandResult<{
+  action?: "already_resolved" | "resolved";
+  projectedCount?: number;
+  resolvedCount?: number;
+}>;
+
 type StaffAuthenticationCommandResult =
   NormalizedCommandResult<StaffAuthenticationResult>;
 
@@ -244,6 +255,9 @@ type RegisterSessionViewContentProps = {
   onReviewCloseout: (
     args: RegisterCloseoutReviewArgs,
   ) => Promise<RegisterCloseoutCommandResult>;
+  onResolveSyncReview?: (
+    args: ResolveSyncReviewArgs,
+  ) => Promise<ResolveSyncReviewResult>;
   onReopenCloseout?: (args: {
     actorStaffProfileId: string;
     approvalProofId: string;
@@ -283,6 +297,10 @@ type CloseoutStaffAuthIntent =
       decision: "approved" | "rejected";
       decisionNotes?: string;
       kind: "review";
+      registerSessionId: string;
+    }
+  | {
+      kind: "sync_review";
       registerSessionId: string;
     };
 
@@ -438,16 +456,59 @@ function getSyncBadgeClass(tone: PosSyncStatusPresentation["tone"]) {
   }
 }
 
+function formatReviewItemCount(count: number) {
+  return `${count} review ${count === 1 ? "item" : "items"}`;
+}
+
+function formatReviewItemTimestamp(timestamp?: number | null) {
+  return typeof timestamp === "number" && Number.isFinite(timestamp)
+    ? formatTimestamp(timestamp)
+    : null;
+}
+
+function formatReviewItemActivity(item: PosReconciliationItem) {
+  const localEventId = item.localEventId?.toLowerCase() ?? "";
+  const summary = item.summary?.toLowerCase() ?? "";
+
+  if (localEventId.includes("sale-completed")) {
+    if (item.type === "permission" && summary.includes("not open")) {
+      return "Sale completed while Athena did not have this register open.";
+    }
+
+    return "Sale completed from local register activity.";
+  }
+
+  if (localEventId.includes("register-opened")) {
+    return "Register opening came from local register activity.";
+  }
+
+  if (localEventId.includes("register-closed")) {
+    return "Register closeout came from local register activity.";
+  }
+
+  if (localEventId.includes("payment")) {
+    return "Payment update came from local register activity.";
+  }
+
+  return "Local register activity needs review before it is treated as settled.";
+}
+
 function RegisterSessionSyncNotice({
+  errorMessage,
+  isResolving,
+  onResolveReview,
   syncStatus,
 }: {
+  errorMessage?: string;
+  isResolving?: boolean;
+  onResolveReview?: () => void;
   syncStatus: PosSyncStatusPresentation;
 }) {
   if (syncStatus.status === "synced") {
     return null;
   }
 
-  const firstReconciliationItem = syncStatus.reconciliationItems[0];
+  const reconciliationItems = syncStatus.reconciliationItems;
 
   return (
     <section
@@ -458,7 +519,7 @@ function RegisterSessionSyncNotice({
       }`}
     >
       <div className="flex flex-wrap items-start justify-between gap-layout-md">
-        <div className="space-y-1">
+        <div className="max-w-3xl space-y-1">
           <p
             className={`text-[11px] font-medium uppercase tracking-[0.18em] ${
               syncStatus.tone === "danger" ? "text-danger" : "text-warning"
@@ -471,23 +532,102 @@ function RegisterSessionSyncNotice({
           <p className="text-sm leading-6 text-muted-foreground">
             {syncStatus.description}
           </p>
-          {syncStatus.status === "needs_review" && firstReconciliationItem ? (
-            <p className="text-sm leading-6 text-foreground">
-              {formatPosReconciliationType(firstReconciliationItem.type)}:{" "}
-              {firstReconciliationItem.summary?.trim() ||
-                "Review synced register activity before closeout is settled."}
+          {syncStatus.status === "needs_review" &&
+          reconciliationItems.length > 0 ? (
+            <div className="space-y-2 pt-layout-xs">
+              <p className="text-xs font-medium text-foreground">
+                {formatReviewItemCount(reconciliationItems.length)}
+              </p>
+              <div className="grid gap-2">
+                {reconciliationItems.map((item, index) => {
+                  const reportedAt = formatReviewItemTimestamp(item.createdAt);
+
+                  return (
+                    <article
+                      className="rounded-md border border-danger/15 bg-background/70 p-layout-sm"
+                      key={item.id ?? `${item.type ?? "review"}-${index}`}
+                    >
+                      <div className="space-y-1">
+                        <p className="text-sm font-medium text-foreground">
+                          {formatPosReconciliationType(item.type)}
+                        </p>
+                        <p className="text-sm leading-6 text-muted-foreground">
+                          {item.summary?.trim() ||
+                            "Review synced register activity before closeout is settled."}
+                        </p>
+                      </div>
+                      {item.localEventId ||
+                      typeof item.sequence === "number" ||
+                      reportedAt ? (
+                        <dl className="mt-layout-sm grid gap-layout-sm text-xs text-muted-foreground sm:grid-cols-3">
+                          {item.localEventId ? (
+                            <div className="min-w-0">
+                              <dt className="font-medium uppercase tracking-[0.16em] text-muted-foreground">
+                                Activity
+                              </dt>
+                              <dd className="text-foreground">
+                                {formatReviewItemActivity(item)}
+                              </dd>
+                            </div>
+                          ) : null}
+                          {typeof item.sequence === "number" ? (
+                            <div>
+                              <dt className="font-medium uppercase tracking-[0.16em] text-muted-foreground">
+                                Upload order
+                              </dt>
+                              <dd className="text-foreground">
+                                #{item.sequence} in local queue
+                              </dd>
+                            </div>
+                          ) : null}
+                          {reportedAt ? (
+                            <div>
+                              <dt className="font-medium uppercase tracking-[0.16em] text-muted-foreground">
+                                Reported
+                              </dt>
+                              <dd className="text-foreground">{reportedAt}</dd>
+                            </div>
+                          ) : null}
+                        </dl>
+                      ) : null}
+                    </article>
+                  );
+                })}
+              </div>
+            </div>
+          ) : null}
+          {errorMessage ? (
+            <p className="text-sm leading-6 text-destructive">
+              {errorMessage}
             </p>
           ) : null}
         </div>
-        <Badge
-          className={getSyncBadgeClass(syncStatus.tone)}
-          size="sm"
-          variant="outline"
-        >
-          {syncStatus.pendingEventCount
-            ? `${syncStatus.pendingEventCount} pending`
-            : syncStatus.label}
-        </Badge>
+        <div className="flex flex-wrap items-center justify-end gap-layout-sm">
+          {syncStatus.status === "needs_review" && onResolveReview ? (
+            <LoadingButton
+              className="border-border bg-background text-foreground hover:bg-muted"
+              disabled={isResolving}
+              isLoading={Boolean(isResolving)}
+              onClick={onResolveReview}
+              size="sm"
+              type="button"
+              variant="outline"
+            >
+              Apply reviewed sales
+            </LoadingButton>
+          ) : null}
+          {syncStatus.status !== "needs_review" ? (
+            <Badge
+              className={getSyncBadgeClass(syncStatus.tone)}
+              size="sm"
+              variant="outline"
+            >
+              {syncStatus.pendingEventCount
+                ? `${syncStatus.pendingEventCount} pending`
+                : syncStatus.label}
+            </Badge>
+          ) : null}
+        </div>
       </div>
     </section>
   );
@@ -572,6 +712,7 @@ export function RegisterSessionViewContent({
   onRecordDeposit,
   onReopenCloseout,
   onReviewCloseout,
+  onResolveSyncReview,
   onSubmitCloseout,
   orgUrlSlug,
   registerSessionSnapshot,
@@ -592,6 +733,8 @@ export function RegisterSessionViewContent({
   const [pendingCloseoutAction, setPendingCloseoutAction] = useState<
     "approved" | "rejected" | "reopen" | "submit" | null
   >(null);
+  const [syncReviewErrorMessage, setSyncReviewErrorMessage] = useState("");
+  const [isResolvingSyncReview, setIsResolvingSyncReview] = useState(false);
   const [closeoutStaffAuthIntent, setCloseoutStaffAuthIntent] =
     useState<CloseoutStaffAuthIntent | null>(null);
   const [reopenedCloseoutSubmitIntent, setReopenedCloseoutSubmitIntent] =
@@ -999,6 +1142,46 @@ export function RegisterSessionViewContent({
     }
 
     const intent = closeoutStaffAuthIntent;
+
+    if (intent.kind === "sync_review") {
+      if (!onResolveSyncReview) {
+        setSyncReviewErrorMessage(
+          "Sync review resolution is not available yet. Try again after the register tools refresh.",
+        );
+        setCloseoutStaffAuthIntent(null);
+        return;
+      }
+
+      setSyncReviewErrorMessage("");
+      setIsResolvingSyncReview(true);
+      setCloseoutStaffAuthIntent(null);
+
+      try {
+        const commandResult = await onResolveSyncReview({
+          actorStaffProfileId: result.staffProfileId,
+          registerSessionId: intent.registerSessionId,
+        });
+
+        if (commandResult.kind !== "ok") {
+          setSyncReviewErrorMessage(commandResult.error.message);
+          return;
+        }
+
+        toast.success(
+          commandResult.data?.action === "already_resolved"
+            ? "Register review already resolved"
+            : commandResult.data?.projectedCount
+              ? commandResult.data.projectedCount === 1
+                ? "Reviewed sale applied"
+                : `${commandResult.data.projectedCount} reviewed sales applied`
+              : "Register review resolved",
+        );
+      } finally {
+        setIsResolvingSyncReview(false);
+      }
+      return;
+    }
+
     const action = intent.kind === "submit" ? "submit" : intent.decision;
 
     setCloseoutErrorMessage("");
@@ -1214,6 +1397,12 @@ export function RegisterSessionViewContent({
               ? "Approve variance"
               : "Reject variance",
         }
+      : closeoutStaffAuthIntent?.kind === "sync_review"
+        ? {
+            title: "Manager sign-in required",
+            description: "Authenticate to apply reviewed synced sales",
+            submitLabel: "Apply reviewed sales",
+          }
       : {
           title: "Closeout sign-in required",
           description: "Authenticate to submit closeout",
@@ -1274,7 +1463,21 @@ export function RegisterSessionViewContent({
       registerSession?.reconciliationItems ??
       [],
   });
+  const canResolveSyncReview =
+    syncStatus.status === "needs_review" && Boolean(onResolveSyncReview);
   const headerTerminalName = registerSession?.terminalName?.trim();
+
+  function requestResolveSyncReview() {
+    if (!registerSession || !canResolveSyncReview) {
+      return;
+    }
+
+    setSyncReviewErrorMessage("");
+    setCloseoutStaffAuthIntent({
+      kind: "sync_review",
+      registerSessionId: registerSession._id,
+    });
+  }
   const sessionCode = registerSession
     ? formatSessionCode(registerSession._id)
     : undefined;
@@ -1541,7 +1744,8 @@ export function RegisterSessionViewContent({
           return Promise.resolve(
             onAuthenticateStaff({
               allowedRoles:
-                closeoutStaffAuthIntent?.kind === "review"
+                closeoutStaffAuthIntent?.kind === "review" ||
+                closeoutStaffAuthIntent?.kind === "sync_review"
                   ? ["manager"]
                   : ["cashier", "manager"],
               pinHash: args.pinHash,
@@ -1632,7 +1836,14 @@ export function RegisterSessionViewContent({
       <FadeIn>
         <div className="container mx-auto space-y-6 p-6">
           {registerSession ? (
-            <RegisterSessionSyncNotice syncStatus={syncStatus} />
+            <RegisterSessionSyncNotice
+              errorMessage={syncReviewErrorMessage}
+              isResolving={isResolvingSyncReview}
+              onResolveReview={
+                canResolveSyncReview ? requestResolveSyncReview : undefined
+              }
+              syncStatus={syncStatus}
+            />
           ) : null}
           {registerSession ? (
             <RegisterSessionSupportEvidence
@@ -2687,6 +2898,9 @@ export function RegisterSessionView() {
   const recordRegisterSessionDeposit = useMutation(
     api.cashControls.deposits.recordRegisterSessionDeposit,
   );
+  const resolveRegisterSessionSyncReview = useMutation(
+    api.cashControls.deposits.resolveRegisterSessionSyncReview,
+  );
   const submitRegisterSessionCloseout = useMutation(
     api.cashControls.closeouts.submitRegisterSessionCloseout,
   );
@@ -2741,6 +2955,25 @@ export function RegisterSessionView() {
     }
 
     return result;
+  }
+
+  async function onResolveSyncReview(args: ResolveSyncReviewArgs) {
+    if (!activeStore?._id) {
+      return userError({
+        code: "authentication_failed",
+        message: "Select a store before resolving this register review",
+      });
+    }
+
+    const result = await runCommand(() =>
+      resolveRegisterSessionSyncReview({
+        actorStaffProfileId: args.actorStaffProfileId as Id<"staffProfile">,
+        registerSessionId: args.registerSessionId as Id<"registerSession">,
+        storeId: activeStore._id,
+      }),
+    );
+
+    return result as ResolveSyncReviewResult;
   }
 
   async function onSubmitCloseout(args: RegisterCloseoutSubmitArgs) {
@@ -3018,6 +3251,7 @@ export function RegisterSessionView() {
       onRecordDeposit={onRecordDeposit}
       onReopenCloseout={onReopenCloseout}
       onReviewCloseout={onReviewCloseout}
+      onResolveSyncReview={onResolveSyncReview}
       onSubmitCloseout={onSubmitCloseout}
       orgUrlSlug={params?.orgUrlSlug}
       registerSessionSnapshot={registerSessionSnapshot ?? null}

--- a/packages/athena-webapp/src/components/operations/OperationsQueueView.test.tsx
+++ b/packages/athena-webapp/src/components/operations/OperationsQueueView.test.tsx
@@ -977,4 +977,90 @@ describe("OperationsQueueViewContent", () => {
 
     consoleErrorSpy.mockRestore();
   });
+
+  it("surfaces approval command user errors from sale adjustments", async () => {
+    const { default: userEvent } = await import("@testing-library/user-event");
+    const user = userEvent.setup();
+    const submitStockBatch = vi.fn();
+    const decideApprovalRequest = vi.fn().mockResolvedValue({
+      kind: "user_error",
+      error: {
+        code: "precondition_failed",
+        message:
+          "This transaction already has an item adjustment waiting for approval.",
+      },
+    });
+    const authenticateStaffCredential = vi.fn().mockResolvedValue(
+      ok({
+        activeRoles: ["manager"],
+        staffProfile: {},
+        staffProfileId: "staff-manager-1",
+      }),
+    );
+    const authenticateStaffCredentialForApproval = vi.fn().mockResolvedValue(
+      ok({
+        approvalProofId: "proof-1",
+        approvedByStaffProfileId: "staff-manager-1",
+        expiresAt: Date.now() + 60_000,
+      }),
+    );
+
+    mockedHooks.useMutation.mockReset();
+    mockedHooks.useQuery.mockReset();
+    const mutationOrder = [
+      submitStockBatch,
+      decideApprovalRequest,
+      authenticateStaffCredential,
+      authenticateStaffCredentialForApproval,
+      vi.fn(),
+      vi.fn(),
+      vi.fn(),
+      vi.fn(),
+      vi.fn(),
+    ];
+    let mutationCallIndex = 0;
+    mockedHooks.useMutation.mockImplementation(
+      () => mutationOrder[mutationCallIndex++ % mutationOrder.length],
+    );
+    const queueSnapshot = {
+      approvalRequests: [
+        {
+          _id: "approval-1",
+          requestType: "pos_item_adjustment",
+          status: "pending",
+          workItemTitle: "Item adjustment review",
+        },
+      ],
+      workItems: [],
+    };
+    let queryCallIndex = 0;
+    mockedHooks.useQuery.mockImplementation(() => {
+      queryCallIndex += 1;
+
+      return queryCallIndex % 2 === 1
+        ? queueSnapshot
+        : baseProps.inventoryItems;
+    });
+
+    render(<OperationsQueueView />);
+
+    await user.click(screen.getByRole("button", { name: /unlock approvals/i }));
+    await user.click(
+      within(
+        screen.getByRole("dialog", { name: /unlock approval decisions/i }),
+      ).getByRole("button", { name: /unlock approvals/i }),
+    );
+    await waitFor(() => expect(authenticateStaffCredential).toHaveBeenCalled());
+
+    await user.click(
+      screen.getByRole("button", { name: /approve adjustment/i }),
+    );
+
+    await waitFor(() =>
+      expect(mockedToast.error).toHaveBeenCalledWith(
+        "This transaction already has an item adjustment waiting for approval.",
+      ),
+    );
+    expect(mockedToast.error).not.toHaveBeenCalledWith("Please try again.");
+  });
 });

--- a/packages/athena-webapp/src/components/pos/OrderSummary.tsx
+++ b/packages/athena-webapp/src/components/pos/OrderSummary.tsx
@@ -97,6 +97,13 @@ interface OrderSummaryProps {
       phone?: string;
     };
   } | null;
+  completedAdjustmentSummary?: {
+    originalTotal: number;
+    totalDelta: number;
+    settlementAmount: number;
+    settlementDirection: string;
+    settlementMethod?: string;
+  } | null;
   presentation?: "workspace" | "rail";
   cashierName?: string;
   receiptMessaging?: ReceiptMessagingConfig;
@@ -135,6 +142,7 @@ export function OrderSummary({
   readOnly = false,
   completedOrderNumber,
   completedTransactionData,
+  completedAdjustmentSummary,
   presentation = "workspace",
   cashierName,
   receiptMessaging,
@@ -208,6 +216,16 @@ export function OrderSummary({
   }, []);
   const showCompletedPaymentBreakdown =
     Boolean(completedTransactionData) && completedPaymentBreakdown.length > 1;
+  const hasCompletedAdjustment = Boolean(completedAdjustmentSummary);
+  const completedSummaryTitle = hasCompletedAdjustment
+    ? "Adjusted sale recorded"
+    : "Sale recorded";
+  const completedSummaryEyebrow = hasCompletedAdjustment
+    ? "Adjusted transaction summary"
+    : "Transaction summary";
+  const completedTotalLabel = hasCompletedAdjustment
+    ? "Adjusted total"
+    : "Total";
   const isEditingPaymentAmount = editingPaymentId !== null;
   const cartItemsCount = effectiveCartItems.reduce(
     (sum, item) => sum + item.quantity,
@@ -333,6 +351,32 @@ export function OrderSummary({
   const balanceDueLabelClass = isPaymentAmountOverpaying
     ? "text-success"
     : "text-transaction-signal";
+
+  const completedAdjustmentSettlementLabel =
+    completedAdjustmentSummary?.settlementDirection === "refund"
+      ? "Refund due"
+      : completedAdjustmentSummary?.settlementDirection === "collection" ||
+          completedAdjustmentSummary?.settlementDirection === "collect"
+        ? "Balance due"
+        : "Adjustment settlement";
+  const completedAdjustmentSettlementValue =
+    completedAdjustmentSummary?.settlementDirection === "none"
+      ? "No payment movement"
+      : completedAdjustmentSummary
+        ? [
+            formatStoredAmount(
+              formatter,
+              completedAdjustmentSummary.settlementAmount,
+            ),
+            completedAdjustmentSummary.settlementMethod
+              ? `via ${formatPaymentMethod(
+                  completedAdjustmentSummary.settlementMethod,
+                )}`
+              : null,
+          ]
+            .filter(Boolean)
+            .join(" ")
+        : null;
 
   useEffect(() => {
     if (selectedPaymentMethod === null) {
@@ -523,10 +567,10 @@ export function OrderSummary({
             </div>
             <div className="min-w-0 flex-1 space-y-1">
               <p className="text-xs font-semibold uppercase tracking-[0.24em] text-muted-foreground">
-                Transaction summary
+                {completedSummaryEyebrow}
               </p>
               <h2 className="text-xl font-semibold tracking-tight text-foreground">
-                Sale recorded
+                {completedSummaryTitle}
               </h2>
             </div>
           </div>
@@ -555,10 +599,49 @@ export function OrderSummary({
           </div>
           {completedTransactionData && (
             <div className="flex items-center justify-between text-sm">
-              <span className="text-muted-foreground">Amount paid</span>
+              <span className="text-muted-foreground">
+                {hasCompletedAdjustment
+                  ? "Original amount paid"
+                  : "Amount paid"}
+              </span>
               <span className="font-medium text-foreground">
                 {formatStoredAmount(formatter, completedTransactionAmountPaid)}
               </span>
+            </div>
+          )}
+          {completedAdjustmentSummary && (
+            <div className="space-y-4 border-y border-border/70 py-4 text-sm">
+              <div className="flex items-center justify-between gap-3">
+                <span className="text-muted-foreground">
+                  Original sale total
+                </span>
+                <span className="font-medium text-foreground">
+                  {formatStoredAmount(
+                    formatter,
+                    completedAdjustmentSummary.originalTotal,
+                  )}
+                </span>
+              </div>
+              <div className="flex items-center justify-between gap-3">
+                <span className="text-muted-foreground">Item adjustment</span>
+                <span className="font-medium text-foreground">
+                  {completedAdjustmentSummary.totalDelta > 0 ? "+" : ""}
+                  {formatStoredAmount(
+                    formatter,
+                    completedAdjustmentSummary.totalDelta,
+                  )}
+                </span>
+              </div>
+              {completedAdjustmentSettlementValue ? (
+                <div className="flex items-center justify-between gap-3">
+                  <span className="text-muted-foreground">
+                    {completedAdjustmentSettlementLabel}
+                  </span>
+                  <span className="max-w-[58%] text-right font-medium text-foreground">
+                    {completedAdjustmentSettlementValue}
+                  </span>
+                </div>
+              ) : null}
             </div>
           )}
           {showCompletedPaymentBreakdown && (
@@ -583,17 +666,22 @@ export function OrderSummary({
               </div>
             </div>
           )}
-          {completedTransactionData && completedTransactionChangeGiven > 0 && (
-            <div className="flex items-center justify-between text-sm">
-              <span className="text-muted-foreground">Change given</span>
-              <span className="font-medium text-foreground">
-                {formatStoredAmount(formatter, completedTransactionChangeGiven)}
-              </span>
-            </div>
-          )}
+          {completedTransactionData &&
+            completedTransactionChangeGiven > 0 &&
+            !hasCompletedAdjustment && (
+              <div className="flex items-center justify-between text-sm">
+                <span className="text-muted-foreground">Change given</span>
+                <span className="font-medium text-foreground">
+                  {formatStoredAmount(
+                    formatter,
+                    completedTransactionChangeGiven,
+                  )}
+                </span>
+              </div>
+            )}
           <div className="flex items-baseline justify-between gap-4 pb-4">
             <span className="text-xs font-semibold uppercase tracking-[0.22em] text-muted-foreground">
-              Total
+              {completedTotalLabel}
             </span>
             <span className="text-3xl font-semibold tracking-tight text-foreground">
               {formatStoredAmount(formatter, total)}

--- a/packages/athena-webapp/src/components/pos/transactions/TransactionView.test.tsx
+++ b/packages/athena-webapp/src/components/pos/transactions/TransactionView.test.tsx
@@ -295,11 +295,44 @@ vi.mock("sonner", () => ({
 }));
 
 vi.mock("../OrderSummary", () => ({
-  OrderSummary: () => <div data-testid="order-summary" />,
+  OrderSummary: ({
+    completedAdjustmentSummary,
+    completedTransactionData,
+  }: {
+    completedAdjustmentSummary?: {
+      originalTotal: number;
+      settlementAmount: number;
+      settlementDirection: string;
+      totalDelta: number;
+    } | null;
+    completedTransactionData?: { total: number } | null;
+  }) => (
+    <div data-testid="order-summary">
+      {completedAdjustmentSummary ? (
+        <span>
+          adjusted summary {completedTransactionData?.total} original{" "}
+          {completedAdjustmentSummary.originalTotal} delta{" "}
+          {completedAdjustmentSummary.totalDelta}
+        </span>
+      ) : null}
+    </div>
+  ),
 }));
 
 vi.mock("../CartItems", () => ({
-  CartItems: () => <div data-testid="cart-items" />,
+  CartItems: ({
+    cartItems,
+  }: {
+    cartItems: Array<{ name: string; price: number; quantity: number }>;
+  }) => (
+    <div data-testid="cart-items">
+      {cartItems.map((item) => (
+        <span key={item.name}>
+          {item.name} qty {item.quantity} total {item.price * item.quantity}
+        </span>
+      ))}
+    </div>
+  ),
 }));
 
 vi.mock("../../traces/WorkflowTraceRouteLink", () => ({
@@ -344,6 +377,7 @@ describe("TransactionView", () => {
     total: 1000,
     hasTrace: false,
     sessionTraceId: null,
+    terminalId: "terminal_1",
     paymentMethod: "cash",
     payments: [{ method: "cash", amount: 1000, timestamp: 123 }],
     totalPaid: 1000,
@@ -402,9 +436,11 @@ describe("TransactionView", () => {
     paymentMutation: ReturnType<typeof vi.fn>,
     approvalMutation: ReturnType<typeof vi.fn> = vi.fn(),
     itemAdjustmentMutation: ReturnType<typeof vi.fn> = vi.fn(),
+    terminalAuthMutation: ReturnType<typeof vi.fn> = authMutation,
   ) {
     const mutations = [
       authMutation,
+      terminalAuthMutation,
       approvalMutation,
       paymentMutation,
       customerMutation,
@@ -909,10 +945,6 @@ describe("TransactionView", () => {
       kind: "ok",
       data: {
         activeRoles: ["cashier"],
-        posLocalStaffProof: {
-          expiresAt: Date.now() + 60_000,
-          token: "proof-token-1",
-        },
         staffProfile: { firstName: "Kwamina", lastName: "Mensah" },
         staffProfileId: "staff_1",
       },
@@ -1009,10 +1041,6 @@ describe("TransactionView", () => {
       kind: "ok",
       data: {
         activeRoles: ["manager"],
-        posLocalStaffProof: {
-          expiresAt: Date.now() + 60_000,
-          token: "proof-token-1",
-        },
         staffProfile: { firstName: "Kwamina", lastName: "Mensah" },
         staffProfileId: "staff_1",
       },
@@ -1346,6 +1374,7 @@ describe("TransactionView", () => {
     render(<TransactionView />);
 
     expect(screen.queryByText("Adjustment state")).not.toBeInTheDocument();
+    expect(screen.queryByText("Adjusted sale")).not.toBeInTheDocument();
     expect(screen.getByText("Completed")).toBeInTheDocument();
   });
 
@@ -1354,13 +1383,26 @@ describe("TransactionView", () => {
     useQueryMock.mockReturnValue({
       ...baseTransaction,
       total: 2000,
+      subtotal: 2000,
+      items: [
+        {
+          _id: "item_1",
+          productId: "product_1",
+          productName: "Closure wig",
+          productSku: "CW-18",
+          productSkuId: "sku_1",
+          quantity: 2,
+          totalPrice: 2000,
+          unitPrice: 1000,
+        },
+      ],
       adjustmentSummary: {
         appliedCount: 1,
-        effectiveNetTotal: 1500,
+        effectiveNetTotal: 1000,
         hasAdjustments: true,
         originalTotal: 2000,
         pendingCount: 1,
-        totalAppliedAdjustmentDelta: -500,
+        totalAppliedAdjustmentDelta: -1000,
       },
       adjustments: [
         {
@@ -1377,12 +1419,22 @@ describe("TransactionView", () => {
         {
           _id: "event-1",
           actorStaffName: "Ama Mensah",
-          adjustedTotal: 1500,
+          adjustedTotal: 1000,
           appliedAt: 150,
           createdAt: 150,
-          lineItems: [],
+          lineItems: [
+            {
+              adjustedQuantity: 1,
+              originalQuantity: 2,
+              productName: "Closure wig",
+              productSku: "CW-18",
+              quantityDelta: -1,
+              totalDelta: -1000,
+              unitPrice: 1000,
+            },
+          ],
           originalTotal: 2000,
-          settlementAmount: 500,
+          settlementAmount: 1000,
           settlementDirection: "refund",
           status: "applied",
         },
@@ -1391,11 +1443,20 @@ describe("TransactionView", () => {
 
     render(<TransactionView />);
 
-    expect(screen.getByText("Adjustment state")).toBeInTheDocument();
-    expect(screen.getByText("Adjusted net total")).toBeInTheDocument();
+    expect(screen.getByText("Adjusted sale")).toBeInTheDocument();
+    expect(screen.getByText("Adjusted sale total")).toBeInTheDocument();
+    expect(screen.getByText("Original sale total")).toBeInTheDocument();
+    expect(screen.getByText("Item adjustment")).toBeInTheDocument();
     expect(screen.getByText("Item adjustment pending approval")).toBeInTheDocument();
     expect(screen.getByText("Item adjustment applied")).toBeInTheDocument();
+    expect(screen.getByText(/2 original to 1 adjusted/)).toBeInTheDocument();
     expect(screen.getAllByText("Refund due").length).toBeGreaterThan(0);
+    expect(screen.getByTestId("cart-items")).toHaveTextContent(
+      "Closure wig qty 1 total 1000",
+    );
+    expect(screen.getByTestId("order-summary")).toHaveTextContent(
+      "adjusted summary 1000 original 2000 delta -1000",
+    );
   });
 
   it("opens the item adjustment workflow and requires a settlement method for refunds", async () => {
@@ -1457,9 +1518,57 @@ describe("TransactionView", () => {
     expect(itemAdjustmentMutation).not.toHaveBeenCalled();
   });
 
+  it("cancels the item adjustment workflow and clears the draft", async () => {
+    const user = userEvent.setup();
+    mockTransactionMutations(vi.fn(), vi.fn(), vi.fn(), vi.fn(), vi.fn());
+    useParamsMock.mockReturnValue({ transactionId: "txn_items" });
+    useQueryMock.mockReturnValue({
+      ...baseTransaction,
+      total: 2000,
+      items: [
+        {
+          _id: "item_1",
+          productId: "product_1",
+          productName: "Closure wig",
+          productSku: "CW-18",
+          productSkuId: "sku_1",
+          quantity: 2,
+          totalPrice: 2000,
+          unitPrice: 1000,
+        },
+      ],
+    });
+
+    render(<TransactionView />);
+
+    await user.click(screen.getByRole("button", { name: "Update" }));
+    await user.click(
+      screen.getByRole("button", { name: "Items or quantities" }),
+    );
+    await user.click(screen.getByRole("button", { name: /decrease closure wig/i }));
+    await user.type(
+      screen.getByLabelText("Item adjustment reason"),
+      "Customer received one unit.",
+    );
+    await user.click(screen.getByRole("button", { name: "Cancel item adjustment" }));
+
+    expect(screen.queryByText("Review item adjustment")).not.toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole("button", { name: "Items or quantities" }),
+    );
+
+    expect(
+      screen.getByLabelText("Adjusted quantity for Closure wig"),
+    ).toHaveValue(2);
+    expect(screen.getByLabelText("Item adjustment reason")).toHaveValue("");
+    expect(screen.queryByText("Refund due")).not.toBeInTheDocument();
+  });
+
   it("submits item adjustments through the shared approval runner", async () => {
     const user = userEvent.setup();
-    const authMutation = vi.fn().mockResolvedValue({
+    const authMutation = vi.fn();
+    const terminalAuthMutation = vi.fn().mockResolvedValue({
       kind: "ok",
       data: {
         activeRoles: ["manager"],
@@ -1516,6 +1625,7 @@ describe("TransactionView", () => {
       vi.fn(),
       approvalMutation,
       itemAdjustmentMutation,
+      terminalAuthMutation,
     );
     useParamsMock.mockReturnValue({ transactionId: "txn_items" });
     useQueryMock.mockReturnValue({
@@ -1554,6 +1664,15 @@ describe("TransactionView", () => {
     await user.click(screen.getByRole("button", { name: "Confirm" }));
 
     await waitFor(() => {
+      expect(authMutation).not.toHaveBeenCalled();
+      expect(terminalAuthMutation).toHaveBeenCalledWith({
+        allowedRoles: ["cashier", "manager"],
+        allowActiveSessionsOnOtherTerminals: true,
+        pinHash: "hashed:1234",
+        storeId: "store_1",
+        terminalId: "terminal_1",
+        username: "manager",
+      });
       expect(approvalMutation).toHaveBeenCalledWith({
         actionKey: "pos.transaction.adjust_items",
         pinHash: "hashed:1234",
@@ -1610,7 +1729,8 @@ describe("TransactionView", () => {
       };
       kind: "ok";
     }>();
-    const authMutation = vi.fn().mockResolvedValue({
+    const authMutation = vi.fn();
+    const terminalAuthMutation = vi.fn().mockResolvedValue({
       kind: "ok",
       data: {
         activeRoles: ["manager"],
@@ -1653,6 +1773,7 @@ describe("TransactionView", () => {
       vi.fn(),
       approvalMutation,
       itemAdjustmentMutation,
+      terminalAuthMutation,
     );
     useParamsMock.mockReturnValue({ transactionId: "txn_items" });
     useQueryMock.mockReturnValue({
@@ -1709,7 +1830,8 @@ describe("TransactionView", () => {
 
   it("allows equal-total item adjustments without a settlement method", async () => {
     const user = userEvent.setup();
-    const authMutation = vi.fn().mockResolvedValue({
+    const authMutation = vi.fn();
+    const terminalAuthMutation = vi.fn().mockResolvedValue({
       kind: "ok",
       data: {
         activeRoles: ["cashier"],
@@ -1728,6 +1850,7 @@ describe("TransactionView", () => {
       vi.fn(),
       vi.fn(),
       itemAdjustmentMutation,
+      terminalAuthMutation,
     );
     useParamsMock.mockReturnValue({ transactionId: "txn_equal" });
     useQueryMock.mockReturnValue({

--- a/packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx
+++ b/packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx
@@ -251,6 +251,9 @@ export function TransactionView() {
   const correctAuth = useMutation(
     api.operations.staffCredentials.authenticateStaffCredential,
   );
+  const correctTerminalAuth = useMutation(
+    api.operations.staffCredentials.authenticateStaffCredentialForTerminal,
+  );
   const approveCommand = useMutation(
     api.operations.staffCredentials.authenticateStaffCredentialForApproval,
   );
@@ -360,15 +363,88 @@ export function TransactionView() {
     );
   }, [transaction]);
 
+  const appliedAdjustments = useMemo(() => {
+    if (!transaction) return [];
+    return (transaction.adjustments ?? []).filter(
+      (adjustment: (typeof transaction.adjustments)[number]) =>
+        adjustment.status === "applied",
+    );
+  }, [transaction]);
+  const latestAppliedAdjustment = appliedAdjustments[0] ?? null;
+  const hasAppliedItemAdjustment = appliedAdjustments.length > 0;
+  const adjustedCartItems: CartItem[] = useMemo(() => {
+    if (!transaction) return [];
+
+    const appliedLineItems = [...appliedAdjustments]
+      .sort(
+        (first, second) =>
+          (first.appliedAt ?? first.createdAt) -
+          (second.appliedAt ?? second.createdAt),
+      )
+      .flatMap((adjustment) => adjustment.lineItems ?? []);
+
+    return transaction.items
+      .map((item: (typeof transaction.items)[number]) => {
+        const adjustedLine =
+          appliedLineItems.find(
+            (line) => line.productSku && line.productSku === item.productSku,
+          ) ??
+          appliedLineItems.find(
+            (line) => line.productName === item.productName,
+          );
+        const adjustedQuantity =
+          typeof adjustedLine?.adjustedQuantity === "number"
+            ? adjustedLine.adjustedQuantity
+            : typeof adjustedLine?.quantityDelta === "number"
+              ? item.quantity + adjustedLine.quantityDelta
+              : item.quantity;
+
+        return {
+          id: item._id,
+          name: item.productName,
+          barcode: item.barcode || "",
+          sku: item.productSku,
+          price: item.unitPrice,
+          quantity: Math.max(0, adjustedQuantity),
+          productId: item.productId,
+          skuId: item.productSkuId,
+          image: item.image || undefined,
+        };
+      })
+      .filter((item) => item.quantity > 0);
+  }, [appliedAdjustments, transaction]);
+  const displayCartItems = hasAppliedItemAdjustment
+    ? adjustedCartItems
+    : cartItems;
+  const effectiveSaleTotal =
+    transaction?.adjustmentSummary?.effectiveNetTotal ??
+    transaction?.effectiveNetTotal ??
+    transaction?.total ??
+    0;
+  const originalSaleTotal =
+    transaction?.adjustmentSummary?.originalTotal ??
+    transaction?.originalTotal ??
+    transaction?.total ??
+    0;
+  const totalAppliedAdjustmentDelta =
+    transaction?.adjustmentSummary?.totalAppliedAdjustmentDelta ??
+    transaction?.totalAppliedAdjustmentDelta ??
+    effectiveSaleTotal - originalSaleTotal;
+  const effectiveSubtotal = transaction
+    ? Math.max(0, effectiveSaleTotal - (transaction.tax ?? 0))
+    : 0;
+
   const completedData = useMemo(() => {
     if (!transaction) return undefined;
     return {
       paymentMethod: transaction.paymentMethod || "cash",
       completedAt: transaction.completedAt,
-      cartItems,
-      subtotal: transaction.subtotal,
+      cartItems: displayCartItems,
+      subtotal: hasAppliedItemAdjustment
+        ? effectiveSubtotal
+        : transaction.subtotal,
       tax: transaction.tax,
-      total: transaction.total,
+      total: hasAppliedItemAdjustment ? effectiveSaleTotal : transaction.total,
       payments: transaction.payments.map(
         (
           payment: {
@@ -393,7 +469,13 @@ export function TransactionView() {
             }
           : undefined),
     };
-  }, [transaction, cartItems]);
+  }, [
+    displayCartItems,
+    effectiveSaleTotal,
+    effectiveSubtotal,
+    hasAppliedItemAdjustment,
+    transaction,
+  ]);
 
   const itemAdjustmentDraft = useMemo(() => {
     if (!transaction) {
@@ -532,6 +614,31 @@ export function TransactionView() {
       };
     }
 
+    if (pendingCorrection === "line_items") {
+      if (!transaction?.terminalId) {
+        return {
+          kind: "user_error" as const,
+          error: {
+            code: "authentication_failed" as const,
+            message:
+              "Transaction terminal is unavailable. Refresh the transaction and try again.",
+          },
+        };
+      }
+      const transactionTerminalId = transaction.terminalId;
+
+      return runCommand(() =>
+        correctTerminalAuth({
+          allowedRoles: ["cashier", "manager"],
+          allowActiveSessionsOnOtherTerminals: true,
+          pinHash: args.pinHash,
+          storeId: activeStore._id,
+          terminalId: transactionTerminalId,
+          username: args.username,
+        }),
+      );
+    }
+
     return runCommand(() =>
       correctAuth({
         allowedRoles: ["cashier", "manager"],
@@ -553,6 +660,13 @@ export function TransactionView() {
     setCorrectedQuantities({});
     setItemAdjustmentReason("");
     setItemAdjustmentSettlementMethod("");
+  }
+
+  function cancelItemAdjustmentWorkflow() {
+    resetItemAdjustmentWorkflow();
+    setCorrectionError(null);
+    setPendingCorrection(null);
+    setSelectedCorrection(null);
   }
 
   async function runCustomerCorrection(staff: StaffAuthenticationResult) {
@@ -728,7 +842,9 @@ export function TransactionView() {
     }
     const staffProofToken = args?.staff?.posLocalStaffProof?.token;
     if (!args?.staffProfileId || !staffProofToken) {
-      setCorrectionError("Staff sign-in is required before adjusting transaction items");
+      setCorrectionError(
+        "Staff sign-in is required before adjusting transaction items",
+      );
       return;
     }
     const payloadSettlementDirection: "collect" | "refund" | "none" =
@@ -1455,13 +1571,25 @@ export function TransactionView() {
                             {correctionError}
                           </p>
                         ) : null}
-                        <Button
-                          disabled={correctionSubmitting}
-                          onClick={() => requestCorrectionSubmit("line_items")}
-                          type="button"
-                        >
-                          Submit item adjustment
-                        </Button>
+                        <div className="grid gap-2">
+                          <Button
+                            disabled={correctionSubmitting}
+                            onClick={() =>
+                              requestCorrectionSubmit("line_items")
+                            }
+                            type="button"
+                          >
+                            Submit item adjustment
+                          </Button>
+                          <Button
+                            disabled={correctionSubmitting}
+                            onClick={cancelItemAdjustmentWorkflow}
+                            type="button"
+                            variant="outline"
+                          >
+                            Cancel item adjustment
+                          </Button>
+                        </div>
                       </div>
                     ) : selectedCorrection &&
                       !["customer", "payment_method"].includes(
@@ -1480,34 +1608,52 @@ export function TransactionView() {
                 <section className="space-y-4 overflow-hidden rounded-[calc(var(--radius)*1.35)] border border-border/80 bg-surface-raised p-5 shadow-surface">
                   <div className="space-y-1">
                     <h2 className="font-display text-xl font-semibold text-foreground">
-                      Adjustment state
+                      {hasAppliedItemAdjustment
+                        ? "Adjusted sale"
+                        : "Adjustment state"}
                     </h2>
                     <p className="text-sm text-muted-foreground">
                       Original sale totals stay locked. Adjusted totals are
-                      shown separately.
+                      shown for closeout and reporting.
                     </p>
                   </div>
                   <dl className="grid gap-3 rounded-lg border border-border bg-background p-4 text-sm">
                     <div className="flex items-center justify-between gap-3">
-                      <dt className="text-muted-foreground">Original total</dt>
+                      <dt className="text-muted-foreground">
+                        Original sale total
+                      </dt>
                       <dd className="font-numeric font-medium">
                         {formatStoredAmount(
                           ghsCurrencyFormatter,
-                          transaction.adjustmentSummary.originalTotal,
+                          originalSaleTotal,
                         )}
                       </dd>
                     </div>
                     <div className="flex items-center justify-between gap-3">
                       <dt className="text-muted-foreground">
-                        Adjusted net total
+                        Adjusted sale total
                       </dt>
                       <dd className="font-numeric font-semibold">
                         {formatStoredAmount(
                           ghsCurrencyFormatter,
-                          transaction.adjustmentSummary.effectiveNetTotal,
+                          effectiveSaleTotal,
                         )}
                       </dd>
                     </div>
+                    {hasAppliedItemAdjustment ? (
+                      <div className="flex items-center justify-between gap-3 border-t border-border/70 pt-3">
+                        <dt className="text-muted-foreground">
+                          Item adjustment
+                        </dt>
+                        <dd className="font-numeric font-medium text-foreground">
+                          {totalAppliedAdjustmentDelta > 0 ? "+" : ""}
+                          {formatStoredAmount(
+                            ghsCurrencyFormatter,
+                            totalAppliedAdjustmentDelta,
+                          )}
+                        </dd>
+                      </div>
+                    ) : null}
                     {transaction.adjustmentSummary.pendingCount > 0 ? (
                       <div className="flex items-center justify-between gap-3 border-t border-border/70 pt-3">
                         <dt className="text-muted-foreground">
@@ -1555,6 +1701,44 @@ export function TransactionView() {
                                 adjustment.settlementAmount,
                               )}
                         </p>
+                        {adjustment.lineItems.length > 0 ? (
+                          <div className="mt-4 space-y-2 border-t border-border/70 pt-3">
+                            <p className="text-[11px] font-medium uppercase tracking-[0.16em] text-muted-foreground">
+                              Items adjusted
+                            </p>
+                            <div className="space-y-2">
+                              {adjustment.lineItems.map((line) => (
+                                <div
+                                  className="grid gap-1 rounded-md bg-background px-3 py-2 text-sm"
+                                  key={`${adjustment._id}-${line.productName}-${line.productSku ?? "sku"}`}
+                                >
+                                  <div className="flex items-start justify-between gap-3">
+                                    <span className="font-medium text-foreground">
+                                      {line.productName}
+                                    </span>
+                                    {typeof line.totalDelta === "number" ? (
+                                      <span className="font-numeric text-foreground">
+                                        {line.totalDelta > 0 ? "+" : ""}
+                                        {formatStoredAmount(
+                                          ghsCurrencyFormatter,
+                                          line.totalDelta,
+                                        )}
+                                      </span>
+                                    ) : null}
+                                  </div>
+                                  <p className="text-xs text-muted-foreground">
+                                    {line.productSku ? `${line.productSku} · ` : ""}
+                                    {typeof line.originalQuantity ===
+                                      "number" &&
+                                    typeof line.adjustedQuantity === "number"
+                                      ? `${line.originalQuantity} original to ${line.adjustedQuantity} adjusted`
+                                      : "Quantity adjusted"}
+                                  </p>
+                                </div>
+                              ))}
+                            </div>
+                          </div>
+                        ) : null}
                       </div>
                     ))}
                   </div>
@@ -1639,12 +1823,26 @@ export function TransactionView() {
               ) : null}
 
               <OrderSummary
-                cartItems={cartItems}
+                cartItems={displayCartItems}
                 readOnly
                 presentation="rail"
                 registerNumber={transaction.registerNumber}
                 completedOrderNumber={transaction.transactionNumber}
                 completedTransactionData={completedData}
+                completedAdjustmentSummary={
+                  hasAppliedItemAdjustment && latestAppliedAdjustment
+                    ? {
+                        originalTotal: originalSaleTotal,
+                        settlementAmount:
+                          latestAppliedAdjustment.settlementAmount,
+                        settlementDirection:
+                          latestAppliedAdjustment.settlementDirection,
+                        settlementMethod:
+                          latestAppliedAdjustment.settlementMethod,
+                        totalDelta: totalAppliedAdjustmentDelta,
+                      }
+                    : null
+                }
                 cashierName={
                   transaction.cashier
                     ? (formatStaffDisplayName(transaction.cashier) ?? undefined)
@@ -1671,7 +1869,7 @@ export function TransactionView() {
             </div>
 
             <CartItems
-              cartItems={cartItems}
+              cartItems={displayCartItems}
               readOnly
               className="h-full min-h-0"
             />

--- a/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts
@@ -1985,6 +1985,201 @@ describe("useRegisterViewModel", () => {
     expect(mockStartSession).not.toHaveBeenCalled();
   });
 
+  it("does not operate from a stale local drawer when the cloud register session is closed", async () => {
+    mockRegisterState = {
+      phase: "readyToStart",
+      terminal: { _id: "terminal-1", displayName: "Front Counter" },
+      cashier: {
+        _id: "staff-1",
+        firstName: "Ama",
+        lastName: "Kusi",
+        activeRoles: ["manager"],
+      },
+      activeRegisterSession: {
+        _id: "drawer-1",
+        status: "closed",
+        terminalId: "terminal-1",
+        registerNumber: "1",
+        openingFloat: 5_000,
+        expectedCash: 5_000,
+        openedAt: Date.now(),
+      },
+      activeSession: null,
+      activeSessionConflict: null,
+      resumableSession: null,
+    };
+    mockActiveSession = null;
+    mockListLocalEvents.mockResolvedValue({
+      ok: true,
+      value: [
+        buildLocalEvent({
+          sequence: 1,
+          type: "register.opened",
+          localRegisterSessionId: "local-register-1",
+          payload: {
+            localRegisterSessionId: "local-register-1",
+            openingFloat: 5_000,
+            expectedCash: 5_000,
+            status: "open",
+          },
+          sync: { status: "synced", uploaded: true },
+        }),
+      ],
+    });
+    mockListLocalCloudMappings.mockResolvedValue({
+      ok: true,
+      value: [
+        {
+          entity: "registerSession",
+          localId: "local-register-1",
+          cloudId: "drawer-1",
+          mappedAt: 1_100,
+        },
+      ],
+    });
+
+    const { useRegisterViewModel } = await import("./useRegisterViewModel");
+    const { result } = renderHook(() => useRegisterViewModel());
+
+    await act(async () => {
+      result.current.authDialog?.onAuthenticated(
+        buildStaffAuthenticationResult(),
+      );
+    });
+    await waitForLocalRegisterEffects(result);
+
+    expect(result.current.drawerGate).not.toBeNull();
+    expect(result.current.drawerGate?.mode).toBe("initialSetup");
+    expect(result.current.productEntry.disabled).toBe(true);
+    expect(
+      mockAppendLocalEvent.mock.calls.some(
+        ([event]) => event.type === "session.started",
+      ),
+    ).toBe(false);
+  });
+
+  it("keeps an active local sale recoverable when its mapped cloud register session is closed", async () => {
+    mockRegisterState = {
+      phase: "readyToStart",
+      terminal: { _id: "terminal-1", displayName: "Front Counter" },
+      cashier: {
+        _id: "staff-1",
+        firstName: "Ama",
+        lastName: "Kusi",
+        activeRoles: ["manager"],
+      },
+      activeRegisterSession: {
+        _id: "drawer-1",
+        status: "closed",
+        terminalId: "terminal-1",
+        registerNumber: "1",
+        openingFloat: 5_000,
+        expectedCash: 5_000,
+        openedAt: Date.now(),
+      },
+      activeSession: null,
+      activeSessionConflict: null,
+      resumableSession: null,
+    };
+    mockActiveSession = null;
+    mockListLocalEvents.mockResolvedValue({
+      ok: true,
+      value: [
+        buildLocalEvent({
+          sequence: 1,
+          type: "register.opened",
+          localRegisterSessionId: "local-register-1",
+          payload: {
+            localRegisterSessionId: "local-register-1",
+            openingFloat: 5_000,
+            expectedCash: 5_000,
+            status: "open",
+          },
+          sync: { status: "synced", uploaded: true },
+        }),
+        buildLocalEvent({
+          sequence: 2,
+          type: "session.started",
+          localRegisterSessionId: "local-register-1",
+          localPosSessionId: "local-sale-1",
+          payload: {
+            localPosSessionId: "local-sale-1",
+            status: "active",
+          },
+          sync: { status: "synced", uploaded: true },
+        }),
+        buildLocalEvent({
+          sequence: 3,
+          type: "cart.item_added",
+          localRegisterSessionId: "local-register-1",
+          localPosSessionId: "local-sale-1",
+          payload: {
+            localItemId: "local-item-1",
+            productId: "product-1",
+            productSkuId: "sku-1",
+            productSku: "SKU-1",
+            productName: "Body Wave",
+            price: 7_500,
+            quantity: 2,
+          },
+          sync: { status: "synced", uploaded: true },
+        }),
+        buildLocalEvent({
+          sequence: 4,
+          type: "session.payments_updated",
+          localRegisterSessionId: "local-register-1",
+          localPosSessionId: "local-sale-1",
+          payload: {
+            localPosSessionId: "local-sale-1",
+            payments: [{ method: "cash", amount: 15_000, timestamp: 1_004 }],
+            stage: "paymentAdded",
+          },
+          sync: { status: "synced", uploaded: true },
+        }),
+      ],
+    });
+    mockListLocalCloudMappings.mockResolvedValue({
+      ok: true,
+      value: [
+        {
+          entity: "registerSession",
+          localId: "local-register-1",
+          cloudId: "drawer-1",
+          mappedAt: 1_100,
+        },
+      ],
+    });
+
+    const { useRegisterViewModel } = await import("./useRegisterViewModel");
+    const { result } = renderHook(() => useRegisterViewModel());
+
+    await act(async () => {
+      result.current.authDialog?.onAuthenticated(
+        buildStaffAuthenticationResult(),
+      );
+    });
+    await waitForLocalRegisterEffects(result);
+
+    expect(result.current.drawerGate).toBeNull();
+    expect(result.current.productEntry.disabled).toBe(true);
+    expect(result.current.checkout.cartItems).toHaveLength(1);
+    expect(result.current.checkout.payments).toEqual([
+      expect.objectContaining({ method: "cash", amount: 15_000 }),
+    ]);
+
+    await act(async () => {
+      await result.current.checkout.onCompleteTransaction();
+    });
+
+    expect(mockAppendLocalEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "transaction.completed",
+        localRegisterSessionId: "local-register-1",
+        localPosSessionId: "local-sale-1",
+      }),
+    );
+  });
+
   it("uses offline authenticated manager roles for drawer access", async () => {
     mockRegisterState = {
       phase: "readyToStart",

--- a/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts
@@ -255,6 +255,38 @@ function getCloseoutCloudRegisterSessionId(
     : (session?._id as Id<"registerSession"> | undefined);
 }
 
+function isKnownCloudRegisterSessionBlockingLocalProjection(
+  cloudRegisterSession:
+    | { _id?: Id<"registerSession"> | string; status?: string }
+    | null
+    | undefined,
+  localRegisterSession:
+    | {
+        cloudRegisterSessionId?: string;
+        localRegisterSessionId?: string;
+      }
+    | null
+    | undefined,
+) {
+  if (
+    !cloudRegisterSession ||
+    !localRegisterSession ||
+    isPosUsableRegisterSessionStatus(cloudRegisterSession.status)
+  ) {
+    return false;
+  }
+
+  const cloudRegisterSessionId = cloudRegisterSession._id?.toString();
+  if (!cloudRegisterSessionId) {
+    return false;
+  }
+
+  return (
+    localRegisterSession.cloudRegisterSessionId === cloudRegisterSessionId ||
+    localRegisterSession.localRegisterSessionId === cloudRegisterSessionId
+  );
+}
+
 function trimOptional(value: string): string | undefined {
   const trimmedValue = value.trim();
   return trimmedValue.length > 0 ? trimmedValue : undefined;
@@ -1050,10 +1082,24 @@ export function useRegisterViewModel(): RegisterViewModel {
   const latestLocalCloseoutIsSynced =
     latestLocalRegisterLifecycleEvent?.type === "register.closeout_started" &&
     latestLocalRegisterLifecycleEvent.sync.status === "synced";
+  const projectedLocalActiveSale = localRegisterReadModel?.activeSale ?? null;
+  const projectedLocalActiveSaleStaffProfileId =
+    projectedLocalActiveSale?.staffProfileId ?? null;
+  const isProjectedLocalActiveSaleOwnedByCurrentStaff = Boolean(
+    projectedLocalActiveSale &&
+      staffProfileId &&
+      projectedLocalActiveSaleStaffProfileId === staffProfileId,
+  );
+  const cloudRegisterSessionBlocksLocalProjection =
+    isKnownCloudRegisterSessionBlockingLocalProjection(
+      registerState?.activeRegisterSession,
+      localRegisterReadModel?.activeRegisterSession,
+    );
   const projectedLocalRegisterSession =
     localRegisterReadModel?.activeRegisterSession &&
     activeStoreId &&
     terminal?._id &&
+    !cloudRegisterSessionBlocksLocalProjection &&
     isPosUsableRegisterSessionStatus(
       localRegisterReadModel.activeRegisterSession.status,
     )
@@ -1128,16 +1174,9 @@ export function useRegisterViewModel(): RegisterViewModel {
   const cloudRegisterSessionId = activeRegisterSessionId?.toString();
   const localEventRegisterSessionId =
     locallyOperableRegisterSession?.localRegisterSessionId ??
+    projectedLocalActiveSale?.localRegisterSessionId ??
     projectedLocalRegisterSession?.localRegisterSessionId ??
     cloudRegisterSessionId;
-  const projectedLocalActiveSale = localRegisterReadModel?.activeSale ?? null;
-  const projectedLocalActiveSaleStaffProfileId =
-    projectedLocalActiveSale?.staffProfileId ?? null;
-  const isProjectedLocalActiveSaleOwnedByCurrentStaff = Boolean(
-    projectedLocalActiveSale &&
-      staffProfileId &&
-      projectedLocalActiveSaleStaffProfileId === staffProfileId,
-  );
   const isProjectedLocalActiveSaleLockedToAnotherStaff = Boolean(
     projectedLocalActiveSale &&
       (!staffProfileId || projectedLocalActiveSaleStaffProfileId !== staffProfileId),
@@ -1692,6 +1731,11 @@ export function useRegisterViewModel(): RegisterViewModel {
     (hasActiveCartDraft || hasActiveCustomerDetails || payments.length > 0),
   );
   const hasActivePosSession = Boolean(operableActiveSession?._id);
+  const hasCloudBlockedRecoverableLocalSale = Boolean(
+    cloudRegisterSessionBlocksLocalProjection &&
+      projectedLocalActiveSale &&
+      isProjectedLocalActiveSaleOwnedByCurrentStaff,
+  );
   const activeSessionNeedsRegisterBinding = Boolean(
     isCloudOperableSession(operableActiveSession) &&
       !operableActiveSession.registerSessionId,
@@ -1734,7 +1778,7 @@ export function useRegisterViewModel(): RegisterViewModel {
       hasCloseoutBlockedDrawerState ||
       hasMissingDrawerRecoveryState ||
       activeSessionHasBlockedRegisterBinding),
-  );
+  ) && !hasCloudBlockedRecoverableLocalSale;
   const closeoutBlockedGateIsRecovery = Boolean(
     hasCloseoutBlockedDrawerState &&
     (hasMissingDrawerRecoveryState || activeSessionHasBlockedRegisterBinding),
@@ -4542,6 +4586,7 @@ export function useRegisterViewModel(): RegisterViewModel {
         !staffProfileId ||
         isProjectedLocalActiveSaleBlockingCurrentStaff ||
         shouldShowDrawerGate ||
+        cloudRegisterSessionBlocksLocalProjection ||
         activeSessionHasBlockedRegisterBinding ||
         isOpeningDrawer,
       showProductLookup: showProductEntry,

--- a/packages/athena-webapp/src/lib/pos/presentation/syncStatusPresentation.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/syncStatusPresentation.ts
@@ -8,7 +8,10 @@ export type PosSyncStatusKind =
 export type PosSyncStatusTone = "success" | "neutral" | "warning" | "danger";
 
 export type PosReconciliationItem = {
+  createdAt?: number | null;
   id?: string;
+  localEventId?: string | null;
+  sequence?: number | null;
   status?: string | null;
   summary?: string | null;
   type?: string | null;


### PR DESCRIPTION
## Summary
- project register-session review items into cash controls after manager review, with clearer operator-facing review details
- tighten POS register-session completion gaps and adjusted-sale presentation
- surface actionable adjustment approval errors and allow dismissed item-adjustment flows
- add regression coverage and a solution note for the POS/register review projection behavior

## Validation
- bun run pr:athena

## Deploy note
- This branch changes Convex and Athena webapp code; deploy should run Convex prod deploy and Athena local-build deploy after merge.