### PR TITLE
fix(pos): apply reviewed register sync closeouts

### DIFF
--- a/docs/solutions/logic-errors/athena-pos-register-sync-closeout-review-recovery-2026-05-23.md
+++ b/docs/solutions/logic-errors/athena-pos-register-sync-closeout-review-recovery-2026-05-23.md
@@ -1,0 +1,67 @@
+---
+title: Athena POS Register Sync Closeout Review Recovery
+date: 2026-05-23
+category: logic-errors
+module: athena-webapp
+problem_type: logic_error
+component: pos
+symptoms:
+  - "Synced register closeouts that need manager review can remain conflicted while the approval row is marked resolved"
+  - "Cash controls can show an active register session even though the local terminal recorded a closeout"
+  - "Operations approvals can omit register sync review work that still needs a manager decision"
+root_cause: review_resolution_without_source_projection
+resolution_type: code_fix
+severity: high
+tags:
+  - pos
+  - cash-controls
+  - register-session
+  - local-sync
+  - approvals
+---
+
+# Athena POS Register Sync Closeout Review Recovery
+
+## Problem
+
+Register sync review commands must resolve the source local sync event, not only
+the review row. A local `register_closed` event can carry the operator's counted
+cash and notes after an offline closeout. If the review action marks the conflict
+resolved without projecting that closeout, cash controls keeps showing the cloud
+register session as active and the operator loses the visible path to approve or
+reject the real local activity.
+
+This is especially risky when the closeout has a variance. The variance is the
+reason manager review is required, but the approval action is approving the
+synced closeout event. The closeout projection then records the counted cash,
+variance, notes, closeout records, and trace context in the register session.
+
+## Solution
+
+Treat register sync reviews as recoverable projections:
+
+- The approval workspace should include register sync conflicts as manager work,
+  with a link back to the register session and readable review-item context.
+- Register detail should present explicit approve and reject actions for synced
+  activity instead of a generic apply button.
+- Approval must project supported local sync event types. For
+  `register_closed`, pass an explicit closeout-variance override into local sync
+  projection only after manager proof is accepted.
+- Rejection should mark the conflicted source sync events rejected and resolve
+  the review rows so the terminal activity is intentionally discarded.
+- Resolved conflict rows whose source `posLocalSyncEvent` is still `conflicted`
+  should stay visible as stale review work. This recovers production states where
+  an earlier command resolved the review metadata without settling the source
+  event.
+
+## Prevention
+
+- Add command-boundary tests for reviewed closeout projection with variance:
+  session status, counted cash, variance, closeout records, notes, and source
+  event status should all change together.
+- Add read-model tests for stale resolved conflicts whose source event remains
+  conflicted so they cannot disappear from cash controls or operations queues.
+- Keep UI tests on both register detail and Operations approvals so approval
+  routing cannot regress to sales-only behavior.
+- When a sync-review command encounters an unsupported conflict shape, return a
+  precondition error instead of silently resolving or skipping it.

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 5711 nodes · 6021 edges · 1702 communities detected
+- 5714 nodes · 6024 edges · 1702 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -1816,40 +1816,40 @@ Cohesion: 0.15
 Nodes (22): assertStaffProfileReadyForCredential(), authenticateStaffCredentialForApprovalWithCtx(), authenticateStaffCredentialForTerminalWithCtx(), authenticateStaffCredentialWithCtx(), createStaffCredentialWithCtx(), getActiveRolesForStaffProfile(), getCredentialById(), getCredentialByUsername() (+14 more)
 
 ### Community 19 - "Community 19"
+Cohesion: 0.09
+Nodes (7): buildMissingDraftResult(), getApprovalRequestCopy(), handleDecideApprovalRequest(), handleDiscardCycleCountDraft(), handleRefreshCycleCountDraftLineBaseline(), handleSaveCycleCountDraftLine(), handleSubmitCycleCountDraft()
+
+### Community 20 - "Community 20"
 Cohesion: 0.12
 Nodes (18): ancestorChain(), collectRawMoneyParses(), collectRawMoneyParsesFromSource(), collectRawNumericHelperNames(), collectSourceFiles(), collectStorefrontDirectMoneyFormats(), containsDisallowedRawNumericParse(), containsTerm() (+10 more)
 
-### Community 20 - "Community 20"
+### Community 21 - "Community 21"
 Cohesion: 0.1
 Nodes (9): collectAcceptedEventIdsWithLocalPrecursors(), collectReviewLocalEventIds(), collectRuntimeRelevantEvents(), collectSyncedLocalEventIds(), derivePosLocalRuntimeSyncStatus(), hasPendingLocalCloseout(), isRuntimeRelevantLocalEvent(), toLocalCloudMappingEntity() (+1 more)
 
-### Community 21 - "Community 21"
+### Community 22 - "Community 22"
 Cohesion: 0.19
 Nodes (23): assertCompoundSolutionCheck(), collectChangedFiles(), collectCompoundSolutionFindings(), collectExistingFiles(), collectMarkdownContents(), collectSourceLineChanges(), countFileLines(), extractFrontmatter() (+15 more)
 
-### Community 22 - "Community 22"
+### Community 23 - "Community 23"
 Cohesion: 0.15
 Nodes (19): appendListSection(), buildMarkdownBundle(), collectCoverage(), evaluateGraphifyFreshness(), fileExists(), formatValidationCommand(), getChangedFilesFromGit(), isLocalGeneratedArtifactPath() (+11 more)
 
-### Community 23 - "Community 23"
+### Community 24 - "Community 24"
 Cohesion: 0.13
 Nodes (18): buildCartSummary(), buildSessionOperationsRow(), expirePosSessionNow(), hasCustomerSnapshotValue(), isUsableRegisterSession(), loadPosSessionItems(), loadSessionCustomer(), loadSessionOperator() (+10 more)
 
-### Community 24 - "Community 24"
+### Community 25 - "Community 25"
 Cohesion: 0.16
 Nodes (22): attentionSeverity(), buildDailyOperationsSnapshotWithCtx(), buildLanes(), buildWeekMetricForDate(), buildWeekMetrics(), emptyCloseSummary(), getCloseItemCounts(), getDailyCloseRecordForDate() (+14 more)
 
-### Community 25 - "Community 25"
+### Community 26 - "Community 26"
 Cohesion: 0.19
 Nodes (23): adjustRegisterSessionExpectedCashForSettlement(), adjustTransactionItems(), applyApprovedAdjustment(), applyInventoryDeltas(), assertPayloadMatchesPlan(), buildAdjustmentApprovalRequirement(), buildServerAdjustmentPlan(), consumeItemAdjustmentApprovalProof() (+15 more)
 
-### Community 26 - "Community 26"
+### Community 27 - "Community 27"
 Cohesion: 0.15
 Nodes (19): acquireExpenseQuantityPatchHold(), adjustExpenseQuantityPatchHold(), createDefaultExpenseSessionCommandService(), createExpenseInventoryHoldGateway(), createExpenseSessionCommandService(), failure(), isActiveRegisterSession(), isSessionExpired() (+11 more)
-
-### Community 27 - "Community 27"
-Cohesion: 0.1
-Nodes (7): buildMissingDraftResult(), getApprovalRequestCopy(), handleDecideApprovalRequest(), handleDiscardCycleCountDraft(), handleRefreshCycleCountDraftLineBaseline(), handleSaveCycleCountDraftLine(), handleSubmitCycleCountDraft()
 
 ### Community 28 - "Community 28"
 Cohesion: 0.11
@@ -2080,20 +2080,20 @@ Cohesion: 0.18
 Nodes (2): formatBlockerList(), runPrePushReview()
 
 ### Community 85 - "Community 85"
+Cohesion: 0.29
+Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
+
+### Community 86 - "Community 86"
 Cohesion: 0.36
 Nodes (10): buildApprovalDecisionRequirement(), buildApprovalDecisionSubject(), consumeApprovalDecisionProofWithCtx(), decideApprovalRequestAsAuthenticatedUserWithCtx(), decideApprovalRequestAsCommandWithCtx(), decideApprovalRequestWithCtx(), mapDecideApprovalRequestError(), omitUndefined() (+2 more)
 
-### Community 86 - "Community 86"
+### Community 87 - "Community 87"
 Cohesion: 0.33
 Nodes (2): OrdersTableToolbarProvider(), useOrdersTableToolbar()
 
-### Community 87 - "Community 87"
+### Community 88 - "Community 88"
 Cohesion: 0.24
 Nodes (5): formatBackendLabel(), formatInventoryNumber(), formatQuantity(), getActivityTitle(), pluralize()
-
-### Community 88 - "Community 88"
-Cohesion: 0.29
-Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
 
 ### Community 89 - "Community 89"
 Cohesion: 0.31
@@ -2225,43 +2225,43 @@ Nodes (6): findAthenaUserByEmailWithCtx(), getAuthenticatedAthenaUserWithCtx(), 
 
 ### Community 121 - "Community 121"
 Cohesion: 0.43
-Nodes (6): buildMtnCollectionsLookupPrefixes(), isTargetEnvironment(), readScopedValue(), resolveConfigForPrefix(), resolveMtnCollectionsConfigFromEnv(), toEnvSegment()
+Nodes (6): sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
 
 ### Community 122 - "Community 122"
+Cohesion: 0.43
+Nodes (6): buildMtnCollectionsLookupPrefixes(), isTargetEnvironment(), readScopedValue(), resolveConfigForPrefix(), resolveMtnCollectionsConfigFromEnv(), toEnvSegment()
+
+### Community 123 - "Community 123"
 Cohesion: 0.46
 Nodes (7): recordApprovalAuditEventWithCtx(), recordApprovalDecisionRecordedAuditEventWithCtx(), recordApprovalProofConsumedAuditEventWithCtx(), recordApprovalRequiredAuditEventWithCtx(), recordApprovedCommandAppliedAuditEventWithCtx(), recordAsyncApprovalRequestCreatedAuditEventWithCtx(), recordManagerApprovalGrantedAuditEventWithCtx()
 
-### Community 123 - "Community 123"
+### Community 124 - "Community 124"
 Cohesion: 0.43
 Nodes (6): assertActiveTerminal(), getActiveManagerElevationWithCtx(), getCandidateElevations(), getStaffDisplayName(), startManagerElevationWithCtx(), toActiveElevation()
 
-### Community 124 - "Community 124"
+### Community 125 - "Community 125"
 Cohesion: 0.36
 Nodes (5): buildPaymentAllocation(), correctSameAmountSinglePaymentAllocationWithCtx(), findSameAmountSinglePaymentAllocation(), listPaymentAllocationsForTargetWithCtx(), recordPaymentAllocationWithCtx()
 
-### Community 125 - "Community 125"
+### Community 126 - "Community 126"
 Cohesion: 0.43
 Nodes (6): buildPosSessionTraceEvent(), buildPosSessionTraceRecord(), buildTraceSummary(), formatPaymentMethod(), recordPosSessionTraceBestEffort(), safeTraceWrite()
 
-### Community 126 - "Community 126"
+### Community 127 - "Community 127"
 Cohesion: 0.5
 Nodes (7): findExistingSku(), findOrCreateQuickAddCategory(), findOrCreateQuickAddSubcategory(), generateSKU(), isBarcodeLike(), mapSkuToCatalogResult(), quickAddCatalogItem()
 
-### Community 127 - "Community 127"
+### Community 128 - "Community 128"
 Cohesion: 0.25
 Nodes (0):
 
-### Community 128 - "Community 128"
+### Community 129 - "Community 129"
 Cohesion: 0.36
 Nodes (4): buildTerminalHealthSummary(), deriveTerminalHealth(), getTerminalHealthSummary(), stripRuntimeStatusIdentity()
 
-### Community 129 - "Community 129"
+### Community 130 - "Community 130"
 Cohesion: 0.25
 Nodes (0):
-
-### Community 130 - "Community 130"
-Cohesion: 0.43
-Nodes (6): sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
 
 ### Community 131 - "Community 131"
 Cohesion: 0.39
@@ -2344,116 +2344,116 @@ Cohesion: 0.52
 Nodes (6): buildCustomerProfileDraft(), buildFullName(), findMatchingCustomerProfile(), normalizeLookupValue(), normalizePhoneNumber(), splitFullName()
 
 ### Community 151 - "Community 151"
+Cohesion: 0.33
+Nodes (2): buildOperationalWorkItem(), createOperationalWorkItemWithCtx()
+
+### Community 152 - "Community 152"
 Cohesion: 0.48
 Nodes (5): buildExpenseSessionTraceEvent(), buildExpenseSessionTraceRecord(), buildTraceSummary(), recordExpenseSessionTraceBestEffort(), safeTraceWrite()
 
-### Community 152 - "Community 152"
+### Community 153 - "Community 153"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 153 - "Community 153"
+### Community 154 - "Community 154"
 Cohesion: 0.48
 Nodes (5): getActiveSessionForRegisterState(), listHeldSessionsForRegisterState(), querySessionsByStatus(), selectRegisterStateLookupStrategy(), summarizeRegisterStateSessions()
 
-### Community 154 - "Community 154"
+### Community 155 - "Community 155"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 155 - "Community 155"
+### Community 156 - "Community 156"
 Cohesion: 0.33
 Nodes (2): getCustomerOperationalTimelineEvents(), resolveCustomerProfileIdForTimeline()
 
-### Community 156 - "Community 156"
+### Community 157 - "Community 157"
 Cohesion: 0.38
 Nodes (3): clearBagItems(), createOrderFromCheckoutSession(), generateOrderNumber()
 
-### Community 157 - "Community 157"
+### Community 158 - "Community 158"
 Cohesion: 0.57
 Nodes (5): getDeliveryAddress(), getLocationDetails(), getPickupLocation(), handleOrderStatusUpdate(), processOrderUpdateEmail()
 
-### Community 158 - "Community 158"
+### Community 159 - "Community 159"
 Cohesion: 0.33
 Nodes (2): appendTransition(), applyOnlineOrderUpdate()
 
-### Community 159 - "Community 159"
+### Community 160 - "Community 160"
 Cohesion: 0.38
 Nodes (3): createWorkflowTraceWithCtx(), getWorkflowTraceByIdWithCtx(), getWorkflowTraceByLookupWithCtx()
 
-### Community 160 - "Community 160"
+### Community 161 - "Community 161"
 Cohesion: 0.38
 Nodes (4): calculateCycleCountQuantityDelta(), hasHighStockAdjustmentVariance(), requiresStockAdjustmentApproval(), resolveStockAdjustmentQuantityDelta()
 
-### Community 161 - "Community 161"
+### Community 162 - "Community 162"
 Cohesion: 0.33
 Nodes (2): handlePinChange(), normalizeOtpCode()
 
-### Community 162 - "Community 162"
+### Community 163 - "Community 163"
 Cohesion: 0.33
 Nodes (2): handleKeypadPress(), setAmountFromTouch()
 
-### Community 163 - "Community 163"
+### Community 164 - "Community 164"
 Cohesion: 0.48
 Nodes (4): applyCommandResult(), async(), handleSubmit(), parseDateTimeLocal()
 
-### Community 164 - "Community 164"
+### Community 165 - "Community 165"
 Cohesion: 0.38
 Nodes (3): formatDeposit(), formatMoney(), summarizeService()
 
-### Community 165 - "Community 165"
+### Community 166 - "Community 166"
 Cohesion: 0.52
 Nodes (6): deriveRegisterPhase(), hasActiveRegisterSession(), hasResumableRegisterSession(), isRegisterReadyToStart(), requiresCashier(), requiresTerminal()
 
-### Community 166 - "Community 166"
+### Community 167 - "Community 167"
 Cohesion: 0.33
 Nodes (2): selectNextOrderedBatch(), selectOrderedBatches()
-
-### Community 167 - "Community 167"
-Cohesion: 0.29
-Nodes (0):
 
 ### Community 168 - "Community 168"
 Cohesion: 0.29
 Nodes (0):
 
 ### Community 169 - "Community 169"
-Cohesion: 0.52
-Nodes (6): addItemToSavedBag(), getActiveSavedBag(), getBaseUrl(), removeItemFromSavedBag(), updateSavedBagItem(), updateSavedBagOwner()
-
-### Community 170 - "Community 170"
 Cohesion: 0.33
 Nodes (2): getProductName(), sortProduct()
 
+### Community 170 - "Community 170"
+Cohesion: 0.29
+Nodes (0):
+
 ### Community 171 - "Community 171"
+Cohesion: 0.52
+Nodes (6): addItemToSavedBag(), getActiveSavedBag(), getBaseUrl(), removeItemFromSavedBag(), updateSavedBagItem(), updateSavedBagOwner()
+
+### Community 172 - "Community 172"
 Cohesion: 0.43
 Nodes (4): createFixtureRepo(), gitEnv(), runGit(), write()
 
-### Community 172 - "Community 172"
+### Community 173 - "Community 173"
 Cohesion: 0.52
 Nodes (5): emitSignal(), handleCheckoutSessionFetch(), handleCheckoutSessionUpdate(), jsonResponse(), withCorsHeaders()
 
-### Community 173 - "Community 173"
+### Community 174 - "Community 174"
 Cohesion: 0.33
 Nodes (2): overwriteFreshGraphifyArtifacts(), write()
 
-### Community 174 - "Community 174"
+### Community 175 - "Community 175"
 Cohesion: 0.38
 Nodes (4): createFixtureRepo(), initializeGitHistory(), runGit(), write()
 
-### Community 175 - "Community 175"
-Cohesion: 0.33
-Nodes (1): ValkeyClient
-
 ### Community 176 - "Community 176"
 Cohesion: 0.33
-Nodes (0):
+Nodes (1): ValkeyClient
 
 ### Community 177 - "Community 177"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 178 - "Community 178"
-Cohesion: 0.4
-Nodes (2): buildOperationalWorkItem(), createOperationalWorkItemWithCtx()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 179 - "Community 179"
 Cohesion: 0.4

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,8 +8,8 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 1774
-- Graph nodes: 5711
-- Graph edges: 6021
+- Graph nodes: 5714
+- Graph edges: 6024
 - Communities: 1702
 
 ## Graph Hotspots

--- a/packages/athena-webapp/convex/cashControls/deposits.test.ts
+++ b/packages/athena-webapp/convex/cashControls/deposits.test.ts
@@ -767,6 +767,175 @@ describe("cash control deposits", () => {
     ]);
   });
 
+  it("applies reviewed synced closeouts with variance after manager approval", async () => {
+    const ctx = createAuthorizedRegisterDepositCtx({
+      operationalEvent: [],
+      posLocalSyncConflict: [
+        {
+          _id: "sync_conflict_closeout",
+          storeId: "store_1",
+          terminalId: "terminal_1",
+          localRegisterSessionId: "local-register-1",
+          localEventId: "event_closeout",
+          sequence: 2,
+          conflictType: "permission",
+          status: "needs_review",
+          summary:
+            "Register closeout variance requires manager review before synced closeout can be applied.",
+          details: {
+            countedCash: 45000,
+            expectedCash: 50000,
+            variance: -5000,
+          },
+          createdAt: 1,
+        },
+      ],
+      posLocalSyncEvent: [
+        {
+          _id: "sync_event_closeout",
+          storeId: "store_1",
+          terminalId: "terminal_1",
+          localRegisterSessionId: "local-register-1",
+          localEventId: "event_closeout",
+          sequence: 2,
+          eventType: "register_closed",
+          occurredAt: 2,
+          staffProfileId: "staff_1",
+          payload: {
+            countedCash: 45000,
+            notes: "I dont know",
+          },
+          status: "conflicted",
+          submittedAt: 4,
+          acceptedAt: 4,
+        },
+      ],
+      posLocalSyncMapping: [
+        {
+          _id: "sync_mapping_1",
+          storeId: "store_1",
+          terminalId: "terminal_1",
+          localRegisterSessionId: "local-register-1",
+          localIdKind: "registerSession",
+          localId: "local-register-1",
+          cloudTable: "registerSession",
+          cloudId: "session_open",
+        },
+      ],
+      registerSession: [
+        {
+          _id: "session_open",
+          closeoutRecords: [],
+          expectedCash: 50000,
+          openedAt: 1,
+          openingFloat: 50000,
+          organizationId: "org_1",
+          registerNumber: "1",
+          status: "active",
+          storeId: "store_1",
+          terminalId: "terminal_1",
+        },
+      ],
+      posTerminal: [
+        {
+          _id: "terminal_1",
+          registerNumber: "1",
+          registeredByUserId: "athena_user_1",
+          status: "active",
+          storeId: "store_1",
+        },
+      ],
+      staffProfile: [
+        {
+          _id: "manager_1",
+          organizationId: "org_1",
+          status: "active",
+          storeId: "store_1",
+        },
+        {
+          _id: "staff_1",
+          organizationId: "org_1",
+          status: "active",
+          storeId: "store_1",
+        },
+      ],
+      staffRoleAssignment: [
+        {
+          _id: "role_1",
+          organizationId: "org_1",
+          role: "manager",
+          staffProfileId: "manager_1",
+          status: "active",
+          storeId: "store_1",
+        },
+        {
+          _id: "role_2",
+          organizationId: "org_1",
+          role: "cashier",
+          staffProfileId: "staff_1",
+          status: "active",
+          storeId: "store_1",
+        },
+      ],
+    });
+
+    const result = await getHandler(resolveRegisterSessionSyncReview)(
+      ctx as never,
+      {
+        actorStaffProfileId: "manager_1" as Id<"staffProfile">,
+        registerSessionId: "session_open" as Id<"registerSession">,
+        storeId: "store_1" as Id<"store">,
+      },
+    );
+
+    expect(result).toEqual(
+      ok({
+        action: "resolved",
+        projectedCount: 0,
+        registerSession: expect.objectContaining({
+          _id: "session_open",
+          status: "closed",
+        }),
+        resolvedCount: 1,
+      }),
+    );
+    expect(ctx.tables.get("registerSession")).toEqual([
+      expect.objectContaining({
+        _id: "session_open",
+        closeoutRecords: [
+          expect.objectContaining({
+            countedCash: 45000,
+            expectedCash: 50000,
+            notes: "I dont know",
+            type: "closed",
+            variance: -5000,
+          }),
+        ],
+        countedCash: 45000,
+        status: "closed",
+        variance: -5000,
+      }),
+    ]);
+    expect(ctx.tables.get("posLocalSyncEvent")).toEqual([
+      expect.objectContaining({
+        _id: "sync_event_closeout",
+        projectedAt: expect.any(Number),
+        status: "projected",
+      }),
+    ]);
+    expect(ctx.tables.get("operationalEvent")).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          eventType: "register_session_sync_review_resolved",
+          message: "Applied reviewed synced register closeout.",
+          metadata: expect.objectContaining({
+            projectedCloseoutCount: 1,
+          }),
+        }),
+      ]),
+    );
+  });
+
   it("ignores unmapped local register ids that are not valid cloud session ids", async () => {
     const conflict = {
       _id: "sync_conflict_1",
@@ -799,6 +968,75 @@ describe("cash control deposits", () => {
         "store_1" as Id<"store">,
       ),
     ).resolves.toEqual(new Map());
+  });
+
+  it("keeps resolved sync conflicts reviewable when the source event is still conflicted", async () => {
+    const conflict = {
+      _id: "sync_conflict_1",
+      storeId: "store_1",
+      terminalId: "terminal_1",
+      localRegisterSessionId: "local-register-1",
+      localEventId: "event_1",
+      sequence: 1,
+      conflictType: "permission",
+      status: "resolved",
+      summary:
+        "Register closeout variance requires manager review before synced closeout can be applied.",
+      details: {},
+      createdAt: 1,
+    };
+    const ctx = createQueryCtx({
+      posLocalSyncConflict: [conflict],
+      posLocalSyncEvent: [
+        {
+          _id: "sync_event_1",
+          storeId: "store_1",
+          terminalId: "terminal_1",
+          localRegisterSessionId: "local-register-1",
+          localEventId: "event_1",
+          sequence: 1,
+          eventType: "register_closed",
+          occurredAt: 2,
+          staffProfileId: "staff_1",
+          payload: { countedCash: 45000 },
+          status: "conflicted",
+          submittedAt: 3,
+        },
+      ],
+      posLocalSyncMapping: [
+        {
+          _id: "sync_mapping_1",
+          storeId: "store_1",
+          terminalId: "terminal_1",
+          localRegisterSessionId: "local-register-1",
+          localIdKind: "registerSession",
+          localId: "local-register-1",
+          cloudTable: "registerSession",
+          cloudId: "session_open",
+        },
+      ],
+      registerSession: [
+        {
+          _id: "session_open",
+          storeId: "store_1",
+          terminalId: "terminal_1",
+        },
+      ],
+    });
+
+    await expect(
+      listOpenLocalSyncConflictsByRegisterSession(
+        ctx as never,
+        "store_1" as Id<"store">,
+      ),
+    ).resolves.toEqual(
+      new Map([
+        [
+          "session_open",
+          [expect.objectContaining({ _id: "sync_conflict_1" })],
+        ],
+      ]),
+    );
   });
 
   it("resolves mapped sync conflicts beyond the dashboard session display limit", async () => {

--- a/packages/athena-webapp/convex/cashControls/deposits.ts
+++ b/packages/athena-webapp/convex/cashControls/deposits.ts
@@ -68,7 +68,11 @@ const registerSessionSyncReviewResultValidator = v.union(
   v.object({
     kind: v.literal("ok"),
     data: v.object({
-      action: v.union(v.literal("already_resolved"), v.literal("resolved")),
+      action: v.union(
+        v.literal("already_resolved"),
+        v.literal("resolved"),
+        v.literal("rejected"),
+      ),
       projectedCount: v.optional(v.number()),
       registerSession: v.union(v.null(), v.any()),
       resolvedCount: v.number(),
@@ -154,7 +158,7 @@ type RecordRegisterSessionDepositResult = {
 };
 
 type ResolveRegisterSessionSyncReviewResult = {
-  action: "already_resolved" | "resolved";
+  action: "already_resolved" | "resolved" | "rejected";
   projectedCount?: number;
   registerSession: Doc<"registerSession"> | null;
   resolvedCount: number;
@@ -473,24 +477,58 @@ export async function listOpenLocalSyncConflictsByRegisterSession(
   ctx: Pick<QueryCtx, "db">,
   storeId: Id<"store">,
 ) {
-  const conflicts = await ctx.db
-    .query("posLocalSyncConflict")
-    .withIndex("by_store_status", (q) =>
-      q.eq("storeId", storeId).eq("status", "needs_review"),
-    )
-    .take(SYNC_CONFLICT_LIMIT);
-  const entries = await Promise.all(
-    conflicts.map(async (conflict) => {
-      const registerSessionMapping = await ctx.db
-        .query("posLocalSyncMapping")
-        .withIndex("by_store_terminal_local", (q) =>
+  const [needsReviewConflicts, resolvedConflicts] = await Promise.all([
+    ctx.db
+      .query("posLocalSyncConflict")
+      .withIndex("by_store_status", (q) =>
+        q.eq("storeId", storeId).eq("status", "needs_review"),
+      )
+      .take(SYNC_CONFLICT_LIMIT),
+    ctx.db
+      .query("posLocalSyncConflict")
+      .withIndex("by_store_status", (q) =>
+        q.eq("storeId", storeId).eq("status", "resolved"),
+      )
+      .take(SYNC_CONFLICT_LIMIT),
+  ]);
+  const staleResolvedConflicts = await Promise.all(
+    resolvedConflicts.map(async (conflict) => {
+      const syncEvent = await ctx.db
+        .query("posLocalSyncEvent")
+        .withIndex("by_store_terminal_localEvent", (q) =>
           q
             .eq("storeId", conflict.storeId)
             .eq("terminalId", conflict.terminalId)
-            .eq("localRegisterSessionId", conflict.localRegisterSessionId)
-            .eq("localIdKind", "registerSession")
-            .eq("localId", conflict.localRegisterSessionId),
+            .eq("localEventId", conflict.localEventId),
         )
+        .unique();
+
+      return syncEvent?.status === "conflicted" ? conflict : null;
+    }),
+  );
+	  const conflicts = [
+	    ...needsReviewConflicts,
+	    ...staleResolvedConflicts.filter(
+	      (conflict): conflict is Doc<"posLocalSyncConflict"> => conflict !== null,
+	    ),
+	  ];
+	  const entries = await Promise.all(
+	    conflicts.map(async (conflict) => {
+	      const { terminalId, localRegisterSessionId } = conflict;
+	      if (!terminalId || !localRegisterSessionId) {
+	        return null;
+	      }
+
+	      const registerSessionMapping = await ctx.db
+	        .query("posLocalSyncMapping")
+        .withIndex("by_store_terminal_local", (q) =>
+	          q
+	            .eq("storeId", conflict.storeId)
+	            .eq("terminalId", terminalId)
+	            .eq("localRegisterSessionId", localRegisterSessionId)
+	            .eq("localIdKind", "registerSession")
+	            .eq("localId", localRegisterSessionId),
+	        )
         .unique();
       if (registerSessionMapping?.cloudTable === "registerSession") {
         return [
@@ -509,22 +547,23 @@ export async function listOpenLocalSyncConflictsByRegisterSession(
       ).normalizeId;
       const cloudRegisterSessionId =
         normalizeId?.call(
-          ctx.db,
-          "registerSession",
-          conflict.localRegisterSessionId,
-        ) ?? null;
-      if (cloudRegisterSessionId) {
-        const registerSession = await ctx.db.get(
-          "registerSession",
-          cloudRegisterSessionId,
-        );
-        if (
-          registerSession?.storeId === conflict.storeId &&
-          registerSession.terminalId === conflict.terminalId
-        ) {
-          return [cloudRegisterSessionId, conflict] as const;
-        }
-      }
+	          ctx.db,
+	          "registerSession",
+	          localRegisterSessionId,
+	        ) ?? null;
+	      if (cloudRegisterSessionId) {
+	        const registerSession = await ctx.db.get(
+	          "registerSession",
+	          cloudRegisterSessionId,
+	        );
+	        if (!registerSession) return null;
+	        if (
+	          registerSession.storeId === conflict.storeId &&
+	          registerSession.terminalId === terminalId
+	        ) {
+	          return [cloudRegisterSessionId, conflict] as const;
+	        }
+	      }
 
       return null;
     }),
@@ -1109,6 +1148,7 @@ export const recordRegisterSessionDeposit = mutation({
 export const resolveRegisterSessionSyncReview = mutation({
   args: {
     actorStaffProfileId: v.id("staffProfile"),
+    decision: v.optional(v.union(v.literal("approved"), v.literal("rejected"))),
     registerSessionId: v.id("registerSession"),
     storeId: v.id("store"),
   },
@@ -1159,6 +1199,8 @@ export const resolveRegisterSessionSyncReview = mutation({
     const resolvedAt = Date.now();
     const localSyncRepository = createConvexLocalSyncRepository(ctx);
     const projectedTransactionIds: string[] = [];
+    let projectedCloseoutCount = 0;
+    const decision = args.decision ?? "approved";
 
     for (const conflict of conflicts) {
       const terminalId = conflict.terminalId ?? registerSession.terminalId;
@@ -1182,15 +1224,38 @@ export const resolveRegisterSessionSyncReview = mutation({
         });
       }
 
+      if (decision === "rejected") {
+        if (syncEvent.status === "conflicted") {
+          await localSyncRepository.patchEvent(syncEvent._id, {
+            rejectionCode: "manager_rejected",
+            rejectionMessage:
+              "Manager rejected synced register activity during cash-controls review.",
+            status: "rejected",
+          });
+        }
+        continue;
+      }
+
       const shouldApplyReviewedSale =
         syncEvent.eventType === "sale_completed" &&
         (!conflict.localRegisterSessionId ||
           syncEvent.localRegisterSessionId === conflict.localRegisterSessionId) &&
         conflict.conflictType === "permission" &&
         conflict.summary === "Register was not open before this sale synced.";
+      const shouldApplyReviewedCloseout =
+        syncEvent.eventType === "register_closed" &&
+        (!conflict.localRegisterSessionId ||
+          syncEvent.localRegisterSessionId === conflict.localRegisterSessionId) &&
+        conflict.conflictType === "permission" &&
+        conflict.summary ===
+          "Register closeout variance requires manager review before synced closeout can be applied.";
 
-      if (!shouldApplyReviewedSale) {
-        continue;
+      if (!shouldApplyReviewedSale && !shouldApplyReviewedCloseout) {
+        return userError({
+          code: "precondition_failed",
+          message:
+            "This register review still needs attention before the synced activity can be applied.",
+        });
       }
 
       if (syncEvent.status === "projected") {
@@ -1209,11 +1274,17 @@ export const resolveRegisterSessionSyncReview = mutation({
         localSyncRepository,
         syncEvent,
       );
-      if (!parsedEvent.ok || parsedEvent.event.eventType !== "sale_completed") {
+      if (
+        !parsedEvent.ok ||
+        (shouldApplyReviewedSale &&
+          parsedEvent.event.eventType !== "sale_completed") ||
+        (shouldApplyReviewedCloseout &&
+          parsedEvent.event.eventType !== "register_closed")
+      ) {
         return userError({
           code: "precondition_failed",
           message:
-            "This register review could not be applied because the synced sale details are incomplete.",
+            "This register review could not be applied because the synced activity details are incomplete.",
         });
       }
 
@@ -1226,6 +1297,7 @@ export const resolveRegisterSessionSyncReview = mutation({
         now: resolvedAt,
         options: {
           allowClosedRegisterSaleProjection: true,
+          allowRegisterCloseoutVarianceProjection: shouldApplyReviewedCloseout,
           trustStoredStaffProof: true,
         },
       });
@@ -1246,6 +1318,9 @@ export const resolveRegisterSessionSyncReview = mutation({
         status: "projected",
         projectedAt: resolvedAt,
       });
+      if (shouldApplyReviewedCloseout) {
+        projectedCloseoutCount += 1;
+      }
       projectedTransactionIds.push(
         ...projection.mappings
           .filter(
@@ -1272,7 +1347,15 @@ export const resolveRegisterSessionSyncReview = mutation({
       actorUserId: athenaUser._id,
       eventType: "register_session_sync_review_resolved",
       message:
-        projectedTransactionIds.length === 0
+        decision === "rejected"
+          ? conflicts.length === 1
+            ? "Rejected synced register review."
+            : `Rejected ${conflicts.length} synced register reviews.`
+          : projectedCloseoutCount > 0
+            ? projectedCloseoutCount === 1
+              ? "Applied reviewed synced register closeout."
+              : `Applied ${projectedCloseoutCount} reviewed synced register closeouts.`
+          : projectedTransactionIds.length === 0
           ? conflicts.length === 1
             ? "Resolved synced register review."
             : `Resolved ${conflicts.length} synced register reviews.`
@@ -1282,6 +1365,8 @@ export const resolveRegisterSessionSyncReview = mutation({
       metadata: {
         conflictIds: conflicts.map((conflict) => conflict._id),
         conflictTypes: conflicts.map((conflict) => conflict.conflictType),
+        decision,
+        projectedCloseoutCount,
         projectedTransactionIds,
       },
       organizationId: store.organizationId,
@@ -1293,7 +1378,7 @@ export const resolveRegisterSessionSyncReview = mutation({
     });
 
     return ok({
-      action: "resolved",
+      action: decision === "rejected" ? "rejected" : "resolved",
       registerSession: await ctx.db.get("registerSession", args.registerSessionId),
       projectedCount: projectedTransactionIds.length,
       resolvedCount: conflicts.length,

--- a/packages/athena-webapp/convex/operations/operationalWorkItems.test.ts
+++ b/packages/athena-webapp/convex/operations/operationalWorkItems.test.ts
@@ -120,4 +120,92 @@ describe("getQueueSnapshot", () => {
       }),
     ]);
   });
+
+  it("surfaces register sync conflicts as pending approval work", async () => {
+    const ctx = {
+      db: {
+        get: vi.fn(async (tableName: string, id: string) => {
+          if (tableName === "store" && id === "store-1") {
+            return { _id: "store-1", organizationId: "org-1" };
+          }
+          if (tableName === "registerSession" && id === "session-1") {
+            return {
+              _id: "session-1",
+              countedCash: null,
+              expectedCash: 50000,
+              registerNumber: "2",
+              status: "active",
+              storeId: "store-1",
+              terminalId: "terminal-1",
+            };
+          }
+          if (tableName === "posTerminal" && id === "terminal-1") {
+            return { _id: "terminal-1", displayName: "Wigshop" };
+          }
+          return null;
+        }),
+        query: vi.fn((tableName: string) => ({
+          withIndex: vi.fn(() => ({
+            take: vi.fn(async () => {
+              if (tableName === "posLocalSyncConflict") {
+                return [
+                  {
+                    _id: "sync-conflict-1",
+                    conflictType: "permission",
+                    createdAt: 20,
+                    localEventId: "event-sale-completed-1",
+                    localRegisterSessionId: "local-session-1",
+                    sequence: 2,
+                    status: "needs_review",
+                    storeId: "store-1",
+                    summary:
+                      "Register was not open before this sale synced.",
+                    terminalId: "terminal-1",
+                  },
+                ];
+              }
+              return [];
+            }),
+            unique: vi.fn(async () => {
+              if (tableName === "posLocalSyncMapping") {
+                return {
+                  cloudId: "session-1",
+                  cloudTable: "registerSession",
+                };
+              }
+              return null;
+            }),
+          })),
+        })),
+      },
+    };
+
+    const result = await getHandler(getQueueSnapshot)(ctx, {
+      storeId: "store-1" as Id<"store">,
+    });
+
+    expect(result.approvalRequests).toEqual([
+      expect.objectContaining({
+        _id: "register-sync-review:session-1",
+        metadata: expect.objectContaining({
+          conflictCount: 1,
+          reviewItems: [
+            expect.objectContaining({
+              id: "sync-conflict-1",
+              sequence: 2,
+              type: "permission",
+            }),
+          ],
+        }),
+        registerSessionSummary: expect.objectContaining({
+          registerNumber: "2",
+          registerSessionId: "session-1",
+          terminalName: "Wigshop",
+        }),
+        requestType: "register_sync_review",
+        subjectType: "register_session_sync_review",
+        workItemTitle: "Synced register activity review",
+      }),
+    ]);
+  });
 });

--- a/packages/athena-webapp/convex/operations/operationalWorkItems.ts
+++ b/packages/athena-webapp/convex/operations/operationalWorkItems.ts
@@ -10,10 +10,13 @@ import {
   requireAuthenticatedAthenaUserWithCtx,
   requireOrganizationMemberRoleWithCtx,
 } from "../lib/athenaUserAuth";
+import { listOpenLocalSyncConflictsByRegisterSession } from "../cashControls/deposits";
 
 const MAX_QUEUE_ITEMS = 100;
 const TERMINAL_WORK_ITEM_STATUSES = new Set(["completed", "cancelled"]);
 const OPEN_WORK_ITEM_STATUSES = ["open", "in_progress"] as const;
+const REGISTER_SYNC_REVIEW_REQUEST_TYPE = "register_sync_review";
+const REGISTER_SYNC_REVIEW_SUBJECT_TYPE = "register_session_sync_review";
 
 function itemAdjustmentTransactionId(request: Doc<"approvalRequest">) {
   if (
@@ -87,6 +90,12 @@ function sanitizeApprovalRequestMetadata(
     transactionId: metadata.transactionId,
     transactionNumber: metadata.transactionNumber,
   };
+}
+
+function formatRegisterSyncReviewTitle(conflictCount: number) {
+  return conflictCount === 1
+    ? "Synced register activity review"
+    : `${conflictCount} synced register activity reviews`;
 }
 
 export function buildOperationalWorkItem(args: {
@@ -220,7 +229,8 @@ export const getQueueSnapshot = query({
       userId: athenaUser._id,
     });
 
-    const [workItems, approvalRequests] = await Promise.all([
+    const [workItems, approvalRequests, syncConflictsBySessionId] =
+      await Promise.all([
       Promise.all(
         OPEN_WORK_ITEM_STATUSES.map((status) =>
           ctx.db
@@ -237,6 +247,7 @@ export const getQueueSnapshot = query({
           q.eq("storeId", args.storeId).eq("status", "pending"),
         )
         .take(MAX_QUEUE_ITEMS),
+      listOpenLocalSyncConflictsByRegisterSession(ctx, args.storeId),
     ]);
 
     const openWorkItems = workItems;
@@ -287,6 +298,10 @@ export const getQueueSnapshot = query({
           registerSessionIds.add(request.subjectId);
         }
       }
+    }
+
+    for (const registerSessionId of syncConflictsBySessionId.keys()) {
+      registerSessionIds.add(registerSessionId);
     }
 
     const [
@@ -400,8 +415,7 @@ export const getQueueSnapshot = query({
       >,
     );
 
-    return {
-      approvalRequests: approvalRequests.map((request) => {
+    const mappedApprovalRequests = approvalRequests.map((request) => {
         const linkedTransactionId = itemAdjustmentTransactionId(request);
         const linkedTransaction = linkedTransactionId
           ? posTransactionMap.get(linkedTransactionId)
@@ -457,7 +471,60 @@ export const getQueueSnapshot = query({
             ? workItemMap.get(request.workItemId)?.title
             : null,
         };
-      }),
+      });
+    const mappedSyncReviewRequests = Array.from(
+      syncConflictsBySessionId.entries(),
+    ).map(([registerSessionId, conflicts]) => {
+      const linkedRegisterSession = registerSessionMap.get(registerSessionId);
+      const firstConflict = conflicts[0];
+
+      return {
+        _id: `register-sync-review:${registerSessionId}`,
+        createdAt: firstConflict?.createdAt,
+        metadata: {
+          conflictCount: conflicts.length,
+          reviewItems: conflicts.map((conflict) => ({
+            id: conflict._id,
+            localEventId: conflict.localEventId,
+            sequence: conflict.sequence,
+            summary: conflict.summary,
+            type: conflict.conflictType,
+          })),
+        },
+        notes: null,
+        reason:
+          firstConflict?.summary ??
+          "Synced register activity needs manager review.",
+        registerSessionSummary: linkedRegisterSession
+          ? {
+              countedCash: linkedRegisterSession.countedCash ?? null,
+              expectedCash: linkedRegisterSession.expectedCash,
+              registerNumber: linkedRegisterSession.registerNumber ?? null,
+              registerSessionId: linkedRegisterSession._id,
+              status: linkedRegisterSession.status,
+              terminalName: linkedRegisterSession.terminalId
+                ? (terminalMap
+                    .get(linkedRegisterSession.terminalId)
+                    ?.displayName?.trim() ?? null)
+                : null,
+              variance: linkedRegisterSession.variance ?? null,
+            }
+          : null,
+        requestedByStaffName: null,
+        requestType: REGISTER_SYNC_REVIEW_REQUEST_TYPE,
+        status: "pending",
+        storeId: args.storeId,
+        subjectId: registerSessionId,
+        subjectType: REGISTER_SYNC_REVIEW_SUBJECT_TYPE,
+        transactionSummary: null,
+        workItemTitle: formatRegisterSyncReviewTitle(conflicts.length),
+      };
+    });
+
+    return {
+      approvalRequests: [...mappedApprovalRequests, ...mappedSyncReviewRequests]
+        .sort((left, right) => (right.createdAt ?? 0) - (left.createdAt ?? 0))
+        .slice(0, MAX_QUEUE_ITEMS),
       workItems: openWorkItems.map((item) => ({
         ...item,
         assignedStaffName: item.assignedToStaffProfileId

--- a/packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts
+++ b/packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts
@@ -30,6 +30,7 @@ type ProjectEventArgs = {
   now: number;
   options?: {
     allowClosedRegisterSaleProjection?: boolean;
+    allowRegisterCloseoutVarianceProjection?: boolean;
     trustStoredStaffProof?: boolean;
   };
 };
@@ -1582,7 +1583,10 @@ async function projectRegisterClosed(
 
   const countedCash = payload.countedCash ?? registerSession.expectedCash;
   const variance = countedCash - registerSession.expectedCash;
-  if (roundMoney(variance) !== 0) {
+  if (
+    roundMoney(variance) !== 0 &&
+    args.options?.allowRegisterCloseoutVarianceProjection !== true
+  ) {
     const conflict = await createConflict(repository, args, {
       conflictType: "permission",
       summary:

--- a/packages/athena-webapp/src/components/cash-controls/RegisterSessionView.test.tsx
+++ b/packages/athena-webapp/src/components/cash-controls/RegisterSessionView.test.tsx
@@ -515,7 +515,7 @@ describe("RegisterSessionViewContent", () => {
     expect(screen.getByText("#13 in local queue")).toBeInTheDocument();
   });
 
-  it("resolves synced register review items after manager sign-in", async () => {
+  it("approves synced register review items after manager sign-in", async () => {
     const user = userEvent.setup();
     const onAuthenticateStaff = vi.fn().mockResolvedValue(
       ok({
@@ -559,11 +559,11 @@ describe("RegisterSessionViewContent", () => {
     );
 
     await user.click(
-      screen.getByRole("button", { name: "Apply reviewed sales" }),
+      screen.getByRole("button", { name: "Approve synced sales" }),
     );
     await user.click(
       screen.getByRole("button", {
-        name: "Confirm staff for Apply reviewed sales",
+        name: "Confirm staff for Approve synced sales",
       }),
     );
 
@@ -576,6 +576,64 @@ describe("RegisterSessionViewContent", () => {
     );
     expect(onResolveSyncReview).toHaveBeenCalledWith({
       actorStaffProfileId: "manager-1",
+      decision: "approved",
+      registerSessionId: "session-1",
+    });
+  });
+
+  it("rejects synced register review items after manager sign-in", async () => {
+    const user = userEvent.setup();
+    const onAuthenticateStaff = vi.fn().mockResolvedValue(
+      ok({
+        activeRoles: ["manager"],
+        staffProfile: { fullName: "Ato Kofi" },
+        staffProfileId: "manager-1",
+      }),
+    );
+    const onResolveSyncReview = vi.fn().mockResolvedValue(
+      ok({ action: "rejected", projectedCount: 0, resolvedCount: 1 }),
+    );
+
+    render(
+      <RegisterSessionViewContent
+        currency="GHS"
+        isLoading={false}
+        onRecordDeposit={vi.fn()}
+        {...closeoutHandlers}
+        onAuthenticateStaff={onAuthenticateStaff}
+        onResolveSyncReview={onResolveSyncReview}
+        registerSessionSnapshot={{
+          ...baseSnapshot,
+          registerSession: {
+            ...baseSnapshot.registerSession,
+            localSyncStatus: {
+              status: "needs_review",
+              reconciliationItems: [
+                {
+                  id: "sync_conflict_1",
+                  status: "needs_review",
+                  summary: "Register was not open before this sale synced.",
+                  type: "permission",
+                },
+              ],
+            },
+          },
+        }}
+      />,
+    );
+
+    await user.click(
+      screen.getByRole("button", { name: "Reject synced activity" }),
+    );
+    await user.click(
+      screen.getByRole("button", {
+        name: "Confirm staff for Reject synced activity",
+      }),
+    );
+
+    expect(onResolveSyncReview).toHaveBeenCalledWith({
+      actorStaffProfileId: "manager-1",
+      decision: "rejected",
       registerSessionId: "session-1",
     });
   });

--- a/packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx
+++ b/packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx
@@ -208,11 +208,12 @@ type RegisterCloseoutCommandResult =
 
 type ResolveSyncReviewArgs = {
   actorStaffProfileId: string;
+  decision: "approved" | "rejected";
   registerSessionId: string;
 };
 
 type ResolveSyncReviewResult = NormalizedCommandResult<{
-  action?: "already_resolved" | "resolved";
+  action?: "already_resolved" | "resolved" | "rejected";
   projectedCount?: number;
   resolvedCount?: number;
 }>;
@@ -301,6 +302,7 @@ type CloseoutStaffAuthIntent =
     }
   | {
       kind: "sync_review";
+      decision: "approved" | "rejected";
       registerSessionId: string;
     };
 
@@ -496,12 +498,12 @@ function formatReviewItemActivity(item: PosReconciliationItem) {
 function RegisterSessionSyncNotice({
   errorMessage,
   isResolving,
-  onResolveReview,
+  onReviewDecision,
   syncStatus,
 }: {
   errorMessage?: string;
   isResolving?: boolean;
-  onResolveReview?: () => void;
+  onReviewDecision?: (decision: "approved" | "rejected") => void;
   syncStatus: PosSyncStatusPresentation;
 }) {
   if (syncStatus.status === "synced") {
@@ -603,18 +605,29 @@ function RegisterSessionSyncNotice({
           ) : null}
         </div>
         <div className="flex flex-wrap items-center justify-end gap-layout-sm">
-          {syncStatus.status === "needs_review" && onResolveReview ? (
+          {syncStatus.status === "needs_review" && onReviewDecision ? (
+            <>
             <LoadingButton
               className="border-border bg-background text-foreground hover:bg-muted"
               disabled={isResolving}
               isLoading={Boolean(isResolving)}
-              onClick={onResolveReview}
+              onClick={() => onReviewDecision("approved")}
               size="sm"
               type="button"
               variant="outline"
             >
-              Apply reviewed sales
+              Approve synced sales
             </LoadingButton>
+            <Button
+              disabled={isResolving}
+              onClick={() => onReviewDecision("rejected")}
+              size="sm"
+              type="button"
+              variant="outline"
+            >
+              Reject synced activity
+            </Button>
+            </>
           ) : null}
           {syncStatus.status !== "needs_review" ? (
             <Badge
@@ -1159,6 +1172,7 @@ export function RegisterSessionViewContent({
       try {
         const commandResult = await onResolveSyncReview({
           actorStaffProfileId: result.staffProfileId,
+          decision: intent.decision,
           registerSessionId: intent.registerSessionId,
         });
 
@@ -1170,6 +1184,8 @@ export function RegisterSessionViewContent({
         toast.success(
           commandResult.data?.action === "already_resolved"
             ? "Register review already resolved"
+            : commandResult.data?.action === "rejected"
+              ? "Synced register activity rejected"
             : commandResult.data?.projectedCount
               ? commandResult.data.projectedCount === 1
                 ? "Reviewed sale applied"
@@ -1400,8 +1416,14 @@ export function RegisterSessionViewContent({
       : closeoutStaffAuthIntent?.kind === "sync_review"
         ? {
             title: "Manager sign-in required",
-            description: "Authenticate to apply reviewed synced sales",
-            submitLabel: "Apply reviewed sales",
+            description:
+              closeoutStaffAuthIntent.decision === "approved"
+                ? "Authenticate to approve and apply reviewed synced sales"
+                : "Authenticate to reject reviewed synced activity",
+            submitLabel:
+              closeoutStaffAuthIntent.decision === "approved"
+                ? "Approve synced sales"
+                : "Reject synced activity",
           }
       : {
           title: "Closeout sign-in required",
@@ -1467,7 +1489,7 @@ export function RegisterSessionViewContent({
     syncStatus.status === "needs_review" && Boolean(onResolveSyncReview);
   const headerTerminalName = registerSession?.terminalName?.trim();
 
-  function requestResolveSyncReview() {
+  function requestResolveSyncReview(decision: "approved" | "rejected") {
     if (!registerSession || !canResolveSyncReview) {
       return;
     }
@@ -1475,6 +1497,7 @@ export function RegisterSessionViewContent({
     setSyncReviewErrorMessage("");
     setCloseoutStaffAuthIntent({
       kind: "sync_review",
+      decision,
       registerSessionId: registerSession._id,
     });
   }
@@ -1839,7 +1862,7 @@ export function RegisterSessionViewContent({
             <RegisterSessionSyncNotice
               errorMessage={syncReviewErrorMessage}
               isResolving={isResolvingSyncReview}
-              onResolveReview={
+              onReviewDecision={
                 canResolveSyncReview ? requestResolveSyncReview : undefined
               }
               syncStatus={syncStatus}
@@ -2968,6 +2991,7 @@ export function RegisterSessionView() {
     const result = await runCommand(() =>
       resolveRegisterSessionSyncReview({
         actorStaffProfileId: args.actorStaffProfileId as Id<"staffProfile">,
+        decision: args.decision,
         registerSessionId: args.registerSessionId as Id<"registerSession">,
         storeId: activeStore._id,
       }),

--- a/packages/athena-webapp/src/components/operations/OperationsQueueView.test.tsx
+++ b/packages/athena-webapp/src/components/operations/OperationsQueueView.test.tsx
@@ -143,10 +143,11 @@ vi.mock("@/components/staff-auth/StaffAuthenticationDialog", () => ({
 
 const baseProps = {
   approvalRequests: [] as {
-    _id: Id<"approvalRequest">;
+    _id: string;
     metadata?: {
       amount?: number;
       adjustmentType?: string;
+      conflictCount?: number;
       largestAbsoluteDelta?: number;
       lineItems?: Array<{
         countedQuantity?: number;
@@ -160,6 +161,13 @@ const baseProps = {
       paymentMethod?: string;
       previousPaymentMethod?: string;
       reasonCode?: string;
+      reviewItems?: Array<{
+        id?: string;
+        localEventId?: string;
+        sequence?: number;
+        summary?: string;
+        type?: string;
+      }>;
       transactionId?: Id<"posTransaction">;
       countedCash?: number;
       expectedCash?: number;
@@ -742,6 +750,75 @@ describe("OperationsQueueViewContent", () => {
     ).toBeInTheDocument();
   });
 
+  it("renders synced register activity reviews in approvals", async () => {
+    const { default: userEvent } = await import("@testing-library/user-event");
+    const user = userEvent.setup();
+
+    render(
+      <OperationsQueueViewContent
+        {...baseProps}
+        approvalRequests={[
+          {
+            _id: "register-sync-review:register-2",
+            createdAt: 1_714_620_000_000,
+            metadata: {
+              conflictCount: 1,
+              reviewItems: [
+                {
+                  id: "sync-conflict-1",
+                  localEventId: "event-sale-completed-1",
+                  sequence: 2,
+                  summary: "Register was not open before this sale synced.",
+                  type: "permission",
+                },
+              ],
+            },
+            reason: "Register was not open before this sale synced.",
+            registerSessionSummary: {
+              countedCash: null,
+              expectedCash: 50_000,
+              registerNumber: "2",
+              registerSessionId: "register-2" as Id<"registerSession">,
+              status: "active",
+              terminalName: "Wigshop",
+              variance: null,
+            },
+            requestType: "register_sync_review",
+            status: "pending",
+            workItemTitle: "Synced register activity review",
+          },
+        ]}
+        orgUrlSlug="wigclub"
+        storeUrlSlug="wigclub"
+      />,
+    );
+
+    expect(screen.getByText("Synced register activity")).toBeInTheDocument();
+    expect(
+      screen.getByText("Review local register activity before it is applied to cash controls."),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /wigshop \/ register 2/i }),
+    ).toHaveAttribute(
+      "href",
+      "/$orgUrlSlug/store/$storeUrlSlug/cash-controls/registers/$sessionId?o=%252F",
+    );
+    expect(
+      screen.getByText("Register was not open before this sale synced."),
+    ).toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole("button", { name: /approve synced sales/i }),
+    );
+
+    expect(baseProps.onDecideApprovalRequest).toHaveBeenCalledWith({
+      approvalRequestId: "register-sync-review:register-2",
+      decision: "approved",
+      registerSessionId: "register-2",
+      requestType: "register_sync_review",
+    });
+  });
+
   it("renders the live operations page without the register closeout surface", () => {
     render(<OperationsQueueView />);
 
@@ -780,6 +857,7 @@ describe("OperationsQueueViewContent", () => {
     const mutationOrder = [
       submitStockBatch,
       decideApprovalRequest,
+      vi.fn(),
       authenticateStaffCredential,
       authenticateStaffCredentialForApproval,
       vi.fn(),
@@ -867,6 +945,7 @@ describe("OperationsQueueViewContent", () => {
     mockedHooks.useQuery.mockReset();
     mockedHooks.useMutation.mockReturnValue(vi.fn());
     mockedHooks.useMutation
+      .mockReturnValueOnce(vi.fn())
       .mockReturnValueOnce(vi.fn())
       .mockReturnValueOnce(vi.fn())
       .mockReturnValueOnce(vi.fn())
@@ -964,6 +1043,7 @@ describe("OperationsQueueViewContent", () => {
     const mutationOrder = [
       submitStockBatch,
       decideApprovalRequest,
+      vi.fn(),
       authenticateStaffCredential,
       authenticateStaffCredentialForApproval,
       vi.fn(),
@@ -1050,6 +1130,7 @@ describe("OperationsQueueViewContent", () => {
     const mutationOrder = [
       submitStockBatch,
       decideApprovalRequest,
+      vi.fn(),
       authenticateStaffCredential,
       authenticateStaffCredentialForApproval,
       vi.fn(),

--- a/packages/athena-webapp/src/components/operations/OperationsQueueView.tsx
+++ b/packages/athena-webapp/src/components/operations/OperationsQueueView.tsx
@@ -32,6 +32,7 @@ import { presentCommandToast } from "@/lib/errors/presentCommandToast";
 import { formatStoredAmount } from "@/lib/pos/displayAmounts";
 import {
   runCommand,
+  type NormalizedApprovalCommandResult,
   type NormalizedCommandResult,
 } from "@/lib/errors/runCommand";
 import { getOrigin } from "@/lib/navigationUtils";
@@ -68,10 +69,11 @@ type QueueWorkItem = {
 };
 
 type QueueApprovalRequest = {
-  _id: Id<"approvalRequest">;
+  _id: string;
   metadata?: {
     amount?: number;
     adjustmentType?: string;
+    conflictCount?: number;
     largestAbsoluteDelta?: number;
     lineItems?: Array<{
       adjustedQuantity?: number;
@@ -94,6 +96,13 @@ type QueueApprovalRequest = {
     settlementMethod?: string;
     adjustedTotal?: number;
     originalTotal?: number;
+    reviewItems?: Array<{
+      id?: string;
+      localEventId?: string;
+      sequence?: number;
+      summary?: string;
+      type?: string;
+    }>;
     totalDelta?: number;
     transactionId?: Id<"posTransaction">;
     countedCash?: number;
@@ -189,10 +198,25 @@ function getApprovalRequestCopy(requestType: string) {
     };
   }
 
+  if (requestType === "register_sync_review") {
+    return {
+      approveLabel: "Approve synced sales",
+      approvedToast: "Synced register activity approved",
+      description:
+        "Manager approval applies reviewed synced sales to the register session. Reject it to leave the synced activity unapplied.",
+      rejectedToast: "Synced register activity rejected",
+      rejectLabel: "Reject synced activity",
+    };
+  }
+
   return null;
 }
 
 function formatApprovalRequestType(requestType: string) {
+  if (requestType === "register_sync_review") {
+    return "Synced register activity";
+  }
+
   return requestType
     .split("_")
     .filter(Boolean)
@@ -358,6 +382,17 @@ function getVarianceReviewSummary(request: QueueApprovalRequest) {
   };
 }
 
+function getRegisterSyncReviewSummary(request: QueueApprovalRequest) {
+  if (request.requestType !== "register_sync_review") {
+    return null;
+  }
+
+  return {
+    registerSession: request.registerSessionSummary ?? null,
+    reviewItems: request.metadata?.reviewItems ?? [],
+  };
+}
+
 function formatApprovalDate(timestamp?: number) {
   if (typeof timestamp !== "number") return "Unknown";
 
@@ -402,13 +437,15 @@ type OperationsQueueViewContentProps = {
   hasFullAdminAccess: boolean;
   inventoryItems: InventorySnapshotItem[];
   isCycleCountDraftSaving?: boolean;
-  isDecidingApprovalRequestId?: Id<"approvalRequest"> | null;
+  isDecidingApprovalRequestId?: string | null;
   isLoadingPermissions: boolean;
   isLoadingQueue: boolean;
   isSubmittingStockBatch: boolean;
   onDecideApprovalRequest: (args: {
-    approvalRequestId: Id<"approvalRequest">;
+    approvalRequestId: string;
     decision: "approved" | "rejected";
+    registerSessionId?: Id<"registerSession">;
+    requestType?: string;
   }) => Promise<void>;
   onLockApprovalDecisions?: () => void;
   onRequestApprovalDecisionUnlock?: () => void;
@@ -733,6 +770,8 @@ export function OperationsQueueViewContent({
                           getItemAdjustmentSummary(request);
                         const varianceReviewSummary =
                           getVarianceReviewSummary(request);
+                        const registerSyncReviewSummary =
+                          getRegisterSyncReviewSummary(request);
 
                         return (
                           <article
@@ -1335,6 +1374,79 @@ export function OperationsQueueViewContent({
                               </div>
                             ) : null}
 
+                            {registerSyncReviewSummary ? (
+                              <div className="border-t border-border/70 bg-surface px-layout-md py-layout-md">
+                                <div>
+                                  <p className="text-[11px] font-medium uppercase tracking-[0.18em] text-muted-foreground">
+                                    Synced register activity
+                                  </p>
+                                  <p className="mt-1 text-sm text-muted-foreground">
+                                    Review local register activity before it is
+                                    applied to cash controls.
+                                  </p>
+                                </div>
+
+                                <dl className="mt-layout-sm grid gap-layout-sm rounded-lg border border-border bg-background p-layout-sm text-sm md:grid-cols-3">
+                                  <div>
+                                    <dt className="text-xs text-muted-foreground">
+                                      Register session
+                                    </dt>
+                                    <dd className="mt-1 font-medium text-foreground">
+                                      {registerSyncReviewSummary.registerSession &&
+                                      orgUrlSlug &&
+                                      storeUrlSlug ? (
+                                        <Link
+                                          className="inline-flex items-center gap-1 underline-offset-4 hover:underline"
+                                          params={{
+                                            orgUrlSlug,
+                                            sessionId:
+                                              registerSyncReviewSummary
+                                                .registerSession
+                                                .registerSessionId,
+                                            storeUrlSlug,
+                                          }}
+                                          search={{ o: getOrigin() }}
+                                          to="/$orgUrlSlug/store/$storeUrlSlug/cash-controls/registers/$sessionId"
+                                        >
+                                          {formatRegisterSessionLabel(
+                                            registerSyncReviewSummary.registerSession,
+                                          )}
+                                          <ArrowUpRight
+                                            aria-hidden="true"
+                                            className="h-3 w-3"
+                                          />
+                                        </Link>
+                                      ) : registerSyncReviewSummary.registerSession ? (
+                                        formatRegisterSessionLabel(
+                                          registerSyncReviewSummary.registerSession,
+                                        )
+                                      ) : (
+                                        "Register session"
+                                      )}
+                                    </dd>
+                                  </div>
+                                  <div>
+                                    <dt className="text-xs text-muted-foreground">
+                                      Review items
+                                    </dt>
+                                    <dd className="mt-1 font-medium text-foreground">
+                                      {registerSyncReviewSummary.reviewItems
+                                        .length || 1}
+                                    </dd>
+                                  </div>
+                                  <div>
+                                    <dt className="text-xs text-muted-foreground">
+                                      Latest issue
+                                    </dt>
+                                    <dd className="mt-1 font-medium text-foreground">
+                                      {registerSyncReviewSummary.reviewItems[0]
+                                        ?.summary ?? request.reason}
+                                    </dd>
+                                  </div>
+                                </dl>
+                              </div>
+                            ) : null}
+
                             {approvalCopy ? (
                               <div className="border-t border-border/70 bg-surface px-layout-md py-layout-md">
                                 <div className="flex flex-col gap-layout-md lg:flex-row lg:items-center lg:justify-between">
@@ -1356,6 +1468,15 @@ export function OperationsQueueViewContent({
                                         onDecideApprovalRequest({
                                           approvalRequestId: request._id,
                                           decision: "approved",
+                                          ...(request.requestType ===
+                                          "register_sync_review"
+                                            ? {
+                                                registerSessionId:
+                                                  request.registerSessionSummary
+                                                    ?.registerSessionId,
+                                                requestType: request.requestType,
+                                              }
+                                            : {}),
                                         })
                                       }
                                       size="sm"
@@ -1373,6 +1494,15 @@ export function OperationsQueueViewContent({
                                         onDecideApprovalRequest({
                                           approvalRequestId: request._id,
                                           decision: "rejected",
+                                          ...(request.requestType ===
+                                          "register_sync_review"
+                                            ? {
+                                                registerSessionId:
+                                                  request.registerSessionSummary
+                                                    ?.registerSessionId,
+                                                requestType: request.requestType,
+                                              }
+                                            : {}),
                                         })
                                       }
                                       size="sm"
@@ -1435,7 +1565,7 @@ export function OperationsQueueView({
   const [isSubmittingStockBatch, setIsSubmittingStockBatch] = useState(false);
   const [isSavingCycleCountDraft, setIsSavingCycleCountDraft] = useState(false);
   const [decisioningApprovalRequestId, setDecisioningApprovalRequestId] =
-    useState<Id<"approvalRequest"> | null>(null);
+    useState<string | null>(null);
   const [isApprovalUnlockOpen, setIsApprovalUnlockOpen] = useState(false);
   const [approvalDecisionUnlock, setApprovalDecisionUnlock] =
     useState<ApprovalDecisionUnlock | null>(null);
@@ -1489,6 +1619,9 @@ export function OperationsQueueView({
   );
   const decideApprovalRequest = useMutation(
     operationsApi.approvalRequests.decideApprovalRequest,
+  );
+  const resolveRegisterSessionSyncReview = useMutation(
+    api.cashControls.deposits.resolveRegisterSessionSyncReview,
   );
   const authenticateStaffCredential = useMutation(
     operationsApi.staffCredentials.authenticateStaffCredential,
@@ -1667,8 +1800,10 @@ export function OperationsQueueView({
   };
 
   const handleDecideApprovalRequest = async (args: {
-    approvalRequestId: Id<"approvalRequest">;
+    approvalRequestId: string;
     decision: "approved" | "rejected";
+    registerSessionId?: Id<"registerSession">;
+    requestType?: string;
   }) => {
     if (decisioningApprovalRequestId) {
       return;
@@ -1736,13 +1871,39 @@ export function OperationsQueueView({
         return;
       }
 
-      const result = await runCommand(() =>
-        decideApprovalRequest({
-          approvalRequestId: args.approvalRequestId,
-          approvalProofId: approvalProofResult.data.approvalProofId,
-          decision: args.decision,
-        }),
-      );
+      let result: NormalizedApprovalCommandResult<unknown>;
+
+      if (args.requestType === "register_sync_review") {
+        if (!args.registerSessionId) {
+          result = {
+            kind: "user_error",
+            error: {
+              code: "not_found",
+              message:
+                "Register session was not available for this synced activity review.",
+            },
+          };
+        } else {
+          const registerSessionId = args.registerSessionId;
+          result = await runCommand(() =>
+            resolveRegisterSessionSyncReview({
+              actorStaffProfileId:
+                approvalProofResult.data.approvedByStaffProfileId,
+              decision: args.decision,
+              registerSessionId,
+              storeId: activeStore._id,
+            }),
+          );
+        }
+      } else {
+        result = await runCommand(() =>
+          decideApprovalRequest({
+            approvalRequestId: args.approvalRequestId as Id<"approvalRequest">,
+            approvalProofId: approvalProofResult.data.approvalProofId,
+            decision: args.decision,
+          }),
+        );
+      }
 
       if (result.kind !== "ok") {
         presentCommandToast(result);


### PR DESCRIPTION
## Summary

Register sync reviews now recover both completed sales and closeout events instead of clearing review work without applying the underlying local activity. This fixes the Wigshop case where a reviewed synced closeout remained in the local sync log while the cloud register session stayed active.

## What Changed

- Surface register sync conflicts in the Operations approvals workspace with register links and review-item context.
- Split the register detail action into explicit approve and reject paths for synced activity.
- Allow manager-approved `register_closed` sync events with variance to project into the cloud register session, including counted cash, variance, notes, closeout records, and trace metadata.
- Keep stale resolved conflicts reviewable when the source local sync event is still conflicted, so the production Wigshop closeout can be recovered instead of hidden.

## Testing

- `bun run --filter '@athena/webapp' test -- convex/cashControls/deposits.test.ts convex/operations/operationalWorkItems.test.ts src/components/cash-controls/RegisterSessionView.test.tsx src/components/operations/OperationsQueueView.test.tsx`
- Pre-push validation: graphify check, architecture check, targeted cash-controls/POS suites, `tsc`, `@athena/webapp:build`, full `@athena/webapp:test` (268 files, 2,208 tests), Convex audit, changed-file lint, runtime behavior scenarios.
- Prod validation against the Wigshop register confirmed the closeout sync event is still present and conflicted, while the cloud register remains unclosed until the resurfaced review is approved.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
