### PR TITLE
fix(pos): harden item adjustment approvals

### DIFF
--- a/docs/solutions/logic-errors/athena-pos-item-adjustment-cash-preflight-2026-05-21.md
+++ b/docs/solutions/logic-errors/athena-pos-item-adjustment-cash-preflight-2026-05-21.md
@@ -1,0 +1,79 @@
+---
+title: Athena POS Item Adjustment Cash Preflight Must Enforce Drawer Invariants
+date: 2026-05-21
+category: logic-errors
+module: athena-webapp
+problem_type: logic_error
+component: pos
+symptoms:
+  - "Approving a queued item adjustment can fail with register session expected cash cannot be negative"
+  - "A failed approval leaves the pending item adjustment in place, so later edits report that an adjustment is already waiting for approval"
+root_cause: validate_only_cash_settlement_preflight_returned_before_checking_expected_cash_invariant
+resolution_type: code_fix
+severity: high
+tags:
+  - pos
+  - item-adjustments
+  - cash-controls
+  - approvals
+---
+
+# Athena POS Item Adjustment Cash Preflight Must Enforce Drawer Invariants
+
+## Problem
+
+Item adjustment submission validates settlement effects before creating the
+manager approval request. Cash refunds must not be queued when applying them
+would make the register session's expected cash negative, because the approval
+resolver later runs the real settlement mutation and will fail against the
+drawer invariant.
+
+When the preflight path skips that invariant, operators can create an approval
+request that cannot currently apply. The approval attempt then returns the
+negative expected-cash error, while the still-pending approval blocks follow-up
+edits with the existing pending-adjustment message.
+
+The public mutation must also map the invariant failure into the shared command
+result shape. If it rethrows the domain error, browser `runCommand` treats it as
+unexpected and the transaction view renders generic retry copy instead of the
+operator-actionable backend message.
+
+Approval-time failures need their own cleanup path. A request that was queued
+before the preflight fix, or that became invalid because drawer cash changed
+after queueing, can still fail when a manager approves it. If that failure is
+returned as a user error without retiring the approval request, the request
+stays pending and the next edit attempt is blocked by the duplicate pending
+approval message.
+
+## Solution
+
+Keep `validateOnly` side-effect free, but do not let it bypass the same
+precondition checks as the mutating path. Compute the proposed expected-cash
+balance, reject negative balances, and only then return without patching the
+register session.
+
+Before running cash preflight, preserve idempotency and conflict ordering:
+
+- Return the already-applied adjustment when the same payload is retried.
+- Report an existing applied item adjustment before drawer-cash preconditions.
+- Return an existing matching pending approval instead of creating another one.
+- Run the cash preflight before creating any new approval request.
+- Include the same domain invariant in the public mutation's user-error mapper
+  so the transaction view can surface it inline.
+- When an approval-time item adjustment apply fails on the drawer-cash
+  invariant, mark that approval request cancelled before returning the user
+  error so it no longer blocks a corrected submission and is not represented as
+  a manager rejection.
+
+## Prevention
+
+- Any `validateOnly` path must enforce invariants and skip only writes.
+- Tests for approval-gated commands should prove invalid state cannot be queued
+  for later approval.
+- Public mutation tests should cover every domain invariant that the browser is
+  expected to render inline.
+- Approval command tests should assert that approval-time item adjustment
+  precondition failures retire the pending request while still returning the
+  operator-actionable error.
+- Keep retry/idempotency assertions next to preflight assertions so a new
+  precondition does not hide the more specific applied-or-pending state.

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 5704 nodes · 6007 edges · 1702 communities detected
+- 5711 nodes · 6021 edges · 1702 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -1840,44 +1840,44 @@ Cohesion: 0.16
 Nodes (22): attentionSeverity(), buildDailyOperationsSnapshotWithCtx(), buildLanes(), buildWeekMetricForDate(), buildWeekMetrics(), emptyCloseSummary(), getCloseItemCounts(), getDailyCloseRecordForDate() (+14 more)
 
 ### Community 25 - "Community 25"
+Cohesion: 0.19
+Nodes (23): adjustRegisterSessionExpectedCashForSettlement(), adjustTransactionItems(), applyApprovedAdjustment(), applyInventoryDeltas(), assertPayloadMatchesPlan(), buildAdjustmentApprovalRequirement(), buildServerAdjustmentPlan(), consumeItemAdjustmentApprovalProof() (+15 more)
+
+### Community 26 - "Community 26"
 Cohesion: 0.15
 Nodes (19): acquireExpenseQuantityPatchHold(), adjustExpenseQuantityPatchHold(), createDefaultExpenseSessionCommandService(), createExpenseInventoryHoldGateway(), createExpenseSessionCommandService(), failure(), isActiveRegisterSession(), isSessionExpired() (+11 more)
 
-### Community 26 - "Community 26"
+### Community 27 - "Community 27"
+Cohesion: 0.1
+Nodes (7): buildMissingDraftResult(), getApprovalRequestCopy(), handleDecideApprovalRequest(), handleDiscardCycleCountDraft(), handleRefreshCycleCountDraftLineBaseline(), handleSaveCycleCountDraftLine(), handleSubmitCycleCountDraft()
+
+### Community 28 - "Community 28"
 Cohesion: 0.11
 Nodes (13): cancelItemAdjustmentWorkflow(), exitCorrectionWorkflow(), formatCorrectionEventType(), formatCorrectionHistoryChange(), formatCorrectionHistoryTitle(), formatPaymentMethodLabel(), getCorrectionHistoryChangeParts(), isManagerStaff() (+5 more)
 
-### Community 27 - "Community 27"
+### Community 29 - "Community 29"
 Cohesion: 0.23
 Nodes (23): asRecord(), createMappingIndex(), errorFor(), errorMessage(), getCompletedSale(), getExpectedCashDelta(), getOrCreateSale(), getPhase() (+15 more)
 
-### Community 28 - "Community 28"
+### Community 30 - "Community 30"
 Cohesion: 0.09
 Nodes (2): buildCashControlsDashboardSnapshot(), sumDepositsBySession()
 
-### Community 29 - "Community 29"
+### Community 31 - "Community 31"
 Cohesion: 0.1
 Nodes (4): listCompletedTransactionsForDay(), listSessionItems(), listTransactionItems(), readAllQueryResults()
 
-### Community 30 - "Community 30"
+### Community 32 - "Community 32"
 Cohesion: 0.15
 Nodes (16): buildGitProcessEnv(), collectCommandsForChangedFiles(), fileExists(), formatMissingPathPrefixError(), getChangedFilesForHarnessReview(), hasAnyHarnessDocs(), loadReviewTarget(), loadReviewTargets() (+8 more)
 
-### Community 31 - "Community 31"
+### Community 33 - "Community 33"
 Cohesion: 0.2
 Nodes (18): acquireInventoryHold(), acquireInventoryHoldsBatch(), adjustInventoryHold(), buildSkuActivityIdempotencyKey(), consumeInventoryHoldsForSession(), getActiveHoldForSessionSku(), listActiveSessionHolds(), markHoldExpired() (+10 more)
 
-### Community 32 - "Community 32"
-Cohesion: 0.2
-Nodes (21): adjustRegisterSessionExpectedCashForSettlement(), adjustTransactionItems(), applyApprovedAdjustment(), applyInventoryDeltas(), assertPayloadMatchesPlan(), buildAdjustmentApprovalRequirement(), buildServerAdjustmentPlan(), consumeItemAdjustmentApprovalProof() (+13 more)
-
-### Community 33 - "Community 33"
+### Community 34 - "Community 34"
 Cohesion: 0.25
 Nodes (21): buildActiveCycleCountDraftsSubmissionKey(), buildCycleCountDraftSubmissionKey(), createCycleCountDraftWithCtx(), discardCycleCountDraftCommandWithCtx(), ensureCycleCountDraftCommandWithCtx(), ensureCycleCountDraftWithCtx(), findOpenCycleCountDraftWithCtx(), getActiveCycleCountDraftSummaryWithCtx() (+13 more)
-
-### Community 34 - "Community 34"
-Cohesion: 0.11
-Nodes (7): buildMissingDraftResult(), getApprovalRequestCopy(), handleDecideApprovalRequest(), handleDiscardCycleCountDraft(), handleRefreshCycleCountDraftLineBaseline(), handleSaveCycleCountDraftLine(), handleSubmitCycleCountDraft()
 
 ### Community 35 - "Community 35"
 Cohesion: 0.27
@@ -2080,8 +2080,8 @@ Cohesion: 0.18
 Nodes (2): formatBlockerList(), runPrePushReview()
 
 ### Community 85 - "Community 85"
-Cohesion: 0.29
-Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
+Cohesion: 0.36
+Nodes (10): buildApprovalDecisionRequirement(), buildApprovalDecisionSubject(), consumeApprovalDecisionProofWithCtx(), decideApprovalRequestAsAuthenticatedUserWithCtx(), decideApprovalRequestAsCommandWithCtx(), decideApprovalRequestWithCtx(), mapDecideApprovalRequestError(), omitUndefined() (+2 more)
 
 ### Community 86 - "Community 86"
 Cohesion: 0.33
@@ -2092,84 +2092,84 @@ Cohesion: 0.24
 Nodes (5): formatBackendLabel(), formatInventoryNumber(), formatQuantity(), getActivityTitle(), pluralize()
 
 ### Community 88 - "Community 88"
+Cohesion: 0.29
+Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
+
+### Community 89 - "Community 89"
 Cohesion: 0.31
 Nodes (7): buildCustomerCreateInput(), cancelPendingAdd(), commitCustomer(), handleAddFromSearch(), handleClearCustomer(), handleSelectCustomer(), toCustomerInfo()
 
-### Community 89 - "Community 89"
+### Community 90 - "Community 90"
 Cohesion: 0.25
 Nodes (6): handleEdit(), handleReset(), handleSubmit(), itemToFormState(), parseServiceCatalogForm(), validateServiceCatalogForm()
 
-### Community 90 - "Community 90"
+### Community 91 - "Community 91"
 Cohesion: 0.25
 Nodes (6): mapProductByIdResult(), useConvexProductIdLookup(), useConvexRegisterCatalog(), useConvexRegisterCatalogAvailability(), useConvexRegisterCatalogAvailabilityState(), usePrewarmRegisterCatalogOfflineSnapshots()
-
-### Community 91 - "Community 91"
-Cohesion: 0.18
-Nodes (0):
 
 ### Community 92 - "Community 92"
 Cohesion: 0.18
 Nodes (0):
 
 ### Community 93 - "Community 93"
+Cohesion: 0.18
+Nodes (0):
+
+### Community 94 - "Community 94"
 Cohesion: 0.2
 Nodes (2): diagnoseAthenaQaLiveSmoke(), stripUrlQuery()
 
-### Community 94 - "Community 94"
+### Community 95 - "Community 95"
 Cohesion: 0.31
 Nodes (6): expenseItemSuccess(), expenseSessionSuccess(), itemSuccess(), operationSuccess(), sessionSuccess(), success()
 
-### Community 95 - "Community 95"
+### Community 96 - "Community 96"
 Cohesion: 0.22
 Nodes (2): isValidEmail(), validateCustomerInfo()
 
-### Community 96 - "Community 96"
+### Community 97 - "Community 97"
+Cohesion: 0.38
+Nodes (8): buildTraceEvent(), buildTraceRecord(), displayTraceAmount(), formatTransactionLabel(), recordRegisterSessionTraceBestEffort(), resolveOccurredAt(), resolveStoreCurrency(), safeTraceWrite()
+
+### Community 98 - "Community 98"
 Cohesion: 0.22
 Nodes (2): listProductSkusByProductId(), readAllQueryResults()
 
-### Community 97 - "Community 97"
+### Community 99 - "Community 99"
 Cohesion: 0.31
 Nodes (7): buildVariantSkuMoneyPayload(), createVariantSku(), modifyProduct(), onSubmit(), parseVariantDisplayMoney(), saveProduct(), updateVariantSku()
 
-### Community 98 - "Community 98"
+### Community 100 - "Community 100"
 Cohesion: 0.29
 Nodes (6): handleFileSelect(), handleRevert(), handleUpload(), resetEditState(), uploadImage(), validateFile()
 
-### Community 99 - "Community 99"
+### Community 101 - "Community 101"
 Cohesion: 0.27
 Nodes (5): classifyTerminalHealth(), formatAge(), formatStatusLabel(), getReviewEvidenceCount(), getSnapshotAgeSummary()
 
-### Community 100 - "Community 100"
+### Community 102 - "Community 102"
 Cohesion: 0.27
 Nodes (5): blocked(), evaluateLocalPosReadiness(), localReadinessMatchesInput(), localReadinessRecordFromSnapshots(), refreshLocalPosReadinessFromSnapshots()
 
-### Community 101 - "Community 101"
+### Community 103 - "Community 103"
 Cohesion: 0.38
 Nodes (7): buildPosTerminalRuntimeCopyDiagnostics(), buildPosTerminalRuntimeStatus(), buildSyncMetrics(), mapSyncStatus(), normalizeStaffAuthorityStatus(), snapshotAges(), toSafeFailureMessage()
 
-### Community 102 - "Community 102"
+### Community 104 - "Community 104"
 Cohesion: 0.2
 Nodes (0):
 
-### Community 103 - "Community 103"
+### Community 105 - "Community 105"
 Cohesion: 0.38
 Nodes (9): awardPointsForGuestOrders(), awardPointsForPastOrder(), getBaseUrl(), getEligiblePastOrders(), getOrderRewardPoints(), getPointHistory(), getRewardTiers(), getUserPoints() (+1 more)
 
-### Community 104 - "Community 104"
+### Community 106 - "Community 106"
 Cohesion: 0.4
 Nodes (8): fileExists(), isJsonObject(), normalizeGraphJsonArtifact(), normalizeGraphJsonContents(), resolveGraphifyPython(), runGraphifyRebuild(), sortJsonArray(), sortJsonValue()
 
-### Community 105 - "Community 105"
-Cohesion: 0.44
-Nodes (8): buildApprovalDecisionRequirement(), buildApprovalDecisionSubject(), consumeApprovalDecisionProofWithCtx(), decideApprovalRequestAsAuthenticatedUserWithCtx(), decideApprovalRequestAsCommandWithCtx(), decideApprovalRequestWithCtx(), mapDecideApprovalRequestError(), omitUndefined()
-
-### Community 106 - "Community 106"
+### Community 107 - "Community 107"
 Cohesion: 0.39
 Nodes (6): buildInventoryMovement(), buildSkuActivityForInventoryMovement(), getSkuActivityTypeForMovement(), recordInventoryMovementWithCtx(), recordInventoryMovementWithDispositionWithCtx(), recordSkuActivityForInventoryMovementWithCtx()
-
-### Community 107 - "Community 107"
-Cohesion: 0.42
-Nodes (7): buildTraceEvent(), buildTraceRecord(), displayTraceAmount(), recordRegisterSessionTraceBestEffort(), resolveOccurredAt(), resolveStoreCurrency(), safeTraceWrite()
 
 ### Community 108 - "Community 108"
 Cohesion: 0.42
@@ -2225,43 +2225,43 @@ Nodes (6): findAthenaUserByEmailWithCtx(), getAuthenticatedAthenaUserWithCtx(), 
 
 ### Community 121 - "Community 121"
 Cohesion: 0.43
-Nodes (6): sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
-
-### Community 122 - "Community 122"
-Cohesion: 0.43
 Nodes (6): buildMtnCollectionsLookupPrefixes(), isTargetEnvironment(), readScopedValue(), resolveConfigForPrefix(), resolveMtnCollectionsConfigFromEnv(), toEnvSegment()
 
-### Community 123 - "Community 123"
+### Community 122 - "Community 122"
 Cohesion: 0.46
 Nodes (7): recordApprovalAuditEventWithCtx(), recordApprovalDecisionRecordedAuditEventWithCtx(), recordApprovalProofConsumedAuditEventWithCtx(), recordApprovalRequiredAuditEventWithCtx(), recordApprovedCommandAppliedAuditEventWithCtx(), recordAsyncApprovalRequestCreatedAuditEventWithCtx(), recordManagerApprovalGrantedAuditEventWithCtx()
 
-### Community 124 - "Community 124"
+### Community 123 - "Community 123"
 Cohesion: 0.43
 Nodes (6): assertActiveTerminal(), getActiveManagerElevationWithCtx(), getCandidateElevations(), getStaffDisplayName(), startManagerElevationWithCtx(), toActiveElevation()
 
-### Community 125 - "Community 125"
+### Community 124 - "Community 124"
 Cohesion: 0.36
 Nodes (5): buildPaymentAllocation(), correctSameAmountSinglePaymentAllocationWithCtx(), findSameAmountSinglePaymentAllocation(), listPaymentAllocationsForTargetWithCtx(), recordPaymentAllocationWithCtx()
 
-### Community 126 - "Community 126"
+### Community 125 - "Community 125"
 Cohesion: 0.43
 Nodes (6): buildPosSessionTraceEvent(), buildPosSessionTraceRecord(), buildTraceSummary(), formatPaymentMethod(), recordPosSessionTraceBestEffort(), safeTraceWrite()
 
-### Community 127 - "Community 127"
+### Community 126 - "Community 126"
 Cohesion: 0.5
 Nodes (7): findExistingSku(), findOrCreateQuickAddCategory(), findOrCreateQuickAddSubcategory(), generateSKU(), isBarcodeLike(), mapSkuToCatalogResult(), quickAddCatalogItem()
 
-### Community 128 - "Community 128"
+### Community 127 - "Community 127"
 Cohesion: 0.25
 Nodes (0):
 
-### Community 129 - "Community 129"
+### Community 128 - "Community 128"
 Cohesion: 0.36
 Nodes (4): buildTerminalHealthSummary(), deriveTerminalHealth(), getTerminalHealthSummary(), stripRuntimeStatusIdentity()
 
-### Community 130 - "Community 130"
+### Community 129 - "Community 129"
 Cohesion: 0.25
 Nodes (0):
+
+### Community 130 - "Community 130"
+Cohesion: 0.43
+Nodes (6): sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
 
 ### Community 131 - "Community 131"
 Cohesion: 0.39

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,8 +8,8 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 1774
-- Graph nodes: 5704
-- Graph edges: 6007
+- Graph nodes: 5711
+- Graph edges: 6021
 - Communities: 1702
 
 ## Graph Hotspots

--- a/packages/athena-webapp/convex/operations/approvalRequests.test.ts
+++ b/packages/athena-webapp/convex/operations/approvalRequests.test.ts
@@ -635,6 +635,15 @@ describe("approval request helpers", () => {
         message: "Register session expected cash cannot be negative.",
       },
     });
+    expect(tables.approvalRequest.get("approval-item-1")).toMatchObject({
+      decisionNotes: "Register session expected cash cannot be negative.",
+      reviewedByStaffProfileId: "staff-manager-1",
+      reviewedByUserId: "manager-1",
+      status: "cancelled",
+    });
+    expect(tables.approvalRequest.get("approval-item-1")?.metadata).toMatchObject({
+      applyFailureMessage: "Register session expected cash cannot be negative.",
+    });
   });
 
   it("returns duplicate pending item adjustment failures as user errors", async () => {

--- a/packages/athena-webapp/convex/operations/approvalRequests.ts
+++ b/packages/athena-webapp/convex/operations/approvalRequests.ts
@@ -25,6 +25,11 @@ import { commandResultValidator } from "../lib/commandResultValidators";
 import { consumeApprovalProofWithCtx } from "./approvalProofs";
 
 const APPROVAL_DECISION_ACTION_KEY = "operations.approval_request.decide";
+const ITEM_ADJUSTMENT_REQUEST_TYPE = "pos_item_adjustment";
+const ITEM_ADJUSTMENT_SUBJECT_TYPE = "pos_transaction_item_adjustment";
+const ITEM_ADJUSTMENT_RETIRED_PRECONDITION_MESSAGES = new Set([
+  "Register session expected cash cannot be negative.",
+]);
 
 type DecideApprovalRequestArgs = {
   approvalProofId?: Id<"approvalProof">;
@@ -111,6 +116,50 @@ async function consumeApprovalDecisionProofWithCtx(
   return result.data;
 }
 
+function shouldRetireItemAdjustmentApprovalAfterApplyFailure(error: unknown) {
+  const message = error instanceof Error ? error.message : "";
+
+  return ITEM_ADJUSTMENT_RETIRED_PRECONDITION_MESSAGES.has(message);
+}
+
+async function retireItemAdjustmentApprovalAfterApplyFailure(
+  ctx: MutationCtx,
+  args: {
+    approvalRequestId: Id<"approvalRequest">;
+    error: unknown;
+    reviewedByStaffProfileId?: Id<"staffProfile">;
+    reviewedByUserId?: Id<"athenaUser">;
+  },
+) {
+  const approvalRequest = await ctx.db.get(
+    "approvalRequest",
+    args.approvalRequestId,
+  );
+
+  if (
+    !approvalRequest ||
+    approvalRequest.status !== "pending" ||
+    approvalRequest.requestType !== ITEM_ADJUSTMENT_REQUEST_TYPE ||
+    approvalRequest.subjectType !== ITEM_ADJUSTMENT_SUBJECT_TYPE
+  ) {
+    return;
+  }
+
+  const message = args.error instanceof Error ? args.error.message : "";
+
+  await ctx.db.patch("approvalRequest", args.approvalRequestId, {
+    decidedAt: Date.now(),
+    decisionNotes: message,
+    metadata: {
+      ...(approvalRequest.metadata ?? {}),
+      applyFailureMessage: message,
+    },
+    reviewedByStaffProfileId: args.reviewedByStaffProfileId,
+    reviewedByUserId: args.reviewedByUserId,
+    status: "cancelled",
+  });
+}
+
 export async function decideApprovalRequestWithCtx(
   ctx: MutationCtx,
   args: DecideApprovalRequestArgs,
@@ -163,10 +212,26 @@ export async function decideApprovalRequestWithCtx(
   }
 
   if (
-    approvalRequest.requestType === "pos_item_adjustment" &&
-    approvalRequest.subjectType === "pos_transaction_item_adjustment"
+    approvalRequest.requestType === ITEM_ADJUSTMENT_REQUEST_TYPE &&
+    approvalRequest.subjectType === ITEM_ADJUSTMENT_SUBJECT_TYPE
   ) {
-    await resolveTransactionItemAdjustmentApprovalDecisionWithCtx(ctx, args);
+    try {
+      await resolveTransactionItemAdjustmentApprovalDecisionWithCtx(ctx, args);
+    } catch (error) {
+      if (
+        args.decision === "approved" &&
+        shouldRetireItemAdjustmentApprovalAfterApplyFailure(error)
+      ) {
+        await retireItemAdjustmentApprovalAfterApplyFailure(ctx, {
+          approvalRequestId: args.approvalRequestId,
+          error,
+          reviewedByStaffProfileId: args.reviewedByStaffProfileId,
+          reviewedByUserId: args.reviewedByUserId,
+        });
+      }
+
+      throw error;
+    }
   }
 
   if (

--- a/packages/athena-webapp/convex/operations/registerSessionTracing.test.ts
+++ b/packages/athena-webapp/convex/operations/registerSessionTracing.test.ts
@@ -276,6 +276,64 @@ describe("recordRegisterSessionTraceBestEffort", () => {
     );
   });
 
+  it("records item adjustment events on the register-session trace without blocking it", async () => {
+    vi.mocked(createWorkflowTraceWithCtx).mockResolvedValue("trace-1" as never);
+    vi.mocked(registerWorkflowTraceLookupWithCtx).mockResolvedValue(
+      "lookup-1" as never,
+    );
+    vi.mocked(appendWorkflowTraceEventWithCtx).mockResolvedValue(
+      "event-1" as never,
+    );
+    const { ctx } = buildCtx();
+
+    await recordRegisterSessionTraceBestEffort(ctx, {
+      stage: "item_adjustment_applied",
+      session: buildSession(),
+      adjustmentId: "adjustment-1" as Id<"posTransactionAdjustment">,
+      amount: 50_000,
+      approvalRequestId: "approval-1" as Id<"approvalRequest">,
+      occurredAt: 222,
+      registerSessionExpectedCashDelta: -50_000,
+      settlementDirection: "refund",
+      settlementMethod: "cash",
+      transactionId: "txn-1" as Id<"posTransaction">,
+      transactionNumber: "POS-111111",
+    });
+
+    expect(createWorkflowTraceWithCtx).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        status: "started",
+        completedAt: undefined,
+      }),
+    );
+    expect(appendWorkflowTraceEventWithCtx).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        details: expect.objectContaining({
+          adjustmentId: "adjustment-1",
+          amount: 50_000,
+          approvalRequestId: "approval-1",
+          registerSessionExpectedCashDelta: -50_000,
+          settlementDirection: "refund",
+          settlementMethod: "cash",
+          transactionId: "txn-1",
+          transactionNumber: "POS-111111",
+        }),
+        message: `Applied item adjustment refund of ${formatStoredTraceAmount("GHS", 50_000)} for transaction #POS-111111.`,
+        occurredAt: 222,
+        status: "info",
+        step: "register_session_item_adjustment_applied",
+        subjectRefs: expect.objectContaining({
+          adjustmentId: "adjustment-1",
+          approvalRequestId: "approval-1",
+          posTransactionId: "txn-1",
+          registerSessionId: "session-1",
+        }),
+      }),
+    );
+  });
+
   it("uses the current time for non-open milestones when no occurredAt is provided", async () => {
     vi.spyOn(Date, "now").mockReturnValue(444);
     vi.mocked(createWorkflowTraceWithCtx).mockResolvedValue("trace-1" as never);

--- a/packages/athena-webapp/convex/operations/registerSessionTracing.ts
+++ b/packages/athena-webapp/convex/operations/registerSessionTracing.ts
@@ -22,6 +22,8 @@ export type RegisterSessionTraceStage =
   | "closeout_submitted"
   | "closeout_reopened"
   | "approval_pending"
+  | "item_adjustment_approval_pending"
+  | "item_adjustment_applied"
   | "closeout_approved"
   | "closeout_rejected"
   | "closed";
@@ -50,13 +52,19 @@ type RegisterSessionTraceArgs = {
   session: RegisterSessionTraceableSession;
   occurredAt?: number;
   amount?: number;
+  adjustmentId?: Id<"posTransactionAdjustment">;
   approvalRequestId?: Id<"approvalRequest">;
   actorStaffProfileId?: Id<"staffProfile">;
   actorUserId?: Id<"athenaUser">;
   countedCash?: number;
   correctedOpeningFloat?: number;
   previousOpeningFloat?: number;
+  registerSessionExpectedCashDelta?: number;
   reason?: string;
+  settlementDirection?: "collect" | "refund" | "none";
+  settlementMethod?: string;
+  transactionId?: Id<"posTransaction">;
+  transactionNumber?: string;
   variance?: number;
 };
 
@@ -114,6 +122,20 @@ function displayTraceAmount(
 
     return currencyFormatter("GHS").format(displayAmount);
   }
+}
+
+function formatTransactionLabel(input: RegisterSessionTraceArgs) {
+  const transactionNumber = input.transactionNumber?.trim();
+
+  if (transactionNumber) {
+    return `transaction #${transactionNumber}`;
+  }
+
+  if (input.transactionId) {
+    return `transaction ${String(input.transactionId)}`;
+  }
+
+  return "the transaction";
 }
 
 async function resolveStoreCurrency(
@@ -177,6 +199,9 @@ function buildTraceEvent(args: {
   const details = Object.fromEntries(
     Object.entries({
       amount: args.input.amount,
+      adjustmentId: args.input.adjustmentId
+        ? String(args.input.adjustmentId)
+        : undefined,
       approvalRequestId: args.input.approvalRequestId
         ? String(args.input.approvalRequestId)
         : undefined,
@@ -184,17 +209,32 @@ function buildTraceEvent(args: {
       correctedOpeningFloat: args.input.correctedOpeningFloat,
       expectedCash: args.input.session.expectedCash,
       previousOpeningFloat: args.input.previousOpeningFloat,
+      registerSessionExpectedCashDelta:
+        args.input.registerSessionExpectedCashDelta,
       reason: args.input.reason,
       registerStatus: args.input.session.status,
+      settlementDirection: args.input.settlementDirection,
+      settlementMethod: args.input.settlementMethod,
+      transactionId: args.input.transactionId
+        ? String(args.input.transactionId)
+        : undefined,
+      transactionNumber: args.input.transactionNumber,
       variance: args.input.variance ?? args.input.session.variance,
     }).filter(([, value]) => value !== undefined),
   );
   const subjectRefs = {
     ...args.traceSeed.subjectRefs,
+    ...(args.input.adjustmentId
+      ? { adjustmentId: String(args.input.adjustmentId) }
+      : {}),
     ...(args.input.approvalRequestId
       ? { approvalRequestId: String(args.input.approvalRequestId) }
       : {}),
+    ...(args.input.transactionId
+      ? { posTransactionId: String(args.input.transactionId) }
+      : {}),
   };
+  const transactionLabel = formatTransactionLabel(args.input);
 
   switch (args.input.stage) {
     case "opened":
@@ -263,6 +303,31 @@ function buildTraceEvent(args: {
         step: "register_session_approval_pending",
         status: "blocked" as const,
         message: "Register closeout is pending manager approval.",
+        occurredAt,
+        details,
+        subjectRefs,
+      };
+    case "item_adjustment_approval_pending":
+      return {
+        kind: "system_action" as const,
+        step: "register_session_item_adjustment_approval_pending",
+        status: "info" as const,
+        message: `Queued item adjustment for ${transactionLabel} for manager approval.`,
+        occurredAt,
+        details,
+        subjectRefs,
+      };
+    case "item_adjustment_applied":
+      return {
+        kind: "system_action" as const,
+        step: "register_session_item_adjustment_applied",
+        status: "info" as const,
+        message:
+          args.input.settlementDirection === "refund" && (args.input.amount ?? 0) > 0
+            ? `Applied item adjustment refund of ${displayTraceAmount(args.input.amount, args.currency)} for ${transactionLabel}.`
+            : args.input.settlementDirection === "collect" && (args.input.amount ?? 0) > 0
+              ? `Applied item adjustment collection of ${displayTraceAmount(args.input.amount, args.currency)} for ${transactionLabel}.`
+              : `Applied item adjustment for ${transactionLabel}.`,
         occurredAt,
         details,
         subjectRefs,

--- a/packages/athena-webapp/convex/pos/application/adjustTransactionItems.test.ts
+++ b/packages/athena-webapp/convex/pos/application/adjustTransactionItems.test.ts
@@ -10,6 +10,7 @@ import { consumeCommandApprovalProofWithCtx } from "../../operations/approvalAct
 import { recordInventoryMovementWithCtx } from "../../operations/inventoryMovements";
 import { recordOperationalEventWithCtx } from "../../operations/operationalEvents";
 import { recordPaymentAllocationWithCtx } from "../../operations/paymentAllocations";
+import { recordRegisterSessionTraceBestEffort } from "../../operations/registerSessionTracing";
 import {
   getPosTransactionById,
   getStoreById,
@@ -36,6 +37,10 @@ vi.mock("../../operations/operationalEvents", () => ({
 
 vi.mock("../../operations/paymentAllocations", () => ({
   recordPaymentAllocationWithCtx: vi.fn(),
+}));
+
+vi.mock("../../operations/registerSessionTracing", () => ({
+  recordRegisterSessionTraceBestEffort: vi.fn(),
 }));
 
 vi.mock("../infrastructure/repositories/transactionRepository", () => ({
@@ -165,8 +170,13 @@ function createFakeCtx() {
           _id: "register-session-1",
           countedCash: 1200,
           expectedCash: 1000,
+          openedAt: 1,
+          openingFloat: 1000,
+          organizationId: "org-1",
+          registerNumber: "3",
           storeId: "store-1",
           status: "active",
+          terminalId: "terminal-1",
         },
       ],
     ]),
@@ -299,6 +309,10 @@ beforeEach(() => {
   vi.mocked(recordOperationalEventWithCtx).mockResolvedValue({
     _id: "event-1" as Id<"operationalEvent">,
   } as never);
+  vi.mocked(recordRegisterSessionTraceBestEffort).mockResolvedValue({
+    traceCreated: true,
+    traceId: "register_session:register-session-1",
+  } as never);
 });
 
 describe("adjustTransactionItems", () => {
@@ -352,6 +366,43 @@ describe("adjustTransactionItems", () => {
     expect(recordInventoryMovementWithCtx).not.toHaveBeenCalled();
     expect(recordPaymentAllocationWithCtx).not.toHaveBeenCalled();
     expect(recordOperationalEventWithCtx).not.toHaveBeenCalled();
+    expect(recordRegisterSessionTraceBestEffort).toHaveBeenCalledWith(
+      ctx as never,
+      expect.objectContaining({
+        actorStaffProfileId: "cashier-1",
+        amount: 500,
+        approvalRequestId: "approvalRequest-1",
+        settlementDirection: "refund",
+        settlementMethod: "cash",
+        stage: "item_adjustment_approval_pending",
+        transactionId: "txn-1",
+        transactionNumber: "POS-111111",
+      }),
+    );
+  });
+
+  it("rejects cash refunds that would make expected cash negative before creating approval requests", async () => {
+    const { ctx, tables } = createFakeCtx();
+    tables.registerSession.set("register-session-1", {
+      ...(tables.registerSession.get("register-session-1") ?? {}),
+      expectedCash: 400,
+    });
+
+    await expect(
+      adjustTransactionItems(ctx as never, {
+        actorStaffProfileId: "cashier-1" as Id<"staffProfile">,
+        payload: basePayload(),
+        reason: "Customer was charged for two instead of one",
+        transactionId: "txn-1" as Id<"posTransaction">,
+      }),
+    ).rejects.toThrow("Register session expected cash cannot be negative.");
+
+    expect(tables.approvalRequest.size).toBe(0);
+    expect(tables.posTransactionAdjustment.size).toBe(0);
+    expect(recordInventoryMovementWithCtx).not.toHaveBeenCalled();
+    expect(recordPaymentAllocationWithCtx).not.toHaveBeenCalled();
+    expect(recordOperationalEventWithCtx).not.toHaveBeenCalled();
+    expect(recordRegisterSessionTraceBestEffort).not.toHaveBeenCalled();
   });
 
   it("applies a matching refund adjustment once without mutating original transaction rows", async () => {
@@ -433,6 +484,32 @@ describe("adjustTransactionItems", () => {
             }),
           ],
         }),
+      }),
+    );
+    expect(recordRegisterSessionTraceBestEffort).toHaveBeenCalledWith(
+      ctx as never,
+      expect.objectContaining({
+        amount: 500,
+        approvalRequestId,
+        settlementDirection: "refund",
+        settlementMethod: "cash",
+        stage: "item_adjustment_approval_pending",
+        transactionId: "txn-1",
+        transactionNumber: "POS-111111",
+      }),
+    );
+    expect(recordRegisterSessionTraceBestEffort).toHaveBeenCalledWith(
+      ctx as never,
+      expect.objectContaining({
+        adjustmentId: "posTransactionAdjustment-1",
+        amount: 500,
+        approvalRequestId,
+        registerSessionExpectedCashDelta: -500,
+        settlementDirection: "refund",
+        settlementMethod: "cash",
+        stage: "item_adjustment_applied",
+        transactionId: "txn-1",
+        transactionNumber: "POS-111111",
       }),
     );
     expect(tables.productSku.get("sku-1")).toMatchObject({

--- a/packages/athena-webapp/convex/pos/application/commands/adjustTransactionItems.ts
+++ b/packages/athena-webapp/convex/pos/application/commands/adjustTransactionItems.ts
@@ -10,6 +10,11 @@ import { recordInventoryMovementWithCtx } from "../../../operations/inventoryMov
 import { recordOperationalEventWithCtx } from "../../../operations/operationalEvents";
 import { recordPaymentAllocationWithCtx } from "../../../operations/paymentAllocations";
 import {
+  recordRegisterSessionTraceBestEffort,
+  type RegisterSessionTraceableSession,
+  type RegisterSessionTraceStage,
+} from "../../../operations/registerSessionTracing";
+import {
   createTransactionAdjustmentForTransaction,
   getActiveTransactionAdjustment,
   getProductSkuById,
@@ -355,6 +360,72 @@ async function findAppliedAdjustmentByFingerprint(
   };
 }
 
+async function getRegisterSessionForTrace(
+  ctx: MutationCtx,
+  args: {
+    registerSessionId?: Id<"registerSession">;
+    storeId: Id<"store">;
+  },
+) {
+  if (!args.registerSessionId) {
+    return null;
+  }
+
+  const session = await ctx.db.get("registerSession", args.registerSessionId);
+
+  if (!session || session.storeId !== args.storeId) {
+    return null;
+  }
+
+  return session as RegisterSessionTraceableSession;
+}
+
+async function recordItemAdjustmentRegisterSessionTrace(
+  ctx: MutationCtx,
+  args: {
+    actorStaffProfileId?: Id<"staffProfile">;
+    actorUserId?: Id<"athenaUser">;
+    adjustmentId?: Id<"posTransactionAdjustment">;
+    approvalRequestId?: Id<"approvalRequest">;
+    plan: AdjustmentPlan;
+    registerSessionExpectedCashDelta?: number;
+    stage: Extract<
+      RegisterSessionTraceStage,
+      "item_adjustment_approval_pending" | "item_adjustment_applied"
+    >;
+    transaction: {
+      _id: Id<"posTransaction">;
+      registerSessionId?: Id<"registerSession">;
+      storeId: Id<"store">;
+      transactionNumber: string;
+    };
+  },
+) {
+  const session = await getRegisterSessionForTrace(ctx, {
+    registerSessionId: args.transaction.registerSessionId,
+    storeId: args.transaction.storeId,
+  });
+
+  if (!session) {
+    return;
+  }
+
+  await recordRegisterSessionTraceBestEffort(ctx, {
+    actorStaffProfileId: args.actorStaffProfileId,
+    actorUserId: args.actorUserId,
+    adjustmentId: args.adjustmentId,
+    amount: args.plan.settlementAmount,
+    approvalRequestId: args.approvalRequestId,
+    registerSessionExpectedCashDelta: args.registerSessionExpectedCashDelta,
+    session,
+    settlementDirection: args.plan.settlementDirection,
+    settlementMethod: args.plan.settlementMethod,
+    stage: args.stage,
+    transactionId: args.transaction._id,
+    transactionNumber: args.transaction.transactionNumber,
+  });
+}
+
 async function createApprovalRequestForAdjustment(
   ctx: MutationCtx,
   args: {
@@ -371,8 +442,7 @@ async function createApprovalRequestForAdjustment(
   },
 ) {
   const store = await getStoreById(ctx, args.transaction.storeId);
-
-  return ctx.db.insert(
+  const approvalRequestId = await ctx.db.insert(
     "approvalRequest",
     buildApprovalRequest({
       metadata: {
@@ -420,6 +490,17 @@ async function createApprovalRequestForAdjustment(
       subjectType: ITEM_ADJUSTMENT_SUBJECT_TYPE,
     }),
   );
+
+  await recordItemAdjustmentRegisterSessionTrace(ctx, {
+    actorStaffProfileId: args.actorStaffProfileId,
+    actorUserId: args.actorUserId,
+    approvalRequestId,
+    plan: args.plan,
+    stage: "item_adjustment_approval_pending",
+    transaction: args.transaction,
+  });
+
+  return approvalRequestId;
 }
 
 async function findPendingItemAdjustmentApprovalRequest(
@@ -708,14 +789,14 @@ async function adjustRegisterSessionExpectedCashForSettlement(
 
   const expectedCashDelta =
     args.direction === "collect" ? args.amount : -args.amount;
-  if (args.validateOnly) {
-    return expectedCashDelta;
-  }
-
   const nextExpectedCash = registerSession.expectedCash + expectedCashDelta;
 
   if (nextExpectedCash < 0) {
     throw new Error("Register session expected cash cannot be negative.");
+  }
+
+  if (args.validateOnly) {
+    return expectedCashDelta;
   }
 
   await ctx.db.patch("registerSession", args.registerSessionId, {
@@ -911,6 +992,17 @@ async function applyApprovedAdjustment(
     updatedAt: now,
   });
 
+  await recordItemAdjustmentRegisterSessionTrace(ctx, {
+    actorStaffProfileId: args.actorStaffProfileId,
+    actorUserId: args.actorUserId,
+    adjustmentId,
+    approvalRequestId: args.approvalRequestId,
+    plan: args.plan,
+    registerSessionExpectedCashDelta,
+    stage: "item_adjustment_applied",
+    transaction: args.transaction,
+  });
+
   return {
     adjustmentId,
     approvalProofId: args.approvalProofId,
@@ -942,14 +1034,6 @@ export async function adjustTransactionItems(
     payload: args.payload,
     transaction,
   });
-  await adjustRegisterSessionExpectedCashForSettlement(ctx, {
-    amount: plan.settlementAmount,
-    direction: plan.settlementDirection,
-    method: plan.settlementMethod,
-    registerSessionId: transaction.registerSessionId,
-    storeId: transaction.storeId,
-    validateOnly: true,
-  });
   const existing = await findAppliedAdjustmentByFingerprint(ctx, {
     fingerprint: plan.fingerprint,
     payloadSubject: plan.payloadSubject,
@@ -959,6 +1043,16 @@ export async function adjustTransactionItems(
 
   if (existing) {
     return existing;
+  }
+
+  const appliedAdjustment = await findAppliedAdjustmentForTransaction(ctx, {
+    storeId: transaction.storeId,
+    transactionId: transaction._id,
+  });
+  if (appliedAdjustment) {
+    throw new Error(
+      "This transaction already has an item adjustment applied.",
+    );
   }
 
   if (!args.approvalProofId) {
@@ -974,6 +1068,17 @@ export async function adjustTransactionItems(
       throw new Error(
         "This transaction already has an item adjustment waiting for approval.",
       );
+    }
+
+    if (!pendingApprovalRequest) {
+      await adjustRegisterSessionExpectedCashForSettlement(ctx, {
+        amount: plan.settlementAmount,
+        direction: plan.settlementDirection,
+        method: plan.settlementMethod,
+        registerSessionId: transaction.registerSessionId,
+        storeId: transaction.storeId,
+        validateOnly: true,
+      });
     }
 
     const approvalRequestId =
@@ -999,6 +1104,15 @@ export async function adjustTransactionItems(
       transactionId: args.transactionId,
     };
   }
+
+  await adjustRegisterSessionExpectedCashForSettlement(ctx, {
+    amount: plan.settlementAmount,
+    direction: plan.settlementDirection,
+    method: plan.settlementMethod,
+    registerSessionId: transaction.registerSessionId,
+    storeId: transaction.storeId,
+    validateOnly: true,
+  });
 
   const approvalRequest =
     await requireMatchingPendingItemAdjustmentApprovalRequest(ctx, {

--- a/packages/athena-webapp/convex/pos/public/transactions.test.ts
+++ b/packages/athena-webapp/convex/pos/public/transactions.test.ts
@@ -487,6 +487,28 @@ describe("adjustTransactionItems public mutation", () => {
     );
   });
 
+  it("surfaces register-session expected cash failures as item adjustment user errors", async () => {
+    vi.mocked(itemAdjustmentCommands.adjustTransactionItems).mockRejectedValue(
+      new Error("Register session expected cash cannot be negative."),
+    );
+
+    await expect(
+      getHandler(adjustTransactionItems)(createAuthorizedItemAdjustmentCtx() as never, {
+        actorStaffProfileId: "staff-1",
+        payload,
+        reason: "Customer was charged for two instead of one",
+        staffProofToken: "proof-token-1",
+        transactionId: "txn-1",
+      }),
+    ).resolves.toMatchObject({
+      kind: "user_error",
+      error: {
+        code: "precondition_failed",
+        message: "Register session expected cash cannot be negative.",
+      },
+    });
+  });
+
   it("requires a signed-in staff actor before adjusting items", async () => {
     await expect(
       getHandler(adjustTransactionItems)({} as never, {

--- a/packages/athena-webapp/convex/pos/public/transactions.ts
+++ b/packages/athena-webapp/convex/pos/public/transactions.ts
@@ -188,6 +188,7 @@ function mapCorrectionError(error: unknown): CommandResult<never> | null {
     message === "This transaction already has an item adjustment waiting for approval." ||
     message === "This transaction already has an item adjustment applied." ||
     message === "Register closeout is under review. Reopen the register before updating adjustment settlement." ||
+    message === "Register session expected cash cannot be negative." ||
     message.startsWith("Approval proof ")
   ) {
     return userError({ code: "precondition_failed", message });

--- a/packages/athena-webapp/src/components/operations/OperationsQueueView.test.tsx
+++ b/packages/athena-webapp/src/components/operations/OperationsQueueView.test.tsx
@@ -513,15 +513,32 @@ describe("OperationsQueueViewContent", () => {
                   quantityDelta: -1,
                   sku: "CW-18",
                 },
+                {
+                  adjustedQuantity: 1,
+                  originalQuantity: 1,
+                  productName: "Unchanged bundle",
+                  productSkuId: "sku-2" as Id<"productSku">,
+                  quantityDelta: 0,
+                  sku: "UB-18",
+                },
               ],
               originalTotal: 20000,
               settlementAmount: 5000,
               settlementDirection: "refund",
-              settlementMethod: "cash",
+              settlementMethod: "mobile_money",
               totalDelta: -5000,
               transactionId: "txn-1" as Id<"posTransaction">,
             },
             notes: "Customer only received one unit.",
+            registerSessionSummary: {
+              countedCash: null,
+              expectedCash: 15_000,
+              registerNumber: "3",
+              registerSessionId: "register-3" as Id<"registerSession">,
+              status: "active",
+              terminalName: "Front Counter",
+              variance: null,
+            },
             requestedByStaffName: "Ato Kwamina",
             requestType: "pos_item_adjustment",
             status: "pending",
@@ -543,11 +560,34 @@ describe("OperationsQueueViewContent", () => {
 
     expect(screen.getAllByText("Review item adjustment").length).toBeGreaterThan(0);
     expect(screen.getByText("#434898")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "#434898" })).toHaveAttribute(
+      "href",
+      "/$orgUrlSlug/store/$storeUrlSlug/pos/transactions/$transactionId?o=%252F",
+    );
+    expect(
+      screen.getByRole("link", { name: /view register session/i }),
+    ).toHaveAttribute(
+      "href",
+      "/$orgUrlSlug/store/$storeUrlSlug/cash-controls/registers/$sessionId?o=%252F",
+    );
+    expect(
+      screen.getByRole("link", { name: /front counter \/ register 3/i }),
+    ).toHaveAttribute(
+      "href",
+      "/$orgUrlSlug/store/$storeUrlSlug/cash-controls/registers/$sessionId?o=%252F",
+    );
     expect(screen.getByText("Original total")).toBeInTheDocument();
     expect(screen.getByText("Adjusted total")).toBeInTheDocument();
+    expect(screen.getByText("Register session")).toBeInTheDocument();
     expect(screen.getByText("Refund due")).toBeInTheDocument();
+    expect(screen.getByText("Original payment")).toBeInTheDocument();
+    expect(screen.getByText("Cash")).toBeInTheDocument();
+    expect(screen.getByText("Refund payout")).toBeInTheDocument();
+    expect(screen.getByText("Mobile Money")).toBeInTheDocument();
     expect(screen.getByText("Closure wig")).toBeInTheDocument();
     expect(screen.getByText("CW-18")).toBeInTheDocument();
+    expect(screen.queryByText("Unchanged bundle")).not.toBeInTheDocument();
+    expect(screen.queryByText("UB-18")).not.toBeInTheDocument();
     expect(
       screen.getByText(
         (_, element) =>

--- a/packages/athena-webapp/src/components/operations/OperationsQueueView.tsx
+++ b/packages/athena-webapp/src/components/operations/OperationsQueueView.tsx
@@ -5,7 +5,6 @@ import {
   ArrowUpRight,
   ClipboardCheck,
   Clock3,
-  ExternalLink,
   Lock,
   LockOpen,
 } from "lucide-react";
@@ -129,6 +128,10 @@ type QueueApprovalRequest = {
 
 export type OperationsWorkflow = "stock" | "queue" | "approvals";
 
+type QueueApprovalLineItem = NonNullable<
+  NonNullable<QueueApprovalRequest["metadata"]>["lineItems"]
+>[number];
+
 function getDefaultWorkflow(args: {
   approvalRequests: QueueApprovalRequest[];
   workItems: QueueWorkItem[];
@@ -212,6 +215,71 @@ function formatSkuProductName(productName?: string) {
   return normalizedName.charAt(0).toUpperCase() + normalizedName.slice(1);
 }
 
+function hasItemAdjustmentChange(lineItem: QueueApprovalLineItem) {
+  const quantityChanged =
+    typeof lineItem.originalQuantity === "number" &&
+    typeof lineItem.adjustedQuantity === "number" &&
+    lineItem.originalQuantity !== lineItem.adjustedQuantity;
+  const deltaChanged =
+    typeof lineItem.quantityDelta === "number" && lineItem.quantityDelta !== 0;
+
+  return quantityChanged || deltaChanged;
+}
+
+function TransactionReferenceLink({
+  orgUrlSlug,
+  storeUrlSlug,
+  transaction,
+}: {
+  orgUrlSlug?: string;
+  storeUrlSlug?: string;
+  transaction: QueueApprovalRequest["transactionSummary"];
+}) {
+  if (!transaction) {
+    return <span>Transaction unavailable</span>;
+  }
+
+  const transactionLabel = `#${transaction.transactionNumber}`;
+
+  if (!orgUrlSlug || !storeUrlSlug) {
+    return <span>{transactionLabel}</span>;
+  }
+
+  return (
+    <Link
+      className="inline-flex items-center gap-1 text-foreground underline-offset-4 transition-colors hover:text-primary hover:underline"
+      params={{
+        orgUrlSlug,
+        storeUrlSlug,
+        transactionId: transaction.transactionId,
+      }}
+      search={{ o: getOrigin() }}
+      to="/$orgUrlSlug/store/$storeUrlSlug/pos/transactions/$transactionId"
+    >
+      {transactionLabel}
+      <ArrowUpRight aria-hidden="true" className="h-3 w-3" />
+    </Link>
+  );
+}
+
+function formatRegisterSessionLabel(
+  registerSession: NonNullable<QueueApprovalRequest["registerSessionSummary"]>,
+) {
+  if (registerSession.terminalName && registerSession.registerNumber) {
+    return `${registerSession.terminalName} / Register ${registerSession.registerNumber}`;
+  }
+
+  if (registerSession.terminalName) {
+    return registerSession.terminalName;
+  }
+
+  if (registerSession.registerNumber) {
+    return `Register ${registerSession.registerNumber}`;
+  }
+
+  return "Register session";
+}
+
 function getInventoryApprovalLineItems(request: QueueApprovalRequest) {
   if (request.requestType !== "inventory_adjustment_review") {
     return [];
@@ -246,8 +314,9 @@ function getItemAdjustmentSummary(request: QueueApprovalRequest) {
 
   return {
     adjustedTotal: request.metadata?.adjustedTotal,
-    lineItems: request.metadata?.lineItems ?? [],
+    lineItems: request.metadata?.lineItems?.filter(hasItemAdjustmentChange) ?? [],
     originalTotal: request.metadata?.originalTotal,
+    registerSession: request.registerSessionSummary ?? null,
     settlementAmount: request.metadata?.settlementAmount,
     settlementDirection: request.metadata?.settlementDirection ?? "none",
     settlementMethod: request.metadata?.settlementMethod,
@@ -824,7 +893,7 @@ export function OperationsQueueViewContent({
                                           search={{ o: getOrigin() }}
                                           to="/$orgUrlSlug/store/$storeUrlSlug/pos/transactions/$transactionId"
                                         >
-                                          <ExternalLink aria-hidden="true" />
+                                          <ArrowUpRight aria-hidden="true" />
                                           View transaction
                                         </Link>
                                       </Button>
@@ -832,15 +901,19 @@ export function OperationsQueueViewContent({
                                   </div>
                                 </div>
 
-                                <dl className="mt-layout-sm grid gap-layout-sm rounded-lg border border-border bg-background p-layout-sm text-sm md:grid-cols-4">
+                                <dl className="mt-layout-sm grid gap-layout-sm rounded-lg border border-border bg-background p-layout-sm text-sm md:grid-cols-3 xl:grid-cols-6">
                                   <div>
                                     <dt className="text-xs text-muted-foreground">
                                       Transaction
                                     </dt>
                                     <dd className="mt-1 font-medium text-foreground">
-                                      {paymentCorrectionSummary.transaction
-                                        ? `#${paymentCorrectionSummary.transaction.transactionNumber}`
-                                        : "Transaction unavailable"}
+                                      <TransactionReferenceLink
+                                        orgUrlSlug={orgUrlSlug}
+                                        storeUrlSlug={storeUrlSlug}
+                                        transaction={
+                                          paymentCorrectionSummary.transaction
+                                        }
+                                      />
                                     </dd>
                                   </div>
                                   <div>
@@ -897,26 +970,49 @@ export function OperationsQueueViewContent({
                                       correction
                                     </p>
                                   </div>
-                                  {itemAdjustmentSummary.transaction &&
-                                  orgUrlSlug &&
-                                  storeUrlSlug ? (
-                                    <Button asChild size="sm" variant="utility">
-                                      <Link
-                                        params={{
-                                          orgUrlSlug,
-                                          storeUrlSlug,
-                                          transactionId:
-                                            itemAdjustmentSummary.transaction
-                                              .transactionId,
-                                        }}
-                                        search={{ o: getOrigin() }}
-                                        to="/$orgUrlSlug/store/$storeUrlSlug/pos/transactions/$transactionId"
-                                      >
-                                        <ExternalLink aria-hidden="true" />
-                                        View transaction
-                                      </Link>
-                                    </Button>
-                                  ) : null}
+                                  <div className="flex flex-wrap items-center gap-2">
+                                    {itemAdjustmentSummary.registerSession &&
+                                    orgUrlSlug &&
+                                    storeUrlSlug ? (
+                                      <Button asChild size="sm" variant="utility">
+                                        <Link
+                                          params={{
+                                            orgUrlSlug,
+                                            sessionId:
+                                              itemAdjustmentSummary
+                                                .registerSession
+                                                .registerSessionId,
+                                            storeUrlSlug,
+                                          }}
+                                          search={{ o: getOrigin() }}
+                                          to="/$orgUrlSlug/store/$storeUrlSlug/cash-controls/registers/$sessionId"
+                                        >
+                                          <ArrowUpRight aria-hidden="true" />
+                                          View register session
+                                        </Link>
+                                      </Button>
+                                    ) : null}
+                                    {itemAdjustmentSummary.transaction &&
+                                    orgUrlSlug &&
+                                    storeUrlSlug ? (
+                                      <Button asChild size="sm" variant="utility">
+                                        <Link
+                                          params={{
+                                            orgUrlSlug,
+                                            storeUrlSlug,
+                                            transactionId:
+                                              itemAdjustmentSummary.transaction
+                                                .transactionId,
+                                          }}
+                                          search={{ o: getOrigin() }}
+                                          to="/$orgUrlSlug/store/$storeUrlSlug/pos/transactions/$transactionId"
+                                        >
+                                          <ArrowUpRight aria-hidden="true" />
+                                          View transaction
+                                        </Link>
+                                      </Button>
+                                    ) : null}
+                                  </div>
                                 </div>
 
                                 <dl className="mt-layout-sm grid gap-layout-sm rounded-lg border border-border bg-background p-layout-sm text-sm md:grid-cols-4">
@@ -925,9 +1021,13 @@ export function OperationsQueueViewContent({
                                       Transaction
                                     </dt>
                                     <dd className="mt-1 font-medium text-foreground">
-                                      {itemAdjustmentSummary.transaction
-                                        ? `#${itemAdjustmentSummary.transaction.transactionNumber}`
-                                        : "Transaction unavailable"}
+                                      <TransactionReferenceLink
+                                        orgUrlSlug={orgUrlSlug}
+                                        storeUrlSlug={storeUrlSlug}
+                                        transaction={
+                                          itemAdjustmentSummary.transaction
+                                        }
+                                      />
                                     </dd>
                                   </div>
                                   <div>
@@ -955,9 +1055,59 @@ export function OperationsQueueViewContent({
                                             ghsCurrencyFormatter,
                                             itemAdjustmentSummary.adjustedTotal,
                                           )
+                                      : "Unknown"}
+                                    </dd>
+                                  </div>
+                                  <div>
+                                    <dt className="text-xs text-muted-foreground">
+                                      Original payment
+                                    </dt>
+                                    <dd className="mt-1 font-medium text-foreground">
+                                      {itemAdjustmentSummary.transaction
+                                        ?.paymentMethod
+                                        ? formatApprovalRequestType(
+                                            itemAdjustmentSummary.transaction
+                                              .paymentMethod,
+                                          )
                                         : "Unknown"}
                                     </dd>
                                   </div>
+                                  {itemAdjustmentSummary.registerSession ? (
+                                    <div>
+                                      <dt className="text-xs text-muted-foreground">
+                                        Register session
+                                      </dt>
+                                      <dd className="mt-1 font-medium text-foreground">
+                                        {orgUrlSlug && storeUrlSlug ? (
+                                          <Link
+                                            className="inline-flex items-center gap-1 underline-offset-4 hover:underline"
+                                            params={{
+                                              orgUrlSlug,
+                                              sessionId:
+                                                itemAdjustmentSummary
+                                                  .registerSession
+                                                  .registerSessionId,
+                                              storeUrlSlug,
+                                            }}
+                                            search={{ o: getOrigin() }}
+                                            to="/$orgUrlSlug/store/$storeUrlSlug/cash-controls/registers/$sessionId"
+                                          >
+                                            {formatRegisterSessionLabel(
+                                              itemAdjustmentSummary.registerSession,
+                                            )}
+                                            <ArrowUpRight
+                                              aria-hidden="true"
+                                              className="h-3 w-3"
+                                            />
+                                          </Link>
+                                        ) : (
+                                          formatRegisterSessionLabel(
+                                            itemAdjustmentSummary.registerSession,
+                                          )
+                                        )}
+                                      </dd>
+                                    </div>
+                                  ) : null}
                                   <div>
                                     <dt className="text-xs text-muted-foreground">
                                       {itemAdjustmentSummary.settlementDirection ===
@@ -983,6 +1133,24 @@ export function OperationsQueueViewContent({
                                           : "Unknown"}
                                     </dd>
                                   </div>
+                                  {itemAdjustmentSummary.settlementDirection !==
+                                  "none" ? (
+                                    <div>
+                                      <dt className="text-xs text-muted-foreground">
+                                        {itemAdjustmentSummary.settlementDirection ===
+                                        "refund"
+                                          ? "Refund payout"
+                                          : "Collection method"}
+                                      </dt>
+                                      <dd className="mt-1 font-medium text-foreground">
+                                        {itemAdjustmentSummary.settlementMethod
+                                          ? formatApprovalRequestType(
+                                              itemAdjustmentSummary.settlementMethod,
+                                            )
+                                          : "Unknown"}
+                                      </dd>
+                                    </div>
+                                  ) : null}
                                 </dl>
 
                                 {itemAdjustmentSummary.lineItems.length > 0 ? (

--- a/packages/athena-webapp/src/components/pos/terminals/POSTerminalHealthView.tsx
+++ b/packages/athena-webapp/src/components/pos/terminals/POSTerminalHealthView.tsx
@@ -5,7 +5,10 @@ import { Activity, AlertTriangle, MonitorCheck } from "lucide-react";
 
 import View from "@/components/View";
 import { FadeIn } from "@/components/common/FadeIn";
-import { PageLevelHeader, PageWorkspace } from "@/components/common/PageLevelHeader";
+import {
+  PageLevelHeader,
+  PageWorkspace,
+} from "@/components/common/PageLevelHeader";
 import { EmptyState } from "@/components/states/empty/empty-state";
 import { NoPermissionView } from "@/components/states/no-permission/NoPermissionView";
 import { ProtectedAdminSignInView } from "@/components/states/signed-out/ProtectedAdminSignInView";
@@ -24,6 +27,7 @@ import {
   getStaffAuthorityLabel,
 } from "./terminalHealthPresentation";
 import type { TerminalHealthSummary } from "./terminalHealthTypes";
+import { getOrigin } from "~/src/lib/navigationUtils";
 
 const posTerminalApi = api.inventory.posTerminal as unknown as {
   listTerminalHealth: FunctionReference<
@@ -114,7 +118,9 @@ export function POSTerminalHealthViewContent({
                 <div className="rounded-lg border border-dashed border-border bg-surface-raised px-layout-lg py-layout-xl">
                   <EmptyState
                     description="Register this checkout station from POS settings before terminal health can report."
-                    icon={<MonitorCheck className="h-16 w-16 text-muted-foreground" />}
+                    icon={
+                      <MonitorCheck className="h-16 w-16 text-muted-foreground" />
+                    }
                     title="No POS terminals registered"
                   />
                 </div>
@@ -138,23 +144,42 @@ export function POSTerminalHealthViewContent({
                                 terminalId: String(summary.terminal._id),
                               }}
                               to="/$orgUrlSlug/store/$storeUrlSlug/pos/terminals/$terminalId"
+                              search={{ o: getOrigin() }}
                             >
                               {summary.terminal.displayName}
                             </Link>
                             <div className="flex flex-wrap gap-layout-xs text-sm text-muted-foreground">
-                              <span>{formatRegisterNumber(summary.terminal.registerNumber)}</span>
-                              <span>Last check-in {formatTerminalTimestamp(runtimeStatus?.receivedAt)}</span>
-                              <span>{getStaffAuthorityLabel(runtimeStatus?.staffAuthority)}</span>
+                              <span>
+                                {formatRegisterNumber(
+                                  summary.terminal.registerNumber,
+                                )}
+                              </span>
+                              <span>
+                                Last check-in{" "}
+                                {formatTerminalTimestamp(
+                                  runtimeStatus?.receivedAt,
+                                )}
+                              </span>
+                              <span>
+                                {getStaffAuthorityLabel(
+                                  runtimeStatus?.staffAuthority,
+                                )}
+                              </span>
                             </div>
                           </div>
-                          <Badge className={classification.toneClassName} variant="outline">
+                          <Badge
+                            className={classification.toneClassName}
+                            variant="outline"
+                          >
                             {classification.label}
                           </Badge>
                         </div>
 
                         <div className="mt-layout-md grid gap-layout-sm md:grid-cols-2 xl:grid-cols-4">
                           <div>
-                            <p className="text-xs font-medium uppercase text-muted-foreground">Sync</p>
+                            <p className="text-xs font-medium uppercase text-muted-foreground">
+                              Sync
+                            </p>
                             <p className="mt-1 text-sm text-foreground">
                               {runtimeStatus
                                 ? `${runtimeStatus.sync.pendingEventCount} pending / ${runtimeStatus.sync.reviewEventCount + getReviewEvidenceCount(summary.syncEvidence)} review`
@@ -162,21 +187,29 @@ export function POSTerminalHealthViewContent({
                             </p>
                           </div>
                           <div>
-                            <p className="text-xs font-medium uppercase text-muted-foreground">Snapshot age</p>
+                            <p className="text-xs font-medium uppercase text-muted-foreground">
+                              Snapshot age
+                            </p>
                             <p className="mt-1 text-sm text-foreground">
                               {getSnapshotAgeSummary(runtimeStatus?.snapshots)}
                             </p>
                           </div>
                           <div>
-                            <p className="text-xs font-medium uppercase text-muted-foreground">Active session</p>
+                            <p className="text-xs font-medium uppercase text-muted-foreground">
+                              Active session
+                            </p>
                             <p className="mt-1 text-sm text-foreground">
-                              Register session evidence is shown in cash controls
+                              Register session evidence is shown in cash
+                              controls
                             </p>
                           </div>
                           <div>
-                            <p className="text-xs font-medium uppercase text-muted-foreground">Cloud cursor</p>
+                            <p className="text-xs font-medium uppercase text-muted-foreground">
+                              Cloud cursor
+                            </p>
                             <p className="mt-1 text-sm text-foreground">
-                              {summary.syncEvidence.acceptedThroughSequence == null
+                              {summary.syncEvidence.acceptedThroughSequence ==
+                              null
                                 ? "No accepted sequence"
                                 : `Accepted through ${summary.syncEvidence.acceptedThroughSequence}`}
                             </p>
@@ -198,14 +231,12 @@ export function POSTerminalHealthViewContent({
 export function POSTerminalHealthView() {
   const { isLoading: isLoadingUser, user } = useAuth();
   const { activeStore, isLoadingStores } = useGetActiveStore();
-  const {
-    canAccessPOS,
-    isLoading: isLoadingPermissions,
-  } = usePermissions();
+  const { canAccessPOS, isLoading: isLoadingPermissions } = usePermissions();
   const params = useParams({ strict: false }) as
     | { orgUrlSlug?: string; storeUrlSlug?: string }
     | undefined;
-  const isLoadingAccess = isLoadingUser || isLoadingStores || isLoadingPermissions;
+  const isLoadingAccess =
+    isLoadingUser || isLoadingStores || isLoadingPermissions;
   const canViewHealth = canAccessPOS();
   const canQuery = Boolean(activeStore?._id && user && canViewHealth);
   const healthSummaries = useQuery(

--- a/packages/athena-webapp/src/components/pos/transactions/TransactionView.test.tsx
+++ b/packages/athena-webapp/src/components/pos/transactions/TransactionView.test.tsx
@@ -32,6 +32,22 @@ vi.mock("convex/react", () => ({
 }));
 
 vi.mock("@tanstack/react-router", () => ({
+  Link: ({
+    children,
+    params,
+    to,
+  }: {
+    children?: React.ReactNode;
+    params?: Record<string, string>;
+    to: string;
+  }) => {
+    const href = Object.entries(params ?? {}).reduce(
+      (path, [key, value]) => path.replace(`$${key}`, value),
+      to,
+    );
+
+    return <a href={href}>{children}</a>;
+  },
   useParams: (...args: unknown[]) => useParamsMock(...args),
 }));
 
@@ -1877,7 +1893,8 @@ describe("TransactionView", () => {
     render(<TransactionView />);
 
     expect(screen.getByText("Adjusted sale")).toBeInTheDocument();
-    expect(screen.getByText("Adjusted sale total")).toBeInTheDocument();
+    expect(screen.getByText("Applied sale total")).toBeInTheDocument();
+    expect(screen.getByText("Pending sale total")).toBeInTheDocument();
     expect(screen.getByText("Original sale total")).toBeInTheDocument();
     expect(screen.getByText("Item adjustment")).toBeInTheDocument();
     expect(screen.getByText("Item adjustment pending approval")).toBeInTheDocument();
@@ -1892,6 +1909,56 @@ describe("TransactionView", () => {
     expect(screen.getByTestId("order-summary")).toHaveTextContent(
       "adjusted summary 1000 original 2000 delta -1000",
     );
+  });
+
+  it("shows pending item adjustment totals as projected instead of applied", () => {
+    useParamsMock.mockReturnValue({ transactionId: "txn_pending_adjustment" });
+    useQueryMock.mockReturnValue({
+      ...baseTransaction,
+      total: 604396,
+      subtotal: 604396,
+      adjustmentSummary: {
+        appliedCount: 0,
+        effectiveNetTotal: 604396,
+        hasAdjustments: true,
+        originalTotal: 604396,
+        pendingCount: 1,
+        totalAppliedAdjustmentDelta: 0,
+      },
+      adjustments: [
+        {
+          _id: "approval-1",
+          actorStaffName: "Ato Kwamina",
+          adjustedTotal: 504396,
+          createdAt: 200,
+          lineItems: [
+            {
+              adjustedQuantity: 9,
+              originalQuantity: 11,
+              productName: "Vibes",
+              productSku: "6N2Y-YFV-HFQ",
+              quantityDelta: -2,
+              totalDelta: -100000,
+              unitPrice: 50000,
+            },
+          ],
+          originalTotal: 604396,
+          settlementAmount: 100000,
+          settlementDirection: "refund",
+          status: "pending_approval",
+        },
+      ],
+    });
+
+    render(<TransactionView />);
+
+    expect(screen.getByText("Adjustment state")).toBeInTheDocument();
+    expect(screen.getByText("Original sale total")).toBeInTheDocument();
+    expect(screen.getByText("GH₵6,043.96")).toBeInTheDocument();
+    expect(screen.getByText("Pending sale total")).toBeInTheDocument();
+    expect(screen.getByText("GH₵5,043.96")).toBeInTheDocument();
+    expect(screen.queryByText("Applied sale total")).not.toBeInTheDocument();
+    expect(screen.queryByText("Adjusted sale total")).not.toBeInTheDocument();
   });
 
   it("opens the item adjustment workflow and requires a settlement method for refunds", async () => {
@@ -2374,6 +2441,95 @@ describe("TransactionView", () => {
         transactionId: "txn_equal",
       }),
     );
+  });
+
+  it("renders item adjustment command errors returned by the backend", async () => {
+    const user = userEvent.setup();
+    const authMutation = vi.fn();
+    const terminalAuthMutation = vi.fn().mockResolvedValue({
+      kind: "ok",
+      data: {
+        activeRoles: ["cashier"],
+        posLocalStaffProof: {
+          expiresAt: Date.now() + 60_000,
+          token: "proof-token-1",
+        },
+        staffProfile: { firstName: "Kwamina", lastName: "Mensah" },
+        staffProfileId: "staff_1",
+      },
+    });
+    const itemAdjustmentMutation = vi.fn().mockResolvedValue({
+      kind: "user_error",
+      error: {
+        code: "precondition_failed",
+        message: "Register session expected cash cannot be negative.",
+      },
+    });
+    mockTransactionMutations(
+      authMutation,
+      vi.fn(),
+      vi.fn(),
+      vi.fn(),
+      itemAdjustmentMutation,
+      terminalAuthMutation,
+    );
+    useParamsMock.mockReturnValue({
+      orgUrlSlug: "wigclub",
+      storeUrlSlug: "osu",
+      transactionId: "txn_cash_refund",
+    });
+    useQueryMock.mockReturnValue({
+      ...baseTransaction,
+      paymentMethod: "mobile_money",
+      payments: [{ method: "mobile_money", amount: 2000, timestamp: 123 }],
+      registerSessionId: "session_1",
+      total: 2000,
+      totalPaid: 2000,
+      items: [
+        {
+          _id: "item_1",
+          productId: "product_1",
+          productName: "Closure wig",
+          productSku: "CW-18",
+          productSkuId: "sku_1",
+          quantity: 2,
+          totalPrice: 2000,
+          unitPrice: 1000,
+        },
+      ],
+    });
+
+    render(<TransactionView />);
+
+    await user.click(screen.getByRole("button", { name: "Update" }));
+    await user.click(
+      screen.getByRole("button", { name: "Items or quantities" }),
+    );
+    await user.click(screen.getByRole("button", { name: /decrease closure wig/i }));
+    await user.selectOptions(screen.getByLabelText("Settlement method"), "cash");
+    await user.type(
+      screen.getByLabelText("Item adjustment reason"),
+      "Customer was charged for two instead of one.",
+    );
+    await user.click(
+      screen.getByRole("button", { name: "Submit item adjustment" }),
+    );
+    await user.click(screen.getByRole("button", { name: "Confirm" }));
+
+    expect(
+      await screen.findByText("Drawer expected cash is below this refund."),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Correct the register session opening float so expected cash can cover the cash refund, then submit the item adjustment again.",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Register session expected cash cannot be negative.")).not.toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /review register session/i })).toHaveAttribute(
+      "href",
+      "/wigclub/store/osu/cash-controls/registers/session_1",
+    );
+    expect(screen.queryByText("Please try again.")).not.toBeInTheDocument();
   });
 
   it("formats correction history labels for fallback and partial payment changes", () => {

--- a/packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx
+++ b/packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx
@@ -1,8 +1,9 @@
 import { useMemo, useState } from "react";
-import { useParams } from "@tanstack/react-router";
+import { Link, useParams } from "@tanstack/react-router";
 import { useMutation, useQuery } from "convex/react";
 import { toast } from "sonner";
 import {
+  ArrowUpRight,
   Banknote,
   Ban,
   CheckCircle2,
@@ -10,10 +11,10 @@ import {
   Minus,
   MoveRight,
   Plus,
-  WalletCards,
+  RefreshCw,
   Smartphone,
   User,
-  RefreshCw,
+  WalletCards,
 } from "lucide-react";
 
 import View from "../../View";
@@ -58,9 +59,12 @@ import { useApprovedCommand } from "../../operations/useApprovedCommand";
 import type { ApprovalRequirement } from "~/shared/approvalPolicy";
 import { formatStoredAmount } from "~/src/lib/pos/displayAmounts";
 import { currencyFormatter } from "~/shared/currencyFormatter";
+import { getOrigin } from "~/src/lib/navigationUtils";
 
 type RouteParams =
   | {
+      orgUrlSlug?: string;
+      storeUrlSlug?: string;
       transactionId: string;
     }
   | undefined;
@@ -117,6 +121,8 @@ const PAYMENT_METHOD_OPTIONS = [
 ] satisfies Array<{ label: string; value: PosPaymentMethod }>;
 
 const ghsCurrencyFormatter = currencyFormatter("GHS");
+const REGISTER_EXPECTED_CASH_ERROR =
+  "Register session expected cash cannot be negative.";
 
 function isAdjustedLineItem(line: {
   adjustedQuantity?: number;
@@ -489,8 +495,22 @@ export function TransactionView() {
         adjustment.status === "applied",
     );
   }, [transaction]);
+  const pendingAdjustments = useMemo(() => {
+    if (!transaction) return [];
+    return (transaction.adjustments ?? []).filter(
+      (adjustment: (typeof transaction.adjustments)[number]) =>
+        adjustment.status === "pending_approval",
+    );
+  }, [transaction]);
   const latestAppliedAdjustment = appliedAdjustments[0] ?? null;
+  const latestPendingAdjustment = [...pendingAdjustments].sort(
+    (first, second) => second.createdAt - first.createdAt,
+  )[0] ?? null;
   const hasAppliedItemAdjustment = appliedAdjustments.length > 0;
+  const pendingSaleTotal =
+    typeof latestPendingAdjustment?.adjustedTotal === "number"
+      ? latestPendingAdjustment.adjustedTotal
+      : null;
   const adjustedCartItems: CartItem[] = useMemo(() => {
     if (!transaction) return [];
 
@@ -552,6 +572,20 @@ export function TransactionView() {
   const effectiveSubtotal = transaction
     ? Math.max(0, effectiveSaleTotal - (transaction.tax ?? 0))
     : 0;
+  const showRegisterExpectedCashRecovery =
+    selectedCorrection === "line_items" &&
+    correctionError === REGISTER_EXPECTED_CASH_ERROR;
+  const registerSessionRecoveryLink =
+    showRegisterExpectedCashRecovery &&
+    transaction?.registerSessionId &&
+    params?.orgUrlSlug &&
+    params?.storeUrlSlug
+      ? {
+          orgUrlSlug: params.orgUrlSlug,
+          sessionId: transaction.registerSessionId,
+          storeUrlSlug: params.storeUrlSlug,
+        }
+      : null;
 
   const completedData = useMemo(() => {
     if (!transaction) return undefined;
@@ -1973,9 +2007,36 @@ export function TransactionView() {
                         />
                         {selectedCorrection === "line_items" &&
                         correctionError ? (
-                          <p className="text-sm text-destructive">
-                            {correctionError}
-                          </p>
+                          showRegisterExpectedCashRecovery ? (
+                            <div className="space-y-3 rounded-md border border-destructive/20 bg-destructive/5 p-4 text-sm">
+                              <p className="font-medium text-destructive">
+                                Drawer expected cash is below this refund.
+                              </p>
+                              <p className="leading-5 text-muted-foreground">
+                                Correct the register session opening float so
+                                expected cash can cover the cash refund, then
+                                submit the item adjustment again.
+                              </p>
+                              {registerSessionRecoveryLink ? (
+                                <Link
+                                  className="inline-flex items-center gap-1 pt-1 font-medium text-destructive underline-offset-4 hover:underline"
+                                  params={registerSessionRecoveryLink}
+                                  search={{ o: getOrigin() }}
+                                  to="/$orgUrlSlug/store/$storeUrlSlug/cash-controls/registers/$sessionId"
+                                >
+                                  Review register session
+                                  <ArrowUpRight
+                                    aria-hidden="true"
+                                    className="h-3 w-3"
+                                  />
+                                </Link>
+                              ) : null}
+                            </div>
+                          ) : (
+                            <p className="text-sm text-destructive">
+                              {correctionError}
+                            </p>
+                          )
                         ) : null}
                         <div className="grid gap-2">
                           <Button
@@ -2019,8 +2080,9 @@ export function TransactionView() {
                         : "Adjustment state"}
                     </h2>
                     <p className="text-sm text-muted-foreground">
-                      Original sale totals stay locked. Adjusted totals are
-                      shown for closeout and reporting.
+                      {hasAppliedItemAdjustment
+                        ? "Original sale totals stay locked. Applied totals are shown for closeout and reporting."
+                        : "Original sale totals stay locked. Pending totals apply after approval."}
                     </p>
                   </div>
                   <dl className="grid gap-3 rounded-lg border border-border bg-background p-4 text-sm">
@@ -2035,17 +2097,32 @@ export function TransactionView() {
                         )}
                       </dd>
                     </div>
-                    <div className="flex items-center justify-between gap-3">
-                      <dt className="text-muted-foreground">
-                        Adjusted sale total
-                      </dt>
-                      <dd className="font-numeric font-semibold">
-                        {formatStoredAmount(
-                          ghsCurrencyFormatter,
-                          effectiveSaleTotal,
-                        )}
-                      </dd>
-                    </div>
+                    {hasAppliedItemAdjustment ? (
+                      <div className="flex items-center justify-between gap-3">
+                        <dt className="text-muted-foreground">
+                          Applied sale total
+                        </dt>
+                        <dd className="font-numeric font-semibold">
+                          {formatStoredAmount(
+                            ghsCurrencyFormatter,
+                            effectiveSaleTotal,
+                          )}
+                        </dd>
+                      </div>
+                    ) : null}
+                    {pendingSaleTotal !== null ? (
+                      <div className="flex items-center justify-between gap-3">
+                        <dt className="text-muted-foreground">
+                          Pending sale total
+                        </dt>
+                        <dd className="font-numeric font-semibold">
+                          {formatStoredAmount(
+                            ghsCurrencyFormatter,
+                            pendingSaleTotal,
+                          )}
+                        </dd>
+                      </div>
+                    ) : null}
                     {hasAppliedItemAdjustment ? (
                       <div className="flex items-center justify-between gap-3 border-t border-border/70 pt-3">
                         <dt className="text-muted-foreground">


### PR DESCRIPTION
## Summary

POS item adjustments now fail before they queue invalid approvals, surface the cash-drawer recovery path clearly, and leave enough trace context for managers to resolve the register session state. The approval queue also shows the changed items, payment/refund methods, and links out to the associated transaction and register session.

This ships the backend invariant fix, the approval/transaction UI updates, register-session trace events for queued/applied adjustments, and the moved POS terminal health origin-link fix together because they are all part of the dirty POS operations state being delivered from the root checkout.

## What Changed

- Validate cash refunds before creating item-adjustment approvals, and cancel invalid pending approvals when approval-time application hits the expected-cash invariant.
- Surface the exact expected-cash user error through the public transaction mutation and guide operators to review the register session opening float before retrying.
- Update approval cards to show only changed item rows, original payment, refund payout, transaction/register-session link affordances, and pending adjusted totals.
- Append item-adjustment queued/applied events to the register-session workflow trace with transaction, approval, settlement, and cash-delta metadata.
- Preserve origin navigation on POS terminal health links and refresh graphify output.

## Testing

- Focused iteration tests for item adjustments, approval queue, transaction view, register-session traces, public mutation errors, approval requests, and POS terminal health.
- Pre-push suite passed: graphify check, architecture check, full `@athena/webapp` tests, Convex audit, changed Convex/frontend lint, TypeScript, production build, targeted workflow suites, and behavior harness scenarios.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)