### PR TITLE
Add completed POS transaction void flow

### DIFF
--- a/docs/plans/2026-05-21-001-feat-completed-transaction-void-plan.html
+++ b/docs/plans/2026-05-21-001-feat-completed-transaction-void-plan.html
@@ -1,0 +1,276 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>feat: Add Completed Transaction Void Workflow</title>
+  <style>
+    :root {
+      color-scheme: light;
+      --bg: #f7f8fb;
+      --paper: #ffffff;
+      --ink: #172033;
+      --muted: #5c677d;
+      --border: #d9deea;
+      --accent: #285e75;
+      --accent-soft: #e8f3f6;
+      --risk: #8a4b12;
+      --risk-soft: #fff3df;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      background: var(--bg);
+      color: var(--ink);
+      font: 15px/1.55 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }
+    main {
+      max-width: 1120px;
+      margin: 0 auto;
+      padding: 40px 20px 64px;
+    }
+    header {
+      background: var(--paper);
+      border: 1px solid var(--border);
+      border-radius: 10px;
+      padding: 28px;
+      box-shadow: 0 10px 32px rgba(23, 32, 51, 0.06);
+    }
+    h1, h2, h3 { line-height: 1.2; margin: 0; }
+    h1 { font-size: clamp(1.8rem, 4vw, 2.6rem); letter-spacing: 0; }
+    h2 { font-size: 1.22rem; margin-bottom: 12px; }
+    h3 { font-size: 1rem; margin: 16px 0 8px; }
+    p { margin: 10px 0 0; }
+    a { color: var(--accent); }
+    .meta {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      margin-top: 18px;
+      color: var(--muted);
+      font-size: 0.92rem;
+    }
+    .pill {
+      border: 1px solid var(--border);
+      border-radius: 999px;
+      padding: 4px 10px;
+      background: #fbfcff;
+    }
+    nav {
+      margin: 20px 0;
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+      gap: 8px;
+    }
+    nav a {
+      display: block;
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      background: var(--paper);
+      padding: 10px 12px;
+      text-decoration: none;
+      font-weight: 600;
+    }
+    section {
+      margin-top: 18px;
+      background: var(--paper);
+      border: 1px solid var(--border);
+      border-radius: 10px;
+      padding: 22px;
+    }
+    ul, ol { margin: 10px 0 0 20px; padding: 0; }
+    li { margin: 6px 0; }
+    code {
+      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      background: #eef1f7;
+      border-radius: 5px;
+      padding: 1px 5px;
+      font-size: 0.92em;
+    }
+    .callout {
+      border-left: 4px solid var(--accent);
+      background: var(--accent-soft);
+      padding: 12px 14px;
+      border-radius: 8px;
+      margin-top: 12px;
+    }
+    .risk {
+      border-left-color: var(--risk);
+      background: var(--risk-soft);
+    }
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+      gap: 12px;
+      margin-top: 12px;
+    }
+    article {
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      padding: 14px;
+      background: #fbfcff;
+    }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      margin-top: 12px;
+      font-size: 0.95rem;
+    }
+    th, td {
+      border: 1px solid var(--border);
+      padding: 10px;
+      text-align: left;
+      vertical-align: top;
+    }
+    th { background: #f1f4f9; }
+    .flow {
+      display: grid;
+      gap: 8px;
+      margin-top: 12px;
+    }
+    .flow div {
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      padding: 10px 12px;
+      background: #fbfcff;
+    }
+    footer {
+      margin-top: 24px;
+      color: var(--muted);
+      font-size: 0.9rem;
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <header>
+      <h1>feat: Add Completed Transaction Void Workflow</h1>
+      <p>Add a manager-approved workflow for voiding completed POS transactions from transaction detail. The plan replaces the current legacy direct void path with an audited reversal command that preserves original sale facts and records payment, inventory, cash-control, and operational evidence.</p>
+      <div class="meta">
+        <span class="pill">Type: feat</span>
+        <span class="pill">Status: active</span>
+        <span class="pill">Date: 2026-05-21</span>
+        <span class="pill">Deepened: 2026-05-21</span>
+        <span class="pill">Source: <a href="2026-05-21-001-feat-completed-transaction-void-plan.md">markdown plan</a></span>
+      </div>
+    </header>
+
+    <nav aria-label="Plan sections">
+      <a href="#scope">Scope</a>
+      <a href="#decisions">Key Decisions</a>
+      <a href="#design">Flow</a>
+      <a href="#units">Implementation Units</a>
+      <a href="#risks">Risks</a>
+      <a href="#verification">Verification</a>
+    </nav>
+
+    <section id="scope">
+      <h2>Scope</h2>
+      <p>The workflow covers full void of a completed POS transaction when the current operating-day and register state can safely accept the reversal. Partial refunds, exchanges, external gateway refunds, and post-close historical refunds are deliberately deferred.</p>
+      <div class="callout">
+        <strong>Boundary:</strong> Original sale rows, transaction number, receipt history, cashier attribution, and completed-sale item rows remain audit facts. The void is additive reversal evidence plus terminal status.
+      </div>
+    </section>
+
+    <section id="decisions">
+      <h2>Key Decisions</h2>
+      <ul>
+        <li>Replace the exposed void path with a browser-safe <code>CommandResult</code> workflow.</li>
+        <li>Require manager approval for completed-sale voids through the existing approval proof system.</li>
+        <li>Use existing ledgers: <code>paymentAllocation</code>, <code>inventoryMovement</code>, SKU activity, <code>operationalEvent</code>, and daily close review items.</li>
+        <li>Block direct voids for transactions with pending/applied item adjustments and transactions inside completed store operating-day closes.</li>
+        <li>Expose the action inside the existing transaction update panel, with reason capture and durable inline errors.</li>
+      </ul>
+    </section>
+
+    <section id="design">
+      <h2>Intended Flow</h2>
+      <p>This is directional guidance for review, not an implementation specification.</p>
+      <div class="flow">
+        <div>1. Operator chooses <strong>Void sale</strong>, enters a reason, and authenticates staff identity.</div>
+        <div>2. Transaction detail calls the void command without approval proof and receives <code>approval_required</code>.</div>
+        <div>3. Manager approval mints an action/store/subject/role-bound proof.</div>
+        <div>4. The command validates transaction status, adjustment state, register identity, daily close state, and proof.</div>
+        <div>5. The command records payment allocation reversal, cash drawer reversal, inventory movements, SKU activity, and operational event.</div>
+        <div>6. The transaction is patched to <code>status: "void"</code>; the UI renders void metadata and disables further updates.</div>
+      </div>
+    </section>
+
+    <section id="units">
+      <h2>Implementation Units</h2>
+      <div class="grid">
+        <article>
+          <h3>U1. Command Contract</h3>
+          <p>Add the completed-sale void approval action and public mutation command-result contract. Tests cover approval-required, proof retry, and safe user errors.</p>
+        </article>
+        <article>
+          <h3>U2. Ledger Reversal</h3>
+          <p>Record outbound payment allocations, register cash reversal, inventory movements, SKU activity, and void status with validation-before-write ordering and idempotent retry behavior.</p>
+        </article>
+        <article>
+          <h3>U3. Daily Close Boundaries</h3>
+          <p>Block voids for completed daily closes and item-adjusted transactions; preserve existing daily close void review items.</p>
+        </article>
+        <article>
+          <h3>U4. Operational History</h3>
+          <p>Record void operational events and return void metadata in transaction read models for detail and history surfaces.</p>
+        </article>
+        <article>
+          <h3>U5. Transaction UI</h3>
+          <p>Add the guarded destructive action to <code>TransactionView</code>, reusing staff sign-in, manager approval, and inline command errors.</p>
+        </article>
+        <article>
+          <h3>U6. Validation Docs</h3>
+          <p>Update harness and testing docs so future POS void work maps to command approval, cash-control, daily-close, and UI validation slices.</p>
+        </article>
+      </div>
+    </section>
+
+    <section id="risks">
+      <h2>Risks</h2>
+      <table>
+        <thead>
+          <tr><th>Risk</th><th>Mitigation</th></tr>
+        </thead>
+        <tbody>
+          <tr><td>Closed operating-day reports are corrupted.</td><td>Block direct voids inside completed daily closes using store operating-day range semantics; use reopen EOD or a future refund workflow.</td></tr>
+          <tr><td>Inventory restoration lacks audit evidence.</td><td>Record committed inventory movements and SKU activity for each restored SKU.</td></tr>
+          <tr><td>Cash drawer and payment allocation diverge.</td><td>Reuse existing retail void payment allocation and register-session void helpers with focused tests.</td></tr>
+          <tr><td>Partial reversal state appears after helper-level writes.</td><td>Validate blockers before writes, patch transaction status last, and require source-scoped idempotency or command-owned consolidation.</td></tr>
+          <tr><td>Adjusted transactions are reversed incorrectly.</td><td>Block pending/applied item-adjusted transactions in v1.</td></tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section id="verification">
+      <h2>Verification Strategy</h2>
+      <ul>
+        <li>Backend command tests for approval, validation, payment allocation, inventory movement, register cash, daily close blocks, and idempotent retry behavior.</li>
+        <li>Read-model tests for void metadata and transaction history.</li>
+        <li>Transaction UI tests for reason capture, approval retry, inline errors, success state, and already-void state.</li>
+        <li>Harness documentation and validation map updates, followed by package validation during implementation.</li>
+      </ul>
+      <div class="callout risk">
+        <strong>Implementation note:</strong> after code changes, rebuild graphify and regenerate any generated harness docs instead of editing generated files by hand.
+      </div>
+    </section>
+
+    <section>
+      <h2>Primary References</h2>
+      <ul>
+        <li><code>packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts</code></li>
+        <li><code>packages/athena-webapp/convex/pos/public/transactions.ts</code></li>
+        <li><code>packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts</code></li>
+        <li><code>packages/athena-webapp/convex/pos/application/commands/adjustTransactionItems.ts</code></li>
+        <li><code>packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx</code></li>
+        <li><a href="https://help.shopify.com/en/manual/sell-in-person/shopify-pos/order-management/complete-refund-orders?locale=en">Shopify POS returns and refunds</a></li>
+        <li><a href="https://docs.stripe.com/refunds?dashboard-or-api=api&amp;locale=en-GB">Stripe refund and cancel payments</a></li>
+      </ul>
+    </section>
+
+    <footer>
+      Canonical source: <a href="2026-05-21-001-feat-completed-transaction-void-plan.md">2026-05-21-001-feat-completed-transaction-void-plan.md</a>
+    </footer>
+  </main>
+</body>
+</html>

--- a/docs/plans/2026-05-21-001-feat-completed-transaction-void-plan.md
+++ b/docs/plans/2026-05-21-001-feat-completed-transaction-void-plan.md
@@ -1,0 +1,431 @@
+---
+title: "feat: Add Completed Transaction Void Workflow"
+type: feat
+status: active
+date: 2026-05-21
+deepened: 2026-05-21
+---
+
+# feat: Add Completed Transaction Void Workflow
+
+## Summary
+
+Add a manager-approved workflow for voiding completed POS transactions from the transaction detail screen. The implementation should replace the current legacy direct void path with an audited reversal command that preserves the original sale, records the void through payment allocation, inventory movement, operational event, and daily-close review rails, and blocks unsafe mutation of completed operating days.
+
+---
+
+## Problem Frame
+
+Athena already has a `voidTransaction` backend command, but it is not ready to expose to operators: it returns a legacy `{ success, error }` shape, skips the command approval rail, patches SKU quantities without inventory movement evidence, and does not record the void as an operational event. A completed sale void is a financial and inventory reversal, so it must follow the same command-boundary rigor as payment corrections and item adjustments.
+
+---
+
+## Requirements
+
+- R1. Operators can void a completed POS transaction from transaction detail only after staff sign-in, a reason, and manager approval.
+- R2. The original completed sale remains auditable; the void is represented as an explicit reversal rather than an invisible edit.
+- R3. Voiding reverses payment reporting through `paymentAllocation` and cash drawer state through the existing register-session cash-control bridge.
+- R4. Voiding restores inventory through committed `inventoryMovement` and SKU activity evidence, not direct SKU field mutation alone.
+- R5. The command blocks unsafe states: missing transaction, already void/refunded transaction, pending/applied item adjustments, missing register identity, closed daily close, or cash drawer state that cannot accept a cash reversal.
+- R6. Transaction detail, transaction history, daily operations, and daily close surfaces show voided status and review context with calm operator-facing copy.
+- R7. Tests cover command results, approval proof handling, inventory/payment reversal, daily-close boundary behavior, and transaction-detail UI behavior.
+
+---
+
+## Scope Boundaries
+
+- This plan does not implement partial refunds, exchanges, or post-close refund workflows. It handles full void of a completed POS transaction when the operating day/register state can safely accept the reversal.
+- This plan does not integrate an external payment gateway refund API. Athena's current in-store POS payment model records operational payment allocations; gateway refunds remain future work if card/MoMo providers become first-class external integrations.
+- This plan does not change original sale totals, original item rows, cashier attribution, transaction number generation, or receipt history. The original fact stays intact.
+- This plan does not broaden staff permissions outside the existing manager approval model.
+
+### Deferred to Follow-Up Work
+
+- Partial return/refund workflow: separate plan covering item-level return quantities, refund destinations, and exchange/balance-due states.
+- Post-daily-close refund workflow: separate plan for recording today-side refund movements against historical sales without mutating completed operating-day reports.
+- Customer receipt/messaging updates for voided sales: separate UI/content pass if receipts need customer-facing void/refund communication.
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts` contains the legacy `voidTransaction` command and the existing `recordRegisterSessionVoid` bridge.
+- `packages/athena-webapp/convex/pos/public/transactions.ts` exposes the legacy void mutation and the newer command-result patterns for customer, payment, and item correction commands.
+- `packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts` shows the manager-approval pattern for completed transaction payment-method correction.
+- `packages/athena-webapp/convex/pos/application/commands/adjustTransactionItems.ts` shows approved completed-sale item adjustments, inventory movement creation, settlement payment allocation, and register-session cash validation.
+- `packages/athena-webapp/convex/pos/infrastructure/integrations/paymentAllocationService.ts` already has `recordRetailVoidPaymentAllocations` using `allocationType: "retail_sale_void"`.
+- `packages/athena-webapp/convex/operations/inventoryMovements.ts` provides idempotent source-scoped inventory movement recording and SKU activity linkage.
+- `packages/athena-webapp/convex/operations/dailyClose.ts` already queries `status: "void"` POS transactions and turns them into `voided_sale` review items.
+- `packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx` already owns completed-transaction update workflows and uses `useApprovedCommand` for payment and item approvals.
+- `packages/athena-webapp/docs/agent/architecture.md` requires command-result failures, domain-owned approval policy, server-enforced proof consumption, and safe operator-facing copy.
+- `packages/athena-webapp/docs/agent/testing.md` defines the focused validation slices for command approval, completed transaction adjustment, POS/register/cash-control changes, and Convex changes.
+
+### Institutional Learnings
+
+- `docs/solutions/logic-errors/athena-pos-ledger-safe-corrections-2026-04-30.md`: completed transaction corrections must preserve original operational facts, record operational events, and avoid direct edits that hide the recovery action.
+- `docs/solutions/logic-errors/athena-pos-register-review-and-adjusted-sale-projection-2026-05-21.md`: transaction detail and cash controls must project review/adjustment state explicitly instead of only storing events.
+- `docs/solutions/logic-errors/athena-sku-activity-traceability-2026-05-13.md`: every SKU-affecting mutation needs source-aware inventory movement and SKU activity evidence.
+- `docs/solutions/logic-errors/athena-pos-drawer-invariants-at-command-boundaries-2026-04-24.md`: UI gates are not enough; register/drawer invariants belong at command boundaries.
+
+### External References
+
+- [Shopify POS returns and refunds](https://help.shopify.com/en/manual/sell-in-person/shopify-pos/order-management/complete-refund-orders?locale=en): POS refund flows require permissions, reasons, payment-method limits, and explicit restock handling.
+- [Stripe refund and cancel payments](https://docs.stripe.com/refunds?dashboard-or-api=api&locale=en-GB): completed payments are refunded after success, cancellation applies before completion/capture, refund totals are capped by the original payment, and refund state should be traceable.
+
+---
+
+## Key Technical Decisions
+
+- Replace the exposed void path with a command-result workflow: this aligns voiding with existing correction commands and prevents raw backend errors from reaching the transaction detail UI.
+- Require manager approval for completed-sale voids: a void reverses payment, inventory, and reporting state, so it belongs behind `approval_required` with an action/store/subject/role-bound proof.
+- Preserve the original sale and record reversal facts: set the transaction to `status: "void"` only after payment allocations, inventory movements, register-session cash effects, approval evidence, and operational event recording succeed.
+- Use existing ledgers instead of new void-specific tables: `paymentAllocation`, `inventoryMovement`, `skuActivity`, `operationalEvent`, and daily close review items already provide the audit surfaces this workflow needs.
+- Block voids for transactions with item adjustments in the first implementation: applied or pending adjustments introduce an effective-sale projection that a simple full-sale void could reverse incorrectly.
+- Block voids when the sale's store operating day is already completed: use the same store/day range semantics as daily operations and EOD Review rather than deriving the day from a naive calendar date. Reopening EOD is the existing workflow for revising a completed operating day; a future refund workflow can model same-day refund activity against historical sales without mutating closed reports.
+- Keep UI entry inside `TransactionView`'s update surface: operators are already trained to correct completed transaction metadata and item adjustments there, and the page has staff sign-in and manager approval plumbing.
+
+---
+
+## Open Questions
+
+### Resolved During Planning
+
+- Should this be a direct transaction edit or audited reversal? Audited reversal, because completed sales are financial and inventory facts that must remain inspectable.
+- Should the first version support historical post-close refunds? No. This plan blocks completed daily-close mutation and defers historical refund handling to a separate workflow.
+- Should inventory restoration reuse item-adjustment logic? Reuse the ledger pattern and source-scoped movement helpers, but keep a distinct void source and reason code so SKU timelines can distinguish voids from item corrections.
+
+### Deferred to Implementation
+
+- Exact helper placement inside `completeTransaction.ts` versus a new `voidCompletedTransaction.ts` file: choose during implementation based on whether the file becomes too large, but keep the public mutation thin either way.
+- Exact transaction query shape for detecting a completed daily close from `completedAt`: implementation should reuse `dailyClose` operating-day range helpers where possible, but may need a small internal query/helper if existing functions are not exported cleanly.
+- Exact UI copy after visual fitting: product-copy tone is fixed, but final button/dialog text should be tuned in the browser.
+
+---
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+```mermaid
+sequenceDiagram
+    participant Operator as Operator
+    participant UI as TransactionView
+    participant Approval as Manager Approval
+    participant Command as voidCompletedTransaction
+    participant Ledgers as Payment/Inventory/Cash Ledgers
+    participant Ops as Operational Event + Daily Close
+
+    Operator->>UI: Choose Void sale, enter reason, staff sign-in
+    UI->>Command: Attempt void without approval proof
+    Command-->>UI: approval_required
+    UI->>Approval: Manager credentials for pos.transaction.void
+    Approval-->>UI: approvalProofId
+    UI->>Command: Retry with proof
+    Command->>Command: Validate transaction, adjustments, register, daily close
+    Command->>Ledgers: Record retail_sale_void, cash reversal, inventory movements
+    Command->>Ops: Record pos_transaction_voided event
+    Command->>Command: Patch transaction status void + voidedAt
+    Command-->>UI: ok void summary
+    UI-->>Operator: Voided state and disabled update actions
+```
+
+---
+
+## Implementation Units
+
+- U1. **Define the Completed-Sale Void Command Contract**
+
+**Goal:** Introduce the command-result and manager-approval contract for voiding completed POS transactions, replacing the legacy public void mutation shape.
+
+**Requirements:** R1, R2, R5, R7
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `packages/athena-webapp/convex/operations/approvalActions.ts`
+- Modify: `packages/athena-webapp/convex/pos/public/transactions.ts`
+- Modify: `packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts`
+- Test: `packages/athena-webapp/convex/pos/public/transactions.test.ts`
+- Test: `packages/athena-webapp/convex/pos/application/completeTransaction.test.ts`
+- Test: `packages/athena-webapp/convex/operations/staffCredentials.test.ts`
+
+**Approach:**
+- Add an approval action for completed transaction voids with subject type `pos_transaction` and required role `manager`.
+- Change the public void mutation to return `commandResultValidator(...)` with `ok`, `user_error`, and `approval_required` behavior, mirroring payment-method correction and item adjustment.
+- Require `actorStaffProfileId`, a non-empty reason, and an approval proof before mutation effects are applied.
+- Keep compatibility exports from `convex/inventory/pos.ts`, but route callers to the new command contract.
+- Map expected domain failures to `user_error` codes; reserve thrown errors for unexpected faults.
+
+**Execution note:** Implement command behavior test-first because this replaces a legacy financial mutation contract.
+
+**Patterns to follow:**
+- `packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts`
+- `packages/athena-webapp/convex/pos/application/commands/adjustTransactionItems.ts`
+- `packages/athena-webapp/convex/lib/commandResultValidators.ts`
+
+**Test scenarios:**
+- Happy path: first command attempt for a completed transaction with reason and staff identity returns `approval_required` and does not patch transaction, inventory, register, or payment allocation state.
+- Happy path: retry with matching approval proof succeeds and returns transaction id, transaction number, voidedAt, payment allocation ids, inventory movement ids, and operational event id.
+- Error path: missing staff identity returns `authentication_failed`.
+- Error path: blank reason returns `validation_failed`.
+- Error path: missing transaction returns `not_found`.
+- Error path: transaction status other than `completed` returns `validation_failed` or `conflict` without side effects.
+- Error path: mismatched, expired, or consumed approval proof fails safely and leaves transaction unchanged.
+- Integration: public mutation validator accepts the void success payload and approval-required payload without browser-unsafe fields.
+
+**Verification:**
+- The public void mutation follows the same browser-safe command-result contract as existing completed-transaction correction mutations.
+
+---
+
+- U2. **Apply Audited Payment, Cash, and Inventory Reversal**
+
+**Goal:** Make a successful void write all ledger evidence in one command boundary before marking the transaction void.
+
+**Requirements:** R2, R3, R4, R5, R7
+
+**Dependencies:** U1
+
+**Files:**
+- Modify: `packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts`
+- Modify: `packages/athena-webapp/convex/pos/infrastructure/integrations/paymentAllocationService.ts`
+- Modify: `packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts`
+- Test: `packages/athena-webapp/convex/pos/application/completeTransaction.test.ts`
+- Test: `packages/athena-webapp/convex/operations/paymentAllocations.test.ts`
+- Test: `packages/athena-webapp/convex/operations/inventoryMovements.test.ts`
+
+**Approach:**
+- Reuse `recordRetailVoidPaymentAllocations` for outbound payment ledger rows, but return inserted/allocation ids so the void command can include them in the result and operational event.
+- Reuse `recordRegisterSessionVoid` for cash drawer reversal when the transaction has a register session, while enforcing terminal/register identity.
+- Replace direct SKU quantity restoration with an inventory movement per transaction item using a void-specific movement type and reason code.
+- Patch `productSku.inventoryCount` and `productSku.quantityAvailable` in the same command boundary as the inventory movement, following the item-adjustment restock pattern.
+- Perform all validation before writes, then make the reversal idempotent enough that a retry after a partial client failure does not duplicate ledger rows if the transaction is already voided. If existing register-session helpers execute as a separate internal mutation, keep the implementation explicit about ordering, retry behavior, and whether the helper should be moved behind a command-owned shared function.
+
+**Execution note:** Characterize current void side effects before replacing direct SKU restoration, then update expectations to the new ledger-backed behavior.
+
+**Patterns to follow:**
+- `packages/athena-webapp/convex/pos/application/commands/adjustTransactionItems.ts`
+- `packages/athena-webapp/convex/operations/inventoryMovements.ts`
+- `packages/athena-webapp/convex/pos/infrastructure/integrations/paymentAllocationService.ts`
+
+**Test scenarios:**
+- Happy path: cash transaction void records `retail_sale_void` payment allocations with `direction: "out"` and the original transaction as target.
+- Happy path: cash transaction tied to an open/active register reduces expected cash by the original cash delta and updates variance when counted cash exists.
+- Happy path: non-cash transaction records outbound payment allocation but does not change expected cash.
+- Happy path: each transaction item restores SKU count and available quantity and records an inventory movement linked to the transaction and register session.
+- Edge case: cash overpayment with `changeGiven` reverses only the net cash drawer effect.
+- Error path: transaction with `registerSessionId` and no terminal id returns a safe user error before any ledger writes.
+- Error path: SKU missing or belonging to another store fails before patching transaction status.
+- Integration: SKU activity timeline can attribute the stock restoration to a committed inventory movement source.
+
+**Verification:**
+- A successful void has payment, cash, inventory, and SKU activity evidence; the transaction is not marked void without those reversal records.
+
+---
+
+- U3. **Enforce Daily Close and Adjustment Boundaries**
+
+**Goal:** Prevent voids from corrupting adjusted sales or completed operating-day reports.
+
+**Requirements:** R2, R5, R6, R7
+
+**Dependencies:** U1, U2
+
+**Files:**
+- Modify: `packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts`
+- Modify: `packages/athena-webapp/convex/operations/dailyClose.ts`
+- Modify: `packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts`
+- Test: `packages/athena-webapp/convex/pos/application/completeTransaction.test.ts`
+- Test: `packages/athena-webapp/convex/operations/dailyClose.test.ts`
+- Test: `packages/athena-webapp/convex/operations/dailyOperations.test.ts`
+
+**Approach:**
+- Detect pending or applied `posTransactionAdjustment` records for the transaction and block void with guidance to resolve adjustment state first.
+- Detect whether the transaction's `completedAt` falls inside a completed daily close snapshot for the store using the repo's operating-day range semantics, then block direct void with guidance to reopen EOD Review or use a future refund workflow.
+- Preserve existing daily close behavior that lists `status: "void"` transactions as `voided_sale` review items for the open/current day.
+- Keep original sales totals semantics intact: completed sales exclude voided transactions, while voided sales appear as review evidence.
+
+**Patterns to follow:**
+- `packages/athena-webapp/convex/operations/dailyClose.ts`
+- `packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts`
+- `docs/solutions/logic-errors/athena-pos-register-review-and-adjusted-sale-projection-2026-05-21.md`
+
+**Test scenarios:**
+- Happy path: transaction from the current uncompleted operating day can be voided and appears in daily close review as `voided_sale`.
+- Error path: transaction in a completed daily close returns a safe user error before payment/inventory/register mutations.
+- Edge case: transaction completed near a calendar-day boundary is classified by the store operating-day range, not by naive local/UTC date slicing.
+- Error path: transaction with pending item adjustment approval cannot be voided.
+- Error path: transaction with applied item adjustment cannot be voided in this first version.
+- Integration: daily close summary excludes voided transactions from completed sales totals while preserving void review metadata.
+- Integration: daily operations view data remains consistent for completed, adjusted, and voided transaction categories.
+
+**Verification:**
+- Voids cannot rewrite closed operating-day facts or adjusted-sale projections, and current-day voids remain manager-reviewable in EOD Review.
+
+---
+
+- U4. **Record Operational History and Transaction Read Model State**
+
+**Goal:** Make void state visible and auditable in transaction detail, correction history, and downstream review surfaces.
+
+**Requirements:** R2, R5, R6, R7
+
+**Dependencies:** U1, U2, U3
+
+**Files:**
+- Modify: `packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts`
+- Modify: `packages/athena-webapp/convex/pos/application/queries/getTransactions.ts`
+- Modify: `packages/athena-webapp/convex/schemas/pos/posTransaction.ts`
+- Test: `packages/athena-webapp/convex/pos/application/getTransactions.test.ts`
+- Test: `packages/athena-webapp/convex/pos/application/completeTransaction.test.ts`
+
+**Approach:**
+- Record an operational event such as completed-sale voided, linked to the original transaction subject, actor staff, approver staff, reason, payment allocation ids, inventory movement ids, and register session.
+- Add or normalize read-model fields needed by UI: `voidedAt`, `voidReason` or safe reuse of notes, `voidedByStaffProfileId` if schema support is warranted, `voidApprovalRequestId`, and `voidOperationalEventId`.
+- Ensure correction/update history includes void events in the same timeline area as existing transaction updates.
+- Prefer explicit void metadata over overloading free-form notes when the schema change is small and improves reporting clarity.
+
+**Patterns to follow:**
+- `packages/athena-webapp/convex/operations/operationalEvents.ts`
+- `packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts`
+- `packages/athena-webapp/convex/pos/application/queries/getTransactions.ts`
+
+**Test scenarios:**
+- Happy path: successful void records one operational event with transaction subject, actor, approver, reason, and ledger ids.
+- Happy path: transaction detail query returns void status, void metadata, and void event in history.
+- Edge case: legacy voided transactions with only `notes` and `voidedAt` still render without crashing.
+- Error path: void event is not created when approval proof fails or validation blocks the command.
+- Integration: transaction list/detail read models distinguish completed and voided transactions without recalculating original sale facts.
+
+**Verification:**
+- Operators and reviewers can inspect who voided the sale, who approved it, why it was voided, and which ledger records were created.
+
+---
+
+- U5. **Expose the Void Workflow in Transaction Detail**
+
+**Goal:** Add a usable, safe UI for completed-sale voids on the transaction detail screen.
+
+**Requirements:** R1, R5, R6, R7
+
+**Dependencies:** U1, U3, U4
+
+**Files:**
+- Modify: `packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx`
+- Modify: `packages/athena-webapp/src/components/pos/transactions/TransactionView.test.tsx`
+- Modify: `packages/athena-webapp/src/lib/errors/presentCommandToast.test.ts`
+- Test: `packages/athena-webapp/src/components/pos/transactions/TransactionView.test.tsx`
+
+**Approach:**
+- Add a destructive "Void sale" option inside the existing transaction update panel for `status: "completed"` transactions.
+- Require a reason before staff authentication and manager approval.
+- Reuse `useApprovedCommand` and staff credential authentication flows already present in `TransactionView`.
+- Render durable inline errors for validation failures such as completed EOD, adjusted sale, already voided, or missing register state.
+- After success, close the update panel, show void status in the transaction header/summary, disable further update actions, and keep receipt printing behavior read-only.
+- Keep copy restrained and operational per `docs/product-copy-tone.md`; avoid alarmist or backend-shaped wording.
+
+**Patterns to follow:**
+- Existing payment correction and item adjustment flows in `TransactionView.tsx`
+- `packages/athena-webapp/src/components/operations/useApprovedCommand.tsx`
+- `packages/athena-webapp/src/lib/errors/runCommand.ts`
+
+**Test scenarios:**
+- Happy path: operator opens Update, selects Void sale, enters reason, authenticates staff, receives manager approval prompt, and successful command renders a voided state.
+- Happy path: manager requester can complete inline manager proof when allowed by the approval requirement.
+- Error path: blank reason blocks submission before command call.
+- Error path: command `user_error` renders inline safe copy and keeps the dialog open for correction.
+- Error path: `approval_required` without inline mode queues or explains manager review according to the shared approval dialog behavior.
+- Edge case: transaction already `void` shows void metadata and no update/void action.
+- Integration: UI passes the approval proof and approval request id back to the same void command retry path.
+
+**Verification:**
+- The browser flow makes voiding discoverable but guarded, and the page clearly reflects the final void state without exposing raw backend text.
+
+---
+
+- U6. **Validation, Harness, and Documentation Alignment**
+
+**Goal:** Keep repo validation and implementation documentation aligned with the new financial reversal path.
+
+**Requirements:** R6, R7
+
+**Dependencies:** U1, U2, U3, U4, U5
+
+**Files:**
+- Modify: `packages/athena-webapp/docs/agent/testing.md`
+- Modify: `scripts/harness-app-registry.ts`
+- Regenerate: `packages/athena-webapp/docs/agent/validation-map.json`
+- Regenerate: `packages/athena-webapp/docs/agent/validation-guide.md`
+- Regenerate: `graphify-out/`
+- Test: `packages/athena-webapp/convex/pos/application/completeTransaction.test.ts`
+- Test: `packages/athena-webapp/convex/pos/public/transactions.test.ts`
+- Test: `packages/athena-webapp/src/components/pos/transactions/TransactionView.test.tsx`
+
+**Approach:**
+- Extend the focused validation guidance for completed transaction correction/adjustment to include completed transaction void.
+- Update harness registry metadata so touched POS command and transaction UI surfaces map to the right regression slices.
+- Regenerate generated docs and graphify after code changes during implementation.
+- Ensure final implementation validates command approval, Convex audit/lint, TypeScript, build, and the relevant POS/cash-control/daily-close focused tests.
+
+**Patterns to follow:**
+- Existing testing guide sections for command approval and completed-transaction item adjustment.
+- Repo harness generation flow documented in `packages/athena-webapp/docs/agent/testing.md`.
+
+**Test scenarios:**
+- Test expectation: none for documentation text itself, beyond harness validation proving generated docs and validation maps stay consistent.
+- Integration: harness review includes touched POS transaction command/UI surfaces in mapped validation.
+
+**Verification:**
+- Future agents touching this flow get the right focused validation requirements from the repo harness.
+
+---
+
+## System-Wide Impact
+
+- **Interaction graph:** The change crosses `TransactionView`, public Convex mutations, POS command services, approval proofs, payment allocations, register sessions, inventory movements, SKU activity, operational events, daily operations, and daily close.
+- **Error propagation:** Expected failures must return `CommandResult` `user_error`; approval flows return `approval_required`; thrown errors remain unexpected faults handled by the route/generic error boundary.
+- **State lifecycle risks:** The command must avoid partial reversal state. Validation should happen before side effects, ledger writes should be ordered before the transaction status patch, and any helper that runs outside the main mutation's atomic write set needs explicit idempotency or consolidation into the command-owned write path.
+- **API surface parity:** `convex/inventory/pos.ts` re-exports the public mutation, generated Convex refs may need refresh, and frontend callers should use `runCommand`.
+- **Integration coverage:** Unit tests must be paired with read-model and UI tests because ledger correctness alone does not prove operators can inspect the void.
+- **Unchanged invariants:** Original sale rows, transaction number, receipt history, cashier attribution, and completed-sale item rows remain original audit facts; void is additive reversal evidence plus terminal status.
+
+---
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Voiding a closed operating day corrupts completed EOD reports | Block direct void when the transaction belongs to a completed daily close; guide to reopen EOD or future refund workflow. |
+| Inventory counts restore without audit trail | Use `recordInventoryMovementWithCtx` and SKU activity linkage for each restored SKU. |
+| Payment allocation and register expected cash diverge | Reuse `recordRetailVoidPaymentAllocations` and `recordRegisterSessionVoid`, and test cash/non-cash/change-given cases. |
+| Helper-level writes create partial reversal state | Validate all blockers before side effects, patch transaction status last, and make source-scoped payment/inventory/register writes idempotent or consolidate them into one command-owned write path. |
+| Item-adjusted transactions are reversed incorrectly | Block pending/applied adjusted transactions in v1; plan a separate effective-sale void if needed later. |
+| UI exposes a destructive action too casually | Keep it inside the existing update panel, require reason/staff/manager approval, use destructive styling and clear voided state. |
+| Legacy voided transactions lack new metadata | Make read models tolerant of `status: "void"` with only `voidedAt` and `notes`. |
+
+---
+
+## Documentation / Operational Notes
+
+- Update operator-facing copy according to `docs/product-copy-tone.md`.
+- Update package testing guidance and harness registry if touched-file coverage changes.
+- After implementation modifies code, run `bun run graphify:rebuild` before final handoff.
+- If new public Convex exports or generated client refs are required, refresh artifacts through `bunx convex dev --once` from `packages/athena-webapp` when the workspace has Convex deployment credentials.
+
+---
+
+## Sources & References
+
+- Related code: `packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts`
+- Related code: `packages/athena-webapp/convex/pos/public/transactions.ts`
+- Related code: `packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts`
+- Related code: `packages/athena-webapp/convex/pos/application/commands/adjustTransactionItems.ts`
+- Related code: `packages/athena-webapp/convex/operations/dailyClose.ts`
+- Related code: `packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx`
+- Institutional learning: `docs/solutions/logic-errors/athena-pos-ledger-safe-corrections-2026-04-30.md`
+- Institutional learning: `docs/solutions/logic-errors/athena-pos-register-review-and-adjusted-sale-projection-2026-05-21.md`
+- Institutional learning: `docs/solutions/logic-errors/athena-sku-activity-traceability-2026-05-13.md`
+- External docs: [Shopify POS returns and refunds](https://help.shopify.com/en/manual/sell-in-person/shopify-pos/order-management/complete-refund-orders?locale=en)
+- External docs: [Stripe refund and cancel payments](https://docs.stripe.com/refunds?dashboard-or-api=api&locale=en-GB)

--- a/docs/solutions/logic-errors/athena-pos-completed-transaction-void-reversal-2026-05-21.md
+++ b/docs/solutions/logic-errors/athena-pos-completed-transaction-void-reversal-2026-05-21.md
@@ -1,0 +1,74 @@
+---
+title: Athena POS Completed Transaction Voids Use Approved Ledger Reversal
+date: 2026-05-21
+category: logic-errors
+module: athena-webapp
+problem_type: logic_error
+component: pos
+symptoms:
+  - "A completed sale void could patch transaction state without approval proof"
+  - "Inventory restoration could happen through direct SKU edits without movement evidence"
+  - "Payment and cash reversal state could be difficult to reconstruct from operational history"
+  - "Retried void submissions could create multiple pending approval requests for one sale"
+root_cause: completed_sale_void_without_command_boundary
+resolution_type: code_fix
+severity: high
+tags:
+  - pos
+  - voids
+  - payment-allocation
+  - inventory-movement
+  - approval-policy
+---
+
+# Athena POS Completed Transaction Voids Use Approved Ledger Reversal
+
+## Problem
+
+A completed POS sale is a financial and inventory fact. Voiding it as a direct
+transaction edit hides too much: the operator intent, manager approval, payment
+reversal, cash drawer effect, and stock restoration can drift across separate
+records or disappear from the audit trail.
+
+## Solution
+
+Treat completed-sale voids as command-boundary reversals:
+
+- Return `approval_required` from the same command that will perform the void.
+- Reuse an existing pending void approval request for the sale so retries are
+  idempotent.
+- Consume a manager approval proof server-side before any durable reversal write.
+- Validate daily close, register session identity, terminal identity,
+  transaction status, and item adjustment boundaries before writing payment,
+  cash, inventory, or transaction state.
+- Preserve the original completed sale and mark the transaction void only after
+  reversal evidence is recorded.
+- Record outbound `retail_sale_void` payment allocations for the original
+  transaction target.
+- Use register-session cash-control rails for cash reversals instead of
+  recalculating drawer totals in the UI.
+- Restore stock through committed `inventoryMovement` rows so SKU activity can
+  explain why inventory increased.
+- Aggregate duplicate sale lines by SKU before restoration so one transaction
+  cannot under-restore inventory.
+- Record a `pos_transaction_voided` operational event with approval and reversal
+  references, then expose void metadata through transaction read models.
+
+## Prevention
+
+- Do not add a browser-only void button around a direct mutation.
+- Do not restore SKU quantity without an inventory movement source and SKU
+  activity evidence.
+- Do not allow voids for sales inside completed EOD Review, sales with pending
+  or applied item adjustments, sales missing drawer identity, or cash sales
+  whose register state cannot accept the reversal.
+- Query the relevant EOD Review operating date directly; avoid fixed-size scans
+  for closeout eligibility.
+- Keep the transaction detail UI on the shared command approval runner so future
+  POS reversal workflows reuse the same approval proof path.
+- Test the command contract, no-side-effect blocked states, ledger reversal,
+  read-model projection, and transaction-detail workflow together.
+
+## Related Issues
+
+- Linear: V26-619, V26-620, V26-621, V26-622, V26-623, V26-624.

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 5683 nodes · 5967 edges · 1702 communities detected
+- 5704 nodes · 6007 edges · 1702 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -1804,136 +1804,136 @@ Cohesion: 0.16
 Nodes (25): asArray(), asBoolean(), asMtnMomoSetupStatus(), asNumber(), asOptionalArray(), asRecord(), assignOrDelete(), asString() (+17 more)
 
 ### Community 16 - "Community 16"
-Cohesion: 0.15
-Nodes (22): buildDocumentationStatus(), buildEmptyHistoryMetric(), buildGraphifyStatus(), buildInferentialSummaryNote(), buildSummary(), collectHarnessScorecard(), countMissingSnippets(), createFileSystem() (+14 more)
+Cohesion: 0.16
+Nodes (23): applyApprovedTransactionVoid(), buildCompleteTransactionResult(), buildVoidApprovalRequirement(), calculateCanonicalTransactionTotals(), calculateTotalPaid(), completedTransactionLabel(), completeTransaction(), createTransactionFromSessionHandler() (+15 more)
 
 ### Community 17 - "Community 17"
 Cohesion: 0.15
-Nodes (22): assertStaffProfileReadyForCredential(), authenticateStaffCredentialForApprovalWithCtx(), authenticateStaffCredentialForTerminalWithCtx(), authenticateStaffCredentialWithCtx(), createStaffCredentialWithCtx(), getActiveRolesForStaffProfile(), getCredentialById(), getCredentialByUsername() (+14 more)
+Nodes (22): buildDocumentationStatus(), buildEmptyHistoryMetric(), buildGraphifyStatus(), buildInferentialSummaryNote(), buildSummary(), collectHarnessScorecard(), countMissingSnippets(), createFileSystem() (+14 more)
 
 ### Community 18 - "Community 18"
+Cohesion: 0.15
+Nodes (22): assertStaffProfileReadyForCredential(), authenticateStaffCredentialForApprovalWithCtx(), authenticateStaffCredentialForTerminalWithCtx(), authenticateStaffCredentialWithCtx(), createStaffCredentialWithCtx(), getActiveRolesForStaffProfile(), getCredentialById(), getCredentialByUsername() (+14 more)
+
+### Community 19 - "Community 19"
 Cohesion: 0.12
 Nodes (18): ancestorChain(), collectRawMoneyParses(), collectRawMoneyParsesFromSource(), collectRawNumericHelperNames(), collectSourceFiles(), collectStorefrontDirectMoneyFormats(), containsDisallowedRawNumericParse(), containsTerm() (+10 more)
 
-### Community 19 - "Community 19"
+### Community 20 - "Community 20"
 Cohesion: 0.1
 Nodes (9): collectAcceptedEventIdsWithLocalPrecursors(), collectReviewLocalEventIds(), collectRuntimeRelevantEvents(), collectSyncedLocalEventIds(), derivePosLocalRuntimeSyncStatus(), hasPendingLocalCloseout(), isRuntimeRelevantLocalEvent(), toLocalCloudMappingEntity() (+1 more)
 
-### Community 20 - "Community 20"
+### Community 21 - "Community 21"
 Cohesion: 0.19
 Nodes (23): assertCompoundSolutionCheck(), collectChangedFiles(), collectCompoundSolutionFindings(), collectExistingFiles(), collectMarkdownContents(), collectSourceLineChanges(), countFileLines(), extractFrontmatter() (+15 more)
 
-### Community 21 - "Community 21"
+### Community 22 - "Community 22"
 Cohesion: 0.15
 Nodes (19): appendListSection(), buildMarkdownBundle(), collectCoverage(), evaluateGraphifyFreshness(), fileExists(), formatValidationCommand(), getChangedFilesFromGit(), isLocalGeneratedArtifactPath() (+11 more)
 
-### Community 22 - "Community 22"
+### Community 23 - "Community 23"
 Cohesion: 0.13
 Nodes (18): buildCartSummary(), buildSessionOperationsRow(), expirePosSessionNow(), hasCustomerSnapshotValue(), isUsableRegisterSession(), loadPosSessionItems(), loadSessionCustomer(), loadSessionOperator() (+10 more)
 
-### Community 23 - "Community 23"
+### Community 24 - "Community 24"
 Cohesion: 0.16
 Nodes (22): attentionSeverity(), buildDailyOperationsSnapshotWithCtx(), buildLanes(), buildWeekMetricForDate(), buildWeekMetrics(), emptyCloseSummary(), getCloseItemCounts(), getDailyCloseRecordForDate() (+14 more)
 
-### Community 24 - "Community 24"
+### Community 25 - "Community 25"
 Cohesion: 0.15
 Nodes (19): acquireExpenseQuantityPatchHold(), adjustExpenseQuantityPatchHold(), createDefaultExpenseSessionCommandService(), createExpenseInventoryHoldGateway(), createExpenseSessionCommandService(), failure(), isActiveRegisterSession(), isSessionExpired() (+11 more)
 
-### Community 25 - "Community 25"
+### Community 26 - "Community 26"
+Cohesion: 0.11
+Nodes (13): cancelItemAdjustmentWorkflow(), exitCorrectionWorkflow(), formatCorrectionEventType(), formatCorrectionHistoryChange(), formatCorrectionHistoryTitle(), formatPaymentMethodLabel(), getCorrectionHistoryChangeParts(), isManagerStaff() (+5 more)
+
+### Community 27 - "Community 27"
 Cohesion: 0.23
 Nodes (23): asRecord(), createMappingIndex(), errorFor(), errorMessage(), getCompletedSale(), getExpectedCashDelta(), getOrCreateSale(), getPhase() (+15 more)
 
-### Community 26 - "Community 26"
+### Community 28 - "Community 28"
 Cohesion: 0.09
 Nodes (2): buildCashControlsDashboardSnapshot(), sumDepositsBySession()
 
-### Community 27 - "Community 27"
+### Community 29 - "Community 29"
 Cohesion: 0.1
 Nodes (4): listCompletedTransactionsForDay(), listSessionItems(), listTransactionItems(), readAllQueryResults()
 
-### Community 28 - "Community 28"
+### Community 30 - "Community 30"
 Cohesion: 0.15
 Nodes (16): buildGitProcessEnv(), collectCommandsForChangedFiles(), fileExists(), formatMissingPathPrefixError(), getChangedFilesForHarnessReview(), hasAnyHarnessDocs(), loadReviewTarget(), loadReviewTargets() (+8 more)
 
-### Community 29 - "Community 29"
+### Community 31 - "Community 31"
 Cohesion: 0.2
 Nodes (18): acquireInventoryHold(), acquireInventoryHoldsBatch(), adjustInventoryHold(), buildSkuActivityIdempotencyKey(), consumeInventoryHoldsForSession(), getActiveHoldForSessionSku(), listActiveSessionHolds(), markHoldExpired() (+10 more)
 
-### Community 30 - "Community 30"
+### Community 32 - "Community 32"
 Cohesion: 0.2
 Nodes (21): adjustRegisterSessionExpectedCashForSettlement(), adjustTransactionItems(), applyApprovedAdjustment(), applyInventoryDeltas(), assertPayloadMatchesPlan(), buildAdjustmentApprovalRequirement(), buildServerAdjustmentPlan(), consumeItemAdjustmentApprovalProof() (+13 more)
 
-### Community 31 - "Community 31"
+### Community 33 - "Community 33"
 Cohesion: 0.25
 Nodes (21): buildActiveCycleCountDraftsSubmissionKey(), buildCycleCountDraftSubmissionKey(), createCycleCountDraftWithCtx(), discardCycleCountDraftCommandWithCtx(), ensureCycleCountDraftCommandWithCtx(), ensureCycleCountDraftWithCtx(), findOpenCycleCountDraftWithCtx(), getActiveCycleCountDraftSummaryWithCtx() (+13 more)
 
-### Community 32 - "Community 32"
+### Community 34 - "Community 34"
 Cohesion: 0.11
 Nodes (7): buildMissingDraftResult(), getApprovalRequestCopy(), handleDecideApprovalRequest(), handleDiscardCycleCountDraft(), handleRefreshCycleCountDraftLineBaseline(), handleSaveCycleCountDraftLine(), handleSubmitCycleCountDraft()
 
-### Community 33 - "Community 33"
+### Community 35 - "Community 35"
 Cohesion: 0.27
 Nodes (20): asBoolean(), asMtnMomoSetupStatus(), asNumber(), asOptionalArray(), asRecord(), asString(), cleanUndefined(), firstDefined() (+12 more)
 
-### Community 34 - "Community 34"
+### Community 36 - "Community 36"
 Cohesion: 0.17
 Nodes (17): assertRegisterSessionIdentity(), assertRegisterSessionMatchesTransaction(), assertValidRegisterSessionTransition(), buildClosedRegisterSessionPatch(), buildRegisterSession(), buildRegisterSessionCloseoutPatch(), buildRegisterSessionDepositPatch(), buildRegisterSessionOpeningFloatCorrectionPatch() (+9 more)
 
-### Community 35 - "Community 35"
+### Community 37 - "Community 37"
 Cohesion: 0.18
 Nodes (19): assertIdempotentReplayMatches(), assertProductSkuBelongsToStore(), assertSkuActivityArgs(), buildActiveReservationEntries(), buildAvailabilityWarnings(), buildSkuActivityEvent(), buildTimeline(), getImpactQuantities() (+11 more)
 
-### Community 36 - "Community 36"
+### Community 38 - "Community 38"
 Cohesion: 0.18
 Nodes (16): createDefaultSessionCommandService(), createPosSessionCommandService(), failure(), isActiveRegisterSession(), isSessionExpired(), registerSessionMatchesIdentity(), resolveRegisterSessionBinding(), runBindSessionToRegisterSessionCommand() (+8 more)
 
-### Community 37 - "Community 37"
+### Community 39 - "Community 39"
 Cohesion: 0.1
 Nodes (4): handleChange(), isSkuReserved(), parseVariantInputValue(), shouldDisable()
 
-### Community 38 - "Community 38"
+### Community 40 - "Community 40"
 Cohesion: 0.13
 Nodes (11): CashPositionSummary(), cn(), formatCashExposureSupporting(), formatCurrency(), formatStaffByline(), formatTimestamp(), getSessionActionLabel(), getSessionOpenedLine() (+3 more)
 
-### Community 39 - "Community 39"
+### Community 41 - "Community 41"
 Cohesion: 0.15
 Nodes (11): checkIfItemsHaveChanged(), createOnlineOrder(), createPatchObject(), findBestValuePromoCode(), handleExistingSession(), handleOrderCreation(), handlePlaceOrder(), listSessionItems() (+3 more)
 
-### Community 40 - "Community 40"
+### Community 42 - "Community 42"
 Cohesion: 0.13
 Nodes (8): formatInventoryNumber(), formatReservationSourceSummary(), getInventoryItemDisplayName(), getReservationLabels(), getSkuDetailEntries(), handleDraftChange(), rowMatchesStockAdjustmentSearch(), setDraftValue()
 
-### Community 41 - "Community 41"
-Cohesion: 0.14
-Nodes (12): cancelItemAdjustmentWorkflow(), exitCorrectionWorkflow(), formatCorrectionEventType(), formatCorrectionHistoryChange(), formatCorrectionHistoryTitle(), formatPaymentMethodLabel(), getCorrectionHistoryChangeParts(), isManagerStaff() (+4 more)
-
-### Community 42 - "Community 42"
+### Community 43 - "Community 43"
 Cohesion: 0.12
 Nodes (7): createEmptyMemoryStore(), createMemoryPosLocalStorageAdapter(), normalizeStaffAuthorityRecord(), normalizeUsername(), PosLocalStoreSchemaError, preserveWrappedStaffProof(), staffAuthorityKey()
 
-### Community 43 - "Community 43"
+### Community 44 - "Community 44"
 Cohesion: 0.18
 Nodes (17): bestFuzzyTokenScore(), extractIdentifierFromUrl(), findExactMatches(), firstNonEmpty(), isBarcodeShapedInput(), isProbablySameToken(), levenshteinDistance(), normalizeIdentifier() (+9 more)
 
-### Community 44 - "Community 44"
+### Community 45 - "Community 45"
 Cohesion: 0.15
 Nodes (10): capitalizeFirstLetter(), capitalizeWords(), cn(), currencyFormatter(), formatDate(), getErrorForField(), getProductName(), getRelativeTime() (+2 more)
 
-### Community 45 - "Community 45"
+### Community 46 - "Community 46"
 Cohesion: 0.21
 Nodes (16): commandForPort(), defaultCommand(), isProcessAlive(), isReachable(), listPreviews(), optionsFromEnv(), pruneState(), readState() (+8 more)
 
-### Community 46 - "Community 46"
+### Community 47 - "Community 47"
 Cohesion: 0.19
 Nodes (16): applyStockAdjustmentBatchWithCtx(), assertDistinctStockAdjustmentLineItems(), buildResolvedStockAdjustmentStatus(), buildStockAdjustmentDecisionEventType(), buildStockAdjustmentSourceId(), buildStockAdjustmentTitle(), listInventorySnapshotWithCtx(), listProductSkusForStockAdjustmentScopeWithCtx() (+8 more)
 
-### Community 47 - "Community 47"
+### Community 48 - "Community 48"
 Cohesion: 0.17
 Nodes (13): buildSkuContinuityContextById(), deriveContinuityStatus(), getPlannedActionAt(), getStartOfCurrentDay(), hasLateInbound(), hasRelatedPurchaseOrderContext(), hasStalePlannedAction(), isInboundStatus() (+5 more)
-
-### Community 48 - "Community 48"
-Cohesion: 0.23
-Nodes (14): buildCompleteTransactionResult(), calculateCanonicalTransactionTotals(), calculateTotalPaid(), completeTransaction(), createTransactionFromSessionHandler(), isUsableRegisterSession(), recordRegisterSessionSale(), recordRegisterSessionVoid() (+6 more)
 
 ### Community 49 - "Community 49"
 Cohesion: 0.11
@@ -2160,80 +2160,80 @@ Cohesion: 0.4
 Nodes (8): fileExists(), isJsonObject(), normalizeGraphJsonArtifact(), normalizeGraphJsonContents(), resolveGraphifyPython(), runGraphifyRebuild(), sortJsonArray(), sortJsonValue()
 
 ### Community 105 - "Community 105"
+Cohesion: 0.44
+Nodes (8): buildApprovalDecisionRequirement(), buildApprovalDecisionSubject(), consumeApprovalDecisionProofWithCtx(), decideApprovalRequestAsAuthenticatedUserWithCtx(), decideApprovalRequestAsCommandWithCtx(), decideApprovalRequestWithCtx(), mapDecideApprovalRequestError(), omitUndefined()
+
+### Community 106 - "Community 106"
+Cohesion: 0.39
+Nodes (6): buildInventoryMovement(), buildSkuActivityForInventoryMovement(), getSkuActivityTypeForMovement(), recordInventoryMovementWithCtx(), recordInventoryMovementWithDispositionWithCtx(), recordSkuActivityForInventoryMovementWithCtx()
+
+### Community 107 - "Community 107"
 Cohesion: 0.42
 Nodes (7): buildTraceEvent(), buildTraceRecord(), displayTraceAmount(), recordRegisterSessionTraceBestEffort(), resolveOccurredAt(), resolveStoreCurrency(), safeTraceWrite()
 
-### Community 106 - "Community 106"
+### Community 108 - "Community 108"
 Cohesion: 0.42
 Nodes (7): getRegisterCatalogPrice(), listRegisterCatalog(), listRegisterCatalogAvailabilitySnapshot(), listScopedRegisterCatalogSkus(), mapSkuToRegisterCatalogRow(), readCategoryName(), readColorName()
 
-### Community 107 - "Community 107"
+### Community 109 - "Community 109"
 Cohesion: 0.28
 Nodes (4): buildCtx(), buildManagerProof(), buildRegisterOpenedEvent(), createFakeConvexCtx()
 
-### Community 108 - "Community 108"
+### Community 110 - "Community 110"
 Cohesion: 0.5
 Nodes (7): getNonEmptyString(), getOperationalEventJourney(), getOperationalEventStatus(), getOperationalEventStep(), isFailureStatus(), isOperationalEventDoc(), normalizeEvent()
 
-### Community 109 - "Community 109"
+### Community 111 - "Community 111"
 Cohesion: 0.39
 Nodes (7): calculateRefundAmount(), getAmountRefunded(), getAvailableItems(), getItemsToRefund(), getNetAmount(), shouldShowReturnToStock(), validateRefund()
 
-### Community 110 - "Community 110"
+### Community 112 - "Community 112"
 Cohesion: 0.25
 Nodes (2): buildUsername(), normalizeNameSegment()
 
-### Community 111 - "Community 111"
+### Community 113 - "Community 113"
 Cohesion: 0.39
 Nodes (6): handleDeliveryRestrictionToggle(), handlePickupRestrictionToggle(), handleSaveDeliveryRestriction(), handleSavePickupRestriction(), saveDeliveryRestriction(), savePickupRestriction()
 
-### Community 112 - "Community 112"
+### Community 114 - "Community 114"
 Cohesion: 0.44
 Nodes (1): Logger
 
-### Community 113 - "Community 113"
+### Community 115 - "Community 115"
 Cohesion: 0.22
 Nodes (0):
 
-### Community 114 - "Community 114"
+### Community 116 - "Community 116"
 Cohesion: 0.22
 Nodes (2): ClusterRedis, StandaloneRedis
 
-### Community 115 - "Community 115"
+### Community 117 - "Community 117"
 Cohesion: 0.42
 Nodes (8): assertCoverageToolchainParity(), checkCoverageToolchainParity(), collectCoverageToolchainFailures(), declaredVersion(), formatFailureMessage(), installedVersion(), readManifest(), runFrozenInstall()
 
-### Community 116 - "Community 116"
+### Community 118 - "Community 118"
 Cohesion: 0.46
 Nodes (7): deleteDirectoryInR2(), deleteFileInR2(), getR2(), listItemsInR2Directory(), readEnvValue(), resolveR2ConfigFromEnv(), uploadFileToR2()
 
-### Community 117 - "Community 117"
+### Community 119 - "Community 119"
 Cohesion: 0.25
 Nodes (0):
 
-### Community 118 - "Community 118"
+### Community 120 - "Community 120"
 Cohesion: 0.5
 Nodes (6): findAthenaUserByEmailWithCtx(), getAuthenticatedAthenaUserWithCtx(), getAuthenticatedUserRecord(), normalizeEmail(), requireAuthenticatedAthenaUserWithCtx(), syncAuthenticatedAthenaUserWithCtx()
 
-### Community 119 - "Community 119"
+### Community 121 - "Community 121"
 Cohesion: 0.43
 Nodes (6): sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
 
-### Community 120 - "Community 120"
+### Community 122 - "Community 122"
 Cohesion: 0.43
 Nodes (6): buildMtnCollectionsLookupPrefixes(), isTargetEnvironment(), readScopedValue(), resolveConfigForPrefix(), resolveMtnCollectionsConfigFromEnv(), toEnvSegment()
 
-### Community 121 - "Community 121"
+### Community 123 - "Community 123"
 Cohesion: 0.46
 Nodes (7): recordApprovalAuditEventWithCtx(), recordApprovalDecisionRecordedAuditEventWithCtx(), recordApprovalProofConsumedAuditEventWithCtx(), recordApprovalRequiredAuditEventWithCtx(), recordApprovedCommandAppliedAuditEventWithCtx(), recordAsyncApprovalRequestCreatedAuditEventWithCtx(), recordManagerApprovalGrantedAuditEventWithCtx()
-
-### Community 122 - "Community 122"
-Cohesion: 0.5
-Nodes (7): buildApprovalDecisionRequirement(), buildApprovalDecisionSubject(), consumeApprovalDecisionProofWithCtx(), decideApprovalRequestAsAuthenticatedUserWithCtx(), decideApprovalRequestAsCommandWithCtx(), decideApprovalRequestWithCtx(), mapDecideApprovalRequestError()
-
-### Community 123 - "Community 123"
-Cohesion: 0.39
-Nodes (5): buildInventoryMovement(), buildSkuActivityForInventoryMovement(), getSkuActivityTypeForMovement(), recordInventoryMovementWithCtx(), recordSkuActivityForInventoryMovementWithCtx()
 
 ### Community 124 - "Community 124"
 Cohesion: 0.43
@@ -2460,56 +2460,56 @@ Cohesion: 0.4
 Nodes (2): buildPersistedRuntimeStatus(), buildRuntimeStatus()
 
 ### Community 180 - "Community 180"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 181 - "Community 181"
 Cohesion: 0.73
 Nodes (5): buildOrderStatusMessage(), buildPickupDetails(), sendPaymentVerificationEmails(), sendPODOrderEmails(), shouldSendToAdmins()
 
-### Community 181 - "Community 181"
+### Community 182 - "Community 182"
 Cohesion: 0.6
 Nodes (5): createVendorCommandWithCtx(), createVendorWithCtx(), mapCreateVendorError(), normalizeVendorLookupKey(), trimOptional()
 
-### Community 182 - "Community 182"
+### Community 183 - "Community 183"
 Cohesion: 0.6
 Nodes (5): find_block_end(), list_convex_files(), main(), scan_file(), strip_code()
 
-### Community 183 - "Community 183"
+### Community 184 - "Community 184"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 184 - "Community 184"
+### Community 185 - "Community 185"
 Cohesion: 0.53
 Nodes (4): includesRegisterSessionStatus(), isCashControlVisibleRegisterSessionStatus(), isPosUsableRegisterSessionStatus(), isRegisterSessionConflictBlockingStatus()
 
-### Community 185 - "Community 185"
+### Community 186 - "Community 186"
 Cohesion: 0.33
 Nodes (1): DataTableToolbar()
 
-### Community 186 - "Community 186"
+### Community 187 - "Community 187"
 Cohesion: 0.53
 Nodes (2): SelectedProductsProvider(), useSelectedProducts()
 
-### Community 187 - "Community 187"
+### Community 188 - "Community 188"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 188 - "Community 188"
+### Community 189 - "Community 189"
 Cohesion: 0.47
 Nodes (3): historyRecord(), snapshot(), storedReportSnapshot()
 
-### Community 189 - "Community 189"
+### Community 190 - "Community 190"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 190 - "Community 190"
+### Community 191 - "Community 191"
 Cohesion: 0.4
 Nodes (2): buildApprovalRetryArgs(), getAsyncApprovalRequestId()
 
-### Community 191 - "Community 191"
+### Community 192 - "Community 192"
 Cohesion: 0.47
 Nodes (3): getSummaryAmount(), getSummaryLabel(), getSummaryPanel()
-
-### Community 192 - "Community 192"
-Cohesion: 0.33
-Nodes (0):
 
 ### Community 193 - "Community 193"
 Cohesion: 0.33
@@ -2520,20 +2520,20 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 195 - "Community 195"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 196 - "Community 196"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 197 - "Community 197"
 Cohesion: 0.53
 Nodes (3): handleUpdateFees(), parseDeliveryFeeInputs(), parseOptionalDeliveryFeeInput()
 
-### Community 196 - "Community 196"
+### Community 198 - "Community 198"
 Cohesion: 0.47
 Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
-
-### Community 197 - "Community 197"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 198 - "Community 198"
-Cohesion: 0.33
-Nodes (0):
 
 ### Community 199 - "Community 199"
 Cohesion: 0.33
@@ -2552,140 +2552,140 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 203 - "Community 203"
-Cohesion: 0.53
-Nodes (4): calculatePosChange(), calculatePosRemainingDue(), calculatePosTotalPaid(), roundPosAmount()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 204 - "Community 204"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 205 - "Community 205"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.53
+Nodes (4): calculatePosChange(), calculatePosRemainingDue(), calculatePosTotalPaid(), roundPosAmount()
 
 ### Community 206 - "Community 206"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
-
-### Community 207 - "Community 207"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
-
-### Community 208 - "Community 208"
 Cohesion: 0.33
 Nodes (0):
 
+### Community 207 - "Community 207"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 208 - "Community 208"
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
+
 ### Community 209 - "Community 209"
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
+
+### Community 210 - "Community 210"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 211 - "Community 211"
 Cohesion: 0.47
 Nodes (4): fetchPosTransaction(), getBaseUrl(), getPosTransactionByReceiptToken(), PosTransactionReceiptError
 
-### Community 210 - "Community 210"
+### Community 212 - "Community 212"
 Cohesion: 0.47
 Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
-
-### Community 211 - "Community 211"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 212 - "Community 212"
-Cohesion: 0.4
-Nodes (2): handleConfirm(), handlePrimaryAction()
 
 ### Community 213 - "Community 213"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 214 - "Community 214"
-Cohesion: 0.53
-Nodes (5): getRemainingForFreeDelivery(), hasWaiverConfigured(), isAnyFeeWaived(), isFeeWaived(), meetsThreshold()
+Cohesion: 0.4
+Nodes (2): handleConfirm(), handlePrimaryAction()
 
 ### Community 215 - "Community 215"
-Cohesion: 0.47
-Nodes (3): onSubmit(), reportAuthFailure(), resendVerificationCode()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 216 - "Community 216"
 Cohesion: 0.53
-Nodes (4): coverageSummary(), write(), writePackageSummaries(), writeRealBaselineSummaries()
+Nodes (5): getRemainingForFreeDelivery(), hasWaiverConfigured(), isAnyFeeWaived(), isFeeWaived(), meetsThreshold()
 
 ### Community 217 - "Community 217"
+Cohesion: 0.47
+Nodes (3): onSubmit(), reportAuthFailure(), resendVerificationCode()
+
+### Community 218 - "Community 218"
+Cohesion: 0.53
+Nodes (4): coverageSummary(), write(), writePackageSummaries(), writeRealBaselineSummaries()
+
+### Community 219 - "Community 219"
 Cohesion: 0.67
 Nodes (5): collectRepoCodeFiles(), collectStaleGraphifyArtifacts(), copyGraphifyCheckInputs(), fileExists(), runGraphifyCheck()
 
-### Community 218 - "Community 218"
+### Community 220 - "Community 220"
 Cohesion: 0.4
 Nodes (2): createFixtureRoot(), write()
 
-### Community 219 - "Community 219"
+### Community 221 - "Community 221"
 Cohesion: 0.53
 Nodes (4): collectDefaultPlanHtmlFiles(), collectPlanHtmlFindings(), hasRemoteReference(), runPlanHtmlValidation()
 
-### Community 220 - "Community 220"
+### Community 222 - "Community 222"
 Cohesion: 0.5
 Nodes (2): createAuthorizedRegisterDepositCtx(), createQueryCtx()
 
-### Community 221 - "Community 221"
+### Community 223 - "Community 223"
 Cohesion: 0.6
 Nodes (4): buildInStorePaymentAllocations(), normalizeInStorePayments(), resolveRegisterSessionForInStoreCollectionWithCtx(), selectRegisterSessionForAttribution()
 
-### Community 222 - "Community 222"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 223 - "Community 223"
-Cohesion: 0.4
-Nodes (0):
-
 ### Community 224 - "Community 224"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 225 - "Community 225"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 226 - "Community 226"
 Cohesion: 0.6
 Nodes (3): formatStoredAmount(), toDisplayAmount(), toPesewas()
 
-### Community 225 - "Community 225"
+### Community 227 - "Community 227"
 Cohesion: 0.7
 Nodes (4): compactRecord(), ensureCustomerProfileFromSourcesWithCtx(), findExistingProfile(), loadCustomerSources()
 
-### Community 226 - "Community 226"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 227 - "Community 227"
-Cohesion: 0.4
-Nodes (0):
-
 ### Community 228 - "Community 228"
-Cohesion: 0.7
-Nodes (4): buildDecision(), classifyCorrectionIntent(), isSupportedCorrectionIntent(), isUnsupportedHighRiskCorrectionIntent()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 229 - "Community 229"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 230 - "Community 230"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.7
+Nodes (4): buildDecision(), classifyCorrectionIntent(), isSupportedCorrectionIntent(), isUnsupportedHighRiskCorrectionIntent()
 
 ### Community 231 - "Community 231"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 232 - "Community 232"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 233 - "Community 233"
 Cohesion: 0.7
 Nodes (4): getPaystackHeaders(), initializeTransaction(), initiateRefund(), verifyTransaction()
 
-### Community 233 - "Community 233"
+### Community 234 - "Community 234"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 234 - "Community 234"
+### Community 235 - "Community 235"
 Cohesion: 0.6
 Nodes (3): buildOnlineOrderReturnExchangePlan(), getApprovalReason(), getKind()
 
-### Community 235 - "Community 235"
+### Community 236 - "Community 236"
 Cohesion: 0.5
 Nodes (2): getNonEmptyString(), normalizeStorefrontObservabilityEvent()
-
-### Community 236 - "Community 236"
-Cohesion: 0.4
-Nodes (0):
 
 ### Community 237 - "Community 237"
 Cohesion: 0.4
@@ -2704,12 +2704,12 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 241 - "Community 241"
-Cohesion: 0.5
-Nodes (2): handleFileSelect(), validateFile()
-
-### Community 242 - "Community 242"
 Cohesion: 0.4
 Nodes (0):
+
+### Community 242 - "Community 242"
+Cohesion: 0.5
+Nodes (2): handleFileSelect(), validateFile()
 
 ### Community 243 - "Community 243"
 Cohesion: 0.4
@@ -2724,12 +2724,12 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 246 - "Community 246"
-Cohesion: 0.5
-Nodes (2): getBalanceDueLabel(), getBalanceDuePanel()
-
-### Community 247 - "Community 247"
 Cohesion: 0.4
 Nodes (0):
+
+### Community 247 - "Community 247"
+Cohesion: 0.5
+Nodes (2): getBalanceDueLabel(), getBalanceDuePanel()
 
 ### Community 248 - "Community 248"
 Cohesion: 0.4
@@ -2944,28 +2944,28 @@ Cohesion: 0.83
 Nodes (3): mapOpenDrawerUserError(), normalizeRegisterNumber(), openDrawer()
 
 ### Community 301 - "Community 301"
-Cohesion: 0.83
-Nodes (3): createDbGetMock(), createDbMock(), createDbQueryMock()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 302 - "Community 302"
 Cohesion: 0.83
-Nodes (3): buildRegisterState(), getActiveSessionConflictForRegisterState(), getRegisterState()
+Nodes (3): createDbGetMock(), createDbMock(), createDbQueryMock()
 
 ### Community 303 - "Community 303"
+Cohesion: 0.83
+Nodes (3): buildRegisterState(), getActiveSessionConflictForRegisterState(), getRegisterState()
+
+### Community 304 - "Community 304"
 Cohesion: 0.67
 Nodes (2): lookupByBarcode(), mapSkuToCatalogResult()
 
-### Community 304 - "Community 304"
+### Community 305 - "Community 305"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 305 - "Community 305"
-Cohesion: 0.83
-Nodes (3): createPosLocalStaffProofToken(), hashPosLocalStaffProofToken(), toHex()
 
 ### Community 306 - "Community 306"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): createPosLocalStaffProofToken(), hashPosLocalStaffProofToken(), toHex()
 
 ### Community 307 - "Community 307"
 Cohesion: 0.5
@@ -2976,24 +2976,24 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 309 - "Community 309"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 310 - "Community 310"
 Cohesion: 0.67
 Nodes (2): expectIndex(), getTableIndexes()
 
-### Community 310 - "Community 310"
+### Community 311 - "Community 311"
 Cohesion: 0.83
 Nodes (3): findExistingCustomerProfileId(), getStoreOrganizationId(), recordStoreFrontCustomerMilestone()
 
-### Community 311 - "Community 311"
+### Community 312 - "Community 312"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 312 - "Community 312"
-Cohesion: 0.83
-Nodes (3): formatStaffDisplayName(), formatStaffDisplayNameOrFallback(), normalizeNamePart()
 
 ### Community 313 - "Community 313"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): formatStaffDisplayName(), formatStaffDisplayNameOrFallback(), normalizeNamePart()
 
 ### Community 314 - "Community 314"
 Cohesion: 0.5
@@ -3008,12 +3008,12 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 317 - "Community 317"
-Cohesion: 0.67
-Nodes (2): countGroupedAnalytics(), groupAnalytics()
-
-### Community 318 - "Community 318"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 318 - "Community 318"
+Cohesion: 0.67
+Nodes (2): countGroupedAnalytics(), groupAnalytics()
 
 ### Community 319 - "Community 319"
 Cohesion: 0.5
@@ -3036,24 +3036,24 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 324 - "Community 324"
-Cohesion: 0.67
-Nodes (2): handleSubmit(), resetReplacementFields()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 325 - "Community 325"
 Cohesion: 0.67
-Nodes (2): CashierAuthDialog(), getStaffDisplayName()
+Nodes (2): handleSubmit(), resetReplacementFields()
 
 ### Community 326 - "Community 326"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): CashierAuthDialog(), getStaffDisplayName()
 
 ### Community 327 - "Community 327"
-Cohesion: 0.67
-Nodes (2): getLocalOperatingDate(), getLocalOperatingDateRange()
-
-### Community 328 - "Community 328"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 328 - "Community 328"
+Cohesion: 0.67
+Nodes (2): getLocalOperatingDate(), getLocalOperatingDateRange()
 
 ### Community 329 - "Community 329"
 Cohesion: 0.5
@@ -3068,108 +3068,108 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 332 - "Community 332"
-Cohesion: 0.67
-Nodes (2): applyCommandResult(), handleCreateCase()
-
-### Community 333 - "Community 333"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 333 - "Community 333"
+Cohesion: 0.67
+Nodes (2): applyCommandResult(), handleCreateCase()
 
 ### Community 334 - "Community 334"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 335 - "Community 335"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 336 - "Community 336"
 Cohesion: 0.67
 Nodes (2): getRiskStyles(), RiskIndicators()
 
-### Community 336 - "Community 336"
+### Community 337 - "Community 337"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 337 - "Community 337"
-Cohesion: 0.67
-Nodes (2): useGetArchivedProducts(), useGetProducts()
 
 ### Community 338 - "Community 338"
 Cohesion: 0.67
-Nodes (2): getReceiptPageHeightMm(), setContinuousReceiptPageSize()
+Nodes (2): useGetArchivedProducts(), useGetProducts()
 
 ### Community 339 - "Community 339"
+Cohesion: 0.67
+Nodes (2): getReceiptPageHeightMm(), setContinuousReceiptPageSize()
+
+### Community 340 - "Community 340"
 Cohesion: 1.0
 Nodes (3): canAccessFullAdminSurface(), canAccessStoreDaySurface(), getSurfaceAccess()
 
-### Community 340 - "Community 340"
+### Community 341 - "Community 341"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 341 - "Community 341"
+### Community 342 - "Community 342"
 Cohesion: 0.67
 Nodes (2): extractTraceId(), runCommand()
 
-### Community 342 - "Community 342"
+### Community 343 - "Community 343"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 343 - "Community 343"
-Cohesion: 0.67
-Nodes (2): formatStoredAmount(), formatStoredCurrencyAmount()
 
 ### Community 344 - "Community 344"
 Cohesion: 0.67
-Nodes (2): buildExpenseReceiptHtml(), parseReceiptLocation()
+Nodes (2): formatStoredAmount(), formatStoredCurrencyAmount()
 
 ### Community 345 - "Community 345"
+Cohesion: 0.67
+Nodes (2): buildExpenseReceiptHtml(), parseReceiptLocation()
+
+### Community 346 - "Community 346"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 346 - "Community 346"
+### Community 347 - "Community 347"
 Cohesion: 0.67
 Nodes (2): mapActiveSessionDto(), normalizeCartItems()
 
-### Community 347 - "Community 347"
+### Community 348 - "Community 348"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 348 - "Community 348"
+### Community 349 - "Community 349"
 Cohesion: 0.67
 Nodes (2): isSeedReadLoading(), resolveLocalPosEntryContext()
 
-### Community 349 - "Community 349"
+### Community 350 - "Community 350"
 Cohesion: 0.83
 Nodes (3): derivePosLocalSyncStatus(), getContiguousSyncedSequence(), getSyncState()
 
-### Community 350 - "Community 350"
+### Community 351 - "Community 351"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 351 - "Community 351"
+### Community 352 - "Community 352"
 Cohesion: 0.83
 Nodes (3): isBrowserFingerprintResult(), readStoredTerminalFingerprint(), readStoredTerminalFingerprintHash()
 
-### Community 352 - "Community 352"
+### Community 353 - "Community 353"
 Cohesion: 0.67
 Nodes (2): getCashierDisplayName(), useExpenseRegisterViewModel()
 
-### Community 353 - "Community 353"
+### Community 354 - "Community 354"
 Cohesion: 0.67
 Nodes (2): buildPosSyncStatusPresentation(), normalizeStatus()
 
-### Community 354 - "Community 354"
+### Community 355 - "Community 355"
 Cohesion: 0.83
 Nodes (3): getBaseUrl(), getUserRedeemedOffers(), submitOffer()
 
-### Community 355 - "Community 355"
+### Community 356 - "Community 356"
 Cohesion: 0.83
 Nodes (3): getAllStores(), getBaseUrl(), getStore()
 
-### Community 356 - "Community 356"
+### Community 357 - "Community 357"
 Cohesion: 0.83
 Nodes (3): getAllSubcategories(), getBaseUrl(), getSubategory()
-
-### Community 357 - "Community 357"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 358 - "Community 358"
 Cohesion: 0.5
@@ -3200,59 +3200,59 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 365 - "Community 365"
-Cohesion: 0.67
-Nodes (2): useOptionalStoreContext(), useStoreContext()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 366 - "Community 366"
 Cohesion: 0.67
-Nodes (2): clearFilters(), onMobileFiltersCloseClick()
+Nodes (2): useOptionalStoreContext(), useStoreContext()
 
 ### Community 367 - "Community 367"
+Cohesion: 0.67
+Nodes (2): clearFilters(), onMobileFiltersCloseClick()
+
+### Community 368 - "Community 368"
 Cohesion: 0.83
 Nodes (3): cancelOrder(), getErrorMessage(), placeOrder()
 
-### Community 368 - "Community 368"
+### Community 369 - "Community 369"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 369 - "Community 369"
-Cohesion: 0.83
-Nodes (3): bootstrapCheckout(), createBootstrapToken(), createMarker()
 
 ### Community 370 - "Community 370"
 Cohesion: 0.83
-Nodes (3): createFixtureRoot(), write(), writeGraphifyWikiArtifacts()
+Nodes (3): bootstrapCheckout(), createBootstrapToken(), createMarker()
 
 ### Community 371 - "Community 371"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): createFixtureRoot(), write(), writeGraphifyWikiArtifacts()
 
 ### Community 372 - "Community 372"
-Cohesion: 0.67
-Nodes (2): buildHarnessDocPaths(), buildHarnessDocPathsForArchetype()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 373 - "Community 373"
 Cohesion: 0.67
-Nodes (2): shutdown(), stopValkeyRuntimeServer()
+Nodes (2): buildHarnessDocPaths(), buildHarnessDocPathsForArchetype()
 
 ### Community 374 - "Community 374"
+Cohesion: 0.67
+Nodes (2): shutdown(), stopValkeyRuntimeServer()
+
+### Community 375 - "Community 375"
 Cohesion: 0.83
 Nodes (3): createFixtureRepo(), createInferentialArtifact(), write()
 
-### Community 375 - "Community 375"
+### Community 376 - "Community 376"
 Cohesion: 0.67
 Nodes (2): collectHarnessTestTargets(), runHarnessTest()
-
-### Community 376 - "Community 376"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 377 - "Community 377"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 378 - "Community 378"
-Cohesion: 0.67
+Cohesion: 0.5
 Nodes (0):
 
 ### Community 379 - "Community 379"
@@ -3260,12 +3260,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 380 - "Community 380"
-Cohesion: 1.0
-Nodes (2): providerErrorCategory(), sendWhatsAppReceiptTemplate()
-
-### Community 381 - "Community 381"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 381 - "Community 381"
+Cohesion: 1.0
+Nodes (2): providerErrorCategory(), sendWhatsAppReceiptTemplate()
 
 ### Community 382 - "Community 382"
 Cohesion: 0.67
@@ -3296,12 +3296,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 389 - "Community 389"
-Cohesion: 1.0
-Nodes (2): buildCtx(), createDb()
-
-### Community 390 - "Community 390"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 390 - "Community 390"
+Cohesion: 1.0
+Nodes (2): buildCtx(), createDb()
 
 ### Community 391 - "Community 391"
 Cohesion: 0.67
@@ -3320,20 +3320,20 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 395 - "Community 395"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 396 - "Community 396"
 Cohesion: 1.0
 Nodes (2): hashPosTerminalSyncSecret(), toHex()
 
-### Community 396 - "Community 396"
-Cohesion: 0.67
-Nodes (0):
-
 ### Community 397 - "Community 397"
 Cohesion: 0.67
-Nodes (1): PosServerError
+Nodes (0):
 
 ### Community 398 - "Community 398"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): PosServerError
 
 ### Community 399 - "Community 399"
 Cohesion: 0.67
@@ -3348,28 +3348,28 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 402 - "Community 402"
-Cohesion: 1.0
-Nodes (2): getActiveRegisterSessionForRegisterState(), mapRegisterSessionToCashDrawerSummary()
-
-### Community 403 - "Community 403"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 403 - "Community 403"
+Cohesion: 1.0
+Nodes (2): getActiveRegisterSessionForRegisterState(), mapRegisterSessionToCashDrawerSummary()
 
 ### Community 404 - "Community 404"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 405 - "Community 405"
-Cohesion: 1.0
-Nodes (2): buildServiceCatalogItem(), normalizeServiceCatalogNameKey()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 406 - "Community 406"
 Cohesion: 1.0
-Nodes (2): expectIndex(), getTableIndexes()
+Nodes (2): buildServiceCatalogItem(), normalizeServiceCatalogNameKey()
 
 ### Community 407 - "Community 407"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): expectIndex(), getTableIndexes()
 
 ### Community 408 - "Community 408"
 Cohesion: 0.67
@@ -3384,36 +3384,36 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 411 - "Community 411"
-Cohesion: 1.0
-Nodes (2): listBagItems(), loadBagWithItems()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 412 - "Community 412"
 Cohesion: 1.0
-Nodes (2): buildRegisterSessionTraceSeed(), formatRegisterSessionLabel()
+Nodes (2): listBagItems(), loadBagWithItems()
 
 ### Community 413 - "Community 413"
 Cohesion: 1.0
-Nodes (2): getWorkflowTraceViewByIdWithCtx(), getWorkflowTraceViewByLookupWithCtx()
+Nodes (2): buildRegisterSessionTraceSeed(), formatRegisterSessionLabel()
 
 ### Community 414 - "Community 414"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getWorkflowTraceViewByIdWithCtx(), getWorkflowTraceViewByLookupWithCtx()
 
 ### Community 415 - "Community 415"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 416 - "Community 416"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 417 - "Community 417"
 Cohesion: 1.0
 Nodes (2): createWorkflowTraceId(), normalizeWorkflowTraceLookupValue()
 
-### Community 417 - "Community 417"
-Cohesion: 0.67
-Nodes (1): View()
-
 ### Community 418 - "Community 418"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): View()
 
 ### Community 419 - "Community 419"
 Cohesion: 0.67
@@ -3428,12 +3428,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 422 - "Community 422"
-Cohesion: 1.0
-Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
-
-### Community 423 - "Community 423"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 423 - "Community 423"
+Cohesion: 1.0
+Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
 
 ### Community 424 - "Community 424"
 Cohesion: 0.67
@@ -3445,11 +3445,11 @@ Nodes (0):
 
 ### Community 426 - "Community 426"
 Cohesion: 0.67
-Nodes (1): FadeIn()
+Nodes (0):
 
 ### Community 427 - "Community 427"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): FadeIn()
 
 ### Community 428 - "Community 428"
 Cohesion: 0.67
@@ -3457,15 +3457,15 @@ Nodes (0):
 
 ### Community 429 - "Community 429"
 Cohesion: 0.67
-Nodes (1): VideoPlayer()
+Nodes (0):
 
 ### Community 430 - "Community 430"
-Cohesion: 1.0
-Nodes (2): handleRefundOrder(), toast()
+Cohesion: 0.67
+Nodes (1): VideoPlayer()
 
 ### Community 431 - "Community 431"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): handleRefundOrder(), toast()
 
 ### Community 432 - "Community 432"
 Cohesion: 0.67
@@ -3525,79 +3525,79 @@ Nodes (0):
 
 ### Community 446 - "Community 446"
 Cohesion: 0.67
-Nodes (1): SingleLineError()
+Nodes (0):
 
 ### Community 447 - "Community 447"
 Cohesion: 0.67
-Nodes (1): ErrorPage()
+Nodes (1): SingleLineError()
 
 ### Community 448 - "Community 448"
 Cohesion: 0.67
-Nodes (1): AppSkeleton()
+Nodes (1): ErrorPage()
 
 ### Community 449 - "Community 449"
 Cohesion: 0.67
-Nodes (1): DashboardSkeleton()
+Nodes (1): AppSkeleton()
 
 ### Community 450 - "Community 450"
 Cohesion: 0.67
-Nodes (1): TableSkeleton()
+Nodes (1): DashboardSkeleton()
 
 ### Community 451 - "Community 451"
 Cohesion: 0.67
-Nodes (1): TransactionsSkeleton()
+Nodes (1): TableSkeleton()
 
 ### Community 452 - "Community 452"
 Cohesion: 0.67
-Nodes (1): NotFound()
+Nodes (1): TransactionsSkeleton()
 
 ### Community 453 - "Community 453"
+Cohesion: 0.67
+Nodes (1): NotFound()
+
+### Community 454 - "Community 454"
 Cohesion: 1.0
 Nodes (2): getWorkflowTraceRouteTarget(), WorkflowTraceRouteLink()
 
-### Community 454 - "Community 454"
+### Community 455 - "Community 455"
 Cohesion: 0.67
 Nodes (1): AppContextMenu()
 
-### Community 455 - "Community 455"
+### Community 456 - "Community 456"
 Cohesion: 0.67
 Nodes (1): Badge()
 
-### Community 456 - "Community 456"
-Cohesion: 0.67
-Nodes (0):
-
 ### Community 457 - "Community 457"
 Cohesion: 0.67
-Nodes (1): LoadingButton()
+Nodes (0):
 
 ### Community 458 - "Community 458"
 Cohesion: 0.67
-Nodes (1): onChange()
+Nodes (1): LoadingButton()
 
 ### Community 459 - "Community 459"
 Cohesion: 0.67
-Nodes (1): AlertModal()
+Nodes (1): onChange()
 
 ### Community 460 - "Community 460"
 Cohesion: 0.67
-Nodes (1): OverlayModal()
+Nodes (1): AlertModal()
 
 ### Community 461 - "Community 461"
 Cohesion: 0.67
-Nodes (1): Skeleton()
+Nodes (1): OverlayModal()
 
 ### Community 462 - "Community 462"
 Cohesion: 0.67
-Nodes (1): Toaster()
+Nodes (1): Skeleton()
 
 ### Community 463 - "Community 463"
 Cohesion: 0.67
-Nodes (1): Spinner()
+Nodes (1): Toaster()
 
 ### Community 464 - "Community 464"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): Spinner()
 
 ### Community 465 - "Community 465"
 Cohesion: 0.67
@@ -3629,11 +3629,11 @@ Nodes (0):
 
 ### Community 472 - "Community 472"
 Cohesion: 0.67
-Nodes (1): useAuth()
+Nodes (0):
 
 ### Community 473 - "Community 473"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): useAuth()
 
 ### Community 474 - "Community 474"
 Cohesion: 0.67
@@ -3644,44 +3644,44 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 476 - "Community 476"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 477 - "Community 477"
 Cohesion: 1.0
 Nodes (2): getApprovalGuidance(), presentCommandToast()
 
-### Community 477 - "Community 477"
+### Community 478 - "Community 478"
 Cohesion: 0.67
 Nodes (1): isInMaintenanceMode()
 
-### Community 478 - "Community 478"
+### Community 479 - "Community 479"
 Cohesion: 0.67
 Nodes (0):
-
-### Community 479 - "Community 479"
-Cohesion: 1.0
-Nodes (2): createTerminalSyncSecretToken(), registerAndProvisionPosTerminal()
 
 ### Community 480 - "Community 480"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): createTerminalSyncSecretToken(), registerAndProvisionPosTerminal()
 
 ### Community 481 - "Community 481"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 482 - "Community 482"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 483 - "Community 483"
 Cohesion: 1.0
 Nodes (2): readProjectedLocalRegisterModel(), readScopedPosLocalEvents()
 
-### Community 483 - "Community 483"
+### Community 484 - "Community 484"
 Cohesion: 0.67
 Nodes (0):
-
-### Community 484 - "Community 484"
-Cohesion: 1.0
-Nodes (2): buildLocalEvent(), isUploadSequenceEventType()
 
 ### Community 485 - "Community 485"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): buildLocalEvent(), isUploadSequenceEventType()
 
 ### Community 486 - "Community 486"
 Cohesion: 0.67
@@ -3689,67 +3689,67 @@ Nodes (0):
 
 ### Community 487 - "Community 487"
 Cohesion: 0.67
-Nodes (1): App()
+Nodes (0):
 
 ### Community 488 - "Community 488"
-Cohesion: 1.0
-Nodes (2): collectSourceFiles(), findIllegalConvexImports()
+Cohesion: 0.67
+Nodes (1): App()
 
 ### Community 489 - "Community 489"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): collectSourceFiles(), findIllegalConvexImports()
 
 ### Community 490 - "Community 490"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 491 - "Community 491"
-Cohesion: 1.0
-Nodes (2): getAthenaDesignTokenStyle(), withAthenaTheme()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 492 - "Community 492"
 Cohesion: 1.0
-Nodes (2): mockGetSku(), validateInventoryForTransaction()
+Nodes (2): getAthenaDesignTokenStyle(), withAthenaTheme()
 
 ### Community 493 - "Community 493"
-Cohesion: 0.67
-Nodes (1): hashPassword()
+Cohesion: 1.0
+Nodes (2): mockGetSku(), validateInventoryForTransaction()
 
 ### Community 494 - "Community 494"
 Cohesion: 0.67
-Nodes (1): createVersionChecker()
+Nodes (1): hashPassword()
 
 ### Community 495 - "Community 495"
 Cohesion: 0.67
-Nodes (1): manualChunks()
+Nodes (1): createVersionChecker()
 
 ### Community 496 - "Community 496"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): manualChunks()
 
 ### Community 497 - "Community 497"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 498 - "Community 498"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 499 - "Community 499"
 Cohesion: 1.0
 Nodes (2): getAllColors(), getBaseUrl()
 
-### Community 499 - "Community 499"
+### Community 500 - "Community 500"
 Cohesion: 0.67
 Nodes (0):
-
-### Community 500 - "Community 500"
-Cohesion: 1.0
-Nodes (2): getBaseUrl(), getLastViewedProduct()
 
 ### Community 501 - "Community 501"
 Cohesion: 1.0
-Nodes (2): getBaseUrl(), getUserOffersEligibility()
+Nodes (2): getBaseUrl(), getLastViewedProduct()
 
 ### Community 502 - "Community 502"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getBaseUrl(), getUserOffersEligibility()
 
 ### Community 503 - "Community 503"
 Cohesion: 0.67
@@ -3764,12 +3764,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 506 - "Community 506"
-Cohesion: 1.0
-Nodes (2): handleKeyDown(), handleRedeemPromoCode()
-
-### Community 507 - "Community 507"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 507 - "Community 507"
+Cohesion: 1.0
+Nodes (2): handleKeyDown(), handleRedeemPromoCode()
 
 ### Community 508 - "Community 508"
 Cohesion: 0.67
@@ -3780,12 +3780,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 510 - "Community 510"
-Cohesion: 1.0
-Nodes (2): getPromoAlertCopy(), PromoAlert()
-
-### Community 511 - "Community 511"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 511 - "Community 511"
+Cohesion: 1.0
+Nodes (2): getPromoAlertCopy(), PromoAlert()
 
 ### Community 512 - "Community 512"
 Cohesion: 0.67
@@ -3852,16 +3852,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 528 - "Community 528"
-Cohesion: 1.0
-Nodes (2): collectWorkflowFiles(), runWorkflowCheck()
-
-### Community 529 - "Community 529"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 530 - "Community 530"
+### Community 529 - "Community 529"
 Cohesion: 1.0
-Nodes (2): createFixtureRepo(), write()
+Nodes (2): collectWorkflowFiles(), runWorkflowCheck()
+
+### Community 530 - "Community 530"
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 531 - "Community 531"
 Cohesion: 1.0
@@ -3880,20 +3880,20 @@ Cohesion: 1.0
 Nodes (2): createFixtureRepo(), write()
 
 ### Community 535 - "Community 535"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): createFixtureRepo(), write()
 
 ### Community 536 - "Community 536"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 537 - "Community 537"
-Cohesion: 1.0
-Nodes (2): collectRootScriptTestFiles(), runRootScriptsCoverage()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 538 - "Community 538"
 Cohesion: 1.0
-Nodes (0):
+Nodes (2): collectRootScriptTestFiles(), runRootScriptsCoverage()
 
 ### Community 539 - "Community 539"
 Cohesion: 1.0
@@ -8550,861 +8550,859 @@ Nodes (0):
 ## Knowledge Gaps
 - **1 isolated node(s):** `HelpRequested`
   These have ≤1 connection - possible missing edges or undocumented components.
-- **Thin community `Community 538`** (2 nodes): `paymentAllocationAttribution.test.ts`, `readProjectFile()`
+- **Thin community `Community 539`** (2 nodes): `paymentAllocationAttribution.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 539`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
+- **Thin community `Community 540`** (2 nodes): `registerSessions.test.ts`, `getHandler()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 540`** (2 nodes): `createCommandShimBin()`, `convexAuditScript.test.ts`
+- **Thin community `Community 541`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 541`** (2 nodes): `policy.ts`, `assertSupportedCustomerMessagePolicy()`
+- **Thin community `Community 542`** (2 nodes): `createCommandShimBin()`, `convexAuditScript.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 542`** (2 nodes): `repository.test.ts`, `queryResult()`
+- **Thin community `Community 543`** (2 nodes): `policy.ts`, `assertSupportedCustomerMessagePolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 543`** (2 nodes): `webhookSecurity.test.ts`, `sign()`
+- **Thin community `Community 544`** (2 nodes): `repository.test.ts`, `queryResult()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 544`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
+- **Thin community `Community 545`** (2 nodes): `webhookSecurity.test.ts`, `sign()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 545`** (2 nodes): `subcategories.ts`, `removeStorefrontHiddenSubcategoryList()`
+- **Thin community `Community 546`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 546`** (2 nodes): `storefrontCors.test.ts`, `readRouteFile()`
+- **Thin community `Community 547`** (2 nodes): `subcategories.ts`, `removeStorefrontHiddenSubcategoryList()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 547`** (2 nodes): `whatsapp.ts`, `mapWebhookStatus()`
+- **Thin community `Community 548`** (2 nodes): `storefrontCors.test.ts`, `readRouteFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 548`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
+- **Thin community `Community 549`** (2 nodes): `whatsapp.ts`, `mapWebhookStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 549`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
+- **Thin community `Community 550`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 550`** (2 nodes): `mapAthenaAuthSyncError()`, `auth.ts`
+- **Thin community `Community 551`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 551`** (2 nodes): `getHandler()`, `bestSeller.test.ts`
+- **Thin community `Community 552`** (2 nodes): `mapAthenaAuthSyncError()`, `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 552`** (2 nodes): `userErrorFromExpenseItemCommandFailure()`, `expenseSessionItems.ts`
+- **Thin community `Community 553`** (2 nodes): `getHandler()`, `bestSeller.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 553`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
+- **Thin community `Community 554`** (2 nodes): `userErrorFromExpenseItemCommandFailure()`, `expenseSessionItems.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 554`** (2 nodes): `posSessionItems.ts`, `userErrorFromSessionItemFailure()`
+- **Thin community `Community 555`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 555`** (2 nodes): `productUtil.ts`, `buildAllProductsCacheKey()`
+- **Thin community `Community 556`** (2 nodes): `posSessionItems.ts`, `userErrorFromSessionItemFailure()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 556`** (2 nodes): `promoCode.ts`, `calculateSelectedProductPromoDiscount()`
+- **Thin community `Community 557`** (2 nodes): `productUtil.ts`, `buildAllProductsCacheKey()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 557`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
+- **Thin community `Community 558`** (2 nodes): `promoCode.ts`, `calculateSelectedProductPromoDiscount()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 558`** (2 nodes): `commandResultValidator()`, `commandResultValidators.ts`
+- **Thin community `Community 559`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 559`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
+- **Thin community `Community 560`** (2 nodes): `commandResultValidator()`, `commandResultValidators.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 560`** (2 nodes): `callAnthropic()`, `anthropic.ts`
+- **Thin community `Community 561`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 561`** (2 nodes): `callOpenAi()`, `openai.ts`
+- **Thin community `Community 562`** (2 nodes): `callAnthropic()`, `anthropic.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 562`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
+- **Thin community `Community 563`** (2 nodes): `callOpenAi()`, `openai.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 563`** (2 nodes): `consumeCommandApprovalProofWithCtx()`, `approvalActions.ts`
+- **Thin community `Community 564`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 564`** (2 nodes): `createOperationalEventCtx()`, `approvalAuditEvents.test.ts`
+- **Thin community `Community 565`** (2 nodes): `consumeCommandApprovalProofWithCtx()`, `approvalActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 565`** (2 nodes): `createApprovalProofMutationCtx()`, `approvalProofs.test.ts`
+- **Thin community `Community 566`** (2 nodes): `createOperationalEventCtx()`, `approvalAuditEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 566`** (2 nodes): `buildApprovalRequest()`, `approvalRequestHelpers.ts`
+- **Thin community `Community 567`** (2 nodes): `createApprovalProofMutationCtx()`, `approvalProofs.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 567`** (2 nodes): `createApprovalRequestMutationCtx()`, `approvalRequests.test.ts`
+- **Thin community `Community 568`** (2 nodes): `buildApprovalRequest()`, `approvalRequestHelpers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 568`** (2 nodes): `buildOperationalEventMessage()`, `eventBuilders.ts`
+- **Thin community `Community 569`** (2 nodes): `createApprovalRequestMutationCtx()`, `approvalRequests.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 569`** (2 nodes): `createInventoryMovementCtx()`, `inventoryMovements.test.ts`
+- **Thin community `Community 570`** (2 nodes): `buildOperationalEventMessage()`, `eventBuilders.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 570`** (2 nodes): `getHandler()`, `operationalWorkItems.test.ts`
+- **Thin community `Community 571`** (2 nodes): `createInventoryMovementCtx()`, `inventoryMovements.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 571`** (2 nodes): `skuActivity.test.ts`, `createIndexedDb()`
+- **Thin community `Community 572`** (2 nodes): `getHandler()`, `operationalWorkItems.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 572`** (2 nodes): `formatValidTime()`, `EmailOTP.ts`
+- **Thin community `Community 573`** (2 nodes): `skuActivity.test.ts`, `createIndexedDb()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 573`** (2 nodes): `quickAddCatalogItem.test.ts`, `createQuickAddCtx()`
+- **Thin community `Community 574`** (2 nodes): `formatValidTime()`, `EmailOTP.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 574`** (2 nodes): `expectNoCompletionSideEffects()`, `completeTransaction.test.ts`
+- **Thin community `Community 575`** (2 nodes): `quickAddCatalogItem.test.ts`, `createQuickAddCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 575`** (2 nodes): `createMutationCtx()`, `correctTransactionPaymentMethod.test.ts`
+- **Thin community `Community 576`** (2 nodes): `createMutationCtx()`, `correctTransactionPaymentMethod.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 576`** (2 nodes): `buildCorrectionOperationalEvent()`, `correctionEvents.ts`
+- **Thin community `Community 577`** (2 nodes): `buildCorrectionOperationalEvent()`, `correctionEvents.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 577`** (2 nodes): `mockCorrectionHistoryDb()`, `getTransactions.test.ts`
+- **Thin community `Community 578`** (2 nodes): `mockCorrectionHistoryDb()`, `getTransactions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 578`** (2 nodes): `createRegisterCatalogCtx()`, `listRegisterCatalog.test.ts`
+- **Thin community `Community 579`** (2 nodes): `createRegisterCatalogCtx()`, `listRegisterCatalog.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 579`** (2 nodes): `transactionAdjustmentPlanner.test.ts`, `baseInput()`
+- **Thin community `Community 580`** (2 nodes): `transactionAdjustmentPlanner.test.ts`, `baseInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 580`** (2 nodes): `getCashierForRegisterState()`, `cashierRepository.ts`
+- **Thin community `Community 581`** (2 nodes): `getCashierForRegisterState()`, `cashierRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 581`** (2 nodes): `createExpenseSessionCommandRepository()`, `expenseSessionCommandRepository.ts`
+- **Thin community `Community 582`** (2 nodes): `createExpenseSessionCommandRepository()`, `expenseSessionCommandRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 582`** (2 nodes): `createConvexLocalSyncRepository()`, `localSyncRepository.ts`
+- **Thin community `Community 583`** (2 nodes): `createConvexLocalSyncRepository()`, `localSyncRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 583`** (2 nodes): `sessionCommandRepository.test.ts`, `readProjectFile()`
+- **Thin community `Community 584`** (2 nodes): `sessionCommandRepository.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 584`** (2 nodes): `sessionRepository.test.ts`, `buildSession()`
+- **Thin community `Community 585`** (2 nodes): `sessionRepository.test.ts`, `buildSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 585`** (2 nodes): `requireRegisterCatalogStoreAccess()`, `catalog.ts`
+- **Thin community `Community 586`** (2 nodes): `requireRegisterCatalogStoreAccess()`, `catalog.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 586`** (2 nodes): `transactions.ts`, `mapCorrectionError()`
+- **Thin community `Community 587`** (2 nodes): `transactions.ts`, `mapCorrectionError()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 587`** (2 nodes): `getSource()`, `moduleWiring.test.ts`
+- **Thin community `Community 588`** (2 nodes): `getSource()`, `moduleWiring.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 588`** (2 nodes): `createStockOpsAccessQueryCtx()`, `access.test.ts`
+- **Thin community `Community 589`** (2 nodes): `createStockOpsAccessQueryCtx()`, `access.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 589`** (2 nodes): `requireStoreFullAdminAccess()`, `access.ts`
+- **Thin community `Community 590`** (2 nodes): `requireStoreFullAdminAccess()`, `access.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 590`** (2 nodes): `createCycleCountDraftCtx()`, `cycleCountDrafts.test.ts`
+- **Thin community `Community 591`** (2 nodes): `createCycleCountDraftCtx()`, `cycleCountDrafts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 591`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
+- **Thin community `Community 592`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 592`** (2 nodes): `createReservationActivityCtx()`, `checkoutSession.test.ts`
+- **Thin community `Community 593`** (2 nodes): `createReservationActivityCtx()`, `checkoutSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 593`** (2 nodes): `createQueryCtx()`, `customerBehaviorTimeline.test.ts`
+- **Thin community `Community 594`** (2 nodes): `createQueryCtx()`, `customerBehaviorTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 594`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
+- **Thin community `Community 595`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 595`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
+- **Thin community `Community 596`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 596`** (2 nodes): `createMutationCtx()`, `customerEngagementEvents.test.ts`
+- **Thin community `Community 597`** (2 nodes): `createMutationCtx()`, `customerEngagementEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 597`** (2 nodes): `getSource()`, `onlineOrder.test.ts`
+- **Thin community `Community 598`** (2 nodes): `getSource()`, `onlineOrder.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 598`** (2 nodes): `updateOnlineOrderItem()`, `onlineOrderItem.ts`
+- **Thin community `Community 599`** (2 nodes): `updateOnlineOrderItem()`, `onlineOrderItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 599`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
+- **Thin community `Community 600`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 600`** (2 nodes): `rewards.ts`, `formatPointsLabel()`
+- **Thin community `Community 601`** (2 nodes): `rewards.ts`, `formatPointsLabel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 601`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
+- **Thin community `Community 602`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 602`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
+- **Thin community `Community 603`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 603`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
+- **Thin community `Community 604`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 604`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
+- **Thin community `Community 605`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 605`** (2 nodes): `user.ts`, `getStoreFrontActorById()`
+- **Thin community `Community 606`** (2 nodes): `user.ts`, `getStoreFrontActorById()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 606`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
+- **Thin community `Community 607`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 607`** (2 nodes): `buildExpenseSessionTraceSeed()`, `expenseSession.ts`
+- **Thin community `Community 608`** (2 nodes): `buildExpenseSessionTraceSeed()`, `expenseSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 608`** (2 nodes): `posSession.ts`, `buildPosSessionTraceSeed()`
+- **Thin community `Community 609`** (2 nodes): `posSession.ts`, `buildPosSessionTraceSeed()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 609`** (2 nodes): `presentation.ts`, `buildWorkflowTraceViewModel()`
+- **Thin community `Community 610`** (2 nodes): `presentation.ts`, `buildWorkflowTraceViewModel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 610`** (2 nodes): `schemaIndexes.test.ts`, `getTableIndexes()`
+- **Thin community `Community 611`** (2 nodes): `schemaIndexes.test.ts`, `getTableIndexes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 611`** (2 nodes): `serviceIntake.ts`, `validateServiceIntakeInput()`
+- **Thin community `Community 612`** (2 nodes): `serviceIntake.ts`, `validateServiceIntakeInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 612`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
+- **Thin community `Community 613`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 613`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
+- **Thin community `Community 614`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 614`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
+- **Thin community `Community 615`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 615`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
+- **Thin community `Community 616`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 616`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
+- **Thin community `Community 617`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 617`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
+- **Thin community `Community 618`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 618`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
+- **Thin community `Community 619`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 619`** (2 nodes): `StoreView.tsx`, `Navigation()`
+- **Thin community `Community 620`** (2 nodes): `StoreView.tsx`, `Navigation()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 620`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
+- **Thin community `Community 621`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 621`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
+- **Thin community `Community 622`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 622`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
+- **Thin community `Community 623`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 623`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
+- **Thin community `Community 624`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 624`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
+- **Thin community `Community 625`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 625`** (2 nodes): `ProductImages.tsx`, `Header()`
+- **Thin community `Community 626`** (2 nodes): `ProductImages.tsx`, `Header()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 626`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
+- **Thin community `Community 627`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 627`** (2 nodes): `setIsUpdatingSku()`, `CopyImagesView.tsx`
+- **Thin community `Community 628`** (2 nodes): `setIsUpdatingSku()`, `CopyImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 628`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
+- **Thin community `Community 629`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 629`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
+- **Thin community `Community 630`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 630`** (2 nodes): `AnalyticsCombinedUsers()`, `AnalyticsCombinedUsers.tsx`
+- **Thin community `Community 631`** (2 nodes): `AnalyticsCombinedUsers()`, `AnalyticsCombinedUsers.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 631`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
+- **Thin community `Community 632`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 632`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
+- **Thin community `Community 633`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 633`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
+- **Thin community `Community 634`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 634`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
+- **Thin community `Community 635`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 635`** (2 nodes): `StoreInsights.tsx`, `getTrendIcon()`
+- **Thin community `Community 636`** (2 nodes): `StoreInsights.tsx`, `getTrendIcon()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 636`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
+- **Thin community `Community 637`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 637`** (2 nodes): `readSource()`, `analyticsWorkspaceEfficiency.test.ts`
+- **Thin community `Community 638`** (2 nodes): `readSource()`, `analyticsWorkspaceEfficiency.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 638`** (2 nodes): `LogItems()`, `LogItems.tsx`
+- **Thin community `Community 639`** (2 nodes): `LogItems()`, `LogItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 639`** (2 nodes): `Header()`, `LogView.tsx`
+- **Thin community `Community 640`** (2 nodes): `Header()`, `LogView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 640`** (2 nodes): `Navigation()`, `LogsView.tsx`
+- **Thin community `Community 641`** (2 nodes): `Navigation()`, `LogsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 641`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
+- **Thin community `Community 642`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 642`** (2 nodes): `Passthrough()`, `app-sidebar.test.tsx`
+- **Thin community `Community 643`** (2 nodes): `Passthrough()`, `app-sidebar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 643`** (2 nodes): `SidebarMenuCollapsible()`, `app-sidebar.tsx`
+- **Thin community `Community 644`** (2 nodes): `SidebarMenuCollapsible()`, `app-sidebar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 644`** (2 nodes): `Auth()`, `Auth.tsx`
+- **Thin community `Community 645`** (2 nodes): `Auth()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 645`** (2 nodes): `resolveSignIn()`, `InputOTP.test.tsx`
+- **Thin community `Community 646`** (2 nodes): `resolveSignIn()`, `InputOTP.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 646`** (2 nodes): `Login()`, `index.tsx`
+- **Thin community `Community 647`** (2 nodes): `Login()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 647`** (2 nodes): `DataTableColumnHeader()`, `data-table-column-header.tsx`
+- **Thin community `Community 648`** (2 nodes): `DataTableColumnHeader()`, `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 648`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
+- **Thin community `Community 649`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 649`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
+- **Thin community `Community 650`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 650`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
+- **Thin community `Community 651`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 651`** (2 nodes): `formatReviewReason()`, `formatReviewReason.ts`
+- **Thin community `Community 652`** (2 nodes): `formatReviewReason()`, `formatReviewReason.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 652`** (2 nodes): `registerSessionColumns.tsx`, `RegisterSessionLink()`
+- **Thin community `Community 653`** (2 nodes): `registerSessionColumns.tsx`, `RegisterSessionLink()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 653`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
+- **Thin community `Community 654`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 654`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
+- **Thin community `Community 655`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 655`** (2 nodes): `ExpenseView()`, `ExpenseView.tsx`
+- **Thin community `Community 656`** (2 nodes): `ExpenseView()`, `ExpenseView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 656`** (2 nodes): `handleAddBestSeller()`, `BestSellersDialog.tsx`
+- **Thin community `Community 657`** (2 nodes): `handleAddBestSeller()`, `BestSellersDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 657`** (2 nodes): `handleAddFeaturedItem()`, `FeaturedSectionDialog.tsx`
+- **Thin community `Community 658`** (2 nodes): `handleAddFeaturedItem()`, `FeaturedSectionDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 658`** (2 nodes): `Navigation()`, `Home.tsx`
+- **Thin community `Community 659`** (2 nodes): `Navigation()`, `Home.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 659`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
+- **Thin community `Community 660`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 660`** (2 nodes): `ShopLookDialog.tsx`, `handleAddFeaturedItem()`
+- **Thin community `Community 661`** (2 nodes): `ShopLookDialog.tsx`, `handleAddFeaturedItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 661`** (2 nodes): `ShopLookImageUploader.tsx`, `ShopLookImageUploader()`
+- **Thin community `Community 662`** (2 nodes): `ShopLookImageUploader.tsx`, `ShopLookImageUploader()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 662`** (2 nodes): `JoinTeam()`, `index.tsx`
+- **Thin community `Community 663`** (2 nodes): `JoinTeam()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 663`** (2 nodes): `Reveal()`, `AthenaLandingPage.tsx`
+- **Thin community `Community 664`** (2 nodes): `Reveal()`, `AthenaLandingPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 664`** (2 nodes): `cn()`, `OperationReviewItemCard.tsx`
+- **Thin community `Community 665`** (2 nodes): `cn()`, `OperationReviewItemCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 665`** (2 nodes): `buildParams()`, `OperationsSummaryMetric.tsx`
+- **Thin community `Community 666`** (2 nodes): `buildParams()`, `OperationsSummaryMetric.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 666`** (2 nodes): `StockAdjustmentWorkspace.test.tsx`, `renderStockAdjustmentWorkspace()`
+- **Thin community `Community 667`** (2 nodes): `StockAdjustmentWorkspace.test.tsx`, `renderStockAdjustmentWorkspace()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 667`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
+- **Thin community `Community 668`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 668`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
+- **Thin community `Community 669`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 669`** (2 nodes): `OrderMetricsPanel()`, `OrderMetricsPanel.tsx`
+- **Thin community `Community 670`** (2 nodes): `OrderMetricsPanel()`, `OrderMetricsPanel.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 670`** (2 nodes): `getTimeFilter()`, `OrdersView.tsx`
+- **Thin community `Community 671`** (2 nodes): `getTimeFilter()`, `OrdersView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 671`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
+- **Thin community `Community 672`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 672`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
+- **Thin community `Community 673`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 673`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
+- **Thin community `Community 674`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 674`** (2 nodes): `if()`, `orderColumns.tsx`
+- **Thin community `Community 675`** (2 nodes): `if()`, `orderColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 675`** (2 nodes): `OrganizationSwitcher()`, `organization-switcher.tsx`
+- **Thin community `Community 676`** (2 nodes): `OrganizationSwitcher()`, `organization-switcher.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 676`** (2 nodes): `cn()`, `CartItems.tsx`
+- **Thin community `Community 677`** (2 nodes): `cn()`, `CartItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 677`** (2 nodes): `buildLocalAuthorityRecord()`, `CashierAuthDialog.test.tsx`
+- **Thin community `Community 678`** (2 nodes): `buildLocalAuthorityRecord()`, `CashierAuthDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 678`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
+- **Thin community `Community 679`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 679`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
+- **Thin community `Community 680`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 680`** (2 nodes): `PinInput.tsx`, `PinInput()`
+- **Thin community `Community 681`** (2 nodes): `PinInput.tsx`, `PinInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 681`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
+- **Thin community `Community 682`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 682`** (2 nodes): `ProductCard.tsx`, `handleClick()`
+- **Thin community `Community 683`** (2 nodes): `ProductCard.tsx`, `handleClick()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 683`** (2 nodes): `ProductEntry.tsx`, `handleClearSearch()`
+- **Thin community `Community 684`** (2 nodes): `ProductEntry.tsx`, `handleClearSearch()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 684`** (2 nodes): `SearchResultsSection.test.tsx`, `buildProduct()`
+- **Thin community `Community 685`** (2 nodes): `SearchResultsSection.test.tsx`, `buildProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 685`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
+- **Thin community `Community 686`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 686`** (2 nodes): `handlePrintReceipt()`, `ExpenseReportView.tsx`
+- **Thin community `Community 687`** (2 nodes): `handlePrintReceipt()`, `ExpenseReportView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 687`** (2 nodes): `isToday()`, `ExpenseReportsView.tsx`
+- **Thin community `Community 688`** (2 nodes): `isToday()`, `ExpenseReportsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 688`** (2 nodes): `toExpenseReportRows()`, `expenseReportRows.ts`
+- **Thin community `Community 689`** (2 nodes): `toExpenseReportRows()`, `expenseReportRows.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 689`** (2 nodes): `buildCheckout()`, `ExpenseCompletionPanel.test.tsx`
+- **Thin community `Community 690`** (2 nodes): `buildCheckout()`, `ExpenseCompletionPanel.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 690`** (2 nodes): `ExpenseCompletionPanel()`, `ExpenseCompletionPanel.tsx`
+- **Thin community `Community 691`** (2 nodes): `ExpenseCompletionPanel()`, `ExpenseCompletionPanel.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 691`** (2 nodes): `POSRegisterView.test.tsx`, `pressDebugPanelShortcut()`
+- **Thin community `Community 692`** (2 nodes): `POSRegisterView.test.tsx`, `pressDebugPanelShortcut()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 692`** (2 nodes): `RegisterCheckoutPanel.tsx`, `RegisterCheckoutPanel()`
+- **Thin community `Community 693`** (2 nodes): `RegisterCheckoutPanel.tsx`, `RegisterCheckoutPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 693`** (2 nodes): `RegisterCustomerAttribution.test.tsx`, `makeCustomer()`
+- **Thin community `Community 694`** (2 nodes): `RegisterCustomerAttribution.test.tsx`, `makeCustomer()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 694`** (2 nodes): `RegisterCustomerPanel.tsx`, `RegisterCustomerPanel()`
+- **Thin community `Community 695`** (2 nodes): `RegisterCustomerPanel.tsx`, `RegisterCustomerPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 695`** (2 nodes): `RegisterDrawerGate.test.tsx`, `renderGate()`
+- **Thin community `Community 696`** (2 nodes): `RegisterDrawerGate.test.tsx`, `renderGate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 696`** (2 nodes): `RegisterSessionPanel.tsx`, `RegisterSessionPanel()`
+- **Thin community `Community 697`** (2 nodes): `RegisterSessionPanel.tsx`, `RegisterSessionPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 697`** (2 nodes): `POSTerminalHealthView.tsx`, `CountMetric()`
+- **Thin community `Community 698`** (2 nodes): `POSTerminalHealthView.tsx`, `CountMetric()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 698`** (2 nodes): `transactionColumns.test.tsx`, `renderTransactionCell()`
+- **Thin community `Community 699`** (2 nodes): `transactionColumns.test.tsx`, `renderTransactionCell()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 699`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
+- **Thin community `Community 700`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 700`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
+- **Thin community `Community 701`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 701`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
+- **Thin community `Community 702`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 702`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
+- **Thin community `Community 703`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 703`** (2 nodes): `ProductStatus.tsx`, `ProductStatus()`
+- **Thin community `Community 704`** (2 nodes): `ProductStatus.tsx`, `ProductStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 704`** (2 nodes): `SKUSelector.tsx`, `SKUSelector()`
+- **Thin community `Community 705`** (2 nodes): `SKUSelector.tsx`, `SKUSelector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 705`** (2 nodes): `product-actions.tsx`, `useArchiveProduct()`
+- **Thin community `Community 706`** (2 nodes): `product-actions.tsx`, `useArchiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 706`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
+- **Thin community `Community 707`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 707`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
+- **Thin community `Community 708`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 708`** (2 nodes): `Products.tsx`, `Products()`
+- **Thin community `Community 709`** (2 nodes): `Products.tsx`, `Products()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 709`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
+- **Thin community `Community 710`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 710`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
+- **Thin community `Community 711`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 711`** (2 nodes): `PromoCodePreview.tsx`, `Discount()`
+- **Thin community `Community 712`** (2 nodes): `PromoCodePreview.tsx`, `Discount()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 712`** (2 nodes): `PromoCodesView.test.tsx`, `readSource()`
+- **Thin community `Community 713`** (2 nodes): `PromoCodesView.test.tsx`, `readSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 713`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
+- **Thin community `Community 714`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 714`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
+- **Thin community `Community 715`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 715`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
+- **Thin community `Community 716`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 716`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
+- **Thin community `Community 717`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 717`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
+- **Thin community `Community 718`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 718`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
+- **Thin community `Community 719`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 719`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
+- **Thin community `Community 720`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 720`** (2 nodes): `ServiceCasesView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 721`** (2 nodes): `ServiceCasesView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 721`** (2 nodes): `ServiceCatalogView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 722`** (2 nodes): `ServiceCatalogView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 722`** (2 nodes): `ServiceIntakeForm.tsx`, `ServiceIntakeForm()`
+- **Thin community `Community 723`** (2 nodes): `ServiceIntakeForm.tsx`, `ServiceIntakeForm()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 723`** (2 nodes): `ServiceIntakeView.auth.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 724`** (2 nodes): `ServiceIntakeView.auth.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 724`** (2 nodes): `ServiceIntakeView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 725`** (2 nodes): `ServiceIntakeView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 725`** (2 nodes): `StaffAuthenticationDialog.tsx`, `handleKeyDown()`
+- **Thin community `Community 726`** (2 nodes): `StaffAuthenticationDialog.tsx`, `handleKeyDown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 726`** (2 nodes): `staffPinPolicy.ts`, `normalizeStaffPin()`
+- **Thin community `Community 727`** (2 nodes): `staffPinPolicy.ts`, `normalizeStaffPin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 727`** (2 nodes): `onClick()`, `empty-state.tsx`
+- **Thin community `Community 728`** (2 nodes): `onClick()`, `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 728`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
+- **Thin community `Community 729`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 729`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
+- **Thin community `Community 730`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 730`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
+- **Thin community `Community 731`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 731`** (2 nodes): `ProtectedAdminSignInView.tsx`, `ProtectedAdminSignInView()`
+- **Thin community `Community 732`** (2 nodes): `ProtectedAdminSignInView.tsx`, `ProtectedAdminSignInView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 732`** (2 nodes): `ContactView()`, `ContactView.tsx`
+- **Thin community `Community 733`** (2 nodes): `ContactView()`, `ContactView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 733`** (2 nodes): `Header()`, `Header.tsx`
+- **Thin community `Community 734`** (2 nodes): `Header()`, `Header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 734`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
+- **Thin community `Community 735`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 735`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
+- **Thin community `Community 736`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 736`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
+- **Thin community `Community 737`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 737`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
+- **Thin community `Community 738`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 738`** (2 nodes): `useChart()`, `chart.tsx`
+- **Thin community `Community 739`** (2 nodes): `useChart()`, `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 739`** (2 nodes): `handleCopy()`, `copy-button.tsx`
+- **Thin community `Community 740`** (2 nodes): `handleCopy()`, `copy-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 740`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
+- **Thin community `Community 741`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 741`** (2 nodes): `Label()`, `label.tsx`
+- **Thin community `Community 742`** (2 nodes): `Label()`, `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 742`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
+- **Thin community `Community 743`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 743`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
+- **Thin community `Community 744`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 744`** (2 nodes): `store-modal.tsx`, `onSubmit()`
+- **Thin community `Community 745`** (2 nodes): `store-modal.tsx`, `onSubmit()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 745`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
+- **Thin community `Community 746`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 746`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
+- **Thin community `Community 747`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 747`** (2 nodes): `select-native.tsx`, `cn()`
+- **Thin community `Community 748`** (2 nodes): `select-native.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 748`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
+- **Thin community `Community 749`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 749`** (2 nodes): `webp-image.tsx`, `WebpImage()`
+- **Thin community `Community 750`** (2 nodes): `webp-image.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 750`** (2 nodes): `BagItems()`, `BagItems.tsx`
+- **Thin community `Community 751`** (2 nodes): `BagItems()`, `BagItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 751`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
+- **Thin community `Community 752`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 752`** (2 nodes): `Bags()`, `Bags.tsx`
+- **Thin community `Community 753`** (2 nodes): `Bags()`, `Bags.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 753`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
+- **Thin community `Community 754`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 754`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
+- **Thin community `Community 755`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 755`** (2 nodes): `UserBag.tsx`, `UserBag()`
+- **Thin community `Community 756`** (2 nodes): `UserBag.tsx`, `UserBag()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 756`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
+- **Thin community `Community 757`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 757`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
+- **Thin community `Community 758`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 758`** (2 nodes): `UserView.tsx`, `UserActions()`
+- **Thin community `Community 759`** (2 nodes): `UserView.tsx`, `UserActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 759`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
+- **Thin community `Community 760`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 760`** (2 nodes): `UserBehaviorInsights.tsx`, `UserBehaviorInsights()`
+- **Thin community `Community 761`** (2 nodes): `UserBehaviorInsights.tsx`, `UserBehaviorInsights()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 761`** (2 nodes): `wrapper()`, `ManagerElevationContext.test.tsx`
+- **Thin community `Community 762`** (2 nodes): `wrapper()`, `ManagerElevationContext.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 762`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
+- **Thin community `Community 763`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 763`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
+- **Thin community `Community 764`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 764`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
+- **Thin community `Community 765`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 765`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
+- **Thin community `Community 766`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 766`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
+- **Thin community `Community 767`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 767`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
+- **Thin community `Community 768`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 768`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
+- **Thin community `Community 769`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 769`** (2 nodes): `useConvexAuthIdentity.ts`, `useConvexAuthIdentity()`
+- **Thin community `Community 770`** (2 nodes): `useConvexAuthIdentity.ts`, `useConvexAuthIdentity()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 770`** (2 nodes): `useCopyText.ts`, `useCopyText()`
+- **Thin community `Community 771`** (2 nodes): `useCopyText.ts`, `useCopyText()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 771`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
+- **Thin community `Community 772`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 772`** (2 nodes): `useDebounce.ts`, `useDebounce()`
+- **Thin community `Community 773`** (2 nodes): `useDebounce.ts`, `useDebounce()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 773`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
+- **Thin community `Community 774`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 774`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
+- **Thin community `Community 775`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 775`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
+- **Thin community `Community 776`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 776`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
+- **Thin community `Community 777`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 777`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
+- **Thin community `Community 778`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 778`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
+- **Thin community `Community 779`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 779`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
+- **Thin community `Community 780`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 780`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
+- **Thin community `Community 781`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 781`** (2 nodes): `usePermissions.ts`, `usePermissions()`
+- **Thin community `Community 782`** (2 nodes): `usePermissions.ts`, `usePermissions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 782`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
+- **Thin community `Community 783`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 783`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
+- **Thin community `Community 784`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 784`** (2 nodes): `useProtectedAdminPageState.ts`, `useProtectedAdminPageState()`
+- **Thin community `Community 785`** (2 nodes): `useProtectedAdminPageState.ts`, `useProtectedAdminPageState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 785`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
+- **Thin community `Community 786`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 786`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
+- **Thin community `Community 787`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 787`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
+- **Thin community `Community 788`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 788`** (2 nodes): `toOperatorMessage()`, `operatorMessages.ts`
+- **Thin community `Community 789`** (2 nodes): `toOperatorMessage()`, `operatorMessages.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 789`** (2 nodes): `presentUnexpectedErrorToast.ts`, `presentUnexpectedErrorToast()`
+- **Thin community `Community 790`** (2 nodes): `presentUnexpectedErrorToast.ts`, `presentUnexpectedErrorToast()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 790`** (2 nodes): `getOrigin()`, `navigationUtils.ts`
+- **Thin community `Community 791`** (2 nodes): `getOrigin()`, `navigationUtils.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 791`** (2 nodes): `addItem()`, `addItem.ts`
+- **Thin community `Community 792`** (2 nodes): `addItem()`, `addItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 792`** (2 nodes): `bootstrapRegister()`, `bootstrapRegister.ts`
+- **Thin community `Community 793`** (2 nodes): `bootstrapRegister()`, `bootstrapRegister.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 793`** (2 nodes): `holdSession()`, `holdSession.ts`
+- **Thin community `Community 794`** (2 nodes): `holdSession()`, `holdSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 794`** (2 nodes): `openDrawer()`, `openDrawer.ts`
+- **Thin community `Community 795`** (2 nodes): `openDrawer()`, `openDrawer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 795`** (2 nodes): `startSession.ts`, `startSession()`
+- **Thin community `Community 796`** (2 nodes): `startSession.ts`, `startSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 796`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
+- **Thin community `Community 797`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 797`** (2 nodes): `registerAvailabilitySnapshot.test.ts`, `buildAvailabilityRow()`
+- **Thin community `Community 798`** (2 nodes): `registerAvailabilitySnapshot.test.ts`, `buildAvailabilityRow()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 798`** (2 nodes): `registerAvailabilitySnapshot.ts`, `readRegisterAvailabilitySnapshotState()`
+- **Thin community `Community 799`** (2 nodes): `registerAvailabilitySnapshot.ts`, `readRegisterAvailabilitySnapshotState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 799`** (2 nodes): `syncScheduler.test.ts`, `baseEvent()`
+- **Thin community `Community 800`** (2 nodes): `syncScheduler.test.ts`, `baseEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 800`** (2 nodes): `syncStatus.test.ts`, `event()`
+- **Thin community `Community 801`** (2 nodes): `syncStatus.test.ts`, `event()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 801`** (2 nodes): `terminalRuntimeStatus.test.ts`, `buildLocalEvent()`
+- **Thin community `Community 802`** (2 nodes): `terminalRuntimeStatus.test.ts`, `buildLocalEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 802`** (2 nodes): `useRegisterCatalogIndex.ts`, `useRegisterCatalogIndex()`
+- **Thin community `Community 803`** (2 nodes): `useRegisterCatalogIndex.ts`, `useRegisterCatalogIndex()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 803`** (2 nodes): `pinHash.ts`, `hashPin()`
+- **Thin community `Community 804`** (2 nodes): `pinHash.ts`, `hashPin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 804`** (2 nodes): `hasOrgNotFoundPayload()`, `index.tsx`
+- **Thin community `Community 805`** (2 nodes): `hasOrgNotFoundPayload()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 805`** (2 nodes): `$sessionId.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 806`** (2 nodes): `$sessionId.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 806`** (2 nodes): `registers.index.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 807`** (2 nodes): `registers.index.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 807`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
+- **Thin community `Community 808`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 808`** (2 nodes): `ApprovalsRoute()`, `approvals.tsx`
+- **Thin community `Community 809`** (2 nodes): `ApprovalsRoute()`, `approvals.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 809`** (2 nodes): `DailyCloseHistoryRoute()`, `daily-close-history.tsx`
+- **Thin community `Community 810`** (2 nodes): `DailyCloseHistoryRoute()`, `daily-close-history.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 810`** (2 nodes): `DailyCloseRoute()`, `daily-close.tsx`
+- **Thin community `Community 811`** (2 nodes): `DailyCloseRoute()`, `daily-close.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 811`** (2 nodes): `OpenWorkRoute()`, `open-work.tsx`
+- **Thin community `Community 812`** (2 nodes): `OpenWorkRoute()`, `open-work.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 812`** (2 nodes): `DailyOpeningRoute()`, `opening.tsx`
+- **Thin community `Community 813`** (2 nodes): `DailyOpeningRoute()`, `opening.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 813`** (2 nodes): `stock-adjustments.tsx`, `StockAdjustmentsRoute()`
+- **Thin community `Community 814`** (2 nodes): `stock-adjustments.tsx`, `StockAdjustmentsRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 814`** (2 nodes): `ExpenseRouteComponent()`, `expense.index.tsx`
+- **Thin community `Community 815`** (2 nodes): `ExpenseRouteComponent()`, `expense.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 815`** (2 nodes): `terminals.route.test.tsx`, `routeBuilder()`
+- **Thin community `Community 816`** (2 nodes): `terminals.route.test.tsx`, `routeBuilder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 816`** (2 nodes): `published.index.tsx`, `RouteComponent()`
+- **Thin community `Community 817`** (2 nodes): `published.index.tsx`, `RouteComponent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 817`** (2 nodes): `Index()`, `index.tsx`
+- **Thin community `Community 818`** (2 nodes): `Index()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 818`** (2 nodes): `AthenaLoginReadyView()`, `_layout.index.tsx`
+- **Thin community `Community 819`** (2 nodes): `AthenaLoginReadyView()`, `_layout.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 819`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
+- **Thin community `Community 820`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 820`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 821`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 821`** (2 nodes): `view-patterns.tsx`, `cn()`
+- **Thin community `Community 822`** (2 nodes): `view-patterns.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 822`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
+- **Thin community `Community 823`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 823`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
+- **Thin community `Community 824`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 824`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
+- **Thin community `Community 825`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 825`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 826`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 826`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
+- **Thin community `Community 827`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 827`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
+- **Thin community `Community 828`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 828`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
+- **Thin community `Community 829`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 829`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 830`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 830`** (2 nodes): `usePrint.test.ts`, `setWindowOpenMock()`
+- **Thin community `Community 831`** (2 nodes): `usePrint.test.ts`, `setWindowOpenMock()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 831`** (2 nodes): `formatNumber()`, `formatNumber.ts`
+- **Thin community `Community 832`** (2 nodes): `formatNumber()`, `formatNumber.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 832`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
+- **Thin community `Community 833`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 833`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
+- **Thin community `Community 834`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 834`** (2 nodes): `updateGuest()`, `guest.ts`
+- **Thin community `Community 835`** (2 nodes): `updateGuest()`, `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 835`** (2 nodes): `posTransaction.test.ts`, `jsonResponse()`
+- **Thin community `Community 836`** (2 nodes): `posTransaction.test.ts`, `jsonResponse()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 836`** (2 nodes): `storefront.ts`, `getStore()`
+- **Thin community `Community 837`** (2 nodes): `storefront.ts`, `getStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 837`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
+- **Thin community `Community 838`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 838`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
+- **Thin community `Community 839`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 839`** (2 nodes): `AuthComponent()`, `Auth.tsx`
+- **Thin community `Community 840`** (2 nodes): `AuthComponent()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 840`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
+- **Thin community `Community 841`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 841`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
+- **Thin community `Community 842`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 842`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
+- **Thin community `Community 843`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 843`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
+- **Thin community `Community 844`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 844`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
+- **Thin community `Community 845`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 845`** (2 nodes): `PickupDetails()`, `index.tsx`
+- **Thin community `Community 846`** (2 nodes): `PickupDetails()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 846`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
+- **Thin community `Community 847`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 847`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
+- **Thin community `Community 848`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 848`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
+- **Thin community `Community 849`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 849`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
+- **Thin community `Community 850`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 850`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
+- **Thin community `Community 851`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 851`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
+- **Thin community `Community 852`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 852`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
+- **Thin community `Community 853`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 853`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
+- **Thin community `Community 854`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 854`** (2 nodes): `useCountdown()`, `hooks.ts`
+- **Thin community `Community 855`** (2 nodes): `useCountdown()`, `hooks.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 855`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
+- **Thin community `Community 856`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 856`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
+- **Thin community `Community 857`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 857`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
+- **Thin community `Community 858`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 858`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
+- **Thin community `Community 859`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 859`** (2 nodes): `resolveHomepageContent()`, `homePageContent.ts`
+- **Thin community `Community 860`** (2 nodes): `resolveHomepageContent()`, `homePageContent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 860`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
+- **Thin community `Community 861`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 861`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
+- **Thin community `Community 862`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 862`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
+- **Thin community `Community 863`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 863`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
+- **Thin community `Community 864`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 864`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
+- **Thin community `Community 865`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 865`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
+- **Thin community `Community 866`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 866`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
+- **Thin community `Community 867`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 867`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
+- **Thin community `Community 868`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 868`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
+- **Thin community `Community 869`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 869`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
+- **Thin community `Community 870`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 870`** (2 nodes): `ProductPage.test.tsx`, `makePageState()`
+- **Thin community `Community 871`** (2 nodes): `ProductPage.test.tsx`, `makePageState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 871`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
+- **Thin community `Community 872`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 872`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
+- **Thin community `Community 873`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 873`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
+- **Thin community `Community 874`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 874`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
+- **Thin community `Community 875`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 875`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
+- **Thin community `Community 876`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 876`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
+- **Thin community `Community 877`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 877`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
+- **Thin community `Community 878`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 878`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
+- **Thin community `Community 879`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 879`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
+- **Thin community `Community 880`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 880`** (2 nodes): `BagItem()`, `BagItem.tsx`
+- **Thin community `Community 881`** (2 nodes): `BagItem()`, `BagItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 881`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
+- **Thin community `Community 882`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 882`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
+- **Thin community `Community 883`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 883`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
+- **Thin community `Community 884`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 884`** (2 nodes): `CountrySelect()`, `country-select.tsx`
+- **Thin community `Community 885`** (2 nodes): `CountrySelect()`, `country-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 885`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
+- **Thin community `Community 886`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 886`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
+- **Thin community `Community 887`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 887`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
+- **Thin community `Community 888`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 888`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
+- **Thin community `Community 889`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 889`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
+- **Thin community `Community 890`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 890`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
+- **Thin community `Community 891`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 891`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
+- **Thin community `Community 892`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 892`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
+- **Thin community `Community 893`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 893`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
+- **Thin community `Community 894`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 894`** (2 nodes): `useCheckout.ts`, `useCheckout()`
+- **Thin community `Community 895`** (2 nodes): `useCheckout.ts`, `useCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 895`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
+- **Thin community `Community 896`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 896`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
+- **Thin community `Community 897`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 897`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
+- **Thin community `Community 898`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 898`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
+- **Thin community `Community 899`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 899`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
+- **Thin community `Community 900`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 900`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
+- **Thin community `Community 901`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 901`** (2 nodes): `useGetStore.ts`, `useGetStore()`
+- **Thin community `Community 902`** (2 nodes): `useGetStore.ts`, `useGetStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 902`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
+- **Thin community `Community 903`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 903`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
+- **Thin community `Community 904`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 904`** (2 nodes): `useLogout.ts`, `useLogout()`
+- **Thin community `Community 905`** (2 nodes): `useLogout.ts`, `useLogout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 905`** (2 nodes): `useModalState.tsx`, `useModalState()`
+- **Thin community `Community 906`** (2 nodes): `useModalState.tsx`, `useModalState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 906`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
+- **Thin community `Community 907`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 907`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
+- **Thin community `Community 908`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 908`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
+- **Thin community `Community 909`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 909`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
+- **Thin community `Community 910`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 910`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
+- **Thin community `Community 911`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 911`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
+- **Thin community `Community 912`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 912`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
+- **Thin community `Community 913`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 913`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
+- **Thin community `Community 914`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 914`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
+- **Thin community `Community 915`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 915`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
+- **Thin community `Community 916`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 916`** (2 nodes): `useBagQueries()`, `bag.ts`
+- **Thin community `Community 917`** (2 nodes): `useBagQueries()`, `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 917`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
+- **Thin community `Community 918`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 918`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
+- **Thin community `Community 919`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 919`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
+- **Thin community `Community 920`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 920`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
+- **Thin community `Community 921`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 921`** (2 nodes): `posTransaction.ts`, `usePosTransactionQueries()`
+- **Thin community `Community 922`** (2 nodes): `posTransaction.ts`, `usePosTransactionQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 922`** (2 nodes): `product.ts`, `useProductQueries()`
+- **Thin community `Community 923`** (2 nodes): `product.ts`, `useProductQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 923`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
+- **Thin community `Community 924`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 924`** (2 nodes): `reviews.ts`, `useReviewQueries()`
+- **Thin community `Community 925`** (2 nodes): `reviews.ts`, `useReviewQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 925`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
+- **Thin community `Community 926`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 926`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
+- **Thin community `Community 927`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 927`** (2 nodes): `user.ts`, `useUserQueries()`
+- **Thin community `Community 928`** (2 nodes): `user.ts`, `useUserQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 928`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
+- **Thin community `Community 929`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 929`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
+- **Thin community `Community 930`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 930`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
+- **Thin community `Community 931`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 931`** (2 nodes): `validateEmail()`, `email.ts`
+- **Thin community `Community 932`** (2 nodes): `validateEmail()`, `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 932`** (2 nodes): `router.tsx`, `createRouter()`
+- **Thin community `Community 933`** (2 nodes): `router.tsx`, `createRouter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 933`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
+- **Thin community `Community 934`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 934`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
+- **Thin community `Community 935`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 935`** (2 nodes): `ContactUs()`, `contact-us.tsx`
+- **Thin community `Community 936`** (2 nodes): `ContactUs()`, `contact-us.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 936`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
+- **Thin community `Community 937`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 937`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
+- **Thin community `Community 938`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 938`** (2 nodes): `tos.index.tsx`, `TosSection()`
+- **Thin community `Community 939`** (2 nodes): `tos.index.tsx`, `TosSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 939`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
+- **Thin community `Community 940`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 940`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
+- **Thin community `Community 941`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 941`** (2 nodes): `HomeRoute()`, `index.tsx`
+- **Thin community `Community 942`** (2 nodes): `HomeRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 942`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
+- **Thin community `Community 943`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 943`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
+- **Thin community `Community 944`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 944`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
+- **Thin community `Community 945`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 945`** (2 nodes): `ReceiptShareRoute()`, `index.tsx`
+- **Thin community `Community 946`** (2 nodes): `ReceiptShareRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 946`** (2 nodes): `test-connection.js`, `main()`
+- **Thin community `Community 947`** (2 nodes): `test-connection.js`, `main()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 947`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
+- **Thin community `Community 948`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 948`** (2 nodes): `run()`, `architecture-boundary-check.ts`
+- **Thin community `Community 949`** (2 nodes): `run()`, `architecture-boundary-check.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 949`** (2 nodes): `readRepoFile()`, `deploy-qa-vps.test.ts`
+- **Thin community `Community 950`** (2 nodes): `readRepoFile()`, `deploy-qa-vps.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 950`** (2 nodes): `runCommand()`, `github-pr-merge.test.ts`
+- **Thin community `Community 951`** (2 nodes): `runCommand()`, `github-pr-merge.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 951`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
+- **Thin community `Community 952`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 952`** (2 nodes): `shutdown()`, `sample-app.ts`
+- **Thin community `Community 953`** (2 nodes): `shutdown()`, `sample-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 953`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
+- **Thin community `Community 954`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 954`** (2 nodes): `validate-plan-html.test.ts`, `createTempRepo()`
+- **Thin community `Community 955`** (2 nodes): `validate-plan-html.test.ts`, `createTempRepo()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 955`** (1 nodes): `api.d.ts`
+- **Thin community `Community 956`** (1 nodes): `api.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 956`** (1 nodes): `api.js`
+- **Thin community `Community 957`** (1 nodes): `api.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 957`** (1 nodes): `dataModel.d.ts`
+- **Thin community `Community 958`** (1 nodes): `dataModel.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 958`** (1 nodes): `server.d.ts`
+- **Thin community `Community 959`** (1 nodes): `server.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 959`** (1 nodes): `server.js`
+- **Thin community `Community 960`** (1 nodes): `server.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 960`** (1 nodes): `app.ts`
+- **Thin community `Community 961`** (1 nodes): `app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 961`** (1 nodes): `auth.config.js`
+- **Thin community `Community 962`** (1 nodes): `auth.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 962`** (1 nodes): `auth.ts`
+- **Thin community `Community 963`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 963`** (1 nodes): `authConfig.test.ts`
+- **Thin community `Community 964`** (1 nodes): `authConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 964`** (1 nodes): `authConfig.ts`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 965`** (1 nodes): `registerSessions.test.ts`
+- **Thin community `Community 965`** (1 nodes): `authConfig.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 966`** (1 nodes): `r2.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,8 +8,8 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 1774
-- Graph nodes: 5683
-- Graph edges: 5967
+- Graph nodes: 5704
+- Graph edges: 6007
 - Communities: 1702
 
 ## Graph Hotspots

--- a/graphify-out/wiki/packages/storefront-webapp.md
+++ b/graphify-out/wiki/packages/storefront-webapp.md
@@ -19,9 +19,9 @@ Landing page for packages/storefront-webapp. Use this page to orient around grap
 ## Graph Hotspots
 - `storefrontJourneyEvents.ts` (45 edges, Community 3) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
 - `createJourneyEvent()` (40 edges, Community 3) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
-- `getStoreConfigV2()` (17 edges, Community 33) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)
+- `getStoreConfigV2()` (17 edges, Community 35) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)
 - `checkoutSession.ts` (14 edges, Community 58) - [`packages/storefront-webapp/src/api/checkoutSession.ts`](../../../packages/storefront-webapp/src/api/checkoutSession.ts)
-- `storeConfig.ts` (14 edges, Community 33) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)
+- `storeConfig.ts` (14 edges, Community 35) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)
 
 ## Navigation
 - [wiki index](../index.md) - back to the wiki index

--- a/graphify-out/wiki/packages/valkey-proxy-server.md
+++ b/graphify-out/wiki/packages/valkey-proxy-server.md
@@ -18,7 +18,7 @@ Landing page for packages/valkey-proxy-server. Use this page to orient around gr
 
 ## Graph Hotspots
 - `app.js` (14 edges, Community 64) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
-- `app.test.js` (6 edges, Community 114) - [`packages/valkey-proxy-server/app.test.js`](../../../packages/valkey-proxy-server/app.test.js)
+- `app.test.js` (6 edges, Community 116) - [`packages/valkey-proxy-server/app.test.js`](../../../packages/valkey-proxy-server/app.test.js)
 - `createRedisClient()` (4 edges, Community 64) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
 - `createRedisCluster()` (3 edges, Community 64) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
 - `deleteKeysIndividually()` (3 edges, Community 64) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)

--- a/packages/athena-webapp/convex/cashControls/registerSessions.test.ts
+++ b/packages/athena-webapp/convex/cashControls/registerSessions.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { Id } from "../_generated/dataModel";
 import {
   assertRegisterSessionIdentity,
@@ -12,7 +12,19 @@ import {
   buildRegisterSession,
   buildRegisterSessionTransactionPatch,
   calculateRegisterSessionCashDelta,
+  recordRegisterSessionTransaction,
 } from "../operations/registerSessions";
+import { recordRegisterSessionTraceBestEffort } from "../operations/registerSessionTracing";
+
+vi.mock("../operations/registerSessionTracing", () => ({
+  recordRegisterSessionTraceBestEffort: vi.fn(() => ({
+    traceCreated: false,
+  })),
+}));
+
+function getHandler(definition: unknown) {
+  return (definition as { _handler: Function })._handler;
+}
 
 describe("cash controls register sessions", () => {
   it("opens sessions with opening float as the initial expected cash", () => {
@@ -161,6 +173,42 @@ describe("cash controls register sessions", () => {
       expectedCash: 5000,
       variance: 7000,
     });
+  });
+
+  it("skips duplicate register-session transaction writes by idempotency key", async () => {
+    const session = {
+      ...buildRegisterSession({
+        storeId: "store_1" as Id<"store">,
+        openingFloat: 5000,
+        registerNumber: "A1",
+        terminalId: "terminal_1" as Id<"posTerminal">,
+      }),
+      _id: "register_session_1",
+      expectedCash: 13000,
+      recordedTransactionKeys: ["posTransaction:txn-1:void"],
+    };
+    const patch = vi.fn();
+    const ctx = {
+      db: {
+        get: vi.fn(async () => session),
+        patch,
+      },
+    };
+
+    await expect(
+      getHandler(recordRegisterSessionTransaction)(ctx, {
+        adjustmentKind: "void",
+        changeGiven: 1000,
+        idempotencyKey: "posTransaction:txn-1:void",
+        payments: [{ amount: 9000, method: "cash", timestamp: 1 }],
+        registerSessionId: "register_session_1",
+        storeId: "store_1",
+        terminalId: "terminal_1",
+      }),
+    ).resolves.toEqual(session);
+
+    expect(patch).not.toHaveBeenCalled();
+    expect(recordRegisterSessionTraceBestEffort).not.toHaveBeenCalled();
   });
 
   it("computes closeout variance before final signoff", () => {

--- a/packages/athena-webapp/convex/operations/approvalActions.ts
+++ b/packages/athena-webapp/convex/operations/approvalActions.ts
@@ -40,6 +40,10 @@ export const APPROVAL_ACTIONS = {
     key: "pos.transaction.adjust_items",
     label: "Adjust transaction items",
   },
+  transactionVoid: {
+    key: "pos.transaction.void",
+    label: "Void completed transaction",
+  },
 } as const satisfies Record<string, ApprovalActionIdentity>;
 
 export type ConsumeCommandApprovalProofArgs = {

--- a/packages/athena-webapp/convex/operations/approvalRequests.test.ts
+++ b/packages/athena-webapp/convex/operations/approvalRequests.test.ts
@@ -8,6 +8,7 @@ import {
   decideApprovalRequestWithCtx,
 } from "./approvalRequests";
 import { resolveTransactionItemAdjustmentApprovalDecisionWithCtx } from "../pos/application/commands/adjustTransactionItems";
+import { resolveTransactionVoidApprovalDecisionWithCtx } from "../pos/application/commands/completeTransaction";
 
 const mockedAuthServer = vi.hoisted(() => ({
   getAuthUserId: vi.fn(),
@@ -19,6 +20,10 @@ vi.mock("@convex-dev/auth/server", () => ({
 
 vi.mock("../pos/application/commands/adjustTransactionItems", () => ({
   resolveTransactionItemAdjustmentApprovalDecisionWithCtx: vi.fn(),
+}));
+
+vi.mock("../pos/application/commands/completeTransaction", () => ({
+  resolveTransactionVoidApprovalDecisionWithCtx: vi.fn(),
 }));
 
 function createApprovalRequestMutationCtx(args: {
@@ -360,6 +365,78 @@ describe("approval request helpers", () => {
     });
   });
 
+  it("routes completed sale void approvals through the async resolver", async () => {
+    vi.mocked(resolveTransactionVoidApprovalDecisionWithCtx).mockClear();
+    const { ctx, tables } = createApprovalRequestMutationCtx({
+      authUserId: "auth-user-1",
+      role: "full_admin",
+    });
+    tables.approvalRequest.set("approval-void-1", {
+      _id: "approval-void-1",
+      organizationId: "org-1",
+      posTransactionId: "txn-1",
+      requestType: "pos_transaction_void",
+      status: "pending",
+      storeId: "store-1",
+      subjectId: "txn-1",
+      subjectType: "pos_transaction",
+    });
+
+    await decideApprovalRequestWithCtx(ctx, {
+      approvalProofId: "proof-1" as Id<"approvalProof">,
+      approvalRequestId: "approval-void-1" as Id<"approvalRequest">,
+      decision: "approved",
+      reviewedByStaffProfileId: "staff-manager-1" as Id<"staffProfile">,
+      reviewedByUserId: "manager-1" as Id<"athenaUser">,
+    });
+
+    expect(resolveTransactionVoidApprovalDecisionWithCtx).toHaveBeenCalledWith(
+      ctx,
+      {
+        approvalProofId: "proof-1",
+        approvalRequestId: "approval-void-1",
+        decision: "approved",
+        reviewedByStaffProfileId: "staff-manager-1",
+        reviewedByUserId: "manager-1",
+      },
+    );
+    expect(tables.approvalRequest.get("approval-void-1")).toMatchObject({
+      status: "approved",
+    });
+  });
+
+  it("preserves the queued void reason as decision notes when approval has no notes", async () => {
+    vi.mocked(resolveTransactionVoidApprovalDecisionWithCtx).mockClear();
+    const { ctx, tables } = createApprovalRequestMutationCtx({
+      authUserId: "auth-user-1",
+      role: "full_admin",
+    });
+    tables.approvalRequest.set("approval-void-1", {
+      _id: "approval-void-1",
+      notes: "Duplicate sale entered.",
+      organizationId: "org-1",
+      posTransactionId: "txn-1",
+      requestType: "pos_transaction_void",
+      status: "pending",
+      storeId: "store-1",
+      subjectId: "txn-1",
+      subjectType: "pos_transaction",
+    });
+
+    await decideApprovalRequestWithCtx(ctx, {
+      approvalProofId: "proof-1" as Id<"approvalProof">,
+      approvalRequestId: "approval-void-1" as Id<"approvalRequest">,
+      decision: "approved",
+      reviewedByStaffProfileId: "staff-manager-1" as Id<"staffProfile">,
+      reviewedByUserId: "manager-1" as Id<"athenaUser">,
+    });
+
+    expect(tables.approvalRequest.get("approval-void-1")).toMatchObject({
+      decisionNotes: "Duplicate sale entered.",
+      status: "approved",
+    });
+  });
+
   it("does not route already-decided POS item adjustment approvals to the async resolver", async () => {
     const { ctx, tables } = createApprovalRequestMutationCtx({
       authUserId: "auth-user-1",
@@ -598,6 +675,45 @@ describe("approval request helpers", () => {
         code: "precondition_failed",
         message:
           "This transaction already has an item adjustment waiting for approval.",
+      },
+    });
+  });
+
+  it("maps queued void resolver precondition failures to command user errors", async () => {
+    const { ctx, tables } = createApprovalRequestMutationCtx({
+      authUserId: "auth-user-1",
+      role: "full_admin",
+    });
+    tables.approvalRequest.set("approval-void-1", {
+      _id: "approval-void-1",
+      organizationId: "org-1",
+      posTransactionId: "txn-1",
+      requestType: "pos_transaction_void",
+      status: "pending",
+      storeId: "store-1",
+      subjectId: "txn-1",
+      subjectType: "pos_transaction",
+    });
+    tables.approvalProof.set("proof-1", {
+      ...tables.approvalProof.get("proof-1"),
+      subjectId: "approval-void-1",
+      subjectLabel: "pos_transaction_void",
+    });
+    vi.mocked(resolveTransactionVoidApprovalDecisionWithCtx).mockRejectedValueOnce(
+      new Error("Drawer closed. Open the drawer before voiding this sale."),
+    );
+
+    await expect(
+      decideApprovalRequestAsCommandWithCtx(ctx, {
+        approvalProofId: "proof-1" as Id<"approvalProof">,
+        approvalRequestId: "approval-void-1" as Id<"approvalRequest">,
+        decision: "approved",
+      }),
+    ).resolves.toMatchObject({
+      kind: "user_error",
+      error: {
+        code: "precondition_failed",
+        message: "Drawer closed. Open the drawer before voiding this sale.",
       },
     });
   });

--- a/packages/athena-webapp/convex/operations/approvalRequests.ts
+++ b/packages/athena-webapp/convex/operations/approvalRequests.ts
@@ -8,6 +8,7 @@ import { v } from "convex/values";
 import { resolveStockAdjustmentApprovalDecisionWithCtx } from "../stockOps/adjustments";
 import { resolvePaymentMethodCorrectionApprovalDecisionWithCtx } from "../pos/application/commands/correctTransaction";
 import { resolveTransactionItemAdjustmentApprovalDecisionWithCtx } from "../pos/application/commands/adjustTransactionItems";
+import { resolveTransactionVoidApprovalDecisionWithCtx } from "../pos/application/commands/completeTransaction";
 import {
   requireOrganizationMemberRoleWithCtx,
   requireAuthenticatedAthenaUserWithCtx,
@@ -26,6 +27,7 @@ import { consumeApprovalProofWithCtx } from "./approvalProofs";
 const APPROVAL_DECISION_ACTION_KEY = "operations.approval_request.decide";
 
 type DecideApprovalRequestArgs = {
+  approvalProofId?: Id<"approvalProof">;
   approvalRequestId: Id<"approvalRequest">;
   decision: "approved" | "rejected" | "cancelled";
   reviewedByUserId?: Id<"athenaUser">;
@@ -39,6 +41,12 @@ type PublicDecideApprovalRequestArgs = {
   decision: "approved" | "rejected" | "cancelled";
   decisionNotes?: string;
 };
+
+function omitUndefined<T extends Record<string, unknown>>(value: T) {
+  return Object.fromEntries(
+    Object.entries(value).filter(([, entryValue]) => entryValue !== undefined),
+  ) as Partial<T>;
+}
 
 function buildApprovalDecisionSubject(approvalRequest: {
   _id: Id<"approvalRequest">;
@@ -161,11 +169,26 @@ export async function decideApprovalRequestWithCtx(
     await resolveTransactionItemAdjustmentApprovalDecisionWithCtx(ctx, args);
   }
 
+  if (
+    approvalRequest.requestType === "pos_transaction_void" &&
+    approvalRequest.subjectType === "pos_transaction"
+  ) {
+    await resolveTransactionVoidApprovalDecisionWithCtx(ctx, args);
+  }
+
+  const decisionNotes =
+    args.decisionNotes ??
+    (approvalRequest.requestType === "pos_transaction_void"
+      ? approvalRequest.notes ?? approvalRequest.reason
+      : undefined);
+
   await ctx.db.patch("approvalRequest", args.approvalRequestId, {
     status: args.decision,
     reviewedByUserId: args.reviewedByUserId,
     reviewedByStaffProfileId: args.reviewedByStaffProfileId,
-    decisionNotes: args.decisionNotes,
+    ...omitUndefined({
+      decisionNotes,
+    }),
     decidedAt: Date.now(),
   });
 
@@ -217,6 +240,7 @@ export async function decideApprovalRequestAsAuthenticatedUserWithCtx(
 
   return decideApprovalRequestWithCtx(ctx, {
     ...args,
+    approvalProofId: args.approvalProofId,
     reviewedByStaffProfileId: approvalProof.approvedByStaffProfileId,
     reviewedByUserId: reviewer._id,
   });
@@ -257,6 +281,7 @@ function mapDecideApprovalRequestError(
     message === "Stock adjustment batch not found for this approval request." ||
     message === "Payment method approval request not found." ||
     message === "Item adjustment approval request not found." ||
+    message === "Void approval request not found." ||
     message === "Transaction not found."
   ) {
     return userError({
@@ -281,6 +306,22 @@ function mapDecideApprovalRequestError(
     message === "Item adjustment approval request does not match this payload." ||
     message === "Item adjustment payload is stale for this transaction." ||
     message === "Item adjustment cannot reduce inventory below zero." ||
+    message === "Void approval request has already been decided." ||
+    message === "Void approval request does not match this sale." ||
+    message === "Void approval request is missing transaction details." ||
+    message === "Manager approval is required to void a completed sale." ||
+    message === "Reason is required to void a completed sale." ||
+    message === "Sale is already voided." ||
+    message === "Sale is already refunded." ||
+    message === "Only completed sales can be voided." ||
+    message ===
+      "This sale has item adjustments. Resolve the adjustment before voiding it." ||
+    message ===
+      "EOD Review is completed for this sale. Reopen EOD Review before voiding it." ||
+    message === "Register sale is missing drawer context." ||
+    message === "Drawer closed. Open the drawer before voiding this sale." ||
+    message ===
+      "Sale item inventory record not found. Review inventory before voiding this sale." ||
     message ===
       "This transaction already has an item adjustment waiting for approval." ||
     message === "Register session expected cash cannot be negative." ||

--- a/packages/athena-webapp/convex/operations/inventoryMovements.test.ts
+++ b/packages/athena-webapp/convex/operations/inventoryMovements.test.ts
@@ -4,6 +4,7 @@ import {
   buildInventoryMovement,
   buildSkuActivityForInventoryMovement,
   recordInventoryMovementWithCtx,
+  recordInventoryMovementWithDispositionWithCtx,
   summarizeInventoryMovements,
 } from "./inventoryMovements";
 
@@ -172,5 +173,45 @@ describe("inventory movement helpers", () => {
       inventoryMovementId: first?._id,
       stockQuantityDelta: 4,
     });
+  });
+
+  it("reports whether source-scoped movement recording inserted or reused a row", async () => {
+    const { ctx, tables } = createInventoryMovementCtx({
+      productSku: new Map([
+        [
+          "sku-1",
+          {
+            _id: "sku-1",
+            inventoryCount: 5,
+            productId: "product-1",
+            quantityAvailable: 5,
+            storeId: "store-1",
+          },
+        ],
+      ]),
+    });
+    const args = {
+      movementType: "pos_transaction_void",
+      productId: "product-1" as Id<"product">,
+      productSkuId: "sku-1" as Id<"productSku">,
+      quantityDelta: 1,
+      reasonCode: "pos_transaction_void",
+      sourceId: "txn-1",
+      sourceType: "posTransaction",
+      storeId: "store-1" as Id<"store">,
+    };
+
+    const first = await recordInventoryMovementWithDispositionWithCtx(ctx, args);
+    const second = await recordInventoryMovementWithDispositionWithCtx(ctx, args);
+
+    expect(first).toMatchObject({
+      disposition: "inserted",
+      movement: { _id: expect.any(String) },
+    });
+    expect(second).toMatchObject({
+      disposition: "existing",
+      movement: { _id: first.movement?._id },
+    });
+    expect(tables.inventoryMovement).toHaveLength(1);
   });
 });

--- a/packages/athena-webapp/convex/operations/inventoryMovements.ts
+++ b/packages/athena-webapp/convex/operations/inventoryMovements.ts
@@ -187,6 +187,49 @@ export async function recordInventoryMovementWithCtx(
   return movement;
 }
 
+export async function recordInventoryMovementWithDispositionWithCtx(
+  ctx: MutationCtx,
+  args: RecordInventoryMovementArgs,
+) {
+  // eslint-disable-next-line @convex-dev/no-collect-in-query -- Source-scoped dedupe needs the full indexed set for this source, which is bounded by the originating operation's line items.
+  const existingMovements = await ctx.db
+    .query("inventoryMovement")
+    .withIndex("by_storeId_source", (q) =>
+      q
+        .eq("storeId", args.storeId)
+        .eq("sourceType", args.sourceType)
+        .eq("sourceId", args.sourceId),
+    )
+    .collect();
+
+  const existingMovement = existingMovements.find((movement) =>
+    matchesExistingMovement(movement, args),
+  );
+
+  if (existingMovement) {
+    await recordSkuActivityForInventoryMovementWithCtx(ctx, {
+      ...args,
+      inventoryMovementId: existingMovement._id,
+    });
+    return { movement: existingMovement, disposition: "existing" as const };
+  }
+
+  const movementId = await ctx.db.insert(
+    "inventoryMovement",
+    buildInventoryMovement(args),
+  );
+  const movement = await ctx.db.get("inventoryMovement", movementId);
+
+  if (movement) {
+    await recordSkuActivityForInventoryMovementWithCtx(ctx, {
+      ...args,
+      inventoryMovementId: movement._id,
+    });
+  }
+
+  return { movement, disposition: "inserted" as const };
+}
+
 export const recordInventoryMovement = internalMutation({
   args: {
     storeId: v.id("store"),

--- a/packages/athena-webapp/convex/operations/registerSessions.ts
+++ b/packages/athena-webapp/convex/operations/registerSessions.ts
@@ -180,7 +180,7 @@ export function buildRegisterSessionTransactionPatch(
     changeGiven: args.changeGiven,
     payments: args.payments,
   });
-  const updates: Record<string, number | RegisterSessionStatus> = {};
+  const updates: Record<string, number | RegisterSessionStatus | string[]> = {};
 
   if (expectedCashDelta > 0) {
     const nextExpectedCash =
@@ -621,6 +621,7 @@ export const recordRegisterSessionTransaction = internalMutation({
       })
     ),
     changeGiven: v.optional(v.number()),
+    idempotencyKey: v.optional(v.string()),
     registerNumber: v.optional(v.string()),
     terminalId: v.id("posTerminal"),
   },
@@ -639,7 +640,21 @@ export const recordRegisterSessionTransaction = internalMutation({
       throw new Error("Register session is not accepting new transactions.");
     }
 
+    if (
+      args.idempotencyKey &&
+      session.recordedTransactionKeys?.includes(args.idempotencyKey)
+    ) {
+      return session;
+    }
+
     const updates = buildRegisterSessionTransactionPatch(session, args);
+
+    if (args.idempotencyKey) {
+      updates.recordedTransactionKeys = [
+        ...(session.recordedTransactionKeys ?? []),
+        args.idempotencyKey,
+      ];
+    }
 
     if (Object.keys(updates).length > 0) {
       await ctx.db.patch("registerSession", args.registerSessionId, updates);

--- a/packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts
+++ b/packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts
@@ -1,7 +1,14 @@
 import { internal } from "../../../_generated/api";
 import type { Id } from "../../../_generated/dataModel";
 import type { MutationCtx } from "../../../_generated/server";
+import type { ApprovalRequirement } from "../../../../shared/approvalPolicy";
 import { capitalizeWords, generateTransactionNumber } from "../../../utils";
+import { buildApprovalRequest } from "../../../operations/approvalRequestHelpers";
+import {
+  APPROVAL_ACTIONS,
+  consumeCommandApprovalProofWithCtx,
+} from "../../../operations/approvalActions";
+import { recordOperationalEventWithCtx } from "../../../operations/operationalEvents";
 import {
   recordRetailSalePaymentAllocations,
   recordRetailVoidPaymentAllocations,
@@ -14,6 +21,7 @@ import {
   getPosTransactionById,
   getProductSkuById,
   getStoreById,
+  listTransactionAdjustments,
   listSessionItems,
   listTransactionItems,
   patchPosSession,
@@ -22,7 +30,9 @@ import {
 } from "../../infrastructure/repositories/transactionRepository";
 import {
   ok,
+  approvalRequired,
   userError,
+  type ApprovalCommandResult,
   type CommandResult,
 } from "../../../../shared/commandResult";
 import { isPosUsableRegisterSessionStatus } from "../../../../shared/registerSessionStatus";
@@ -32,7 +42,10 @@ import {
   type SkuActivityRecorder,
   validateInventoryAvailability,
 } from "../../../inventory/helpers/inventoryHolds";
-import { recordInventoryMovementWithCtx } from "../../../operations/inventoryMovements";
+import {
+  recordInventoryMovementWithCtx,
+  recordInventoryMovementWithDispositionWithCtx,
+} from "../../../operations/inventoryMovements";
 import { recordSkuActivityEventWithCtx } from "../../../operations/skuActivity";
 
 type PosPaymentInput = {
@@ -253,6 +266,7 @@ async function recordRegisterSessionVoid(
   ctx: MutationCtx,
   args: {
     changeGiven?: number;
+    idempotencyKey: string;
     payments: PosPaymentInput[];
     registerSessionId: Id<"registerSession">;
     registerNumber?: string;
@@ -265,6 +279,7 @@ async function recordRegisterSessionVoid(
     {
       adjustmentKind: "void",
       changeGiven: args.changeGiven,
+      idempotencyKey: args.idempotencyKey,
       payments: args.payments,
       registerSessionId: args.registerSessionId,
       registerNumber: args.registerNumber,
@@ -533,80 +548,758 @@ export async function completeTransaction(
   });
 }
 
+const TRANSACTION_VOID_ACTION = APPROVAL_ACTIONS.transactionVoid;
+const TRANSACTION_VOID_REQUEST_TYPE = "pos_transaction_void";
+type VoidTransactionResult = {
+  transactionId: Id<"posTransaction">;
+  transactionNumber: string;
+  voidedAt: number;
+  paymentAllocationIds: Array<Id<"paymentAllocation">>;
+  inventoryMovementIds: Array<Id<"inventoryMovement">>;
+  operationalEventId?: Id<"operationalEvent">;
+  approvalProofId?: Id<"approvalProof">;
+  approvalRequestId?: Id<"approvalRequest">;
+  approverStaffProfileId?: Id<"staffProfile">;
+};
+
+function completedTransactionLabel(transaction: { transactionNumber: string }) {
+  return `Transaction #${transaction.transactionNumber}`;
+}
+
+function buildVoidApprovalRequirement(args: {
+  approvalRequestId?: Id<"approvalRequest">;
+  reason: string;
+  transaction: {
+    _id: Id<"posTransaction">;
+    total: number;
+    transactionNumber: string;
+  };
+}): ApprovalRequirement {
+  return {
+    action: TRANSACTION_VOID_ACTION,
+    reason: "Manager approval is required to void a completed sale.",
+    requiredRole: "manager",
+    selfApproval: "allowed",
+    subject: {
+      id: args.transaction._id,
+      label: completedTransactionLabel(args.transaction),
+      type: "pos_transaction",
+    },
+    copy: {
+      title: "Manager approval required",
+      message:
+        "A manager needs to review this completed sale void before it is applied.",
+      primaryActionLabel: "Request approval",
+      secondaryActionLabel: "Cancel",
+    },
+    resolutionModes: [
+      { kind: "inline_manager_proof" },
+      {
+        kind: "async_request",
+        requestType: TRANSACTION_VOID_REQUEST_TYPE,
+        approvalRequestId: args.approvalRequestId,
+      },
+    ],
+    metadata: {
+      reason: args.reason,
+      total: args.transaction.total,
+      transactionNumber: args.transaction.transactionNumber,
+    },
+  };
+}
+
+async function findPendingVoidApprovalRequest(
+  ctx: MutationCtx,
+  args: {
+    storeId: Id<"store">;
+    transactionId: Id<"posTransaction">;
+  },
+) {
+  const pendingRequests = await ctx.db
+    .query("approvalRequest")
+    .withIndex("by_storeId_status_posTransactionId", (q) =>
+      q
+        .eq("storeId", args.storeId)
+        .eq("status", "pending")
+        .eq("posTransactionId", args.transactionId),
+    )
+    .take(10);
+
+  return (
+    pendingRequests.find(
+      (request) =>
+        request.requestType === TRANSACTION_VOID_REQUEST_TYPE &&
+        request.subjectType === "pos_transaction" &&
+        request.subjectId === args.transactionId,
+    ) ?? null
+  );
+}
+
+async function createVoidApprovalRequest(
+  ctx: MutationCtx,
+  args: {
+    actorStaffProfileId?: Id<"staffProfile">;
+    actorUserId?: Id<"athenaUser">;
+    reason: string;
+    transaction: NonNullable<Awaited<ReturnType<typeof getPosTransactionById>>>;
+  },
+) {
+  const store = await getStoreById(ctx, args.transaction.storeId);
+  const approvalRequestId = await ctx.db.insert(
+    "approvalRequest",
+    buildApprovalRequest({
+      metadata: {
+        actionKey: TRANSACTION_VOID_ACTION.key,
+        transactionId: args.transaction._id,
+        transactionNumber: args.transaction.transactionNumber,
+        total: args.transaction.total,
+      },
+      notes: args.reason,
+      organizationId: store?.organizationId,
+      posTransactionId: args.transaction._id,
+      reason: "Manager approval is required to void a completed sale.",
+      registerSessionId: args.transaction.registerSessionId,
+      requestType: TRANSACTION_VOID_REQUEST_TYPE,
+      requestedByStaffProfileId: args.actorStaffProfileId,
+      requestedByUserId: args.actorUserId,
+      storeId: args.transaction.storeId,
+      subjectId: args.transaction._id,
+      subjectType: "pos_transaction",
+    }),
+  );
+
+  await recordOperationalEventWithCtx(ctx, {
+    actorStaffProfileId: args.actorStaffProfileId,
+    actorUserId: args.actorUserId,
+    approvalRequestId,
+    customerProfileId: args.transaction.customerProfileId,
+    eventType: "pos_transaction_void_approval_requested",
+    message: `Void requested for ${completedTransactionLabel(args.transaction)}.`,
+    metadata: {
+      actionKey: TRANSACTION_VOID_ACTION.key,
+      approvalMode: "async_approval",
+      approvalRequestId,
+      requiredRole: "manager",
+      transactionNumber: args.transaction.transactionNumber,
+      total: args.transaction.total,
+    },
+    posTransactionId: args.transaction._id,
+    reason: args.reason,
+    registerSessionId: args.transaction.registerSessionId,
+    storeId: args.transaction.storeId,
+    subjectId: args.transaction._id,
+    subjectLabel: completedTransactionLabel(args.transaction),
+    subjectType: "pos_transaction",
+  });
+
+  return approvalRequestId;
+}
+
+async function requireMatchingPendingVoidApprovalRequest(
+  ctx: MutationCtx,
+  args: {
+    approvalRequestId?: Id<"approvalRequest">;
+    storeId: Id<"store">;
+    transactionId: Id<"posTransaction">;
+  },
+) {
+  if (!args.approvalRequestId) {
+    return null;
+  }
+
+  const approvalRequest = await ctx.db.get(
+    "approvalRequest",
+    args.approvalRequestId,
+  );
+
+  if (
+    !approvalRequest ||
+    approvalRequest.requestType !== TRANSACTION_VOID_REQUEST_TYPE ||
+    approvalRequest.subjectType !== "pos_transaction"
+  ) {
+    return userError({
+      code: "precondition_failed",
+      message: "Void approval request not found.",
+    });
+  }
+
+  if (approvalRequest.status !== "pending") {
+    return userError({
+      code: "precondition_failed",
+      message: "Void approval request has already been decided.",
+    });
+  }
+
+  if (
+    approvalRequest.storeId !== args.storeId ||
+    approvalRequest.subjectId !== args.transactionId
+  ) {
+    return userError({
+      code: "precondition_failed",
+      message: "Void approval request does not match this sale.",
+    });
+  }
+
+  return ok(approvalRequest);
+}
+
+function completedDailyCloseRange(dailyClose: {
+  operatingDate?: string;
+  reportSnapshot?: {
+    closeMetadata?: {
+      startAt?: number;
+      endAt?: number;
+    };
+  };
+}) {
+  const snapshotRange = dailyClose.reportSnapshot?.closeMetadata;
+  if (
+    typeof snapshotRange?.startAt === "number" &&
+    typeof snapshotRange.endAt === "number"
+  ) {
+    return {
+      startAt: snapshotRange.startAt,
+      endAt: snapshotRange.endAt,
+    };
+  }
+
+  if (
+    typeof dailyClose.operatingDate === "string" &&
+    /^\d{4}-\d{2}-\d{2}$/.test(dailyClose.operatingDate)
+  ) {
+    const startAt = Date.parse(`${dailyClose.operatingDate}T00:00:00.000Z`);
+    if (Number.isFinite(startAt)) {
+      return {
+        startAt,
+        endAt: startAt + 24 * 60 * 60 * 1000,
+      };
+    }
+  }
+
+  return null;
+}
+
+async function transactionFallsInCompletedDailyClose(
+  ctx: MutationCtx,
+  transaction: NonNullable<Awaited<ReturnType<typeof getPosTransactionById>>>,
+) {
+  const operatingDate = new Date(transaction.completedAt)
+    .toISOString()
+    .slice(0, 10);
+  const completedCloses = await ctx.db
+    .query("dailyClose")
+    .withIndex("by_storeId_status_operatingDate", (q) =>
+      q
+        .eq("storeId", transaction.storeId)
+        .eq("status", "completed")
+        .eq("operatingDate", operatingDate),
+    )
+    .take(10);
+
+  return completedCloses.some((dailyClose) => {
+    if (
+      dailyClose.lifecycleStatus !== undefined &&
+      dailyClose.lifecycleStatus !== "active"
+    ) {
+      return false;
+    }
+
+    const range = completedDailyCloseRange(dailyClose);
+    return (
+      range !== null &&
+      transaction.completedAt >= range.startAt &&
+      transaction.completedAt < range.endAt
+    );
+  });
+}
+
+async function validateTransactionVoidPreconditions(
+  ctx: MutationCtx,
+  transaction: NonNullable<Awaited<ReturnType<typeof getPosTransactionById>>>,
+) {
+  if (transaction.status === "void") {
+    return userError({
+      code: "conflict",
+      message: "Sale is already voided.",
+    });
+  }
+
+  if (transaction.status === "refunded") {
+    return userError({
+      code: "conflict",
+      message: "Sale is already refunded.",
+    });
+  }
+
+  if (transaction.status !== "completed") {
+    return userError({
+      code: "precondition_failed",
+      message: "Only completed sales can be voided.",
+    });
+  }
+
+  const adjustments = await listTransactionAdjustments(ctx, transaction._id);
+  const blockingAdjustment = adjustments.find(
+    (adjustment: { status?: string }) =>
+      adjustment.status === "pending_approval" ||
+      adjustment.status === "applied",
+  );
+
+  if (blockingAdjustment) {
+    return userError({
+      code: "precondition_failed",
+      message:
+        "This sale has item adjustments. Resolve the adjustment before voiding it.",
+    });
+  }
+
+  if (await transactionFallsInCompletedDailyClose(ctx, transaction)) {
+    return userError({
+      code: "precondition_failed",
+      message:
+        "EOD Review is completed for this sale. Reopen EOD Review before voiding it.",
+    });
+  }
+
+  if (!transaction.registerSessionId || !transaction.terminalId) {
+    return userError({
+      code: "precondition_failed",
+      message: "Register sale is missing drawer context.",
+    });
+  }
+
+  const registerSession = await getRegisterSessionById(
+    ctx,
+    transaction.registerSessionId,
+  );
+
+  if (
+    !registerSession ||
+    registerSession.storeId !== transaction.storeId ||
+    !isUsableRegisterSession(registerSession) ||
+    !registerSessionMatchesIdentity(registerSession, {
+      terminalId: transaction.terminalId,
+    })
+  ) {
+    return userError({
+      code: "precondition_failed",
+      message: "Drawer closed. Open the drawer before voiding this sale.",
+    });
+  }
+
+  const items = await listTransactionItems(ctx, transaction._id);
+  const skuRows = [];
+
+  for (const item of items) {
+    const sku = await getProductSkuById(ctx, item.productSkuId);
+
+    if (!sku || (sku.storeId && sku.storeId !== transaction.storeId)) {
+      return userError({
+        code: "precondition_failed",
+        message:
+          "Sale item inventory record not found. Review inventory before voiding this sale.",
+      });
+    }
+
+    skuRows.push({ item, sku });
+  }
+
+  return ok({ items: skuRows });
+}
+
+async function applyApprovedTransactionVoid(
+  ctx: MutationCtx,
+  args: {
+    approvalMode: "inline_manager_proof" | "async_approval_request";
+    approvalProofId: Id<"approvalProof">;
+    approvalRequestId?: Id<"approvalRequest">;
+    approverStaffProfileId: Id<"staffProfile">;
+    items: Array<{
+      item: Awaited<ReturnType<typeof listTransactionItems>>[number];
+      sku: NonNullable<Awaited<ReturnType<typeof getProductSkuById>>>;
+    }>;
+    reason: string;
+    requesterStaffProfileId?: Id<"staffProfile">;
+    requesterUserId?: Id<"athenaUser">;
+    reviewerUserId?: Id<"athenaUser">;
+    transaction: NonNullable<Awaited<ReturnType<typeof getPosTransactionById>>>;
+  },
+): Promise<CommandResult<VoidTransactionResult>> {
+  const registerSessionId = args.transaction.registerSessionId;
+  const terminalId = args.transaction.terminalId;
+  if (!registerSessionId || !terminalId) {
+    return userError({
+      code: "precondition_failed",
+      message: "Register sale is missing drawer context.",
+    });
+  }
+
+  const approvalEvent = await recordOperationalEventWithCtx(ctx, {
+    actorStaffProfileId: args.approverStaffProfileId,
+    actorUserId: args.reviewerUserId ?? args.requesterUserId,
+    approvalRequestId: args.approvalRequestId,
+    customerProfileId: args.transaction.customerProfileId,
+    eventType: "pos_transaction_void_approval_proof_consumed",
+    message: `Manager approval proof consumed for ${completedTransactionLabel(args.transaction)} void.`,
+    metadata: {
+      actionKey: TRANSACTION_VOID_ACTION.key,
+      approvalMode: args.approvalMode,
+      approvalProofId: args.approvalProofId,
+      approverStaffProfileId: args.approverStaffProfileId,
+      requesterStaffProfileId: args.requesterStaffProfileId,
+      reviewerUserId: args.reviewerUserId,
+      transactionNumber: args.transaction.transactionNumber,
+    },
+    posTransactionId: args.transaction._id,
+    reason: args.reason,
+    registerSessionId,
+    storeId: args.transaction.storeId,
+    subjectId: args.transaction._id,
+    subjectLabel: completedTransactionLabel(args.transaction),
+    subjectType: "pos_transaction",
+  });
+
+  await recordRegisterSessionVoid(ctx, {
+    changeGiven: args.transaction.changeGiven,
+    idempotencyKey: `posTransaction:${args.transaction._id}:void`,
+    payments: args.transaction.payments,
+    registerSessionId,
+    registerNumber: args.transaction.registerNumber,
+    storeId: args.transaction.storeId,
+    terminalId,
+  });
+
+  const store = await getStoreById(ctx, args.transaction.storeId);
+  const paymentAllocations = await recordRetailVoidPaymentAllocations(ctx, {
+    changeGiven: args.transaction.changeGiven,
+    organizationId: store?.organizationId,
+    payments: args.transaction.payments,
+    posTransactionId: args.transaction._id,
+    registerSessionId,
+    storeId: args.transaction.storeId,
+    transactionNumber: args.transaction.transactionNumber,
+  });
+
+  const inventoryMovementIds: Array<Id<"inventoryMovement">> = [];
+
+  const voidInventoryBySku = new Map<
+    Id<"productSku">,
+    {
+      productId: Id<"product">;
+      productSkuId: Id<"productSku">;
+      quantity: number;
+      sku: (typeof args.items)[number]["sku"];
+    }
+  >();
+
+  for (const { item, sku } of args.items) {
+    const existing = voidInventoryBySku.get(item.productSkuId);
+    if (existing) {
+      existing.quantity += item.quantity;
+      continue;
+    }
+
+    voidInventoryBySku.set(item.productSkuId, {
+      productId: item.productId ?? sku.productId,
+      productSkuId: item.productSkuId,
+      quantity: item.quantity,
+      sku,
+    });
+  }
+
+  for (const entry of voidInventoryBySku.values()) {
+    const movementResult = await recordInventoryMovementWithDispositionWithCtx(ctx, {
+      storeId: args.transaction.storeId,
+      organizationId: store?.organizationId,
+      movementType: "pos_transaction_void",
+      sourceType: "posTransaction",
+      sourceId: args.transaction._id,
+      quantityDelta: entry.quantity,
+      productId: entry.productId,
+      productSkuId: entry.productSkuId,
+      actorUserId: args.requesterUserId,
+      actorStaffProfileId: args.requesterStaffProfileId,
+      customerProfileId: args.transaction.customerProfileId,
+      registerSessionId: args.transaction.registerSessionId,
+      posTransactionId: args.transaction._id,
+      reasonCode: "pos_transaction_void",
+      notes: `Void ${args.transaction.transactionNumber}`,
+    });
+    const movement = movementResult.movement;
+
+    if (movement?._id) {
+      inventoryMovementIds.push(movement._id);
+    }
+
+    if (movementResult.disposition === "inserted") {
+      await patchProductSku(ctx, entry.productSkuId, {
+        quantityAvailable: entry.sku.quantityAvailable + entry.quantity,
+        inventoryCount: entry.sku.inventoryCount + entry.quantity,
+      });
+    }
+  }
+
+  const paymentAllocationIds = paymentAllocations
+    .map((allocation) => allocation?._id)
+    .filter(Boolean) as Array<Id<"paymentAllocation">>;
+
+  const event = await recordOperationalEventWithCtx(ctx, {
+    actorStaffProfileId: args.requesterStaffProfileId,
+    actorUserId: args.requesterUserId,
+    approvalRequestId: args.approvalRequestId,
+    customerProfileId: args.transaction.customerProfileId,
+    eventType: "pos_transaction_voided",
+    message: `Voided ${completedTransactionLabel(args.transaction)}.`,
+    metadata: {
+      actionKey: TRANSACTION_VOID_ACTION.key,
+      approvalMode: args.approvalMode,
+      approvalOperationalEventId: approvalEvent?._id,
+      approvalProofId: args.approvalProofId,
+      approverStaffProfileId: args.approverStaffProfileId,
+      inventoryMovementIds,
+      paymentAllocationIds,
+      requesterStaffProfileId: args.requesterStaffProfileId,
+      reviewerUserId: args.reviewerUserId,
+      representation:
+        "preserve_original_sale_with_payment_register_inventory_reversal",
+      transactionNumber: args.transaction.transactionNumber,
+    },
+    posTransactionId: args.transaction._id,
+    reason: args.reason,
+    registerSessionId: args.transaction.registerSessionId,
+    storeId: args.transaction.storeId,
+    subjectId: args.transaction._id,
+    subjectLabel: completedTransactionLabel(args.transaction),
+    subjectType: "pos_transaction",
+  });
+
+  const voidedAt = Date.now();
+
+  await patchPosTransaction(ctx, args.transaction._id, {
+    status: "void",
+    voidedAt,
+    voidReason: args.reason,
+    voidedByStaffProfileId: args.requesterStaffProfileId,
+    voidApprovalProofId: args.approvalProofId,
+    voidApprovalRequestId: args.approvalRequestId,
+    voidApprovedByStaffProfileId: args.approverStaffProfileId,
+    voidOperationalEventId: event?._id,
+  });
+
+  return ok({
+    transactionId: args.transaction._id,
+    transactionNumber: args.transaction.transactionNumber,
+    voidedAt,
+    paymentAllocationIds,
+    inventoryMovementIds,
+    operationalEventId: event?._id,
+    approvalProofId: args.approvalProofId,
+    approvalRequestId: args.approvalRequestId,
+    approverStaffProfileId: args.approverStaffProfileId,
+  });
+}
+
 export async function voidTransaction(
   ctx: MutationCtx,
   args: {
+    actorStaffProfileId?: Id<"staffProfile">;
+    actorUserId?: Id<"athenaUser">;
+    approvalProofId?: Id<"approvalProof">;
+    approvalRequestId?: Id<"approvalRequest">;
     transactionId: Id<"posTransaction">;
     reason: string;
     staffProfileId?: Id<"staffProfile">;
   },
-) {
+): Promise<ApprovalCommandResult<VoidTransactionResult>> {
+  const actorStaffProfileId = args.actorStaffProfileId ?? args.staffProfileId;
   const transaction = await getPosTransactionById(ctx, args.transactionId);
   if (!transaction) {
-    return {
-      success: false,
-      error: "Transaction not found",
-    };
-  }
-
-  if (transaction.status !== "completed") {
-    return {
-      success: false,
-      error: "Can only void completed transactions",
-    };
-  }
-
-  if (transaction.registerSessionId) {
-    if (!transaction.terminalId) {
-      return {
-        success: false,
-        error: "Register session transactions must include a terminal.",
-      };
-    }
-
-    await recordRegisterSessionVoid(ctx, {
-      changeGiven: transaction.changeGiven,
-      payments: transaction.payments,
-      registerSessionId: transaction.registerSessionId,
-      registerNumber: transaction.registerNumber,
-      storeId: transaction.storeId,
-      terminalId: transaction.terminalId,
+    return userError({
+      code: "not_found",
+      message: "Transaction not found.",
     });
   }
 
-  const store = await getStoreById(ctx, transaction.storeId);
-  await recordRetailVoidPaymentAllocations(ctx, {
-    changeGiven: transaction.changeGiven,
-    organizationId: store?.organizationId,
-    payments: transaction.payments,
-    posTransactionId: transaction._id,
-    registerSessionId: transaction.registerSessionId,
+  const reason = args.reason.trim();
+  if (!reason) {
+    return userError({
+      code: "validation_failed",
+      message: "Reason is required to void a completed sale.",
+    });
+  }
+
+  const preconditions = await validateTransactionVoidPreconditions(
+    ctx,
+    transaction,
+  );
+  if (preconditions.kind !== "ok") {
+    return preconditions;
+  }
+
+  if (!args.approvalProofId) {
+    const existingApprovalRequest = await findPendingVoidApprovalRequest(ctx, {
+      storeId: transaction.storeId,
+      transactionId: transaction._id,
+    });
+    const approvalRequestId =
+      existingApprovalRequest?._id ??
+      (await createVoidApprovalRequest(ctx, {
+        actorStaffProfileId,
+        actorUserId: args.actorUserId,
+        reason,
+        transaction,
+      }));
+
+    return approvalRequired(
+      buildVoidApprovalRequirement({
+        approvalRequestId,
+        reason,
+        transaction,
+      }),
+    );
+  }
+
+  const matchingApprovalRequest =
+    await requireMatchingPendingVoidApprovalRequest(ctx, {
+      approvalRequestId: args.approvalRequestId,
+      storeId: transaction.storeId,
+      transactionId: transaction._id,
+    });
+  if (matchingApprovalRequest?.kind === "user_error") {
+    return matchingApprovalRequest;
+  }
+
+  const approvalProof = await consumeCommandApprovalProofWithCtx(ctx, {
+    action: TRANSACTION_VOID_ACTION,
+    approvalProofId: args.approvalProofId,
+    requestedByStaffProfileId: actorStaffProfileId,
+    requiredRole: "manager",
     storeId: transaction.storeId,
-    transactionNumber: transaction.transactionNumber,
+    subject: {
+      type: "pos_transaction",
+      id: transaction._id,
+    },
   });
 
-  await patchPosTransaction(ctx, args.transactionId, {
-    status: "void",
-    voidedAt: Date.now(),
-    notes: args.reason,
-  });
+  if (approvalProof.kind !== "ok") {
+    return userError({
+      code: "precondition_failed",
+      message: approvalProof.error.message,
+    });
+  }
 
-  const items = await listTransactionItems(ctx, args.transactionId);
-  await Promise.all(
-    items.map(async (item) => {
-      const sku = await getProductSkuById(ctx, item.productSkuId);
-      if (!sku) {
-        return;
-      }
-
-      await patchProductSku(ctx, item.productSkuId, {
-        quantityAvailable: sku.quantityAvailable + item.quantity,
-        inventoryCount: sku.inventoryCount + item.quantity,
+  return applyApprovedTransactionVoid(ctx, {
+    approvalMode: "inline_manager_proof",
+    approvalProofId: approvalProof.data.approvalProofId,
+    approvalRequestId:
+      matchingApprovalRequest?.kind === "ok"
+        ? matchingApprovalRequest.data._id
+        : undefined,
+    approverStaffProfileId: approvalProof.data.approvedByStaffProfileId,
+    items: preconditions.data.items,
+    reason,
+    requesterStaffProfileId: actorStaffProfileId,
+    requesterUserId: args.actorUserId,
+    transaction,
+  }).then(async (result) => {
+    if (result.kind === "ok" && matchingApprovalRequest?.kind === "ok") {
+      await ctx.db.patch("approvalRequest", matchingApprovalRequest.data._id, {
+        status: "approved",
+        reviewedByStaffProfileId: approvalProof.data.approvedByStaffProfileId,
+        decisionNotes: reason,
+        decidedAt: result.data.voidedAt,
       });
-    }),
+    }
+
+    return result;
+  });
+}
+
+export async function resolveTransactionVoidApprovalDecisionWithCtx(
+  ctx: MutationCtx,
+  args: {
+    approvalProofId?: Id<"approvalProof">;
+    approvalRequestId: Id<"approvalRequest">;
+    decision: "approved" | "rejected" | "cancelled";
+    decisionNotes?: string;
+    reviewedByStaffProfileId?: Id<"staffProfile">;
+    reviewedByUserId?: Id<"athenaUser">;
+  },
+) {
+  const approvalRequest = await ctx.db.get(
+    "approvalRequest",
+    args.approvalRequestId,
   );
 
-  return { success: true };
+  if (
+    !approvalRequest ||
+    approvalRequest.requestType !== TRANSACTION_VOID_REQUEST_TYPE ||
+    approvalRequest.subjectType !== "pos_transaction"
+  ) {
+    throw new Error("Void approval request not found.");
+  }
+
+  if (args.decision !== "approved") {
+    return null;
+  }
+
+  if (!args.approvalProofId || !args.reviewedByStaffProfileId) {
+    throw new Error("Manager approval is required to void a completed sale.");
+  }
+
+  const transactionId = approvalRequest.posTransactionId ?? approvalRequest.subjectId;
+  if (!transactionId) {
+    throw new Error("Void approval request is missing transaction details.");
+  }
+
+  const transaction = await getPosTransactionById(
+    ctx,
+    transactionId as Id<"posTransaction">,
+  );
+  if (!transaction) {
+    throw new Error("Transaction not found.");
+  }
+
+  const matchingApprovalRequest =
+    await requireMatchingPendingVoidApprovalRequest(ctx, {
+      approvalRequestId: args.approvalRequestId,
+      storeId: transaction.storeId,
+      transactionId: transaction._id,
+    });
+  if (matchingApprovalRequest?.kind === "user_error") {
+    throw new Error(matchingApprovalRequest.error.message);
+  }
+
+  const preconditions = await validateTransactionVoidPreconditions(
+    ctx,
+    transaction,
+  );
+  if (preconditions.kind !== "ok") {
+    throw new Error(preconditions.error.message);
+  }
+
+  const result = await applyApprovedTransactionVoid(ctx, {
+    approvalMode: "async_approval_request",
+    approvalProofId: args.approvalProofId,
+    approvalRequestId: args.approvalRequestId,
+    approverStaffProfileId: args.reviewedByStaffProfileId,
+    items: preconditions.data.items,
+    reason:
+      args.decisionNotes ??
+      approvalRequest.notes ??
+      approvalRequest.reason ??
+      "Manager approved completed sale void.",
+    requesterStaffProfileId: approvalRequest.requestedByStaffProfileId,
+    requesterUserId: approvalRequest.requestedByUserId,
+    reviewerUserId: args.reviewedByUserId,
+    transaction,
+  });
+
+  if (result.kind !== "ok") {
+    throw new Error(result.error.message);
+  }
+
+  return result.data;
 }
 
 export async function createTransactionFromSessionHandler(

--- a/packages/athena-webapp/convex/pos/application/completeTransaction.test.ts
+++ b/packages/athena-webapp/convex/pos/application/completeTransaction.test.ts
@@ -10,27 +10,40 @@ import {
   completeTransaction,
   createTransactionFromSessionHandler,
   buildCompleteTransactionResult,
+  resolveTransactionVoidApprovalDecisionWithCtx,
+  voidTransaction,
 } from "./commands/completeTransaction";
 import {
   consumeInventoryHoldsForSession,
   readActiveInventoryHoldQuantitiesForSession,
   validateInventoryAvailability,
 } from "../../inventory/helpers/inventoryHolds";
-import { recordInventoryMovementWithCtx } from "../../operations/inventoryMovements";
+import {
+  recordInventoryMovementWithCtx,
+  recordInventoryMovementWithDispositionWithCtx,
+} from "../../operations/inventoryMovements";
 import {
   createPosTransaction,
   createPosTransactionItem,
+  getPosTransactionById,
   getPosSessionById,
   getRegisterSessionById,
   getProductSkuById,
   getStoreById,
+  listTransactionAdjustments,
   listSessionItems,
+  listTransactionItems,
   patchPosTransaction,
   patchPosSession,
   patchProductSku,
 } from "../infrastructure/repositories/transactionRepository";
-import { recordRetailSalePaymentAllocations } from "../infrastructure/integrations/paymentAllocationService";
+import {
+  recordRetailSalePaymentAllocations,
+  recordRetailVoidPaymentAllocations,
+} from "../infrastructure/integrations/paymentAllocationService";
 import { updateCustomerStats } from "../infrastructure/repositories/customerRepository";
+import { consumeCommandApprovalProofWithCtx } from "../../operations/approvalActions";
+import { recordOperationalEventWithCtx } from "../../operations/operationalEvents";
 
 vi.mock("../../workflowTraces/core", () => ({
   appendWorkflowTraceEventWithCtx: vi.fn(),
@@ -46,6 +59,7 @@ vi.mock("../infrastructure/repositories/transactionRepository", () => ({
   getPosTransactionById: vi.fn(),
   getProductSkuById: vi.fn(),
   getStoreById: vi.fn(),
+  listTransactionAdjustments: vi.fn(),
   listSessionItems: vi.fn(),
   listTransactionItems: vi.fn(),
   patchPosSession: vi.fn(),
@@ -56,6 +70,20 @@ vi.mock("../infrastructure/repositories/transactionRepository", () => ({
 vi.mock("../infrastructure/integrations/paymentAllocationService", () => ({
   recordRetailSalePaymentAllocations: vi.fn(),
   recordRetailVoidPaymentAllocations: vi.fn(),
+}));
+
+vi.mock("../../operations/approvalActions", () => ({
+  APPROVAL_ACTIONS: {
+    transactionVoid: {
+      key: "pos.transaction.void",
+      label: "Void completed transaction",
+    },
+  },
+  consumeCommandApprovalProofWithCtx: vi.fn(),
+}));
+
+vi.mock("../../operations/operationalEvents", () => ({
+  recordOperationalEventWithCtx: vi.fn(),
 }));
 
 vi.mock("../infrastructure/repositories/customerRepository", () => ({
@@ -70,6 +98,7 @@ vi.mock("../../inventory/helpers/inventoryHolds", () => ({
 
 vi.mock("../../operations/inventoryMovements", () => ({
   recordInventoryMovementWithCtx: vi.fn(),
+  recordInventoryMovementWithDispositionWithCtx: vi.fn(),
 }));
 
 beforeEach(() => {
@@ -96,6 +125,72 @@ function expectNoCompletionSideEffects() {
   expect(createWorkflowTraceWithCtx).not.toHaveBeenCalled();
   expect(registerWorkflowTraceLookupWithCtx).not.toHaveBeenCalled();
   expect(appendWorkflowTraceEventWithCtx).not.toHaveBeenCalled();
+}
+
+function expectNoVoidBusinessSideEffects() {
+  expect(patchPosTransaction).not.toHaveBeenCalled();
+  expect(patchProductSku).not.toHaveBeenCalled();
+  expect(recordRetailVoidPaymentAllocations).not.toHaveBeenCalled();
+  expect(recordInventoryMovementWithCtx).not.toHaveBeenCalled();
+  expect(recordInventoryMovementWithDispositionWithCtx).not.toHaveBeenCalled();
+}
+
+function createVoidCtx(overrides?: {
+  approvalRequests?: unknown[];
+  completedDailyCloses?: unknown[];
+  inventoryMovements?: unknown[];
+  insert?: ReturnType<typeof vi.fn>;
+  patch?: ReturnType<typeof vi.fn>;
+}) {
+  const approvalRequests = overrides?.approvalRequests ?? [];
+  return {
+    db: {
+      get: vi.fn(async (tableName: string, id: string) => {
+        if (tableName === "approvalRequest") {
+          return (
+            approvalRequests.find(
+              (request) => (request as { _id?: string })._id === id,
+            ) ?? null
+          );
+        }
+
+        return null;
+      }),
+      insert:
+        overrides?.insert ??
+        vi.fn(async (tableName: string) =>
+          tableName === "approvalRequest" ? "approval-request-1" : `${tableName}-1`,
+        ),
+      patch: overrides?.patch ?? vi.fn(),
+      query: vi.fn((tableName: string) => ({
+        withIndex: vi.fn(() => ({
+          collect: vi
+            .fn()
+            .mockResolvedValue(
+              tableName === "dailyClose"
+                ? (overrides?.completedDailyCloses ?? [])
+                : tableName === "approvalRequest"
+                  ? approvalRequests
+                  : tableName === "inventoryMovement"
+                    ? (overrides?.inventoryMovements ?? [])
+                : [],
+            ),
+          take: vi
+            .fn()
+            .mockResolvedValue(
+              tableName === "dailyClose"
+                ? (overrides?.completedDailyCloses ?? [])
+                : tableName === "approvalRequest"
+                  ? approvalRequests
+                  : tableName === "inventoryMovement"
+                    ? (overrides?.inventoryMovements ?? [])
+                : [],
+            ),
+        })),
+      })),
+    },
+    runMutation: vi.fn(),
+  };
 }
 
 describe("buildCompleteTransactionResult", () => {
@@ -131,6 +226,726 @@ describe("buildCompleteTransactionResult", () => {
     });
 
     expect(result.status).toBe("validationFailed");
+  });
+});
+
+describe("voidTransaction", () => {
+  const completedTransaction = {
+    _id: "txn-1" as Id<"posTransaction">,
+    changeGiven: 2,
+    completedAt: Date.UTC(2026, 4, 21, 10),
+    customerProfileId: "customer-1" as Id<"customerProfile">,
+    payments: [{ method: "cash", amount: 12, timestamp: 1 }],
+    registerNumber: "1",
+    registerSessionId: "register-1" as Id<"registerSession">,
+    status: "completed",
+    storeId: "store-1" as Id<"store">,
+    terminalId: "terminal-1" as Id<"posTerminal">,
+    transactionNumber: "POS-0001",
+  };
+
+  beforeEach(() => {
+    vi.mocked(getPosTransactionById).mockResolvedValue(
+      completedTransaction as never,
+    );
+    vi.mocked(getStoreById).mockResolvedValue({
+      _id: "store-1",
+      organizationId: "org-1",
+    } as never);
+    vi.mocked(getRegisterSessionById).mockResolvedValue({
+      _id: "register-1",
+      status: "open",
+      storeId: "store-1",
+      terminalId: "terminal-1",
+    } as never);
+    vi.mocked(listTransactionAdjustments).mockResolvedValue([] as never);
+    vi.mocked(listTransactionItems).mockResolvedValue([
+      {
+        _id: "txn-item-1",
+        productId: "product-1",
+        productSkuId: "sku-1",
+        productName: "Sneaker",
+        productSku: "SKU-1",
+        quantity: 1,
+      },
+    ] as never);
+    vi.mocked(getProductSkuById).mockResolvedValue({
+      _id: "sku-1",
+      inventoryCount: 4,
+      productId: "product-1",
+      quantityAvailable: 4,
+      sku: "SKU-1",
+      storeId: "store-1",
+    } as never);
+    vi.mocked(recordOperationalEventWithCtx).mockResolvedValue({
+      _id: "event-1",
+    } as never);
+    vi.mocked(recordRetailVoidPaymentAllocations).mockResolvedValue([
+      { _id: "payment-allocation-1" },
+    ] as never);
+    vi.mocked(recordInventoryMovementWithCtx).mockResolvedValue({
+      _id: "inventory-movement-1",
+    } as never);
+    vi.mocked(recordInventoryMovementWithDispositionWithCtx).mockResolvedValue({
+      disposition: "inserted",
+      movement: { _id: "inventory-movement-1" },
+    } as never);
+    vi.mocked(consumeCommandApprovalProofWithCtx).mockResolvedValue({
+      kind: "ok",
+      data: {
+        approvalProofId: "approval-proof-1",
+        approvedByStaffProfileId: "manager-1",
+      },
+    } as never);
+  });
+
+  it("returns approval_required without mutating ledger state on the first attempt", async () => {
+    const ctx = createVoidCtx();
+
+    await expect(
+      voidTransaction(ctx as never, {
+        actorStaffProfileId: "staff-1" as Id<"staffProfile">,
+        reason: "Duplicate sale",
+        transactionId: "txn-1" as Id<"posTransaction">,
+      }),
+    ).resolves.toMatchObject({
+      kind: "approval_required",
+      approval: {
+        action: { key: "pos.transaction.void" },
+        requiredRole: "manager",
+        subject: {
+          id: "txn-1",
+          type: "pos_transaction",
+        },
+      },
+    });
+
+    expect(ctx.db.insert).toHaveBeenCalledWith(
+      "approvalRequest",
+      expect.objectContaining({
+        requestType: "pos_transaction_void",
+        subjectId: "txn-1",
+        subjectType: "pos_transaction",
+      }),
+    );
+    expectNoVoidBusinessSideEffects();
+    expect(ctx.runMutation).not.toHaveBeenCalled();
+  });
+
+  it("reuses a pending void approval request on command retries", async () => {
+    const ctx = createVoidCtx({
+      approvalRequests: [
+        {
+          _id: "approval-existing-1",
+          requestType: "pos_transaction_void",
+          status: "pending",
+          storeId: "store-1",
+          subjectId: "txn-1",
+          subjectType: "pos_transaction",
+        },
+      ],
+    });
+
+    await expect(
+      voidTransaction(ctx as never, {
+        actorStaffProfileId: "staff-1" as Id<"staffProfile">,
+        reason: "Duplicate sale",
+        transactionId: "txn-1" as Id<"posTransaction">,
+      }),
+    ).resolves.toMatchObject({
+      kind: "approval_required",
+      approval: {
+        resolutionModes: expect.arrayContaining([
+          expect.objectContaining({
+            approvalRequestId: "approval-existing-1",
+            kind: "async_request",
+          }),
+        ]),
+      },
+    });
+
+    expect(ctx.db.insert).not.toHaveBeenCalled();
+    expectNoVoidBusinessSideEffects();
+  });
+
+  it("consumes a manager approval proof and records payment, register, inventory, and audit reversal evidence", async () => {
+    const ctx = createVoidCtx();
+    vi.mocked(recordOperationalEventWithCtx)
+      .mockResolvedValueOnce({ _id: "approval-event-1" } as never)
+      .mockResolvedValueOnce({ _id: "void-event-1" } as never);
+
+    await expect(
+      voidTransaction(ctx as never, {
+        actorStaffProfileId: "staff-1" as Id<"staffProfile">,
+        approvalProofId: "approval-proof-1" as Id<"approvalProof">,
+        reason: "Duplicate sale",
+        transactionId: "txn-1" as Id<"posTransaction">,
+      }),
+    ).resolves.toMatchObject({
+      kind: "ok",
+      data: {
+        approvalProofId: "approval-proof-1",
+        approverStaffProfileId: "manager-1",
+        inventoryMovementIds: ["inventory-movement-1"],
+        operationalEventId: "void-event-1",
+        paymentAllocationIds: ["payment-allocation-1"],
+        transactionId: "txn-1",
+        transactionNumber: "POS-0001",
+      },
+    });
+
+    expect(consumeCommandApprovalProofWithCtx).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        action: expect.objectContaining({ key: "pos.transaction.void" }),
+        approvalProofId: "approval-proof-1",
+        requestedByStaffProfileId: "staff-1",
+        requiredRole: "manager",
+        storeId: "store-1",
+        subject: {
+          id: "txn-1",
+          type: "pos_transaction",
+        },
+      }),
+    );
+    expect(ctx.runMutation).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        adjustmentKind: "void",
+        changeGiven: 2,
+        idempotencyKey: "posTransaction:txn-1:void",
+        registerSessionId: "register-1",
+      }),
+    );
+    expect(recordRetailVoidPaymentAllocations).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        changeGiven: 2,
+        organizationId: "org-1",
+          posTransactionId: "txn-1",
+          registerSessionId: "register-1",
+        }),
+      );
+    expect(recordInventoryMovementWithDispositionWithCtx).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        movementType: "pos_transaction_void",
+        quantityDelta: 1,
+        reasonCode: "pos_transaction_void",
+        sourceId: "txn-1",
+        sourceType: "posTransaction",
+      }),
+    );
+    expect(patchProductSku).toHaveBeenCalledWith(expect.anything(), "sku-1", {
+      inventoryCount: 5,
+      quantityAvailable: 5,
+    });
+    expect(patchPosTransaction).toHaveBeenCalledWith(
+      expect.anything(),
+      "txn-1",
+      expect.objectContaining({
+        status: "void",
+        voidApprovalProofId: "approval-proof-1",
+        voidOperationalEventId: "void-event-1",
+        voidReason: "Duplicate sale",
+        voidedByStaffProfileId: "staff-1",
+      }),
+    );
+  });
+
+  it("marks the matching pending approval request approved when a void completes", async () => {
+    const ctx = createVoidCtx({
+      approvalRequests: [
+        {
+          _id: "approval-request-1",
+          requestType: "pos_transaction_void",
+          status: "pending",
+          storeId: "store-1",
+          subjectId: "txn-1",
+          subjectType: "pos_transaction",
+        },
+      ],
+    });
+
+    await expect(
+      voidTransaction(ctx as never, {
+        actorStaffProfileId: "staff-1" as Id<"staffProfile">,
+        approvalProofId: "approval-proof-1" as Id<"approvalProof">,
+        approvalRequestId: "approval-request-1" as Id<"approvalRequest">,
+        reason: "Duplicate sale",
+        transactionId: "txn-1" as Id<"posTransaction">,
+      }),
+    ).resolves.toMatchObject({
+      kind: "ok",
+      data: {
+        approvalRequestId: "approval-request-1",
+      },
+    });
+
+    expect(ctx.db.patch).toHaveBeenCalledWith(
+      "approvalRequest",
+      "approval-request-1",
+      expect.objectContaining({
+        status: "approved",
+        reviewedByStaffProfileId: "manager-1",
+      }),
+    );
+    expect(ctx.db.patch).not.toHaveBeenCalledWith(
+      "approvalRequest",
+      "approval-request-1",
+      expect.objectContaining({
+        reviewedByUserId: "user-1",
+      }),
+    );
+    expect(recordOperationalEventWithCtx).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        approvalRequestId: "approval-request-1",
+        eventType: "pos_transaction_void_approval_proof_consumed",
+      }),
+    );
+  });
+
+  it("applies a completed-sale void when a queued approval request is approved", async () => {
+    const ctx = createVoidCtx({
+      approvalRequests: [
+        {
+          _id: "approval-request-1",
+          posTransactionId: "txn-1",
+          requestType: "pos_transaction_void",
+          requestedByStaffProfileId: "staff-1",
+          requestedByUserId: "cashier-user-1",
+          status: "pending",
+          storeId: "store-1",
+          subjectId: "txn-1",
+          subjectType: "pos_transaction",
+        },
+      ],
+    });
+
+    await expect(
+      resolveTransactionVoidApprovalDecisionWithCtx(ctx as never, {
+        approvalProofId: "decision-proof-1" as Id<"approvalProof">,
+        approvalRequestId: "approval-request-1" as Id<"approvalRequest">,
+        decision: "approved",
+        decisionNotes: "Duplicate sale",
+        reviewedByStaffProfileId: "manager-1" as Id<"staffProfile">,
+        reviewedByUserId: "manager-user-1" as Id<"athenaUser">,
+      }),
+    ).resolves.toMatchObject({
+      approvalProofId: "decision-proof-1",
+      approvalRequestId: "approval-request-1",
+      approverStaffProfileId: "manager-1",
+      transactionId: "txn-1",
+    });
+
+    expect(consumeCommandApprovalProofWithCtx).not.toHaveBeenCalled();
+    expect(recordRetailVoidPaymentAllocations).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        posTransactionId: "txn-1",
+        registerSessionId: "register-1",
+      }),
+    );
+    expect(recordInventoryMovementWithDispositionWithCtx).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        actorStaffProfileId: "staff-1",
+        actorUserId: "cashier-user-1",
+        movementType: "pos_transaction_void",
+        quantityDelta: 1,
+      }),
+    );
+    expect(recordOperationalEventWithCtx).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        actorStaffProfileId: "manager-1",
+        actorUserId: "manager-user-1",
+        eventType: "pos_transaction_void_approval_proof_consumed",
+      }),
+    );
+    expect(recordOperationalEventWithCtx).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        actorStaffProfileId: "staff-1",
+        actorUserId: "cashier-user-1",
+        eventType: "pos_transaction_voided",
+        metadata: expect.objectContaining({
+          approverStaffProfileId: "manager-1",
+          reviewerUserId: "manager-user-1",
+        }),
+      }),
+    );
+    expect(patchPosTransaction).toHaveBeenCalledWith(
+      expect.anything(),
+      "txn-1",
+      expect.objectContaining({
+        status: "void",
+        voidApprovalProofId: "decision-proof-1",
+        voidApprovalRequestId: "approval-request-1",
+        voidApprovedByStaffProfileId: "manager-1",
+      }),
+    );
+    expect(ctx.db.patch).not.toHaveBeenCalledWith(
+      "approvalRequest",
+      "approval-request-1",
+      expect.any(Object),
+    );
+  });
+
+  it("does not apply void side effects when a queued void approval is rejected", async () => {
+    const ctx = createVoidCtx({
+      approvalRequests: [
+        {
+          _id: "approval-request-1",
+          posTransactionId: "txn-1",
+          requestType: "pos_transaction_void",
+          requestedByStaffProfileId: "staff-1",
+          status: "pending",
+          storeId: "store-1",
+          subjectId: "txn-1",
+          subjectType: "pos_transaction",
+        },
+      ],
+    });
+
+    await expect(
+      resolveTransactionVoidApprovalDecisionWithCtx(ctx as never, {
+        approvalProofId: "decision-proof-1" as Id<"approvalProof">,
+        approvalRequestId: "approval-request-1" as Id<"approvalRequest">,
+        decision: "rejected",
+        reviewedByStaffProfileId: "manager-1" as Id<"staffProfile">,
+        reviewedByUserId: "manager-user-1" as Id<"athenaUser">,
+      }),
+    ).resolves.toBeNull();
+
+    expectNoVoidBusinessSideEffects();
+  });
+
+  it.each([
+    [
+      "missing approval proof",
+      {
+        approvalProofId: undefined,
+        reviewedByStaffProfileId: "manager-1" as Id<"staffProfile">,
+      },
+      "Manager approval is required to void a completed sale.",
+    ],
+    [
+      "missing reviewer staff",
+      {
+        approvalProofId: "decision-proof-1" as Id<"approvalProof">,
+        reviewedByStaffProfileId: undefined,
+      },
+      "Manager approval is required to void a completed sale.",
+    ],
+  ])("rejects queued void approval with %s", async (_label, overrides, message) => {
+    const ctx = createVoidCtx({
+      approvalRequests: [
+        {
+          _id: "approval-request-1",
+          posTransactionId: "txn-1",
+          requestType: "pos_transaction_void",
+          requestedByStaffProfileId: "staff-1",
+          status: "pending",
+          storeId: "store-1",
+          subjectId: "txn-1",
+          subjectType: "pos_transaction",
+        },
+      ],
+    });
+
+    await expect(
+      resolveTransactionVoidApprovalDecisionWithCtx(ctx as never, {
+        approvalRequestId: "approval-request-1" as Id<"approvalRequest">,
+        decision: "approved",
+        reviewedByUserId: "manager-user-1" as Id<"athenaUser">,
+        ...overrides,
+      }),
+    ).rejects.toThrow(message);
+
+    expectNoVoidBusinessSideEffects();
+  });
+
+  it("rejects queued void approvals missing transaction details", async () => {
+    const ctx = createVoidCtx({
+      approvalRequests: [
+        {
+          _id: "approval-request-1",
+          requestType: "pos_transaction_void",
+          requestedByStaffProfileId: "staff-1",
+          status: "pending",
+          storeId: "store-1",
+          subjectType: "pos_transaction",
+        },
+      ],
+    });
+
+    await expect(
+      resolveTransactionVoidApprovalDecisionWithCtx(ctx as never, {
+        approvalProofId: "decision-proof-1" as Id<"approvalProof">,
+        approvalRequestId: "approval-request-1" as Id<"approvalRequest">,
+        decision: "approved",
+        reviewedByStaffProfileId: "manager-1" as Id<"staffProfile">,
+        reviewedByUserId: "manager-user-1" as Id<"athenaUser">,
+      }),
+    ).rejects.toThrow("Void approval request is missing transaction details.");
+
+    expectNoVoidBusinessSideEffects();
+  });
+
+  it("rejects queued void approvals when the transaction is missing", async () => {
+    vi.mocked(getPosTransactionById).mockResolvedValue(null);
+    const ctx = createVoidCtx({
+      approvalRequests: [
+        {
+          _id: "approval-request-1",
+          posTransactionId: "txn-1",
+          requestType: "pos_transaction_void",
+          requestedByStaffProfileId: "staff-1",
+          status: "pending",
+          storeId: "store-1",
+          subjectId: "txn-1",
+          subjectType: "pos_transaction",
+        },
+      ],
+    });
+
+    await expect(
+      resolveTransactionVoidApprovalDecisionWithCtx(ctx as never, {
+        approvalProofId: "decision-proof-1" as Id<"approvalProof">,
+        approvalRequestId: "approval-request-1" as Id<"approvalRequest">,
+        decision: "approved",
+        reviewedByStaffProfileId: "manager-1" as Id<"staffProfile">,
+        reviewedByUserId: "manager-user-1" as Id<"athenaUser">,
+      }),
+    ).rejects.toThrow("Transaction not found.");
+
+    expectNoVoidBusinessSideEffects();
+  });
+
+  it("rejects mismatched pending approval requests before consuming manager proof", async () => {
+    const ctx = createVoidCtx({
+      approvalRequests: [
+        {
+          _id: "approval-request-1",
+          requestType: "pos_transaction_void",
+          status: "pending",
+          storeId: "store-1",
+          subjectId: "txn-other",
+          subjectType: "pos_transaction",
+        },
+      ],
+    });
+
+    await expect(
+      voidTransaction(ctx as never, {
+        actorStaffProfileId: "staff-1" as Id<"staffProfile">,
+        approvalProofId: "approval-proof-1" as Id<"approvalProof">,
+        approvalRequestId: "approval-request-1" as Id<"approvalRequest">,
+        reason: "Duplicate sale",
+        transactionId: "txn-1" as Id<"posTransaction">,
+      }),
+    ).resolves.toMatchObject({
+      kind: "user_error",
+      error: {
+        code: "precondition_failed",
+      },
+    });
+
+    expect(consumeCommandApprovalProofWithCtx).not.toHaveBeenCalled();
+    expectNoVoidBusinessSideEffects();
+  });
+
+  it("blocks completed sales without drawer identity before approval consumption", async () => {
+    vi.mocked(getPosTransactionById).mockResolvedValue({
+      ...completedTransaction,
+      registerSessionId: undefined,
+      terminalId: undefined,
+    } as never);
+
+    await expect(
+      voidTransaction(createVoidCtx() as never, {
+        actorStaffProfileId: "staff-1" as Id<"staffProfile">,
+        approvalProofId: "approval-proof-1" as Id<"approvalProof">,
+        reason: "Duplicate sale",
+        transactionId: "txn-1" as Id<"posTransaction">,
+      }),
+    ).resolves.toMatchObject({
+      kind: "user_error",
+      error: {
+        code: "precondition_failed",
+        message: "Register sale is missing drawer context.",
+      },
+    });
+
+    expect(consumeCommandApprovalProofWithCtx).not.toHaveBeenCalled();
+    expectNoVoidBusinessSideEffects();
+  });
+
+  it("aggregates duplicate SKU sale lines before restoring inventory", async () => {
+    vi.mocked(listTransactionItems).mockResolvedValue([
+      {
+        _id: "txn-item-1",
+        productId: "product-1",
+        productSkuId: "sku-1",
+        productName: "Sneaker",
+        productSku: "SKU-1",
+        quantity: 1,
+      },
+      {
+        _id: "txn-item-2",
+        productId: "product-1",
+        productSkuId: "sku-1",
+        productName: "Sneaker",
+        productSku: "SKU-1",
+        quantity: 2,
+      },
+    ] as never);
+
+    await expect(
+      voidTransaction(createVoidCtx() as never, {
+        actorStaffProfileId: "staff-1" as Id<"staffProfile">,
+        approvalProofId: "approval-proof-1" as Id<"approvalProof">,
+        reason: "Duplicate sale",
+        transactionId: "txn-1" as Id<"posTransaction">,
+      }),
+    ).resolves.toMatchObject({
+      kind: "ok",
+    });
+
+    expect(recordInventoryMovementWithDispositionWithCtx).toHaveBeenCalledTimes(1);
+    expect(recordInventoryMovementWithDispositionWithCtx).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        productSkuId: "sku-1",
+        quantityDelta: 3,
+      }),
+    );
+    expect(patchProductSku).toHaveBeenCalledTimes(1);
+    expect(patchProductSku).toHaveBeenCalledWith(expect.anything(), "sku-1", {
+      inventoryCount: 7,
+      quantityAvailable: 7,
+    });
+  });
+
+  it("does not restore SKU quantities again when void inventory movement already exists", async () => {
+    vi.mocked(recordInventoryMovementWithDispositionWithCtx).mockResolvedValueOnce({
+      disposition: "existing",
+      movement: { _id: "inventory-movement-existing" as Id<"inventoryMovement"> },
+    } as never);
+
+    await expect(
+      voidTransaction(createVoidCtx() as never, {
+        actorStaffProfileId: "staff-1" as Id<"staffProfile">,
+        approvalProofId: "approval-proof-1" as Id<"approvalProof">,
+        reason: "Duplicate sale",
+        transactionId: "txn-1" as Id<"posTransaction">,
+      }),
+    ).resolves.toMatchObject({
+      kind: "ok",
+      data: {
+        inventoryMovementIds: ["inventory-movement-existing"],
+      },
+    });
+
+    expect(recordInventoryMovementWithDispositionWithCtx).toHaveBeenCalledTimes(1);
+    expect(patchProductSku).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["missing", null],
+    ["closed", { _id: "register-1", status: "closed", storeId: "store-1", terminalId: "terminal-1" }],
+    ["wrong-store", { _id: "register-1", status: "open", storeId: "store-other", terminalId: "terminal-1" }],
+    ["wrong-terminal", { _id: "register-1", status: "open", storeId: "store-1", terminalId: "terminal-other" }],
+  ] as const)(
+    "blocks completed-sale voids with a %s register session before approval consumption",
+    async (_label, registerSession) => {
+      vi.mocked(getRegisterSessionById).mockResolvedValue(registerSession as never);
+
+      await expect(
+        voidTransaction(createVoidCtx() as never, {
+          actorStaffProfileId: "staff-1" as Id<"staffProfile">,
+          approvalProofId: "approval-proof-1" as Id<"approvalProof">,
+          reason: "Duplicate sale",
+          transactionId: "txn-1" as Id<"posTransaction">,
+        }),
+      ).resolves.toMatchObject({
+        kind: "user_error",
+        error: {
+          code: "precondition_failed",
+          message: "Drawer closed. Open the drawer before voiding this sale.",
+        },
+      });
+
+      expect(consumeCommandApprovalProofWithCtx).not.toHaveBeenCalled();
+      expectNoVoidBusinessSideEffects();
+    },
+  );
+
+  it.each(["pending_approval", "applied"] as const)(
+    "blocks transactions with %s item adjustments before approval consumption",
+    async (status) => {
+      vi.mocked(listTransactionAdjustments).mockResolvedValue([
+        { _id: "adjustment-1", status },
+      ] as never);
+
+      await expect(
+        voidTransaction(createVoidCtx() as never, {
+          actorStaffProfileId: "staff-1" as Id<"staffProfile">,
+          approvalProofId: "approval-proof-1" as Id<"approvalProof">,
+          reason: "Duplicate sale",
+          transactionId: "txn-1" as Id<"posTransaction">,
+        }),
+      ).resolves.toMatchObject({
+        kind: "user_error",
+        error: {
+          code: "precondition_failed",
+        },
+      });
+
+      expect(consumeCommandApprovalProofWithCtx).not.toHaveBeenCalled();
+      expectNoVoidBusinessSideEffects();
+    },
+  );
+
+  it("blocks transactions from a completed EOD Review before reversal writes", async () => {
+    const ctx = createVoidCtx({
+      completedDailyCloses: [
+        {
+          _id: "daily-close-1",
+          lifecycleStatus: "active",
+          operatingDate: "2026-05-21",
+          reportSnapshot: {
+            closeMetadata: {
+              startAt: Date.UTC(2026, 4, 21, 0),
+              endAt: Date.UTC(2026, 4, 22, 0),
+            },
+          },
+          status: "completed",
+          storeId: "store-1",
+        },
+      ],
+    });
+
+    await expect(
+      voidTransaction(ctx as never, {
+        actorStaffProfileId: "staff-1" as Id<"staffProfile">,
+        approvalProofId: "approval-proof-1" as Id<"approvalProof">,
+        reason: "Duplicate sale",
+        transactionId: "txn-1" as Id<"posTransaction">,
+      }),
+    ).resolves.toMatchObject({
+      kind: "user_error",
+      error: {
+        code: "precondition_failed",
+        message:
+          "EOD Review is completed for this sale. Reopen EOD Review before voiding it.",
+      },
+    });
+
+    expect(consumeCommandApprovalProofWithCtx).not.toHaveBeenCalled();
+    expectNoVoidBusinessSideEffects();
   });
 });
 

--- a/packages/athena-webapp/convex/pos/application/getTransactions.test.ts
+++ b/packages/athena-webapp/convex/pos/application/getTransactions.test.ts
@@ -183,6 +183,42 @@ describe("getCompletedTransactions", () => {
     ]);
   });
 
+  it("keeps voided completed sales visible in the completed history read model", async () => {
+    vi.mocked(listCompletedTransactions).mockResolvedValue([
+      {
+        _id: "txn-void" as Id<"posTransaction">,
+        storeId: "store-1" as Id<"store">,
+        transactionNumber: "POS-VOID",
+        total: 1000,
+        paymentMethod: "cash",
+        payments: [{ amount: 1000, method: "cash", timestamp: 1 }],
+        status: "void",
+        completedAt: 100,
+        voidedAt: 200,
+        voidReason: "Duplicate sale",
+        voidApprovalRequestId: "approval-request-1" as Id<"approvalRequest">,
+        voidApprovalProofId: "approval-proof-1" as Id<"approvalProof">,
+      },
+    ] as never);
+    vi.mocked(getCashierById).mockResolvedValue(null as never);
+    vi.mocked(getPosSessionById).mockResolvedValue(null as never);
+    vi.mocked(listTransactionItems).mockResolvedValue([] as never);
+
+    const result = await getCompletedTransactions({} as never, {
+      storeId: "store-1" as Id<"store">,
+    });
+
+    expect(result).toEqual([
+      expect.objectContaining({
+        status: "void",
+        voidedAt: 200,
+        voidReason: "Duplicate sale",
+        voidApprovalRequestId: "approval-request-1",
+        voidApprovalProofId: "approval-proof-1",
+      }),
+    ]);
+  });
+
   it("passes the completed-from lower bound into the completed transaction repository", async () => {
     vi.mocked(listCompletedTransactions).mockResolvedValue([] as never);
 
@@ -475,6 +511,88 @@ describe("getTransactionById", () => {
         registerNumber: "2",
         registerSessionId: "register-session-1",
         registerSessionStatus: "closing",
+      }),
+    );
+  });
+
+  it("returns void metadata and void audit history for transaction detail", async () => {
+    vi.mocked(getPosTransactionById).mockResolvedValue({
+      _id: "txn-void" as Id<"posTransaction">,
+      storeId: "store-1" as Id<"store">,
+      transactionNumber: "POS-VOID",
+      subtotal: 1000,
+      tax: 0,
+      total: 1000,
+      paymentMethod: "cash",
+      payments: [{ method: "cash", amount: 1000, timestamp: 1 }],
+      totalPaid: 1000,
+      status: "void",
+      completedAt: 100,
+      notes: "Legacy void note",
+      voidedAt: 200,
+      voidReason: "Duplicate sale",
+      voidedByStaffProfileId: "staff-1" as Id<"staffProfile">,
+      voidApprovalRequestId: "approval-request-1" as Id<"approvalRequest">,
+      voidApprovalProofId: "approval-proof-1" as Id<"approvalProof">,
+      voidApprovedByStaffProfileId: "manager-1" as Id<"staffProfile">,
+      voidOperationalEventId: "event-void" as Id<"operationalEvent">,
+    } as never);
+    vi.mocked(getCashierById).mockResolvedValue(null as never);
+    vi.mocked(getPosSessionById).mockResolvedValue(null as never);
+    vi.mocked(listTransactionItems).mockResolvedValue([] as never);
+
+    const result = await getTransactionById(
+      {
+        db: mockCorrectionHistoryDb({
+          correctionHistory: [
+            {
+              _id: "event-void",
+              actorStaffProfileId: "staff-1",
+              createdAt: 200,
+              eventType: "pos_transaction_voided",
+              message: "Voided Transaction #POS-VOID.",
+              metadata: {
+                inventoryMovementIds: ["movement-1"],
+                paymentAllocationIds: ["allocation-1"],
+              },
+              reason: "Duplicate sale",
+            },
+          ],
+          get: vi.fn(async (tableName: string, id: string) => {
+            if (tableName === "staffProfile" && id === "staff-1") {
+              return {
+                _id: "staff-1",
+                firstName: "Ama",
+                lastName: "Mensah",
+              };
+            }
+            return null;
+          }),
+        }),
+      } as never,
+      {
+        transactionId: "txn-void" as Id<"posTransaction">,
+      },
+    );
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        status: "void",
+        voidedAt: 200,
+        voidReason: "Duplicate sale",
+        voidedByStaffProfileId: "staff-1",
+        voidApprovalRequestId: "approval-request-1",
+        voidApprovalProofId: "approval-proof-1",
+        voidApprovedByStaffProfileId: "manager-1",
+        voidOperationalEventId: "event-void",
+        correctionHistory: [
+          expect.objectContaining({
+            _id: "event-void",
+            actorStaffName: "Ama M.",
+            eventType: "pos_transaction_voided",
+            reason: "Duplicate sale",
+          }),
+        ],
       }),
     );
   });

--- a/packages/athena-webapp/convex/pos/application/queries/getTransactions.ts
+++ b/packages/athena-webapp/convex/pos/application/queries/getTransactions.ts
@@ -279,7 +279,12 @@ export async function getCompletedTransactions(
         paymentMethod: transaction.paymentMethod || null,
         paymentMethods,
         hasMultiplePaymentMethods: paymentMethods.length > 1,
+        status: transaction.status,
         completedAt: transaction.completedAt,
+        voidedAt: transaction.voidedAt,
+        voidReason: transaction.voidReason,
+        voidApprovalRequestId: transaction.voidApprovalRequestId,
+        voidApprovalProofId: transaction.voidApprovalProofId,
         hasTrace: Boolean(sessionTraceId),
         sessionTraceId,
         cashierName: cashier
@@ -443,6 +448,13 @@ export async function getTransactionById(
     status: transaction.status,
     completedAt: transaction.completedAt,
     notes: transaction.notes,
+    voidedAt: transaction.voidedAt,
+    voidReason: transaction.voidReason ?? transaction.notes,
+    voidedByStaffProfileId: transaction.voidedByStaffProfileId,
+    voidApprovalRequestId: transaction.voidApprovalRequestId,
+    voidApprovalProofId: transaction.voidApprovalProofId,
+    voidApprovedByStaffProfileId: transaction.voidApprovedByStaffProfileId,
+    voidOperationalEventId: transaction.voidOperationalEventId,
     cashier: cashier
       ? {
           _id: cashier._id,

--- a/packages/athena-webapp/convex/pos/infrastructure/integrations/paymentAllocationService.ts
+++ b/packages/athena-webapp/convex/pos/infrastructure/integrations/paymentAllocationService.ts
@@ -68,9 +68,9 @@ export async function recordRetailVoidPaymentAllocations(
     targetType: "pos_transaction",
   });
 
-  await Promise.all(
+  const recordedAllocations = await Promise.all(
     allocations.map((allocation) => recordPaymentAllocationWithCtx(ctx, allocation)),
   );
 
-  return allocations.length > 0;
+  return recordedAllocations.filter(Boolean);
 }

--- a/packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts
+++ b/packages/athena-webapp/convex/pos/infrastructure/repositories/transactionRepository.ts
@@ -251,30 +251,47 @@ export async function listCompletedTransactions(
     limit?: number;
   },
 ) {
+  const limit = args.limit ?? 50;
   if (args.registerSessionId) {
-    return ctx.db
-      .query("posTransaction")
-      .withIndex("by_storeId_status_registerSessionId_completedAt", (q) =>
-        q
-          .eq("storeId", args.storeId)
-          .eq("status", "completed")
-          .eq("registerSessionId", args.registerSessionId)
-          .gte("completedAt", args.completedFrom ?? 0),
-      )
-      .order("desc")
-      .take(args.limit ?? 50);
+    const [completed, voided] = await Promise.all(
+      (["completed", "void"] as const).map((status) =>
+        ctx.db
+          .query("posTransaction")
+          .withIndex("by_storeId_status_registerSessionId_completedAt", (q) =>
+            q
+              .eq("storeId", args.storeId)
+              .eq("status", status)
+              .eq("registerSessionId", args.registerSessionId)
+              .gte("completedAt", args.completedFrom ?? 0),
+          )
+          .order("desc")
+          .take(limit),
+      ),
+    );
+
+    return [...completed, ...voided]
+      .sort((first, second) => second.completedAt - first.completedAt)
+      .slice(0, limit);
   }
 
-  return ctx.db
-    .query("posTransaction")
-    .withIndex("by_storeId_status_completedAt", (q) =>
-      q
-        .eq("storeId", args.storeId)
-        .eq("status", "completed")
-        .gte("completedAt", args.completedFrom ?? 0),
-    )
-    .order("desc")
-    .take(args.limit ?? 50);
+  const [completed, voided] = await Promise.all(
+    (["completed", "void"] as const).map((status) =>
+      ctx.db
+        .query("posTransaction")
+        .withIndex("by_storeId_status_completedAt", (q) =>
+          q
+            .eq("storeId", args.storeId)
+            .eq("status", status)
+            .gte("completedAt", args.completedFrom ?? 0),
+        )
+        .order("desc")
+        .take(limit),
+    ),
+  );
+
+  return [...completed, ...voided]
+    .sort((first, second) => second.completedAt - first.completedAt)
+    .slice(0, limit);
 }
 
 export async function listCompletedTransactionsForDay(

--- a/packages/athena-webapp/convex/pos/public/transactions.test.ts
+++ b/packages/athena-webapp/convex/pos/public/transactions.test.ts
@@ -5,9 +5,12 @@ import {
   correctTransactionPaymentMethod,
   getCompletedTransactions,
   getTransactionById,
+  voidTransaction,
 } from "./transactions";
+import type { Id } from "../../_generated/dataModel";
 import * as athenaUserAuth from "../../lib/athenaUserAuth";
 import * as itemAdjustmentCommands from "../application/commands/adjustTransactionItems";
+import * as completeTransactionCommands from "../application/commands/completeTransaction";
 import * as transactionQueries from "../application/queries/getTransactions";
 
 vi.mock("../../lib/athenaUserAuth", () => ({
@@ -26,6 +29,13 @@ vi.mock("../application/queries/getTransactions", () => ({
 
 vi.mock("../application/commands/adjustTransactionItems", () => ({
   adjustTransactionItems: vi.fn(),
+}));
+
+vi.mock("../application/commands/completeTransaction", () => ({
+  completeTransaction: vi.fn(),
+  createTransactionFromSessionHandler: vi.fn(),
+  updateInventory: vi.fn(),
+  voidTransaction: vi.fn(),
 }));
 
 type SerializedValidator = {
@@ -67,6 +77,20 @@ describe("POS public transaction query validators", () => {
     expect(JSON.stringify(validator)).toContain("posTransactionAdjustment");
   });
 
+  it("allows completed transaction voids to return approval requirements and stable success data", () => {
+    const validator = parseValidator(exportReturns(voidTransaction));
+    const validatorJson = JSON.stringify(validator);
+
+    expect(validator.type).toBe("union");
+    expect(validatorJson).toContain("approval_required");
+    expect(validatorJson).toContain("inline_manager_proof");
+    expect(validatorJson).toContain("paymentAllocation");
+    expect(validatorJson).toContain("inventoryMovement");
+    expect(validatorJson).toContain("operationalEvent");
+    expect(validatorJson).toContain("approvalProof");
+    expect(validatorJson).toContain("voidedAt");
+  });
+
   it("exposes session trace ids for completed transaction lists", () => {
     const validator = parseValidator(exportReturns(getCompletedTransactions));
 
@@ -86,6 +110,8 @@ describe("POS public transaction query validators", () => {
           fieldType: { type: "boolean" },
           optional: false,
         },
+        status: expect.any(Object),
+        voidedAt: expect.any(Object),
       },
     });
   });
@@ -102,6 +128,218 @@ describe("POS public transaction query validators", () => {
         terminalId: expect.any(Object),
       },
     });
+  });
+});
+
+describe("voidTransaction public mutation", () => {
+  function createAuthorizedVoidCtx(overrides?: {
+    credential?: Record<string, unknown> | null;
+    proof?: Record<string, unknown> | null;
+    staffProfile?: Record<string, unknown> | null;
+  }) {
+    const staffProof = {
+      _id: "proof-row-1",
+      credentialId: "credential-1",
+      credentialVersion: 3,
+      expiresAt: Date.now() + 60_000,
+      staffProfileId: "staff-1",
+      status: "active",
+      storeId: "store-1",
+      terminalId: "terminal-1",
+      ...overrides?.proof,
+    };
+    const staffProfile = {
+      _id: "staff-1",
+      status: "active",
+      storeId: "store-1",
+      ...overrides?.staffProfile,
+    };
+    const credential = {
+      _id: "credential-1",
+      localVerifierVersion: 3,
+      staffProfileId: "staff-1",
+      status: "active",
+      storeId: "store-1",
+      ...overrides?.credential,
+    };
+
+    vi.mocked(transactionQueries.getTransaction).mockResolvedValue({
+      _id: "txn-1",
+      storeId: "store-1",
+      terminalId: "terminal-1",
+    } as never);
+    vi.mocked(athenaUserAuth.requireAuthenticatedAthenaUserWithCtx).mockResolvedValue({
+      _id: "user-1",
+    } as never);
+
+    return {
+      db: {
+        get: vi.fn(async (tableName: string, id: string) => {
+          if (tableName === "store" && id === "store-1") {
+            return { _id: "store-1", organizationId: "org-1" };
+          }
+          if (tableName === "staffProfile" && id === "staff-1") {
+            return overrides?.staffProfile === null ? null : staffProfile;
+          }
+          if (tableName === "staffCredential" && id === "credential-1") {
+            return credential;
+          }
+          return null;
+        }),
+        patch: vi.fn(),
+        query: vi.fn(() => ({
+          withIndex: vi.fn(() => ({
+            unique: vi.fn(async () =>
+              overrides?.proof === null ? null : staffProof,
+            ),
+          })),
+        })),
+      },
+    };
+  }
+
+  it("requires a signed-in staff actor before voiding a completed transaction", async () => {
+    await expect(
+      getHandler(voidTransaction)({} as never, {
+        reason: "Duplicate sale",
+        transactionId: "txn-1" as Id<"posTransaction">,
+      }),
+    ).resolves.toMatchObject({
+      kind: "user_error",
+      error: {
+        code: "authentication_failed",
+      },
+    });
+
+    expect(completeTransactionCommands.voidTransaction).not.toHaveBeenCalled();
+  });
+
+  it("wraps command approval requirements on the shared command-result rail", async () => {
+    vi.mocked(completeTransactionCommands.voidTransaction).mockResolvedValue({
+      approval: {
+        action: {
+          key: "pos.transaction.void",
+        },
+        copy: {
+          title: "Manager approval required",
+          message: "Review completed sale void.",
+        },
+        reason: "Manager approval is required.",
+        requiredRole: "manager",
+        resolutionModes: [{ kind: "inline_manager_proof" }],
+        subject: {
+          id: "txn-1",
+          type: "pos_transaction",
+        },
+      },
+      kind: "approval_required",
+      transactionId: "txn-1",
+    } as never);
+
+    await expect(
+      getHandler(voidTransaction)(createAuthorizedVoidCtx() as never, {
+        actorStaffProfileId: "staff-1" as Id<"staffProfile">,
+        reason: "Duplicate sale",
+        staffProofToken: "proof-token-1",
+        transactionId: "txn-1" as Id<"posTransaction">,
+      }),
+    ).resolves.toMatchObject({
+      kind: "approval_required",
+      approval: {
+        action: {
+          key: "pos.transaction.void",
+        },
+      },
+    });
+    expect(
+      athenaUserAuth.requireOrganizationMemberRoleWithCtx,
+    ).toHaveBeenCalledWith(expect.any(Object), {
+      allowedRoles: ["full_admin", "pos_only"],
+      failureMessage: "You cannot void this transaction.",
+      organizationId: "org-1",
+      userId: "user-1",
+    });
+    expect(completeTransactionCommands.voidTransaction).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.objectContaining({
+        actorStaffProfileId: "staff-1",
+        actorUserId: "user-1",
+      }),
+    );
+    expect(
+      vi.mocked(completeTransactionCommands.voidTransaction).mock.calls[0]?.[1],
+    ).not.toHaveProperty("staffProofToken");
+  });
+
+  it.each([
+    ["missing staff profile", { staffProfile: null }],
+    ["inactive staff profile", { staffProfile: { status: "inactive" } }],
+    ["cross-store staff profile", { staffProfile: { storeId: "store-other" } }],
+    ["missing staff proof", { proof: null }],
+    ["expired staff proof", { proof: { expiresAt: Date.now() - 1 } }],
+    ["mismatched staff proof", { proof: { staffProfileId: "staff-other" } }],
+    ["cross-terminal staff proof", { proof: { terminalId: "terminal-other" } }],
+    ["inactive staff credential", { credential: { status: "revoked" } }],
+    [
+      "mismatched staff credential",
+      { credential: { staffProfileId: "staff-other" } },
+    ],
+  ])("rejects %s before invoking the void command", async (_label, overrides) => {
+    await expect(
+      getHandler(voidTransaction)(
+        createAuthorizedVoidCtx(overrides as never) as never,
+        {
+          actorStaffProfileId: "staff-1" as Id<"staffProfile">,
+          reason: "Duplicate sale",
+          staffProofToken: "proof-token-1",
+          transactionId: "txn-1" as Id<"posTransaction">,
+        },
+      ),
+    ).resolves.toMatchObject({
+      kind: "user_error",
+      error: {
+        code: "authentication_failed",
+      },
+    });
+    expect(completeTransactionCommands.voidTransaction).not.toHaveBeenCalled();
+  });
+
+  it("does not use staff proof or invoke void command when authentication fails", async () => {
+    vi.mocked(
+      athenaUserAuth.requireAuthenticatedAthenaUserWithCtx,
+    ).mockRejectedValueOnce(new Error("Sign in again to continue."));
+    const ctx = createAuthorizedVoidCtx();
+
+    await expect(
+      getHandler(voidTransaction)(ctx as never, {
+        actorStaffProfileId: "staff-1" as Id<"staffProfile">,
+        reason: "Duplicate sale",
+        staffProofToken: "proof-token-1",
+        transactionId: "txn-1" as Id<"posTransaction">,
+      }),
+    ).rejects.toThrow("Sign in again to continue.");
+
+    expect(ctx.db.patch).not.toHaveBeenCalled();
+    expect(completeTransactionCommands.voidTransaction).not.toHaveBeenCalled();
+  });
+
+  it("does not use staff proof or invoke void command when authorization fails", async () => {
+    vi.mocked(
+      athenaUserAuth.requireOrganizationMemberRoleWithCtx,
+    ).mockRejectedValueOnce(new Error("You cannot void this transaction."));
+    const ctx = createAuthorizedVoidCtx();
+
+    await expect(
+      getHandler(voidTransaction)(ctx as never, {
+        actorStaffProfileId: "staff-1" as Id<"staffProfile">,
+        reason: "Duplicate sale",
+        staffProofToken: "proof-token-1",
+        transactionId: "txn-1" as Id<"posTransaction">,
+      }),
+    ).rejects.toThrow("You cannot void this transaction.");
+
+    expect(ctx.db.patch).not.toHaveBeenCalled();
+    expect(completeTransactionCommands.voidTransaction).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/athena-webapp/convex/pos/public/transactions.ts
+++ b/packages/athena-webapp/convex/pos/public/transactions.ts
@@ -132,6 +132,20 @@ const adjustTransactionItemsResultValidator = commandResultValidator(
   }),
 );
 
+const voidTransactionResultValidator = commandResultValidator(
+  v.object({
+    transactionId: v.id("posTransaction"),
+    transactionNumber: v.string(),
+    voidedAt: v.number(),
+    paymentAllocationIds: v.array(v.id("paymentAllocation")),
+    inventoryMovementIds: v.array(v.id("inventoryMovement")),
+    operationalEventId: v.optional(v.id("operationalEvent")),
+    approvalProofId: v.optional(v.id("approvalProof")),
+    approvalRequestId: v.optional(v.id("approvalRequest")),
+    approverStaffProfileId: v.optional(v.id("staffProfile")),
+  }),
+);
+
 function mapCorrectionError(error: unknown): CommandResult<never> | null {
   const message = error instanceof Error ? error.message : "";
 
@@ -255,7 +269,12 @@ export const getCompletedTransactions = query({
       paymentMethod: v.union(v.string(), v.null()),
       paymentMethods: v.array(v.string()),
       hasMultiplePaymentMethods: v.boolean(),
+      status: v.string(),
       completedAt: v.number(),
+      voidedAt: v.optional(v.number()),
+      voidReason: v.optional(v.string()),
+      voidApprovalRequestId: v.optional(v.id("approvalRequest")),
+      voidApprovalProofId: v.optional(v.id("approvalProof")),
       hasTrace: v.boolean(),
       sessionTraceId: v.union(v.string(), v.null()),
       cashierName: v.union(v.string(), v.null()),
@@ -304,6 +323,13 @@ export const getTransactionById = query({
       status: v.string(),
       completedAt: v.number(),
       notes: v.optional(v.string()),
+      voidedAt: v.optional(v.number()),
+      voidReason: v.optional(v.string()),
+      voidedByStaffProfileId: v.optional(v.id("staffProfile")),
+      voidApprovalRequestId: v.optional(v.id("approvalRequest")),
+      voidApprovalProofId: v.optional(v.id("approvalProof")),
+      voidApprovedByStaffProfileId: v.optional(v.id("staffProfile")),
+      voidOperationalEventId: v.optional(v.id("operationalEvent")),
       cashier: v.union(
         v.null(),
         v.object({
@@ -398,11 +424,128 @@ export const getTransactionById = query({
 
 export const voidTransaction = mutation({
   args: {
+    approvalRequestId: v.optional(v.id("approvalRequest")),
+    approvalProofId: v.optional(v.id("approvalProof")),
     transactionId: v.id("posTransaction"),
     reason: v.string(),
     staffProfileId: v.optional(v.id("staffProfile")),
+    actorStaffProfileId: v.optional(v.id("staffProfile")),
+    staffProofToken: v.string(),
   },
-  handler: async (ctx, args) => voidTransactionCommand(ctx, args),
+  returns: voidTransactionResultValidator,
+  handler: async (ctx, args) => {
+    const actorStaffProfileId = args.actorStaffProfileId ?? args.staffProfileId;
+
+    if (!actorStaffProfileId) {
+      return userError({
+        code: "authentication_failed",
+        message: "Staff sign-in is required before voiding a completed sale.",
+      });
+    }
+
+    if (!args.reason.trim()) {
+      return userError({
+        code: "validation_failed",
+        message: "Reason is required to void a completed sale.",
+      });
+    }
+
+    const transaction = await getTransactionQuery(ctx, {
+      transactionId: args.transactionId,
+    });
+    if (!transaction) {
+      return userError({
+        code: "not_found",
+        message: "Transaction not found.",
+      });
+    }
+
+    const store = await ctx.db.get("store", transaction.storeId);
+    if (!store) {
+      return userError({
+        code: "not_found",
+        message: "Store not found.",
+      });
+    }
+
+    const athenaUser = await requireAuthenticatedAthenaUserWithCtx(ctx);
+    await requireOrganizationMemberRoleWithCtx(ctx, {
+      allowedRoles: ["full_admin", "pos_only"],
+      failureMessage: "You cannot void this transaction.",
+      organizationId: store.organizationId,
+      userId: athenaUser._id,
+    });
+
+    const staffProfile = await ctx.db.get("staffProfile", actorStaffProfileId);
+    if (
+      !staffProfile ||
+      staffProfile.status !== "active" ||
+      staffProfile.storeId !== transaction.storeId
+    ) {
+      return userError({
+        code: "authentication_failed",
+        message: "Void staff profile is not active for this store.",
+      });
+    }
+
+    const staffProofTokenHash = await hashPosLocalStaffProofToken(
+      args.staffProofToken,
+    );
+    const proof = await ctx.db
+      .query("posLocalStaffProof")
+      .withIndex("by_tokenHash", (q) => q.eq("tokenHash", staffProofTokenHash))
+      .unique();
+    if (
+      !proof ||
+      proof.status !== "active" ||
+      proof.staffProfileId !== actorStaffProfileId ||
+      proof.storeId !== transaction.storeId ||
+      proof.expiresAt <= Date.now()
+    ) {
+      return userError({
+        code: "authentication_failed",
+        message: "Void staff proof is invalid or expired.",
+      });
+    }
+
+    if (transaction.terminalId && proof.terminalId !== transaction.terminalId) {
+      return userError({
+        code: "authentication_failed",
+        message: "Void staff proof is invalid for this terminal.",
+      });
+    }
+
+    const credential = await ctx.db.get("staffCredential", proof.credentialId);
+    if (
+      !credential ||
+      credential.status !== "active" ||
+      credential.staffProfileId !== actorStaffProfileId ||
+      credential.storeId !== transaction.storeId ||
+      credential.localVerifierVersion !== proof.credentialVersion
+    ) {
+      return userError({
+        code: "authentication_failed",
+        message: "Void staff proof is invalid or expired.",
+      });
+    }
+
+    await ctx.db.patch("posLocalStaffProof", proof._id, {
+      lastUsedAt: Date.now(),
+    });
+
+    const { staffProofToken: _staffProofToken, ...commandArgs } = args;
+    const result = await voidTransactionCommand(ctx, {
+      ...commandArgs,
+      actorStaffProfileId,
+      actorUserId: athenaUser._id,
+    });
+
+    if (result.kind === "approval_required") {
+      return result;
+    }
+
+    return result;
+  },
 });
 
 export const createTransactionFromSession = mutation({

--- a/packages/athena-webapp/convex/schemas/operations/registerSession.ts
+++ b/packages/athena-webapp/convex/schemas/operations/registerSession.ts
@@ -6,6 +6,7 @@ export const registerSessionSchema = v.object({
   terminalId: v.optional(v.id("posTerminal")),
   registerNumber: v.optional(v.string()),
   workflowTraceId: v.optional(v.string()),
+  recordedTransactionKeys: v.optional(v.array(v.string())),
   status: v.union(
     v.literal("open"),
     v.literal("active"),

--- a/packages/athena-webapp/convex/schemas/pos/posTransaction.ts
+++ b/packages/athena-webapp/convex/schemas/pos/posTransaction.ts
@@ -38,5 +38,11 @@ export const posTransactionSchema = v.object({
   refundReason: v.optional(v.string()),
   refundedAt: v.optional(v.number()),
   voidedAt: v.optional(v.number()),
+  voidReason: v.optional(v.string()),
+  voidedByStaffProfileId: v.optional(v.id("staffProfile")),
+  voidApprovalRequestId: v.optional(v.id("approvalRequest")),
+  voidApprovalProofId: v.optional(v.id("approvalProof")),
+  voidApprovedByStaffProfileId: v.optional(v.id("staffProfile")),
+  voidOperationalEventId: v.optional(v.id("operationalEvent")),
   receiptPrinted: v.optional(v.boolean()),
 });

--- a/packages/athena-webapp/src/components/pos/transactions/TransactionView.test.tsx
+++ b/packages/athena-webapp/src/components/pos/transactions/TransactionView.test.tsx
@@ -203,6 +203,7 @@ vi.mock("../../operations/CommandApprovalDialog", () => ({
     approval,
     onAuthenticateForApproval,
     onApproved,
+    onDismiss,
     open,
     requestedByStaffProfileId,
   }: {
@@ -240,6 +241,7 @@ vi.mock("../../operations/CommandApprovalDialog", () => ({
       approvedByStaffProfileId: string;
       expiresAt: number;
     }) => void;
+    onDismiss: () => void;
     open: boolean;
     requestedByStaffProfileId?: string;
   }) =>
@@ -284,6 +286,9 @@ vi.mock("../../operations/CommandApprovalDialog", () => ({
             is pending in the review queue.
           </p>
         )}
+        <button onClick={onDismiss} type="button">
+          Cancel
+        </button>
       </div>
     ) : null,
 }));
@@ -417,6 +422,38 @@ describe("TransactionView", () => {
     };
   }
 
+  function voidApprovalRequirement(
+    transactionId = "txn_void",
+    options: { includeAsyncRequest?: boolean } = {},
+  ) {
+    return {
+      action: { key: "pos.transaction.void" },
+      copy: {
+        title: "Manager approval required",
+        message:
+          "A manager needs to review this completed sale void before it is applied.",
+        primaryActionLabel: "Approve void",
+      },
+      reason: "Manager approval is required to void a completed POS sale.",
+      requiredRole: "manager" as const,
+      resolutionModes: options.includeAsyncRequest
+        ? [
+            { kind: "inline_manager_proof" },
+            {
+              approvalRequestId: "approval-void-1",
+              kind: "async_request",
+              requestType: "pos_transaction_void",
+            },
+          ]
+        : [{ kind: "inline_manager_proof" }],
+      subject: {
+        id: transactionId,
+        label: "Transaction #POS-123456",
+        type: "pos_transaction",
+      },
+    };
+  }
+
   beforeEach(() => {
     useActionMock.mockReset();
     useActionMock.mockReturnValue(vi.fn());
@@ -437,6 +474,7 @@ describe("TransactionView", () => {
     approvalMutation: ReturnType<typeof vi.fn> = vi.fn(),
     itemAdjustmentMutation: ReturnType<typeof vi.fn> = vi.fn(),
     terminalAuthMutation: ReturnType<typeof vi.fn> = authMutation,
+    voidMutation: ReturnType<typeof vi.fn> = vi.fn(),
   ) {
     const mutations = [
       authMutation,
@@ -445,6 +483,7 @@ describe("TransactionView", () => {
       paymentMutation,
       customerMutation,
       itemAdjustmentMutation,
+      voidMutation,
     ];
     let mutationIndex = 0;
     useMutationMock.mockImplementation(
@@ -672,6 +711,391 @@ describe("TransactionView", () => {
     expect(
       screen.getByRole("button", { name: "Items or quantities" }),
     ).toBeInTheDocument();
+  });
+
+  it("opens manager approval for completed sale voids", async () => {
+    const user = userEvent.setup();
+    const authMutation = vi.fn().mockResolvedValue({
+      kind: "ok",
+      data: {
+        activeRoles: ["cashier"],
+        posLocalStaffProof: { expiresAt: 2, token: "proof-token-1" },
+        staffProfile: { firstName: "Kwamina", lastName: "Mensah" },
+        staffProfileId: "staff_1",
+      },
+    });
+    const voidMutation = vi.fn().mockResolvedValue({
+      kind: "approval_required",
+      approval: voidApprovalRequirement("txn_void"),
+    });
+    mockTransactionMutations(
+      authMutation,
+      vi.fn(),
+      vi.fn(),
+      vi.fn(),
+      vi.fn(),
+      authMutation,
+      voidMutation,
+    );
+    useParamsMock.mockReturnValue({ transactionId: "txn_void" });
+    useQueryMock.mockReturnValue(baseTransaction);
+
+    render(<TransactionView />);
+
+    await user.click(screen.getByRole("button", { name: "Void sale" }));
+    await user.type(
+      screen.getByLabelText("Void reason"),
+      "Duplicate sale recorded.",
+    );
+    await user.click(screen.getByRole("button", { name: "Submit void" }));
+    await user.click(screen.getByRole("button", { name: "Confirm" }));
+
+    expect(screen.getByText("Manager approval required")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "A manager needs to review this completed sale void before it is applied.",
+      ),
+    ).toBeInTheDocument();
+    expect(voidMutation).toHaveBeenCalledWith({
+      actorStaffProfileId: "staff_1",
+      approvalProofId: undefined,
+      approvalRequestId: undefined,
+      reason: "Duplicate sale recorded.",
+      staffProofToken: "proof-token-1",
+      transactionId: "txn_void",
+    });
+  });
+
+  it("queues completed sale voids when the approval response includes an async request", async () => {
+    const user = userEvent.setup();
+    const authMutation = vi.fn().mockResolvedValue({
+      kind: "ok",
+      data: {
+        activeRoles: ["cashier"],
+        posLocalStaffProof: { expiresAt: 2, token: "proof-token-1" },
+        staffProfile: { firstName: "Kwamina", lastName: "Mensah" },
+        staffProfileId: "staff_1",
+      },
+    });
+    const voidMutation = vi.fn().mockResolvedValue({
+      kind: "approval_required",
+      approval: voidApprovalRequirement("txn_void_async", {
+        includeAsyncRequest: true,
+      }),
+    });
+    mockTransactionMutations(
+      authMutation,
+      vi.fn(),
+      vi.fn(),
+      vi.fn(),
+      vi.fn(),
+      authMutation,
+      voidMutation,
+    );
+    useParamsMock.mockReturnValue({ transactionId: "txn_void_async" });
+    useQueryMock.mockReturnValue(baseTransaction);
+
+    render(<TransactionView />);
+
+    await user.click(screen.getByRole("button", { name: "Void sale" }));
+    await user.type(screen.getByLabelText("Void reason"), "Duplicate sale.");
+    await user.click(screen.getByRole("button", { name: "Submit void" }));
+    await user.click(screen.getByRole("button", { name: "Confirm" }));
+
+    expect(screen.queryByText("Manager approval required")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Void reason")).not.toBeInTheDocument();
+  });
+
+  it("does not retry the void command when manager approval is cancelled", async () => {
+    const user = userEvent.setup();
+    const authMutation = vi.fn().mockResolvedValue({
+      kind: "ok",
+      data: {
+        activeRoles: ["cashier"],
+        posLocalStaffProof: { expiresAt: 2, token: "proof-token-1" },
+        staffProfile: { firstName: "Kwamina", lastName: "Mensah" },
+        staffProfileId: "staff_1",
+      },
+    });
+    const voidMutation = vi.fn().mockResolvedValue({
+      kind: "approval_required",
+      approval: voidApprovalRequirement("txn_void_cancel"),
+    });
+    mockTransactionMutations(
+      authMutation,
+      vi.fn(),
+      vi.fn(),
+      vi.fn(),
+      vi.fn(),
+      authMutation,
+      voidMutation,
+    );
+    useParamsMock.mockReturnValue({ transactionId: "txn_void_cancel" });
+    useQueryMock.mockReturnValue(baseTransaction);
+
+    render(<TransactionView />);
+
+    await user.click(screen.getByRole("button", { name: "Void sale" }));
+    await user.type(screen.getByLabelText("Void reason"), "Duplicate sale.");
+    await user.click(screen.getByRole("button", { name: "Submit void" }));
+    await user.click(screen.getByRole("button", { name: "Confirm" }));
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(voidMutation).toHaveBeenCalledTimes(1);
+    expect(
+      screen.queryByText("Manager approval required"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows a voided state after a manager-approved void succeeds", async () => {
+    const user = userEvent.setup();
+    const authMutation = vi.fn().mockResolvedValue({
+      kind: "ok",
+      data: {
+        activeRoles: ["manager"],
+        posLocalStaffProof: { expiresAt: 2, token: "proof-token-1" },
+        staffProfile: { firstName: "Kwamina", lastName: "Mensah" },
+        staffProfileId: "staff_1",
+      },
+    });
+    const approvalMutation = vi.fn().mockResolvedValue({
+      kind: "ok",
+      data: {
+        approvalProofId: "proof-void-1",
+        approvedByStaffProfileId: "staff_manager",
+        expiresAt: 2,
+      },
+    });
+    const voidMutation = vi
+      .fn()
+      .mockResolvedValueOnce({
+        kind: "approval_required",
+        approval: voidApprovalRequirement("txn_void_success", {
+          includeAsyncRequest: true,
+        }),
+      })
+      .mockResolvedValueOnce({
+        kind: "ok",
+        data: {
+          transactionId: "txn_void_success",
+          transactionNumber: "POS-123456",
+          voidedAt: 456,
+          paymentAllocationIds: ["allocation_1"],
+          inventoryMovementIds: ["movement_1"],
+          approvalProofId: "proof-void-1",
+          approverStaffProfileId: "staff_manager",
+        },
+      });
+    mockTransactionMutations(
+      authMutation,
+      vi.fn(),
+      vi.fn(),
+      approvalMutation,
+      vi.fn(),
+      authMutation,
+      voidMutation,
+    );
+    useParamsMock.mockReturnValue({ transactionId: "txn_void_success" });
+    useQueryMock.mockReturnValue(baseTransaction);
+
+    render(<TransactionView />);
+
+    await user.click(screen.getByRole("button", { name: "Void sale" }));
+    await user.type(
+      screen.getByLabelText("Void reason"),
+      "Duplicate sale recorded.",
+    );
+    await user.click(screen.getByRole("button", { name: "Submit void" }));
+    await user.click(screen.getByRole("button", { name: "Confirm" }));
+
+    await waitFor(() => {
+      expect(screen.getAllByText("Voided").length).toBeGreaterThan(0);
+      expect(screen.getByText("Sale voided")).toBeInTheDocument();
+    });
+    expect(screen.getByText("Duplicate sale recorded.")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Void sale" })).not.toBeInTheDocument();
+    expect(voidMutation).toHaveBeenLastCalledWith({
+      actorStaffProfileId: "staff_1",
+      approvalProofId: "proof-void-1",
+      approvalRequestId: "approval-void-1",
+      reason: "Duplicate sale recorded.",
+      staffProofToken: "proof-token-1",
+      transactionId: "txn_void_success",
+    });
+  });
+
+  it("renders normalized backend blocking copy for void failures", async () => {
+    const user = userEvent.setup();
+    const authMutation = vi.fn().mockResolvedValue({
+      kind: "ok",
+      data: {
+        activeRoles: ["manager"],
+        posLocalStaffProof: { expiresAt: 2, token: "proof-token-1" },
+        staffProfile: { firstName: "Kwamina", lastName: "Mensah" },
+        staffProfileId: "staff_1",
+      },
+    });
+    const voidMutation = vi.fn().mockResolvedValue({
+      kind: "user_error",
+      error: {
+        code: "precondition_failed",
+        message:
+          "Register session is already closed for this completed transaction.",
+      },
+    });
+    mockTransactionMutations(
+      authMutation,
+      vi.fn(),
+      vi.fn(),
+      vi.fn(),
+      vi.fn(),
+      authMutation,
+      voidMutation,
+    );
+    useParamsMock.mockReturnValue({ transactionId: "txn_void_blocked" });
+    useQueryMock.mockReturnValue(baseTransaction);
+
+    render(<TransactionView />);
+
+    await user.click(screen.getByRole("button", { name: "Void sale" }));
+    await user.type(screen.getByLabelText("Void reason"), "Duplicate sale.");
+    await user.click(screen.getByRole("button", { name: "Submit void" }));
+    await user.click(screen.getByRole("button", { name: "Confirm" }));
+
+    expect(
+      await screen.findByText(
+        "Register closed. Reopen the register before voiding this sale.",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(
+        "Register session is already closed for this completed transaction.",
+      ),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders normalized daily-close copy for void failures", async () => {
+    const user = userEvent.setup();
+    const authMutation = vi.fn().mockResolvedValue({
+      kind: "ok",
+      data: {
+        activeRoles: ["manager"],
+        posLocalStaffProof: { expiresAt: 2, token: "proof-token-1" },
+        staffProfile: { firstName: "Kwamina", lastName: "Mensah" },
+        staffProfileId: "staff_1",
+      },
+    });
+    const voidMutation = vi.fn().mockResolvedValue({
+      kind: "user_error",
+      error: {
+        code: "precondition_failed",
+        message: "Daily close is complete for this operating day.",
+      },
+    });
+    mockTransactionMutations(
+      authMutation,
+      vi.fn(),
+      vi.fn(),
+      vi.fn(),
+      vi.fn(),
+      authMutation,
+      voidMutation,
+    );
+    useParamsMock.mockReturnValue({ transactionId: "txn_void_daily_close" });
+    useQueryMock.mockReturnValue(baseTransaction);
+
+    render(<TransactionView />);
+
+    await user.click(screen.getByRole("button", { name: "Void sale" }));
+    await user.type(screen.getByLabelText("Void reason"), "Duplicate sale.");
+    await user.click(screen.getByRole("button", { name: "Submit void" }));
+    await user.click(screen.getByRole("button", { name: "Confirm" }));
+
+    expect(
+      await screen.findByText(
+        "Daily close completed. Reopen the day before voiding this sale.",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText("Daily close is complete for this operating day."),
+    ).not.toBeInTheDocument();
+  });
+
+  it("does not render unmapped backend void failure copy", async () => {
+    const user = userEvent.setup();
+    const authMutation = vi.fn().mockResolvedValue({
+      kind: "ok",
+      data: {
+        activeRoles: ["manager"],
+        posLocalStaffProof: { expiresAt: 2, token: "proof-token-1" },
+        staffProfile: { firstName: "Kwamina", lastName: "Mensah" },
+        staffProfileId: "staff_1",
+      },
+    });
+    const voidMutation = vi.fn().mockResolvedValue({
+      kind: "user_error",
+      error: {
+        code: "authorization_failed",
+        message: "You cannot void this transaction.",
+      },
+    });
+    mockTransactionMutations(
+      authMutation,
+      vi.fn(),
+      vi.fn(),
+      vi.fn(),
+      vi.fn(),
+      authMutation,
+      voidMutation,
+    );
+    useParamsMock.mockReturnValue({ transactionId: "txn_void_auth" });
+    useQueryMock.mockReturnValue(baseTransaction);
+
+    render(<TransactionView />);
+
+    await user.click(screen.getByRole("button", { name: "Void sale" }));
+    await user.type(screen.getByLabelText("Void reason"), "Duplicate sale.");
+    await user.click(screen.getByRole("button", { name: "Submit void" }));
+    await user.click(screen.getByRole("button", { name: "Confirm" }));
+
+    expect(
+      await screen.findByText(
+        "Sale could not be voided. Check the transaction state and try again.",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText("You cannot void this transaction."),
+    ).not.toBeInTheDocument();
+  });
+
+  it("hides the void submission path when the read model marks the sale blocked", () => {
+    useParamsMock.mockReturnValue({ transactionId: "txn_void_blocked_model" });
+    useQueryMock.mockReturnValue({
+      ...baseTransaction,
+      voidEligibility: { eligible: false },
+    });
+
+    render(<TransactionView />);
+
+    expect(screen.queryByRole("button", { name: "Void sale" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Submit void" })).not.toBeInTheDocument();
+  });
+
+  it("hides the void submission path for already voided transactions", () => {
+    useParamsMock.mockReturnValue({ transactionId: "txn_voided" });
+    useQueryMock.mockReturnValue({
+      ...baseTransaction,
+      status: "void",
+      voidReason: "Duplicate sale.",
+      voidedAt: 456,
+    });
+
+    render(<TransactionView />);
+
+    expect(screen.getAllByText("Voided").length).toBeGreaterThan(0);
+    expect(screen.getByText("Sale voided")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Void sale" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Submit void" })).not.toBeInTheDocument();
   });
 
   it("routes high-risk transaction corrections to safe guidance", async () => {

--- a/packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx
+++ b/packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx
@@ -4,6 +4,7 @@ import { useMutation, useQuery } from "convex/react";
 import { toast } from "sonner";
 import {
   Banknote,
+  Ban,
   CheckCircle2,
   CreditCard,
   Minus,
@@ -92,6 +93,17 @@ type ItemAdjustmentResultData = {
   settlementDirection?: string;
   settlementMethod?: string;
   transactionId: Id<"posTransaction">;
+};
+
+type TransactionVoidResultData = {
+  approvalProofId?: Id<"approvalProof">;
+  approverStaffProfileId?: Id<"staffProfile">;
+  inventoryMovementIds: Array<Id<"inventoryMovement">>;
+  operationalEventId?: Id<"operationalEvent">;
+  paymentAllocationIds: Array<Id<"paymentAllocation">>;
+  transactionId: Id<"posTransaction">;
+  transactionNumber: string;
+  voidedAt: number;
 };
 
 type TransactionWithReceiptDelivery = {
@@ -240,6 +252,45 @@ function getTransactionCorrectionHistory(transaction: {
   ].sort((first, second) => second.createdAt - first.createdAt);
 }
 
+function normalizeVoidCommandError(message: string) {
+  const normalizedMessage = message.toLowerCase();
+
+  if (
+    normalizedMessage.includes("daily close") ||
+    normalizedMessage.includes("operating day") ||
+    normalizedMessage.includes("day is closed")
+  ) {
+    return "Daily close completed. Reopen the day before voiding this sale.";
+  }
+
+  if (
+    normalizedMessage.includes("register") ||
+    normalizedMessage.includes("drawer") ||
+    normalizedMessage.includes("closeout")
+  ) {
+    return "Register closed. Reopen the register before voiding this sale.";
+  }
+
+  if (
+    normalizedMessage.includes("already void") ||
+    normalizedMessage.includes("voided") ||
+    normalizedMessage.includes("not completed") ||
+    normalizedMessage.includes("can only void completed")
+  ) {
+    return "Sale already voided or no longer eligible. Refresh the transaction before continuing.";
+  }
+
+  if (
+    normalizedMessage.includes("staff") ||
+    normalizedMessage.includes("sign") ||
+    normalizedMessage.includes("auth")
+  ) {
+    return "Staff sign-in required. Sign in before voiding this sale.";
+  }
+
+  return "Sale could not be voided. Check the transaction state and try again.";
+}
+
 export function TransactionView() {
   const params = useParams({
     strict: false,
@@ -267,10 +318,18 @@ export function TransactionView() {
   const [correctionError, setCorrectionError] = useState<string | null>(null);
   const [correctionSubmitting, setCorrectionSubmitting] = useState(false);
   const [pendingCorrection, setPendingCorrection] = useState<
-    "customer" | "payment_method" | "line_items" | null
+    "customer" | "payment_method" | "line_items" | "void" | null
   >(null);
   const [correctionHistoryExpanded, setCorrectionHistoryExpanded] =
     useState(false);
+  const [voidPanelOpen, setVoidPanelOpen] = useState(false);
+  const [voidReason, setVoidReason] = useState("");
+  const [voidError, setVoidError] = useState<string | null>(null);
+  const [voidSubmitting, setVoidSubmitting] = useState(false);
+  const [localVoidState, setLocalVoidState] = useState<{
+    reason: string;
+    result: TransactionVoidResultData;
+  } | null>(null);
   const { activeStore, isAuthenticated } = useProtectedAdminPageState();
   const correctAuth = useMutation(
     api.operations.staffCredentials.authenticateStaffCredential,
@@ -290,6 +349,7 @@ export function TransactionView() {
   const adjustTransactionItems = useMutation(
     api.inventory.pos.adjustTransactionItems,
   );
+  const voidTransaction = useMutation(api.inventory.pos.voidTransaction);
   const paymentApprovalRunner = useApprovedCommand({
     storeId: activeStore?._id,
     onAuthenticateForApproval: (args) => {
@@ -326,6 +386,41 @@ export function TransactionView() {
     },
   });
   const itemAdjustmentApprovalRunner = useApprovedCommand({
+    storeId: activeStore?._id,
+    onAuthenticateForApproval: (args) => {
+      if (!activeStore?._id) {
+        return Promise.resolve({
+          kind: "user_error",
+          error: {
+            code: "authentication_failed",
+            message: "Select a store before approving this command",
+          },
+        });
+      }
+
+      return runCommand(
+        () =>
+          approveCommand({
+            actionKey: args.actionKey,
+            pinHash: args.pinHash,
+            reason: args.reason,
+            requiredRole: args.requiredRole,
+            requestedByStaffProfileId: args.requestedByStaffProfileId,
+            storeId: activeStore._id,
+            subject: args.subject,
+            username: args.username,
+          }) as Promise<
+            CommandResult<{
+              approvalProofId: Id<"approvalProof">;
+              approvedByStaffProfileId: Id<"staffProfile">;
+              expiresAt: number;
+              requestedByStaffProfileId?: Id<"staffProfile">;
+            }>
+          >,
+      );
+    },
+  });
+  const voidApprovalRunner = useApprovedCommand({
     storeId: activeStore?._id,
     onAuthenticateForApproval: (args) => {
       if (!activeStore?._id) {
@@ -623,6 +718,30 @@ export function TransactionView() {
     selectedCorrection === "customer" && correctionError;
   const showPaymentMethodCorrectionError =
     showPaymentMethodDirectFlow && correctionError;
+  const transactionRecord = transaction as typeof transaction & {
+    canVoid?: boolean;
+    voidEligibility?: { eligible?: boolean } | null;
+    voidReason?: string | null;
+    voidedAt?: number | null;
+  };
+  const transactionVoidedAt =
+    localVoidState?.result.voidedAt ?? transactionRecord.voidedAt ?? null;
+  const transactionVoidReason =
+    localVoidState?.reason ?? transactionRecord.voidReason ?? null;
+  const isVoidedTransaction =
+    Boolean(localVoidState) ||
+    transaction.status === "void" ||
+    transaction.status === "voided" ||
+    typeof transactionVoidedAt === "number";
+  const readModelAllowsVoid =
+    transactionRecord.canVoid !== false &&
+    transactionRecord.voidEligibility?.eligible !== false;
+  const canVoidTransaction =
+    isCompletedTransaction && !isVoidedTransaction && readModelAllowsVoid;
+  const transactionStatusLabel = isVoidedTransaction ? "Voided" : "Completed";
+  const transactionStatusTime = getRelativeTime(
+    transactionVoidedAt ?? transaction.completedAt,
+  );
 
   async function authenticateCorrectionStaff(args: {
     pinHash: string;
@@ -678,6 +797,13 @@ export function TransactionView() {
     setSelectedCorrection(null);
     setPendingCorrection(null);
     setCorrectionError(null);
+  }
+
+  function exitVoidWorkflow() {
+    setVoidPanelOpen(false);
+    setVoidReason("");
+    setVoidError(null);
+    setPendingCorrection(null);
   }
 
   function resetItemAdjustmentWorkflow() {
@@ -953,6 +1079,104 @@ export function TransactionView() {
     }
   }
 
+  async function runTransactionVoid(args?: {
+    approvalRequestId?: Id<"approvalRequest">;
+    approvalProofId?: Id<"approvalProof">;
+    sameSubmissionApproval?: {
+      pinHash: string;
+      username: string;
+    };
+    staff?: StaffAuthenticationResult;
+    staffProfileId?: Id<"staffProfile">;
+  }) {
+    if (!isAuthenticated) {
+      setVoidError("Sign in again before voiding this sale");
+      return;
+    }
+
+    const reason = voidReason.trim();
+    if (!reason) {
+      setVoidError("Add a reason for this void");
+      return;
+    }
+
+    if (!args?.staffProfileId) {
+      setVoidError("Staff sign-in is required before voiding this sale");
+      return;
+    }
+
+    const staffProofToken = args.staff?.posLocalStaffProof?.token;
+    if (!staffProofToken) {
+      setVoidError("Staff sign-in is required before voiding this sale");
+      return;
+    }
+
+    const staffProfileId = args.staffProfileId;
+
+    setVoidError(null);
+    setVoidSubmitting(true);
+    try {
+      await voidApprovalRunner.run({
+        requestedByStaffProfileId: staffProfileId,
+        execute: async (approvalArgs) =>
+          runCommand(
+            () =>
+              (
+                voidTransaction as unknown as (payload: {
+                  actorStaffProfileId: Id<"staffProfile">;
+                  approvalProofId?: Id<"approvalProof">;
+                  approvalRequestId?: Id<"approvalRequest">;
+                  reason: string;
+                  staffProofToken: string;
+                  transactionId: Id<"posTransaction">;
+                }) => Promise<ApprovalCommandResult<TransactionVoidResultData>>
+              )({
+                actorStaffProfileId: staffProfileId,
+                approvalProofId:
+                  approvalArgs.approvalProofId ?? args.approvalProofId,
+                approvalRequestId:
+                  approvalArgs.approvalRequestId ?? args.approvalRequestId,
+                reason,
+                staffProofToken,
+                transactionId: transactionId as Id<"posTransaction">,
+              }),
+          ),
+        sameSubmissionApproval:
+          args.sameSubmissionApproval && args.staff
+            ? {
+                canAttemptInlineManagerProof: isManagerStaff(args.staff),
+                pinHash: args.sameSubmissionApproval.pinHash,
+                requestedByStaffProfileId:
+                  staffProfileId ?? args.staff.staffProfileId,
+                username: args.sameSubmissionApproval.username,
+              }
+            : undefined,
+        onApprovalRequired: (approval) => {
+          if (!requiresInlineManagerProof(approval)) {
+            exitVoidWorkflow();
+            toast.success("Void queued for manager review");
+          }
+        },
+        onResult: (result) => {
+          if (isApprovalRequiredResult(result)) {
+            return;
+          }
+
+          if (result.kind === "ok") {
+            setLocalVoidState({ reason, result: result.data });
+            exitVoidWorkflow();
+            toast.success("Sale voided");
+            return;
+          }
+
+          setVoidError(normalizeVoidCommandError(result.error.message));
+        },
+      });
+    } finally {
+      setVoidSubmitting(false);
+    }
+  }
+
   function requestCorrectionSubmit(
     kind: "customer" | "payment_method" | "line_items",
   ) {
@@ -1007,6 +1231,17 @@ export function TransactionView() {
     }
 
     setPendingCorrection(kind);
+  }
+
+  function requestVoidSubmit() {
+    setVoidError(null);
+
+    if (!voidReason.trim()) {
+      setVoidError("Add a reason for this void");
+      return;
+    }
+
+    setPendingCorrection("void");
   }
 
   return (
@@ -1065,6 +1300,15 @@ export function TransactionView() {
             return;
           }
 
+          if (correction === "void") {
+            void runTransactionVoid({
+              sameSubmissionApproval: credentials,
+              staff: result,
+              staffProfileId: result.staffProfileId,
+            });
+            return;
+          }
+
           if (correction === "customer") {
             void runCustomerCorrection(result);
           }
@@ -1073,11 +1317,13 @@ export function TransactionView() {
         open={
           pendingCorrection === "customer" ||
           pendingCorrection === "payment_method" ||
-          pendingCorrection === "line_items"
+          pendingCorrection === "line_items" ||
+          pendingCorrection === "void"
         }
       />
       {paymentApprovalRunner.dialog}
       {itemAdjustmentApprovalRunner.dialog}
+      {voidApprovalRunner.dialog}
       <FadeIn className="h-full">
         <div className="container mx-auto h-full min-h-0 px-6 pb-16 pt-6">
           <div className="grid h-full min-h-0 gap-8 xl:grid-cols-[380px,minmax(0,1fr)]">
@@ -1087,12 +1333,20 @@ export function TransactionView() {
                   <div className="flex flex-wrap items-center justify-between gap-3">
                     <Badge
                       variant="outline"
-                      className="w-fit border-[hsl(var(--success)/0.22)] bg-[hsl(var(--success)/0.08)] text-[hsl(var(--success))] flex items-center gap-2"
+                      className={
+                        isVoidedTransaction
+                          ? "flex w-fit items-center gap-2 border-danger/25 bg-danger/10 text-danger"
+                          : "flex w-fit items-center gap-2 border-[hsl(var(--success)/0.22)] bg-[hsl(var(--success)/0.08)] text-[hsl(var(--success))]"
+                      }
                     >
-                      <CheckCircle2 className="w-4 h-4" />
-                      Completed
+                      {isVoidedTransaction ? (
+                        <Ban className="h-4 w-4" />
+                      ) : (
+                        <CheckCircle2 className="h-4 w-4" />
+                      )}
+                      {transactionStatusLabel}
                       <p className="text-xs text-muted-foreground">
-                        {getRelativeTime(transaction.completedAt)}
+                        {transactionStatusTime}
                       </p>
                     </Badge>
                   </div>
@@ -1162,22 +1416,50 @@ export function TransactionView() {
 
                   <div className="border-t border-border/70 bg-muted/20 p-6">
                     {isCompletedTransaction ? (
-                      <Button
-                        className="w-full"
-                        onClick={() => {
-                          if (correctionPanelOpen) {
-                            exitCorrectionWorkflow();
-                            return;
-                          }
+                      <div className="grid gap-2">
+                        {!isVoidedTransaction ? (
+                          <Button
+                            className="w-full"
+                            onClick={() => {
+                              if (correctionPanelOpen) {
+                                exitCorrectionWorkflow();
+                                return;
+                              }
 
-                          setCorrectionPanelOpen(true);
-                          setCorrectionError(null);
-                        }}
-                        type="button"
-                        variant={correctionPanelOpen ? "workflow" : "outline"}
-                      >
-                        Update
-                      </Button>
+                              setCorrectionPanelOpen(true);
+                              setVoidPanelOpen(false);
+                              setCorrectionError(null);
+                            }}
+                            type="button"
+                            variant={
+                              correctionPanelOpen ? "workflow" : "outline"
+                            }
+                          >
+                            Update
+                          </Button>
+                        ) : null}
+                        {canVoidTransaction ? (
+                          <Button
+                            className="w-full"
+                            onClick={() => {
+                              if (voidPanelOpen) {
+                                exitVoidWorkflow();
+                                return;
+                              }
+
+                              setVoidPanelOpen(true);
+                              setCorrectionPanelOpen(false);
+                              setVoidError(null);
+                            }}
+                            type="button"
+                            variant={
+                              voidPanelOpen ? "destructive" : "outline"
+                            }
+                          >
+                            Void sale
+                          </Button>
+                        ) : null}
+                      </div>
                     ) : null}
                   </div>
 
@@ -1191,6 +1473,106 @@ export function TransactionView() {
                   )} */}
                 </CardContent>
               </section>
+
+              {voidPanelOpen && canVoidTransaction ? (
+                <section className="overflow-hidden rounded-[calc(var(--radius)*1.35)] border border-danger/25 bg-surface-raised shadow-surface">
+                  <div className="border-b border-border/70 px-5 py-4">
+                    <div className="flex items-start gap-3">
+                      <div className="mt-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-[calc(var(--radius)*0.85)] bg-danger/10 text-danger">
+                        <Ban className="h-4 w-4" />
+                      </div>
+                      <div className="space-y-1">
+                        <h2 className="font-display text-lg font-semibold text-foreground">
+                          Void completed sale
+                        </h2>
+                        <p className="text-sm leading-6 text-muted-foreground">
+                          Staff sign-in and manager approval are required. The
+                          original sale stays visible for audit.
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+
+                  <div className="space-y-3 p-5">
+                    <Textarea
+                      aria-label="Void reason"
+                      className="min-h-[90px] border-input bg-background"
+                      onChange={(event) => setVoidReason(event.target.value)}
+                      placeholder="Reason for voiding this completed sale."
+                      value={voidReason}
+                    />
+                    {voidError ? (
+                      <p className="text-sm text-destructive">{voidError}</p>
+                    ) : null}
+                    <div className="grid gap-2">
+                      <Button
+                        disabled={voidSubmitting}
+                        onClick={requestVoidSubmit}
+                        type="button"
+                        variant="destructive"
+                      >
+                        Submit void
+                      </Button>
+                      <Button
+                        disabled={voidSubmitting}
+                        onClick={exitVoidWorkflow}
+                        type="button"
+                        variant="outline"
+                      >
+                        Cancel void
+                      </Button>
+                    </div>
+                  </div>
+                </section>
+              ) : null}
+
+              {isVoidedTransaction ? (
+                <section className="space-y-4 overflow-hidden rounded-[calc(var(--radius)*1.35)] border border-danger/25 bg-surface-raised p-5 shadow-surface">
+                  <div className="space-y-1">
+                    <h2 className="font-display text-xl font-semibold text-foreground">
+                      Sale voided
+                    </h2>
+                    <p className="text-sm text-muted-foreground">
+                      Original sale details remain visible. Payment and
+                      inventory reversals are recorded separately.
+                    </p>
+                  </div>
+                  <dl className="grid gap-3 rounded-lg border border-border bg-background p-4 text-sm">
+                    {transactionVoidedAt ? (
+                      <div className="flex items-center justify-between gap-3">
+                        <dt className="text-muted-foreground">Voided</dt>
+                        <dd className="font-medium text-foreground">
+                          {getRelativeTime(transactionVoidedAt)}
+                        </dd>
+                      </div>
+                    ) : null}
+                    {transactionVoidReason ? (
+                      <div className="border-t border-border/70 pt-3">
+                        <dt className="text-muted-foreground">Reason</dt>
+                        <dd className="mt-1 text-foreground">
+                          {transactionVoidReason}
+                        </dd>
+                      </div>
+                    ) : null}
+                    {localVoidState ? (
+                      <div className="grid gap-2 border-t border-border/70 pt-3 text-muted-foreground">
+                        <div className="flex items-center justify-between gap-3">
+                          <dt>Payment reversals</dt>
+                          <dd className="font-numeric text-foreground">
+                            {localVoidState.result.paymentAllocationIds.length}
+                          </dd>
+                        </div>
+                        <div className="flex items-center justify-between gap-3">
+                          <dt>Inventory movements</dt>
+                          <dd className="font-numeric text-foreground">
+                            {localVoidState.result.inventoryMovementIds.length}
+                          </dd>
+                        </div>
+                      </div>
+                    ) : null}
+                  </dl>
+                </section>
+              ) : null}
 
               {correctionPanelOpen ? (
                 <section className="overflow-hidden rounded-[calc(var(--radius)*1.35)] border border-border/80 bg-surface-raised shadow-surface">

--- a/packages/athena-webapp/src/components/pos/transactions/TransactionsView.test.tsx
+++ b/packages/athena-webapp/src/components/pos/transactions/TransactionsView.test.tsx
@@ -54,6 +54,7 @@ vi.mock("../../base/table/data-table", () => ({
     data: Array<{
       transactionNumber: string;
       sessionTraceId: string | null;
+      status?: string;
     }>;
   }) => (
     <div>
@@ -65,6 +66,7 @@ vi.mock("../../base/table/data-table", () => ({
               trace
             </span>
           ) : null}
+          {row.status === "void" ? <span>Voided</span> : null}
         </div>
       ))}
     </div>
@@ -134,6 +136,38 @@ describe("TransactionsView", () => {
     expect(
       screen.queryByTestId("session-trace-POS-654321"),
     ).not.toBeInTheDocument();
+  });
+
+  it("marks voided completed rows in the completed transactions table", () => {
+    getActiveStoreMock.mockReturnValue({
+      activeStore: {
+        _id: "store-1",
+        currency: "GHS",
+      },
+    });
+    useQueryMock.mockReturnValue([
+      {
+        _id: "txn-void",
+        transactionNumber: "POS-VOID",
+        total: 1000,
+        paymentMethod: "cash",
+        paymentMethods: ["cash"],
+        cashierName: "Ada L.",
+        customerName: null,
+        itemCount: 1,
+        completedAt: Date.now(),
+        hasTrace: false,
+        sessionTraceId: null,
+        status: "void",
+        voidedAt: Date.now(),
+        voidReason: "Duplicate sale.",
+      },
+    ]);
+
+    render(<TransactionsView />);
+
+    expect(screen.getByText("POS-VOID")).toBeInTheDocument();
+    expect(screen.getByText("Voided")).toBeInTheDocument();
   });
 
   it("passes the register session filter to the completed transactions query", () => {

--- a/packages/athena-webapp/src/components/pos/transactions/TransactionsView.tsx
+++ b/packages/athena-webapp/src/components/pos/transactions/TransactionsView.tsx
@@ -76,6 +76,9 @@ type CompletedTransaction = {
   completedAt: number;
   hasTrace: boolean;
   sessionTraceId: string | null;
+  status?: string;
+  voidedAt?: number | null;
+  voidReason?: string | null;
 };
 
 export function TransactionsView() {
@@ -167,6 +170,9 @@ export function TransactionsView() {
       completedAt: transaction.completedAt,
       hasTrace: transaction.hasTrace,
       sessionTraceId: null,
+      status: transaction.status === "void" ? "void" : "completed",
+      voidedAt: transaction.voidedAt,
+      voidReason: transaction.voidReason,
     }));
   }, [transactions, formatter]);
 

--- a/packages/athena-webapp/src/components/pos/transactions/transactionColumns.test.tsx
+++ b/packages/athena-webapp/src/components/pos/transactions/transactionColumns.test.tsx
@@ -96,6 +96,26 @@ describe("transactionColumns", () => {
     expect(screen.queryByTestId("session-trace-link")).not.toBeInTheDocument();
   });
 
+  it("marks voided completed transactions distinctly", () => {
+    renderTransactionCell({
+      _id: "txn_void" as CompletedTransactionRow["_id"],
+      transactionNumber: "POS-VOID",
+      formattedTotal: "GHc 10.00",
+      paymentMethodLabel: "Cash",
+      paymentMethod: "cash",
+      cashierName: "Ada L.",
+      customerName: "Walk-in",
+      itemCount: 1,
+      completedAt: 100,
+      hasTrace: false,
+      sessionTraceId: null,
+      status: "void",
+      voidedAt: 200,
+    });
+
+    expect(screen.getByText("Voided")).toBeInTheDocument();
+  });
+
   it("renders a wallet cards icon for transactions with multiple payment methods", () => {
     const { container } = renderTransactionCell(
       {

--- a/packages/athena-webapp/src/components/pos/transactions/transactionColumns.tsx
+++ b/packages/athena-webapp/src/components/pos/transactions/transactionColumns.tsx
@@ -22,6 +22,9 @@ export type CompletedTransactionRow = {
   completedAt: number;
   hasTrace: boolean;
   sessionTraceId: string | null;
+  status?: "completed" | "void";
+  voidedAt?: number | null;
+  voidReason?: string | null;
 };
 
 const getPaymentMethodIcon = ({
@@ -83,6 +86,11 @@ export const transactionColumns: ColumnDef<CompletedTransactionRow>[] = [
               </WorkflowTraceRouteLink>
             </div>
           ) : null}
+          {row.original.status === "void" ? (
+            <span className="w-fit rounded-sm border border-destructive/30 bg-destructive/10 px-1.5 py-0.5 text-xs font-medium text-destructive">
+              Voided
+            </span>
+          ) : null}
         </div>
       );
     },
@@ -105,7 +113,9 @@ export const transactionColumns: ColumnDef<CompletedTransactionRow>[] = [
         search={{ o: getOrigin() }}
         className="flex items-center gap-2"
       >
-        <span>{row.original.formattedTotal}</span>
+        <span className={row.original.status === "void" ? "line-through" : ""}>
+          {row.original.formattedTotal}
+        </span>
         <span className="capitalize text-muted-foreground text-sm">
           {getPaymentMethodIcon({
             paymentMethod: row.original.paymentMethod,


### PR DESCRIPTION
## Summary
- add manager-approved completed POS sale voiding with async approval-request support
- reverse register cash, payment allocations, inventory movement, SKU stock, and transaction read models with idempotency guards
- surface void status in transaction detail and completed-transaction list UI with normalized operator copy
- add plan and solution artifacts for completed-sale void reversal behavior

## Validation
- `bun run pr:athena`
- unanimous reviewer loop approval: correctness, data integrity, security, testing, maintainability, project standards

## Linear
- V26-619
- V26-620
- V26-621
- V26-622
- V26-623
- V26-624
