### PR TITLE
fix(auth): redirect after OTP sign-in

### DIFF
--- a/packages/athena-webapp/src/components/auth/Login/InputOTP.test.tsx
+++ b/packages/athena-webapp/src/components/auth/Login/InputOTP.test.tsx
@@ -13,12 +13,17 @@ import { ATHENA_EMAIL_OTP_PROVIDER_ID } from "../../../../shared/auth";
 
 const mocked = vi.hoisted(() => ({
   signIn: vi.fn(),
+  navigate: vi.fn(),
 }));
 
 vi.mock("@convex-dev/auth/react", () => ({
   useAuthActions: () => ({
     signIn: mocked.signIn,
   }),
+}));
+
+vi.mock("@tanstack/react-router", () => ({
+  useNavigate: () => mocked.navigate,
 }));
 
 vi.mock("@/components/ui/input-otp", () => ({
@@ -46,6 +51,7 @@ vi.mock("@/components/ui/input-otp", () => ({
 describe("InputOTPForm", () => {
   beforeEach(() => {
     mocked.signIn.mockReset();
+    mocked.navigate.mockReset();
     window.sessionStorage.clear();
   });
 
@@ -70,6 +76,7 @@ describe("InputOTPForm", () => {
       PENDING_ATHENA_AUTH_SYNC_KEY,
       "1"
     );
+    expect(mocked.navigate).toHaveBeenCalledWith({ to: "/" });
   });
 
   it("surfaces invalid verification codes to the operator", async () => {
@@ -86,6 +93,7 @@ describe("InputOTPForm", () => {
     await waitFor(() =>
       expect(screen.getByText("Invalid code entered")).toBeInTheDocument()
     );
+    expect(mocked.navigate).not.toHaveBeenCalled();
   });
 
   it("submits a normalized code when Safari autofill provides formatted text", async () => {

--- a/packages/athena-webapp/src/components/auth/Login/InputOTP.tsx
+++ b/packages/athena-webapp/src/components/auth/Login/InputOTP.tsx
@@ -25,6 +25,7 @@ import { useForm } from "react-hook-form";
 import { useEffect, useRef, useState } from "react";
 import { z } from "zod";
 import { ArrowLeft, ArrowRight } from "lucide-react";
+import { useNavigate } from "@tanstack/react-router";
 
 const REQUEST_NEW_CODE_DELAY_SECONDS = 59;
 const OTP_SLOT_INDEXES = [0, 1, 2, 3, 4, 5];
@@ -79,6 +80,7 @@ export function InputOTPForm({
   );
   const signInInFlightRef = useRef(false);
   const { signIn } = useAuthActions();
+  const navigate = useNavigate();
 
   useEffect(() => {
     const handleAuthSyncFailed = () => {
@@ -151,6 +153,7 @@ export function InputOTPForm({
       setIsAuthHandoffPending(true);
       setIsSigningIn(false);
       window.dispatchEvent(new Event(ATHENA_PENDING_AUTH_SYNC_EVENT));
+      navigate({ to: "/" });
       return;
     } catch (e) {
       const message = e instanceof Error ? e.message : "Could not verify code";


### PR DESCRIPTION
## Summary
- Navigate to the authenticated root immediately after a successful OTP sign-in so the existing auth recovery path can resolve the Athena user instead of leaving the OTP form disabled.
- Cover the success and invalid-code paths in the OTP form tests.
- Refresh graphify artifacts after the frontend change.

## Validation
- Reproduced the stuck post-OTP login state on the dev server before the fix.
- Seeded dev OTP records and verified three fresh browser login attempts redirected to /wigclub/store/wigclub/operations without remaining on the login screen.
- bun run --filter '@athena/webapp' test -- src/components/auth/Login/InputOTP.test.tsx src/routes/login/_layout.test.tsx src/hooks/useAuth.test.tsx src/routes/index.test.tsx src/routes/_authed.test.tsx convex/otp/EmailOTP.test.ts
- bun run graphify:rebuild
- bun run pr:athena